### PR TITLE
Hide facilitators, organizations, my profile from menu

### DIFF
--- a/app/views/shared/_navbar_menu.html.erb
+++ b/app/views/shared/_navbar_menu.html.erb
@@ -80,16 +80,18 @@
         <span>Events</span>
       <% end %>
 
-      <%= link_to facilitators_path,
-                  class: "flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-        <i class="fas fa-user-friends"></i>
-        <span>Facilitators</span>
-      <% end %>
+      <% if current_user.super_user %>
+        <%= link_to facilitators_path,
+                    class: "admin-only bg-blue-100 flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+          <i class="fas fa-user-friends"></i>
+          <span>Facilitators</span>
+        <% end %>
 
-      <%= link_to projects_path,
-                  class: "flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-        <i class="fas fa-building"></i>
-        <span>Organizations</span>
+        <%= link_to projects_path,
+                    class: "admin-only bg-blue-100 flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+          <i class="fas fa-building"></i>
+          <span>Organizations</span>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_navbar_menu_mobile.html.erb
+++ b/app/views/shared/_navbar_menu_mobile.html.erb
@@ -61,15 +61,18 @@
           <i class="fas fa-calendar"></i>
           <span>Events</span>
         <% end %>
-        <%= link_to facilitators_path, class: "flex items-center px-4 py-2 text-sm text-white
-                    hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-user-friends"></i>
-          <span>Facilitators</span>
-        <% end %>
-        <%= link_to projects_path, class: "flex items-center px-4 py-2 text-sm text-white
-                    hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-building"></i>
-          <span>Organizations</span>
+
+        <% if current_user.super_user %>
+          <%= link_to facilitators_path, class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-white
+                      hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+            <i class="fas fa-user-friends"></i>
+            <span>Facilitators</span>
+          <% end %>
+          <%= link_to projects_path, class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-white
+                      hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+            <i class="fas fa-building"></i>
+            <span>Organizations</span>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -30,16 +30,18 @@
     <% end %>
   <% end %>
 
-  <%= link_to (current_user.facilitator ? facilitator_path(current_user.facilitator) : generate_facilitator_user_path(current_user)),
-              class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-    <i class="fas fa-user"></i>
-    <span>My profile</span>
+  <% if current_user.super_user %>
+    <%= link_to (current_user.facilitator ? facilitator_path(current_user.facilitator) : generate_facilitator_user_path(current_user)),
+                class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+      <i class="fas fa-user"></i>
+      <span>My profile</span>
+    <% end %>
   <% end %>
 
-  <% if current_user.project_users.any? %>
+  <% if current_user.super_user && current_user.project_users.any? %>
     <% current_user.project_users.each do |project_user| %>
       <%= link_to project_path(project_user.project),
-                  class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+                  class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
         <i class="fas fa-users"></i>
         <span>
           My team<%= " (" + project_user.project.name.truncate(12) + ")" if current_user.project_users.many? %>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
- Stakeholder isn't ready to launch My profile, Facilitators, and Organizations, so hiding them behind super_user for now.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

