### PR TITLE
Fix workshop filter and sort

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -176,7 +176,7 @@ class WorkshopsController < ApplicationController
       :materials, :optional_materials, :time_hours, :time_minutes, :age_range, :setup,
       :introduction, :demonstration, :opening_circle, :warm_up,
       :visualization, :creation, :closing, :notes, :tips, :misc1, :misc2,
-      :windows_type_id, :inactive, :month, :year, :extra_field,
+      :windows_type_id, :inactive, :month, :year, :extra_field, :user_id,
       :time_demonstration, :time_warm_up, :time_creation, :time_closing, :objective_spanish,
       :materials_spanish, :optional_materials_spanish, :timeframe_spanish, :age_range_spanish,
       :setup_spanish, :introduction_spanish, :demonstration_spanish, :opening_circle_spanish, :warm_up_spanish,

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -2,7 +2,12 @@
 
 class WorkshopsController < ApplicationController
   def index
-    @workshops = current_user.curriculum(Workshop).search(params).paginate(page: params[:page], per_page: 20)
+    workshops = current_user.curriculum(Workshop).search(params,
+                                                         super_user: current_user.super_user?) # inactive and active results
+    if params[:title].present?
+      workshops = workshops.title(params[:title])
+    end
+    @workshops = workshops.paginate(page: params[:page], per_page: 50)
 
     load_sortable_fields
     load_metadata

--- a/app/decorators/workshop_decorator.rb
+++ b/app/decorators/workshop_decorator.rb
@@ -101,7 +101,7 @@ class WorkshopDecorator < Draper::Decorator
     end
   end
 
-  def formatted_objective
+  def formatted_objective(length: 100)
     if legacy
       html = html_objective
 
@@ -114,9 +114,9 @@ class WorkshopDecorator < Draper::Decorator
       obj ||= html.text
 
       h.truncate(obj.gsub(title, '').
-          gsub(/(Heart Story Example|Table set-up)/, '').squish, length: 100)
+          gsub(/(Heart Story Example|Table set-up)/, '').squish, length: length)
     else
-      h.truncate(html_objective.text.html_safe.squish, length: 100)
+      h.truncate(html_objective.text.html_safe.squish, length: length)
     end
   end
 

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -119,32 +119,57 @@ class Workshop < ApplicationRecord
     end
   end
 
-  def self.search(params)
-    workshops = all.order(:title)
-    workshops = workshops.search_by_categories( params[:categories] ).order(:title) if params[:categories]
-    workshops = workshops.search_by_sectors( params[:sectors] ).order(:title) if params[:sectors]
+  def self.search(params, super_user: false)
+    workshops = all
 
