### PR TITLE
Fix people search error and reduce show page queries

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -30,7 +30,7 @@ class PeopleController < ApplicationController
 
   def show
     authorize! @person
-    @person = @person.decorate
+    @person = Person.includes(:avatar_attachment, :contact_methods, :user).find(params[:id]).decorate
     track_view(@person)
 
     # Handle paginated sections for Turbo Frame requests

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -25,15 +25,6 @@ class PersonDecorator < ApplicationDecorator
     "missing.png"
   end
 
-  def facilitator_since_date
-    facilitator_affiliations = affiliations.where("title LIKE ?", "%Facilitator%")
-    facilitator_affiliations.minimum(:start_date) || member_since
-  end
-
-  def affiliated_since_date
-    affiliations.minimum(:start_date)
-  end
-
   def affiliated_end_date
     return nil if affiliations.active.exists?
     affiliations.maximum(:end_date)
@@ -70,6 +61,23 @@ class PersonDecorator < ApplicationDecorator
   end
 
   def badges
+    @badges ||= compute_badges
+  end
+
+  def facilitator_since_date
+    @facilitator_since_date ||= begin
+      facilitator_affiliations = affiliations.where("title LIKE ?", "%Facilitator%")
+      facilitator_affiliations.minimum(:start_date) || member_since
+    end
+  end
+
+  def affiliated_since_date
+    @affiliated_since_date ||= affiliations.minimum(:start_date)
+  end
+
+  private
+
+  def compute_badges
     earliest = facilitator_since_date
     years = earliest ? (Time.zone.now.year - earliest.year) : nil
     badges = []
@@ -88,8 +96,6 @@ class PersonDecorator < ApplicationDecorator
     end
     badges
   end
-
-  private
 
   def badge(label, key)
     {

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -66,6 +66,8 @@ class Person < ApplicationRecord
   include SearchCop
   search_scope :search do
     attributes :first_name, :last_name, :email, :email_2
+
+    scope { left_joins(:user, :contact_methods, :addresses) }
     attributes user_first_name: "user.first_name"
     attributes user_last_name:  "user.last_name"
     attributes user_email:      "user.email"
@@ -78,10 +80,10 @@ class Person < ApplicationRecord
     attributes address_phone:  "addresses.phone"
 
     attributes all: [ :first_name, :last_name, :email, :email_2,
-                      :user_first_name, :user_last_name, :user_email, :user_phone,
-                      :contact_methods_phone,
-                      :address_street, :address_city, :address_state, :address_zip,
-                      :address_phone ]
+                      "user.first_name", "user.last_name", "user.email", "user.phone",
+                      "contact_methods.value",
+                      "addresses.street_address", "addresses.city", "addresses.state",
+                      "addresses.zip_code", "addresses.phone" ]
     options :all, type: :text, default: true, default_operator: :or
   end
 


### PR DESCRIPTION
## Summary
- Fix `SearchCop::UnknownAttribute` error on people search by using association paths (`"user.first_name"`) instead of alias symbols (`:user_first_name`) in the default `all` attribute group, and adding the missing `scope { left_joins }` for cross-table search
- Memoize `badges`, `facilitator_since_date`, and `affiliated_since_date` in `PersonDecorator` to eliminate duplicate queries on the show page
- Eager load `user`, `avatar_attachment`, and `contact_methods` in the people show action

## Test plan
- [ ] Search people by contact info (e.g. "u", "123") — should return results without 500 error
- [ ] View a person show page — verify badges, dates, and contact info render correctly
- [ ] Confirm reduced query count in server logs on person show page

🤖 Generated with [Claude Code](https://claude.com/claude-code)