### PR TITLE
Event edit preview btn

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,8 @@
 class EventsController < ApplicationController
   include AhoyTracking
   skip_before_action :authenticate_user!, only: [ :index, :show ]
-  before_action :set_event, only: %i[ show edit update destroy ]
+  skip_before_action :verify_authenticity_token, only: [ :preview ]
+  before_action :set_event, only: %i[ show edit update destroy preview ]
 
   def index
     authorize!
@@ -24,6 +25,14 @@ class EventsController < ApplicationController
   def edit
     authorize! @event
     set_form_variables
+  end
+
+  def preview
+    authorize! @event
+    @event.assign_attributes(event_params)
+    @event = @event.decorate
+    @preview = true
+    render :show
   end
 
   def create

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -23,6 +23,8 @@ class EventPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  alias_rule :preview?, to: :edit?
+
   private
 
   def owner?

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(@event) do |f| %>
+<%= simple_form_for(@event, html: { id: "event-form" }) do |f| %>
   <% f.input :created_by_id, as: :hidden, value: current_user.id %>
 
   <% if @event.errors.any? %>
@@ -305,6 +305,15 @@
       <%= link_to "Cancel",
                   (allowed_to?(:index?, Event) ? events_path : root_path),
                   class: "btn btn-secondary-outline" %>
+      <% if @event.persisted? %>
+        <button type="submit"
+                formaction="<%= preview_event_path(@event) %>"
+                formtarget="_blank"
+                data-turbo="false"
+                class="btn btn-secondary-outline">
+          Preview
+        </button>
+      <% end %>
       <%= f.button :submit, class: "btn btn-primary" %>
     </div>
   </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -4,7 +4,16 @@
     <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
       Edit Event: <%= @event.title %>
     </h1>
-    <%= link_to "View", event_path(@event), class: "btn btn-secondary-outline" %>
+    <div class="flex gap-2">
+      <%= link_to "View", event_path(@event), class: "btn btn-secondary-outline" %>
+      <button type="submit" form="event-form"
+              formaction="<%= preview_event_path(@event) %>"
+              formtarget="_blank"
+              data-turbo="false"
+              class="btn btn-secondary-outline">
+        Preview
+      </button>
+    </div>
   </div>
   <div class="space-y-6">
     <div class="bg-white rounded mt-4 p-6">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,11 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 
+<% if @preview %>
+  <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
+    <span><span class="font-medium">Preview</span> — unsaved changes</span>
+    <button onclick="window.close()" class="btn btn-secondary-outline btn-sm">Close Preview</button>
+  </div>
+<% else %>
 <!-- Top Right Actions -->
 <div class="flex flex-wrap justify-end gap-2">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
@@ -9,6 +15,7 @@
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
 </div>
+<% end %>
 
 <%# ---- HEADER CONTENT ---- %>
 <% if @event.rhino_header.present? %>
@@ -69,3 +76,10 @@
 <div class="mb-12">
   <%= render "assets/display_gallery_media", resource: @event, link: true %>
 </div>
+
+<% if @preview %>
+  <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-lg px-4 py-3 mt-4 flex items-center justify-between">
+    <span><span class="font-medium">Preview</span> — unsaved changes</span>
+    <button onclick="window.close()" class="btn btn-secondary-outline btn-sm">Close Preview</button>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,9 @@ Rails.application.routes.draw do
     resources :comments, only: [ :index, :create ]
   end
   resources :events do
+    member do
+      patch :preview
+    end
     resource :registrations, only: %i[ create destroy ], module: :events, as: :registrant_registration
   end
   resources :people do

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -133,6 +133,13 @@ RSpec.describe EventPolicy, type: :policy do
     end
   end
 
+  describe "#preview?" do
+    it "is an alias of :edit? authorization rule" do
+      policy = policy_for(record: published_event, user: admin_user)
+      expect(:preview?).to be_an_alias_of(policy, :edit?)
+    end
+  end
+
   describe "#update?" do
     let(:owned_event) { build_stubbed :event, created_by: regular_user }
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -179,6 +179,46 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "PATCH /preview" do
+    context "as admin" do
+      before { sign_in admin }
+
+      it "renders the show template with preview changes" do
+        patch preview_event_path(event), params: { event: { title: "Preview Title" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Preview Title")
+        expect(response.body).to include("Preview")
+      end
+
+      it "does not persist changes to the database" do
+        original_title = event.title
+        patch preview_event_path(event), params: { event: { title: "Preview Title" } }
+        expect(event.reload.title).to eq(original_title)
+      end
+    end
+
+    context "as non-admin non-owner" do
+      before { sign_in user }
+
+      it "redirects" do
+        patch preview_event_path(event), params: { event: { title: "Preview Title" } }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as owner" do
+      let(:owned_event) { create(:event, created_by: user) }
+
+      before { sign_in user }
+
+      it "renders the show template" do
+        patch preview_event_path(owned_event), params: { event: { title: "Owner Preview" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Owner Preview")
+      end
+    end
+  end
+
   describe "DELETE /destroy" do
     context "as admin" do
       before { sign_in admin }


### PR DESCRIPTION

### What is the goal of this PR and why is this important? 
Allow users to click "Preview" from Event Edit and view unsaved values.

If we like this, we prob want to add it to the other primary objects (story, workshop, event, news, resource)

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

