### PR TITLE
Show attachments on resources form -- this is until prod data migration

### DIFF
--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -88,6 +88,25 @@
   <!-- Third Row -->
   <%= render "shared/form_image_fields", f: f, include_main_image: true %>
 
+  <% if @resource.attachments.any? %>
+    <div class="bg-red-200 p-3 pb-9">
+      <h3 class="text-lg font-medium mt-6 mb-2">Attachments (need to reattach)</h3>
+      <ul class="list-disc pl-5">
+        <% @resource.attachments.each do |attachment| %>
+          <li>
+            <%= attachment.file_file_name %>
+            <%# if attachment&.persisted? %>
+              <%#= link_to attachment.file_file_name,
+                          url_for(attachment.file), class: "hover:underline" %>
+            <%# else %>
+              <%#= attachment.file_file_name %>
+            <%# end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
 
 
   <!-- Form Actions -->


### PR DESCRIPTION


### What is the goal of this PR and why is this important? 
- Display attachments on Resource form (until prod data is migrated and Attachments converted to Images)

### How did you approach the change?
- Added a red div for attachments

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

