### PR TITLE
Standardize navigation link styling and add homepage seed data

### DIFF
--- a/app/views/banners/edit.html.erb
+++ b/app/views/banners/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
-          <div class="flex items-center justify-between mb-6">
-            <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @banner.class.model_name.human.downcase %></h1>
-            <%= link_to "View", banner_path(@banner),
-                        class: "btn btn-secondary-outline" %>
+          <div class="flex flex-wrap justify-end gap-2 mb-4">
+            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Banners", banners_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "View", banner_path(@banner), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
           </div>
+          <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @banner.class.model_name.human.downcase %></h1>
 
           <div class="space-y-6">
             <div class="mt-4">

--- a/app/views/banners/index.html.erb
+++ b/app/views/banners/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to('New ' + Banner.model_name.human.downcase,
                                 new_banner_path,
-                                class: "btn btn-primary-outline") %>
+                                class: "admin-only bg-blue-100 btn btn-primary-outline") %>
           </div>
         </div>
 

--- a/app/views/banners/show.html.erb
+++ b/app/views/banners/show.html.erb
@@ -1,20 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @banner.class.model_name.human %> details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("Banners", banners_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @banner) %>
-            <%= link_to("Edit", edit_banner_path(@banner), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Banners", banners_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @banner) %>
+          <%= link_to "Edit", edit_banner_path(@banner), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @banner.class.model_name.human %> details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,10 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @category.class.model_name.human.downcase %></h1>
-    <%= link_to "Taggings", taggings_path(category_names_all: @category.name),
-                class: "btn btn-secondary-outline" %>
+  <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Categories", categories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Taggings", taggings_path(category_names_all: @category.name), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "View", category_path(@category), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
+  <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category.class.model_name.human.downcase %></h1>
 
   <div class="space-y-6">
     <div class="mt-4">

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,10 +10,10 @@
       <div class="flex gap-2">
         <%= link_to "Dedupe",
                     dedupe_index_categories_path,
-                    class: "btn btn-secondary-outline" %>
+                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "New #{Category.model_name.human.downcase}",
                     new_category_path,
-                    class: "btn btn-primary-outline" %>
+                    class: "admin-only bg-blue-100 btn btn-primary-outline" %>
       </div>
     </div>
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,20 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @category.class.model_name.human %> details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("Categories", categories_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @category) %>
-            <%= link_to("Edit", edit_category_path(@category), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Categories", categories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @category) %>
+          <%= link_to "Edit", edit_category_path(@category), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @category.class.model_name.human %> details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -2,11 +2,12 @@
 <div class="min-h-screen py-8">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @category_type.class.model_name.human.downcase %></h1>
-        <%= link_to "View", category_type_path(@category_type),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Category Types", category_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", category_type_path(@category_type), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category_type.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -13,7 +13,7 @@
           <div class="flex gap-2">
             <%= link_to("New #{ CategoryType.model_name.human.downcase }",
                         new_category_type_path,
-                        class: "btn btn-primary-outline") %>
+                        class: "admin-only bg-blue-100 btn btn-primary-outline") %>
           </div>
         </div>
 

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -2,20 +2,15 @@
 <div class="min-h-screen py-8">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          Category type details: <%= @category_type.name %>
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("Category types", category_types_path, class: "btn btn-secondary-outline") %>
-          <%= link_to("Categories", categories_path(category_type_id: @category_type.id), class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <%= link_to("Edit", edit_category_type_path(@category_type), class: "btn btn-primary-outline") %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Category types", category_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Categories", categories_path(category_type_id: @category_type.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Edit", edit_category_type_path(@category_type), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        Category type details: <%= @category_type.name %>
+      </h1>
 
       <div class="flex items-center gap-6 mt-2 mb-2">
         <p class="text-gray-700">

--- a/app/views/community_news/edit.html.erb
+++ b/app/views/community_news/edit.html.erb
@@ -1,12 +1,16 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-          <div class="flex items-center justify-between mb-6">
-            <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @community_news.class.model_name.human.downcase %></h1>
-            <%= link_to "External URL", safe_url(@community_news.reference_url), target: "_blank", rel: "noopener noreferrer",
-                        class: "btn btn-secondary-outline" if @community_news.reference_url.present? %>
+          <div class="flex flex-wrap justify-end gap-2 mb-4">
+            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Community News", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <% if @community_news.reference_url.present? %>
+              <%= link_to "External URL", safe_url(@community_news.reference_url), target: "_blank", rel: "noopener noreferrer",
+                          class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <% end %>
             <%= link_to "View", community_news_path(@community_news, no_redirect: true),
-                        class: "btn btn-secondary-outline" %>
+                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
           </div>
+          <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @community_news.class.model_name.human.downcase %></h1>
 
           <div class="space-y-6">
             <div class="mt-4">

--- a/app/views/community_news/show.html.erb
+++ b/app/views/community_news/show.html.erb
@@ -2,15 +2,13 @@
 <% community_news_url   = community_news_url(@community_news) %>
 <% community_news_title = ERB::Util.url_encode(@community_news.title) %>
 <div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Buttons -->
-      <div class="text-right mb-4 space-x-1">
-        <%= link_to "Community news", community_news_index_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "External URL", safe_url(@community_news.reference_url), target: "_blank", rel: "noopener noreferrer",
-                    class: "btn btn-secondary-outline" if @community_news.reference_url.present? %>
+      <!-- Top Right Utility Links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Community news", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @community_news) %>
           <%= link_to "Edit", edit_community_news_path(@community_news),
-                      class: "btn btn-secondary-outline admin-only bg-blue-100" %>
+                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @community_news %>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-6">
-          <!-- Header + View Button -->
-          <div class="flex items-center justify-between mb-4">
-            <h1 class="text-2xl font-semibold text-gray-900">Edit event registration</h1>
-            <%= link_to 'View', event_registration_path(@event_registration), class: "btn btn-secondary-outline" %>
+          <div class="flex flex-wrap justify-end gap-2 mb-4">
+            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Event Registrations", event_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "View", event_registration_path(@event_registration), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
           </div>
+          <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit event registration</h1>
 
           <div class="border-b border-gray-300 mb-6"></div>
 

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -9,7 +9,7 @@
             <div class="flex gap-2">
               <%= link_to "Export CSV",
                           event_registrations_path(request.query_parameters.merge(format: :csv)),
-                          class: "btn btn-secondary-outline" %>
+                          class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
               <% if allowed_to?(:new?, EventRegistration) %>
                 <%= link_to "New #{EventRegistration.model_name.human.downcase}",
                             new_event_registration_path,

--- a/app/views/event_registrations/show.html.erb
+++ b/app/views/event_registrations/show.html.erb
@@ -1,9 +1,10 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<% if allowed_to?(:index?, EventRegistration) %>
-  <div class="flex justify-end mb-4">
-    <%= link_to "Event Registrations", event_registrations_path, class: "btn btn-secondary-outline bg-blue-100" %>
-  </div>
-<% end %>
+<div class="flex flex-wrap justify-end gap-2 mb-4">
+  <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <% if allowed_to?(:index?, EventRegistration) %>
+    <%= link_to "Event Registrations", event_registrations_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <% end %>
+</div>
   <div class="max-w-lg mx-auto">
 
     <!-- Ticket Container -->

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,19 +1,21 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "View", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  </div>
   <div class="flex items-center justify-between mb-3">
     <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
       Edit event: <%= @event.title %>
     </h1>
-    <div class="flex gap-2">
-      <%= link_to "View", event_path(@event), class: "btn btn-secondary-outline" %>
-      <button type="submit" form="event-form"
-              formaction="<%= preview_event_path(@event) %>"
-              formtarget="_blank"
-              data-turbo="false"
-              class="btn btn-secondary-outline">
-        Preview
-      </button>
-    </div>
+    <button type="submit" form="event-form"
+            formaction="<%= preview_event_path(@event) %>"
+            formtarget="_blank"
+            data-turbo="false"
+            class="btn btn-secondary-outline">
+      Preview
+    </button>
   </div>
   <div class="space-y-6">
     <div class="bg-white rounded mt-4 p-6">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,11 +7,11 @@
   </div>
 <% else %>
 <!-- Top Right Actions -->
-<div class="flex flex-wrap justify-end gap-2">
+<div class="flex flex-wrap justify-end gap-2 mb-4">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% if allowed_to?(:edit?, @event) %>
-    <%= link_to "Edit", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    <%= link_to "Edit", edit_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
 </div>

--- a/app/views/faqs/edit.html.erb
+++ b/app/views/faqs/edit.html.erb
@@ -1,12 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            Edit <%= @faq.class.model_name.human.downcase %>
-          </h1>
-          <%= link_to "View", faq_path(@faq),
-                      class: "btn btn-secondary-outline h-10 px-4 py-2 text-sm font-medium" %>
+        <div class="flex flex-wrap justify-end gap-2 mb-4">
+          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "FAQs", faqs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "View", faq_path(@faq), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         </div>
+        <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+          Edit <%= @faq.class.model_name.human.downcase %>
+        </h1>
 
         <div class="bg-white rounded p-6">
           <div class="mt-4">

--- a/app/views/faqs/show.html.erb
+++ b/app/views/faqs/show.html.erb
@@ -1,20 +1,16 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @faq.class.model_name.human %>
-          Details
-        </h1>
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("FAQs", faqs_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @faq) %>
-            <%= link_to("Edit", edit_faq_path(@faq), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "FAQs", faqs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @faq) %>
+          <%= link_to "Edit", edit_faq_path(@faq), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @faq.class.model_name.human %>
+        Details
+      </h1>
       <div class="space-y-6">
         <div class="mt-4">
           <%= render @faq, hide_options: true %>

--- a/app/views/monthly_reports/show.html.erb
+++ b/app/views/monthly_reports/show.html.erb
@@ -8,18 +8,16 @@
     <div class="bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6 space-y-6">
 
       <!-- Header -->
-      <div class="flex items-center justify-between">
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @monthly_report.title %>
-        </h1>
-
-        <div class="flex gap-2">
-          <%= link_to "Back to Monthly Reports", monthly_reports_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @monthly_report) %>
-            <%= link_to "Edit Log", edit_monthly_report_path(@monthly_report), class: "btn btn-primary-outline" %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Monthly Reports", monthly_reports_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @monthly_report) %>
+          <%= link_to "Edit", edit_monthly_report_path(@monthly_report), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900">
+        <%= @monthly_report.title %>
+      </h1>
 
       <!-- Workshop Info -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-gray-800">

--- a/app/views/organization_statuses/edit.html.erb
+++ b/app/views/organization_statuses/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @organization_status.class.model_name.human.downcase %></h1>
-        <%= link_to "View", organization_status_path(@organization_status),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", organization_status_path(@organization_status), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @organization_status.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/organization_statuses/index.html.erb
+++ b/app/views/organization_statuses/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to("New #{ OrganizationStatus.model_name.human.downcase }",
                         new_organization_status_path,
-                        class: "btn btn-primary-outline") %>
+                        class: "admin-only bg-blue-100 btn btn-primary-outline") %>
           </div>
         </div>
 

--- a/app/views/organization_statuses/show.html.erb
+++ b/app/views/organization_statuses/show.html.erb
@@ -1,18 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @organization_status.class.model_name.human %> details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("OrganizationStatuses", organization_statuses_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <%= link_to("Edit", edit_organization_status_path(@organization_status), class: "btn btn-primary-outline") %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @organization_status) %>
+          <%= link_to "Edit", edit_organization_status_path(@organization_status), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @organization_status.class.model_name.human %> details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/quotes/edit.html.erb
+++ b/app/views/quotes/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @quote.class.model_name.human.downcase %></h1>
-        <%= link_to "View", quote_path(@quote),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Quotes", quotes_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", quote_path(@quote), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @quote.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to("New #{Quote.model_name.human.downcase}",
                                 new_quote_path,
-                                class: "btn btn-primary-outline") %>
+                                class: "admin-only bg-blue-100 btn btn-primary-outline") %>
           </div>
         </div>
 

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -3,18 +3,12 @@
 
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Buttons -->
-      <div class="text-right mb-4 space-x-1">
-        <span class="inline-block text-sm">
-          <%#= render "bookmarks/editable_bookmark_button", resource: @quote %>
-        </span>
-
-        <%= link_to "Home", root_path,
-                    class: "btn btn-secondary-outline" %>
-
+      <!-- Top Right Utility Links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @quote) %>
           <%= link_to "Edit", edit_quote_path(@quote),
