### PR TITLE
Fix display on Taggings index 

### DIFF
--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -2,7 +2,7 @@ class ResourceDecorator < ApplicationDecorator
   include ::Linkable
 
   def detail(length: nil)
-    length ? text&.truncate(length) : text  # TODO - rename field
+    length ? body&.truncate(length) : body  # TODO - rename field
   end
 
   def default_display_image

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,6 +29,12 @@ class Category < ApplicationRecord
     category_type_id.present? ? where(category_type_id: category_type_id) : all }
   scope :category_name, ->(category_name) {
     category_name.present? ? where("categories.name LIKE ?", "%#{category_name}%") : all }
+  scope :category_names_all, ->(names) do
+    return all if names.blank?
+    parsed = Array(names).flat_map { |n| n.to_s.split("--") }.map(&:strip).reject(&:blank?).map(&:downcase)
+    return all if parsed.empty?
+    where("LOWER(categories.name) IN (?)", parsed)
+  end
 
   private
 

--- a/app/views/taggings/index.html.erb
+++ b/app/views/taggings/index.html.erb
@@ -1,7 +1,7 @@
 <% sector_names = @sector_names_all.to_s.split("--").join(", ") %>
 <% category_full_names =
      if @category_names_all.present?
-       Category.names(@category_names_all)
+       Category.category_names_all(@category_names_all)
                .includes(:category_type)
                .map { |c| "#{c.category_type&.name&.titleize}: #{c.name}" }
                .join(", ")
@@ -25,7 +25,7 @@
     </div>
 
     <!-- ACTIVE FILTERS -->
-    <% if sector_names.present? || category_full_names.present? %>
+    <% if sector_names.present? || category_full_names.present? || @category_names_all.present? %>
       <div class="mt-4 text-center">
         <% if sector_names.present? %>
           <div class="text-3xl md:text-4xl font-semibold text-gray-900 leading-tight">
@@ -33,9 +33,9 @@
           </div>
         <% end %>
 
-        <% if category_full_names.present? %>
+        <% if category_full_names.present? || @category_names_all.present? %>
           <div class="mt-2 text-base md:text-lg text-gray-600 font-semibold">
-            <%= category_full_names %>
+            <%= category_full_names || @category_names_all %>
           </div>
         <% end %>
       </div>
@@ -46,7 +46,7 @@
   <div class="space-y-6">
 
     <!-- EMPTY / NO RESULTS STATES -->
-    <% if sector_names.blank? && category_full_names.blank? %>
+    <% if sector_names.blank? && category_full_names.blank? && @category_names_all.blank? %>
       <div class="bg-white border border-gray-200 rounded-xl p-10 text-center text-gray-400">
         Select a service population or explore tags to view related content.
       </div>
@@ -55,7 +55,7 @@
       <div class="bg-white border border-gray-200 rounded-xl p-10 text-center text-gray-500">
         No items have this tag combination:
         <div class="font-semibold text-gray-700">
-          <%= [sector_names.presence, category_full_names.presence].compact.join(", ") %>
+          <%= [sector_names.presence, category_full_names.presence, @category_names_all.presence].compact.join(", ") %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
- Fix page so only full-match category_names_all are mentioned and matched

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->
Before (`Teen` matches many categories):
<img width="1004" height="526" alt="Screenshot 2026-02-09 at 10 38 24 AM" src="https://github.com/user-attachments/assets/078158af-b450-467c-b018-afc5ef9e273a" />

After (`Teen` matches no categories):
<img width="930" height="432" alt="Screenshot 2026-02-09 at 10 38 54 AM" src="https://github.com/user-attachments/assets/59d9caa5-a7fe-4b19-bf16-52f1ee0141c6" />
