### PR TITLE
Fix org address search to support multi-term queries

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -71,6 +71,7 @@ class Organization < ApplicationRecord
         addresses.country LIKE :wildcard OR
         addresses.district LIKE :wildcard OR
         addresses.locality LIKE :wildcard OR
+        addresses.phone LIKE :wildcard OR
         addresses.zip_code LIKE :wildcard OR
         CAST(addresses.la_city_council_district AS CHAR) LIKE :wildcard OR
         CAST(addresses.la_service_planning_area AS CHAR) LIKE :wildcard OR

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Organization do
       results = Organization.address("Los Angeles")
       expect(results).not_to include(org_no_address)
     end
+
+    it 'finds organization by phone number' do
+      org_la.addresses.first.update!(phone: "213-555-1234")
+      results = Organization.address("213-555-1234")
+      expect(results).to include(org_la)
+      expect(results).not_to include(org_ny)
+    end
   end
 
   describe '.search_by_params' do


### PR DESCRIPTION
Split address search input into individual terms so full addresses like "123 Main St, Los Angeles, CA 90001" match across fields. Previously the entire string was matched against each field individually, returning 0 results. Also switch from left_joins to joins with distinct to prevent duplicates.

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

