### PR TITLE
Replace eye-slash icon with closed-eye SVG for password hide toggle

### DIFF
--- a/app/frontend/javascript/controllers/password_toggle_controller.js
+++ b/app/frontend/javascript/controllers/password_toggle_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ["input", "icon"];
+    static targets = ["input", "eyeOpen", "eyeClosed"];
 
     toggle() {
         const isPassword = this.inputTarget.type === "password"
         this.inputTarget.type = isPassword ? "text" : "password"
 
-        this.iconTarget.classList.toggle("fa-eye")
-        this.iconTarget.classList.toggle("fa-eye-slash")
+        this.eyeOpenTarget.style.display = isPassword ? "none" : ""
+        this.eyeClosedTarget.style.display = isPassword ? "" : "none"
     }
 }

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -26,7 +26,8 @@
                                spellcheck: "false",
                       data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa-solid fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa-solid fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
         <p class="text-sm text-gray-500 mt-1">Password must be at least 5 characters long</p>
@@ -47,7 +48,8 @@
                                spellcheck: "false",
                       data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa-solid fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa-solid fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,7 +34,8 @@
             class="toggle-password"
             data-action="password-toggle#toggle"
             aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -21,7 +21,8 @@
                                spellcheck: "false",
                                data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>
@@ -51,7 +52,8 @@
                                spellcheck: "false",
                                data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
         <p class="text-sm text-gray-500 mt-1">Password must be at least 5 characters long</p>
@@ -72,7 +74,8 @@
                                spellcheck: "false",
                                data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -34,7 +34,8 @@
                                spellcheck: "false",
                                data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>
@@ -55,7 +56,8 @@
                                spellcheck: "false",
                                data: { password_toggle_target: "input" } %>
           <button type="button" class="toggle-password" data-action="password-toggle#toggle" aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="icon"></i>
+            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
       </div>


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
- Make the eye toggle friendlier!

BEFORE:

<img width="478" height="449" alt="Screenshot 2026-02-19 at 9 11 29 AM" src="https://github.com/user-attachments/assets/caf17076-401a-424f-83ca-b90a6cf800de" />


AFTER:

<img width="532" height="467" alt="Screenshot 2026-02-19 at 9 10 02 AM" src="https://github.com/user-attachments/assets/613af89b-9323-42df-ade6-ac9d4afa9c83" />

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

