### PR TITLE
Add the ability to CRUD workshops as series 'parents'

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -59,6 +59,7 @@ class WorkshopsController < ApplicationController
 
   def new
     @workshop = current_user.workshops.build
+    @potential_series_workshops = Workshop.published.where.not(id: @workshop.id).order(:title)
     @image    = @workshop.images.build
   end
 
@@ -69,6 +70,7 @@ class WorkshopsController < ApplicationController
 
   def edit
     @workshop = Workshop.find(params[:id])
+    @potential_series_workshops = Workshop.published.where.not(id: @workshop.id).order(:title)
     @image    = @workshop.images.build if @workshop.images.empty?
   end
 
@@ -165,11 +167,20 @@ class WorkshopsController < ApplicationController
 
   def workshop_params
     params.require(:workshop).permit(
-      :title, :full_name, :objective,
+      :title, :full_name, :objective, :featured,
       :materials, :optional_materials, :time_hours, :time_minutes, :age_range, :setup,
       :introduction, :demonstration, :opening_circle, :warm_up,
       :visualization, :creation, :closing, :notes, :tips, :misc1, :misc2,
-      :windows_type_id, :inactive, :month, :year,
+      :windows_type_id, :inactive, :month, :year, :extra_field,
+      :time_demonstration, :time_warm_up, :time_creation, :time_closing, :objective_spanish,
+      :materials_spanish, :optional_materials_spanish, :timeframe_spanish, :age_range_spanish,
+      :setup_spanish, :introduction_spanish, :demonstration_spanish, :opening_circle_spanish, :warm_up_spanish,
+      :visualization_spanish, :creation_spanish, :closing_spanish, :notes_spanish, :tips_spanish,
+      :misc1_spanish, :misc2_spanish, :extra_field_spanish,
+
+      workshop_series_children_attributes: [:id, :workshop_child_id, :workshop_parent_id,
+                                            :series_description, :series_description_spanish,
+                                            :series_order, :_destroy],
       images_attributes: %i[file owner_id owner_type id _destroy]
     )
   end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -32,6 +32,7 @@ class Workshop < ApplicationRecord
 
   # When this workshop is the parent in a series
   has_many :workshop_series_children,
+           -> { order(:series_order) },
            class_name: "WorkshopSeriesMembership",
            foreign_key: "workshop_parent_id",
            dependent: :destroy

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -30,6 +30,18 @@ class Workshop < ApplicationRecord
   has_many :attachments, as: :owner, dependent: :destroy
   has_many :workshop_age_ranges
 
+  # When this workshop is the parent in a series
+  has_many :workshop_series_children,
+           class_name: "WorkshopSeriesMembership",
+           foreign_key: "workshop_parent_id",
+           dependent: :destroy
+
+  # When this workshop is the child in a series
+  has_many :workshop_series_parents,
+           class_name: "WorkshopSeriesMembership",
+           foreign_key: "workshop_child_id",
+           dependent: :destroy
+
   has_attached_file :thumbnail, default_url: "/images/workshop_default.jpg"
   validates_attachment_content_type :thumbnail, content_type: /\Aimage\/.*\Z/
 
@@ -56,6 +68,10 @@ class Workshop < ApplicationRecord
 
   accepts_nested_attributes_for :workshop_variations,
                                 reject_if: proc { |object| object.nil? }
+
+  accepts_nested_attributes_for :workshop_series_children,
+                                reject_if: proc { |attributes| attributes['workshop_child_id'].blank? },
+                                allow_destroy: true
 
   # Scopes
   scope :published, -> { where(inactive: false) }

--- a/app/models/workshop_series_membership.rb
+++ b/app/models/workshop_series_membership.rb
@@ -1,0 +1,4 @@
+class WorkshopSeriesMembership < ApplicationRecord
+  belongs_to :workshop_parent, class_name: "Workshop"
+  belongs_to :workshop_child, class_name: "Workshop"
+end

