### PR TITLE
fix: update Website button on edit story page to only display when the website_url is present. resolves #683

### DIFF
--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -5,7 +5,7 @@
         <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @story.class.model_name.human %></h1>
         <div class="text-right text-end space-x-2">
           <%= link_to "Website", safe_url(@story.external_url), target: "_blank", rel: "noopener noreferrer",
-                      class: "btn btn-secondary-outline" if @story.external_url %>
+                      class: "btn btn-secondary-outline" if @story.external_url.present? %>
           <%= link_to "View",
                       story_path(@story),
                       class: "btn btn-secondary-outline" %>

--- a/spec/views/stories/edit.html.erb_spec.rb
+++ b/spec/views/stories/edit.html.erb_spec.rb
@@ -32,4 +32,31 @@ RSpec.describe "stories/edit", type: :view do
       assert_select "select[name=?]", "story[created_by_id]"
     end
   end
+
+  it "does not render the Website button when website_url is nil" do
+    story.update(website_url: nil)
+    assign(:story, story.decorate)
+
+    render
+
+    assert_select "a", text: "Website", count: 0
+  end
+
+  it "does not render the Website button when website_url is blank" do
+    story.update(website_url: "")
+    assign(:story, story.decorate)
+
+    render
+
+    assert_select "a", text: "Website", count: 0
+  end
+
+  it "renders the Website button when website_url is present" do
+    story.update(website_url: "https://example.com")
+    assign(:story, story.decorate)
+
+    render
+
+    assert_select "a", text: "Website"
+  end
 end


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #683

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
The goal of this PR is to fix the bug where the Website button is rendered on the Edit Story page when the `@story.external_url` is blank (i.e. `""`).

### How did you approach the change?
<!-- What did you do? -->
The existing logic was already hiding the Website button when `@story.external_url` is `nil`. I updated the conditional to also hide the Website button when `@story.external_url` is blank.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->
No
