### PR TITLE
Add system test for facilitator password reset flow

### DIFF
--- a/spec/system/facilitator_changes_password_test.rb
+++ b/spec/system/facilitator_changes_password_test.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Facilitators can change their password quickly and easily' do
+  describe 'Facilitator changes password through reset link' do
+    context 'when facilitator requests password change' do
+      before do
+        @user = create(:user)
+        create(:facilitator, user: @user)
+      end
+
+      it 'completes the full password reset flow successfully' do
+        visit '/users/sign_in'
+
+        expect(page).to have_content('Log in')
+        expect(page).to have_content('Email')
+        expect(page).to have_content('Password')
+        expect(page).to have_link('Forgot your password?')
+
+        click_link('Forgot your password?')
+
+        expect(page).to have_current_path('/users/password/new')
+        expect(page).to have_content('Forgot your password?')
+
+        fill_in 'user_email', with: @user.email
+        click_button 'Email me reset password instructions'
+
+        expect(page).to have_content(
+          'You will receive an email with instructions on how to reset your password in a few minutes.'
+        )
+
+        # Retrieve Reset Link from Email
+        notification = Notification.find_by(
+          kind: 'reset_password',
+          recipient_email: @user.email
+        )
+
+        email_body = notification.email_body_text
+        path_match = email_body.match(%r{/users/password/edit\?reset_password_token=[^\s]+})
+        reset_path = path_match[0]
+
+        # Set new password
+        visit reset_path
+
+        fill_in 'New password', with: 'NewPassword123!'
+        fill_in 'Confirm new password', with: 'NewPassword123!'
+        click_button 'Set password'
+
+        expect(page).to have_content('Your password has been set successfully')
+        expect(page).to have_current_path('/')
+
+        # Test Login with New Password
+        sign_out @user
+
+        visit '/users/sign_in'
+        fill_in 'user_email', with: @user.email
+        fill_in 'user_password', with: 'NewPassword123!'
+        click_button 'Log in'
+
+        expect(page).to have_content('Signed in successfully')
+
+        # Verify Old Password is Invalid
+        sign_out @user
+
+        visit '/users/sign_in'
+        fill_in 'user_email', with: @user.email
+        fill_in 'user_password', with: 'wrongpassword'
+        click_button 'Log in'
+
+        expect(page).to have_content('Invalid Email or password.')
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #63 

### What is the goal of this PR and why is this important? 
Add system test for facilitator password reset functionality to ensure facilitators can change password.

### How did you approach the change?
Created a facilitator user, navigated through the password reset request flow, retrieved the reset email from the notifications database, extracted the reset token, and followed the complete password reset sequence including setting a new password and verifying successful login.

### Anything else to add?
Maybe there should be a flash message saying they entered an invalid address if it doesn't exist in the db, or maybe like "If your email exists in our system, you will receive reset instructions shortly." And when I was using the notifications db email it says "Hello Kurtis" even though the user name is different - maybe it's just in the db because in terminal it shows the user's actual name.

