### PR TITLE
fix: resolve error where an organization does not persist when added to a user. resolves #684

### DIFF
--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -4,6 +4,7 @@ class ProjectUser < ApplicationRecord
 
   # Validations
   validates_presence_of :project_id
+  validates_presence_of :title
 
   # Enum
   enum :position, { default: 0, liaison: 1, leader: 2, assistant: 3 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,10 +43,11 @@ class User < ApplicationRecord
   # Nested attributes
   accepts_nested_attributes_for :user_forms
   accepts_nested_attributes_for :project_users, allow_destroy: true,
-    reject_if: proc { |attrs| attrs["project_id"].blank? || attrs["title"].blank? }
+    reject_if: proc { |attrs| attrs["project_id"].blank? && attrs["title"].blank? }
 
   # Validations
   validates :email, presence: true, uniqueness: { case_sensitive: false }
+  validates_associated :project_users
 
   # Search Cop
   include SearchCop

--- a/app/views/facilitators/_project_user_fields.html.erb
+++ b/app/views/facilitators/_project_user_fields.html.erb
@@ -9,7 +9,9 @@
                   selected: f.object.project_id,
                   input_html: {
                     class: "block w-full rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500"
-                  } %>
+                  },
+                  required: true,
+                  error: "Organization can't be blank" %>
     </div>
 
     <div>

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "users/show", type: :view do
   let!(:workshop) { create(:workshop, title: "Mindful Art", user: user, windows_type: windows_type) }
 
   let!(:project) { create(:project, name: "Healing Arts") }
-  let!(:project_user) { create(:project_user, project: project, user: user, position: :leader) }
+  let!(:project_user) { create(:project_user, project: project, title: "Title", user: user, position: :leader) }
 
   before do
     assign(:user, user)


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #684

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
The goal of this PR is to address the error where an organization does not persist when added to a user.

### How did you approach the change?
<!-- What did you do? -->
I identified that the root cause of the persistence error is that the `project_user` record was being silently rejected when the `title` field is left blank due to the `user` model definition.
https://github.com/rubyforgood/awbw/blob/4488ab810a7b24b25cc2489f461498fe13b8dccb/app/models/user.rb#L45-L46

I updated the `user` model to validate the `project_users` and added a missing validation for the `title` field on the `project_user` model.

I updated the `rejected_if` logic for `project_users` on the `user` model to ignore records where `project_id` and `title` are both blank.

I updated the `Organization` input so that the error validation works as expected.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

