### PR TITLE
Bypass email obfuscation in FAQ answer content

### DIFF
--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -118,7 +118,7 @@
 
       <% end %>
 
-      <span class="prose max-w-none text-gray-600 px-6"><%= simple_format(faq.answer) %></span>
+      <span class="prose max-w-none text-gray-600 px-6"><!--email_off--><%= simple_format(faq.answer) %><!--email_on--></span>
     <% end %>
   </div>
 


### PR DESCRIPTION
## Summary
- Wraps FAQ answer output with `<!--email_off-->` / `<!--email_on-->` comments to prevent the hosting provider from redacting email addresses in FAQ content
- Matches the pattern used in #1117 for the people index

Fixes #1123

## Test plan
- [ ] Verify FAQ answers containing email addresses display correctly in production
- [ ] Verify inline edit cancel still renders the answer properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)