### PR TITLE
Hide gallery assets on idea forms, show only on regular CRUDs (#1110)

### DIFF
--- a/app/views/shared/_form_image_fields.html.erb
+++ b/app/views/shared/_form_image_fields.html.erb
@@ -16,6 +16,7 @@
 <% include_downloadable_asset  ||= false %>
 <% primary_title       ||= "Primary image" %>
 <% downloadable_title       ||= "Downloadable attachment" %>
+<% include_gallery_assets = true unless local_assigns.key?(:include_gallery_assets) %>
 <% gallery_title       ||= "Gallery attachments" %>
 
 <div class="image-fields my-3">
@@ -57,34 +58,38 @@
       <% end %>
 
       <%# ---- GALLERY IMAGES ---- %>
-      <% counter = 1 %>
-      <%= f.fields_for :gallery_assets do |img| %>
-        <div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
-          <%= render "shared/form_image_field",
-                     f: img,
-                     label: "#{gallery_title} #{counter}" %>
-        </div>
-        <% counter += 1 %>
+      <% if include_gallery_assets %>
+        <% counter = 1 %>
+        <%= f.fields_for :gallery_assets do |img| %>
+          <div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
+            <%= render "shared/form_image_field",
+                       f: img,
+                       label: "#{gallery_title} #{counter}" %>
+          </div>
+          <% counter += 1 %>
+        <% end %>
       <% end %>
 
     </div>
 
-    <!-- Add file button (bottom-right) -->
-    <div class="mt-4 flex justify-end">
-      <%= link_to_add_association "Add another file",
-                                  f,
-                                  :gallery_assets,
-                                  insertion_node: ".image-fields-row",
-                                  insertion_method: :append,
-                                  partial: "shared/form_image_field_insert",
-                                  render_options: {
-                                    locals: {
-                                      label: "Additional #{gallery_title}",
-                                      resource: f.object.gallery_assets.build,
-                                    }
-                                  },
-                                  class: "text-blue-600 hover:text-blue-800 font-medium text-sm pr-2 pb-6" %>
-    </div>
+    <% if include_gallery_assets %>
+      <!-- Add file button (bottom-right) -->
+      <div class="mt-4 flex justify-end">
+        <%= link_to_add_association "Add another file",
+                                    f,
+                                    :gallery_assets,
+                                    insertion_node: ".image-fields-row",
+                                    insertion_method: :append,
+                                    partial: "shared/form_image_field_insert",
+                                    render_options: {
+                                      locals: {
+                                        label: "Additional #{gallery_title}",
+                                        resource: f.object.gallery_assets.build,
+                                      }
+                                    },
+                                    class: "text-blue-600 hover:text-blue-800 font-medium text-sm pr-2 pb-6" %>
+      </div>
+    <% end %>
   </div>
 
   <% if f.object.respond_to?(:images) && f.object.images.any? %>

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -259,8 +259,8 @@
     <% end %>
 
     <div id="attachments">
-      <%= render "shared/form_image_fields", f: f, include_primary_asset: true,
-                 primary_title: "Primary attachment", gallery_title: "Additional attachment" %>
+      <%= render "shared/form_image_fields", f: f, include_primary_asset: false,
+                 gallery_title: "Additional attachment" %>
     </div>
 
     <div id="publish-preferences" class="flex pt-6 gap-4">

--- a/app/views/workshop_ideas/_form.html.erb
+++ b/app/views/workshop_ideas/_form.html.erb
@@ -386,7 +386,7 @@
     </div>
 
 
-  <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
+  <%= render "shared/form_image_fields", f: f, include_primary_asset: false %>
     <div class="action-buttons mt-8 flex justify-center gap-3">
       <% if allowed_to?(:destroy?, f.object) %>
         <%= link_to "Delete", @workshop_idea, class: "btn btn-danger-outline",

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -143,7 +143,7 @@
         </div>
       </div>
     <% end %>
-    <%= render "shared/form_image_fields", f: f, include_primary_asset: true unless promoted_to_variation %>
+    <%= render "shared/form_image_fields", f: f, include_primary_asset: false unless promoted_to_variation %>
     <div class="action-buttons mt-8 flex justify-center gap-3 pt-6">
       <% if allowed_to?(:destroy?, f.object) && f.object. workshop_variations.none? && !promoted_to_variation %>
         <span class="admin-only bg-blue-100 p-3">


### PR DESCRIPTION
- This work Closes #1110 

### What is the goal of this PR and why is this important? 
Add include_gallery_assets flag to shared _form_image_fields partial (defaults to true). Idea forms pass include_primary_asset: false so they get gallery-only uploads, while regular CRUD forms keep both primary and gallery assets.


