### PR TITLE
make the turbo progress bar a bit easier to see

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -210,3 +210,11 @@ textarea.comment-truncated:focus {
     display: none !important;
   }
 }
+
+/* Turbo progress bar */
+.turbo-progress-bar {
+  height: 7px;
+  background-color: #0076ff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  border-radius: 0 2px 2px 0;
+}


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Users may not notice the small turbo progress bar. This makes it a bit bigger.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

https://github.com/user-attachments/assets/86e3b4fa-3408-4de3-83df-32825f9afa18



