### PR TITLE
Fixes #543: Fix text overflow for facilitator helper

### DIFF
--- a/app/helpers/facilitator_helper.rb
+++ b/app/helpers/facilitator_helper.rb
@@ -4,20 +4,20 @@ module FacilitatorHelper
 						class: "group inline-flex items-center gap-2 px-4 py-2
                   border border-primary text-primary rounded-lg
                   hover:bg-primary hover:text-white transition-colors duration-200
-                  font-medium shadow-sm leading-none whitespace-nowrap w-60" do
+                  font-medium shadow-sm leading-none whitespace-nowrap" do
 
 			facilitator = facilitator.decorate
 
 			# --- Avatar ---
 			avatar = if facilitator.avatar_image.present?
 								 image_tag url_for(facilitator.avatar_image.file),
-													 class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm"
+													 class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
 							 elsif facilitator.user&.avatar.present?
 								 image_tag url_for(facilitator.user.avatar),
-													 class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm"
+													 class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
 							 else
 								 image_tag "missing.png",
-													 class: "w-10 h-10 rounded-full object-cover border border-dashed border-gray-300"
+													 class: "w-10 h-10 rounded-full object-cover border border-dashed border-gray-300 flex-shrink-0"
 							 end
 
 			# --- Name: stays one line & turns white on hover ---
@@ -25,7 +25,7 @@ module FacilitatorHelper
 				:span,
 				facilitator.name.to_s.truncate(21),
 				title: facilitator.name.to_s,
-				class: "font-semibold text-gray-900 whitespace-nowrap group-hover:text-white"
+				class: "font-semibold text-gray-900 group-hover:text-white"
 			)
 
 			# --- Pronouns ---
@@ -40,7 +40,7 @@ module FacilitatorHelper
 			text_block = content_tag(
 				:div,
 				safe_join([name, pronouns].compact),
-				class: "flex flex-col leading-tight text-left"
+				class: "flex flex-col leading-tight text-left min-w-0 "
 			)
 
 			avatar + text_block


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you get them in faster 😊 -->

- This work closes #543

### What is the goal of this PR and why is this important?
Fixes text overflow when the facilitator name is displayed, ensuring the button resizes correctly instead of overflowing.

### How did you approach the change?
Removed the fixed width that was constraining the button and added `min-w-0` so flexbox can calculate widths correctly.

### Anything else to add?
Nothing else.