--- a/app/models/workshop_series_membership.rb
+++ b/app/models/workshop_series_membership.rb
@@ -1,4 +1,6 @@
 class WorkshopSeriesMembership < ApplicationRecord
   belongs_to :workshop_parent, class_name: "Workshop"
   belongs_to :workshop_child, class_name: "Workshop"
+
+  validates :series_order, presence: true, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/views/workshops/_flex.html.erb
+++ b/app/views/workshops/_flex.html.erb
@@ -1,23 +1,38 @@
+<% workshop_series_membership ||= nil %>
+<% spanish ||= false %>
+
+<% if !spanish && workshop_series_membership&.series_description.present? %>
+  <% description = workshop_series_membership.series_description %>
+<% elsif spanish && workshop_series_membership &&
+  (workshop_series_membership.series_description_spanish || workshop_series_membership.series_description) %>
+  <% description = workshop_series_membership.series_description_spanish || workshop_series_membership.series_description %>
+<% else %>
+  <% description = workshop.formatted_objective %>
+<% end %>
+
 <div class='list-group-item list-group-item-custom'>
   <div class='row'>
-    <div class='col-xs-2 fixed-width'>
+    <div class='col-md-2'>
       <div class='portrait-img content-img-popular popular-img'
            style="background-image: url(<%= workshop.thumbnail_image %>);
                   max-height: 50px;" ></div>
     </div>
-    <div class='col-xs-6 col-xs-6-custom content-heading span'>
+    <div class="<%= workshop_series_membership ? "col-md-10" : "col-md-6 col-xs-6-custom" %> content-heading span">
       <h3><%= link_to workshop.title, link_route %></h3>
       <small><%= "#{workshop.windows_type.label unless workshop.windows_type.nil?} - #{workshop.date}" %></small><br/>
       <small>Author: <%= workshop.author %></small>
-      <p class='workshop-description'><%= truncate(workshop.formatted_objective, :length => 120, :omission => '... ', :separator => ' ') %></p>
-      <a><%= link_to "Read more", link_route, :target=>"blank" %></a>
+      <p class='workshop-description'>
+        <%= truncate(description, :length => 120, :omission => '... ', :separator => ' ') %>
+      </p>
     </div>
-    <div class="col-xs-3 col-md-3">
-      <small>
-        <span title="<%= workshop.categories.map(&:name).to_sentence %>">
-          <%= workshop.categories.map(&:name).to_sentence.truncate(150) %>
-        </span>
-      </small>
-    </div>
+    <% unless workshop_series_membership %>
+      <div class="col-md-3">
+        <small>
+          <span title="<%= workshop.categories.map(&:name).to_sentence %>">
+            <%= workshop.categories.map(&:name).to_sentence.truncate(150) %>
+          </span>
+        </small>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -21,7 +21,7 @@
                     label: "Workshop type",
                     required: true,
                     collection: WindowsType.pluck(:name, :id).sort_by(&:first),
-                    selected: @workshop.windows_type_id || WindowsType.where("name like 'adult%'").last&.id %>%>
+                    selected: @workshop.windows_type_id || WindowsType.where("name like 'adult%'").last&.id %>
       </div>
 
       <% if request.path == workshops_share_idea_path %>
@@ -227,6 +227,28 @@
               </div>
             <% end %>
             <br/>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-wrapper mb-3">
