### PR TITLE
Extract display image logic into DisplayImagePresenter service

### DIFF
--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+class DisplayImagePresenter
+  WIDTH_CLASSES = {
+    "18" => "w-18", "24" => "w-24", "32" => "w-32", "full" => "w-full"
+  }.freeze
+
+  HEIGHT_CLASSES = {
+    "14" => "h-14", "18" => "h-18", "24" => "h-24", "32" => "h-32", "full" => "h-full"
+  }.freeze
+
+  PDF_PREVIEW_SIZES = { hero: [ 1200, 1200 ], gallery: [ 300, 300 ], index: [ 300, 300 ] }.freeze
+
+  Result = Struct.new(
+    :display_type, :renderable, :alt_text, :image_classes, :wrapper_classes,
+    :link_href, :link_options, :show_pdf_link, :pdf_link_path, :filename,
+    keyword_init: true
+  )
+
+  def self.call(**args)
+    new(**args).call
+  end
+
+  def initialize(resource: nil, item: nil, file: nil, field_name: :primary_asset,
+                 variant: :gallery, width: "32", height: nil,
+                 link: nil, link_to_object: false, display_open_pdf_link: false,
+                 idx: 0, item_type: "PrimaryAsset", extra_image_classes: "",
+                 view_context:)
+    @resource = resource
+    @item = item
+    @file = file || item&.file || resource&.try(field_name)&.file
+    @variant = variant
+    @width = width.to_s
+    @height = (height || width).to_s
+    @link_to_object = link_to_object
+    @link = link.nil? ? link_to_object : link
+    @display_open_pdf_link = display_open_pdf_link
+    @idx = idx
+    @item_type = item_type
+    @extra_image_classes = extra_image_classes
+    @view_context = view_context
+  end
+
+  def call
+    type = resolve_display_type
+    return Result.new(display_type: :none) if type == :none
+
+    Result.new(
+      display_type: type,
+      renderable: resolve_renderable(type),
+      alt_text: build_alt_text(type),
+      image_classes: build_image_classes(type),
+      wrapper_classes: build_wrapper_classes,
+      link_href: @link ? resolve_link_href(type) : nil,
+      link_options: build_link_options,
+      show_pdf_link: show_pdf_link?,
+      pdf_link_path: show_pdf_link? ? @view_context.rails_blob_path(@file, disposition: :inline) : nil,
+      filename: as_file? ? blob&.filename.to_s : nil
+    )
+  end
+
+  private
+
+  def resolve_display_type
+    if @file.is_a?(Symbol)
+      :icon
+    elsif as_file?
+      if !@file.previewable? && pdf? && @variant != :hero
+        :pdf_document
+      else
+        :active_storage
+      end
+    elsif @file.is_a?(String)
+      :fallback
+    else
+      :none
+    end
+  end
+
+  def resolve_renderable(type)
+    case type
+    when :active_storage then resolve_active_storage_renderable
+    when :fallback then @file
+    end
+  end
+
+  def resolve_active_storage_renderable
+    if @file.previewable?
+      resolve_previewable
+    elsif @variant == :hero
+      @file
+    elsif use_thumbnail?
+      @file.variant(:thumbnail)
+    else
+      @file
+    end
+  end
+
+  def resolve_previewable
+    if pdf?
+      preview_size = PDF_PREVIEW_SIZES.fetch(@variant, [ 300, 300 ])
+      @file.preview(resize_to_limit: preview_size)
+    elsif use_thumbnail?
+      @file.variant(:thumbnail)
+    else
+      @file.preview(resize_to_limit: PDF_PREVIEW_SIZES.fetch(@variant, [ 300, 300 ]))
+    end
+  end
+
+  def use_thumbnail?
+    (@variant == :index || @variant == :gallery || small_dimensions?) && @file.variable?
+  end
+
+  def small_dimensions?
+    @width.to_i > 0 && @width.to_i <= 32 && @height.to_i > 0 && @height.to_i <= 32
+  end
+
+  def build_alt_text(type)
+    case type
+    when :active_storage
+      label = @file.previewable? ? "preview" : "image"
+      "#{@item_type} #{label} #{@idx + 1} (#{blob&.filename})"
+    when :fallback
+      "#{@item_type} fallback image #{@idx + 1}"
+    end
+  end
+
+  def build_image_classes(type)
+    w = WIDTH_CLASSES.fetch(@width, "w-auto")
+    h = HEIGHT_CLASSES.fetch(@height, "h-auto")
+    object_fit = pdf? ? "object-contain bg-gray-100" : "object-cover"
+
+    base = case @variant
+    when :hero
+      "hero-size w-full rounded-lg shadow-sm border border-gray-200 #{@extra_image_classes}"
+    when :gallery
+      "gallery-size #{w} #{h} #{object_fit} rounded border border-gray-300 shadow-sm hover:opacity-90 transition-opacity #{@extra_image_classes}"
+    when :index
+      "w-full h-full #{object_fit} #{@extra_image_classes}"
+    end
+
+    if type == :active_storage
+      "#{base} hover:opacity-95 transition-opacity"
+    else
+      base
+    end
+  end
+
+  def build_wrapper_classes
+    w = WIDTH_CLASSES.fetch(@width, "w-auto")
+    h = HEIGHT_CLASSES.fetch(@height, "h-auto")
+
+    case @variant
+    when :hero then "mb-8"
+    when :gallery then "flex grow"
+    when :index then "index-size #{w} #{h} shrink-0 overflow-hidden rounded border border-gray-300"
+    end
+  end
+
+  def resolve_link_href(type)
+    if @link_to_object && @resource
+      @view_context.polymorphic_path(@resource)
+    elsif type == :active_storage
+      @view_context.url_for(@file)
+    elsif type == :icon
+      nil
+    else
+      @view_context.asset_path(@file)
+    end
+  end
+
+  def build_link_options
+    if @link_to_object
+      { class: "display-image-link", data: { turbo_frame: "_top", turbo_prefetch: false } }
+    else
+      { class: "display-image-link", target: "_blank", rel: "noopener noreferrer" }
+    end
+  end
+
+  def show_pdf_link?
+    @display_open_pdf_link && as_file? && @file.previewable? && pdf?
+  end
+
+  def as_file?
+    return false if @file.is_a?(Symbol)
+    return true if @file.respond_to?(:attached?) && @file.attached?
+    @file.is_a?(ActiveStorage::Blob) || @file.is_a?(ActiveStorage::Attachment)
+  end
+
+  def blob
+    @file.respond_to?(:blob) ? @file.blob : @file
+  end
+
+  def pdf?
+    @file.respond_to?(:content_type) && @file.content_type == "application/pdf"
+  end
+end

