### PR TITLE
Add stimulus dropdown controller

### DIFF
--- a/app/frontend/javascript/controllers/dropdown_controller.js
+++ b/app/frontend/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,82 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="dropdown"
+export default class extends Controller {
+  //Your element should have it's initial utility classes defined when the page
+  //loads (eg. class="hidden"). Pass into the controller what classes should be toggled including
+  //the classes from the initial state (data-dropdown-utility-class="hidden block")
+
+  static classes = ["utility"];
+  static values = {
+    element: String,
+  };
+
+  connect() {
+    this.open = false;
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
+    this.handleEscapeKey = this.handleEscapeKey.bind(this);
+  }
+
+  toggle() {
+    const element = document.getElementById(this.elementValue);
+    if (!element) return;
+
+    this.utilityClasses.forEach((c) => element.classList.toggle(c));
+    this.manageEventListeners();
+    this.open = !this.open;
+  }
+
+  manageEventListeners() {
+    if (this.open) {
+      this.removeEventListeners();
+    } else {
+      // Add delay to avoid immediate trigger
+      setTimeout(() => {
+        this.addEventListeners();
+      }, 0);
+    }
+  }
+
+  addEventListeners() {
+    document.addEventListener("click", this.handleOutsideClick);
+    document.addEventListener("keydown", this.handleEscapeKey);
+  }
+
+  removeEventListeners() {
+    document.removeEventListener("click", this.handleOutsideClick);
+    document.removeEventListener("keydown", this.handleEscapeKey);
+  }
+
+  handleOutsideClick(event) {
+    const element = document.getElementById(this.elementValue);
+    if (!element) return;
+
+    const isClickInsideElement = element.contains(event.target);
+    const isClickOnToggle = this.element.contains(event.target);
+
+    if (!isClickInsideElement && !isClickOnToggle) {
+      this.close();
+    }
+  }
+
+  handleEscapeKey(event) {
+    if (event.key === "Escape") {
+      this.close();
+    }
+  }
+
+  close() {
+    const element = document.getElementById(this.elementValue);
+    if (!element) return;
+
+    if (this.open) {
+      this.utilityClasses.forEach((c) => element.classList.toggle(c));
+      this.removeEventListeners();
+      this.open = false;
+    }
+  }
+
+  disconnect() {
+    this.removeEventListeners();
+  }
+}

--- a/app/frontend/javascript/controllers/hello_controller.js
+++ b/app/frontend/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -1,7 +1,4 @@
 import { application } from "./application";
 
-import HelloController from "./hello_controller";
-application.register("hello", HelloController);
-
 import DropdownController from "./dropdown_controller";
 application.register("dropdown", DropdownController);

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -1,4 +1,7 @@
-import { application } from "./application"
+import { application } from "./application";
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import HelloController from "./hello_controller";
+application.register("hello", HelloController);
+
+import DropdownController from "./dropdown_controller";
+application.register("dropdown", DropdownController);

--- a/app/views/shared/tailwind/_navbar.html.erb
+++ b/app/views/shared/tailwind/_navbar.html.erb
@@ -1,8 +1,3 @@
-<%# TODO This needs to be change to stimulus and remove tailwind el-menu which requires a commercial license %>
-<script
-  src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"
-  type="module"
-></script>
 <nav class="relative bg-[#063b8d] print:hidden">
   <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
     <div class="relative flex items-center justify-between py-2.5">
@@ -10,13 +5,15 @@
         <!-- Mobile menu button-->
         <button
           type="button"
-          command="--toggle"
-          commandfor="mobile-menu"
           class="
             relative inline-flex items-center justify-center rounded-md p-2 text-gray-400
             hover:bg-white/5 hover:text-white focus:outline-2 focus:-outline-offset-1
             focus:outline-indigo-500
           "
+          data-controller="dropdown"
+          data-dropdown-utility-class="hidden block"
+          data-dropdown-element-value="mobile-menu"
+          data-action="dropdown#toggle"
         >
           <span class="absolute -inset-0.5"></span>
           <span class="sr-only">Open main menu</span>
@@ -68,9 +65,7 @@
             <div class="flex justify-between">
 
               <%= render "shared/tailwind/navbar_text" %>
-              <el-dropdown class="relative ml-3">
-                <%= render "shared/tailwind/navbar_new_button" %>
-              </el-dropdown>
+              <%= render "shared/tailwind/navbar_new_button" %>
             </div>
           <% end %>
         </div>
@@ -89,8 +84,7 @@
     </div>
   </div>
 
-  <el-disclosure id="mobile-menu"
-    hidden class="block md:hidden">
+  <div id="mobile-menu" class="hidden md:hidden">
     <div class="space-y-1 px-2 pt-2 pb-3">
       <%= link_to workshops_path, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5
           hover:text-white" do %>
@@ -110,12 +104,12 @@
       workshops_share_idea_path,
       class:
         "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5
-                                                                                  hover:text-white" %>
+                                                                                                                                                    hover:text-white" %>
       <%= link_to "New workshop variation",
       new_workshop_variation_path,
       class:
         "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5
-                                                                                  hover:text-white" %>
+                                                                                                                                                    hover:text-white" %>
     </div>
-  </el-disclosure>
+  </div>
 </nav>

--- a/app/views/shared/tailwind/_navbar.html.erb
+++ b/app/views/shared/tailwind/_navbar.html.erb
@@ -77,9 +77,7 @@
         "
       >
         <!-- Profile dropdown -->