+      <button type="button" class="accordion-toggle">Series workshops</button>
+      <div class="accordion-content" style="display: none; padding: 10px; border: 1px solid #ccc; border-top: none;">
+        <div class="row mb-2">
+          If this is a Workshop is a series, add the other "series workshops" below.
+          You can also add a series-specific description for each workshop in the series, and the order in which they should appear.
+          (The main workshop description will appear if you don't add a "series description".)
+        </div>
+        <div class="row mb-2">
+          <div class="form-group image-fields-wrapper">
+            <%= f.fields_for :workshop_series_children do |child_workshop_membership| %>
+              <%= render 'workshop_series_child_fields', :f => child_workshop_membership %>
+            <% end %>
+            <div class="links small">
+              <%= link_to_add_association 'Add Another Workshop to this Series', f, :workshop_series_children,
+                                          partial: 'workshop_series_child_fields', class:'btn-underline' %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/workshops/_show.html.erb
+++ b/app/views/workshops/_show.html.erb
@@ -358,6 +358,28 @@
         <% end %>
 
       <% end %>
+
+      <% if workshop.workshop_series_children.any? %>
+        <div class="single-workshop-detail">
+          <h3 class='normal curriculum-title'>Series workshops</h3>
+          <hr>
+          <div id="series-workshops-list">
+            <% workshop.workshop_series_children.each do |workshop_series_membership| %>
+              <%= render 'workshops/flex',
+                         workshop: workshop_series_membership.workshop_child.decorate,
+                         link_route: workshop_path(workshop_series_membership.workshop_child),
+                         workshop_series_membership: workshop_series_membership
+              %>
+            <% end %>
+          </div>
+
+          <div class='small wysiwyg-content clearfix'>
+            <div class="wysiwyg-content__inner-wrapper">
+              <p><%= workshop.age_range.html_safe %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </div>
   </li>
 
@@ -580,6 +602,29 @@
             </div>
           </div>
         <% end %>
+
+      <% if workshop.workshop_series_children.any? %>
+        <div class="single-workshop-detail">
+          <h3 class='normal curriculum-title'>Series workshops</h3>
+          <hr>
+          <div id="series-workshops-list">
+            <% workshop.workshop_series_children.each do |workshop_series_membership| %>
+              <%= render 'workshops/flex',
+                         workshop: workshop_series_membership.workshop_child.decorate,
+                         link_route: workshop_path(workshop_series_membership.workshop_child),
+                         workshop_series_membership: workshop_series_membership,
+                         spanish: true
+              %>
+            <% end %>
+          </div>
+
+          <div class='small wysiwyg-content clearfix'>
+            <div class="wysiwyg-content__inner-wrapper">
+              <p><%= workshop.age_range.html_safe %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </div>
   </li>
 <% end %>

--- a/app/views/workshops/_workshop_series_child_fields.html.erb
+++ b/app/views/workshops/_workshop_series_child_fields.html.erb
@@ -1,0 +1,13 @@
+<div class="nested-fields display-flex gap-2 items-center" style="display: flex">
+  <%= f.input :workshop_child_id,
+              as: :select,
+              label: "Select Series Workshops",
+              collection: @potential_series_workshops,
+              label_method: :title, # display title in options
+              value_method: :id  %>
+
+  <%= f.input :series_description, as: :text, input_html: { rows: 1 } %>
+  <%= f.input :series_description_spanish, as: :text, input_html: { rows: 1 } %>
+  <%= f.input :series_order, as: :integer %>
+  <%= link_to_remove_association "Remove", f , class:"btn-underline" %>
+</div>

--- a/db/migrate/20250918000354_create_workshop_series_membership.rb
+++ b/db/migrate/20250918000354_create_workshop_series_membership.rb
@@ -1,0 +1,20 @@
+class CreateWorkshopSeriesMembership < ActiveRecord::Migration[8.1]
+  def change
+    create_table :workshop_series_memberships do |t|
+      t.integer :workshop_parent_id, null: false
+      t.integer :workshop_child_id, null: false
+      t.string :series_description
+      t.string :series_description_spanish
+      t.integer :series_order, default: 1
+
+      t.timestamps
+
+    end
+
+    add_foreign_key :workshop_series_memberships, :workshops, column: :workshop_parent_id
+    add_foreign_key :workshop_series_memberships, :workshops, column: :workshop_child_id
+
+    add_index :workshop_series_memberships, [:workshop_parent_id, :workshop_child_id], unique: true,
+              name: "index_workshop_series_memberships_on_parent_and_child"
+  end
+end

--- a/db/migrate/20250918000354_create_workshop_series_membership.rb
+++ b/db/migrate/20250918000354_create_workshop_series_membership.rb
@@ -5,7 +5,7 @@ class CreateWorkshopSeriesMembership < ActiveRecord::Migration[8.1]
       t.integer :workshop_child_id, null: false
       t.string :series_description
       t.string :series_description_spanish
-      t.integer :series_order, default: 1
+      t.integer :series_order, default: 1, null: false
 
       t.timestamps
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_09_13_171135) do
-
+ActiveRecord::Schema[8.1].define(version: 2025_09_18_000354) do
   create_table "addresses", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "organization_id", null: false