--- a/app/views/assets/_display_image.html.erb
+++ b/app/views/assets/_display_image.html.erb
@@ -11,174 +11,59 @@
 <% extra_image_classes ||= "" %>
 <% width ||= "32" %>
 <% height ||= width %>
-<%
-  # --------------------------------------------------
-  # Normalize file input
-  # --------------------------------------------------
-  icon_display ||= file.is_a?(Symbol)
-  active_storage_file = if !icon_display && file.respond_to?(:attached?) && file.attached?
-    file
-  elsif !icon_display && (file.is_a?(ActiveStorage::Blob) || file.is_a?(ActiveStorage::Attachment))
-    file
-  end
-  asset_fallback = file.is_a?(String) ? file : nil
 
-  return unless icon_display || active_storage_file || asset_fallback
-
-  # Normalize blob access — Blob IS the blob, Attachment/Attached delegates to .blob
-  active_storage_blob = active_storage_file.respond_to?(:blob) ? active_storage_file.blob : active_storage_file
-
-  # Tailwind width / height maps
-  width_classes = {
-  "18"   => "w-18",
-  "24"   => "w-24",
-  "32"   => "w-32",
-  "full" => "w-full"
-  }.freeze
-
-  height_classes = {
-  "14"   => "h-14",
-  "18"   => "h-18",
-  "24"   => "h-24",
-  "32"   => "h-32",
-  "full" => "h-full"
-  }.freeze
-
-  width_class  = width_classes.fetch(width.to_s, "w-auto")
-  height_class = height_classes.fetch(height.to_s, "h-auto")
-
-  # --------------------------------------------------
-  # Variant sizing
-  # --------------------------------------------------
-  is_pdf = active_storage_file&.content_type == "application/pdf"
-  object_fit = is_pdf ? "object-contain bg-gray-100" : "object-cover"
-
-  sizes = {
-    hero: {
-      wrapper: "mb-8",
-      image:   "hero-size w-full rounded-lg shadow-sm border border-gray-200 #{extra_image_classes}"
-    },
-
-    gallery: {
-      wrapper: "flex grow",
-      image:   "gallery-size #{width_class} #{height_class} #{object_fit} rounded border border-gray-300
-                shadow-sm hover:opacity-90 transition-opacity #{extra_image_classes}",
-      preview: [300, 300]
-    },
-
-    index: {
-      wrapper: "index-size #{width_class} #{height_class} shrink-0 overflow-hidden rounded border border-gray-300",
-      image:   "w-full h-full #{object_fit} #{extra_image_classes}",
-      preview: [300, 300]
-    }
-  }.fetch(variant)
-
-  # --------------------------------------------------
-  # Link target
-  # --------------------------------------------------
-  link_href =
-    if link_to_object && resource
-      polymorphic_path(resource)
-    elsif active_storage_file
-      url_for(active_storage_file)
-    elsif icon_display
-      nil
-    else
-      asset_path(asset_fallback)
-    end
+<% result = DisplayImagePresenter.call(
+     resource: resource, item: item, file: file, field_name: field_name,
+     variant: variant, width: width, height: height,
+     link: link, link_to_object: link_to_object,
+     display_open_pdf_link: display_open_pdf_link,
+     idx: idx, item_type: item_type, extra_image_classes: extra_image_classes,
+     view_context: self
+   )
+   return if result.display_type == :none
 %>
