### PR TITLE
Update image migration audit page

### DIFF
--- a/app/controllers/image_migration_audit_controller.rb
+++ b/app/controllers/image_migration_audit_controller.rb
@@ -5,54 +5,49 @@ class ImageMigrationAuditController < ApplicationController
 	def index
 		@results = []
 
-		# -----------------------------------------------------------------
-		# Configure models to audit
-		# -----------------------------------------------------------------
+		models_to_audit = params[:models].to_s.downcase.split("-")
 		audit(User,
 					as: [:avatar],
 					paperclip: [:avatar]
-		)
+		) if models_to_audit.empty? || models_to_audit.include?("user")
 
 		audit(Workshop, # includes WorkshopIdea
 					as: [:thumbnail, :header, :images, :attachments],
 					paperclip: [:thumbnail, :header]
-		)
+		) if models_to_audit.empty? || models_to_audit.include?("workshop")
 
 		audit(Resource,
 					as: [:attachments, :images],
 					paperclip: []
-		)
+		) if models_to_audit.empty? || models_to_audit.include?("resource")
 
 		audit(WorkshopLog,
 					as: [:media_files],
 					paperclip: []
-		)
+		) if models_to_audit.empty? || models_to_audit.include?("workshop_log")
 
 		audit(Report,
 					as: [:image, :form_file, :images, :media_files],
 					paperclip: [:image, :form_file]
-		)
+		) if models_to_audit.empty? || models_to_audit.include?("report")
 
+		audit(Attachment,
+					as: [:file],
+					paperclip: [:file]
+		) if models_to_audit.empty? || models_to_audit.include?("attachment")
 
+		audit(Image,
+					as: [:file],
+					paperclip: [:file]
+		) if models_to_audit.empty? || models_to_audit.include?("image")
 
-		# audit(
-		# 	Attachment,
-		# 	as_associations: [:file],
-		# 	paperclip_groups: [:file]
-		# )
-		# audit(
-		# 	Image,
-		# 	as_associations: [:file],
-		# 	paperclip_groups: [:file]
-		# )
-		# audit(
-		# 	MediaFile,
-		# 	as_associations: [:file],
-		# 	paperclip_groups: [:file]
-		# )
+		audit(MediaFile,
+					as: [:file],
+					paperclip: [:file]
+		) if models_to_audit.empty? || models_to_audit.include?("media_file")
 
 		# -----------------------------------------------------------------
-		# Filter only records that actually have data
+		# Filter only records that have at least one attachment present
 		# -----------------------------------------------------------------
 		@results.select! do |row|
 			row[:attachments].any? do |att|

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -12,7 +12,8 @@ class Report < ApplicationRecord
   has_one_attached :image # old paperclip -- TODO convert these to MainImage records
   has_one_attached :form_file # old paperclip -- TODO convert these to GalleryImage records
   # Image associations
-  has_many :media_files, dependent: :destroy
+  has_many :images, as: :owner, dependent: :destroy # TODO - convert to GalleryImages
+  has_many :media_files, dependent: :destroy # TODO - convert to GalleryImages
   has_one :main_image, -> { where(type: "Images::MainImage") },
           as: :owner, class_name: "Images::MainImage", dependent: :destroy
   has_many :gallery_images, -> { where(type: "Images::GalleryImage") },

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -21,7 +21,7 @@ class Resource < ApplicationRecord
 
   # Image associations
   has_many :attachments, as: :owner, dependent: :destroy # TODO - convert to GalleryImages
-  has_many :images, as: :owner, dependent: :destroy
+  has_many :images, as: :owner, dependent: :destroy # TODO - convert to GalleryImages
   has_one :main_image, -> { where(type: "Images::MainImage") },
           as: :owner, class_name: "Images::MainImage", dependent: :destroy
   has_many :gallery_images, -> { where(type: "Images::GalleryImage") },

