### PR TITLE
feat: update workshop log error message to use Organization instead of Project. resolves #817

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,7 @@
 
 en:
   hello: "Hello world"
+  activerecord:
+    attributes:
+      workshop_log:
+        project: "Organization"


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #817

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Update workshop log error message to use Organization instead of Project.

### How did you approach the change?
<!-- What did you do? -->
Since `project = organization`, I updated the `I18n` configuration for the `workshop_log.project` attribute to be labeled as `Organization`.

<img width="1075" height="447" alt="image" src="https://github.com/user-attachments/assets/4cb1f8cd-6690-4fce-a36b-626b2c6d7567" />

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

N/A