### PR TITLE
Add CategoryType CRUD and admin UI improvements

### DIFF
--- a/app/controllers/category_types_controller.rb
+++ b/app/controllers/category_types_controller.rb
@@ -1,0 +1,64 @@
+class CategoryTypesController < ApplicationController
+  before_action :set_category_type, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    authorize!
+    per_page = params[:number_of_items_per_page].presence || 25
+    base_scope = authorized_scope(CategoryType.all)
+    @count_display = base_scope.count
+    @category_types = base_scope.order(:name).paginate(page: params[:page], per_page: per_page).decorate
+  end
+
+  def show
+    @category_type = @category_type.decorate
+    authorize! @category_type
+  end
+
+  def new
+    @category_type = CategoryType.new.decorate
+    authorize! @category_type
+  end
+
+  def edit
+    @category_type = @category_type.decorate
+    authorize! @category_type
+  end
+
+  def create
+    @category_type = CategoryType.new(category_type_params)
+    authorize! @category_type
+
+    if @category_type.save
+      redirect_to category_types_path, notice: "Category type was successfully created."
+    else
+      @category_type = @category_type.decorate
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    authorize! @category_type
+    if @category_type.update(category_type_params)
+      redirect_to category_types_path, notice: "Category type was successfully updated.", status: :see_other
+    else
+      @category_type = @category_type.decorate
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    authorize! @category_type
+    @category_type.destroy!
+    redirect_to category_types_path, notice: "Category type was successfully destroyed."
+  end
+
+  private
+
+  def set_category_type
+    @category_type = CategoryType.find(params[:id])
+  end
+
+  def category_type_params
+    params.require(:category_type).permit(:name, :display_text, :published, :story_specific)
+  end
+end

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -28,9 +28,9 @@
 }
 
 /* Used to generate classes from `domain_theme.rb`*/