-<%#
-  --------------------------------------------------
-  # Inner content (NO LINKS HERE)
-  # --------------------------------------------------
-%>
+
 <% inner = capture do %>
-  <div class="<%= variant %>-item <%= resource&.class&.table_name %>-<%= idx %> <%= sizes[:wrapper] %>">
-    <% if active_storage_file %>
-      <% if active_storage_file.previewable? %>
-        <%# Use preview for PDFs in hero, thumbnail variant for small images, full preview for larger images %>
-        <% if active_storage_file.content_type == "application/pdf" %>
-          <% if variant == :hero %>
-            <% image_to_render = active_storage_file.preview(resize_to_limit: [1200, 1200]) %>
-          <% else %>
-            <% image_to_render = active_storage_file.preview(resize_to_limit: sizes[:preview]) %>
-          <% end %>
-        <% elsif (variant == :index || variant == :gallery || (width.to_i > 0 && width.to_i <= 32 && height.to_i <= 32)) && 
-             active_storage_file.variable? %>
-        <% image_to_render = active_storage_file.variant(:thumbnail) %>
-      <% else %>
-        <% image_to_render = active_storage_file.preview(resize_to_limit: sizes[:preview]) %>
-      <% end %>
-      <%= image_tag(
-              image_to_render,
-              class: "#{sizes[:image]} hover:opacity-95 transition-opacity",
-              alt: "#{item_type} preview #{idx + 1} (#{active_storage_blob&.filename})"
-            ) %>
-    <% elsif active_storage_file.content_type == "application/pdf" && variant != :hero %>
+  <div class="<%= variant %>-item <%= resource&.class&.table_name %>-<%= idx %> <%= result.wrapper_classes %>">
+    <% case result.display_type %>
+    <% when :active_storage %>
+      <%= image_tag result.renderable,
+                    class: result.image_classes,
+                    alt: result.alt_text %>
+    <% when :pdf_document %>
       <div class="flex items-center gap-3 p-4 border rounded-lg bg-gray-50">
         <i class="fas fa-file-pdf text-red-600 text-2xl"></i>
-        <span class="font-medium underline hover:no-underline"><%= active_storage_blob&.filename %></span>
+        <span class="font-medium underline hover:no-underline"><%= result.filename %></span>
       </div>
