### PR TITLE
Rightsize the database connection pool for inprocess solidqueue

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ base: &base
   adapter: trilogy
   encoding: utf8mb4              # <-- forces UTF-8 everywhere
   collation: utf8mb4_unicode_ci  # <-- portable across MySQL 5.7/8.0 and MariaDB
-  pool: 5
+  pool: <%= ENV.fetch("DB_POOL", 10) %>
   user: root
   password:
   host: 127.0.0.1


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Reduce waiting time -- we're seeing some in HoneyComb already. Not clear _why_ but this is one possibility.
### How did you approach the change?
<!-- What did you do? -->
Checked the number. 

Currently 5
Needs: 7 -- 3 (puma) + 4 (3 solid queue running in puma plus 1 for supervisor)

Made it configurable, default to 10. Extra connections are close to free.
### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

