### PR TITLE
Fix: Story Idea bookmark NoMethodError

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -16,6 +16,10 @@ class ApplicationDecorator < Draper::Decorator
     h.polymorphic_path(object)
   end
 
+  def published?
+    object.respond_to?(:published?) ? object.published? : true
+  end
+
   def external_link?
     false
   end


### PR DESCRIPTION
- This work Closes #1098

### What is the goal of this PR and why is this important?

- The bookmarks page crashes with `NoMethodError (undefined method 'published?' for an instance of StoryIdeaDecorator)` when a user has bookmarked a story idea
- `StoryIdea`, `WorkshopIdea`, and `WorkshopLog` don't have a `published?` method or `published` database column, but the bookmarks view calls `published?` unconditionally on all bookmarkable types

### How did you approach the change?

- Added a default `published?` method to `ApplicationDecorator` that delegates to the model when it responds to `published?`, and returns `true` otherwise
- Models with a publish concept (e.g., `Resource`, `Story`, `CommunityNews`) still use their existing `published?` logic
- Models without a publish concept (e.g., `StoryIdea`, `WorkshopIdea`, `WorkshopLog`) are treated as always published, which is the correct behavior

### Anything else to add?

- This also prevents the same crash for `WorkshopIdea` and `WorkshopLog` bookmarks, which have the same issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)