-                      class: "btn btn-secondary-outline admin-only bg-blue-100" %>
+                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
       </div>
 

--- a/app/views/resources/edit.html.erb
+++ b/app/views/resources/edit.html.erb
@@ -1,14 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @resource.class.model_name.human.downcase %></h1>
-
-        <div class="text-end">
-          <%= link_to "External URL", safe_url(@resource.url), target: "_blank", rel: "noopener noreferrer",
-                      class: "btn btn-secondary-outline" if @resource.url.present? %>
-          <%= link_to "View", resource_path(@resource, no_redirect: true), class: "btn btn-secondary-outline" %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Resources", resources_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", resource_path(@resource, no_redirect: true), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-3">Edit <%= @resource.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
           <div class="mt-4 bg-white rounded p-3">

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Buttons -->
-      <div class="text-right mb-4 space-x-1">
-        <%= link_to "Resources", resources_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
+      <!-- Top Right Utility Links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Resources", resources_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @resource) %>
-          <%= link_to("Edit", edit_resource_path(@resource),
-                      class: "admin-only bg-blue-100 btn btn-primary-outline") %>
+          <%= link_to "Edit", edit_resource_path(@resource),
+                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
-        <span class="inline-block text-md">
+        <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @resource.object %>
         </span>
         <%= link_to ("<span title='Download #{@resource.kind}'>" +

--- a/app/views/sectors/edit.html.erb
+++ b/app/views/sectors/edit.html.erb
@@ -1,10 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit sector</h1>
-        <%= link_to "Taggings", taggings_path(sector_names_all: @sector.name),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Sectors", sectors_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Taggings", taggings_path(sector_names_all: @sector.name), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", sector_path(@sector), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit sector</h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/sectors/index.html.erb
+++ b/app/views/sectors/index.html.erb
@@ -10,10 +10,10 @@
           <div class="flex gap-2">
             <%= link_to "Dedupe",
                         dedupe_index_sectors_path,
-                        class: "btn btn-secondary-outline" %>
+                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
             <%= link_to "New #{Sector.model_name.human.downcase}",
                         new_sector_path,
-                        class: "btn btn-primary-outline" %>
+                        class: "admin-only bg-blue-100 btn btn-primary-outline" %>
           </div>
         </div>
 

--- a/app/views/sectors/show.html.erb
+++ b/app/views/sectors/show.html.erb
@@ -1,20 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          Sector details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("Sectors", sectors_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @sector) %>
-            <%= link_to("Edit", edit_sector_path(@sector), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Sectors", sectors_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @sector) %>
+          <%= link_to "Edit", edit_sector_path(@sector), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        Sector details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,17 +1,18 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
-            Edit <%= @story.class.model_name.human.downcase %>
-          </h1>
-          <div class="text-right space-x-2">
+        <div class="flex flex-wrap justify-end gap-2 mb-4">
+          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% if @story.external_url.present? %>
             <%= link_to "External URL", safe_url(@story.external_url), target: "_blank", rel: "noopener noreferrer",
-                        class: "btn btn-secondary-outline" if @story.external_url.present? %>
-            <%= link_to "View",
-                        story_path(@story, no_redirect: true),
-                        class: "btn btn-secondary-outline" %>
-          </div>
+                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% end %>
+          <%= link_to "View", story_path(@story, no_redirect: true),
+                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         </div>
+        <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
+          Edit <%= @story.class.model_name.human.downcase %>
+        </h1>
         <div class="space-y-6">
           <div class="bg-white rounded mt-4 p-6">
             <%= render "form" %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -3,15 +3,13 @@
 
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Buttons -->
-      <div class="text-right mb-4 space-x-1">
-        <%= link_to "External URL", safe_url(@story.external_url), target: "_blank", rel: "noopener noreferrer",
-                    class: "btn btn-secondary-outline" if @story.external_url.present? %>
-        <%= link_to "Stories", stories_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
+      <!-- Top Right Utility Links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @story) %>
           <%= link_to "Edit", edit_story_path(@story),
-                      class: "btn btn-secondary-outline admin-only bg-blue-100" %>
+                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @story %>

--- a/app/views/story_ideas/edit.html.erb
+++ b/app/views/story_ideas/edit.html.erb
@@ -1,18 +1,16 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
-        <div class="text-end text-right items-end items-right">
-          <% if @story_idea.stories.any? %>
-            <% @story_idea.stories.each do |story| %>
-              <%= link_to "View Story", story_path(story),
-                          class: "btn btn-secondary-outline" %>
-            <% end %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if @story_idea.stories.any? %>
+          <% @story_idea.stories.each do |story| %>
+            <%= link_to "View Story", story_path(story), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
           <% end %>
-          <%= link_to "View", story_idea_path(@story_idea),
-                      class: "btn btn-secondary-outline" %>
-        </div>
+        <% end %>
+        <%= link_to "View", story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -1,22 +1,17 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          Story Idea: <%= @story_idea.title %>
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <% if allowed_to?(:index?, StoryIdea) %>
-            <%= link_to("StoryIdeas", story_ideas_path, class: "btn btn-secondary-outline") %>
-          <% end %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @story_idea) %>
-            <%= link_to("Edit", edit_story_idea_path(@story_idea), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, StoryIdea) %>
+          <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @story_idea) %>
+          <%= link_to "Edit", edit_story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        Story Idea: <%= @story_idea.title %>
+      </h1>
 
       <div class="space-y-6">
         <!-- Organization and Workshop (muted gray, smaller) -->

