### PR TITLE
eager load tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = true
 
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }


### PR DESCRIPTION
Devise seems to be able to trigger test failures if things aren't loaded
in the right order.  without eager loading, the following results in
spec failures:

`rspec spec/requests/events_spec.rb`

```
      RuntimeError:
        Could not find a valid mapping for #<User id: 942, address: nil, address2: nil, agency_id: nil, avatar_content_type: nil, avatar_file_name: nil, avatar_file_size: nil, avatar_updated_at: nil, best_time_to_call: nil, birthday: nil, city: nil, city2: nil, comment: nil, confirmed: true, created_at: "2025-09-13 21:42:16.000000000 +0000", email: [FILTERED], facilitator_id: nil, first_name: "Quinn", inactive: false, last_name: "Gibson", legacy: false, legacy_id: nil, notes: nil, phone: nil, phone2: nil, phone3: nil, primary_address: nil, state: nil, state2: nil, subscribecode: nil, super_user: false, updated_at: "2025-09-13 21:42:16.000000000 +0000", zip: nil, zip2: nil>
      # ./.direnv/ruby/gems/devise-4.9.4/lib/devise/mapping.rb:46:in `find_scope!'
      # ./.direnv/ruby/gems/devise-4.9.4/lib/devise/test/integration_helpers.rb:38:in `sign_in'
```

these can be shown to be loading dependent by running another test in
front of them:

`rspec --order defined spec/system/login_spec spec/requests`