-    t.string "street", null: false
     t.string "city", null: false
-    t.string "state", null: false
-    t.string "zip", null: false
     t.string "country"
-    t.string "locality"
     t.string "county"
+    t.datetime "created_at", null: false
     t.integer "la_city_council_district"
-    t.integer "la_supervisorial_district"
     t.integer "la_service_planning_area"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.integer "la_supervisorial_district"
+    t.string "locality"
+    t.bigint "organization_id", null: false
+    t.string "state", null: false
+    t.string "street", null: false
+    t.datetime "updated_at", null: false
+    t.string "zip", null: false
     t.index ["organization_id"], name: "index_addresses_on_organization_id"
   end
 
-  create_table "admins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "admins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "current_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
@@ -48,7 +47,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table "age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "age_ranges", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.datetime "updated_at", precision: nil, null: false
@@ -56,14 +55,14 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["windows_type_id"], name: "index_age_ranges_on_windows_type_id"
   end
 
-  create_table "answer_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "answer_options", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.integer "order"
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "attachments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "file_content_type"
     t.string "file_file_name"
@@ -74,14 +73,14 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "banners", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "banners", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "content"
     t.datetime "created_at", precision: nil, null: false
     t.boolean "show"
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "bookmark_annotations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "bookmark_annotations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "annotation", size: :medium
     t.integer "bookmark_id"
     t.datetime "created_at", precision: nil, null: false
@@ -89,7 +88,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["bookmark_id"], name: "index_bookmark_annotations_on_bookmark_id"
   end
 
-  create_table "bookmarks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "bookmarks", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "bookmarkable_id"
     t.string "bookmarkable_type"
     t.datetime "created_at", precision: nil, null: false
@@ -98,7 +97,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "categories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "categories", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "legacy_id"
     t.integer "metadatum_id"
@@ -108,7 +107,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["metadatum_id"], name: "index_categories_on_metadatum_id"
   end
 
-  create_table "categorizable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "categorizable_items", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "categorizable_id"
     t.string "categorizable_type"
     t.integer "category_id"
@@ -119,7 +118,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["category_id"], name: "index_categorizable_items_on_category_id"
   end
 
-  create_table "ckeditor_assets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ckeditor_assets", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "actual_url"
     t.integer "assetable_id"
     t.string "assetable_type", limit: 30
@@ -135,7 +134,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["assetable_type", "type", "assetable_id"], name: "idx_ckeditor_assetable_type"
   end
 
-  create_table "event_registrations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "event_registrations", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
     t.bigint "event_id"
@@ -145,7 +144,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["event_id"], name: "index_event_registrations_on_event_id"
   end
 
-  create_table "events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "events", charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
     t.datetime "end_date", precision: nil
@@ -157,16 +156,16 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
   end
 
   create_table "facilitator_organizations", charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "facilitator_id", null: false
     t.bigint "organization_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["facilitator_id", "organization_id"], name: "index_facilitator_organizations_on_ids", unique: true
     t.index ["facilitator_id"], name: "index_facilitator_organizations_on_facilitator_id"
     t.index ["organization_id"], name: "index_facilitator_organizations_on_organization_id"
   end
 
-  create_table "facilitators", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "facilitators", charset: "utf8mb3", force: :cascade do |t|
     t.string "city", null: false
     t.string "country", null: false
     t.datetime "created_at", null: false
@@ -183,7 +182,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.string "zip", null: false
   end
 
-  create_table "faqs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "faqs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "answer", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.boolean "inactive"
@@ -192,7 +191,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "footers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "footers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "adult_program"
     t.string "children_program"
     t.datetime "created_at", precision: nil, null: false
@@ -201,7 +200,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "form_builders", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "form_builders", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.text "description", size: :medium
     t.string "name"
@@ -211,7 +210,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["windows_type_id"], name: "index_form_builders_on_windows_type_id"
   end
 
