### PR TITLE
Fix ApiController to inherit from ApiController::Base

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::ApiController < ActionController::Base
+class Api::V1::ApiController < ApiController::Base
   protect_from_forgery with: :null_session, :if => Proc.new { |c| c.request.format.json? }
 
   rescue_from AuthenticationFailed, with: :authentication_failed


### PR DESCRIPTION
Fix ApiController to inherit from ApiController::Base

Allows admins/sign_in to work
