### PR TITLE
Add system test for viewing Community News on dashboard

### DIFF
--- a/spec/system/person_views_community_news_spec.rb
+++ b/spec/system/person_views_community_news_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Facilitators can view Community News on the dashboard' do
+RSpec.describe 'People can view Community News on the dashboard' do
   describe 'Viewing Community News and Events' do
     before do
       page.driver.browser.manage.window.resize_to(1400, 4000)
-      
       user = create(:user)
       create(:person, user: user)
-      
+
       create(
         :event,
         :featured,
@@ -18,7 +17,7 @@ RSpec.describe 'Facilitators can view Community News on the dashboard' do
         end_date: 3.weeks.from_now,
         description: 'Join us for our annual leadership conference'
       )
-      
+
       create(
         :community_news,
         :featured,
@@ -27,7 +26,7 @@ RSpec.describe 'Facilitators can view Community News on the dashboard' do
         title: 'March Community Newsletter',
         rhino_body: '<p>Exciting updates this month!</p>'
       )
-      
+
       sign_in user
       visit '/'
     end
@@ -37,13 +36,10 @@ RSpec.describe 'Facilitators can view Community News on the dashboard' do
         expect(page).to have_content('Upcoming Events')
       end
 
-      it 'has a "View all events" link' do
-        expect(page).to have_link('View all events')
-      end
-
       it 'navigates to events page when "View all events" is clicked' do
+        expect(page).to have_link('View all events')
         click_link('View all events')
-        
+
         expect(page).to have_current_path(events_path)
         expect(page).to have_content('Community of Practice Events')
         expect(page).to have_content('Annual Leadership Summit')
@@ -55,13 +51,10 @@ RSpec.describe 'Facilitators can view Community News on the dashboard' do
         expect(page).to have_content('Community News')
       end
 
-      it 'has a "Read all news" link' do
-        expect(page).to have_link('Read all news')
-      end
-
       it 'navigates to community news page when "Read all news" is clicked' do
+        expect(page).to have_link('Read all news')
         click_link('Read all news')
-        
+
         expect(page).to have_current_path(community_news_index_path)
         expect(page).to have_content('Community news')
         expect(page).to have_content('March Community Newsletter')


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #42

### What is the goal of this PR and why is this important? 
Add a system test to verify facilitators/people can view Community News and Upcoming Events on the dashboard.

### How did you approach the change?
Wrote a system test that logs in a person and verifies the Community News and Upcoming Events sections exist with working navigation links.


### Anything else to add?
Added window resize to ensure all dashboard elements are visible during testing.

