### PR TITLE
Show email on person profile buttons and bypass obfuscation

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -40,7 +40,9 @@ module PersonHelper
       )
 
       subtitle_tag = if subtitle.present?
-        content_tag(:span, subtitle, class: "text-xs text-gray-500 font-normal truncate")
+        "<!--email_off-->".html_safe +
+          content_tag(:span, subtitle, class: "text-xs text-gray-500 font-normal truncate") +
+          "<!--email_on-->".html_safe
       else
         "".html_safe
       end

--- a/app/views/organizations/_affiliation_fields.html.erb
+++ b/app/views/organizations/_affiliation_fields.html.erb
@@ -6,7 +6,8 @@
     <div style="width: 350px; min-width: 350px; flex-shrink: 0;">
       <% if f.object.persisted? && f.object.person.present? %>
         <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
-        <%= person_profile_button(f.object.person, truncate_at: 30) %>
+        <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
+        <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
         <%= f.hidden_field :person_id %>
       <% else %>
         <%= f.input :person_id,

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -299,7 +299,7 @@
       <% else %>
         <% f.object.user&.person&.affiliations&.each do |affiliation| %>
           <div class="ps-6 mb-2">
-            <li><%= affiliation.title || affiliation.position %> - <%= person_profile_button(affiliation.user.person) if affiliation.persisted? && affiliation.user.person %></li>
+            <li><%= affiliation.title || affiliation.position %> - <%= person_profile_button(affiliation.user.person, subtitle: (affiliation.user.person.preferred_email if affiliation.user.person.profile_show_email? || allowed_to?(:manage?, Person))) if affiliation.persisted? && affiliation.user.person %></li>
           </div>
         <% end %>
       <% end %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -22,7 +22,8 @@
               <% cache [person, current_user.super_user?] do %>
               <tr class="hover:bg-gray-50 transition-colors duration-150">
                 <td class="px-4 py-2">
-                  <%= person_profile_button(person, subtitle: person.preferred_email, data: { turbo_frame: "_top" }) %>
+                  <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
+                  <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
                 </td>
                 <td class="px-4 py-2 text-center text-sm text-gray-800">
                   <%= person.member_since&.year %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -70,9 +70,9 @@
           <!-- Contact info + social -->
           <div class="mt-3 flex flex-wrap justify-center md:justify-start items-center gap-x-4 gap-y-2 text-sm">
             <% email = @person.user&.email || @person.email %>
-            <% if @person.profile_show_email? && email.present? %>
+            <% if (@person.profile_show_email? || allowed_to?(:manage?, Person)) && email.present? %>
               <span class="text-gray-600">
-                📧 <%= mail_to email, email, class: "text-blue-600 hover:underline" %>
+                📧 <!--email_off--><%= mail_to email, email, class: "text-blue-600 hover:underline" %><!--email_on-->
               </span>
             <% end %>
             <% phone = @person.phone_number || @person.user&.phone %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -41,7 +41,8 @@
             <td class="px-4 py-2 text-left">
               <% if user.person %>
                 <% cache [user.person, "profile_button"] do %>
-                  <%= person_profile_button(user.person) %>
+                  <% show_email = user.person.profile_show_email? || allowed_to?(:manage?, Person) %>
+                  <%= person_profile_button(user.person, subtitle: (user.person.preferred_email if show_email)) %>
                 <% end %>
               <% else %>
                 <%= link_to "Create person",


### PR DESCRIPTION
Display preferred_email as subtitle on person_profile_button across views when the person has opted in (profile_show_email) or the viewer can manage People. Wrap email output with email_off/email_on comments to prevent address obfuscation.

We'll see if it works. 

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #1067

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

