### PR TITLE
Registration create/destroy: use event_registration policy which matches the record

### DIFF
--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -4,7 +4,7 @@ module Events
 
     def create
       @event_registration = @event.event_registrations.new(registrant: current_user)
-      authorize! :event_registration, to: :create?
+      authorize! @event_registration
 
       if @event_registration.save
         success = "You have successfully registered for this event."
@@ -20,51 +20,32 @@ module Events
         end
       end
     end
-    #
-    # def destroy
-    #   registration = @event.event_registrations.find_by(registrant: current_user)
-    #   authorize! :event_registration, to: :destroy?
-    #
-    #   unless registration
-    #     return respond_with_alert("Registration not found")
-    #   end
-    #
-    #   if registration.destroy
-    #     respond_with_notice("You are no longer registered.")
-    #   else
-    #     respond_with_alert(registration.errors.full_messages.to_sentence)
-    #   end
-    # end
 
     def destroy
-      registration = @event.event_registrations.find_by(registrant: current_user)
-      authorize! :event_registration, to: :destroy?
+      @event_registration = @event.event_registrations.find_by(registrant: current_user)
+      authorize! @event_registration
 
-      unless registration
+      unless @event_registration
+        alert = "Registration not found"
         respond_to do |format|
-          format.turbo_stream do
-            flash.now[:alert] = "Registration not found"
-            render turbo_stream: turbo_stream.replace(
-              "flash",
-              partial: "shared/flash_messages"
-            )
-          end
-          format.html { redirect_to @event, alert: "Registration not found" }
+          format.turbo_stream { flash.now[:alert] = alert }
+          format.html { redirect_to @event, alert: alert }
         end
         return
       end
 
-      registration.destroy!
-
-      respond_to do |format|
-        format.turbo_stream do
-          flash.now[:notice] = "You are no longer registered."
-          render turbo_stream: turbo_stream.replace(
-            "flash",
-            partial: "shared/flash_messages"
-          )
+      if @event_registration.destroy
+        success = "You are no longer registered."
+        respond_to do |format|
+          format.turbo_stream { flash.now[:notice] = success }
+          format.html { redirect_to @event, notice: success }
         end
-        format.html { redirect_to @event, notice: "You are no longer registered." }
+      else
+        error = @event_registration.errors.full_messages.to_sentence
+        respond_to do |format|
+          format.turbo_stream { flash.now[:alert] = error }
+          format.html { redirect_to @event, alert: error }
+        end
       end
     end
 

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -4,6 +4,7 @@ class EventRegistrationPolicy < ApplicationPolicy
   # override or add new rules here that are not defined in ApplicationPolicy
 
   def index?   = admin?
+  def create? = admin? || owner?
   def destroy?   = admin? || owner?
 
 

--- a/app/policies/events/registration_policy.rb
+++ b/app/policies/events/registration_policy.rb
@@ -1,18 +1,18 @@
 class Events::RegistrationPolicy < ApplicationPolicy
-  def manage?  = admin? || owner?
-
-  def create?
-    authenticated?
-  end
-
-  def destroy?
-    admin? || owner?
-  end
-
-  private
-
-  def owner?
-    return false unless user
-    record.registrant_id == user.id
-  end
+  # def manage?  = admin? || owner?
+  #
+  # def create?
+  #   authenticated?
+  # end
+  #
+  # def destroy?
+  #   admin? || owner?
+  # end
+  #
+  # private
+  #
+  # def owner?
+  #   return false unless user
+  #   record.registrant_id == user.id
+  # end
 end

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Event show page", type: :system do
   describe "registration button updates via Turbo", js: true do
     before { driven_by(:selenium_chrome_headless) }
 
-    xit "updates Register to De-register and shows badge without full page reload" do # TODO - figure out why register turbo isn't working. line 150 was failing
+    it "updates Register to De-register and shows badge without full page reload" do
       sign_in(user)
       visit event_path(event)
 
@@ -153,7 +153,7 @@ RSpec.describe "Event show page", type: :system do
       expect(page).not_to have_button("Register")
     end
 
-    xit "updates De-register back to Register after de-registering" do # TODO - figure out why de-register turbo isn't working
+    it "updates De-register back to Register after de-registering" do
       create(:event_registration, event: event, registrant: user)
 
       sign_in(user)


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Fix event registrations with new action policy.

### How did you approach the change?
<!-- What did you do? -->

I don't believe `Events:RegistrationPolicy` is being used which makes sense I think. We have the the `Events::RegistrationController` to handle a registrant. Currently a registration is a User so we don't need a separate policy for that. What we are handling is the `event_registration` record. 

I changed this to pass in the `event_registration` record and check the record against the current_user.

I also reverted the turbo_responds changes which was the reason the destroy action wasn't updating the view. The record was deleted but the view wasn't updated because we only where sending a replace of the flash message. Reverting to using the full turbo_stream `destroy.turbo_stream.erb` template.

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

