### PR TITLE
Rename Tutorial to Video Gallery using i18n translation

### DIFF
--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -207,7 +207,7 @@
             %>
 
             <%= render "admin/analytics/popular_list",
-                       title: "Tutorials",
+                       title: Tutorial.model_name.human(count: 2),
                        records: @most_viewed_tutorials,
                        path_method: :tutorial_path,
                        metric: :view_count,

--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -18,8 +18,8 @@
   <% end %>
 
   <%= link_to tutorials_path, class: "flex items-center space-x-2 text-gray-800 px-3 py-2 rounded hover:bg-gray-100 w-max" do %>
-    <i class="fas fa-circle-info"></i>
-    <span>Tutorials</span>
+    <i class="fas fa-circle-play"></i>
+    <span><%= Tutorial.model_name.human(count: 2) %></span>
   <% end %>
 
   <%= link_to "https://www.awbw.org", target: "_blank", class: "flex items-center space-x-2 text-gray-800 px-3 py-2 rounded hover:bg-gray-100 w-max" do %>

--- a/app/views/shared/_navbar_menu.html.erb
+++ b/app/views/shared/_navbar_menu.html.erb
@@ -130,8 +130,8 @@
 
       <%= link_to tutorials_path,
                   class: "flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-        <i class="fas fa-circle-info"></i>
-        <span>Tutorials</span>
+        <i class="fas fa-circle-play"></i>
+        <span><%= Tutorial.model_name.human(count: 2) %></span>
       <% end %>
 
       <%= link_to "https://www.awbw.org", target: "_blank", rel: "noopener noreferrer",

--- a/app/views/shared/_navbar_menu_mobile.html.erb
+++ b/app/views/shared/_navbar_menu_mobile.html.erb
@@ -107,8 +107,8 @@
 
         <%= link_to tutorials_path, class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-circle-info"></i>
-          <span>Tutorials</span>
+          <i class="fas fa-circle-play"></i>
+          <span><%= Tutorial.model_name.human(count: 2) %></span>
         <% end %>
 
         <%= link_to "https://www.awbw.org", target: "_blank", class: "flex items-center px-4 py-2 text-sm text-white

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -4,7 +4,7 @@
     <div class="flex items-start justify-between mb-6">
       <div class="pr-6">
         <h2 class="text-2xl font-semibold mb-2">
-          Tutorials
+          <%= Tutorial.model_name.human(count: 2) %>
         </h2>
 
         <p class="text-gray-600 max-w-2xl">
@@ -38,7 +38,7 @@
             </div>
           <% else %>
             <div class="text-gray-500 italic">
-              No tutorials found matching your filters.
+              No <%= Tutorial.model_name.human(count: 2).downcase %> found matching your filters.
             </div>
           <% end %>
         </div>

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Buttons -->
       <div class="text-right mb-4 space-x-1">
-        <%= link_to "Tutorials", tutorials_path, class: "btn btn-secondary-outline" %>
+        <%= link_to Tutorial.model_name.human(count: 2), tutorials_path, class: "btn btn-secondary-outline" %>
         <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
         <% if allowed_to?(:edit?, @tutorial) %>
           <%= link_to("Edit", edit_tutorial_path(@tutorial),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,11 @@
 
 en:
   hello: "Hello world"
+  activerecord:
+    models:
+      tutorial:
+        one: "Video"
+        other: "Video Gallery"
   helpers:
     submit:
       create: "Submit"


### PR DESCRIPTION

### What is the goal of this PR and why is this important? 
* Add activerecord model name translation for Tutorial (singular: "Video", plural: "Video Gallery") and replace all hardcoded references with model_name.human calls.
* Update nav icons from circle-info to circle-play.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