-    <% else %>
-      <%# Use thumbnail variant for index, gallery and small sizes (only for variable files), full size for hero, original for larger ones %>
-      <% if variant == :hero %>
-        <% image_to_render = active_storage_file %>
-      <% elsif (variant == :index || variant == :gallery || (width.to_i <= 32 && height.to_i <= 32)) && 
-             active_storage_file.variable? %>
-      <% image_to_render = active_storage_file.variant(:thumbnail) %>
-    <% else %>
-      <% image_to_render = active_storage_file %>
-    <% end %>
-    <%= image_tag(
-              image_to_render,
-              class: "#{sizes[:image]} hover:opacity-95 transition-opacity",
-              alt: "#{item_type} image #{idx + 1} (#{active_storage_blob&.filename})"
-            ) %>
-  <% end %>
-<% elsif icon_display %>
-  <div class="<%= sizes[:image] %> hover:opacity-95 transition-opacity">
-    <%= render "assets/display_icon",
+    <% when :icon %>
+      <div class="<%= result.image_classes %> hover:opacity-95 transition-opacity">
+        <%= render "assets/display_icon",
                    resource: resource,
                    width: 18,
                    height: 18,
                    variant: variant %>
+      </div>
+    <% when :fallback %>
+      <%= image_tag result.renderable,
+                    class: result.image_classes,
+                    alt: result.alt_text %>
+    <% end %>
   </div>
-<% else %>
-  <%# ---- Asset fallback (string filename) ---- %>
-  <%= image_tag(
-            asset_fallback,
-            class: sizes[:image],
-            alt: "#{item_type} fallback image #{idx + 1}"
-          ) %>
 <% end %>
-</div>
-<% end %>
-<%#
-  --------------------------------------------------
-  # Optional link wrapper
-  # --------------------------------------------------
-%>
-<% if link && link_href.present? %>
-  <% link_options =
-      if link_to_object
-        { class: "display-image-link", data: { turbo_frame: "_top", turbo_prefetch: false } }
-      else
-        { class: "display-image-link", target: "_blank", rel: "noopener noreferrer" }
-      end %>
-  <%= link_to link_href, **link_options do %>
+
+<% if result.link_href.present? %>
+  <%= link_to result.link_href, **result.link_options do %>
     <%= inner %>
   <% end %>
