### PR TITLE
Remove updated_at from community news, default sort to created_at (#1122)

### DIFF
--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -10,7 +10,7 @@ class CommunityNewsController < ApplicationController
       base_scope = authorized_scope(CommunityNews.includes([ :bookmarks, :primary_asset,
                                                              :author, :organization, author: :person ]))
       filtered = base_scope.search_by_params(params)
-      @sort = %w[created_at updated_at title author organization].include?(params[:sort]) ? params[:sort] : "updated_at"
+      @sort = %w[created_at title author organization].include?(params[:sort]) ? params[:sort] : "created_at"
       @sort_direction = params[:direction] == "asc" ? "asc" : "desc"
       filtered = case @sort
       when "author"

--- a/app/controllers/home/community_news_controller.rb
+++ b/app/controllers/home/community_news_controller.rb
@@ -4,7 +4,7 @@ module Home
       authorize! :home
       @community_news = authorized_scope(CommunityNews
                                               .published
-                                              .order(updated_at: :desc), with: HomePolicy).decorate
+                                              .order(created_at: :desc), with: HomePolicy).decorate
 
       render "home/community_news/index"
     end

--- a/app/views/community_news/_community_news_results.html.erb
+++ b/app/views/community_news/_community_news_results.html.erb
@@ -46,14 +46,6 @@
               <i class="fa-solid <%= sort_icon.call("created_at") %> text-xs opacity-70"></i>
             <% end %>
           </th>
-          <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700 whitespace-nowrap min-w-[7rem]">
-            <%= link_to community_news_index_path(sort_base.merge(sort: "updated_at", direction: (@sort == "updated_at" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                        data: { turbo_frame: "community_news_results" },
-                        class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-              Updated
-              <i class="fa-solid <%= sort_icon.call("updated_at") %> text-xs opacity-70"></i>
-            <% end %>
-          </th>
           <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700">Actions</th>
         </tr>
       </thead>
@@ -90,7 +82,6 @@
             <td class="px-6 py-4 text-gray-600"><%= news.organization&.name || "—" %></td>
 
             <td class="px-6 py-4 text-center text-sm text-gray-500 whitespace-nowrap"><%= news.created_at.strftime("%b %d, %Y") %></td>
-            <td class="px-6 py-4 text-center text-sm text-gray-500 whitespace-nowrap"><%= news.updated_at.strftime("%b %d, %Y") %></td>
 
             <td class="px-6 py-4 text-right">
               <div class="inline-flex gap-2">


### PR DESCRIPTION
- This work Closes #1122

### What is the goal of this PR and why is this important? 
- Remove updated at to community news
- Default sort to created_at

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

