### PR TITLE
Split led_count from bookmarks_count

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -40,7 +40,6 @@ class BookmarksController < ApplicationController
   def create
     @bookmark = current_user.bookmarks.find_or_create_by(bookmark_params)
     @bookmarkable = @bookmark.bookmarkable
-    @bookmarkable.update(led_count: @bookmarkable.led_count + 1) if @bookmarkable.has_attribute?(:led_count)
     respond_to do |format|
       format.html {
         redirect_to authenticated_root_path, notice: "#{@bookmark.bookmarkable_type} added to your bookmarks."
@@ -63,7 +62,6 @@ class BookmarksController < ApplicationController
     if @bookmark
       @bookmark.destroy
       @bookmarkable = @bookmark.bookmarkable
-      @bookmarkable.update(led_count: @bookmarkable.led_count - 1) if @bookmarkable.has_attribute?(:led_count)
       respond_to do |format|
         format.html {
           redirect_to authenticated_root_path, notice: "Bookmark has been deleted."

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -103,11 +103,6 @@ class Resource < ApplicationRecord
     "#{self.title} (#{self.kind.upcase})" unless self.kind.nil?
   end
 
-  # Methods
-  def led_count
-    0
-  end
-
   def name
     title || id
   end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -87,6 +87,11 @@ class Workshop < ApplicationRecord
     ) #{sort_order == "asc" ? "ASC" : "DESC"}
     SQL
   }
+  scope :with_bookmarks_count, -> {
+    left_joins(:bookmarks)
+      .select("workshops.*, COUNT(bookmarks.id) AS bookmarks_count")
+      .group("workshops.id")
+  }
 
   # Search Cop
   include SearchCop

--- a/app/views/bookmarks/_flex.html.erb
+++ b/app/views/bookmarks/_flex.html.erb
@@ -147,7 +147,7 @@
       </div>
 
       <div class="text-sm text-gray-600">
-        Bookmarked:
+        Led:
         <%= workshop.led_count %>
         <%= "time".pluralize(workshop.led_count) %>
       </div>

--- a/app/views/bookmarks/tally.html.erb
+++ b/app/views/bookmarks/tally.html.erb
@@ -45,7 +45,7 @@
     <table class="w-full border border-gray-200 bg-gray-300 rounded-lg shadow-sm">
       <thead>
         <tr>
-          <th colspan="2" class="bg-gray-400 px-4 py-2 text-white">Workshop Led Counts</th>
+          <th colspan="2" class="bg-gray-400 px-4 py-2 text-white">Workshops led (via logs)</th>
         </tr>
         <tr class="bg-gray-400">
           <th class="px-4 py-2 text-left">Count</th>

--- a/app/views/bookmarks/update.turbo_stream.erb
+++ b/app/views/bookmarks/update.turbo_stream.erb
@@ -1,16 +1,21 @@
 <%= turbo_stream.replace dom_id(@bookmarkable, :bookmark_icon), partial: "editable_bookmark_icon", locals: {resource: @bookmarkable} %>
 <%= turbo_stream.replace dom_id(@bookmarkable, :bookmark_button), partial: "editable_bookmark_button", locals: {resource: @bookmarkable} %>
 
