### PR TITLE
Hide windows type from resource show title

### DIFF
--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -22,7 +22,7 @@
         <!-- Title -->
         <div class="font-semibold text-gray-900 mb-2">
           <%= title_with_badges(@resource, font_size: "text-3xl") %>
-          <%= "(#{@resource.windows_type&.short_name})" if @resource.windows_type %>
+          <%#= "(#{@resource.windows_type&.short_name})" if @resource.windows_type %>
         </div>
         <!-- Author and Date -->
         <div class="flex flex-col gap-1">


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
- User doesn't want to see windows type on resource show

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

