### PR TITLE
Add year search to community news and stories indexes

### DIFF
--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -64,6 +64,9 @@ export default class extends Controller {
       select.selectedIndex = 0;
     });
     this.element.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(input => {
+      if (input.checked) {
+        this.toggleClass(input);
+      }
       input.checked = false;
     });
     // this.element.reset();

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -45,6 +45,8 @@ class CommunityNews < ApplicationRecord
     attributes action_text_body: "action_text_rich_texts.plain_text_body"
   end
 
+  scope :by_year, ->(year) { where(created_at: Date.new(year.to_i)..Date.new(year.to_i).end_of_year) }
+
   scope :community_news_name, ->(community_news_name) {
     community_news_name.present? ? where("community_news.name LIKE ?", "%#{community_news_name}%") : all }
 
@@ -55,6 +57,7 @@ class CommunityNews < ApplicationRecord
     conditions[:published] = params[:published] if params[:published].present?
     community_news = self.search(conditions)
 
+    community_news = community_news.by_year(params[:year]) if params[:year].present? && params[:year].match?(/\A\d{4}\z/)
     community_news = community_news.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     community_news = community_news.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
     # community_news = community_news.windows_type_name(params[:windows_type_name]) if params[:windows_type_name].present?

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -51,6 +51,7 @@ class Story < ApplicationRecord
 
   # Scopes
   # See Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
