### PR TITLE
Adjust Resource 'kind' constants

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,7 +10,7 @@ class DashboardController < ApplicationController
 
     @popular_resources = Resource.featured
                                  .published
-                                 .popular
+                                 .published_kinds
                                  .order(ordering: :asc, created_at: :desc)
                                  .decorate
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,15 +1,14 @@
 class ResourcesController < ApplicationController
 
   def index
-    unpaginated = Resource.where(kind: ['Template','Handout', 'Scholarship',
-                                        'Toolkit', 'Form', 'Resource', 'Story']) #TODO - #FIXME brittle
+    unpaginated = Resource.where(kind: Resource::PUBLISHED_KINDS) #TODO - #FIXME brittle
                           .includes(:images, :attachments)
                           .search_by_params(params)
                           .by_created
     @resources = unpaginated.paginate(page: params[:page], per_page: 24)
 
     @resources_count = unpaginated.size
-    @sortable_fields = Resource::KINDS
+    @sortable_fields = Resource::PUBLISHED_KINDS
 
     respond_to do |format|
       format.html
@@ -65,7 +64,7 @@ class ResourcesController < ApplicationController
 
   def search
     process_search
-    @sortable_fields = Resource::KINDS.dup.delete("Story")
+    @sortable_fields = Resource::PUBLISHED_KINDS
     render :index
   end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -35,8 +35,8 @@ class Resource < ApplicationRecord
   accepts_nested_attributes_for :attachments, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :form, reject_if: :all_blank, allow_destroy: true
 
-  KINDS = ['Toolkit', 'Form', 'Template', 'Handout', 'Story']
-  POPULAR_KINDS = [nil, "Resource", "Template", "Handout", "Scholarship", "Toolkit", "Form"]
+  PUBLISHED_KINDS = ["Handout", "Scholarship", "Template", "Toolkit", "Form"]
+  KINDS = PUBLISHED_KINDS + ["Resource", "Story"]
 
   # Search Cop
   include SearchCop
@@ -50,7 +50,7 @@ class Resource < ApplicationRecord
   scope :featured, -> (featured=nil) { featured.present? ? where(featured: featured) : where(featured: true) }
   scope :kind, -> (kind) { where("kind like ?", kind ) }
   scope :leader_spotlights, -> { kind("LeaderSpotlight") }
-  scope :popular, -> { where(kind: POPULAR_KINDS) }
+  scope :published_kinds, -> { where(kind: PUBLISHED_KINDS) }
   scope :published, -> (published=nil) { published.present? ?
                                            where(inactive: !published) : where(inactive: false) }
   scope :recent, -> { published.by_created }

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -14,7 +14,7 @@
     <div class="flex-1 min-w-[200px]">
       <%= f.input :kind,
                   as: :select,
-                  collection: Resource::KINDS,
+                  collection: Resource::PUBLISHED_KINDS,
                   selected: f.object.kind,
                   input_html: { class: "w-full rounded border-gray-300" } %>
     </div>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -56,7 +56,7 @@
         </div>
 
         <div class="flex items-center gap-2">
-          <%= render "search_boxes_kinds", sortable_fields: Resource::KINDS - ["Story"] %>
+          <%= render "search_boxes_kinds", sortable_fields: Resource::PUBLISHED_KINDS %>
         </div>
 
         <!-- Clear Filters -->

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :resource do
     association :user
     title { Faker::Lorem.sentence }
-    kind { [Resource::KINDS.sample] }
+    kind { [Resource::PUBLISHED_KINDS.sample] }
 
     # Use after(:create) to assign sectors
     after(:create) do |resource|


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
- Currently Resources include things that are of kind: 'Story' or 'Resource', but we don't want those showing up on the public Resources index or in dropdowns

### How did you approach the change?
- Replaced usage of arrays of strings with usage of constant
- Changed constants

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