--- a/app/views/tutorials/edit.html.erb
+++ b/app/views/tutorials/edit.html.erb
@@ -1,12 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            Edit <%= @tutorial.class.model_name.human.downcase %>
-          </h1>
-          <%= link_to "View", tutorial_path(@tutorial),
-                      class: "btn btn-secondary-outline h-10 px-4 py-2 text-sm font-medium" %>
+        <div class="flex flex-wrap justify-end gap-2 mb-4">
+          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to Tutorial.model_name.human(count: 2), tutorials_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "View", tutorial_path(@tutorial), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         </div>
+        <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+          Edit <%= @tutorial.class.model_name.human.downcase %>
+        </h1>
 
         <div class="bg-white rounded p-6">
           <div class="mt-4">

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Buttons -->
-      <div class="text-right mb-4 space-x-1">
-        <%= link_to Tutorial.model_name.human(count: 2), tutorials_path, class: "btn btn-secondary-outline" %>
-        <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
+      <!-- Top Right Utility Links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to Tutorial.model_name.human(count: 2), tutorials_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @tutorial) %>
-          <%= link_to("Edit", edit_tutorial_path(@tutorial),
-                      class: "admin-only bg-blue-100 btn btn-primary-outline") %>
+          <%= link_to "Edit", edit_tutorial_path(@tutorial),
+                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
-        <span class="inline-block text-md">
+        <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @tutorial.object %>
         </span>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,24 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow p-6" data-controller="toggle-user-icon">
         <div class="space-y-6">
