### PR TITLE
Facilitators can bookmark workshops

### DIFF
--- a/spec/system/facilitator_bookmarks_workshop_test.rb
+++ b/spec/system/facilitator_bookmarks_workshop_test.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Facilitators can bookmark workshops' do
+    describe "Facilitator bookmarks a workshop" do
+        context "when facilitator is logged in" do
+            before do
+                 user = create(:user)
+                    create(:facilitator, user: user)
+                     adult_window = create(:windows_type, :adult)
+                     @workshop_world = create(:workshop, title: 'The best workshop in the world', windows_type: adult_window)
+
+                     sign_in user
+                     visit '/workshops'
+            end
+
+            it "allows bookmarking a workshop and displays it in bookmarks list" do
+                expect(page).to have_content('Workshops')
+                expect(page).to have_content('The best workshop in the world')
+                # Bookmark the workshop
+                within("#bookmark_icon_workshop_#{@workshop_world.id}") do
+                find('button').click
+                end
+
+                expect(page).to have_content("Workshop added to your bookmarks.")
+
+                # Navigate to bookmarks page
+                visit personal_bookmarks_path
+                expect(page).to have_content('My Bookmarks (1)')
+                expect(page).to have_content('The best workshop in the world')
+            end
+        end
+    end
+end


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #33 

### What is the goal of this PR and why is this important? 
Add a test to ensure facilitators can successfully bookmark workshops

### How did you approach the change?
Createdt the test that simulates a facilitator logging in, navigating to workshops, bookmarking one, and verifying it appears in their bookmarks.

### Anything else to add?
Should I add a navigation via profile like: profile ->My bookmarks? 

