### PR TITLE
Fix workshops dropdown on workshop_logs form

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,7 +4,7 @@ class BookmarksController < ApplicationController
   def index
     bookmarks = Bookmark.search(params)
     @bookmarks = bookmarks.paginate(page: params[:page], per_page: 25)
-    @bookmarks_count = bookmarks.count
+    @bookmarks_count = bookmarks.size
     @windows_types_array = ["", "Adult", "Child", "Family"]
     load_sortable_fields
     respond_to do |format|

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -5,7 +5,7 @@ class EventRegistrationsController < ApplicationController
   def index
     per_page = params[:number_of_items_per_page].presence || 25
     unpaginated = EventRegistration.search_by_params(params)
-    @event_registrations_count = unpaginated.count
+    @event_registrations_count = unpaginated.size
     @event_registrations = unpaginated.paginate(page: params[:page], per_page: per_page)
   end
 

--- a/app/controllers/facilitators_controller.rb
+++ b/app/controllers/facilitators_controller.rb
@@ -15,7 +15,7 @@ class FacilitatorsController < ApplicationController
                      .search_by_params(params.to_unsafe_h)
                      .joins(:user)
                      .order(:first_name, :last_name)
-    @facilitators_count = facilitators.count
+    @facilitators_count = facilitators.size
     @facilitators = facilitators.paginate(page: params[:page], per_page: per_page)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -32,7 +32,7 @@ class ReportsController < ApplicationController
 
   def render_form
     @workshop_list = Workshop.created_by_id(current_user.id)
-                             .where(inactive: false)
+                             .published
                              .order(title: :asc)
 
     build_month_and_year

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -8,7 +8,7 @@ class ResourcesController < ApplicationController
                           .by_created
     @resources = unpaginated.paginate(page: params[:page], per_page: 24)
 
-    @resources_count = unpaginated.count
+    @resources_count = unpaginated.size
     @sortable_fields = Resource::KINDS
 
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
 
     per_page = params[:number_of_items_per_page].presence || 25
     users = User.search_by_params(params).order(:first_name, :last_name)
-    @users_count = users.count
+    @users_count = users.size
     @users = users.paginate(page: params[:page], per_page: per_page)
 
   end

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -13,7 +13,7 @@ class WorkshopLogsController < ApplicationController
       end
     @workshop_logs_unpaginated = permitted_logs.includes(:workshop, :user, :windows_type)
                                             .search(params)
-    @workshop_logs_count = @workshop_logs_unpaginated.count
+    @workshop_logs_count = @workshop_logs_unpaginated.size
     @workshop_logs = @workshop_logs_unpaginated.paginate(page: params[:page], per_page: @per_page)
     set_index_variables
   end
@@ -135,8 +135,7 @@ class WorkshopLogsController < ApplicationController
       @workshop = Workshop.new
     end
 
-    @workshops = Workshop.created_by_id(current_user.id)
-                         .where(inactive: false)
+    @workshops = Workshop.published.or(Workshop.where(id: @workshop_log.workshop_id))
                          .order(title: :asc)
 
     # Build one blank quote if none exists

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -11,7 +11,7 @@ class WorkshopsController < ApplicationController
                                          :workshop_age_ranges, :bookmarks)
                                .paginate(page: params[:page], per_page: params[:per_page] || 50)
 
-    @workshops_count = search_service.workshops.count
+    @workshops_count = search_service.workshops.size
 
     @category_metadata = Metadatum.published.includes(:categories).decorate
     @sectors = Sector.published
@@ -135,7 +135,7 @@ class WorkshopsController < ApplicationController
     @quotes = Quote.where(workshop_id: @workshop.id).active
     @leader_spotlights = @workshop.resources.published.leader_spotlights
     @workshop_variations = @workshop.workshop_variations.active
-    @sectors = @workshop.sectorable_items.where(inactive: false).map { |item| item.sector if item.sector.published }.compact if @workshop.sectorable_items.any?
+    @sectors = @workshop.sectorable_items.published.map { |item| item.sector if item.sector.published }.compact if @workshop.sectorable_items.any?
   end
 
   def set_form_variables
@@ -149,7 +149,7 @@ class WorkshopsController < ApplicationController
   end
 
   def workshops_per_page
