### PR TITLE
Update update/create form submissions to 'Submit'

### DIFF
--- a/app/views/assets/_upload.html.erb
+++ b/app/views/assets/_upload.html.erb
@@ -57,7 +57,7 @@
     </div>
 
     <div>
-      <%= f.submit "Upload Asset",
+      <%= f.submit "Submit",
         class: "w-full bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg
                 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-300
                 transition

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -40,7 +40,7 @@
       <%= link_to "Cancel", banners_path, class: "btn btn-secondary-outline" %>
 
       <%= f.button :submit,
-                   (@banner.new_record? ? "Create Banner" : "Update Banner"),
+                   "Submit",
                    class: "bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700
                            transition-colors duration-150" %>
     </div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -63,7 +63,7 @@
                   class: "btn btn-secondary-outline" %>
 
       <%= f.button :submit,
-                   "Save Category",
+                   "Submit",
                    class: "btn btn-primary" %>
     </div>
 

--- a/app/views/rich_text_assets/_form.html.erb
+++ b/app/views/rich_text_assets/_form.html.erb
@@ -41,7 +41,7 @@
       </div>
 
       <div>
-        <%= f.submit "Upload Asset",
+        <%= f.submit "Submit",
             class: "w-full bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg
                     hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-300
                     transition

--- a/app/views/sectors/_form.html.erb
+++ b/app/views/sectors/_form.html.erb
@@ -40,7 +40,7 @@
                   class: "btn btn-secondary-outline" %>
 
       <%= f.button :submit,
-                   "Save Sector",
+                   "Submit",
                    class: "btn btn-primary" %>
     </div>
 

--- a/app/views/windows_types/_form.html.erb
+++ b/app/views/windows_types/_form.html.erb
@@ -34,7 +34,7 @@
   </div>
 
   <div class="mt-6">
-    <%= f.submit "Save Workshop",
+    <%= f.submit "Submit",
                  class: "px-4 py-2 bg-blue-600 text-white rounded-md" %>
   </div>
 

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -112,7 +112,7 @@
                   method: :delete, data: { confirm: "Are you sure?" } %>
     <% end %>
     <%= link_to "Cancel", workshop_logs_path, class: "btn btn-secondary-outline" %>
-    <%= f.button :submit, "Save Log", class: "btn btn-primary" %>
+    <%= f.button :submit, "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>
 </div>

--- a/spec/system/community_news_asset_upload_spec.rb
+++ b/spec/system/community_news_asset_upload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Community News asset upload", type: :system do
     )
 
     # Submit the asset form
-    click_button "Upload Asset"
+    click_button "Submit"
   end
 
   def delete_asset(asset_type:)

--- a/spec/system/facilitator_submits_story_test.rb
+++ b/spec/system/facilitator_submits_story_test.rb
@@ -50,7 +50,7 @@ RSpec.describe "Facilitators can submit a story", type: :system do
   end
   select @user.name, from: 'story_created_by_id'
   # Submit
-  click_button 'Create Story'
+  click_button 'Submit'
 
   expect(page).to have_content("Story was successfully created.")
   expect(page).to have_content('Healing Through Art')

--- a/spec/system/facilitator_submits_workshop_log_test.rb
+++ b/spec/system/facilitator_submits_workshop_log_test.rb
@@ -65,7 +65,7 @@ RSpec.describe "Facilitators can submit a workshop log" do
         file_inputs = page.all('input[type="file"]', visible: :all)
         file_inputs.last.set(Rails.root.join('spec/fixtures/some_file1.png'))
         # Submit
-        click_button "Save Log"
+        click_button "Submit"
         expect(page).to have_content("Thank you for submitting a workshop log")
       end
 
@@ -76,21 +76,21 @@ RSpec.describe "Facilitators can submit a workshop log" do
         select "The best workshop in the world", from: "workshop_log[workshop_id]"
         fill_in "workshop_log[date]", with: 1.day.ago.strftime("%m-%d-%Y")
         select "", from: "workshop_log[project_id]"
-        click_button "Save Log"
+        click_button "Submit"
         expect(page).to have_content("Project must exist")
 
         # Missing workshop
         visit new_workshop_log_path
         select @project.name, from: "workshop_log[project_id]"
         fill_in "workshop_log[date]", with: 1.day.ago.strftime("%m-%d-%Y")
-        click_button "Save Log"
+        click_button "Submit"
         expect(page).to have_content("Workshop must exist")
 
         # Missing date
         visit new_workshop_log_path
         select "The best workshop in the world", from: "workshop_log[workshop_id]"
         select @project.name, from: "workshop_log[project_id]"
-        click_button "Save Log"
+        click_button "Submit"
         expect(page).to have_content("Date can't be blank")
       end
     end

--- a/spec/system/resource_asset_upload_spec.rb
+++ b/spec/system/resource_asset_upload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Resource asset upload", type: :system do
     )
 
     # Submit the asset form
-    click_button "Upload Asset"
+    click_button "Submit"
   end
 
 

--- a/spec/system/story_idea_asset_upload_spec.rb
+++ b/spec/system/story_idea_asset_upload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Story Idea asset upload", type: :system do
     )
 
     # Submit the asset form
-    click_button "Upload Asset"
+    click_button "Submit"
   end
 
   def delete_asset(asset_type:)

--- a/spec/system/workshop_variation_asset_upload_spec.rb
+++ b/spec/system/workshop_variation_asset_upload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Workshop Variation asset upload", type: :system do
     )
 
     # Submit the asset form
-    click_button "Upload Asset"
+    click_button "Submit"
   end
 
   def delete_asset(asset_type:)


### PR DESCRIPTION
### What is the goal of this PR and why is this important? 
Addresses #822 

My understanding from our meeting with Rudy was that for forms that create and update objects, using "Submit" consistently could be an improvement.  Looked for forms that used phrases like "Update Logs" or "Create x" to update.   

Some forms that are doing other tasks like "Resend confirmation instructions", "sign up",  or "Set password" etc, I kept the same since I think it's clearer for them to have these custom captions for their services.