-@source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray}-{50,{100..900..100},950}");
-@source inline("border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray}-{200,300}");
-@source inline("text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray}-{50,{100..900..100},950}");
+@source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,fuchsia,pink}-{50,{100..900..100},950}");
+@source inline("border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,fuchsia,pink}-{200,300}");
+@source inline("text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,fuchsia,pink}-{50,{100..900..100},950}");
 
 /* ✅ Safelist dynamically generated colors */
 @layer utilities {

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -44,14 +44,15 @@ module AdminCardsHelper
   # -----------------------------
   def reference_cards
     [
+      model_card(:category_types, icon: "📂", intensity: 100),
       model_card(:categories, icon: "🗂️",
                  intensity: 100,
                  params: { published: true }),
+      custom_card("Organization statuses", organization_statuses_path, icon: "🧮", color: :emerald, intensity: 100),
       model_card(:sectors, icon: "🏭",
                  intensity: 100,
                  title: "Sectors",
                  params: { published: true }),
-      custom_card("Organization statuses", organization_statuses_path, icon: "🧮", color: :emerald, intensity: 100),
       custom_card("Windows types", windows_types_path, icon: "🪟")
     ]
   end

--- a/app/policies/category_type_policy.rb
+++ b/app/policies/category_type_policy.rb
@@ -8,4 +8,9 @@ class CategoryTypePolicy < ApplicationPolicy
   def create?  = admin?
   def update?  = admin?
   def destroy? = record.persisted? && admin?
+
+  relation_scope do |relation|
+    next relation if admin?
+    relation.none
+  end
 end

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-7xl mx-auto px-6 py-8 space-y-10">
   <div class="admin-only bg-blue-100 rounded p-6">
     <div class="bg-gray-50 rounded p-6">
-      <div class="flex justify-between items-center mb-6">
+      <div class="mb-6">
         <section class="px-8">
           <div class="flex flex-col items-start mb-4">
             <h1 class="text-3xl font-bold text-gray-900 my-2">Admin Home</h1>
@@ -54,21 +54,20 @@
 
           <div class="mt-20">
             Base data
-           <div class="flex flex-wrap gap-6 mt-3">
+           <div class="flex flex-wrap gap-4 mt-3">
               <% @reference_cards.each do |card| %>
                 <a href="<%= card[:path] %>"
-                 class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+                 class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
                   <%= card[:bg_color] %> <%= card[:text_color] %>
                   <%= card[:hover_bg_color] %>
-                  transition-colors transition-shadow duration-300 p-4
-                  w-full sm:w-1/2 lg:w-1/3">
+                  transition-colors transition-shadow duration-300 px-4 py-3 flex-1">
 
-                  <div class="text-5xl text-gray-700 flex-shrink-0">
+                  <div class="text-3xl text-gray-700 flex-shrink-0">
                     <%= card[:icon] %>
                   </div>
 
-                  <div class="flex-1">
-                    <h3 class="text-xl font-bold text-gray-800 break-words"><%= card[:title] %></h3>
+                  <div>
+                    <h3 class="text-base font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
                   </div>
 
                 </a>

--- a/app/views/category_types/_form.html.erb
+++ b/app/views/category_types/_form.html.erb
@@ -1,0 +1,40 @@
+<%= simple_form_for(@category_type) do |f| %>
+  <div class="form-body space-y-6">
+    <%= f.error_notification %>
+    <%= render "shared/errors", resource: @category_type if @category_type.errors.any? %>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <%= f.input :name,
+                  label: "Name",
+                  input_html: { class: "form-control" },
+                  required: true %>
+      <%= f.input :display_text,
+                  label: "Display Text",
+                  hint: "For display on story idea form",
+                  input_html: { class: "form-control" } %>
+      <div class="flex flex-col items-start gap-4 pt-6">
+        <%= f.input :published,
+                    as: :boolean,
+                    label: "Published",
+                    hint: "Hides all child categories",
+                    input_html: { class: "h-4 w-4" },
+                    wrapper_html: { class: "mb-0" } %>
+        <%= f.input :story_specific,
+                    as: :boolean,
+                    label: "Story specific",
+                    hint: "Needed for story share subsite",
+                    input_html: { class: "h-4 w-4" },
+                    wrapper_html: { class: "mb-0" } %>
+      </div>
+    </div>
+
+    <div class="action-buttons mt-8 flex justify-center gap-3">
+      <% if allowed_to?(:destroy?, f.object) %>
+        <%= link_to "Delete", @category_type, class: "btn btn-danger-outline",
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } %>
+      <% end %>
+      <%= link_to "Cancel", category_types_path, class: "btn btn-secondary-outline" %>
+      <%= f.button :submit, class: "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="min-h-screen py-8">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @category_type.class.model_name.human %></h1>
+        <%= link_to "View", category_type_path(@category_type),
+                            class: "btn btn-secondary-outline" %>
+      </div>
+
+      <div class="space-y-6">
+        <div class="mt-4">
+          <%= render "form" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -1,0 +1,93 @@
+<div class="min-h-screen py-8">
+  <div class="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="admin-only bg-blue-100 rounded p-6">
+      <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:category_types, intensity: 100) %>
+        border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
+      <div class="space-y-6">
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-semibold text-gray-900">
+            <%= CategoryType.model_name.human.pluralize %> (<%= @count_display %>)
+          </h1>
+          <div class="flex gap-2">
+            <%= link_to("New #{ CategoryType.model_name.human.downcase }",
+                        new_category_type_path,
+                        class: "btn btn-primary-outline") %>
+          </div>
+        </div>
+
+        <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Name</th>
+                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Display text</th>
+                <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Published</th>
+                <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Story specific</th>
+                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Categories count</th>
+                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700 w-32">Actions</th>
+              </tr>
+            </thead>
+
+            <tbody class="divide-y divide-gray-100">
+              <% @category_types.each do |category_type| %>
+              <tr>
+                <td class="px-4 py-2 text-gray-700 text-base font-bold">
+                  <%= category_type.name %>
+                </td>
+
+                <td class="px-4 py-2 text-gray-700">
+                  <%= category_type.display_text %>
+                </td>
+
+                <td class="px-4 py-2 text-center text-gray-700">
+                  <% if category_type.published? %>
+                    <span class="fa fa-check-circle text-green-500"></span>
+                  <% else %>
+                    <span class="text-gray-400">--</span>
+                  <% end %>
+                </td>
+
+                <td class="px-4 py-2 text-center text-gray-700">
+                  <% if category_type.story_specific? %>
+                    <span class="fa fa-check-circle text-green-500"></span>
+                  <% else %>
+                    <span class="text-gray-400">--</span>
+                  <% end %>
+                </td>
+
+                <td class="px-4 py-2 text-gray-700">
+                  <%= link_to category_type.categories.count,
+                              categories_path(category_type_id: category_type.id),
+                              class: "btn btn-secondary-default" %>
+                </td>
+
+                <td class="px-4 py-2">
+                  <div class="flex items-center gap-3">
+                    <%= link_to "Edit",
+                                edit_category_type_path(category_type),
+                                class: "btn btn-secondary-outline" %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Empty state -->
+        <% unless @category_types.any? %>
+          <p class="text-gray-500 text-center py-6">
+            No <%= CategoryType.model_name.human.pluralize.downcase %> found.
+          </p>
+        <% end %>
+
+        <!-- Pagination -->
+        <div class="pagination flex justify-center mt-12">
+          <%= tailwind_paginate @category_types %>
+        </div>
+      </div>
+    </div>
+    </div>
+  </div>
+</div>

