### PR TITLE
set turbo_frame to top

### DIFF
--- a/app/views/assets/_display_image.html.erb
+++ b/app/views/assets/_display_image.html.erb
@@ -61,9 +61,12 @@
     end
 %>
 
-<%# --------------------------------------------------
-   # Inner content (NO LINKS HERE)
-   # -------------------------------------------------- %>
+<%#
+  --------------------------------------------------
+  # Inner content (NO LINKS HERE)
+  # --------------------------------------------------
+%>
+
 <% inner = capture do %>
   <div class="<%= variant %>-item <%= resource&.class&.table_name %>-<%= idx %> <%= sizes[:wrapper] %>">
     <% if active_storage_file %>
@@ -73,15 +76,11 @@
               class: "#{sizes[:image]} hover:opacity-95 transition-opacity",
               alt: "#{item_type} preview #{idx + 1} (#{active_storage_file.blob.filename})"
             ) %>
-
       <% elsif active_storage_file.content_type == "application/pdf" %>
         <div class="flex items-center gap-3 p-4 border rounded-lg bg-gray-50">
           <i class="fas fa-file-pdf text-red-600 text-2xl"></i>
-          <span class="font-medium underline hover:no-underline">
-            <%= active_storage_file.blob.filename %>
-          </span>
+          <span class="font-medium underline hover:no-underline"><%= active_storage_file.blob.filename %></span>
         </div>
-
       <% else %>
         <%= image_tag(
               active_storage_file,
@@ -89,7 +88,6 @@
               alt: "#{item_type} image #{idx + 1} (#{active_storage_file.blob.filename})"
             ) %>
       <% end %>
-
     <% elsif icon_display %>
       <div class="<%= sizes[:image] %> hover:opacity-95 transition-opacity">
         <%= render "assets/display_icon",
@@ -105,27 +103,25 @@
             class: sizes[:image],
             alt: "#{item_type} fallback image #{idx + 1}"
           ) %>
-
     <% end %>
-
   </div>
 <% end %>
 
-<%# --------------------------------------------------
-   # Optional link wrapper
-   # -------------------------------------------------- %>
+<%#
+  --------------------------------------------------
+  # Optional link wrapper
+  # --------------------------------------------------
+%>
+
 <% if link && link_href.present? %>
   <% link_options = if link_to_object
-                      { class: "display-image-link", data: { turbo_frame: "_top" } }
+                      { class: "display-image-link", data: { turbo_frame: "_top", turbo_prefetch: false } }
                     else
                       { class: "display-image-link", target: "_blank", rel: "noopener noreferrer" }
-                    end
-  %>
-
+                    end %>
   <%= link_to link_href, **link_options do %>
     <%= inner %>
   <% end %>
-
   <% if active_storage_file&.previewable? && display_open_pdf_link &&
     active_storage_file.content_type == "application/pdf" %>
     <div class="mt-2 text-sm text-gray-600">

--- a/app/views/resources/_resource_card.html.erb
+++ b/app/views/resources/_resource_card.html.erb
@@ -20,7 +20,7 @@
       <!-- IMAGE -->
       <div class="relative w-32 h-32">
         <%= link_to resource_path(resource),
-                    data: { turbo_frame: "_top" },
+                    data: { turbo_frame: "_top", turbo_prefetch: false },
                     class: "block w-full h-full" do %>
 
           <!-- fallback icon -->
@@ -47,7 +47,7 @@
     <div class="flex-1 min-w-0 pl-4 pr-10 pb-12 mt-2 relative">
       <div class="mt-3 mb-2">
         <%= link_to resource_path(resource),
-                    data: { turbo_frame: "_top" },
+                    data: { turbo_frame: "_top", turbo_prefetch: false },
                     class: "inline-flex min-w-0 max-w-full text-lg font-semibold
                             text-gray-900 leading-tight hover:underline" do %>
           <%= title_with_badges(resource, show_hidden_badge: current_user.super_user?).html_safe %>
@@ -61,7 +61,7 @@
           <%= link_to(
                 content_tag(:span, "", class: "fa fa-download"),
                 resource_download_path(resource.object),
-                data: { turbo_frame: "_top" },
+                data: { turbo_frame: "_top", turbo_prefetch: false },
                 class: "btn btn-utility"
               ) %>
         <% end %>
@@ -71,7 +71,7 @@
                 content_tag(:span, "", class: "far fa-edit"),
                 edit_resource_path(resource.object),
                 class: "admin-only bg-blue-100 btn btn-secondary-outline",
-                data: {turbo_frame: "_top"}
+                data: {turbo_frame: "_top", turbo_prefetch: false }
               ) %>
         <% end %>
 

--- a/app/views/workshops/_index_row.html.erb
+++ b/app/views/workshops/_index_row.html.erb
@@ -45,7 +45,7 @@
         <!-- Title with badges (single column, bookmark stays separate) -->
         <%= link_to link_route,
                     class: "hover:underline block",
-                    data: { turbo_frame: "_top" } do %>
+                    data: { turbo_frame: "_top", turbo_prefetch: false } do %>
           <%= title_with_badges(workshop,
                                 show_hidden_badge: current_user.super_user?,
                                 display_windows_type: true).html_safe %>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #605 

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Links were updated in a prior PR. This fixes link's within turbo frames.
### How did you approach the change?
<!-- What did you do? -->
Add turbo_frame "_top"

### Anything else to add?
I see `turbo_prefetch: false` set a lot of places. Turbo 8 default is true which I would assume we want. Prefetch should speed up navigation for users as the link is "prefetched" on mouseover.
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

