### PR TITLE
Remove Resource external_url button (#1106)

### DIFF
--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -1,6 +1,4 @@
 class ResourceDecorator < ApplicationDecorator
-  include ::Linkable
-
   def detail(length: nil)
     length ? body&.truncate(length) : body  # TODO - rename field
   end
@@ -11,10 +9,6 @@ class ResourceDecorator < ApplicationDecorator
 
   def kind_display
     kind == "Scholarship" ? "Scholar-ship" : (kind.present? ? kind.titleize : "Resource")
-  end
-
-  def external_url
-    object.url
   end
 
   def truncated_author

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -4,8 +4,6 @@
       <div class="text-right mb-4 space-x-1">
         <%= link_to "Resources", resources_path, class: "btn btn-secondary-outline" %>
         <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "External URL", safe_url(@resource.url), target: "_blank", rel: "noopener noreferrer",
-                    class: "btn btn-secondary-outline" if @resource.url.present? %>
         <% if allowed_to?(:edit?, @resource) %>
           <%= link_to("Edit", edit_resource_path(@resource),
                       class: "admin-only bg-blue-100 btn btn-primary-outline") %>


### PR DESCRIPTION
- This work Closes #1106

### What is the goal of this PR and why is this important?
- Resources no longer have an `external_url` form field, so the "External URL" button on the show page and the `Linkable` concern in `ResourceDecorator` are dead code

### How did you approach the change?
- Removed the "External URL" `link_to` from `app/views/resources/show.html.erb`
- Removed `include ::Linkable` and the `external_url` method from `ResourceDecorator`
- Resources now fall through to `ApplicationDecorator` defaults (`link_target` → polymorphic path, `external_link?` → `false`)

### Anything else to add?
- `Linkable` remains in use by `StoryDecorator` and `CommunityNewsDecorator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)