### PR TITLE
Change pagination styling

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -1,12 +1,25 @@
 @import "tailwindcss";
 @import "./pagination.css";
+@import "./components/buttons";
 
 @source "../../views/**/*.html.erb";
 @source "../../javascript/**/*.js";
 @source "../../helpers/**/*.rb";
 
+@theme {
+  --color-primary: #063b8d;
+  --color-secondary: var(--color-gray-500);
+  --color-danger: var(--color-red-500);
+  --color-warning: var(--color-yellow-500);
+  --color-info: var(--color-blue-500);
+  --color-success: var(--color-green-500);
+  --color-transparent: transparent;
+}
+
 /* ✅ Safelist dynamically generated colors */
 @layer utilities {
+  .text-transparent { color: transparent; }
+
   /* prettier-ignore */
   ._safelist {
     /* background colors */
@@ -15,7 +28,7 @@
 
     /* text colors */
     @apply text-pink-800 text-indigo-800 text-green-800 text-yellow-800
-    text-red-800 text-purple-800 text-green-200;
+    text-red-800 text-purple-800 text-green-200 text-gray-50 text-transparent;
   }
 
   @keyframes fadeIn {
@@ -28,13 +41,12 @@
   }
 }
 
-@theme {
-  --color-primary: #063b8d;
-  --color-secondary: var(--color-gray-500);
-  --color-danger: var(--color-red-500);
-  --color-warning: var(--color-yellow-500);
-  --color-info: var(--color-blue-500);
-  --color-success: var(--color-green-500);
+.readonly {
+  @apply bg-gray-100 text-gray-500 cursor-not-allowed border-gray-300;
 }
 
-@import "./components/buttons";
+.readonly select,
+.readonly input,
+.readonly textarea {
+  @apply bg-gray-100 text-gray-500 cursor-not-allowed border-gray-300;
+}

--- a/app/renderers/tailwind_pagination_renderer.rb
+++ b/app/renderers/tailwind_pagination_renderer.rb
@@ -66,7 +66,7 @@ class TailwindPaginationRenderer < WillPaginate::ActionView::LinkRenderer
 		@template.tag.span(
 			text,
 			class: "disabled-arrow-classes px-3 py-1
-              bg-transparent text-white"
+              bg-transparent text-transparent"
 		)
 	end
 


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
- I wanted the previous and next arrow buttons to be transparent when you're on the first and last page, respectively
- This required updating the tailwind css

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
- Using this opportunity of updating tailwind css file to add the readonly styling 