+          <!-- Navigation links -->
+          <div class="flex flex-wrap justify-end gap-2 mb-4">
+            <% unless @user.person %>
+              <div class="admin-only bg-blue-100 p-2">
+                No person!
+                <%= link_to "Create person",
+                            new_person_path(user_id: @user.id),
+                            class: "btn btn-warning px-2 py-1" %>
+              </div>
+            <% end %>
+            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <% if @user.person %>
+              <%= link_to "Person profile", person_path(@user.person),
+                          class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <% end %>
+            <%= link_to "View", user_path(@user), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          </div>
           <!-- Header -->
           <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-semibold text-gray-900">
@@ -10,20 +28,7 @@
               <i class="fa-solid fa-lock text-red-500" data-toggle-user-icon-target="lockIcon"
                  style="<%= 'display:none' unless @user.locked_at.present? %>"></i>
             </h1>
-
             <div class="flex space-x-2">
-              <% if @user.person %>
-                <%= link_to "Person profile",
-                            person_path(@user.person),
-                            class: "btn btn-secondary-outline mr-2" %>
-              <% else %>
-                <div class="admin-only bg-blue-100 p-2 mr-2">
-                  No person!
-                  <%= link_to "Create person",
-                              new_person_path(user_id: @user.id),
-                              class: "btn btn-warning px-2 py-1" %>
-                </div>
-              <% end %>
               <%= button_to "Reset password",
                             send_reset_password_instructions_user_path(@user),
                             method: :post,
@@ -39,12 +44,6 @@
                             change_password_path,
                             class: "btn btn-secondary-outline" %>
               <% end %>
-              <%= link_to "Users",
-                          users_path,
-                          class: "btn btn-secondary-outline" %>
-              <%= link_to "View",
-                          user_path(@user),
-                          class: "btn btn-secondary-outline" %>
             </div>
           </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,25 +1,26 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow p-6">
 
-      <!-- Top buttons -->
-      <div class="flex justify-end mb-6">
-        <% if @user.person %>
-          <%= link_to "Person profile",
-                      person_path(@user.person),
-                      class: "btn btn-secondary-outline mr-2" %>
-        <% else %>
-          <div class="admin-only bg-blue-100 p-2 mr-2">
+      <!-- Top links -->
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <% unless @user.person %>
+          <div class="admin-only bg-blue-100 p-2">
             Not associated with a person
             <%= link_to "Create person",
                         new_person_path(user_id: @user.id),
                         class: "btn btn-warning px-2 py-1" %>
           </div>
         <% end %>
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:index?, User) %>
-          <%= link_to "Users", users_path, class: "btn btn-secondary-outline mr-2" %>
+          <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if @user.person %>
+          <%= link_to "Person profile", person_path(@user.person),
+                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:edit?, @user) %>
-          <%= link_to "Edit", edit_user_path(@user), class: "btn btn-primary-outline" %>
+          <%= link_to "Edit", edit_user_path(@user), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
       </div>
 

--- a/app/views/windows_types/edit.html.erb
+++ b/app/views/windows_types/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @windows_type.class.model_name.human.downcase %></h1>
-        <%= link_to "View", windows_type_path(@windows_type),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Windows Types", windows_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", windows_type_path(@windows_type), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @windows_type.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/windows_types/index.html.erb
+++ b/app/views/windows_types/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to("New #{ WindowsType.model_name.human.downcase }",
                         new_windows_type_path,
-                        class: "btn btn-primary-outline") %>
+                        class: "admin-only bg-blue-100 btn btn-primary-outline") %>
           </div>
         </div>
 

