### PR TITLE
Fix error when changing a password

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
     @user = current_user
 
     if @user.update_with_password(pass_params)
-      sign_in(@user, :bypass => true)
+      bypass_sign_in(@user)
       flash[:alert] = 'Your Password was updated.'
       redirect_to root_path
     else


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->


### What is the goal of this PR and why is this important? 
- fix error upon trying to change a password

### How did you approach the change?
- changed to `sign_in(@user, :bypass => true)` to `bypass_sign_in` to avoid an error.

### Anything else to add?
- `sign_in(@user, :bypass => true)` and bypass as an argument is from an older version of Devise

