### PR TITLE
Upgrade Ruby & Bundler used for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.10-buster
+FROM ruby:2.7.8-buster
 
 # Install basic Linux packages
 RUN apt-get update -qq && apt-get install -y \
@@ -31,7 +31,7 @@ ENV RAILS_ENV=production \
     PATH="/gems/bin:$PATH"
 
 # Install bundler
-RUN gem install bundler -v 1.17.3
+RUN gem install bundler -v 2.4.12
 
 # Copy app code and install dependencies
 COPY . .


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

This work is part of #27

### What is the goal of this PR and why is this important? 
The dockerfile will not generate an image as is in main. The version of ruby used in the image does not match the version required by the Gemfile nor does the version of bundler.

### How did you approach the change?
Updated the Dockerfile and tested a deployment of the branch to Digital Ocean.

### Anything else to add?
We need to update CI to build the image as part of the build process as well as deploy main to DO staging as soon as it is updated.

