### PR TITLE
Fix people search not matching on name fields

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -71,6 +71,18 @@ class Person < ApplicationRecord
     attributes user_email:      "user.email"
     attributes user_phone:      "user.phone"
     attributes contact_methods_phone: "contact_methods.value"
+    attributes address_street: "addresses.street_address"
+    attributes address_city:   "addresses.city"
+    attributes address_state:  "addresses.state"
+    attributes address_zip:    "addresses.zip_code"
+    attributes address_phone:  "addresses.phone"
+
+    attributes all: [ :first_name, :last_name, :email, :email_2,
+                      :user_first_name, :user_last_name, :user_email, :user_phone,
+                      :contact_methods_phone,
+                      :address_street, :address_city, :address_state, :address_zip,
+                      :address_phone ]
+    options :all, type: :text, default: true, default_operator: :or
   end
 
   scope :published, -> { searchable.with_active_affiliations }


### PR DESCRIPTION
The SearchCop search_scope was missing a default field mapping, so plain text queries (e.g. "Karla", "Lopez") didn't search any fields by default. Added an `all` attribute group with `default: true` covering first_name, last_name, email, and email_2 — matching the pattern used by Workshop and other models.

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

