### PR TITLE
Add system tests for facilitator workshop search functionality

### DIFF
--- a/spec/system/facilitator_searches_workshop_test.rb
+++ b/spec/system/facilitator_searches_workshop_test.rb
@@ -55,6 +55,24 @@ RSpec.describe 'Facilitators can search for a workshop' do
         expect(page).to have_no_content("The best workshop in the world")
         expect(page).to have_no_content("The best workshop on mars")
       end
+
+      it "searches for workshop with 'the best' keyword for multiple results" do
+       visit workshops_path
+       fill_in 'title', with: "the best"
+       expect(page).to have_content("The best workshop in the world")
+       expect(page).to have_content("The best workshop on mars")
+       expect(page).to have_no_content('oh hello!')
+     end
+
+      it "shows no results for non-matching search" do
+       visit workshops_path
+       fill_in 'title', with: "nonexistent"
+       expect(page).to have_no_content('The best workshop in the world')
+       expect(page).to have_no_content('The best workshop on mars')
+       expect(page).to have_no_content('oh hello!')
+       expect(page).to have_content('Your search returned no results. Please try again.')
+     end
+
       it "shows all workshops when search is cleared" do
         visit workshops_path
         fill_in 'title', with: ""


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #31 

### What is the goal of this PR and why is this important? 
Test that verify facilitators can successfully search for workshops using keywords.

### How did you approach the change?
I followed existing test patterns by creating a facilitator user and sample workshops, then simulated the user flow of navigating to the workshops page and testing various search terms.

### Anything else to add?
Maybe we should add tests for the other options available for sorting/searching. 