--- a/app/models/toolkit_and_form.rb
+++ b/app/models/toolkit_and_form.rb
@@ -1,0 +1,2 @@
+class ToolkitAndForm < Resource
+end

--- a/app/views/image_migration_audit/index.html.erb
+++ b/app/views/image_migration_audit/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th class="border px-3 py-2 text-left">Model</th>
       <th class="border px-3 py-2 text-left">ID</th>
+      <th class="border px-3 py-2 text-left">Owner</th>
       <th class="border px-3 py-2 text-left">Attachment</th>
       <th class="border px-3 py-2 text-left">Paperclip</th>
       <th class="border px-3 py-2 text-left">ActiveStorage preview</th>
@@ -14,16 +15,47 @@
 
   <tbody class="divide-y divide-gray-200">
     <% @results.each do |row| %>
-      <% row[:attachments].each do |att| %>
+    <% row[:attachments]
+         .select { |att| att[:paperclip].present? && att[:paperclip].values.any?(&:present?) }
+         .each do |att| %>
+        <% record = att[:record] || row[:model].classify.constantize.find(row[:id]) %>
         <tr class="align-top">
           <td class="border px-3 py-2 font-mono"><%= row[:model] %></td>
-          <td class="border px-3 py-2 font-mono"><%= row[:id] %></td>
-          <td class="border px-3 py-2 font-mono"><%= att[:name] %></td>
+          <td class="border px-3 py-2 font-mono">
+            <%= record ? link_to(row[:id],
+                  url_for(record),
+                  class: "hover:underline"
+                ) : row[:id] %>
+          </td>
+          <td class="border px-3 py-2">
+            <% owner = record.try(:owner) if record %>
 
-          <td class="border px-3 py-2 font-mono whitespace-pre-wrap">
-            <% att[:paperclip].each do |k,v| %>
-              <%= "#{k}: #{v}" %><br>
+            <% if owner.present? %>
+              <%= link_to(
+                    "#{owner.class.name} ##{owner.id}",
+                    url_for(owner),
+                    class: "hover:underline"
+                  ) %>
+            <% else %>
+              <span class="text-gray-500">—</span>
             <% end %>
+          </td>
+          <td class="border px-3 py-2 font-mono"><%= att[:name] %></td>
+          <td class="border px-3 py-2 font-mono text-left align-top">
+            <table class="text-xs w-full">
+              <% att[:paperclip].each do |k, v| %>
+                <% display_value = if k.to_s.ends_with?("_file_name") && v.present? && v.length > 45
+                                     # break into 45-char chunks and put each on its own line
+                                     v.scan(/.{1,45}/).join("<br>").html_safe
+                                   else
+                                     v
+                                   end %>
+                <tr>
+                  <td class="pr-2 align-top whitespace-nowrap"><%= k %>:</td>
+                  <td class="align-top"><%= display_value %></td>
+                </tr>
+              <% end %>
+            </table>
           </td>
 
           <td class="border px-3 py-2 text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,14 @@
 Rails.application.routes.draw do
+  # temporary direct routes to images for migration audit
+  resources :attachments, only: [:show]
+  resources :media_files, only: [:show]
+  namespace :images do
+    resources :main_images, only: [:show]
+    resources :gallery_images, only: [:show]
+    resources :rich_texts, only: [:show]
+  end
+  resources :images, only: [:show]
+
   # mount Ckeditor::Engine, at: '/admin/ckeditor', as: 'ckeditor'
   apipie
   devise_for :users,


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work is part of [link an issue]

### What is the goal of this PR and why is this important? 
- Show more items (Attachment, Image, MediaFile) on image audit page
- Allow url param filtering so you can selectively include models to display

### How did you approach the change?
- Update image migration audit controller to include Attachment/Image/MediaFile 
- Update page to include links to owners for models that respond_to :owner. 
- Add link to object from audit page 
- Added some temporary show page routes for images

### Anything else to add?
- Add actual show pages for these images