+  scope :by_year, ->(year) { where(created_at: Date.new(year.to_i)..Date.new(year.to_i).end_of_year) }
   scope :story_name, ->(story_name) { story_name.present? ? where("stories.name LIKE ?", "%#{story_name}%") : all }
   scope :facilitator_spotlights, ->(value = nil) {
     return where.not(spotlighted_facilitator_id: nil) if value.blank?
@@ -66,6 +67,7 @@ class Story < ApplicationRecord
     conditions[:published] = params[:published] if params[:published].present?
     stories = self.search(conditions)
 
+    stories = stories.by_year(params[:year]) if params[:year].present? && params[:year].match?(/\A\d{4}\z/)
     stories = stories.facilitator_spotlights(params[:facilitator_spotlights]) if params[:facilitator_spotlights].present?
     stories = stories.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     stories = stories.category_names_all(params[:category_names_all]) if params[:category_names_all].present?

--- a/app/views/community_news/_community_news_results.html.erb
+++ b/app/views/community_news/_community_news_results.html.erb
@@ -1,56 +1,56 @@
 <%= turbo_stream.replace("community_news_count", partial: "community_news_count") %>
-<% if @community_news.any? %>
-  <%
-    sort_base = params.permit(:title, :query, :published, :number_of_items_per_page).to_h.symbolize_keys
-    sort_icon = ->(column) {
-      if @sort == column
-        @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
-      else
-        "fa-sort"
-      end
-    }
-  %>
-  <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm animate-fade blur-on-submit">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
-        <tr>
-          <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-            <%= link_to community_news_index_path(sort_base.merge(sort: "title", direction: (@sort == "title" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                        data: { turbo_frame: "community_news_results" },
-                        class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-              Title
-              <i class="fa-solid <%= sort_icon.call("title") %> text-xs opacity-70"></i>
-            <% end %>
-          </th>
-          <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-            <%= link_to community_news_index_path(sort_base.merge(sort: "author", direction: (@sort == "author" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                        data: { turbo_frame: "community_news_results" },
-                        class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-              Author
-              <i class="fa-solid <%= sort_icon.call("author") %> text-xs opacity-70"></i>
-            <% end %>
-          </th>
-          <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-            <%= link_to community_news_index_path(sort_base.merge(sort: "organization", direction: (@sort == "organization" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                        data: { turbo_frame: "community_news_results" },
-                        class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-              Organization
-              <i class="fa-solid <%= sort_icon.call("organization") %> text-xs opacity-70"></i>
-            <% end %>
-          </th>
-          <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700 whitespace-nowrap min-w-[7rem]">
-            <%= link_to community_news_index_path(sort_base.merge(sort: "created_at", direction: (@sort == "created_at" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                        data: { turbo_frame: "community_news_results" },
-                        class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-              Created At
-              <i class="fa-solid <%= sort_icon.call("created_at") %> text-xs opacity-70"></i>
-            <% end %>
-          </th>
-          <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700">Actions</th>
-        </tr>
-      </thead>
+<%
+  sort_base = params.permit(:title, :query, :published, :year, :number_of_items_per_page).to_h.symbolize_keys
+  sort_icon = ->(column) {
+    if @sort == column
+      @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
+    else
+      "fa-sort"
+    end
+  }
+%>
+<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @community_news.any? %>">
+  <table class="w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
+          <%= link_to community_news_index_path(sort_base.merge(sort: "title", direction: (@sort == "title" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
+                      data: { turbo_frame: "community_news_results" },
+                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
+            Title
+            <i class="fa-solid <%= sort_icon.call("title") %> text-xs opacity-70"></i>
+          <% end %>
+        </th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
+          <%= link_to community_news_index_path(sort_base.merge(sort: "author", direction: (@sort == "author" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
+                      data: { turbo_frame: "community_news_results" },
+                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
+            Author
+            <i class="fa-solid <%= sort_icon.call("author") %> text-xs opacity-70"></i>
+          <% end %>
+        </th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
+          <%= link_to community_news_index_path(sort_base.merge(sort: "organization", direction: (@sort == "organization" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
+                      data: { turbo_frame: "community_news_results" },
+                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
+            Organization
+            <i class="fa-solid <%= sort_icon.call("organization") %> text-xs opacity-70"></i>
+          <% end %>
+        </th>
+        <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700 whitespace-nowrap min-w-[7rem]">
+          <%= link_to community_news_index_path(sort_base.merge(sort: "created_at", direction: (@sort == "created_at" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
+                      data: { turbo_frame: "community_news_results" },
+                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
+            Created At
+            <i class="fa-solid <%= sort_icon.call("created_at") %> text-xs opacity-70"></i>
+          <% end %>
+        </th>
+        <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700">Actions</th>
+      </tr>
+    </thead>
 
-      <tbody class="divide-y divide-gray-100">
+    <tbody class="divide-y divide-gray-100">
+      <% if @community_news.any? %>
         <% @community_news.each do |news| %>
           <tr class="hover:bg-gray-50 transition">
             <td class="px-4 py-2 text-sm text-gray-800 flex items-center gap-2">
@@ -100,22 +100,26 @@
             </td>
           </tr>
         <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% else %>
+        <tr>
+          <td colspan="5" class="text-center py-16">
+            <h2 class="text-gray-600 text-lg mb-2">No community news yet</h2>
+            <% if allowed_to?(:new?, CommunityNews) %>
+              <div class="admin-only bg-blue-100 p-3">
+                <%= link_to "Create a community news",
+                            new_community_news_path,
+                            class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% if @community_news.any? %>
   <!-- Pagination -->
   <div class="mt-6 flex justify-center">
     <div class="pagination mt-6"><%= tailwind_paginate @community_news %></div>
-  </div>
-<% else %>
-  <div class="text-center py-16 bg-white rounded-xl border border-gray-200 shadow-sm">
-    <h2 class="text-gray-600 text-lg mb-2">No community news yet</h2>
-    <% if allowed_to?(:new?, CommunityNews) %>
-      <div class="admin-only bg-blue-100 p-3">
-        <%= link_to "Create a community news",
-                    new_community_news_path,
-                    class: "btn btn-primary" %>
-      </div>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/community_news/_search_boxes.html.erb
+++ b/app/views/community_news/_search_boxes.html.erb
@@ -1,14 +1,16 @@
 <!-- Filters -->
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
-  <%= form_with url: community_news_index_path,
-                method: :get,
-                data: {controller: "collection",
-                      turbo_frame: "community_news_results" },
-                      autocomplete: "off",
-                class: "flex flex-wrap gap-4" do |f| %>
-    <div>
-      <%= f.label :title, "Title contains",
-                  class: "text-sm font-medium text-gray-500 mb-1" %>
+<%= form_with url: community_news_index_path,
+              method: :get,
+              data: {controller: "collection",
+                    turbo_frame: "community_news_results" },
+                    autocomplete: "off",
+              class: "space-y-2" do |f| %>
+  <div class="flex flex-wrap md:flex-nowrap items-end gap-6">
+    <!-- TITLE -->
+    <div class="min-w-[150px] pb-2">
+      <label for="title" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Title contains
+      </label>
 
       <%= f.text_field :title,
                        placeholder: "e.g. Art, Music…",
@@ -17,13 +19,34 @@
                        oninput: "this.form.requestSubmit()" %>
     </div>
 
-    <div class="flex-grow min-w-[200px]">
-      <%= f.label :query, "Keywords",
-                  class: "text-sm font-medium text-gray-500 mb-1" %>
+    <!-- KEYWORDS -->
+    <div class="flex-1 min-w-[200px] pb-2">
+      <label for="query" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Keywords
+      </label>
 
-      <%= f.text_field :query,
-                           class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+      <div class="relative">
+        <%= f.text_field :query,
+                         class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 pr-10
                                  focus:ring-blue-500 focus:border-blue-500" %>
+
+        <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+          <i class="fa fa-search"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- YEAR -->
+    <div class="w-24 pb-2">
+      <label for="year" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Year
+      </label>
+
+      <%= f.text_field :year,
+                       placeholder: "e.g. 2025",
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+                                 focus:ring-blue-500 focus:border-blue-500",
+                       oninput: "this.form.requestSubmit()" %>
     </div>
 
     <% if allowed_to?(:manage?, CommunityNews) %>
@@ -43,7 +66,10 @@
       </div>
     <% end %>
 
-    <!-- Clear -->
-    <div><%= link_to "Clear filters", community_news_index_path, class: "btn btn-utility-outline whitespace-nowrap", data: { action: "collection#clearAndSubmit" } %></div>
-  <% end %>
-</div>
+    <!-- CLEAR FILTERS -->
+    <div class="min-w-[120px] pb-3">
+      <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">&nbsp;</label>
+      <%= link_to "Clear filters", community_news_index_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/stories/_search_boxes.html.erb
+++ b/app/views/stories/_search_boxes.html.erb
@@ -1,14 +1,16 @@
 <!-- Filters -->
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
-  <%= form_with url: stories_path,
-                method: :get,
-                data: {controller: "collection",
-                      turbo_frame: "story_results" },
-                      autocomplete: "off",
-                class: "flex flex-wrap gap-4" do |f| %>
-    <div>
-      <%= f.label :title, "Title contains",
-                  class: "text-sm font-medium text-gray-500 mb-1" %>
+<%= form_with url: stories_path,
+              method: :get,
+              data: {controller: "collection",
+                    turbo_frame: "story_results" },
+                    autocomplete: "off",
+              class: "space-y-2" do |f| %>
+  <div class="flex flex-wrap md:flex-nowrap items-end gap-6">
+    <!-- TITLE -->
+    <div class="min-w-[150px] pb-2">
+      <label for="title" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Title contains
+      </label>
 
       <%= f.text_field :title,
                        value: params[:title],
@@ -18,14 +20,35 @@
                        oninput: "this.form.requestSubmit()" %>
     </div>
 
-    <div class="flex-grow min-w-[200px]">
-      <%= f.label :query, "Keywords",
-                  class: "text-sm font-medium text-gray-500 mb-1" %>
+    <!-- KEYWORDS -->
+    <div class="flex-1 min-w-[200px] pb-2">
+      <label for="query" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Keywords
+      </label>
 
-      <%= f.text_field :query,
-                       value: params[:query],
-                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+      <div class="relative">
+        <%= f.text_field :query,
+                         value: params[:query],
+                         class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 pr-10
                                  focus:ring-blue-500 focus:border-blue-500" %>
+
+        <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+          <i class="fa fa-search"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- YEAR -->
+    <div class="w-24 pb-2">
+      <label for="year" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Year
+      </label>
+
+      <%= f.text_field :year,
+                       placeholder: "e.g. 2025",
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+                                 focus:ring-blue-500 focus:border-blue-500",
+                       oninput: "this.form.requestSubmit()" %>
     </div>
 
     <% if allowed_to?(:manage?, Story) %>
@@ -45,10 +68,10 @@
       </div>
     <% end %>
 
-    <!-- Clear -->
-    <div><%= link_to "Clear filters",
-                  stories_path,
-                  class: "btn btn-utility-outline whitespace-nowrap",
-                  data: { action: "collection#clearAndSubmit" } %></div>
-  <% end %>
-</div>
+    <!-- CLEAR FILTERS -->
+    <div class="min-w-[120px] pb-3">
+      <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">&nbsp;</label>
+      <%= link_to "Clear filters", stories_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/stories/_story_results.html.erb
+++ b/app/views/stories/_story_results.html.erb
@@ -1,38 +1,38 @@
 <%= turbo_stream.replace("story_count", partial: "story_count") %>
-<% if @stories.any? %>
-  <%
-    sort_base = params.permit(:title, :query, :published, :number_of_items_per_page).to_h.symbolize_keys
-    sort_icon = ->(column) {
-      if @sort == column
-        @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
-      else
-        "fa-sort"
-      end
-    }
-    sort_link = ->(column, label) {
-      link_to stories_path(sort_base.merge(sort: column, direction: (@sort == column && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-              data: { turbo_frame: "story_results" },
-              class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do
-        concat label
-        concat content_tag(:i, "", class: "fa-solid #{sort_icon.call(column)} text-xs opacity-70")
-      end
-    }
-  %>
-  <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm animate-fade blur-on-submit">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
-        <tr>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("title", "Title") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("windows_type", "Windows Type") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("workshop", "Workshop") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("author", "Author") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("organization", "Organization") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("updated_at", "Updated At") %></th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Actions</th>
-        </tr>
-      </thead>
+<%
+  sort_base = params.permit(:title, :query, :published, :year, :number_of_items_per_page).to_h.symbolize_keys
+  sort_icon = ->(column) {
+    if @sort == column
+      @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
+    else
+      "fa-sort"
+    end
+  }
+  sort_link = ->(column, label) {
+    link_to stories_path(sort_base.merge(sort: column, direction: (@sort == column && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
+            data: { turbo_frame: "story_results" },
+            class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do
+      concat label
+      concat content_tag(:i, "", class: "fa-solid #{sort_icon.call(column)} text-xs opacity-70")
+    end
+  }
+%>
+<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @stories.any? %>">
+  <table class="w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("title", "Title") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("windows_type", "Windows Type") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("workshop", "Workshop") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("author", "Author") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("organization", "Organization") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><%= sort_link.call("updated_at", "Updated At") %></th>
+        <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Actions</th>
+      </tr>
+    </thead>
 
-      <tbody class="divide-y divide-gray-100">
+    <tbody class="divide-y divide-gray-100">
+      <% if @stories.any? %>
         <% @stories.each do |story| %>
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 text-sm text-gray-800 flex items-center gap-2">
@@ -82,24 +82,27 @@
             </td>
           </tr>
         <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% else %>
+        <tr>
+          <td colspan="7" class="text-center py-16">
+            <h2 class="text-gray-600 text-lg mb-2">No stories found</h2>
+            <% if allowed_to?(:new?, Story) %>
+              <div class="admin-only bg-blue-100 p-3">
+                <%= link_to "Create a story",
+                            new_story_path,
+                            data: {turbo_frame: "_top"},
+                            class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% if @stories.any? %>
   <!-- Pagination -->
   <div class="mt-6 flex justify-center">
     <div class="pagination mt-6"><%= tailwind_paginate @stories %></div>
-  </div>
-<% else %>
-  <div class="text-center py-16 bg-white rounded-xl border border-gray-200 shadow-sm">
-    <h2 class="text-gray-600 text-lg mb-2">No stories found</h2>
-
-    <% if allowed_to?(:new?, Story) %>
-      <div class="admin-only bg-blue-100 p-3">
-        <%= link_to "Create a story",
-                    new_story_path,
-                    data: {turbo_frame: "_top"},
-                    class: "btn btn-primary" %>
-      </div>
-    <% end %>
   </div>
 <% end %>

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -110,6 +110,28 @@ RSpec.describe CommunityNews, type: :model do
       end
     end
 
+    context 'when filtering by year' do
+      let!(:news_2025) do
+        create(:community_news, title: 'Old News', created_at: Date.new(2025, 6, 15))
+      end
+
+      let!(:news_2026) do
+        create(:community_news, title: 'New News', created_at: Date.new(2026, 3, 1))
+      end
+
+      it 'returns records from the specified year' do
+        results = CommunityNews.by_year('2025')
+        expect(results).to include(news_2025)
+        expect(results).not_to include(news_2026)
+      end
+
+      it 'returns records from a different year' do
+        results = CommunityNews.by_year('2026')
+        expect(results).to include(news_2026)
+        expect(results).not_to include(news_2025)
+      end
+    end
+
     context 'LEFT JOIN behavior' do
       it 'includes records without people in search results' do
         results = CommunityNews.search('Special')


### PR DESCRIPTION
- This work Closes #1061

### What is the goal of this PR and why is this important?
Add a year text field filter to community news and stories index pages, allowing users to quickly filter content by the year it was created. Also improves search box styling consistency and fixes a clear-filters bug.

### How did you approach the change?
- Added `by_year` scope to CommunityNews and Story models, filtering `created_at` within the given year
- Only applies filter when input is exactly 4 digits (avoids partial-input queries while typing)
- Restyled both search boxes to match the Resources index pattern (uppercase labels, search icon on keywords, consistent spacing)
- Fixed `clearAndSubmit` in the collection Stimulus controller to toggle checkbox classes back to unselected before unchecking (fixes Kinds filter on Resources not visually resetting)
- Restructured results partials to always render the table with headers, using a colspan row for the empty state so layout width is preserved

### Anything else to add?
Added model specs for the `by_year` scope on CommunityNews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)