### PR TITLE
Migrate feature spec to system spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,63 @@ available at http://localhost:3000/admin/cms
 
 # Tests
 
-To run tests run:
+## Running Tests
+
+To run the full test suite:
 
 ```shell
 bin/rspec
 ```
 
-This will execute all the tests in the `spec/` directory and provide a summary of the results.
+To run specific test types:
+
+```shell
+# Run only model specs
+bin/rspec spec/models/
+
+# Run only system specs (end-to-end tests)
+bin/rspec spec/system/
+
+# Run a specific test file
+bin/rspec spec/models/workshop_spec.rb
+```
+
+## Testing Strategy
+
+This legacy Rails application was recently upgraded from Rails 4.x and originally had no automated tests. We are starting to implement a comprehensive testing strategy using RSpec and FactoryBot.
+
+### Test Structure
+
+- **System Specs** (`spec/system/`): End-to-end browser-based tests using Capybara to verify happy paths of critical behavior
+- **Model Specs** (`spec/models/`): Unit tests for ActiveRecord models, validations, associations, and business logic
+- **Service Specs** (`spec/services/`): Tests for service objects and lower-level building blocks
+- **Mailer Specs** (`spec/mailers/`): Email functionality tests for lower-level building blocks
+- **Factory Definitions** (`spec/factories/`): Test data generators using FactoryBot
+
+### Key Testing Focus Areas
+
+- **System specs to verify happy paths of critical behavior**: User authentication flows, workshop creation and management, search functionality, report submission workflows
+- **Model/mailer/service specs for verifying lower level building blocks**: Business logic validation, email delivery, authentication tokens, permission systems, and data relationships
+
+### Test Configuration
+
+The test suite uses:
+- **RSpec Rails** for the testing framework
+- **FactoryBot** for test data generation
+- **Capybara** for browser automation in system specs
+- **Shoulda Matchers** for model testing helpers
+- **Devise Test Helpers** for authentication in tests
+
+### Running Tests in Development
+
+Ensure MySQL test database is running:
+```shell
+# Using Docker
+docker run --name awbw_mysql_test -e MYSQL_ALLOW_EMPTY_PASSWORD=true -e MYSQL_DATABASE=awbw_test -p 3307:3306 -d mysql:latest
+
+# Setup test database
+RAILS_ENV=test rake db:create db:migrate
+```
 
 User Permissions
 ================

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,12 @@
+RSpec.configure do |config|
+  # Configure default driver for system specs
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+  
+  # Configure JavaScript driver for specs that need browser automation
+  # Usage: it "test name", js: true do
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,10 +3,4 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test
   end
-  
-  # Configure JavaScript driver for specs that need browser automation
-  # Usage: it "test name", js: true do
-  config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
-  end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/system/workshops_spec.rb
+++ b/spec/system/workshops_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe "Workshops" do
+RSpec.describe "Workshops", type: :system do
   before do
+    driven_by(:rack_test)
+    
     create(:footer)
     create(:permission, :adult)
     create(:permission, :children)

--- a/spec/system/workshops_spec.rb
+++ b/spec/system/workshops_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Workshops", type: :system do
+RSpec.describe "Workshops" do
   before do
-    driven_by(:rack_test)
-    
     create(:footer)
     create(:permission, :adult)
     create(:permission, :children)


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Rails 5.1 introduced system tests ... so migrating our solo feature spec to a system spec.

### What is the goal of this PR and why is this important? 
Lay the foundation for (hopefully) more comprehensive spec coverage.

### How did you approach the change?
example for example migration of the existing spec.

### Anything else to add?
We need way more of these specs and better factory-bot factories to support it.