-    if params[:type] == "led"
+    # filter by
+    if params[:categories].present?
+      workshops = workshops.search_by_categories( params[:categories] )
+    end
+    if params[:sectors].present?
+      workshops = workshops.search_by_sectors( params[:sectors] )
+    end
+
+    if params[:query].present?
+      # Columns you want to search
+      cols = "title, full_name, objective, materials, introduction, demonstration, opening_circle,
+            warm_up, creation, closing, notes, tips, misc1, misc2"
+      # Prepare query for BOOLEAN MODE (prefix matching)
+      terms = params[:query].to_s.strip.split.map { |term| "#{term}*" }.join(' ')
+      # Build the MATCH...AGAINST SQL
+      match_sql = "MATCH(#{cols}) AGAINST(? IN BOOLEAN MODE)"
+
+      workshops = workshops.select("workshops.*, #{match_sql} AS all_score", terms)
+                           .where(match_sql, terms)
+    end
+
+    # only show published results to regular users
+    unless super_user
+      workshops = workshops.published
+    end
+
+    # sort by
+    if params[:sort] == 'created'
+      workshops = workshops.order(
+        Arel.sql("
+          CASE
+            WHEN year IS NOT NULL AND month IS NOT NULL THEN
+              STR_TO_DATE(CONCAT(year,'-',month,'-01'), '%Y-%m-%d')
+            ELSE created_at
+          END DESC")
+      )
+    elsif params[:sort] == 'led'
       workshops = workshops.order(led_count: :desc)
-    elsif params[:type] and params[:type] != 'created'
-      workshops = workshops.where(windows_type_id: params[:type].to_i).order(:title)
-      type_sql  = "AND windows_type_id = #{params[:type]}"
+    elsif params[:sort] == "title"
+      workshops = workshops.order(title: :asc)
+    elsif params[:query].present? # params[:sort] == 'keywords'
+      workshops = workshops.order("all_score DESC")
+    else
+      workshops = workshops.order(title: :asc)
     end
 
-    cols = "title, full_name, objective, materials, introduction, demonstration, opening_circle, warm_up, creation, closing, notes, tips, misc1, misc2"
-
-    query_str = "SELECT *, MATCH ( #{cols} ) AGAINST ( '*#{params[:query]}*' IN BOOLEAN MODE ) AS all_score,
-                 MATCH ( title ) AGAINST ( '*#{params[:query]}*' IN BOOLEAN MODE ) AS title_score
-
-                 FROM workshops WHERE MATCH ( #{cols} )
-                 AGAINST ( '*#{params[:query]}*' IN BOOLEAN MODE ) #{type_sql} AND inactive is false ORDER BY title_score DESC;"
-
-    unless params[:query].blank?
-      workshops = workshops.find_by_sql(query_str)
-    end
-
-    if params[:type] == 'created'
-      workshops = workshops.sort{|x,y| Date.parse(y.date) <=> Date.parse(x.date) }
+    if params[:type] == 'led' # TODO - find wherever this gets used and change param name to :sort
+      workshops = workshops.order(led_count: :desc)
     end
 
     workshops

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -112,10 +112,10 @@ class Workshop < ApplicationRecord
   end
 
   def date
-    if month.nil? or year.nil?
-      "#{created_at.month}/#{created_at.year}"
-    else
+    if month.present? && year.present?
       "#{month}/#{year}"
+    else
+      "#{created_at.month}/#{created_at.year}"
     end
   end
 

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -75,16 +75,20 @@ class Workshop < ApplicationRecord
                                 allow_destroy: true
 
   # Scopes
-  scope :published, -> { where(inactive: false) }
+  scope :for_search, -> { published }
+
   scope :featured, -> { where(featured: true) }
-  scope :by_year, -> { order(year: :desc).order(month: :desc) }
+  scope :legacy, -> { where(legacy: true) }
+  scope :published, -> { where(inactive: false) }
   scope :recent, -> { for_search.by_year.order(led_count: :desc).uniq(&:title) }
+  scope :title, -> (title) { where("title like ?", "%#{ title }%") }
+
+  scope :by_created_at, -> { order(created_at: :desc) }
+  scope :by_led_count, -> { order(led_count: :desc) }
   scope :by_rating, -> { by_year.sort_by(&:rating)}
   scope :by_warm_up_and_relaxation, -> { search('Warm Up Relaxation') }
-  scope :by_led_count, -> { order(led_count: :desc) }
-  scope :for_search, -> { published }
-  scope :legacy, -> { where(legacy: true) }
-  scope :by_created_at, -> { order(created_at: :desc) }
+  scope :by_year, -> { order(year: :desc).order(month: :desc) }
+
 
   # Validations
   validates_presence_of :title

--- a/app/views/workshops/_flex.html.erb
+++ b/app/views/workshops/_flex.html.erb
@@ -12,19 +12,32 @@
 
 <div class='list-group-item list-group-item-custom'>
   <div class='row'>
-    <div class='col-md-2'>
-      <div class='portrait-img content-img-popular popular-img'
-           style="background-image: url(<%= workshop.thumbnail_image %>);
-                  max-height: 50px;" ></div>
+    <div class='col-md-9'>
+      <div class='col-md-3'>
+        <div class='portrait-img content-img-popular popular-img'
+             style="background-image: url(<%= workshop.thumbnail_image %>);
+               max-height: 50px;" ></div>
+      </div>
+      <div class="<%= workshop_series_membership ? "col-md-9" : "col-md-6 col-xs-6-custom" %> content-heading span">
+        <h3><%= link_to workshop.title, link_route %></h3>
+        <small>
+          <%= "#{workshop.windows_type.label unless workshop.windows_type.nil?} - #{workshop.date}" %>
+          &nbsp;<%= "(#{ workshop.age_range.strip })" if workshop.age_range.present? %>
+        </small>
+        <br/>
+        <small>Author: <%= workshop.user ? link_to(workshop.author, user_path(workshop.user)) : workshop.author %></small>
+        <br>
+        <small>Favorited: <%= workshop.led_count %></small>
+      </div>
+      <div class="col-md-12">
+        <p class='workshop-description'>
+        <span title="<%= workshop.formatted_objective(length: 500) %>">
+          <%= truncate(description, :length => 120, :omission => '... ', :separator => ' ') %>
+        </span>
+        </p>
+      </div>
     </div>
-    <div class="<%= workshop_series_membership ? "col-md-10" : "col-md-6 col-xs-6-custom" %> content-heading span">
-      <h3><%= link_to workshop.title, link_route %></h3>
-      <small><%= "#{workshop.windows_type.label unless workshop.windows_type.nil?} - #{workshop.date}" %></small><br/>
-      <small>Author: <%= workshop.author %></small>
-      <p class='workshop-description'>
-        <%= truncate(description, :length => 120, :omission => '... ', :separator => ' ') %>
-      </p>
-    </div>
+
     <% unless workshop_series_membership %>
       <div class="col-md-3">
         <small>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -48,11 +48,14 @@
                     placeholder: 'Indicate goals of the workshop',
                     input_html: { rows: 1 } %>
       </div>
-      <div class="col-md-4">
+      <div class="col-md-4" style="display: flex">
         <%= f.input :full_name,
                     as: :text,
                     label: "Author's first & last name",
                     input_html: { rows: 1 } %>
+        <% if current_user.super_user %>
+          <%= f.input :user_id, as: :select, collection: User.order(:last_name, :first_name) %>
+        <% end %>
       </div>
       <div class="col-md-4">
         <%= f.input :age_range,

--- a/app/views/workshops/_sortable_fields.html.erb
+++ b/app/views/workshops/_sortable_fields.html.erb
@@ -1,21 +1,39 @@
-<% sortable_fields.each do |sortable_field| %>
-  <div class="input-group">
-    <%= radio_button_tag :type, sortable_field.id,
-          sortable_field.id.to_s == params[:type],
+<div class="input-group">
+    <%= radio_button_tag :sort, "created",
+          params[:sort] == "created",
           onclick: ("$('form').submit();") %>
 
     <span class="small">
-      <%= sortable_field.name.titleize.gsub("Log", "").gsub("Children", "Children's") %>
+      Newest
     </span>
-  </div>
-<% end %>
+</div>
 
 <div class="input-group">
-    <%= radio_button_tag :type, "created",
-          params[:type] == "created",
-          onclick: ("$('form').submit();") %>
+  <%= radio_button_tag :sort, "title",
+                       params[:sort] == "title",
+                       onclick: ("$('form').submit();") %>
 
-    <span class="small">
-      Date
-    </span>
+  <span class="small">
+    Title
+  </span>
+</div>
+
+<div class="input-group">
+  <%= radio_button_tag :sort, "led",
+                       params[:sort] == "led",
+                       onclick: ("$('form').submit();") %>
+
+  <span class="small">
+    Most favorited
+  </span>
+</div>
+
+<div class="input-group">
+  <%= radio_button_tag :sort, "keywords",
+                       params[:sort] == "keywords",
+                       onclick: ("$('form').submit();") %>
+
+  <span class="small">
+    Keywords
+  </span>
 </div>

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -44,17 +44,23 @@
         <%= render 'sectors_fields', sectors: @sectors %>
       </div>
       <div class='search-wrapper'>
-        <div class='search-field-row'>
-          <%= text_field_tag :query, params[:query], class: 'search',
-                                           placeholder: ' Enter keywords here...' %>
+        <div class='search-field-row col-md-6'>
+          <%= text_field_tag :title, params[:title], class: 'search',
+                             placeholder: 'Title' %>
 
           <div class='btn btn-primary btn-search-wrapper' id="submit-div">
             <i class='fa fa-search'></i>
           </div>
         </div>
-        <div class='apply-all'>
-          <%= link_to 'See All Workshops', workshops_path, class: 'js-view-all underline' %>
+        <div class='search-field-row col-md-6'>
+          <%= text_field_tag :query, params[:query], class: 'search',
+                                           placeholder: 'Keywords' %>
+
+          <div class='btn btn-primary btn-search-wrapper' id="submit-div">
+            <i class='fa fa-search'></i>
+          </div>
         </div>
+        <div class="col-md-12 mb-3"></div>
         <div class='small-gray-title'>
           Last Search Results
         </div>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of a larger effort to respond to facilitator feedback. No specific issue to reference.

### What is the goal of this PR and why is this important? 
- Facilitators reported confusion and errors wrt workshop searching
- 

### How did you approach the change?
- Allow super_users to see non-published results (since we no longer have RailsAdmin)
- Separate params[:query] from new params -- params[:sort] and params[:title]
- Convert raw sql to instead use more AR and rails-y syntax
- Separate filtering code from sorting code, and perform them in that order
- Sort by date conditionally uses month and year, otherwise created_at
- Preserve sort by 'all_score' as default if no other sorts are in params AND params[:query] is present
- Kept clause re when params[:query]=='led' bc it seems like this happens elsewhere in the app (to be removed)
- Ensure this always returns an AR relation


### Anything else to add?
- There's an outstanding issue to add more tests for this method

