### PR TITLE
Add back in bootstrap-will_paginate gem bc it allows will_paginate customization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "search_cop", "~> 1.0.6"
 gem "jwt", "~> 1.2.1"
 gem "httparty"
 gem "will_paginate", "~> 3.1.7"
+gem "bootstrap-will_paginate"
 gem "apipie-rails", "~> 1.5.0"
 gem "rack-cors", require: "rack/cors"
 # gem "ckeditor", "~> 4.3.0" # removed given gh security scan results. still need a replacement.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     brakeman (7.1.1)
       racc
     builder (3.3.0)
@@ -457,6 +459,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
+  bootstrap-will_paginate
   brakeman (~> 7.1.1)
   bundler-audit
   capybara (~> 3.36)


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
- I removed the gem bc we're not using bootstrap, but it caused errors in indexes
- Our current will_paginate calls include an extra options hash that isn't available without the bootstrap-will_paginate's extension of the will_paginate call

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

