### PR TITLE
Use object-contain for PDF preview thumbnails to show full page

### DIFF
--- a/app/views/assets/_display_image.html.erb
+++ b/app/views/assets/_display_image.html.erb
@@ -43,6 +43,9 @@
   # --------------------------------------------------
   # Variant sizing
   # --------------------------------------------------
+  is_pdf = active_storage_file&.content_type == "application/pdf"
+  object_fit = is_pdf ? "object-contain bg-gray-100" : "object-cover"
+
   sizes = {
     hero: {
       wrapper: "mb-8",
@@ -51,14 +54,14 @@
 
     gallery: {
       wrapper: "flex grow",
-      image:   "gallery-size #{width_class} #{height_class} object-cover rounded border border-gray-300
+      image:   "gallery-size #{width_class} #{height_class} #{object_fit} rounded border border-gray-300
                 shadow-sm hover:opacity-90 transition-opacity #{extra_image_classes}",
       preview: [300, 300]
     },
 
     index: {
       wrapper: "index-size #{width_class} #{height_class} shrink-0 overflow-hidden rounded border border-gray-300",
-      image:   "w-full h-full object-cover #{extra_image_classes}",
+      image:   "w-full h-full #{object_fit} #{extra_image_classes}",
       preview: [300, 300]
     }
   }.fetch(variant)

--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -60,7 +60,7 @@
                       id: image_dom_id,
                       alt: "#{label} PDF preview",
                       data: { file_preview_target: "preview" },
-                      class: "w-32 h-32 object-cover border border-gray-300 shadow-sm" %>
+                      class: "w-32 h-32 object-contain border border-gray-300 shadow-sm" %>
 
         <%# ---------- PLACEHOLDER ---------- %>
       <% else %>


### PR DESCRIPTION

### What is the goal of this PR and why is this important? 
PDF previews were using object-cover which cropped the top and bottom of portrait-oriented pages. Switch to object-contain so the entire first page is visible in resource and home index cards.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

