### PR TITLE
Update tags_controller to use scopings on sectors and categories

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -7,13 +7,14 @@ class TagsController < ApplicationController
 
   def sectors
     authorize! Sector, to: :tags_index?
-    @sectors = Sector.published.order(:name)
+    @sectors = Sector.published.has_taggings.order(:name)
   end
 
   def categories
     authorize! Category, to: :tags_index?
     @categories_by_type = Category
       .published
+      .has_taggings
       .joins(:category_type)
       .select("categories.*, category_types.name AS category_type_name")
       .order("category_types.name, categories.position, categories.name")

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -26,6 +26,7 @@ class Category < ApplicationRecord
   after_destroy :expire_categories_cache
 
   # Scopes
+  scope :has_taggings, -> { joins(:categorizable_items).distinct }
   scope :category_type_id, ->(category_type_id) {
     category_type_id.present? ? where(category_type_id: category_type_id) : all }
   scope :category_name, ->(category_name) {

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe "Tags index", type: :request do
   let!(:sector) { create(:sector, :published, name: "Youth") }
   let!(:category_type) { create(:category_type, name: "Theme") }
   let!(:category) { create(:category, :published, name: "Healing", category_type: category_type) }
+  let!(:workshop) { create(:workshop) }
+
+  before do
+    create(:sectorable_item, sector: sector, sectorable: workshop)
+    create(:categorizable_item, category: category, categorizable: workshop)
+  end
 
   describe "as a regular user" do
     let(:user) { create(:user) }
@@ -34,6 +40,22 @@ RSpec.describe "Tags index", type: :request do
       get tags_categories_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Healing")
+    end
+
+    it "only shows sectors that have at least one sectorable_item" do
+      unlinked_sector = create(:sector, :published, name: "Unlinked Sector")
+      get tags_sectors_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Youth")
+      expect(response.body).not_to include("Unlinked Sector")
+    end
+
+    it "only shows categories that have at least one categorizable_item" do
+      unlinked_category = create(:category, :published, name: "Unlinked Category", category_type: category_type)
+      get tags_categories_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Healing")
+      expect(response.body).not_to include("Unlinked Category")
     end
 
     it "does NOT show admin-only controls" do


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [#1066]

### What is the goal of this PR and why is this important? 
The /tags endpoint should only feature button_links to tags that are being used (with at least one taggable) for the Sectors and Categories windows

<img width="1335" height="549" alt="tags" src="https://github.com/user-attachments/assets/e1c400e0-44e5-47d2-9adb-06fbb3fd1650" />