-        <el-dropdown class="relative ml-3">
-          <%= render "shared/tailwind/navbar_user" %>
-        </el-dropdown>
+        <%= render "shared/tailwind/navbar_user" %>
       </div>
     </div>
   </div>
@@ -104,12 +102,12 @@
       workshops_share_idea_path,
       class:
         "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5
-                                                                                                                                                    hover:text-white" %>
+                                                                                                                                                          hover:text-white" %>
       <%= link_to "New workshop variation",
       new_workshop_variation_path,
       class:
         "block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-white/5
-                                                                                                                                                    hover:text-white" %>
+                                                                                                                                                          hover:text-white" %>
     </div>
   </div>
 </nav>

--- a/app/views/shared/tailwind/_navbar_new_button.html.erb
+++ b/app/views/shared/tailwind/_navbar_new_button.html.erb
@@ -1,33 +1,36 @@
-<div class="flex items-center">
-  <button
-    class="
-      rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5
-      hover:text-white
-    "
-  >
-    + NEW
-  </button>
-</div>
-
-<%# TODO This dropdown needs to be change to stimulus and remove tailwind el-menu which requires a commercial license %>
-<el-menu
-  anchor="bottom end"
-  popover
-  class="
-    w-48 origin-top-right rounded-md bg-white py-1 shadow-lg outline outline-black/5
-    transition transition-discrete [--anchor-gap:--spacing(2)] data-closed:scale-95
-    data-closed:transform data-closed:opacity-0 data-enter:duration-100
-    data-enter:ease-out data-leave:duration-75 data-leave:ease-in
-  "
+<div
+  class="relative ml-3"
+  data-controller="dropdown"
+  data-dropdown-utility-class="hidden"
+  data-dropdown-element-value="workshop-dropdown"
 >
-
-  <%= link_to "New workshop idea",
-  workshops_share_idea_path,
-  class:
-    "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
-  <%= link_to "New workshop variation",
-  new_workshop_variation_path,
-  class:
-    "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
-</el-menu>
-
+  <!-- Button wrapper is relative so dropdown anchors here -->
+  <div class="relative flex items-center">
+    <button
+      class="
+        rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5
+        hover:text-white
+      "
+      data-action="dropdown#toggle"
+    >
+      + NEW
+    </button>
+    <!-- Dropdown menu -->
+    <div
+      id="workshop-dropdown"
+      class="
+        absolute right-0 top-11 mt-2 w-48 rounded-md bg-white py-1 shadow-lg outline
+        outline-black/5 transition transition-discrete hidden
+      "
+    >
+      <%= link_to "New workshop idea",
+      workshops_share_idea_path,
+      class:
+        "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
+      <%= link_to "New workshop variation",
+      new_workshop_variation_path,
+      class:
+        "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/tailwind/_navbar_user.html.erb
+++ b/app/views/shared/tailwind/_navbar_user.html.erb
@@ -1,10 +1,17 @@
-<div class="relative ml-3" id="avatar">
+<div
+  class="relative ml-3"
+  id="avatar"
+  data-controller="dropdown"
+  data-dropdown-utility-class="hidden"
+  data-dropdown-element-value="avatar-dropdown"
+>
   <button
     type="button"
     class="
       relative flex rounded-full focus-visible:outline-2
       focus-visible:outline-offset-2 focus-visible:outline-indigo-500
     "
+    data-action="dropdown#toggle"
   >
     <span class="sr-only">Open user menu</span>
     <span class="absolute -inset-1.5"></span>
@@ -13,21 +20,18 @@
       "size-10 rounded-full bg-gray-800 outline -outline-offset-1 outline-white/10" %>
   </button>
   <!-- Dropdown menu -->
-  <%# TODO This dropdown needs to be change to stimulus and remove tailwind el-menu which requires a commercial license %>
-  <el-menu
-    anchor="bottom end"
-    popover
+  <div
     class="
-      w-48 origin-top-right rounded-md bg-white py-1 shadow-lg outline outline-black/5
-      transition transition-discrete [--anchor-gap:--spacing(2)] data-closed:scale-95
-      data-closed:transform data-closed:opacity-0 data-enter:duration-100
-      data-enter:ease-out data-leave:duration-75 data-leave:ease-in
+      absolute right-0 mt-2 w-48 rounded-md bg-white py-1 shadow-lg outline
+      outline-black/5 transition hidden
     "
+    id="avatar-dropdown"
   >
     <% if current_user.super_user? %>
       <%= link_to "Admin",
-                  dashboard_admin_path,
-                  class: "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
+      dashboard_admin_path,
+      class:
+        "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
     <% end %>
     <%= link_to "My profile",
     user_path(current_user),
@@ -46,5 +50,5 @@
     method: :delete,
     class:
       "block px-4 py-2 text-sm text-gray-700 focus:bg-gray-100 focus:outline-hidden" %>
-  </el-menu>
+  </div>
 </div>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->



### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->

JS dropdown menus in Tailwindplus requires a commercial license. This removes that dependency.

### How did you approach the change?
<!-- What did you do? -->
Add a stimulus controller to handle the dropdowns. The controller toggles the utility classes for the target html element. Dropdowns can be closed by the escape key or clicking outside the element.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->
[Screencast from 2025-09-29 06-27-41.webm](https://github.com/user-attachments/assets/41b703bf-0b7b-4b2b-bc64-a9450aeb2cbd)

