### PR TITLE
Remove zip and HTML as accepted upload file types

### DIFF
--- a/app/frontend/javascript/controllers/file_preview_controller.js
+++ b/app/frontend/javascript/controllers/file_preview_controller.js
@@ -2,11 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 const FILE_TYPE_ICONS = {
     "application/pdf": "fa-regular fa-file-pdf",
-    "application/zip": "fa-regular fa-file-zipper",
     "application/msword": "fa-regular fa-file-word",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "fa-regular fa-file-word",
     "application/vnd.oasis.opendocument.text": "fa-regular fa-file-lines",
-    "text/html": "fa-regular fa-file-code",
 }
 
 export default class extends Controller {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,8 +103,7 @@ module ApplicationHelper
         "application/vnd.oasis.opendocument.presentation" => "fa-file-powerpoint",
 
         # Archives
-        "application/gzip" => "fa-file-archive",
-        "application/zip" => "fa-file-archive"
+        "application/gzip" => "fa-file-archive"
     }
 
     if mime

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -9,11 +9,9 @@ class Asset < ApplicationRecord
     "image/heic",
     "image/heif",
     "application/pdf",
-    "application/zip",
     "application/msword", # Word .doc
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # Word .docx
-    "application/vnd.oasis.opendocument.text", # Word document .odt
-    "text/html"
+    "application/vnd.oasis.opendocument.text" # Word document .odt
   ].freeze
 
 
@@ -50,11 +48,9 @@ class Asset < ApplicationRecord
     "image/heic" => "HEIC",
     "image/heif" => "HEIF",
     "application/pdf" => "PDF",
-    "application/zip" => "ZIP",
     "application/msword" => "DOC",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "DOCX",
-    "application/vnd.oasis.opendocument.text" => "ODT",
-    "text/html" => "HTML"
+    "application/vnd.oasis.opendocument.text" => "ODT"
   }.freeze
 
   def self.accept_attribute

--- a/app/models/downloadable_asset.rb
+++ b/app/models/downloadable_asset.rb
@@ -7,10 +7,8 @@ class DownloadableAsset < Asset
     "image/heic",
     "image/heif",
     "application/pdf",
-    "application/zip",
     "application/msword", # Word .doc
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # Word .docx
-    "application/vnd.oasis.opendocument.text", # Word document .odt
-    "text/html"
+    "application/vnd.oasis.opendocument.text" # Word document .odt
   ].freeze
 end

--- a/app/models/rich_text_asset.rb
+++ b/app/models/rich_text_asset.rb
@@ -9,11 +9,9 @@ class RichTextAsset < Asset
     "image/heic",
     "image/heif",
     "application/pdf",
-    "application/zip",
     "application/msword", # Word .doc
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # Word .docx
-    "application/vnd.oasis.opendocument.text", # Word document .odt
-    "text/html"
+    "application/vnd.oasis.opendocument.text" # Word document .odt
   ].freeze
 
   has_many :action_text_mentions,


### PR DESCRIPTION


Closes #1100

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
ZIP files are a common malware/zip-bomb vector and HTML files can contain JavaScript enabling XSS attacks. Neither is needed for workshop leader resource uploads.

