### PR TITLE
Add sortable FAQ drag and drop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ group :development, :test do
   gem "shoulda-matchers", require: false
   gem "debug", "~> 1.11"
 end
+
+gem "positioning", "~> 0.4.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,9 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     polyglot (0.3.5)
+    positioning (0.4.7)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     pp (0.6.2)
       prettyprint
     premailer (1.27.0)
@@ -471,6 +474,7 @@ DEPENDENCIES
   jwt (~> 1.2.1)
   kt-paperclip (~> 7.1.1)
   listen
+  positioning (~> 0.4.7)
   premailer-rails
   pry-rails
   puma (~> 6.0)

--- a/app/controllers/faqs_controller.rb
+++ b/app/controllers/faqs_controller.rb
@@ -4,11 +4,10 @@ class FaqsController < ApplicationController
   layout "tailwind", only: [:index]
 
   def index
-    if current_user.super_user?
-      per_page = params[:number_of_items_per_page].presence || 25
-      @faqs = Faq.all.by_order.paginate(page: params[:page], per_page: per_page)
+    @faqs = if current_user.super_user?
+      Faq.all.by_order
     else
-      @faqs = Faq.active.by_order
+      Faq.active.by_order
     end
   end
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -2,3 +2,6 @@ import { application } from "./application";
 
 import DropdownController from "./dropdown_controller";
 application.register("dropdown", DropdownController);
+
+import SortableController from "./sortable_controller"
+application.register("sortable", SortableController)

--- a/app/frontend/javascript/controllers/sortable_controller.js
+++ b/app/frontend/javascript/controllers/sortable_controller.js
@@ -1,6 +1,21 @@
 import { Controller } from "@hotwired/stimulus";
 import { put } from "@rails/request.js";
 import Sortable from "sortablejs";
+
+/*
+ * Usage
+ * =====
+ *
+ * add data-controller="sortable" to common ancestor
+ *
+ * 1. Add data-sortable-url-value="URL to update position" to the
+ * controller container
+ *
+ * 2. Add data-sortable-handle to the drag handle:
+ *
+ * 3. Add data-sortable-id to the item
+ *
+ */
 export default class extends Controller {
   static values = { url: String };
 
@@ -17,8 +32,8 @@ export default class extends Controller {
 
   onEnd(event) {
     const { newIndex, item } = event;
-    const id = item.dataset["sortable-id"];
-    const url = this.urlValue.replace("ordering", id);
+    const id = item.dataset.sortableId;
+    const url = this.urlValue.replace(":id", id);
     put(url, {
       body: JSON.stringify({ ordering: newIndex }),
     });

--- a/app/frontend/javascript/controllers/sortable_controller.js
+++ b/app/frontend/javascript/controllers/sortable_controller.js
@@ -35,7 +35,7 @@ export default class extends Controller {
     const id = item.dataset.sortableId;
     const url = this.urlValue.replace(":id", id);
     put(url, {
-      body: JSON.stringify({ ordering: newIndex }),
+      body: JSON.stringify({ ordering: newIndex + 1 }), // add 1 to change sortablejs 0-based index to 1-based for positioning gem
     });
   }
 }

--- a/app/frontend/javascript/controllers/sortable_controller.js
+++ b/app/frontend/javascript/controllers/sortable_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus";
+import { put } from "@rails/request.js";
+import Sortable from "sortablejs";
+export default class extends Controller {
+  static values = { url: String };
+
+  connect() {
+    this.sortable = Sortable.create(this.element, {
+      onEnd: this.onEnd.bind(this),
+      handle: "[data-sortable-handle]",
+    });
+  }
+
+  disconnect() {
+    this.sortable.destroy();
+  }
+
+  onEnd(event) {
+    const { newIndex, item } = event;
+    const id = item.dataset["sortable-id"];
+    const url = this.urlValue.replace("ordering", id);
+    put(url, {
+      body: JSON.stringify({ ordering: newIndex }),
+    });
+  }
+}

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -1,4 +1,8 @@
 class Faq < ApplicationRecord
+  # TODO After the production db migration we should "heal_ordering_column!" and add db contraints
+  # https://github.com/brendon/positioning
+  positioned on: [], column: :ordering
+
   # Validations
   validates_presence_of :question, :answer
 

--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -1,4 +1,8 @@
-<div id="<%= dom_id faq %>" data-controller="dropdown">
+<div
+  id="<%= dom_id faq %>"
+  data-controller="dropdown"
+  data-sortable-id="<%= faq.id %>"
+>
 
   <div class="border-b border-gray-300">
     <button
@@ -35,7 +39,7 @@
           <%= faq.inactive %>
         </div>
 
-        <div class="self-center">
+        <div class="self-center" data-sortable-handle="" }>
           <strong>Ordering:</strong>
           <%= faq.ordering %>
         </div>

--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -39,7 +39,7 @@
           <%= faq.inactive %>
         </div>
 
-        <div class="self-center" data-sortable-handle="" }>
+        <div class="self-center" data-sortable-handle="">
           <strong>Ordering:</strong>
           <%= faq.ordering %>
         </div>

