### PR TITLE
feat: update flash messages to be dismissed when a user clicks anywhere else on the page except for alert and error flash messages. resolves #675

### DIFF
--- a/app/frontend/javascript/controllers/dismiss_controller.js
+++ b/app/frontend/javascript/controllers/dismiss_controller.js
@@ -39,7 +39,6 @@ export default class extends Controller {
   }
 
   handleOutsideClick(event) {
-    // Don't dismiss if clicking on the message itself or the close button
     if (!this.element.contains(event.target)) {
       this.hide();
     }

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -38,7 +38,6 @@
     <% timeout =
          persistent ? 12000 : 4000 %>
 
-    <%# Disable outside-click dismissal for alert and error messages %>
     <% disable_outside_click = ["alert", "error"].include?(type.to_s) %>
 
     <div


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #675

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
The goal of this PR is to update the stimulus dismiss controller to handle dismissing the message when a user clicks anywhere else on the page. The `disableOutsideClick` parameter can used to disable this behavior, which is currently applied to alert and error flash messages.

### How did you approach the change?
<!-- What did you do? -->
I updated the dismiss controller to support the outside click disable functionality. Then I added the `disableOutsideClick` parameter to allow disabling the behavior. Then I updated the `_flash_messages` partial to disable the behavior for alert and error flash messages.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

