### PR TITLE
Update button to remove Organization User async with turbo

### DIFF
--- a/app/controllers/organization_users_controller.rb
+++ b/app/controllers/organization_users_controller.rb
@@ -5,13 +5,27 @@ class OrganizationUsersController < ApplicationController
     authorize! @organization_user, to: :destroy?
     organization_user = OrganizationUser.find(params[:id])
     user = organization_user.user
+    destroyed = organization_user.destroy
 
-    if organization_user.destroy
-      flash[:notice] = "Organization user has been deleted."
+    if destroyed
+      flash.now[:notice] = "Person has been removed from the organization."
     else
-      flash[:alert] = "Unable to delete organization user.  Please contact AWBW."
+      flash.now[:alert] = "Unable to remove organization user. Please contact AWBW."
     end
-    redirect_to generate_facilitator_user_path(user)
+
+    respond_to do |format|
+      format.turbo_stream do
+        if destroyed
+          render :destroy
+        else
+          render turbo_stream: turbo_stream.replace("flash_now", partial: "shared/flash_messages"),
+                 status: :unprocessable_entity
+        end
+      end
+      format.html do
+        redirect_to generate_facilitator_user_path(user)
+      end
+    end
   end
 
   private

--- a/app/views/organizations/_organization_user_fields.html.erb
+++ b/app/views/organizations/_organization_user_fields.html.erb
@@ -1,5 +1,5 @@
 <% if current_user&.super_user? %>
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-start mb-4">
+  <div class="nested-fields grid grid-cols-1 md:grid-cols-4 gap-4 items-start mb-4"<% if f.object.persisted? %> id="<%= dom_id(f.object) %>"<% end %>>
 
     <div>
       <%= f.input :user_id,
@@ -32,9 +32,20 @@
                     input_html: { class: "h-4 w-4 text-blue-600 border-gray-300 rounded" } %>
       </div>
 
-      <%= link_to_remove_association "✖ Remove",
-                                     f,
-                                     class: "btn btn-danger-outline whitespace-nowrap" if f.object&.persisted? %>
+      <% if f.object.persisted? %>
+        <%= link_to "✖ Remove",
+                    organization_user_path(f.object),
+                    data: {
+                      turbo_method: :delete,
+                      turbo_confirm: "Remove this person from the organization?",
+                      turbo_stream: true
+                    },
+                    class: "btn btn-danger-outline whitespace-nowrap" %>
+      <% else %>
+        <%= link_to_remove_association "✖ Remove",
+                                       f,
+                                       class: "btn btn-danger-outline whitespace-nowrap" %>
+      <% end %>
     </div>
   </div>
 <% else %>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [#889 ]

### What is the goal of this PR and why is this important? 
Remove button for Organization Users wasn't working.  Opted to try getting it to remove Users asynch from rest of the form with Turbo.  Seems to work well.



https://github.com/user-attachments/assets/37f8afea-957c-4d79-a6ce-0c3dfafa528c


