### PR TITLE
Add truncated event description to event card

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -29,8 +29,8 @@
   </div>
 
 <div class="flex flex-col gap-2 flex-1 min-w-0 pr-1 mr-4 mt-1">
-  <div class="text-sm text-blue-600 font-medium overflow-hidden text-ellipsis whitespace-nowrap">
-    <%= event.rhino_description %>
+  <div class="text-sm font-medium overflow-hidden text-ellipsis whitespace-nowrap">
+    <%= event.rhino_description.to_plain_text %>
   </div>
 </div>
 


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #818

### What is the goal of this PR and why is this important? 
To add a truncated event description to the event card

### How did you approach the change?
Followed the implementation instructions in the issue

### Anything else to add?
I went with Tailwind’s text-ellipsis instead of character-based truncation so it’s responsive. The ... isn’t showing, likely because rhino_description contains HTML?. Do we actually need the ... dots to show, or is visual truncation enough?

