### PR TITLE
fix condition so disabling of cdn is possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /app
 
 # Set environment variables
 ENV RAILS_ENV=production \
-    RACK_ENV=production \
-    BUNDLE_PATH=/gems \
-    BUNDLE_WITHOUT="development test" \
-    BUNDLE_BIN=/gems/bin \
-    PATH="/gems/bin:$PATH"
+  RACK_ENV=production \
+  BUNDLE_PATH=/gems \
+  BUNDLE_WITHOUT="development test" \
+  BUNDLE_BIN=/gems/bin \
+  PATH="/gems/bin:$PATH"
 
 # Install bundler
 RUN gem install bundler -v 4.0.4
@@ -30,7 +30,6 @@ RUN apt-get update -qq && apt-get install -y \
   libreadline-dev \
   libssl-dev \
   libyaml-dev \
-  nodejs \
   npm \
   s3cmd \
   zlib1g-dev
@@ -47,8 +46,8 @@ RUN bundle config set without 'development test' && bundle install
 
 # Precompile assets (if applicable)
 RUN SECRET_KEY_BASE=1 \
-    SMTP_PASSWORD=dummy \
-    bundle exec rake assets:precompile
+  SMTP_PASSWORD=dummy \
+  bundle exec rake assets:precompile
 
 # Sync precompiled assets to DigitalOcean Spaces CDN (optional).
 # Pass --build-arg DO_SPACES_KEY=... etc. to enable.
@@ -56,39 +55,39 @@ ARG DO_SPACES_KEY
 ARG DO_SPACES_SECRET
 ARG DO_SPACES_REGION
 ARG DO_SPACES_BUCKET_ASSETS
-RUN if [ -n "$DO_SPACES_KEY" ]; then \
-      s3cmd --access_key="$DO_SPACES_KEY" \
-            --secret_key="$DO_SPACES_SECRET" \
-            --host="${DO_SPACES_REGION}.digitaloceanspaces.com" \
-            --host-bucket="%(bucket)s.${DO_SPACES_REGION}.digitaloceanspaces.com" \
-            --region="$DO_SPACES_REGION" \
-            --no-mime-magic \
-            --acl-public \
-            --add-header="Cache-Control:public, immutable, max-age=31536000" \
-            sync public/assets/ "s3://${DO_SPACES_BUCKET_ASSETS}/assets/" && \
-      s3cmd --access_key="$DO_SPACES_KEY" \
-            --secret_key="$DO_SPACES_SECRET" \
-            --host="${DO_SPACES_REGION}.digitaloceanspaces.com" \
-            --host-bucket="%(bucket)s.${DO_SPACES_REGION}.digitaloceanspaces.com" \
-            --region="$DO_SPACES_REGION" \
-            --no-mime-magic \
-            --acl-public \
-            --add-header="Cache-Control:public, immutable, max-age=31536000" \
-            sync public/vite/ "s3://${DO_SPACES_BUCKET_ASSETS}/vite/"; \
-    fi
+RUN if [ -n "$DO_SPACES_BUCKET_ASSETS" ]; then \
+  s3cmd --access_key="$DO_SPACES_KEY" \
+  --secret_key="$DO_SPACES_SECRET" \
+  --host="${DO_SPACES_REGION}.digitaloceanspaces.com" \
+  --host-bucket="%(bucket)s.${DO_SPACES_REGION}.digitaloceanspaces.com" \
+  --region="$DO_SPACES_REGION" \
+  --no-mime-magic \
+  --acl-public \
+  --add-header="Cache-Control:public, immutable, max-age=31536000" \
+  sync public/assets/ "s3://${DO_SPACES_BUCKET_ASSETS}/assets/" && \
+  s3cmd --access_key="$DO_SPACES_KEY" \
+  --secret_key="$DO_SPACES_SECRET" \
+  --host="${DO_SPACES_REGION}.digitaloceanspaces.com" \
+  --host-bucket="%(bucket)s.${DO_SPACES_REGION}.digitaloceanspaces.com" \
+  --region="$DO_SPACES_REGION" \
+  --no-mime-magic \
+  --acl-public \
+  --add-header="Cache-Control:public, immutable, max-age=31536000" \
+  sync public/vite/ "s3://${DO_SPACES_BUCKET_ASSETS}/vite/"; \
+  fi
 
 FROM base AS server
 
 RUN apt-get update -qq && apt-get install --no-install-recommends -y \
-    libvips \
-    poppler-utils \
-    tzdata \
-    libxml2 \
-    libxslt1.1 \
-    libffi8 \
-    libreadline8 \
-    libssl3 \
-    zlib1g \
+  libvips \
+  poppler-utils \
+  tzdata \
+  libxml2 \
+  libxslt1.1 \
+  libffi8 \
+  libreadline8 \
+  libssl3 \
+  zlib1g \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -34,7 +34,7 @@
       <div class="flex flex-col md:flex-row md:items-center gap-6 mb-8">
         <div class="flex-shrink-0 flex justify-center md:justify-start">
           <% if @person.avatar&.attached? %>
-            <%= image_tag url_for(@person.avatar),
+            <%= image_tag @person.avatar,
                           id: "person_#{@person.id}_avatar_image",
                           class: "w-28 h-28 rounded-full object-cover border-2 border-gray-200 shadow" %>
           <% elsif @person.user&.avatar&.attached? %>


### PR DESCRIPTION
we need the do_spaces_key elseware. conditinally check for the bucket name.

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
<!-- What are you trying to achieve? -->
Setting asset_host in the rails config is now causing avatar urls to hit the cdn url not the active storage url. I need a way to disable the cdn in production for now.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

