### PR TITLE
Fix flaky reset password person test

### DIFF
--- a/spec/system/reset_password_person_spec.rb
+++ b/spec/system/reset_password_person_spec.rb
@@ -7,14 +7,7 @@ RSpec.describe 'Reset password (person)', type: :system do
 
   before do
     sign_in person_user
-    # Start on a page where the user nav is visible
-    visit root_path
-    # Wait for any flash message overlay to disappear before clicking avatar
-    page.has_no_css?('#flash_now', visible: true, wait: 10)
-    # Open user nav dropdown (wait for avatar to appear after page load)
-    find('#avatar button', wait: 10).click
-    # Click "Change password"
-    click_link 'Change password'
+    visit change_password_path
   end
 
   context "When user uses form to change password" do


### PR DESCRIPTION
## Summary
- Fix flaky `reset_password_person_spec.rb` test that intermittently failed with `Unable to find css "#avatar button"`
- The `before` block was navigating to the change password page by clicking through the avatar dropdown, but the `#flash_now` container div is always present in the DOM, so the flash-dismiss wait was ineffective and the flash overlay sometimes blocked the avatar button
- Replaced the fragile UI navigation with a direct `visit change_password_path`, since the tests are about change password page behavior, not avatar dropdown navigation

Fixes #826

## Test plan
- [ ] Confirm `reset_password_person_spec.rb` passes in CI
- [ ] Confirm no regressions in other system specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)