--- a/app/views/windows_types/show.html.erb
+++ b/app/views/windows_types/show.html.erb
@@ -1,18 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @windows_type.class.model_name.human %> details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <%= link_to("WindowsTypes", windows_types_path, class: "btn btn-secondary-outline") %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <%= link_to("Edit", edit_windows_type_path(@windows_type), class: "btn btn-primary-outline") %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Windows Types", windows_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @windows_type) %>
+          <%= link_to "Edit", edit_windows_type_path(@windows_type), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @windows_type.class.model_name.human %> details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_ideas/edit.html.erb
+++ b/app/views/workshop_ideas/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
-        <%= link_to 'View', workshop_idea_path(@workshop_idea),
-                            class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_ideas/index.html.erb
+++ b/app/views/workshop_ideas/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to "New #{WorkshopIdea.model_name.human.downcase}",
                         new_workshop_idea_path,
-                        class: "btn btn-primary" %>
+                        class: "btn btn-primary-outline" %>
           </div>
         </div>
 

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -1,22 +1,17 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @workshop_idea.class.model_name.human %> details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <% if allowed_to?(:index?, WorkshopIdea) %>
-            <%= link_to("WorkshopIdeas", workshop_ideas_path, class: "btn btn-secondary-outline") %>
-          <% end %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @workshop_idea) %>
-            <%= link_to("Edit", edit_workshop_idea_path(@workshop_idea), class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopIdea) %>
+          <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_idea) %>
+          <%= link_to "Edit", edit_workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        <%= @workshop_idea.class.model_name.human %> details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_logs/edit.html.erb
+++ b/app/views/workshop_logs/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
-        <%= link_to 'View', workshop_log_path(@workshop_log),
-                    class: "btn btn-secondary-outline" %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -2,20 +2,18 @@
 <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6 space-y-6">
 
       <!-- Header -->
-      <div class="flex items-center justify-between">
-        <h1 class="text-2xl font-semibold text-gray-900">
-          <%= @workshop_log.workshop&.title || "Workshop Log" %>
-        </h1>
-
-        <div class="flex gap-2">
-          <% if allowed_to?(:index?, WorkshopLog) %>
-            <%= link_to "Back to Logs", workshop_logs_path, class: "btn btn-secondary-outline" %>
-          <% end %>
-          <% if allowed_to?(:edit?, @workshop_log) %>
-            <%= link_to "Edit Log", edit_workshop_log_path(@workshop_log), class: "btn btn-primary-outline" %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopLog) %>
+          <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_log) %>
+          <%= link_to "Edit", edit_workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900">
+        <%= @workshop_log.workshop&.title || "Workshop Log" %>
+      </h1>
 
       <!-- Workshop Info -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-gray-800">

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -1,24 +1,23 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Edit workshop variation idea</h1>
-        <div class="text-end text-right items-end items-right">
-          <% if @workshop_variation_idea.workshop_variations.any? %>
-            <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
-              <%= link_to "View Variation", workshop_variation_path(workshop_variation),
-                          class: "btn btn-secondary-outline" %>
-            <% end %>
-          <% else %>
-            <% if allowed_to?(:manage?, @workshop_variation_idea) && @workshop_variation_idea.persisted? %>
-              <%= link_to "Promote to Workshop Variation",
-                          new_workshop_variation_path(workshop_variation_idea_id: @workshop_variation_idea.id),
-                          class: "admin-only bg-blue-100 btn btn-secondary-outline ms-2" %>
-            <% end %>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if @workshop_variation_idea.workshop_variations.any? %>
+          <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
+            <%= link_to "View Variation", workshop_variation_path(workshop_variation),
+                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
           <% end %>
-          <%= link_to "View", workshop_variation_idea_path(@workshop_variation_idea),
-                      class: "btn btn-secondary-outline" %>
-        </div>
+        <% else %>
+          <% if allowed_to?(:manage?, @workshop_variation_idea) && @workshop_variation_idea.persisted? %>
+            <%= link_to "Promote to Workshop Variation",
+                        new_workshop_variation_path(workshop_variation_idea_id: @workshop_variation_idea.id),
+                        class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+          <% end %>
+        <% end %>
+        <%= link_to "View", workshop_variation_idea_path(@workshop_variation_idea),
+                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit workshop variation idea</h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -9,7 +9,7 @@
           <div class="flex gap-2">
             <%= link_to "New workshop variation idea",
                         new_workshop_variation_idea_path,
-                        class: "btn btn-primary" %>
+                        class: "btn btn-primary-outline" %>
           </div>
         </div>
 

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -1,24 +1,18 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-6">
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          Workshop Variation Idea Details
-        </h1>
-
-        <!-- Buttons Group -->
-        <div class="flex items-center gap-2">
-          <% if allowed_to?(:index?, WorkshopVariationIdea) %>
-            <%= link_to("WorkshopVariationIdeas", workshop_variation_ideas_path, class: "btn btn-secondary-outline") %>
-          <% end %>
-          <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
-          <% if allowed_to?(:edit?, @workshop_variation_idea) %>
-            <%= link_to("Edit",
-                        edit_workshop_variation_idea_path(@workshop_variation_idea),
-                        class: "btn btn-primary-outline") %>
-          <% end %>
-        </div>
+      <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopVariationIdea) %>
+          <%= link_to "Workshop Variation Ideas", workshop_variation_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_variation_idea) %>
+          <%= link_to "Edit", edit_workshop_variation_idea_path(@workshop_variation_idea),
+                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
       </div>