-<% if @bookmarkable.has_attribute?(:led_count)  %>
-  <%= turbo_stream.update dom_id(@bookmarkable, :bookmark_count) do  %>
-       Bookmarked:
-       <%= @bookmarkable.led_count %>
-       <%= "time".pluralize(@bookmarkable.led_count) %>
-  <% end  %>
-  <%= turbo_stream.update dom_id(@bookmarkable, :bookmark_count_facilitator) do  %>
-      (Bookmarked by
-      <%= pluralize(@bookmarkable.led_count, "facilitator") %>)
-  <% end  %>
+<%= turbo_stream.update dom_id(@bookmarkable, :led_count) do  %>
+  Led:
+  <%= @bookmarkable.led_count %>
+  <%= "time".pluralize(@bookmarkable.led_count) %>)
+<% end  %>
+
+<%= turbo_stream.update dom_id(@bookmarkable, :bookmark_count) do  %>
+  Bookmarked:
+  <%= @bookmarkable.bookmarks_count %>
+  <%= "time".pluralize(@bookmarkable.bookmarks_count) %>
+<% end  %>
+
+<%= turbo_stream.update dom_id(@bookmarkable, :bookmark_count_facilitator) do  %>
+  (Bookmarked by
+  <%= pluralize(@bookmarkable.bookmarks_count, "facilitator") %>,
 <% end  %>
 
 <%= turbo_stream.replace "flash_now", partial: "shared/flash_messages" %>

--- a/app/views/workshops/_index_row.html.erb
+++ b/app/views/workshops/_index_row.html.erb
@@ -65,7 +65,13 @@
         <!-- Bookmarked count -->
         <%= tag.div id: dom_id(workshop, :bookmark_count),
                     class: "text-sm text-gray-600 leading-tight" do %>
-          Bookmarked: <%= workshop.led_count %> <%= "time".pluralize(workshop.led_count) %>
+          Bookmarked: <%= workshop.bookmarks_count %> <%= "time".pluralize(workshop.bookmarks_count.to_i) %>
+        <% end %>
+
+        <!-- Led count -->
+        <%= tag.div id: dom_id(workshop, :led_count),
+                    class: "text-sm text-gray-600 leading-tight" do %>
+          Led: <%= workshop.led_count %> <%= "time".pluralize(workshop.led_count.to_i) %>
         <% end %>
 
         <!-- Age ranges -->

--- a/app/views/workshops/_show_actions_row.html.erb
+++ b/app/views/workshops/_show_actions_row.html.erb
@@ -5,7 +5,11 @@
     <%= render "bookmarks/editable_bookmark_button", resource: workshop.object %>
     <%= tag.span id: dom_id(workshop, :bookmark_count_facilitator), class: "text-gray-600 text-sm" do %>
       (Bookmarked by
-      <%= pluralize(workshop.led_count, "facilitator") %>)
+      <%= pluralize(workshop.bookmarks.count, "facilitator") %>,
+    <% end %>
+    <%= tag.span id: dom_id(workshop, :led_count), class: "text-gray-600 text-sm" do %>
+      Led:
+      <%= pluralize(workshop.led_count, "time") %>)
     <% end %>
   </div>
 

--- a/app/views/workshops/_sort_by_options.html.erb
+++ b/app/views/workshops/_sort_by_options.html.erb
@@ -18,6 +18,14 @@
   <label class="flex items-center gap-1 cursor-pointer">
     <%= radio_button_tag :sort, "led",
                          @sort == "led" %>
+    <span class="text-sm">Most led</span>
+  </label>
+</div>
+
+<div class="flex items-center gap-1">
+  <label class="flex items-center gap-1 cursor-pointer">
+    <%= radio_button_tag :sort, "popularity",
+                         @sort == "popularity" %>
     <span class="text-sm">Most bookmarked</span>
   </label>
 </div>

--- a/spec/services/workshop_search_service_spec.rb
+++ b/spec/services/workshop_search_service_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe WorkshopSearchService, type: :service do
 		create(:workshop, title: "Keyword Match", year: 2025, month: 1, created_at: 2.days.ago, led_count: 1)
 	end
 
+	let!(:bookmark_1) { create(:bookmark, bookmarkable: workshop_1) }
+	let!(:bookmark_2) { create(:bookmark, bookmarkable: workshop_1) }
+
+	let!(:bookmark_3) { create(:bookmark, bookmarkable: workshop_2) }
+
 	describe "#call" do
 		context "sorting by created" do
 			it "orders by year/month desc, then created_at desc, then title asc" do
@@ -46,6 +51,19 @@ RSpec.describe WorkshopSearchService, type: :service do
 																																		 [2, "B Workshop"],
 																																		 [1, "Keyword Match"]
 																																	 ])
+			end
+		end
+
+		context "sorting by bookmarks (popularity)" do
+			it "orders by bookmarks_count desc, then title asc" do
+				service = WorkshopSearchService.new({ sort: 'bookmarks' }).call
+				workshops = service.workshops
+
+				expect(workshops.map { |w| [w.bookmarks_count.to_i, w.title] }).to eq([
+																																								[2, "A Workshop"],
+																																								[1, "B Workshop"],
+																																								[0, "Keyword Match"]
+																																							])
 			end
 		end
 


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #524


### What is the goal of this PR and why is this important? 
- Led count should only be tied to workshop logs, NOT to bookmarking
- Properly sort by bookmarks_count, aka 'popularity'
- Keep sorting by led_count
- Display led_count on workshops row

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

