### PR TITLE
Change action_mailer's default_url_options for host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,6 @@ Rails.application.configure do
   config.active_storage.service = :digitalocean
 
   app_host = ENV.fetch("APP_HOST", "localhost")
-
   Rails.application.routes.default_url_options[:host] = app_host
 
   config.after_initialize do
@@ -96,8 +95,8 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = {
-    host: "example.com",
-    protocol: "https"
+    host: ENV.fetch("APP_HOST", "localhost"),
+    protocol: Rails.env.production? ? "https" : "http"
   }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.


### PR DESCRIPTION
 to use the same env var as we're using for routes (links in password reset emails were opening up example.com)

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
- Change action_mailer's default_url_options for host to use the same env var as we're using for routes (links in password reset emails were opening up example.com)

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