--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -34,15 +34,12 @@
 
     <% if current_user.super_user? %>
       <div class="flex gap-4 px-4 pb-2">
+        <i class="fa-solid fa-sort cursor-move self-center" data-sortable-handle=""></i>
         <div class="self-center">
           <strong>Inactive:</strong>
           <%= faq.inactive %>
         </div>
 
-        <div class="self-center" data-sortable-handle="">
-          <strong>Ordering:</strong>
-          <%= faq.ordering %>
-        </div>
         <%= link_to_button("Edit", edit_faq_path(faq)) %>
       </div>
 

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -9,6 +9,11 @@
     </div>
 
   <% end %>
-  <%= render @faqs %>
+  <div
+    data-controller="sortable"
+    data-sortable-url-value="<%= faq_path(id: ":id") %>"
+  >
+    <%= render @faqs %>
+  </div>
 
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
         "@fortawesome/fontawesome-free": "^7.0.1",
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.18",
+        "@rails/request.js": "^0.0.12",
         "@tailwindcss/vite": "^4.1.13",
+        "sortablejs": "^1.15.6",
         "tailwindcss": "^4.1.13",
         "vite-plugin-rails": "^0.5.0"
       },
@@ -489,6 +491,12 @@
       "version": "8.0.300",
       "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-8.0.300.tgz",
       "integrity": "sha512-X+jxLnyYciTciEeM9crFFsR6DCodCsnoQIzv4hEST6Lx1rEBEjNQbBopnyDT4gr7lBeHJNfb6fEcvZuWFxUSQg==",
+      "license": "MIT"
+    },
+    "node_modules/@rails/request.js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@rails/request.js/-/request.js-0.0.12.tgz",
+      "integrity": "sha512-g3//JBja1s04Zflj7IoMLQuXza9i4ZvtLmm0r0dMwh1QQUs6rL2iKUOGGyERfLsd81SnXC5ucfVV//rtsDlEEA==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1647,6 +1655,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "@fortawesome/fontawesome-free": "^7.0.1",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.18",
+    "@rails/request.js": "^0.0.12",
     "@tailwindcss/vite": "^4.1.13",
+    "sortablejs": "^1.15.6",
     "tailwindcss": "^4.1.13",
     "vite-plugin-rails": "^0.5.0"
   }


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->


### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Add drag and drop sorting of FAQs on the index page.

### How did you approach the change?
<!-- What did you do? -->
Add stimulus controller using sortablejs. This js library handles the nuances of different browsers and handles the drag and drop feature via the frontend. Request.js was add to send the updated ordering id to the controller. I also added the [Positioning](https://github.com/brendon/positioning) gem for proper handling of list orders.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

Removed pagination for index for the time being. Missed it in the previous PR.

[Screencast from 2025-10-01 19-21-11.webm](https://github.com/user-attachments/assets/767897e3-1a47-43de-8976-af7e7ae2cce1)