+      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+        Workshop Variation Idea Details
+      </h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_variations/edit.html.erb
+++ b/app/views/workshop_variations/edit.html.erb
@@ -1,9 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-semibold text-gray-900">Edit workshop variation</h1>
-    <%= link_to 'View', workshop_variation_path(@workshop_variation), class: "btn btn-secondary-outline" %>
+  <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "View", workshop_variation_path(@workshop_variation), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
+  <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop variation</h1>
 
   <div class="border-b border-gray-300 mb-6"></div>
 

--- a/app/views/workshop_variations/index.html.erb
+++ b/app/views/workshop_variations/index.html.erb
@@ -9,7 +9,7 @@
       <div class="flex gap-2">
         <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
                     new_workshop_variation_path,
-                    class: "btn btn-primary" %>
+                    class: "btn btn-primary-outline" %>
       </div>
     </div>
 

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -1,20 +1,14 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
 
-    <div class="flex justify-end mb-6">
+    <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Workshop", workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
+                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       <% if allowed_to?(:edit?, @workshop_variation) %>
-        <div class="p-1">
-          <%= link_to("Edit",
-                      edit_workshop_variation_path(@workshop_variation),
-                      class: "btn btn-primary-outline #{ "admin-only bg-blue-100" if allowed_to?(:manage?, WorkshopVariation) }") %>
-        </div>
+        <%= link_to "Edit", edit_workshop_variation_path(@workshop_variation),
+                    class: "#{ "admin-only bg-blue-100 " if allowed_to?(:manage?, WorkshopVariation) }text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       <% end %>
-      <div class="p-1">
-        <%= link_to("Back to Workshop",
-                    workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
-                    class: "btn btn-secondary-outline") %>
-      </div>
-
     </div>
 
 

--- a/app/views/workshops/_show_actions_row.html.erb
+++ b/app/views/workshops/_show_actions_row.html.erb
@@ -18,15 +18,13 @@
 
   <!-- Right: Utilities -->
   <div class="flex items-center gap-4">
-    <%= link_to "Workshops", workshops_path, class: "btn btn-secondary-outline" %>
-    <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Workshops", workshops_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% if allowed_to?(:edit?, workshop) %>
       <%= link_to "Edit",
                   edit_workshop_path(workshop),
-                  class: "btn btn-secondary-outline admin-only bg-blue-100" %>
+                  class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
-
     <%= print_button(workshop, printable_type: "Workshop", button_text: "Print", image_toggle: true) %>
-
   </div>
 </div>

--- a/app/views/workshops/edit.html.erb
+++ b/app/views/workshops/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
-    <!-- Header + View Button -->
-    <div class="flex items-center justify-between mb-4">
-      <h1 class="text-2xl font-semibold text-gray-900">Edit workshop</h1>
-      <%= link_to "View", workshop_path(@workshop), class: "btn btn-secondary-outline" %>
+    <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Workshops", workshops_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "View", workshop_path(@workshop), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     </div>
+    <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop</h1>
 
     <div class="border-b border-gray-300 mb-6"></div>
 

--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -10,23 +10,28 @@ puts "Creating CommunityNews…"
   "Partner Site Success Story",
   "New Resources Added to the Library",
   "How Creativity Builds Connection"
-].each do |title|
+].each_with_index do |title, i|
+  visibility = if i < 3
+    { published: true, featured: true }
+  elsif i < 6
+    { published: true, publicly_visible: true, publicly_featured: true }
+  else
+    { published: [ true, true, false ].sample, featured: [ true, false ].sample,
+      publicly_visible: [ true, false ].sample, publicly_featured: [ true, false ].sample }
+  end
+
   body_content = Faker::Lorem.paragraph(sentence_count: 6)
   CommunityNews.where(title: title)
                .first_or_create!(
-                  body: body_content,
                   rhino_body: "<p>#{body_content}</p>",
-                  featured: [ true, false ].sample,
-                  published: [ true, true, true, false ].sample,
-                  publicly_visible: [ true, true, false ].sample,
-                  publicly_featured: [ true, false, false, false ].sample,
-                  author_id: User.all.sample.id,
-                  created_by_id: User.first.id,
-                  updated_by_id: User.first.id,
+                  author_id: User.all.sample&.id,
+                  created_by_id: User.first&.id,
+                  updated_by_id: User.first&.id,
                   organization_id: Organization.all.sample&.id,
                   windows_type_id: WindowsType.all.sample&.id,
                   created_at: Time.current - rand(1..60).days,
-                  updated_at: Time.current - rand(1..30).days
+                  updated_at: Time.current - rand(1..30).days,
+                  **visibility
                 )
 end
 
@@ -34,7 +39,6 @@ puts "Creating new StoryIdeas…"
 10.times do |i|
   body_content = Faker::Lorem.paragraph(sentence_count: 10)
   StoryIdea.create!(
-    body: body_content,
     rhino_body: "<p>#{body_content}</p>",
     publish_preferences: StoryIdea::PUBLISH_PREFERENCES.sample,
     permission_given: true,
@@ -44,8 +48,8 @@ puts "Creating new StoryIdeas…"
     windows_type_id: WindowsType.all.sample&.id,
     youtube_url: [ nil, nil, "https://youtube.com/watch?v=dQw4w9WgXcQ",
                   "https://youtube.com/watch?v=abcd1234xyz" ].sample,
-    created_by_id: User.first.id,
-    updated_by_id: User.first.id,
+    created_by_id: User.first&.id,
+    updated_by_id: User.first&.id,
     created_at: Time.current - rand(1..90).days,
     updated_at: Time.current - rand(1..40).days
   )
@@ -63,16 +67,20 @@ puts "Creating Stories…"
   "Community Coming Together Through Workshops",
   "Leadership in Action: A Facilitator’s Story",
   "When Art Opens a Door"