--- a/app/views/category_types/new.html.erb
+++ b/app/views/category_types/new.html.erb
@@ -1,0 +1,17 @@
+<div class="min-h-screen py-8">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
+      <div class="flex items-center justify-between mb-3">
+        <h1 class="text-2xl font-semibold text-gray-900">New <%= @category_type.class.model_name.human %></h1>
+      </div>
+
+      <div class="border-b border-gray-300 mb-6"></div>
+
+      <div class="space-y-6">
+        <div class="mt-4">
+          <%= render "form" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -1,0 +1,68 @@
+<div class="min-h-screen py-8">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
+      <div class="flex items-center justify-between mb-6">
+        <!-- Title -->
+        <h1 class="text-2xl font-semibold text-gray-900">
+          Category type details: <%= @category_type.name %>
+        </h1>
+
+        <!-- Buttons Group -->
+        <div class="flex items-center gap-2">
+          <%= link_to("Category types", category_types_path, class: "btn btn-secondary-outline") %>
+          <%= link_to("Categories", categories_path(category_type_id: @category_type.id), class: "btn btn-secondary-outline") %>
+          <%= link_to "Dashboard", root_path, class: "btn btn-secondary-outline" %>
+          <%= link_to("Edit", edit_category_type_path(@category_type), class: "btn btn-primary-outline") %>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-6 mt-2 mb-2">
+        <p class="text-gray-700">
+          <span class="font-bold">Published:</span>
+          <% if @category_type.published? %>
+            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+          <% else %>
+            <span class="text-gray-400 ml-1">--</span>
+          <% end %>
+        </p>
+        <p class="text-gray-700">
+          <span class="font-bold">Story specific:</span>
+          <% if @category_type.story_specific? %>
+            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+          <% else %>
+            <span class="text-gray-400 ml-1">--</span>
+          <% end %>
+        </p>
+        <p class="text-gray-700">
+          <span class="font-bold">Display text:</span>
+          <span class="ml-1"><%= @category_type.display_text %></span>
+        </p>
+      </div>
+
+      <!-- Associated Categories -->
+      <div class="pt-6 border-t border-gray-200">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">
+          Associated Categories
+        </h2>
+
+        <% if @category_type.categories.any? %>
+          <ul class="space-y-2">
+            <% @category_type.categories.order(:position, :name).each do |category| %>
+              <li class="bg-gray-50 border border-gray-200 rounded-md px-4 py-2">
+                <%= link_to taggings_path(category_names_all: category.name),
+                            class: "font-medium text-gray-900 hover:text-blue-600" do %>
+                  <%= category.name %>
+                  <span class="text-sm text-gray-500 ml-2">(<%= category.categorizable_items.count %> taggings)</span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-sm text-gray-500 italic">
+            No categories are currently associated with this category type.
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen py-8">
   <div class="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
     <div class="admin-only bg-blue-100 rounded p-6">
-      <div class="max-w-7xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl
+      <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow-lg hover:shadow-xl
         transition-shadow duration-200 p-6">
       <div class="space-y-6">
         <!-- Header -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
       get :personal
     end
   end
+  resources :category_types
   resources :categories do
     collection do
       get :dedupe_index

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -16,6 +16,7 @@ module DomainTheme
     tags:                     :lime,
     sectors:                  :lime,
     categories:               :lime,
+    category_types:            :lime,
 
     faqs:                     :stone,
 
@@ -24,8 +25,8 @@ module DomainTheme
     story_ideas:              :rose,
     event_registrations:      :blue,
 
-    banners:                  :stone,
-    users:                    :stone,
+    banners:                  :yellow,
+    users:                    :fuchsia,
 
     admin_only:               :blue,
     user_only:                :amber,


### PR DESCRIPTION
## Summary
- Add full CRUD (controller, views, routes, policy) for CategoryTypes, following existing OrganizationStatuses pattern
- Add CategoryType card to admin home base data section with compact, equal-width layout
- Update DomainTheme colors: category_types (lime), banners (yellow), users (fuchsia)
- Add fuchsia and pink to Tailwind CSS safelist for dynamic class generation
- Apply DomainTheme styling to users index page

## Test plan
- [ ] Verify CategoryType index, show, new, edit, and destroy all work
- [ ] Verify admin home base data section displays cards in a single row with equal widths
- [ ] Verify fuchsia color appears on users index and admin home users card
- [ ] Verify yellow color appears on banners card on admin home
- [ ] Verify lime color appears on category types card on admin home

🤖 Generated with [Claude Code](https://claude.com/claude-code)