### PR TITLE
Replace old 'id_param' method with params[:id]

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,11 +24,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(id_param).decorate
+    @user = User.find(params[:id]).decorate
   end
 
   def edit
-    @user = User.find(id_param)
+    @user = User.find(params[:id])
     if can_access_page?
       @project_users = @user.project_users
       render :edit
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(id_param)
+    @user = User.find(params[:id])
     if can_access_page?
       set_password unless password_param.empty?
 
@@ -93,10 +93,6 @@ class UsersController < ApplicationController
   #     :city2, :state2, :zip2, :primary_address, :notes, :avatar,
   #     project_users_attributes: [:project_id, :position, :_destroy, :id]
   #   )
-  # end
-
-  # def id_param
-  #   params[:id]
   # end
 
   # def password_param


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
There was an error when trying to access the User Profile

### How did you approach the change?
- replaced calls to the commented-out `id_param` method with `params[:id]`
- remove commented-out `def id_param`

