### PR TITLE
Tweak resource download code to download main_attachment or main_image (download_attachment)

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -64,11 +64,22 @@ class ResourcesController < ApplicationController
   end
 
   def download
-    attachment = Resource.find(params[:resource_id]).main_attachment
+    if params[:attachment_id].to_i > 0
+      attachment = Attachment.where(owner_type: "Resource", id: params[:attachment_id]).last
+    else
+      attachment = Resource.find(params[:resource_id]).download_attachment
+    end
+
     if attachment&.file&.blob.present?
       redirect_to rails_blob_url(attachment.file, disposition: "attachment")
     else
-      path = params[:from] == "resources_index" ? resources_path : resource_path(params[:resource_id])
+      if params[:from] == "resources_index"
+        path = resources_path
+			elsif params[:from] == "dashboard_index"
+				path = authenticated_root_path
+			else
+				resource_path(params[:resource_id])
+			end
       redirect_to path,
                   alert: "File not found or not attached."
     end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -98,6 +98,10 @@ class Resource < ApplicationRecord
     end
   end
 
+  def download_attachment
+    main_attachment || main_image
+  end
+
   def type_enum
     types.map { |title| [title.titleize, title ]}
   end

--- a/app/views/resources/_resource_card.html.erb
+++ b/app/views/resources/_resource_card.html.erb
@@ -47,11 +47,13 @@
 
       <div class="flex justify-end items-center mt-4 space-x-2">
         <div class="flex items-center space-x-2">
-          <% if resource.main_attachment&.file&.attached? %>
+          <% if resource.download_attachment&.file&.attached? %>
+            <% from = controller_name == "resources" &&
+              action_name == "index" ? "resources_index" : (controller_name == "dashboard" &&
+              action_name == "index" ? "dashboard_index" : "unknown") %>
             <%= link_to "<span class='fa fa-download' title='Download #{resource.kind}'></span>".html_safe,
                                resource_download_path(resource,
-                                                      from: controller_name == "resources" &&
-                                                        action_name == "index" ? "resources_index" : "unknown"),
+                                                      from: from),
                                class: "btn btn-utility" %>
           <% end %>
           <% if controller_name == "resources" %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -8,11 +8,10 @@
         </span>
       <% end %>
 
-      <%= link_to("Download <span class='fa fa-download'></span>".html_safe,
-                  url_for(@resource.main_attachment.file),
-                  download: @resource.main_attachment.file_file_name,
-                  class: "btn btn-utility") if @resource.main_attachment&.file&.attached? %>
-
+      <%= link_to ("<span title='Download #{@resource.kind} image'>" +
+        " Download <span class='fa fa-download'></span></span>").html_safe,
+                  resource_download_path(@resource),
+                  class: "btn btn-utility" if @resource.download_attachment&.file&.attached? %>
       <%= render "bookmarks/editable_bookmark_button", resource: @resource %>
     </div>
 
@@ -51,14 +50,16 @@
           <% image_url = @resource.main_image_url rescue nil %>
           <% if image_url %>
             <% if @resource.kind == 'LeaderSpotlight' %>
-              <%= link_to image_url, download: @resource.main_image.file_file_name do %>
+              <%= link_to image_url,
+                          download: @resource.main_image.file_file_name do %>
                 <%= image_tag image_url,
                               class: 'max-h-[400px] w-auto rounded-lg shadow-lg mb-4 object-cover',
                               alt: @resource.display_title,
                               onerror: "this.onerror=null;this.src='/assets/missing.png';" %>
               <% end %>
             <% else %>
-              <%= link_to image_url, download: @resource.main_image.file_file_name do %>
+              <%= link_to image_url,
+                          download: @resource.main_image.file_file_name do %>
                 <%= image_tag image_url,
                               class: 'w-full h-48 bg-gray-200 rounded-md flex items-center justify-center text-gray-400 object-cover',
                               alt: @resource.display_title,
@@ -101,11 +102,11 @@
             <% @resource.attachments.each do |attachment| %>
               <% if attachment.file&.attached? %>
                 <li>
-                  <%= link_to("#{ attachment.file_file_name } <span class='fa fa-download'></span>".html_safe,
-                              url_for(attachment.file),
-                              download: attachment.file_file_name,
-                              class: "inline-block px-3 py-1 bg-gray-100 rounded
-                              hover:bg-gray-200 text-xl text-gray-700 transition") if attachment&.file&.attached? %>
+                  <%= link_to ("<span title='Download #{@resource.kind}'>" +
+                                " #{ attachment.file_file_name } <span class='fa fa-download'></span></span>").html_safe,
+                              resource_download_path(@resource,
+                                                     attachment_id: attachment.id),
+                              class: "btn btn-utility" if attachment&.file&.attached? %>
                 </li>
               <% end %>
             <% end %>


### PR DESCRIPTION

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
- Determine which attachment should be used for download
- Streamline download calls

### How did you approach the change?
- Add download_attachment method to determine which attachment should be used for download
- Make all calls to download attachment use the same, active storage friendly logic

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

