### PR TITLE
[482] update workshop variation show view to use youtube_url

### DIFF
--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -64,9 +64,9 @@
 
 
       <!-- URL -->
-      <% if @workshop_variation.reference_url.present? %>
+      <% if @workshop_variation.youtube_url.present? %>
         <div class="prose mx-auto leading-relaxed text-gray-800 text-left">
-          <%= link_to @workshop_variation.reference_url, @workshop_variation.reference_url, target: "_blank",
+          <%= link_to @workshop_variation.youtube_url, @workshop_variation.youtube_url, target: "_blank",
                       rel: "noopener noreferrer",
                       class: "text-blue-600 hover:underline break-words" %>
         </div>

--- a/spec/views/workshop_variations/show.html.erb_spec.rb
+++ b/spec/views/workshop_variations/show.html.erb_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "workshop_variations/show", type: :view do
+  let(:user) { create(:user) }
+  let(:workshop) { create(:workshop, user: user) }
+  let(:inactive) { false }
+  let(:youtube_url) { nil }
+  let(:workshop_variation) { create(:workshop_variation,
+                                    workshop: workshop,
+                                    created_by: user,
+                                    name: "MyName", code: "MyDescription",
+                                    youtube_url: youtube_url,
+                                    inactive: inactive) }
+
+  before(:each) do
+    assign(:workshop_variation, workshop_variation)
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  it "renders attributes" do
+    render
+    expect(rendered).to include(workshop_variation.name)
+    expect(rendered).to include(workshop_variation.code)
+    expect(rendered).to include(workshop.title)
+    expect(rendered).to include(user.name)
+  end
+
+  context 'when the workshop_variation has a youtube_url' do
+    let(:youtube_url) { 'http://www.example.com/watch?v=somevideo' }
+
+    it 'does renders the youtube_url as a link' do
+      render
+      expect(rendered).to have_link(youtube_url, href: youtube_url)
+    end
+  end
+
+  context 'when the workshop_variation is inactive' do
+    let(:inactive) { true }
+
+    it 'displays a hidden indicator' do
+      render
+      expect(rendered).to include('[HIDDEN]')
+    end
+  end
+end


### PR DESCRIPTION
- This work is part of #482

### What is the goal of this PR and why is this important? 
This addresses an issue on the `WorkshopVariation` show view that had an outdated reference to `reference_url`, which was causing a `NoMethodError`.

### How did you approach the change?
- Updated the show view to use the new attribute name `youtube_url`
- Added a spec for the workshop variation show view

### Anything else to add?
nope :smiley: 