-].each do |title|
+].each_with_index do |title, i|
+  visibility = if i < 3
+    { published: true, featured: true }
+  elsif i < 6
+    { published: true, publicly_visible: true, publicly_featured: true }
+  else
+    { published: [ true, true, false ].sample, featured: [ true, false ].sample,
+      publicly_visible: [ true, false ].sample, publicly_featured: [ true, false ].sample }
+  end
+
   body_content = Faker::Lorem.paragraph(sentence_count: 10)
   Story.where(title: title)
        .first_or_create!(
-          body: body_content,
           rhino_body: "<p>#{body_content}</p>",
-          featured: [ true, false, false, false, false, false ].sample,
-          published: [ true, true, true, false ].sample,
-          publicly_visible: [ true, true, false ].sample,
-          publicly_featured: [ true, false, false, false ].sample,
           permission_given: true,
           external_workshop_title: [ nil, nil, nil, nil, nil, nil, "Community Art Night", "Healing Arts Circle" ].sample,
           organization_id: Organization.all.sample&.id,
@@ -86,10 +94,11 @@ puts "Creating Stories…"
             "https://youtube.com/watch?v=dQw4w9WgXcQ",
             "https://youtube.com/watch?v=abcd1234xyz"
           ].sample,
-          created_by_id: User.first.id,
-          updated_by_id: User.first.id,
+          created_by_id: User.first&.id,
+          updated_by_id: User.first&.id,
           created_at: Time.current - rand(1..90).days,
-          updated_at: Time.current - rand(1..40).days
+          updated_at: Time.current - rand(1..40).days,
+          **visibility
        )
 end
 
@@ -106,40 +115,55 @@ puts "Creating Events…"
   "Leaders in Creativity: Facilitator Roundtable",
   "Family Creative Expression Day",
   "Creative Safety & Support Workshop"
-].each do |title|
+].each_with_index do |title, i|
   start_date = Time.current + rand(5..60).days
   end_date   = start_date + rand(1..3).hours
   registration_close = start_date - rand(2..10).days
+
+  visibility = if i < 3
+    { published: true, featured: true }
+  elsif i < 6
+    { published: true, publicly_visible: true, publicly_featured: true }
+  else
+    { published: [ true, true, false ].sample, featured: [ true, false ].sample,
+      publicly_visible: [ true, false ].sample, publicly_featured: [ true, false ].sample }
+  end
+
   Event.where(title: title,
               start_date: start_date,
               end_date: end_date,)
        .first_or_create!(
-    description: Faker::Lorem.paragraph(sentence_count: 6),
-    featured: [ true, false ].sample,
-    published: [ false, false, true ].sample,
-    publicly_visible: [ true, true, false ].sample,
-    publicly_featured: [ true, false, false, false ].sample,
+    rhino_description: Faker::Lorem.paragraph(sentence_count: 6),
     registration_close_date: registration_close,
-    created_by_id: User.first.id,
+    created_by_id: User.first&.id,
     created_at: Time.current - rand(10..90).days,
-    updated_at: Time.current - rand(1..30).days
+    updated_at: Time.current - rand(1..30).days,
+    **visibility
   )
 end
 
 
 
 puts "Creating new Resources…"
-10.times do
+10.times do |i|
   kind = Resource::PUBLISHED_KINDS.sample
+
+  visibility = if i < 3
+    { published: true, featured: true }
+  elsif i < 6
+    { published: true, publicly_visible: true, publicly_featured: true }
+  else
+    { published: [ true, true, false ].sample, featured: [ true, false ].sample,
+      publicly_visible: [ true, false ].sample, publicly_featured: [ true, false ].sample }
+  end
+
   Resource.where(title: Faker::Book.title).first_or_create!(
     body: Faker::Lorem.paragraph(sentence_count: 8),
     author: [ Faker::Name.name, nil ].sample,
     agency: [ Faker::Company.name, nil ].sample,
     kind: kind,
     url: [ "https://example.com/resource/#{SecureRandom.hex(4)}", nil ].sample,
-    featured: [ true, false ].sample,
-    inactive: [ true, false, false ].sample, # mostly false = active
-    publicly_visible: [ true, true, false ].sample,
+    inactive: false,
     legacy: [ true, false, false ].sample,
     legacy_id: rand(1000..9999),
     position: rand(1..50),
@@ -147,7 +171,8 @@ puts "Creating new Resources…"
     workshop_id: Workshop.all.sample&.id,
     user_id: User.all.sample&.id,
     created_at: Time.current - rand(20..120).days,
-    updated_at: Time.current - rand(1..40).days
+    updated_at: Time.current - rand(1..40).days,
+    **visibility
   )
 end
 
