### PR TITLE
Update hard-coded Tutorial display text to Video

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -57,7 +57,7 @@ class TutorialsController < ApplicationController
     end
 
     if success
-      redirect_to @tutorial, notice: "Tutorial was successfully created."
+      redirect_to @tutorial, notice: "Video was successfully created."
     else
       @tutorial = @tutorial.decorate
       set_form_variables
@@ -81,7 +81,7 @@ class TutorialsController < ApplicationController
     end
 
     if success
-      redirect_to @tutorial, notice: "Tutorial was successfully updated.", status: :see_other
+      redirect_to @tutorial, notice: "Video was successfully updated.", status: :see_other
     else
       @tutorial = @tutorial.decorate
       set_form_variables
@@ -92,7 +92,7 @@ class TutorialsController < ApplicationController
   def destroy
     authorize! @tutorial
     @tutorial.destroy!
-    redirect_to tutorials_path, notice: "Tutorial was successfully destroyed."
+    redirect_to tutorials_path, notice: "Video was successfully destroyed."
   end
 
   # Optional hooks for setting variables for forms or index

--- a/app/views/home/video_gallery/index.html.erb
+++ b/app/views/home/video_gallery/index.html.erb
@@ -5,7 +5,7 @@
         <%= render "tutorials/video_card", tutorial: tutorial %>
       <% end %>
     </div>
-    <div class="mt-6 text-right"><%= link_to "Browse all tutorials",
+    <div class="mt-6 text-right"><%= link_to "Browse all videos",
                 tutorials_path,
                 data: { turbo_frame: "_top" },
                 class: "text-primary font-medium hover:underline" %></div>

--- a/app/views/tutorials/_form.html.erb
+++ b/app/views/tutorials/_form.html.erb
@@ -26,7 +26,7 @@
       <div class="flex-1">
         <%= f.input :position,
                     as: :integer,
-                    hint: "Order to display tutorials in (lower numbers display first)" %>
+                    hint: "Order to display videos in (lower numbers display first)" %>
       </div>
     </div>
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The `Tutorial` model's i18n already maps to "Video" (singular) and "Video Gallery" (plural) via `model_name.human`
- A few hard-coded strings still displayed "Tutorial" to users instead of "Video"
- This aligns all user-facing text with the Video Gallery branding

### How did you approach the change?

- Updated flash notices in `TutorialsController`: "Tutorial was successfully created/updated/destroyed" → "Video was successfully ..."
- Updated form hint in `_form.html.erb`: "Order to display tutorials in" → "Order to display videos in"
- Updated link text in `home/video_gallery/index.html.erb`: "Browse all tutorials" → "Browse all videos"

### Anything else to add?

- No code/model/route renames — just 5 lines of display text
- The `Tutorial` model name stays as-is internally; i18n handles the public-facing labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)