### PR TITLE
Fix faq update flash

### DIFF
--- a/app/controllers/faqs_controller.rb
+++ b/app/controllers/faqs_controller.rb
@@ -32,8 +32,10 @@ class FaqsController < ApplicationController
   end
 
   def update
+    notice = "FAQ was successfully updated."
+    flash.now[:notice] = notice
     if @faq.update(faq_params)
-      redirect_to faqs_path, notice: "FAQ was successfully updated.", status: :see_other
+      redirect_to faqs_path, notice: notice, status: :see_other
     else
       set_form_variables
       render :edit, status: :unprocessable_content

--- a/app/views/faqs/_inline_edit.html.erb
+++ b/app/views/faqs/_inline_edit.html.erb
@@ -1,9 +1,12 @@
 <% frame_id = dom_id(model, "#{attribute}_turbo_frame") %>
+
 <% form_class ||= "" %>
+
 <% frame_class ||= "" %>
 
 <%= form_with model: model, data: {turbo: true, turbo_frame: frame_id}, class: "#{form_class}" do %>
   <%= turbo_frame_tag frame_id, class: "#{frame_class}" do %>
+    <%= turbo_flash %>
     <%= yield %>
   <% end %>
 <% end %>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
When an faq is updated inline we should see the flash message.

### How did you approach the change?
<!-- What did you do? -->
Include our turbo_flash helper in the turbo frame and add flash.now to the controller.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

https://github.com/user-attachments/assets/9b3280a9-8fee-434c-a049-22dd7107183e