-  create_table "form_field_answer_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "form_field_answer_options", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "answer_option_id"
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_field_id"
@@ -220,7 +219,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["form_field_id"], name: "index_form_field_answer_options_on_form_field_id"
   end
 
-  create_table "form_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "form_fields", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "answer_datatype"
     t.integer "answer_type"
     t.datetime "created_at", precision: nil, null: false
@@ -235,7 +234,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["form_id"], name: "index_form_fields_on_form_id"
   end
 
-  create_table "forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_builder_id"
     t.integer "owner_id"
@@ -244,7 +243,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["form_builder_id"], name: "index_forms_on_form_builder_id"
   end
 
-  create_table "images", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "images", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "file_content_type"
     t.string "file_file_name"
@@ -257,7 +256,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["owner_id"], name: "index_images_on_owner_id"
   end
 
-  create_table "locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "locations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "city"
     t.string "country"
     t.datetime "created_at", precision: nil, null: false
@@ -265,7 +264,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "media_files", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "media_files", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "file_content_type"
     t.string "file_file_name"
     t.integer "file_file_size"
@@ -274,7 +273,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.integer "workshop_log_id"
   end
 
-  create_table "metadata", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "metadata", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "legacy_id"
     t.string "name"
@@ -282,7 +281,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "monthly_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "monthly_reports", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "best_call_time"
     t.boolean "call_requested"
     t.text "comments", size: :medium
@@ -305,7 +304,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["project_user_id"], name: "index_monthly_reports_on_project_user_id"
   end
 
-  create_table "notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "notifications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "noticeable_id"
     t.string "noticeable_type"
@@ -314,40 +313,40 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
   end
 
   create_table "organizations", charset: "utf8mb3", force: :cascade do |t|
-    t.string "name", null: false
-    t.boolean "is_active", default: true
-    t.date "start_date"
-    t.date "close_date"
-    t.string "website_url"
     t.string "agency_type", null: false
     t.string "agency_type_other"
-    t.string "phone", null: false
+    t.date "close_date"
+    t.datetime "created_at", null: false
+    t.boolean "is_active", default: true
     t.text "mission"
+    t.string "name", null: false
+    t.string "phone", null: false
     t.string "project_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.date "start_date"
+    t.datetime "updated_at", null: false
+    t.string "website_url"
   end
 
-  create_table "permissions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "legacy_id"
     t.string "security_cat"
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "project_obligations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "project_obligations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "project_statuses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "project_statuses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "project_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "project_users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "agency_id"
     t.datetime "created_at", precision: nil, null: false
     t.string "filemaker_code"
@@ -360,7 +359,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["user_id"], name: "index_project_users_on_user_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.text "description", size: :medium
     t.string "district"
@@ -382,7 +381,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["windows_type_id"], name: "index_projects_on_windows_type_id"
   end
 
-  create_table "quotable_item_quotes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "quotable_item_quotes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "legacy_id"
     t.integer "quotable_id"
@@ -392,7 +391,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["quote_id"], name: "index_quotable_item_quotes_on_quote_id"
   end
 
-  create_table "quotes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "quotes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "age"
     t.datetime "created_at", precision: nil, null: false
     t.string "gender", limit: 1
@@ -406,7 +405,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_quotes_on_workshop_id"
   end
 
-  create_table "report_form_field_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "report_form_field_answers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "answer", size: :medium
     t.integer "answer_option_id"
     t.datetime "created_at", precision: nil
@@ -418,7 +417,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["report_id"], name: "index_report_form_field_answers_on_report_id"
   end
 
-  create_table "reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "reports", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "adults_first_time", default: 0
     t.integer "adults_ongoing", default: 0
     t.integer "children_first_time", default: 0
@@ -448,7 +447,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["windows_type_id"], name: "index_reports_on_windows_type_id"
   end
 
-  create_table "resources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "agency"
     t.string "author"
     t.datetime "created_at", precision: nil, null: false
@@ -473,7 +472,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_resources_on_workshop_id"
   end
 
