### PR TITLE
drop some stray scss gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'puma', '~> 6.0' # Add Puma as the web server
 
 gem 'cocoon', '~> 1.2.6'
 
-gem 'font-awesome-rails'
 gem 'wicked'
 gem 'search_cop', '~> 1.0.6'
 gem 'jwt', '~> 1.2.1'
@@ -35,7 +34,6 @@ gem 'rack-cors', :require => 'rack/cors'
 gem 'ckeditor', '~> 4.3.0'
 gem "binding_of_caller"
 gem 'image_processing'
-gem 'foundation_emails'
 gem 'inky-rb', require: 'inky'
 # Stylesheet inlining for email
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,8 +192,6 @@ GEM
       i18n (>= 1.8.11, < 2)
     feature_flipper (2.0.0)
     ffi (1.17.2)
-    font-awesome-rails (4.7.0.9)
-      railties (>= 3.2, < 9.0)
     foundation_emails (2.2.1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -459,8 +457,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   feature_flipper
-  font-awesome-rails
-  foundation_emails
   httparty
   image_processing
   inky-rb


### PR DESCRIPTION
These were getting preloaded by bootsnap, and are no longer used
with the removal of scss
