### PR TITLE
Compose fixes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,7 @@ SMTP_USERNAME=SOME_USERNAME
 SMTP_PASSWORD=SOME_PASSWORD
 SMTP_SERVER=SOME_HOST
 SMTP_PORT=2525
+
+# If using database in docker compose
+DATABASE_URL=trilogy://root@$(docker compose port database 3306)/
+# DATABASE_URL=trilogy://root@localhost::3306/

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,9 @@
-development:
-  host: 127.0.0.1
-  username: root
-  adapter: trilogy
+base: &base
   encoding: utf8
+  url: <%= ENV.fetch("DATABASE_URL", "trilogy://root@localhost") %>
+
+development:
+  <<: *base
   pool: 5
   database: awbw_development
 
@@ -10,9 +11,6 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  host: 127.0.0.1
-  username: root
-  adapter: trilogy
-  encoding: utf8
+  <<: *base
   pool: 5
   database: awbw_test

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,9 @@
 # Resolve the correct DB credentials
-config = YAML.load(ERB.new(File.read(Rails.root.join('config/database.yml'))).result)
-env_config = config[Rails.env]
+config = ActiveRecord::Base.configurations[Rails.env]
 
 # Extract credentials
-adapter = env_config['adapter']
-database = env_config['database']
+adapter = config[:adapter]
+database = config[:database]
 
 # Only run if MySQL is the DB
 if adapter.include?('trilogy')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     platform: linux/amd64
     command: --default-authentication-plugin=mysql_native_password
     ports:
-      - 3306:3306
-    expose:
-      - '3306'
+      - 3306
     volumes:
       - type: volume
         source: mysql-data
@@ -32,9 +30,10 @@ services:
     environment:
       # Fallback so Rails can boot even if .env is minimal.
       # If you prefer traditional keys, set DB_* in .env and configure database.yml accordingly.
-      DATABASE_URL: mysql2://root@database:3306/awbw_development
       RAILS_ENV: development
       RAILS_LOG_TO_STDOUT: "true"
+      DATABASE_URL: trilogy://root@development:3306/
+
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
    Update docker compose to not bind to native port by default
    
    This makes some changes to make docker not specifically bind to the
    native/default `3306` port for mysql.  This allows running multiple
    database container images without conflicting.
    
    the .env.sample file is updated with a DATABASE_URL configuration
    that will read the correct path / port out of the running docker image,
    so this can happen seamlessly.