### PR TITLE
Event registration emails and show page to match event show

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -6,9 +6,10 @@ class EventMailer < ApplicationMailer
 
     @notification_type = "Event registration confirmation"
 
+    @time_zone = @person.user&.time_zone || Time.zone.name
     @event_url = event_url(@event)
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
-    @organization_website  = ENV.fetch("ORGANIZATION_WEBSITE", unauthenticated_root_url)
+    @organization_website  = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 
     mail(
       to: @person.preferred_email,

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -9,52 +9,45 @@
     This message confirms your registration for the following <%= @organization_name %> event:
   </p>
 
-  <div style="text-align: left;">
-    <table width="100%"
-           cellpadding="0"
-           cellspacing="0"
-           style="background-color:#f3f4f6;border-radius:6px;padding:12px;margin:16px 0;">
-      <tr>
-        <td style="padding:6px 0;">
-          <span style="padding-bottom: 12px"><strong>Event</strong></span><br>
-          <%= @event.title %>
-        </td>
-      </tr>
+  <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+    <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+      <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+        <%= @event.pre_title %>
+      </p>
+    <% end %>
 
-      <tr>
-        <td style="padding:6px 0;">
-          <span style="padding-bottom: 12px"><strong>Date</strong></span><br>
-          <%= @event.times(display_day: true, display_date: true) %>
-        </td>
-      </tr>
+    <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+      <%= @event.title %>
+    </h2>
 
-      <% if @event.location.present? %>
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="padding-bottom: 12px"><strong>Location</strong></span><br>
-            <%= @event.location.name %>
-          </td>
-        </tr>
-      <% end %>
+    <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
+    </p>
 
-      <% if @event.videoconference_url.present? %>
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="padding-bottom: 12px"><strong>Videoconference URL</strong></span><br>
-            <a href="<%= @event.videoconference_url %>"><%= @event.videoconference_url %></a>
-          </td>
-        </tr>
-      <% end %>
+    <% if @event.labelled_cost.present? %>
+      <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+        <%= @event.labelled_cost %>
+      </p>
+    <% end %>
 
-      <% if @event.labelled_cost.present? %>
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="padding-bottom: 12px"><strong>Cost</strong></span><br>
-            <%= @event.labelled_cost %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
+    <% if @event.location.present? %>
+      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+        <%= @event.location.name %>
+      </p>
+    <% end %>
+
+    <% if @event.videoconference_url.present? %>
+      <% domain_name = URI.parse(@event.videoconference_url).host&.split(".")&.[](-2)&.capitalize rescue "video call" %>
+      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+        <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= domain_name %></a>
+      </p>
+    <% end %>
+
+    <% if @event.registration_close_date %>
+      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+        Registration closes <%= @event.registration_close_date.in_time_zone(@time_zone).strftime("%B %-d, %Y %l:%M %P %Z") %>
+      </p>
+    <% end %>
   </div>
 
   <% if @event.detail.present? %>
@@ -64,20 +57,15 @@
     </p>
     <hr style="margin: 24px 0;">
   <% end %>
-
-  <% if @event.registration_close_date %>
-    <p>
-      Registration closes on
-      <%= @event.registration_close_date.strftime("%A, %B %-d, %Y at %-l:%M %p %Z") %>.
-    </p>
-  <% end %>
 </div>
-
 
 <p>
   Visit the event page for updates, directions, or calendar links:
 </p>
 
 <p>
+  <% if @event_registration.persisted? %>
+    <a href="<%= event_registration_url(@event_registration) %>" class="button">View registration</a>
+  <% end %>
   <a href="<%= @event_url %>" class="button">View event</a>
 </p>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -4,8 +4,9 @@ Hello <%= @person.full_name %>,
 
 This message confirms your registration for the following event:
 
-<%= @event.title %>
-<%= @event.times(display_day: true, display_date: true) %>
+<% if @event.respond_to?(:pre_title) && @event.pre_title.present? %><%= @event.pre_title %>
+<% end %><%= @event.title %>
+<% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
 
 <% if @event.location.present? %>
 Location: <%= @event.location.name %>
@@ -29,7 +30,7 @@ View the event page:
 
 <% if @event.registration_close_date %>
   Registration closes on
-  <%= @event.registration_close_date.strftime("%A, %B %-d, %Y at %-l:%M %p %Z") %>
+  <%= @event.registration_close_date.in_time_zone(@time_zone).strftime("%A, %B %-d, %Y at %-l:%M %p %Z") %>
 <% end %>
 
 --

--- a/app/views/event_registrations/show.html.erb
+++ b/app/views/event_registrations/show.html.erb
@@ -10,7 +10,7 @@
     <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
 
       <!-- Ticket Header -->
-      <div class="<%= DomainTheme.bg_class_for(:events, intensity: 600) %> text-white px-6 py-4">
+      <div class="bg-blue-900 text-white px-6 py-4">
         <div class="flex items-center justify-between gap-4">
 
           <!-- Left: Logo -->
@@ -54,8 +54,11 @@
         </div>
 
         <!-- Event Name -->
-        <div>
-          <h2 class="text-2xl font-bold text-gray-900 leading-tight">
+        <div class="text-center">
+          <% if @event_registration.event.respond_to?(:pre_title) && @event_registration.event.pre_title.present? %>
+            <p class="text-base font-semibold text-gray-700 mb-1" style="font-family: 'Telefon Bold', sans-serif"><%= @event_registration.event.pre_title %></p>
+          <% end %>
+          <h2 class="text-3xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif">
             <%= link_to @event_registration.event.title, event_path(@event_registration.event), class: "hover:underline" %>
           </h2>
         </div>
@@ -67,32 +70,34 @@
           <div class="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 bg-gray-100 rounded-full"></div>
         </div>
 
-        <!-- Ticket Details -->
-        <div class="grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
+        <!-- Event Details -->
+        <div class="text-center space-y-2">
 
-          <div>
-            <p class="text-gray-500 uppercase tracking-wide text-xs">Date</p>
-            <p class="font-medium text-gray-900">
-              <%= @event_registration.event.decorate.times(display_day: true, display_date: true) %>
-            </p>
+          <div class="text-xl font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif">
+            <%= @event_registration.event.decorate.times(display_day: true, display_date: true, styled: true) %>
           </div>
 
-          <%# if @event_registration.event.location.present? %>
-            <div>
-              <p class="text-gray-500 uppercase tracking-wide text-xs">Location</p>
-              <p class="font-medium text-gray-900">
-                TBA<%#= @event_registration.event.location %>
-              </p>
+          <% if @event_registration.event.decorate.labelled_cost.present? %>
+            <div class="text-lg font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif">
+              <%= @event_registration.event.decorate.labelled_cost %>
             </div>
-          <%# end %>
+          <% end %>
 
+          <% if @event_registration.event.location.present? %>
+            <div class="text-base text-gray-700">
+              <%= @event_registration.event.location.name %>
+            </div>
+          <% end %>
 
           <% if @event_registration.event.videoconference_url.present? %>
-            <div>
-              <p class="text-gray-500 uppercase tracking-wide text-xs">Videoconference</p>
-              <p class="font-medium text-gray-900">
-                <%= link_to "Join online", safe_url(@event_registration.event.videoconference_url), target: "_blank", rel: "noopener noreferrer", class: "text-blue-600 hover:underline" %>
-              </p>
+            <div class="text-base text-gray-700">
+              <%= link_to "Join online", safe_url(@event_registration.event.videoconference_url), target: "_blank", rel: "noopener noreferrer", class: "underline" %>
+            </div>
+          <% end %>
+
+          <% if @event_registration.event.registration_close_date %>
+            <div class="text-base text-gray-700">
+              Registration closes <%= @event_registration.event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %l:%M %P %Z") %>
             </div>
           <% end %>
 
@@ -104,15 +109,15 @@
         <!-- Status + Meta -->
         <div class="flex items-center justify-between mt-4">
           <div>
-            <% registration_color = @event_registration.checked_in? ? "bg-green-100 text-green-800" : "bg-blue-100 text-blue-800" %>
-            <% payment_color = @event_registration.paid? ? "bg-green-100 text-green-800" : "bg-yellow-100 text-orange-800" %>
-
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium <%= registration_color %>">
-              <%= @event_registration.checked_in? ? "Checked In" : "Registered" %>
-            </span>
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium <%= payment_color %>">
-              <%= @event_registration.paid? ? "Paid" : "Payment due" %>
-            </span>
+            <% if @event_registration.checked_in? %>
+              <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                Checked In
+              </span>
+            <% elsif @event_registration.respond_to?(:canceled?) && @event_registration.canceled? %>
+              <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                Canceled
+              </span>
+            <% end %>
           </div>
 
           <p class="text-xs text-gray-500">

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
@@ -16,43 +16,39 @@
                          .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
 </p>
 
-<div style="text-align: left;">
-  <table width="100%"
-         cellpadding="0"
-         cellspacing="0"
-         style="background-color:#f3f4f6;border-radius:6px;padding:12px;margin:16px 0;">
-    <tr>
-      <td style="padding:6px 0;">
-        <strong>Event</strong><br>
-        <%= @event.title %>
-      </td>
-    </tr>
+<div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+  <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+    <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+      <%= @event.pre_title %>
+    </p>
+  <% end %>
 
-    <tr>
-      <td style="padding:6px 0;">
-        <strong>Event date</strong><br>
-        <%= @event.times(display_day: true, display_date: true) %>
-      </td>
-    </tr>
+  <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+    <%= @event.title %>
+  </h2>
 
-    <% if @event.location.present? %>
-      <tr>
-        <td style="padding:6px 0;">
-          <span style="padding-bottom: 12px"><strong>Location</strong></span><br>
-          <%= @event.location %>
-        </td>
-      </tr>
-    <% end %>
+  <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+    <%= @event.times(display_day: true, display_date: true) %>
+  </p>
 
-    <% if @event.labelled_cost.present? %>
-      <tr>
-        <td style="padding:6px 0;">
-          <strong>Cost</strong><br>
-          <%= @event.labelled_cost %>
-        </td>
-      </tr>
-    <% end %>
-  </table>
+  <% if @event.labelled_cost.present? %>
+    <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <%= @event.labelled_cost %>
+    </p>
+  <% end %>
+
+  <% if @event.location.present? %>
+    <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+      <%= @event.location.name %>
+    </p>
+  <% end %>
+
+  <% if @event.videoconference_url.present? %>
+    <% domain_name = URI.parse(@event.videoconference_url).host&.split(".")&.[](-2)&.capitalize rescue "video call" %>
+    <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+      <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= domain_name %></a>
+    </p>
+  <% end %>
 </div>
 
 <p>

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
@@ -20,7 +20,12 @@ Event date
 
 <% if @event.location.present? %>
   Location
-  <%= @event.location %>
+  <%= @event.location.name %>
+<% end %>
+
+<% if @event.videoconference_url.present? %>
+  Videoconference URL
+  <%= @event.videoconference_url %>
 <% end %>
 
 <% if @event.labelled_cost.present? %>

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -9,11 +9,11 @@ class EventMailerPreview < ActionMailer::Preview
   def sample_event_registration
     # Try to reuse existing records to avoid duplication
     event = Event.first || create_event
-    user  = User.first  || create_user
+    person = Person.first || create_person
 
     EventRegistration.new(
       event: event,
-      registrant: user
+      registrant: person
     )
   end
 
@@ -29,12 +29,13 @@ class EventMailerPreview < ActionMailer::Preview
     )
   end
 
-  def create_user
-    User.create!(
+  def create_person
+    user = User.create!(
       email: "participant@example.org",
       first_name: "Alex",
       last_name: "Rivera",
       password: "password123"
     )
+    user.person
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important? 

Update confirmation email, FYI email, and registration show page to use the same visual hierarchy as the event show page: green title with Lato font, blue/bold/uppercase date-time, centered layout with grey card.

- Add pre-title, cost, videoconference ("Join us on Zoom"), and registration close date to emails
- Display times in registrant's time zone for confirmation email
- Replace 2-column grid with centered vertical stack on reg show page
- Fix mailer preview to use Person instead of User for registrant
- Fix unauthenticated_root_url -> root_url in EventMailer
- Add "View registration" button to confirmation email
- Add videoconference URL to FYI email, fix location.name
- Only show status badge for non-default states (checked-in, canceled)
- Change reg show header to dark blue (bg-blue-900)