-  <% if active_storage_file&.previewable? &&
-        display_open_pdf_link &&
-        active_storage_file.content_type == "application/pdf" %>
-  <div class="mt-2 text-sm text-gray-600">
-    <%= link_to "Open PDF",
-                  rails_blob_path(file, disposition: :inline),
+  <% if result.show_pdf_link %>
+    <div class="mt-2 text-sm text-gray-600">
+      <%= link_to "Open PDF",
+                  result.pdf_link_path,
                   target: "_blank",
                   rel: "noopener",
                   class: "underline hover:no-underline" %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
 <% else %>
   <%= inner %>
 <% end %>

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DisplayImagePresenter do
+  let(:view_context) { ApplicationController.new.view_context }
+
+  describe ".call" do
+    context "when file is nil" do
+      it "returns :none display_type" do
+        result = described_class.call(file: nil, view_context: view_context)
+        expect(result.display_type).to eq(:none)
+      end
+    end
+
+    context "when file is a Symbol (icon)" do
+      it "returns :icon display_type" do
+        result = described_class.call(file: :scholarship, view_context: view_context)
+        expect(result.display_type).to eq(:icon)
+      end
+
+      it "does not set a renderable" do
+        result = described_class.call(file: :scholarship, view_context: view_context)
+        expect(result.renderable).to be_nil
+      end
+
+      it "does not set a link_href" do
+        result = described_class.call(file: :scholarship, view_context: view_context)
+        expect(result.link_href).to be_nil
+      end
+    end
+
+    context "when file is a String (fallback)" do
+      it "returns :fallback display_type" do
+        result = described_class.call(file: "workshop_default.jpg", view_context: view_context)
+        expect(result.display_type).to eq(:fallback)
+      end
+
+      it "sets the string as renderable" do
+        result = described_class.call(file: "workshop_default.jpg", view_context: view_context)
+        expect(result.renderable).to eq("workshop_default.jpg")
+      end
+
+      it "builds fallback alt text" do
+        result = described_class.call(file: "workshop_default.jpg", idx: 2, item_type: "Workshop", view_context: view_context)
+        expect(result.alt_text).to eq("Workshop fallback image 3")
+      end
+    end
+
+    context "when file is an Active Storage attachment (image)" do
+      let(:asset) { create(:primary_asset, :with_file) }
+      let(:file) { asset.file }
+
+      it "returns :active_storage display_type" do
+        result = described_class.call(file: file, view_context: view_context)
+        expect(result.display_type).to eq(:active_storage)
+      end
+
+      it "uses variant(:thumbnail) for gallery variant" do
+        result = described_class.call(file: file, variant: :gallery, view_context: view_context)
+        expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
+      end
+
+      it "uses the original file for hero variant" do
+        result = described_class.call(file: file, variant: :hero, view_context: view_context)
+        expect(result.renderable).to eq(file)
+      end
+
+      it "uses variant(:thumbnail) for index variant" do
+        result = described_class.call(file: file, variant: :index, view_context: view_context)
+        expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
+      end
+
+      it "builds alt text with filename" do
+        result = described_class.call(file: file, idx: 0, item_type: "Main", view_context: view_context)
+        expect(result.alt_text).to include("missing.png")
+        expect(result.alt_text).to include("Main image 1")
+      end
+    end
+
+    context "CSS classes" do
+      it "builds hero image classes" do
+        result = described_class.call(file: "test.jpg", variant: :hero, view_context: view_context)
+        expect(result.image_classes).to include("hero-size")
+        expect(result.image_classes).to include("w-full")
+      end
+
+      it "builds gallery image classes with dimensions" do
+        result = described_class.call(file: "test.jpg", variant: :gallery, width: "32", height: "32", view_context: view_context)
+        expect(result.image_classes).to include("gallery-size")
+        expect(result.image_classes).to include("w-32")
+        expect(result.image_classes).to include("h-32")
+      end
+
+      it "builds index wrapper classes with dimensions" do
+        result = described_class.call(file: "test.jpg", variant: :index, width: "24", height: "24", view_context: view_context)
+        expect(result.wrapper_classes).to include("index-size")
+        expect(result.wrapper_classes).to include("w-24")
+        expect(result.wrapper_classes).to include("h-24")
+      end
+
+      it "uses w-auto for unknown widths" do
+        result = described_class.call(file: "test.jpg", variant: :gallery, width: "99", view_context: view_context)
+        expect(result.image_classes).to include("w-auto")
+      end
+
+      it "includes extra_image_classes" do
+        result = described_class.call(file: "test.jpg", variant: :hero, extra_image_classes: "custom-class", view_context: view_context)
+        expect(result.image_classes).to include("custom-class")
+      end
+    end
+
+    context "link options" do
+      it "builds link_to_object options with turbo data" do
+        resource = create(:workshop)
+        allow(view_context).to receive(:polymorphic_path).with(resource).and_return("/workshops/#{resource.id}")
+        result = described_class.call(file: "missing.png", link_to_object: true, resource: resource, view_context: view_context)
+        expect(result.link_options).to include(
+          class: "display-image-link",
+          data: { turbo_frame: "_top", turbo_prefetch: false }
+        )
+        expect(result.link_href).to eq("/workshops/#{resource.id}")
+      end
+
+      it "builds external link options" do
+        result = described_class.call(file: "missing.png", link_to_object: false, link: true, view_context: view_context)
+        expect(result.link_options).to include(
+          class: "display-image-link",
+          target: "_blank",
+          rel: "noopener noreferrer"
+        )
+      end
+
+      it "does not set link_href when link is false" do
+        result = described_class.call(file: "missing.png", link: false, view_context: view_context)
+        expect(result.link_href).to be_nil
+      end
+    end
+
+    context "item parameter" do
+      let(:asset) { create(:primary_asset, :with_file) }
+
+      it "extracts file from item" do
+        result = described_class.call(item: asset, view_context: view_context)
+        expect(result.display_type).to eq(:active_storage)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move input normalization, variant resolution, CSS class building, and link computation out of the 175-line _display_image partial into a presenter service. The partial is now ~70 lines of pure rendering. Leverages Active Storage named :thumbnail variant instead of manual preview/resize calls.

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