-    view_all_workshops? ? @workshops.where(inactive: false).count : 12
+    view_all_workshops? ? @workshops.published.size : 12
   end
 
   def view_all_workshops?

--- a/app/decorators/facilitator_decorator.rb
+++ b/app/decorators/facilitator_decorator.rb
@@ -37,7 +37,7 @@ class FacilitatorDecorator < Draper::Decorator
     badges << ["Seasoned Facilitator (3-10 years)", "gray"] if true || member_since.present? && years >= 3
     badges << ["New Facilitator (<3 years)", "green"] if true || member_since.present? && years < 3
     badges << ["Spotlighted Facilitator", "gray"] if true || stories_as_spotlighted_facilitator
-    badges << ["Events Attended", "blue"] if true || Event.count > 3
+    badges << ["Events Attended", "blue"] if true || Event.all.size > 3
     badges << ["Workshop Author", "gray"] if true || user.workshops.any? # indigo
     badges << ["Story Author", "gray"] if true || user.stories_as_creator.any? # pink
     badges << ["Sector Leader", "purple"] if true || sectorable_items.where(is_leader: true).any?

--- a/app/decorators/workshop_decorator.rb
+++ b/app/decorators/workshop_decorator.rb
@@ -3,7 +3,7 @@ class WorkshopDecorator < Draper::Decorator
   delegate_all
 
   def list_sectors
-    sectorable_items.where(inactive: false).map(&:sector).map(&:name).to_sentence
+    sectorable_items.published.map(&:sector).map(&:name).to_sentence
   end
 
   def display_fields

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -51,7 +51,8 @@ class Resource < ApplicationRecord
   scope :kind, -> (kind) { where("kind like ?", kind ) }
   scope :leader_spotlights, -> { kind("LeaderSpotlight") }
   scope :popular, -> { where(kind: POPULAR_KINDS) }
-  scope :published, -> (published=nil) { published.present? ? where(inactive: !published) : where(inactive: false) }
+  scope :published, -> (published=nil) { published.present? ?
+                                           where(inactive: !published) : where(inactive: false) }
   scope :recent, -> { published.by_created }
   scope :sector_impact, -> { where(kind: "SectorImpact") }
   scope :scholarship, -> { where(kind: "Scholarship") }

--- a/app/models/sectorable_item.rb
+++ b/app/models/sectorable_item.rb
@@ -13,6 +13,8 @@ class SectorableItem < ApplicationRecord
   # Validations
   # validates_presence_of :sectorable_type, :sectorable_id, :sector_id
 
+  scope :published, -> { where(inactive: false) }
+
   # Methods
   def title
     return id unless sectorable && sectorable.class != WorkshopLog

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -77,7 +77,8 @@ class Workshop < ApplicationRecord
   scope :created_by_id, ->(created_by_id) { where(user_id: created_by_id) }
   scope :featured, -> { where(featured: true) }
   scope :legacy, -> { where(legacy: true) }
-  scope :published, -> (published=nil) { published.to_s.present? ? where(inactive: !published) : where(inactive: false) }
+  scope :published, -> (published=nil) { published.to_s.present? ?
+                                           where(inactive: !published) : where(inactive: false) }
   scope :title, -> (title) { where("workshops.title like ?", "%#{ title }%") }
   scope :windows_type_ids, ->(windows_type_ids) { where(windows_type_id: windows_type_ids) }
 
@@ -160,7 +161,7 @@ class Workshop < ApplicationRecord
   end
 
   def log_count
-    workshop_logs.count
+    workshop_logs.size
   end
 
   def main_image_url
@@ -186,7 +187,7 @@ class Workshop < ApplicationRecord
   end
 
   def published_sectors
-    sectorable_items.where(inactive: false).map { |item| item.sector }
+    sectorable_items.published.map { |item| item.sector }
   end
 
   def time_frame_total

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -141,7 +141,7 @@ class WorkshopLog < Report
 
   def update_workshop_log_count
     return unless owner
-    new_led_count = owner.workshop_logs.count
+    new_led_count = owner.workshop_logs.size
     owner.update(led_count: new_led_count)
   end
 


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of #375 

### What is the goal of this PR and why is this important? 
- The dropdown was filtering workshops dropdown by workshops that were created by the current_user, but the User should be able to make a log for any active Workshop (or an inactive one for a log created in the past)

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

