### PR TITLE
Refine welcome banner styling and copy

### DIFF
--- a/app/views/shared/_public_welcome_banner.html.erb
+++ b/app/views/shared/_public_welcome_banner.html.erb
@@ -1,14 +1,15 @@
 <% unless user_signed_in? %>
   <div class="bg-white px-8 py-6 mt-6 mb-6 flex items-center justify-center gap-5">
-    <div class="h-14 w-14 shrink-0 rounded-full overflow-hidden">
+    <div class="h-20 w-20 shrink-0 rounded-full overflow-hidden">
       <%= image_tag "logo-circle.png", class: "h-full w-full object-cover", alt: "AWBW logo" %>
     </div>
-    <div>
+    <div class="max-w-lg">
       <h2 class="text-xl font-semibold text-primary mb-1">Welcome to the AWBW Portal!</h2>
       <p class="text-gray-600">
-        We invite you to explore our public resources below. If you are a Windows Facilitator,
+        We invite you to explore our public content below.
+        Windows Facilitators,
         <%= link_to "log in", new_user_session_path, class: "font-medium text-primary underline hover:text-primary/80" %>
-        to access our full library of curriculum and resources.
+        for access to all our curriculum and resources.
       </p>
     </div>
   </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The welcome banner lost its centered appearance after the text was lengthened in #1170
- The logo was too small relative to the updated layout
- The copy needed tightening to fit the centered design

### How did you approach the change?
- Added `max-w-lg` to the text div so the logo+text group stays compact and visually centered via `justify-center`
- Increased logo from `h-14 w-14` (56px) to `h-20 w-20` (80px)
- Shortened copy to: "We invite you to explore our public content below. Windows Facilitators, log in for access to all our curriculum and resources."

### Anything else to add?
- The workshops page already had the banner partial rendered since the original commit (#1043), so no template changes were needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)