### PR TITLE
remove print button from resource page

### DIFF
--- a/app/views/resources/_resource_card.html.erb
+++ b/app/views/resources/_resource_card.html.erb
@@ -61,7 +61,7 @@
           <%= link_to(
                 content_tag(:span, "", class: "fa fa-download"),
                 resource_download_path(resource.object),
-                data: { turbo: false, turbo_prefetch: false },
+                download: true,
                 class: "btn btn-utility"
               ) %>
         <% end %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -13,14 +13,11 @@
         <span class="inline-block text-md">
           <%= render "bookmarks/editable_bookmark_button", resource: @resource.object %>
         </span>
-        <span class="inline-block text-md">
-          <%= print_button(@resource, printable_type: "Resource", button_text: "Print page") %>
-        </span>
         <%= link_to ("<span title='Download #{@resource.kind}'>" +
           " Download <span class='fa fa-download'></span></span>").html_safe,
                     resource_download_path(@resource),
                     class: "btn btn-utility",
-                    data: {turbo: false} if @resource.downloadable_asset&.file&.attached? %>
+                    download: true if @resource.downloadable_asset&.file&.attached? %>
       </div>
       <!-- Resource Card -->
       <div class="bg-white rounded-lg shadow-md p-6 space-y-6">


### PR DESCRIPTION
This keeps only the "download" button. Use default browser attribute "download" as turbo can handle this correctly without explicilty disabling turbo.

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #1104 

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Stakeholder request.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

