### PR TITLE
feat: Update Workshop selector label in New Workflow Log page

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -3,7 +3,7 @@ class Workshop < ApplicationRecord
   include Rails.application.routes.url_helpers
   include ActionText::Attachable
 
-  belongs_to :windows_type
+  belongs_to :windows_type, optional: true
   belongs_to :user, optional: true
   belongs_to :workshop_idea, optional: true
 
@@ -225,7 +225,7 @@ class Workshop < ApplicationRecord
   end
 
   def type_name
-    "#{id} #{title} #{ " (#{windows_type.short_name})" if windows_type}"
+    "#{title} #{"(#{windows_type.short_name}) " if windows_type}##{id}"
   end
 
   def communal_label(report)

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -1,13 +1,13 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Workshop do
   # pending "add some examples to (or delete) #{__FILE__}"
-  describe "associations" do
+  describe 'associations' do
     # Need create for association tests to work correctly with callbacks/scopes
     subject { create(:workshop) } # Assumes functional factory
 
     it { should belong_to(:user).optional }
-    it { should belong_to(:windows_type) }
+    it { should belong_to(:windows_type).optional }
 
     it { should have_many(:sectorable_items).dependent(:destroy).inverse_of(:sectorable) }
     it { should have_many(:sectors).through(:sectorable_items) }
@@ -34,7 +34,7 @@ RSpec.describe Workshop do
     it { should accept_nested_attributes_for(:workshop_logs).allow_destroy(true) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     # Requires associations for create
     subject { build(:workshop, user: create(:user), windows_type: create(:windows_type)) }
 
@@ -42,22 +42,36 @@ RSpec.describe Workshop do
     it { should validate_length_of(:age_range).is_at_most(16) }
 
     # Conditional presence validation for legacy workshops (month, year)
-    context "when legacy is true" do
+    context 'when legacy is true' do
       before { allow(subject).to receive(:legacy).and_return(true) }
       # Cannot easily test conditional validation with shoulda-matchers, test manually
       # it { should validate_presence_of(:month) }
       # it { should validate_presence_of(:year) }
     end
-    context "when legacy is false" do
+    context 'when legacy is false' do
       before { allow(subject).to receive(:legacy).and_return(false) }
       # it { should_not validate_presence_of(:month) }
       # it { should_not validate_presence_of(:year) }
     end
   end
 
-  it "is valid with valid attributes" do
+  it 'is valid with valid attributes' do
     # Note: Factory needs associations uncommented for create
     # expect(build(:workshop)).to be_valid
+  end
+
+  describe '#type_name' do
+    it 'returns title + windows type (when present) + # + id' do
+      record = create(:workshop, title: 'The best workshop in the world', windows_type: create(:windows_type, :adult))
+
+      expect(record.type_name).to eq "The best workshop in the world (ADULT) ##{record.id}"
+    end
+
+    it 'omits the windows type part when there is no windows_type' do
+      record = create(:workshop, title: 'The best workshop in the world', windows_type: nil)
+
+      expect(record.type_name).to eq "The best workshop in the world ##{record.id}"
+    end
   end
 
   # Add tests for scopes, methods like #rating, #log_count, SearchCop etc.


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes https://github.com/rubyforgood/awbw/issues/685

### What is the goal of this PR and why is this important? 
Update the Workflow select label in the New Workflow Log page as per user feedback in the issue and add tests for the model method.

### How did you approach the change?
Updated the method `type_name` in the model that is responsible for the label in the page.

From the screenshot in the issue it looks like there are `workshops` without `windows_type` but the association definition does not reflect that, possibly making those old entries non valid. Have added `optional` to the association but if that is not what its wanted we can instead:
- Mock `windows_type = nil` instead in the unit test
- Not test that codepath at all

### Anything else to add?
Is `windows_type` nullable or accepted to be nullable?

### Screenshot
<img width="413" height="282" alt="Screenshot 2026-01-19 at 22 26 50" src="https://github.com/user-attachments/assets/65dbe8d5-23c4-4c0b-a750-c8920c159b05" />

