### PR TITLE
use tailwind @source inline

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -17,6 +17,9 @@
   --color-transparent: transparent;
 }
 
+/* Used to generate classes from `domain_theme.rb`*/
+@source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,green}-{50,{100..900..100},950}");
+
 /* ✅ Safelist dynamically generated colors */
 @layer utilities {
   .text-transparent { color: transparent; }

--- a/app/views/dashboard/admin.html.erb
+++ b/app/views/dashboard/admin.html.erb
@@ -75,31 +75,6 @@
     bg-black
     bg-gray-50 bg-gray-100 bg-gray-200 bg-gray-500
 
-    bg-blue-50 bg-blue-100 bg-blue-200 bg-blue-500             events && admin-only
-    bg-emerald-50 bg-emerald-100 bg-emerald-200 bg-emerald-500 projects
-    bg-green-50 bg-green-100 bg-green-200 bg-green-500         facilitator-only
-    bg-indigo-50 bg-indigo-100 bg-indigo-200 bg-indigo-500     workshops
-    bg-lime-50 bg-lime-100 bg-lime-200 bg-lime-500             tags
-    bg-orange-50 bg-orange-100 bg-orange-200 bg-orange-500     community-news
-    bg-purple-50 bg-purple-100 bg-purple-200 bg-purple-500     workshop-variations
-    bg-rose-50 bg-rose-100 bg-rose-200 bg-rose-500             stories
-    bg-sky-50 bg-sky-100 bg-sky-200 bg-sky-500                 facilitators
-    bg-slate-50 bg-slate-100 bg-slate-200 bg-slate-500         quotes
-    bg-teal-50 bg-teal-100 bg-teal-200 bg-teal-500             workshop-logs
-    bg-violet-50 bg-violet-100 bg-violet-200 bg-violet-500     resources
-
-    hover:bg-blue-50 hover:bg-blue-100 hover:bg-blue-200 hover:bg-blue-500
-    hover:bg-indigo-50 hover:bg-indigo-100 hover:bg-indigo-200 hover:bg-indigo-500
-    hover:bg-emerald-50 hover:bg-emerald-100 hover:bg-emerald-200 hover:bg-emerald-500
-    hover:bg-lime-50 hover:bg-lime-100 hover:bg-lime-200 hover:bg-lime-500
-    hover:bg-orange-50 hover:bg-orange-100 hover:bg-orange-200 hover:bg-orange-500
-    hover:bg-purple-50 hover:bg-purple-100 hover:bg-purple-200 hover:bg-purple-500
-    hover:bg-rose-50 hover:bg-rose-100 hover:bg-rose-200 hover:bg-rose-500
-    hover:bg-sky-50 hover:bg-sky-100 hover:bg-sky-200 hover:bg-sky-500
-    hover:bg-slate-50 hover:bg-slate-100 hover:bg-slate-200 hover:bg-slate-500
-    hover:bg-teal-50 hover:bg-teal-100 hover:bg-teal-200 hover:bg-teal-500
-    hover:bg-violet-50 hover:bg-violet-100 hover:bg-violet-200 hover:bg-violet-500
-
     bg-red-800
     bg-cyan-50 bg-cyan-100 bg-cyan-200 bg-cyan-500
     bg-pink-50 bg-pink-100 bg-pink-200 bg-pink-500

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -1,4 +1,6 @@
 module DomainTheme
+  # New colors must be added to the inline source in `application.tailwind.css`
+  # for tailwind to generate the classes
 	COLORS = {
 		workshops:            :indigo,
 		workshop_variations:  :purple,


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->


### What is the goal of this PR and why is this important? 

Tailwind only generates classes detected in source files. We build classes dynamically. 
### How did you approach the change?
<!-- What did you do? -->
This uses tailwinds `@source inline` to generate the range of background colors defined `domain_theme.rb`. The downside to this is that many colors generate by be unused so technically the css will be a larger file than necessary but with a limited number of colors defines I don't see it as a major issue. The alternative is to limit the "shades" of colors we want to build dynamically.

This function can be used for other styles like text color but would require a new source definition.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

Example of generated colors for bg-rose-*
```
--color-rose-100: oklch(94.1% .03 12.58);
--color-rose-200: oklch(89.2% .058 10.001);
--color-rose-300: oklch(81% .117 11.638);
--color-rose-400: oklch(71.2% .194 13.428);
--color-rose-50: oklch(96.9% .015 12.422);
--color-rose-500: oklch(64.5% .246 16.439);
--color-rose-600: oklch(58.6% .253 17.585);
--color-rose-700: oklch(51.4% .222 16.935);
--color-rose-800: oklch(45.5% .188 13.697);
--color-rose-900: oklch(41% .159 10.272);
--color-rose-950: oklch(27.1% .105 12.094)
```

