### PR TITLE
Change hashrocket to newer 'at' syntax in ckeditor route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount Ckeditor::Engine => '/admin/ckeditor', as: 'ckeditor'
+  mount Ckeditor::Engine, at: '/admin/ckeditor', as: 'ckeditor'
   apipie
   get 'cms', to: 'admins/base#show'
 


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->


### What is the goal of this PR and why is this important? 
- Update ckeditor route to use latest rails syntax

### How did you approach the change?
- change `=>` to `at:` in ckeditor route

### Anything else to add?
- Was getting prompted about an issue w routes file, so updated