-  create_table "sectorable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "sectorable_items", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.boolean "inactive", default: true
     t.integer "sector_id"
@@ -483,14 +482,14 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["sector_id"], name: "index_sectorable_items_on_sector_id"
   end
 
-  create_table "sectors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "sectors", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.boolean "published", default: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "user_form_form_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_form_form_fields", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_field_id"
     t.text "text", size: :medium
@@ -500,7 +499,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["user_form_id"], name: "index_user_form_form_fields_on_user_form_id"
   end
 
-  create_table "user_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_id"
     t.datetime "updated_at", precision: nil, null: false
@@ -509,7 +508,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["user_id"], name: "index_user_forms_on_user_id"
   end
 
-  create_table "user_permissions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "permission_id"
     t.datetime "updated_at", precision: nil, null: false
@@ -518,7 +517,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["user_id"], name: "index_user_permissions_on_user_id"
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "address"
     t.string "address2"
     t.integer "agency_id"
@@ -567,7 +566,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "windows_types", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "windows_types", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "legacy_id"
     t.string "name"
@@ -575,7 +574,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "workshop_age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "workshop_age_ranges", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "age_range_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -584,7 +583,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_workshop_age_ranges_on_workshop_id"
   end
 
-  create_table "workshop_logs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "workshop_logs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "challenges", size: :medium
     t.text "comments", size: :medium
     t.datetime "created_at", precision: nil, null: false
@@ -609,7 +608,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_workshop_logs_on_workshop_id"
   end
 
-  create_table "workshop_resources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "workshop_resources", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "resource_id"
     t.datetime "updated_at", precision: nil, null: false
@@ -618,7 +617,19 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_workshop_resources_on_workshop_id"
   end
 
-  create_table "workshop_variations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "workshop_series_memberships", charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "series_description"
+    t.string "series_description_spanish"
+    t.integer "series_order", default: 1
+    t.datetime "updated_at", null: false
+    t.integer "workshop_child_id", null: false
+    t.integer "workshop_parent_id", null: false
+    t.index ["workshop_child_id"], name: "fk_rails_c3357d1053"
+    t.index ["workshop_parent_id", "workshop_child_id"], name: "index_workshop_series_memberships_on_parent_and_child", unique: true
+  end
+
+  create_table "workshop_variations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "code", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.boolean "inactive", default: true
@@ -631,7 +642,7 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
     t.index ["workshop_id"], name: "index_workshop_variations_on_workshop_id"
   end
 
-  create_table "workshops", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "workshops", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "age_range", size: :medium
     t.text "age_range_spanish", size: :medium
     t.string "author_location"
@@ -763,6 +774,8 @@ ActiveRecord::Schema.define(version: 2025_09_13_171135) do
   add_foreign_key "workshop_logs", "workshops"
   add_foreign_key "workshop_resources", "resources"
   add_foreign_key "workshop_resources", "workshops"
+  add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_child_id"
+  add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_parent_id"
   add_foreign_key "workshop_variations", "workshops"
   add_foreign_key "workshops", "users"
   add_foreign_key "workshops", "windows_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -621,7 +621,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_18_000354) do
     t.datetime "created_at", null: false
     t.string "series_description"
     t.string "series_description_spanish"
-    t.integer "series_order", default: 1
+    t.integer "series_order", default: 1, null: false
     t.datetime "updated_at", null: false
     t.integer "workshop_child_id", null: false
     t.integer "workshop_parent_id", null: false


### PR DESCRIPTION


- This work is part of #180 

### What is the goal of this PR and why is this important? 
- Some workshops are currently "parent" workshops of a series of existing workshops
- Users are adding child workshop metadata manually within the description of a parent workshop

### How did you approach the change?
- Add a new model and join table `workshop_series_memberships` with fk's to `workshop_parent_id` and `workshop_child_id`
- Make workshops accept nested attributes for `workshop_series_children`

### Anything else to add?
- `workshop_series_memberships` have fields for `series_description` since usually facilitators want to add series-specific text explaining why that workshop is in the series
- `workshop_series_memberships` has a `series_order` int field so child workshops can be ordered

