### PR TITLE
Fix duplicate "Additional Additional" label and clean up image field titles

### DIFF
--- a/app/views/shared/_form_image_fields.html.erb
+++ b/app/views/shared/_form_image_fields.html.erb
@@ -14,10 +14,10 @@
 <% section_subtitle    ||= nil %>
 <% include_primary_asset  ||= false %>
 <% include_downloadable_asset  ||= false %>
-<% primary_title       ||= "Primary image" %>
+<% primary_title       ||= "Primary (thumbnail/hero)" %>
 <% downloadable_title       ||= "Downloadable attachment" %>
 <% include_gallery_assets = true unless local_assigns.key?(:include_gallery_assets) %>
-<% gallery_title       ||= "Gallery attachments" %>
+<% gallery_title       ||= "Upload" %>
 
 <div class="image-fields my-3">
   <h2 class="text-lg font-semibold text-gray-800 mb-2">

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -185,8 +185,7 @@
     <% end %>
   <% end %>
 
-  <%= render "shared/form_image_fields", f: f, include_primary_asset: true,
-             primary_title: "Primary attachment", gallery_title: "Additional attachment" %>
+  <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
 
   <!-- Accordions -->
   <div class="space-y-4 mt-8">

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -259,8 +259,7 @@
     <% end %>
 
     <div id="attachments">
-      <%= render "shared/form_image_fields", f: f, include_primary_asset: false,
-                 gallery_title: "Additional attachment" %>
+      <%= render "shared/form_image_fields", f: f %>
     </div>
 
     <div id="publish-preferences" class="flex pt-6 gap-4">

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -125,8 +125,7 @@
     <!-- Upload Section -->
     <%= render "shared/form_image_fields", f: f, include_primary_asset: false,
              section_title: "Upload Images / Media Releases",
-             section_subtitle: "Attach photos, PDFs, or signed media release forms",
-             gallery_title: "Upload" %>
+             section_subtitle: "Attach photos, PDFs, or signed media release forms" %>
 
     <div class="action-buttons mt-8 flex justify-center gap-3">
       <% if allowed_to?(:destroy?, f.object) %>


### PR DESCRIPTION

- This work Closes #1109

### What is the goal of this PR and why is this important? 

- Change default primary_title to "Primary (thumbnail/hero)" and gallery_title to "Upload"
- Remove redundant gallery_title/primary_title overrides from callers
- Remove include_primary_asset from _idea forms (gallery only)


