### PR TITLE
Add Payment model, factory, and spec

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,35 @@
+class Payment < ApplicationRecord
+  # --- Associations ---
+  belongs_to :payer,   polymorphic: true
+  belongs_to :payable, polymorphic: true
+
+  # --- Callbacks ---
+  attribute :currency, :string, default: "usd"
+  attribute :status,   :string, default: "pending"
+
+  # --- Validations ---
+  validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :currency, presence: true
+  validates :status, presence: true
+  validates :stripe_payment_intent_id, presence: true
+
+  validates :stripe_payment_intent_id, uniqueness: true, allow_nil: true
+  validates :stripe_charge_id, uniqueness: true, allow_nil: true
+
+  STRIPE_PAYMENT_STATUSES = %w[
+    pending
+    requires_action
+    processing
+    succeeded
+    failed
+    canceled
+    refunded
+    partially_refunded
+  ].freeze
+
+  validates :status, inclusion: { in: STRIPE_PAYMENT_STATUSES }
+
+  scope :for_payable, ->(payable) { where(payable: payable) }
+  scope :successful,  -> { where(status: "succeeded") }
+  scope :pendingish,  -> { where(status: %w[pending requires_action processing]) }
+end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,53 @@
+FactoryBot.define do
+  factory :payment do
+    # Polymorphic associations
+    association :payer, factory: :user
+    association :payable, factory: :event
+
+    # Required attributes
+    amount_cents { 1000 } # $10.00
+    currency { "usd" }
+    status { "succeeded" }
+    stripe_payment_intent_id { "pi_#{SecureRandom.hex(24)}" }
+
+    # Optional attributes
+    stripe_charge_id { nil }
+    failure_code { nil }
+    failure_message { nil }
+    stripe_metadata { nil }
+
+    trait :pending do
+      status { "pending" }
+    end
+
+    trait :processing do
+      status { "processing" }
+    end
+
+    trait :succeeded do
+      status { "succeeded" }
+    end
+
+    trait :failed do
+      status { "failed" }
+      failure_code { "card_declined" }
+      failure_message { "Your card was declined." }
+    end
+
+    trait :canceled do
+      status { "canceled" }
+    end
+
+    trait :refunded do
+      status { "refunded" }
+    end
+
+    trait :partially_refunded do
+      status { "partially_refunded" }
+    end
+
+    trait :with_charge_id do
+      stripe_charge_id { "ch_#{SecureRandom.hex(24)}" }
+    end
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe Payment, type: :model do
+  describe "associations" do
+    subject { create(:payment) }
+
+    it { should belong_to(:payer).required }
+    it { should belong_to(:payable).required }
+  end
+
+  describe "validations" do
+    describe "with build subject" do
+      subject { build(:payment) }
+
+      it { should validate_presence_of(:currency) }
+      it { should validate_presence_of(:status) }
+      it { should validate_presence_of(:stripe_payment_intent_id) }
+      it { should validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
+      it { should validate_inclusion_of(:status).in_array(Payment::STRIPE_PAYMENT_STATUSES) }
+    end
+
+    describe "with create subject for uniqueness" do
+      subject { create(:payment) }
+
+      it { should validate_uniqueness_of(:stripe_payment_intent_id).case_insensitive }
+      it { should validate_uniqueness_of(:stripe_charge_id).case_insensitive.allow_nil }
+    end
+
+    describe "defaults" do
+      it "defaults currency to 'usd'" do
+        payment = Payment.new
+        expect(payment.currency).to eq("usd")
+      end
+
+      it "defaults status to 'pending'" do
+        payment = Payment.new
+        expect(payment.status).to eq("pending")
+      end
+    end
+  end
+
+  describe "constants" do
+    it "defines STRIPE_PAYMENT_STATUSES" do
+      expect(Payment::STRIPE_PAYMENT_STATUSES).to eq(%w[
+        pending
+        requires_action
+        processing
+        succeeded
+        failed
+        canceled
+        refunded
+        partially_refunded
+      ])
+    end
+  end
+
+  describe "scopes" do
+    let(:user) { create(:user) }
+    let(:event1) { create(:event) }
+    let(:event2) { create(:event) }
+
+    describe ".for_payable" do
+      let!(:payment1) { create(:payment, payable: event1) }
+      let!(:payment2) { create(:payment, payable: event2) }
+
+      it "returns payments for the specified payable" do
+        expect(Payment.for_payable(event1)).to include(payment1)
+        expect(Payment.for_payable(event1)).not_to include(payment2)
+      end
+    end
+
+    describe ".successful" do
+      let!(:succeeded_payment) { create(:payment, status: "succeeded") }
+      let!(:pending_payment) { create(:payment, status: "pending") }
+      let!(:failed_payment) { create(:payment, status: "failed") }
+
+      it "returns only payments with succeeded status" do
+        expect(Payment.successful).to include(succeeded_payment)
+        expect(Payment.successful).not_to include(pending_payment)
+        expect(Payment.successful).not_to include(failed_payment)
+      end
+    end
+
+    describe ".pendingish" do
+      let!(:pending_payment) { create(:payment, status: "pending") }
+      let!(:requires_action_payment) { create(:payment, status: "requires_action") }
+      let!(:processing_payment) { create(:payment, status: "processing") }
+      let!(:succeeded_payment) { create(:payment, status: "succeeded") }
+      let!(:failed_payment) { create(:payment, status: "failed") }
+
+      it "returns payments with pending, requires_action, or processing status" do
+        result = Payment.pendingish
+        expect(result).to include(pending_payment)
+        expect(result).to include(requires_action_payment)
+        expect(result).to include(processing_payment)
+        expect(result).not_to include(succeeded_payment)
+        expect(result).not_to include(failed_payment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important? 
Adds foundational Payment model to be used for Stripe Payments on Event Registrations.  This PR precedes introduction and usage of the Stripe API and is met to cover the associations, attributes, defaults, and validations that will be used in its lifecycle.

Thanks for any feedback

