### PR TITLE
Rhino Editor: add bubble menu and link dialog

### DIFF
--- a/app/frontend/javascript/rhino/custom-editor.js
+++ b/app/frontend/javascript/rhino/custom-editor.js
@@ -141,6 +141,8 @@ class CustomEditor extends TipTapEditor {
         </role-toolbar>
 
         ${this.renderTableMenu()} ${renderGridMenu(this.editor)}
+        ${this.renderBubbleMenuToolbar()}
+        ${this.renderLinkDialogAnchoredRegion()}
       </slot>
     `;
   }


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Bubble menu and Link set/unset was missing from the custom editor.

### How did you approach the change?
<!-- What did you do? -->
Add back in default rhino_editor function calls in the custom editor.
### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

https://github.com/user-attachments/assets/87f09d93-22f4-4e51-a7b1-81c6c95a90b9