@@ -266,6 +291,9 @@ workshops = [
      description: "Helps children and teens discover more about their inner selves through mixed-media portrait creation.",
      tips: "<span class='EmailHeader'>Embodied art note…</span>",
      published: true,
+     featured: true,
+     publicly_visible: true,
+     publicly_featured: true,
      searchable: true,
      created_at: Time.zone.parse("2009-08-25 14:50:19"),
      updated_at: Time.zone.parse("2014-07-31 12:32:27")
@@ -292,6 +320,7 @@ workshops = [
      year: 2012,
      description: "Participants create mandalas focused on gratitude, calming the nervous system.",
      published: true,
+     featured: true,
      searchable: true,
      created_at: Time.zone.parse("2012-05-11 14:00:00"),
      updated_at: Time.zone.parse("2015-02-01 09:22:10")
@@ -305,6 +334,9 @@ workshops = [
      year: 2015,
      description: "Explores what safety looks and feels like through imagery and symbolism.",
      published: true,
+     featured: true,
+     publicly_visible: true,
+     publicly_featured: true,
      searchable: true,
      created_at: Time.zone.parse("2015-02-02 10:10:10"),
      updated_at: Time.zone.parse("2016-01-20 08:01:22")
@@ -331,6 +363,7 @@ workshops = [
      year: 2018,
      description: "Participants explore emotional landscapes by drawing and labeling heart maps.",
      published: true,
+     featured: true,
      searchable: true,
      created_at: Time.zone.parse("2018-03-14 09:40:00"),
      updated_at: Time.zone.parse("2019-05-11 16:02:10")
@@ -357,6 +390,9 @@ workshops = [
      year: 2020,
      description: "Participants create symbolic flags representing identity, hopes, and values.",
      published: true,
+     featured: true,
+     publicly_visible: true,
+     publicly_featured: true,
      searchable: true,
      created_at: Time.zone.parse("2020-05-03 12:10:00"),
      updated_at: Time.zone.parse("2021-02-14 10:10:10")
@@ -438,7 +474,7 @@ workshops = [
      month: 4, year: 2022,
      description: "Decorated stones used to tell collaborative stories.",
      notes: "", tips: "", pub_issue: "X/4",
-     misc1: "", misc2: "", published: true, searchable: true,
+     misc1: "", misc2: "", published: true, featured: true, searchable: true,
      created_at: Time.zone.parse("2022-04-04"), updated_at: Time.zone.parse("2023-01-01")
   },
   {
@@ -508,7 +544,62 @@ workshops.each do |workshop|
 end
 puts "Done assigning categories and sectors."
 
-
-# Bookmark
-# Stories
-# # LeaderSpotlight
+puts "Creating Tutorials…"
+[
+  {
+    title: "Getting Started: Your First Workshop",
+    rhino_body: "A step-by-step guide to preparing and leading your first AWBW workshop.",
+    youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    published: true,
+    featured: true,
+    publicly_visible: true,
+    publicly_featured: true,
+    position: 1
+  },
+  {
+    title: "Trauma-Informed Facilitation Basics",
+    rhino_body: "Learn the foundations of trauma-informed facilitation for art-based healing workshops.",
+    youtube_url: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
+    published: true,
+    featured: true,
+    publicly_visible: true,
+    publicly_featured: true,
+    position: 2
+  },
+  {
+    title: "Creating Safe Spaces for Art Expression",
+    rhino_body: "How to set up your workshop environment to foster safety, trust, and creative expression.",
+    youtube_url: "https://www.youtube.com/watch?v=9bZkp7q19f0",
+    published: true,
+    featured: true,
+    publicly_visible: true,
+    publicly_featured: true,
+    position: 3
+  },
+  {
+    title: "Working with Children and Youth",
+    rhino_body: "Techniques and tips for adapting workshops for younger participants.",
+    youtube_url: "https://www.youtube.com/watch?v=kJQP7kiw5Fk",
+    published: true,
+    featured: true,
+    position: 4
+  },
+  {
+    title: "Art Materials and Supply Management",
+    rhino_body: "A practical guide to choosing, organizing, and budgeting for art supplies.",
+    youtube_url: "https://www.youtube.com/watch?v=RgKAFK5djSk",
+    published: true,
+    featured: true,
+    position: 5
+  },
+  {
+    title: "Monthly Reporting Walkthrough",
+    rhino_body: "How to complete your monthly reports and share workshop outcomes with AWBW.",
+    youtube_url: "https://www.youtube.com/watch?v=JGwWNGJdvx8",
+    published: true,
+    featured: true,
+    position: 6
+  }
+].each do |tutorial_data|
+  Tutorial.where(title: tutorial_data[:title]).first_or_create!(tutorial_data)
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Navigation links on show/edit pages used inconsistent styling — some used `btn btn-secondary-outline` buttons, others used text links
- Person and organization profile pages already had a clean, consistent text-link pattern that this PR extends to all other pages
- Homepage sections (Featured Workshops, Community News, Resources, Events, Stories, Video Gallery) lacked seed data with proper visibility flags, so the home index appeared empty in dev

### How did you approach the change?

**Navigation link styling (54 view files):**
- Replaced `btn btn-secondary-outline` navigation links with small gray text links (`text-sm text-gray-500 hover:text-gray-700 px-2 py-1`) across all show/edit pages
- Added `admin-only bg-blue-100` visual indicators on edit links for admin-managed resources
- Standardized link order: Home → Collection → page-specific (Edit/View)
- On edit pages, separated the title+link `justify-between` div into a links row + separate h1
- Added `allowed_to?` auth checks on Edit links for windows_types and organization_statuses show pages (previously missing)
- Standardized index page New button styling with `admin-only bg-blue-100` on admin-managed resources
- Kept action buttons (Download, Print, Preview, New) as `btn` — they're actions, not navigation

**Seed data (dummy_dev_seeds.rb):**
- Added deterministic visibility flags using `each_with_index`: first 3 items `featured` (for authenticated home), next 3 `publicly_featured` (for public home), rest random
- Added 6 Tutorial seeds with `youtube_url` for the Video Gallery section
- Added `featured: true` to 6 workshops, with 3 also `publicly_visible` + `publicly_featured`
- Removed native body/description fields where rhino equivalents are populated

### Anything else to add?

- User-facing resources (workshop ideas, story ideas, workshop variation ideas) intentionally do NOT get `admin-only bg-blue-100` on their edit links
- The `events/show.html.erb` already mostly matched the pattern — only minor tweaks applied

BEFORE:
<img width="593" height="160" alt="Screenshot 2026-02-23 at 11 27 17 AM" src="https://github.com/user-attachments/assets/edcd7c5b-8b6a-4da3-8d4e-0f37cf1b5527" />

AFTER:
<img width="609" height="105" alt="Screenshot 2026-02-23 at 11 26 39 AM" src="https://github.com/user-attachments/assets/19ebe4aa-34b2-4cd6-a806-422b84c8a086" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)