### PR TITLE
Add public event registration form system

### DIFF
--- a/app/controllers/category_types_controller.rb
+++ b/app/controllers/category_types_controller.rb
@@ -59,6 +59,6 @@ class CategoryTypesController < ApplicationController
   end
 
   def category_type_params
-    params.require(:category_type).permit(:name, :display_text, :published, :story_specific)
+    params.require(:category_type).permit(:name, :display_text, :published, :story_specific, :profile_specific)
   end
 end

--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -1,5 +1,5 @@
 class CommunityNewsController < ApplicationController
-  include ExternallyRedirectable, AhoyTracking
+  include ExternallyRedirectable, AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_community_news, only: [ :show, :edit, :update, :destroy ]
 
@@ -127,20 +127,11 @@ class CommunityNewsController < ApplicationController
         .published
         .order(:position, :name)
         .group_by(&:category_type)
-        .select { |type, _| type.nil? || (type.published? && !type.story_specific?) }
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
     @community_news.build_primary_asset if @community_news.primary_asset.blank?
     @community_news.gallery_assets.build
-  end
-
-  def assign_associations(community_news)
-    selected_category_ids = Array(params[:community_news][:category_ids]).reject(&:blank?).map(&:to_i)
-    community_news.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:community_news][:sector_ids]).reject(&:blank?).map(&:to_i)
-    community_news.sectors = Sector.where(id: selected_sector_ids)
-    community_news.save!
   end
 
   private

--- a/app/controllers/concerns/tag_assignable.rb
+++ b/app/controllers/concerns/tag_assignable.rb
@@ -1,0 +1,17 @@
+module TagAssignable
+  extend ActiveSupport::Concern
+
+  private
+
+  def assign_associations(record, param_key: nil)
+    key = param_key || record.model_name.param_key
+
+    selected_category_ids = Array(params[key][:category_ids]).reject(&:blank?).map(&:to_i)
+    record.categories = Category.where(id: selected_category_ids)
+
+    selected_sector_ids = Array(params[key][:sector_ids]).reject(&:blank?).map(&:to_i)
+    record.sectors = Sector.where(id: selected_sector_ids)
+
+    record.save!
+  end
+end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -1,6 +1,7 @@
 class EventRegistrationsController < ApplicationController
   require "csv"
 
+  skip_before_action :authenticate_user!, only: [ :show ]
   before_action :set_event_registration, only: [ :show, :edit, :update, :destroy ]
 
   def index

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -1,0 +1,127 @@
+module Events
+  class PublicRegistrationsController < ApplicationController
+    skip_before_action :authenticate_user!, only: [ :new, :create ]
+    before_action :set_event
+    before_action :ensure_registerable, only: [ :new, :create ]
+
+    rescue_from ActionController::InvalidAuthenticityToken do
+      flash[:alert] = "Your session has expired. Please try submitting the form again."
+      redirect_to new_event_public_registration_path(@event)
+    end
+
+    def new
+      authorize! :public_registration, to: :new?
+
+      @form = registration_form
+      unless @form
+        redirect_to event_path(@event), alert: "Registration form is not available for this event."
+        return
+      end
+
+      @form_fields = @form.form_fields.where(status: :active).reorder(position: :asc)
+      @event = @event.decorate
+    end
+
+    def create
+      authorize! :public_registration, to: :create?
+
+      if params[:public_registration][:website_url].present?
+        redirect_to new_event_public_registration_path(@event)
+        return
+      end
+
+      @form = registration_form
+      form_params = params.dig(:public_registration, :form_fields)&.to_unsafe_h || {}
+
+      @field_errors = validate_required_fields(form_params)
+      if @field_errors.any?
+        @form_fields = @form.form_fields.where(status: :active).reorder(position: :asc)
+        @event = @event.decorate
+        render :new, status: :unprocessable_content
+        return
+      end
+
+      result = EventRegistrationServices::PublicRegistration.call(
+        event: @event,
+        form: @form,
+        form_params: form_params
+      )
+
+      if result.success?
+        sign_in(result.event_registration.registrant.user) unless user_signed_in?
+        redirect_to event_registration_path(result.event_registration),
+                    notice: "You have been successfully registered!"
+      else
+        @form_fields = @form.form_fields.where(status: :active).reorder(position: :asc)
+        @event = @event.decorate
+        flash.now[:alert] = result.errors.join(", ")
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def show
+      authorize! :public_registration, to: :show?
+
+      @form = registration_form
+      unless @form
+        redirect_to event_path(@event), alert: "Registration form not found."
+        return
+      end
+
+      target_user = if params[:user_id].present? && allowed_to?(:index?, EventRegistration)
+        User.find_by(id: params[:user_id])
+      else
+        current_user
+      end
+
+      @user_form = @form.user_forms.find_by(user: target_user)
+      unless @user_form
+        redirect_to event_path(@event), alert: "No registration form submission found."
+        return
+      end
+
+      @form_fields = @form.form_fields.where(status: :active).reorder(position: :asc)
+      @responses = @user_form.user_form_form_fields.index_by(&:form_field_id)
+      @event = @event.decorate
+    end
+
+    private
+
+    def set_event
+      @event = Event.find(params[:event_id])
+    end
+
+    def registration_form
+      @event.forms.find_by(name: EventRegistrationFormBuilder::FORM_NAME)
+    end
+
+    def ensure_registerable
+      unless @event.registerable?
+        redirect_to event_path(@event), alert: "Registration is closed for this event."
+      end
+    end
+
+    def validate_required_fields(form_params)
+      errors = {}
+      @form.form_fields.where(status: :active).find_each do |field|
+        next if field.group_header?
+
+        value = form_params[field.id.to_s]
+
+        if field.is_required && (value.blank? || (value.is_a?(Array) && value.reject(&:blank?).empty?))
+          errors[field.id] = "can't be blank"
+          next
+        end
+
+        next if value.blank?
+
+        if field.number_integer? && value.to_s !~ /\A\d+\z/
+          errors[field.id] = "must be a whole number"
+        elsif field.field_key&.match?(/email(?!_type)/) && value.to_s !~ /\A[^@\s]+@[^@\s]+\z/
+          errors[field.id] = "must be a valid email address"
+        end
+      end
+      errors
+    end
+  end
+end

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -59,7 +59,23 @@ module Events
     end
 
     def set_registrant
-      @registrant = params[:registrant_id] ? Person.find(params[:registrant_id]) : current_user.person
+      if params[:registrant_id]
+        @registrant = Person.find(params[:registrant_id])
+      else
+        @registrant = current_user.person || create_person_for_current_user
+      end
+    end
+
+    def create_person_for_current_user
+      person = Person.create!(
+        first_name: current_user.first_name,
+        last_name: current_user.last_name,
+        email: current_user.email,
+        created_by: current_user,
+        updated_by: current_user
+      )
+      current_user.update!(person: person)
+      person
     end
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,8 @@
 class EventsController < ApplicationController
-  include AhoyTracking
+  include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview manage ]
+  before_action :set_event, only: %i[ show edit update destroy preview manage copy_registration_form ]
 
   def index
     authorize!
@@ -124,6 +124,20 @@ class EventsController < ApplicationController
     end
   end
 
+  def copy_registration_form
+    authorize! @event, to: :manage?
+
+    source_event = Event.find(params[:source_event_id])
+    source_form = source_event.forms.find_by(name: EventRegistrationFormBuilder::FORM_NAME)
+
+    if source_form
+      EventRegistrationFormBuilder.copy!(from_form: source_form, to_event: @event)
+      redirect_to edit_event_path(@event), notice: "Registration form copied successfully."
+    else
+      redirect_to edit_event_path(@event), alert: "Source event has no registration form."
+    end
+  end
+
   private
 
   def event_registrations_csv_string
@@ -168,18 +182,9 @@ class EventsController < ApplicationController
         .published
         .order(:position, :name)
         .group_by(&:category_type)
-        .select { |type, _| type.nil? || (type.published? && !type.story_specific?) }
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
-  end
-
-  def assign_associations(event)
-    selected_category_ids = Array(params[:event][:category_ids]).reject(&:blank?).map(&:to_i)
-    event.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:event][:sector_ids]).reject(&:blank?).map(&:to_i)
-    event.sectors = Sector.where(id: selected_sector_ids)
-    event.save!
   end
 
   def set_event

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,5 @@
 class OrganizationsController < ApplicationController
-  include AhoyTracking
+  include AhoyTracking, TagAssignable
   before_action :set_organization, only: [ :show, :edit, :update, :destroy, :populations_served ]
 
   def index
@@ -90,6 +90,7 @@ class OrganizationsController < ApplicationController
     authorize! @organization
 
     if @organization.save
+      assign_associations(@organization) if params.dig(:organization, :category_ids)
       redirect_to @organization, notice: "Organization was successfully created."
     else
       set_form_variables
@@ -104,6 +105,7 @@ class OrganizationsController < ApplicationController
     @organization.comments.select(&:changed?).each { |c| c.updated_by = current_user }
 
     if @organization.save
+      assign_associations(@organization) if params.dig(:organization, :category_ids)
       redirect_to organization_path(@organization), notice: "Organization was successfully updated.", status: :see_other
     else
       set_form_variables
@@ -135,6 +137,14 @@ class OrganizationsController < ApplicationController
                              }
       @organization.affiliations.proxy_association.target.replace(sorted)
     end
+
+    @org_categories_grouped = Category
+      .includes(:category_type)
+      .published
+      .order(:position, :name)
+      .group_by(&:category_type)
+      .select { |type, _| type&.profile_specific? }
+      .sort_by { |type, _| type&.name.to_s.downcase }
   end
 
   def set_index_variables
@@ -159,6 +169,7 @@ end
   def set_organization
     @organization = Organization.includes(
       :organization_status, :windows_type, :addresses,
+      :categorizable_items,
       { comments: [ :created_by, :updated_by ] },
       { sectorable_items: :sector },
       affiliations: :person
@@ -174,6 +185,7 @@ end
       :profile_show_sectors, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,
       :profile_show_stories, :profile_show_events_registered, :profile_show_workshop_logs,
+      category_ids: [],
       sectorable_items_attributes: [
         :id,
         :sector_id,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,5 +1,5 @@
 class PeopleController < ApplicationController
-  include AhoyTracking
+  include AhoyTracking, TagAssignable
   before_action :set_person, only: %i[ show edit update destroy ]
 
   def index
@@ -120,6 +120,7 @@ class PeopleController < ApplicationController
 
     respond_to do |format|
       if @person.save
+        assign_associations(@person) if params.dig(:person, :category_ids)
         format.html { redirect_to @person, notice: "Person was successfully created." }
       else
         set_form_variables
@@ -140,6 +141,7 @@ class PeopleController < ApplicationController
     @person.comments.select(&:changed?).each { |c| c.updated_by = current_user }
 
     if @person.save
+      assign_associations(@person) if params.dig(:person, :category_ids)
       redirect_to @person, notice: "Person was successfully updated."
     else
       set_form_variables
@@ -201,6 +203,14 @@ class PeopleController < ApplicationController
     @all_sectors = Sector.published.order(:name)
     @sectors_collection = @all_sectors.pluck(:name, :id)
     @current_sector_ids = @person.sectorable_items.map(&:sector_id)
+
+    @person_categories_grouped = Category
+      .includes(:category_type)
+      .published
+      .order(:position, :name)
+      .group_by(&:category_type)
+      .select { |type, _| type&.profile_specific? }
+      .sort_by { |type, _| type&.name.to_s.downcase }
   end
 
   def find_duplicate_people(first_name, last_name, email)
@@ -295,7 +305,7 @@ class PeopleController < ApplicationController
   def person_params
     params.require(:person).permit(
       :avatar,
-      :first_name, :last_name,
+      :first_name, :legal_first_name, :last_name,
       :email, :email_type,
       :email_2, :email_2_type,
       :street_address, :city, :state, :zip, :country, :mailing_address_type,
@@ -329,6 +339,7 @@ class PeopleController < ApplicationController
       :youtube_url,
       :twitter_url,
       :created_by_id, :updated_by_id,
+      category_ids: [],
       sectorable_items_attributes: [ :id, :sector_id, :is_leader, :_destroy ],
       addresses_attributes: [
         :id,

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,5 @@
 class ResourcesController < ApplicationController
-  include ExternallyRedirectable, AhoyTracking
+  include ExternallyRedirectable, AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show ]
 
   def index
@@ -159,18 +159,9 @@ class ResourcesController < ApplicationController
         .published
         .order(:position, :name)
         .group_by(&:category_type)
-        .select { |type, _| type.nil? || (type.published? && !type.story_specific?) }
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
-  end
-
-  def assign_associations(resource)
-    selected_category_ids = Array(params[:resource][:category_ids]).reject(&:blank?).map(&:to_i)
-    resource.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:resource][:sector_ids]).reject(&:blank?).map(&:to_i)
-    resource.sectors = Sector.where(id: selected_sector_ids)
-    resource.save!
   end
 
   def resource_id_param

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,5 +1,5 @@
 class StoriesController < ApplicationController
-  include ExternallyRedirectable, AhoyTracking
+  include ExternallyRedirectable, AhoyTracking, TagAssignable
 
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_story, only: [ :show, :edit, :update, :destroy ]
@@ -156,16 +156,6 @@ class StoriesController < ApplicationController
     @story.build_primary_asset if @story.primary_asset.blank?
     @story.gallery_assets.build
   end
-
-  def assign_associations(story)
-    selected_category_ids = Array(params[:story][:category_ids]).reject(&:blank?).map(&:to_i)
-    story.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:story][:sector_ids]).reject(&:blank?).map(&:to_i)
-    story.sectors = Sector.where(id: selected_sector_ids)
-    story.save!
-  end
-
 
   private
 

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -1,4 +1,5 @@
 class StoryIdeasController < ApplicationController
+  include TagAssignable
   before_action :set_story_idea, only: [ :show, :edit, :update, :destroy ]
 
   def index
@@ -135,15 +136,6 @@ class StoryIdeasController < ApplicationController
     end
     @story_idea.build_primary_asset if @story_idea.primary_asset.blank?
     @story_idea.gallery_assets.build
-  end
-
-  def assign_associations(story_idea)
-    selected_category_ids = Array(params[:story_idea][:category_ids]).reject(&:blank?).map(&:to_i)
-    story_idea.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:story_idea][:sector_ids]).reject(&:blank?).map(&:to_i)
-    story_idea.sectors = Sector.where(id: selected_sector_ids)
-    story_idea.save!
   end
 
   private

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,5 +1,5 @@
 class TutorialsController < ApplicationController
-  include AhoyTracking
+  include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_tutorial, only: [ :show, :edit, :update, :destroy ]
 
@@ -16,7 +16,7 @@ class TutorialsController < ApplicationController
       render :index_lazy
     else
       @sectors = Sector.published.order(:name)
-      @category_types = CategoryType.published.where(story_specific: false).order(:name).decorate
+      @category_types = CategoryType.published.general.order(:name).decorate
 
       render :index
     end
@@ -114,15 +114,6 @@ class TutorialsController < ApplicationController
 
   def set_tutorial
     @tutorial = Tutorial.find(params[:id])
-  end
-
-  def assign_associations(tutorial)
-    selected_category_ids = Array(params[:tutorial][:category_ids]).reject(&:blank?).map(&:to_i)
-    tutorial.categories = Category.where(id: selected_category_ids)
-
-    selected_sector_ids = Array(params[:tutorial][:sector_ids]).reject(&:blank?).map(&:to_i)
-    tutorial.sectors = Sector.where(id: selected_sector_ids)
-    tutorial.save!
   end
 
   # Strong parameters

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -80,7 +80,7 @@ class WorkshopIdeasController < ApplicationController
         .published
         .order(:position, :name)
         .group_by(&:category_type)
-        .select { |type, _| type.nil? || (type.published? && !type.story_specific?) }
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @workshop_idea.build_primary_asset if @workshop_idea.primary_asset.blank?
     @workshop_idea.gallery_assets.build

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -1,10 +1,10 @@
 class WorkshopsController < ApplicationController
-  include AhoyTracking
+  include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show ]
 
   def index
     authorize!
-    @category_types = CategoryType.published.where(story_specific: false).order(:name).decorate
+    @category_types = CategoryType.published.general.order(:name).decorate
     @sectors        = Sector.published.order(:name)
     @windows_types  = WindowsType.all
 
@@ -204,24 +204,13 @@ class WorkshopsController < ApplicationController
         .published
         .order(:position, :name)
         .group_by(&:category_type)
-        .select { |type, _| type.nil? || (type.published? && !type.story_specific?) }
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
 
     @sectors = Sector.published.order(:name)
 
     @workshop.build_primary_asset if @workshop.primary_asset.blank?
     @workshop.gallery_assets.build
-  end
-
-  def assign_associations(workshop)
-    # Convert checkbox values into categorizable_items updates
-    selected_category_ids = Array(params[:workshop][:category_ids]).reject(&:blank?).map(&:to_i)
-    workshop.categories = Category.where(id: selected_category_ids)
-
-    # Convert checkbox values into sectorable_items updates
-    selected_sector_ids = Array(params[:workshop][:sector_ids]).reject(&:blank?).map(&:to_i)
-    workshop.sectors = Sector.where(id: selected_sector_ids)
-    workshop.save!
   end
 
   def log_workshop_error(action, error)

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -76,4 +76,16 @@ module EventHelper
       text_block
     end
   end
+
+  def display_response_text(field, response)
+    return tag.span("—", class: "text-gray-400") if response&.text.blank?
+
+    if field.field_key == "primary_service_area"
+      response.text.split(", ").map { |id| Sector.find_by(id: id)&.name }.compact.join(", ").presence || response.text
+    elsif field.field_key.in?(%w[workshop_environments client_life_experiences primary_age_group])
+      response.text.split(", ").map { |id| Category.find_by(id: id)&.name }.compact.join(", ").presence || response.text
+    else
+      response.text
+    end
+  end
 end

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -9,6 +9,7 @@ class NotificationMailerJob < ApplicationJob
       "report_submitted_fyi" => ->(n) { NotificationMailer.report_submitted_fyi(n) },
       "workshop_log_submitted_fyi" => ->(n) { NotificationMailer.workshop_log_submitted_fyi(n) },
       "reset_password_fyi"   => ->(n) { NotificationMailer.reset_password_fyi(n) },
+      "event_registration_confirmation" => ->(n) { EventMailer.event_registration_confirmation(n.noticeable) },
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) }
     }
 

--- a/app/models/category_type.rb
+++ b/app/models/category_type.rb
@@ -9,8 +9,9 @@ class CategoryType < ApplicationRecord
 
   # Scopes
   # See Publishable
-  scope :general, -> { where(story_specific: false) }
+  scope :general, -> { where(story_specific: false, profile_specific: false) }
   scope :story_specific, -> { where(story_specific: true) }
+  scope :profile_specific, -> { where(profile_specific: true) }
 
   def display_label
     display_text.presence || name.titleize

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ApplicationRecord
   belongs_to :location, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :event_registrations, dependent: :destroy
+  has_many :forms, as: :owner, dependent: :destroy
 
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, as: :sectorable, dependent: :destroy

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -7,7 +7,7 @@ class Form < ApplicationRecord
   # Nested attributes
   accepts_nested_attributes_for :form_fields, allow_destroy: true
 
-  def name
-    owner ? "#{owner.try(:name)} Form" : "New Form"
+  def display_name
+    name.presence || (owner ? "#{owner.try(:name)} Form" : "New Form")
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -200,6 +200,7 @@ class Person < ApplicationRecord
   def strip_whitespace
     self.first_name = first_name&.strip
     self.last_name = last_name&.strip
+    self.legal_first_name = legal_first_name&.strip
     self.email = email&.strip
     self.email_2 = email_2&.strip
   end

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -7,7 +7,7 @@ class EventRegistrationPolicy < ApplicationPolicy
   def create?  = admin? || owner?
   def update?  = admin? || owner?
   def destroy? = record.persisted? && (admin? || owner?)
-  def show?    = admin? || owner?
+  def show? = true
 
 
   relation_scope do |relation|

--- a/app/policies/events/public_registration_policy.rb
+++ b/app/policies/events/public_registration_policy.rb
@@ -1,0 +1,13 @@
+class Events::PublicRegistrationPolicy < ApplicationPolicy
+  def new?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def show?
+    authenticated?
+  end
+end

--- a/app/services/event_registration_form_builder.rb
+++ b/app/services/event_registration_form_builder.rb
@@ -1,0 +1,217 @@
+class EventRegistrationFormBuilder
+  FORM_NAME = "Public Registration"
+
+  def self.build!(event, include_contact_fields: true)
+    new(event, include_contact_fields:).build!
+  end
+
+  def self.copy!(from_form:, to_event:)
+    new_form = to_event.forms.create!(
+      name: from_form.name,
+      form_builder_id: from_form.form_builder_id
+    )
+
+    from_form.form_fields.unscoped.where(form_id: from_form.id).order(:position).each do |source_field|
+      new_field = new_form.form_fields.create!(
+        question: source_field.question,
+        answer_type: source_field.answer_type,
+        answer_datatype: source_field.answer_datatype,
+        status: source_field.status,
+        position: source_field.position,
+        is_required: source_field.is_required,
+        instructional_hint: source_field.instructional_hint,
+        field_key: source_field.field_key,
+        field_group: source_field.field_group
+      )
+
+      source_field.form_field_answer_options.each do |ffao|
+        new_field.form_field_answer_options.create!(answer_option: ffao.answer_option)
+      end
+    end
+
+    new_form
+  end
+
+  def initialize(event, include_contact_fields: true)
+    @event = event
+    @include_contact_fields = include_contact_fields
+  end
+
+  def build!
+    form = @event.forms.create!(name: FORM_NAME)
+    position = 0
+
+    if @include_contact_fields
+      position = build_contact_fields(form, position)
+    end
+
+    position = build_background_fields(form, position)
+    position = build_professional_fields(form, position)
+    position = build_qualitative_fields(form, position)
+    build_payment_fields(form, position)
+
+    form
+  end
+
+  private
+
+  def build_contact_fields(form, position)
+    position = add_header(form, position, "Contact Information", group: "contact")
+
+    position = add_field(form, position, "First Name", :free_form_input_one_line,
+                         key: "first_name", group: "contact", required: true)
+    position = add_field(form, position, "Last Name", :free_form_input_one_line,
+                         key: "last_name", group: "contact", required: true)
+    position = add_field(form, position, "Preferred Nickname", :free_form_input_one_line,
+                         key: "nickname", group: "contact", required: false)
+    position = add_field(form, position, "Preferred Pronouns", :free_form_input_one_line,
+                         key: "pronouns", group: "contact", required: false)
+    position = add_field(form, position, "Primary Email", :free_form_input_one_line,
+                         key: "primary_email", group: "contact", required: true)
+    position = add_field(form, position, "Primary Email Type", :multiple_choice_radio,
+                         key: "primary_email_type", group: "contact", required: true,
+                         options: %w[Personal Work])
+    position = add_field(form, position, "Secondary Email", :free_form_input_one_line,
+                         key: "secondary_email", group: "contact", required: false)
+    position = add_field(form, position, "Secondary Email Type", :multiple_choice_radio,
+                         key: "secondary_email_type", group: "contact", required: false,
+                         options: %w[Personal Work])
+
+    position = add_header(form, position, "Mailing Address", group: "contact")
+    position = add_field(form, position, "Street Address", :free_form_input_one_line,
+                         key: "mailing_street", group: "contact", required: true)
+    position = add_field(form, position, "City", :free_form_input_one_line,
+                         key: "mailing_city", group: "contact", required: true)
+    position = add_field(form, position, "State / Province", :free_form_input_one_line,
+                         key: "mailing_state", group: "contact", required: true)
+    position = add_field(form, position, "Zip / Postal Code", :free_form_input_one_line,
+                         key: "mailing_zip", group: "contact", required: true)
+
+    position = add_field(form, position, "Phone", :free_form_input_one_line,
+                         key: "phone", group: "contact", required: true)
+    position = add_field(form, position, "Phone Type", :multiple_choice_radio,
+                         key: "phone_type", group: "contact", required: true,
+                         options: %w[Mobile Home Work])
+
+    position = add_header(form, position, "Agency / Organization Information", group: "contact")
+    position = add_field(form, position, "Agency / Organization Name", :free_form_input_one_line,
+                         key: "agency_name", group: "contact", required: false)
+    position = add_field(form, position, "Position / Title", :free_form_input_one_line,
+                         key: "agency_position", group: "contact", required: false)
+    position = add_field(form, position, "Agency Street Address", :free_form_input_one_line,
+                         key: "agency_street", group: "contact", required: false)
+    position = add_field(form, position, "Agency City", :free_form_input_one_line,
+                         key: "agency_city", group: "contact", required: false)
+    position = add_field(form, position, "Agency State / Province", :free_form_input_one_line,
+                         key: "agency_state", group: "contact", required: false)
+    position = add_field(form, position, "Agency Zip / Postal Code", :free_form_input_one_line,
+                         key: "agency_zip", group: "contact", required: false)
+    position = add_field(form, position, "Agency Type", :multiple_choice_radio,
+                         key: "agency_type", group: "contact", required: false,
+                         options: [
+                           "Domestic Violence", "Homeless Shelter", "Hospital",
+                           "Mental Health", "School", "After-School Program",
+                           "Community Center", "Other"
+                         ])
+    position = add_field(form, position, "Agency Website", :free_form_input_one_line,
+                         key: "agency_website", group: "contact", required: false)
+
+    position
+  end
+
+  def build_background_fields(form, position)
+    position = add_header(form, position, "Background Information", group: "background")
+
+    position = add_field(form, position, "Racial / Ethnic Identity", :free_form_input_one_line,
+                         key: "racial_ethnic_identity", group: "background", required: false,
+                         hint: "This information helps us understand the diversity of our community.")
+
+    position
+  end
+
+  def build_professional_fields(form, position)
+    position = add_header(form, position, "Professional Information", group: "professional")
+
+    position = add_field(form, position, "Primary Service Area(s)", :multiple_choice_checkbox,
+                         key: "primary_service_area", group: "professional", required: false,
+                         hint: "Select all that apply. These represent the sectors you primarily serve.")
+    position = add_field(form, position, "Workshop Environments", :multiple_choice_checkbox,
+                         key: "workshop_environments", group: "professional", required: false,
+                         hint: "Select all settings where you facilitate or plan to facilitate workshops.")
+    position = add_field(form, position, "Client Life Experiences", :multiple_choice_checkbox,
+                         key: "client_life_experiences", group: "professional", required: false,
+                         hint: "Select all that describe the populations you work with.")
+    position = add_field(form, position, "Primary Age Group(s) Served", :multiple_choice_checkbox,
+                         key: "primary_age_group", group: "professional", required: false,
+                         hint: "Select all age groups you primarily serve.")
+
+    position
+  end
+
+  def build_qualitative_fields(form, position)
+    position = add_header(form, position, "About You", group: "qualitative")
+
+    position = add_field(form, position, "How did you hear about this training?", :free_form_input_paragraph,
+                         key: "referral_source", group: "qualitative", required: false)
+    position = add_field(form, position, "What motivates you to attend this training?", :free_form_input_paragraph,
+                         key: "training_motivation", group: "qualitative", required: false)
+
+    position
+  end
+
+  def build_payment_fields(form, position)
+    position = add_header(form, position, "Payment Information", group: "payment")
+
+    position = add_field(form, position, "Number of Attendees", :free_form_input_one_line,
+                         key: "number_of_attendees", group: "payment", required: true,
+                         hint: "How many people are you registering (including yourself)?",
+                         datatype: :number_integer)
+    position = add_field(form, position, "Payment Method", :multiple_choice_radio,
+                         key: "payment_method", group: "payment", required: true,
+                         options: [ "Credit Card", "Check", "Purchase Order", "Other" ])
+
+    position
+  end
+
+  # --- helpers ---
+
+  def add_header(form, position, title, group:)
+    position += 1
+    form.form_fields.create!(
+      question: title,
+      answer_type: :group_header,
+      status: :active,
+      position: position,
+      is_required: false,
+      field_key: nil,
+      field_group: group
+    )
+    position
+  end
+
+  def add_field(form, position, question, answer_type, key:, group:, required: true, hint: nil, options: nil, datatype: nil)
+    position += 1
+    field = form.form_fields.create!(
+      question: question,
+      answer_type: answer_type,
+      answer_datatype: datatype,
+      status: :active,
+      position: position,
+      is_required: required,
+      instructional_hint: hint,
+      field_key: key,
+      field_group: group
+    )
+
+    if options.present?
+      options.each_with_index do |opt, idx|
+        ao = AnswerOption.find_or_create_by!(name: opt) do |a|
+          a.position = idx
+        end
+        field.form_field_answer_options.create!(answer_option: ao)
+      end
+    end
+
+    position
+  end
+end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -1,0 +1,270 @@
+module EventRegistrationServices
+  class PublicRegistration
+    Result = Struct.new(:success?, :event_registration, :errors, keyword_init: true)
+
+    def self.call(event:, form:, form_params:)
+      new(event:, form:, form_params:).call
+    end
+
+    def initialize(event:, form:, form_params:)
+      @event = event
+      @form = form
+      @form_params = form_params
+      @errors = []
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        user = find_or_create_user
+        person = find_or_create_person(user)
+        user.update!(person: person) unless user.person_id == person.id
+
+        create_mailing_address(person) if field_value("mailing_city").present?
+        create_phone_contact(person) if field_value("phone").present?
+
+        organization = find_or_create_organization if field_value("agency_name").present?
+        create_affiliation(person, organization) if organization
+        create_agency_address(organization) if organization && field_value("agency_city").present?
+
+        assign_tags(person, organization)
+
+        event_registration = create_event_registration(person)
+        user_form = create_user_form(user, event_registration)
+
+        send_notifications(event_registration)
+
+        Result.new(success?: true, event_registration: event_registration, errors: [])
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
+    rescue ActiveRecord::RecordNotUnique => e
+      if e.message.include?("registrant_id")
+        Result.new(success?: false, event_registration: nil,
+                   errors: [ "You are already registered for this event." ])
+      else
+        Result.new(success?: false, event_registration: nil, errors: [ e.message ])
+      end
+    end
+
+    private
+
+    def field_value(key)
+      field = @form.form_fields.find_by(field_key: key)
+      return nil unless field
+      @form_params[field.id.to_s]
+    end
+
+    def resolve_names
+      submitted_first = field_value("first_name")&.strip
+      nickname = field_value("nickname")&.strip
+
+      if nickname.present?
+        { first_name: nickname, legal_first_name: submitted_first }
+      else
+        { first_name: submitted_first, legal_first_name: nil }
+      end
+    end
+
+    def find_or_create_user
+      email = field_value("primary_email")&.strip&.downcase
+      user = User.find_by("LOWER(email) = ?", email)
+      return user if user
+
+      names = resolve_names
+      User.create!(
+        email: email,
+        password: SecureRandom.hex(16),
+        first_name: names[:first_name],
+        last_name: field_value("last_name"),
+        confirmed_at: Time.current
+      )
+    end
+
+    def find_or_create_person(user)
+      return user.person if user.person.present?
+
+      names = resolve_names
+      first_name = names[:first_name]
+      last_name = field_value("last_name")&.strip
+      email = field_value("primary_email")&.strip&.downcase
+      email_type = field_value("primary_email_type")&.downcase
+
+      person = Person.find_by(
+        "LOWER(first_name) = ? AND LOWER(last_name) = ? AND LOWER(email) = ?",
+        first_name&.downcase, last_name&.downcase, email&.downcase
+      )
+      return person if person
+
+      Person.create!(
+        first_name: first_name,
+        legal_first_name: names[:legal_first_name],
+        last_name: last_name,
+        pronouns: field_value("pronouns")&.strip,
+        email: email,
+        email_type: email_type,
+        email_2: field_value("secondary_email")&.strip,
+        email_2_type: field_value("secondary_email_type")&.downcase || "personal",
+        created_by: user,
+        updated_by: user
+      )
+    end
+
+    def create_mailing_address(person)
+      new_city = field_value("mailing_city")&.strip
+      new_state = field_value("mailing_state")&.strip
+
+      existing = person.addresses.find_by(
+        "LOWER(city) = ? AND LOWER(COALESCE(state, '')) = ?",
+        new_city&.downcase, new_state&.downcase.to_s
+      )
+      return existing if existing
+
+      person.addresses.where(primary: true).update_all(primary: false, inactive: true)
+
+      person.addresses.create!(
+        street_address: field_value("mailing_street"),
+        city: new_city,
+        state: new_state,
+        zip_code: field_value("mailing_zip"),
+        locality: "Unknown",
+        address_type: "mailing",
+        primary: true
+      )
+    end
+
+    def create_phone_contact(person)
+      phone_value = field_value("phone")&.strip
+      phone_type = field_value("phone_type")&.downcase
+      contact_type = phone_type == "work" ? "work" : "personal"
+
+      existing = person.contact_methods.find_by(kind: :phone, value: phone_value)
+      return existing if existing
+
+      person.contact_methods.where(kind: :phone, primary: true).update_all(primary: false, inactive: true)
+
+      person.contact_methods.create!(
+        kind: :phone,
+        value: phone_value,
+        contact_type: contact_type,
+        primary: true
+      )
+    end
+
+    def find_or_create_organization
+      name = field_value("agency_name")&.strip
+      return nil if name.blank?
+
+      Organization.find_or_create_by!(name: name) do |org|
+        org.organization_status = OrganizationStatus.find_by(name: "Pending")
+        org.website_url = field_value("agency_website")
+      end
+    end
+
+    def create_affiliation(person, organization)
+      Affiliation.find_or_create_by!(
+        person: person,
+        organization: organization
+      ) do |aff|
+        aff.title = field_value("agency_position")
+        aff.start_date = Date.current
+      end
+    end
+
+    def create_agency_address(organization)
+      new_city = field_value("agency_city")&.strip
+      new_state = field_value("agency_state")&.strip
+
+      existing = organization.addresses.find_by(
+        "LOWER(city) = ? AND LOWER(COALESCE(state, '')) = ?",
+        new_city&.downcase, new_state&.downcase.to_s
+      )
+      return existing if existing
+
+      organization.addresses.where(primary: true).update_all(primary: false, inactive: true)
+
+      organization.addresses.create!(
+        street_address: field_value("agency_street"),
+        city: new_city,
+        state: new_state,
+        zip_code: field_value("agency_zip"),
+        locality: "Unknown",
+        address_type: "work",
+        primary: true
+      )
+    end
+
+    def assign_tags(person, organization)
+      sector_ids = collect_ids_from_checkboxes("primary_service_area")
+      category_ids = collect_ids_from_checkboxes("workshop_environments") +
+                     collect_ids_from_checkboxes("client_life_experiences") +
+                     collect_ids_from_checkboxes("primary_age_group")
+
+      if sector_ids.any?
+        sectors = Sector.where(id: sector_ids)
+        person.sectors = (person.sectors + sectors).uniq
+        organization.sectors = (organization.sectors + sectors).uniq if organization
+      end
+
+      if category_ids.any?
+        categories = Category.where(id: category_ids)
+        person.categories = (person.categories + categories).uniq
+        organization.categories = (organization.categories + categories).uniq if organization
+      end
+    end
+
+    def collect_ids_from_checkboxes(field_key)
+      field = @form.form_fields.find_by(field_key: field_key)
+      return [] unless field
+
+      value = @form_params[field.id.to_s]
+      Array(value).reject(&:blank?).map(&:to_i)
+    end
+
+    def create_event_registration(person)
+      @event.event_registrations.create!(registrant: person)
+    end
+
+    def create_user_form(user, event_registration)
+      user_form = UserForm.create!(user: user, form: @form)
+
+      @form.form_fields.where(status: :active).find_each do |field|
+        next if field.group_header?
+
+        raw_value = @form_params[field.id.to_s]
+        text = if raw_value.is_a?(Array)
+          raw_value.reject(&:blank?).join(", ")
+        else
+          raw_value.to_s
+        end
+
+        UserFormFormField.create!(
+          user_form: user_form,
+          form_field: field,
+          text: text
+        )
+      end
+
+      user_form
+    end
+
+    def send_notifications(event_registration)
+      registrant_email = event_registration.registrant.preferred_email
+
+      NotificationServices::CreateNotification.call(
+        noticeable: event_registration,
+        kind: :event_registration_confirmation,
+        recipient_role: :person,
+        recipient_email: registrant_email,
+        notification_type: 0
+      )
+
+      NotificationServices::CreateNotification.call(
+        noticeable: event_registration,
+        kind: :event_registration_confirmation_fyi,
+        recipient_role: :admin,
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+        notification_type: 0
+      )
+    end
+  end
+end

--- a/app/views/addresses/_address_fields.html.erb
+++ b/app/views/addresses/_address_fields.html.erb
@@ -16,6 +16,7 @@
                   as: :boolean,
                   label: "Primary",
                   input_html: {
+                    checked: f.object.new_record? || f.object.primary?,
                     class: "mr-2 rounded focus:ring-blue-500 text-blue-600"
                   } %>
     </div>

--- a/app/views/category_types/_form.html.erb
+++ b/app/views/category_types/_form.html.erb
@@ -25,6 +25,12 @@
                     hint: "Needed for story share subsite",
                     input_html: { class: "h-4 w-4" },
                     wrapper_html: { class: "mb-0" } %>
+        <%= f.input :profile_specific,
+                    as: :boolean,
+                    label: "Profile specific",
+                    hint: "Shown on person & organization forms",
+                    input_html: { class: "h-4 w-4" },
+                    wrapper_html: { class: "mb-0" } %>
       </div>
     </div>
 

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -25,6 +25,7 @@
                 <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Display text</th>
                 <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Published</th>
                 <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Story specific</th>
+                <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Profile specific</th>
                 <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Categories count</th>
                 <th class="px-4 py-2 text-left text-sm font-medium text-gray-700 w-32">Actions</th>
               </tr>
@@ -51,6 +52,14 @@
 
                 <td class="px-4 py-2 text-center text-gray-700">
                   <% if category_type.story_specific? %>
+                    <span class="fa fa-check-circle text-green-500"></span>
+                  <% else %>
+                    <span class="text-gray-400">--</span>
+                  <% end %>
+                </td>
+
+                <td class="px-4 py-2 text-center text-gray-700">
+                  <% if category_type.profile_specific? %>
                     <span class="fa fa-check-circle text-green-500"></span>
                   <% else %>
                     <span class="text-gray-400">--</span>

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -30,6 +30,14 @@
           <% end %>
         </p>
         <p class="text-gray-700">
+          <span class="font-bold">Profile specific:</span>
+          <% if @category_type.profile_specific? %>
+            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+          <% else %>
+            <span class="text-gray-400 ml-1">--</span>
+          <% end %>
+        </p>
+        <p class="text-gray-700">
           <span class="font-bold">Display text:</span>
           <span class="ml-1"><%= @category_type.display_text %></span>
         </p>

--- a/app/views/contact_methods/_contact_method_fields.html.erb
+++ b/app/views/contact_methods/_contact_method_fields.html.erb
@@ -28,7 +28,7 @@
                   as: :boolean,
                   wrapper: false,
                   label: false,
-                  input_html: { class: "mr-2 text-blue-600 focus:ring-blue-500" } %>
+                  input_html: { checked: f.object.new_record? || f.object.primary?, class: "mr-2 text-blue-600 focus:ring-blue-500" } %>
     </div>
 
     <!-- Inactive -->

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -46,7 +46,15 @@
                   <% @event_registrations.each do |event_registration| %>
                     <tr id="<%= dom_id(event_registration) %>" class="hover:bg-gray-50 transition-colors duration-150">
                       <td class="px-4 py-2 text-sm text-gray-800 align-top">
+                        <div class="flex items-center gap-2">
                           <%= person_profile_button(event_registration.registrant) %>
+                          <% reg_form = event_registration.event.forms.find_by(name: "Public Registration") %>
+                          <% if reg_form && reg_form.user_forms.exists?(user: event_registration.registrant&.user) %>
+                            <i class="fa-solid fa-file-lines text-green-600 shrink-0" title="Completed registration form"></i>
+                          <% elsif reg_form %>
+                            <i class="fa-regular fa-file-lines text-gray-300 shrink-0" title="No registration form submitted"></i>
+                          <% end %>
+                        </div>
                       </td>
                       <% unless @filtered_event %>
                         <td class="px-4 py-2 text-sm text-gray-800 min-w-[50ch]">
@@ -61,8 +69,12 @@
 
                       <!-- Actions -->
                       <td class="px-4 py-2 text-center align-top">
-                        <%= link_to "Edit", edit_event_registration_path(event_registration),
-                                    class: "btn btn-secondary-outline" %>
+                        <div class="flex items-center justify-center gap-2">
+                          <%= link_to "View", event_registration_path(event_registration),
+                                      class: "btn btn-secondary-outline" %>
+                          <%= link_to "Edit", edit_event_registration_path(event_registration),
+                                      class: "btn btn-secondary-outline" %>
+                        </div>
                       </td>
                     </tr>
                   <% end %>

--- a/app/views/event_registrations/show.html.erb
+++ b/app/views/event_registrations/show.html.erb
@@ -49,7 +49,11 @@
           <div class="flex flex-col justify-center min-w-0 flex-1 ml-[4rem]">
             <p class="text-gray-500 uppercase tracking-wide text-xs">Registrant</p>
             <p class="font-medium text-gray-900 text-lg">
-              <%= @event_registration.registrant.full_name %>
+              <% if user_signed_in? %>
+                <%= link_to @event_registration.registrant.full_name, person_path(@event_registration.registrant), class: "text-blue-700 hover:text-blue-900 underline" %>
+              <% else %>
+                <%= @event_registration.registrant.full_name %>
+              <% end %>
             </p>
           </div>
         </div>
@@ -127,6 +131,15 @@
           </p>
 
         </div>
+
+        <% registration_form = @event_registration.event.forms.find_by(name: "Public Registration") %>
+        <% if registration_form && registration_form.user_forms.exists?(user: @event_registration.registrant&.user) %>
+          <div class="mt-4 text-center">
+            <%= link_to "View Registration Form",
+                        event_public_registration_path(@event_registration.event, user_id: @event_registration.registrant&.user&.id),
+                        class: "text-sm text-blue-700 hover:text-blue-900 underline" %>
+          </div>
+        <% end %>
 
       </div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -331,6 +331,51 @@
     </div>
   </div>
 
+  <% if @event.persisted? && allowed_to?(:manage?, @event) %>
+    <div class="admin-only mt-8" data-controller="dropdown">
+      <button
+        type="button"
+        id="registration_form_button"
+        class="flex items-center justify-between cursor-pointer w-full bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
+        data-action="dropdown#toggle"
+        data-dropdown-payload-param='[{"registration_form_section":"hidden"}, {"registration_form_arrow":"rotate-180"}, {"registration_form_button":"rounded-md rounded-t-md"}]'>
+        Registration Form
+        <svg id="registration_form_arrow" class="w-6 h-6 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+      </button>
+
+      <div id="registration_form_section" class="hidden border border-gray-300 p-4 rounded-b-md">
+        <% if @event.forms.exists?(name: "Public Registration") %>
+          <p class="text-sm text-green-700 mb-2">This event has a public registration form.</p>
+          <%= link_to "View public registration page",
+                      new_event_public_registration_path(@event),
+                      class: "text-sm text-blue-700 hover:text-blue-900 underline",
+                      target: "_blank" %>
+        <% else %>
+          <p class="text-sm text-gray-600 mb-3">No registration form yet. Copy one from another event or create one via the console.</p>
+        <% end %>
+
+        <div class="mt-4 border-t border-gray-200 pt-4">
+          <h4 class="text-sm font-medium text-gray-700 mb-2">Copy registration form from another event</h4>
+          <% events_with_forms = Event.joins(:forms).where(forms: { name: "Public Registration" }).where.not(id: @event.id).distinct.order(start_date: :desc) %>
+          <% if events_with_forms.any? %>
+            <%= form_with url: copy_registration_form_event_path(@event), method: :post, local: true, class: "flex items-end gap-3" do %>
+              <div class="flex-1">
+                <select name="source_event_id" class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
+                  <% events_with_forms.each do |ev| %>
+                    <option value="<%= ev.id %>"><%= ev.title %> (<%= ev.start_date.strftime("%Y-%m-%d") %>)</option>
+                  <% end %>
+                </select>
+              </div>
+              <button type="submit" class="btn btn-secondary-outline text-sm">Copy Form</button>
+            <% end %>
+          <% else %>
+            <p class="text-sm text-gray-500">No other events have registration forms to copy.</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="flex items-center justify-between gap-4">
     <div><%= "Created by: #{f.object.created_by.name}" if f.object.created_by %></div>
 

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -21,10 +21,18 @@
     <% elsif !event.published? %>
       <span class="admin-only bg-blue-100 p-1 text-sm text-gray-500 italic">Not published</span>
     <% elsif event.registerable? %>
-      <%= button_to button_text,
-                    event_registrant_registration_path(event_id: event),
+      <% has_public_form = event.object.forms.exists?(name: "Public Registration") %>
+      <% if has_public_form && !user_signed_in? %>
+        <%= link_to button_text,
+                    new_event_public_registration_path(event),
                     class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
                     style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+      <% else %>
+        <%= button_to button_text,
+                      event_registrant_registration_path(event_id: event),
+                      class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
+                      style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+      <% end %>
     <% else %>
       <span class="text-2xl font-bold text-blue-400 italic">Registration closed</span>
     <% end %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -1,0 +1,140 @@
+<%# locals: (field:, value: nil) %>
+<% return if field.group_header? %>
+
+<% error = @field_errors&.dig(field.id) %>
+<% error_border = error ? "border-red-500" : "border-gray-300" %>
+
+<div class="mb-5">
+  <label class="block text-sm font-medium text-gray-700 mb-1" for="public_registration_form_fields_<%= field.id %>">
+    <%= field.question %>
+    <% if field.is_required %>
+      <span class="text-red-500">*</span>
+    <% end %>
+  </label>
+
+  <% if field.instructional_hint.present? %>
+    <p class="text-xs text-gray-500 mb-1"><%= field.instructional_hint %></p>
+  <% end %>
+
+  <% field_name = "public_registration[form_fields][#{field.id}]" %>
+  <% field_id = "public_registration_form_fields_#{field.id}" %>
+
+  <% case field.answer_type %>
+  <% when "free_form_input_one_line" %>
+    <% if field.field_key&.end_with?("_state") %>
+      <select name="<%= field_name %>"
+              id="<%= field_id %>"
+              class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              <%= "required" if field.is_required %>>
+        <option value="">Select a state</option>
+        <% us_states.each do |name, abbr| %>
+          <option value="<%= abbr %>" <%= "selected" if value == abbr %>><%= name %> (<%= abbr %>)</option>
+        <% end %>
+      </select>
+    <% else %>
+      <%
+        input_type = case field.field_key
+                     when /email(?!_type)/ then "email"
+                     when "phone" then "tel"
+                     when "agency_website" then "url"
+                     else
+                       field.number_integer? ? "number" : "text"
+                     end
+        extra_attrs = []
+        extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
+      %>
+      <input type="<%= input_type %>"
+             name="<%= field_name %>"
+             id="<%= field_id %>"
+             value="<%= value %>"
+             class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+             <%= "required" if field.is_required %>
+             <%= raw(extra_attrs.join(" ")) %>>
+    <% end %>
+
+  <% when "free_form_input_paragraph" %>
+    <textarea name="<%= field_name %>"
+              id="<%= field_id %>"
+              rows="4"
+              class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              <%= "required" if field.is_required %>><%= value %></textarea>
+
+  <% when "multiple_choice_radio" %>
+    <div class="flex flex-wrap gap-4 mt-1">
+      <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
+        <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input type="radio"
+                 name="<%= field_name %>"
+                 value="<%= ffao.answer_option.name %>"
+                 class="text-blue-600 focus:ring-blue-500"
+                 <%= "checked" if value == ffao.answer_option.name %>
+                 <%= "required" if field.is_required %>>
+          <%= ffao.answer_option.name %>
+        </label>
+      <% end %>
+    </div>
+
+  <% when "multiple_choice_checkbox" %>
+    <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
+    <% selected_values = Array(value) %>
+
+    <% if field.field_key.in?(%w[primary_service_area workshop_environments client_life_experiences primary_age_group]) %>
+      <%# Professional fields: render dynamic sector/category options %>
+      <% if field.field_key == "primary_service_area" %>
+        <% options = Sector.published.order(:name) %>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+          <% options.each do |sector| %>
+            <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+              <input type="checkbox"
+                     name="<%= checkbox_name %>"
+                     value="<%= sector.id %>"
+                     class="rounded text-blue-600 focus:ring-blue-500"
+                     <%= "checked" if selected_values.include?(sector.id.to_s) %>>
+              <%= sector.name %>
+            </label>
+          <% end %>
+        </div>
+      <% else %>
+        <%# Categories for workshop_environments, client_life_experiences, primary_age_group %>
+        <% category_type_name = {
+          "workshop_environments" => "WorkshopEnvironment",
+          "client_life_experiences" => "StoryPopulation",
+          "primary_age_group" => "AgeRange"
+        }[field.field_key] %>
+        <% ct = CategoryType.find_by(name: category_type_name) %>
+        <% options = ct&.categories&.published&.order(:position, :name) || [] %>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+          <% options.each do |category| %>
+            <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+              <input type="checkbox"
+                     name="<%= checkbox_name %>"
+                     value="<%= category.id %>"
+                     class="rounded text-blue-600 focus:ring-blue-500"
+                     <%= "checked" if selected_values.include?(category.id.to_s) %>>
+              <%= category.name %>
+            </label>
+          <% end %>
+        </div>
+      <% end %>
+    <% else %>
+      <%# Standard answer options %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+        <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
+          <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input type="checkbox"
+                   name="<%= checkbox_name %>"
+                   value="<%= ffao.answer_option.name %>"
+                   class="rounded text-blue-600 focus:ring-blue-500"
+                   <%= "checked" if selected_values.include?(ffao.answer_option.name) %>>
+            <%= ffao.answer_option.name %>
+          </label>
+        <% end %>
+      </div>
+    <% end %>
+
+  <% end %>
+
+  <% if error %>
+    <p class="text-xs text-red-600 mt-1"><%= field.question %> <%= error %></p>
+  <% end %>
+</div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -1,0 +1,114 @@
+<% content_for(:page_bg_class, "public") %>
+
+<div class="max-w-2xl mx-auto py-8 px-4">
+
+  <%# ---- EVENT HEADER ---- %>
+  <div class="text-center mb-8">
+    <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+      <p class="text-base font-semibold text-gray-700 mb-2" style="font-family: 'Telefon Bold', sans-serif; font-size: 42px"><%= @event.pre_title %></p>
+    <% end %>
+    <h1 class="font-bold text-green-800 mb-4" style="font-family: Lato, sans-serif; font-size: 53px"><%= @event.title %></h1>
+
+    <div class="text-center space-y-2">
+      <div class="font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif; font-size: 35px">
+        <%= @event.times(display_day: true, display_date: true, styled: true) %>
+      </div>
+
+      <% if @event.labelled_cost.present? %>
+        <div class="text-xl font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif"><%= @event.labelled_cost %></div>
+      <% end %>
+
+      <% if @event.location.present? %>
+        <div class="text-base text-gray-700"><%= @event.location.name %></div>
+      <% end %>
+    </div>
+  </div>
+
+  <%# ---- REGISTRATION FORM CARD ---- %>
+  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+
+    <%# Card Header %>
+    <div class="bg-blue-900 text-white px-6 py-4">
+      <div class="flex items-center gap-3">
+        <div class="shrink-0">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+        </div>
+        <h2 class="text-xl font-semibold tracking-wide">Registration</h2>
+      </div>
+    </div>
+
+    <%# Card Body %>
+    <div class="px-6 py-6">
+      <% if flash[:alert] %>
+        <div class="bg-red-50 border border-red-300 text-red-800 rounded-lg px-4 py-3 mb-6">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
+
+      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2" do |f| %>
+
+        <%# Honeypot %>
+        <div class="hidden" aria-hidden="true">
+          <input type="text" name="public_registration[website_url]" tabindex="-1" autocomplete="off">
+        </div>
+
+        <%# Row groupings: related fields share a grid row on md+ screens %>
+        <%
+          row_groups = [
+            { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+            { keys: %w[nickname pronouns], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+            { keys: %w[primary_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "primary_email" => "md:col-span-2" } },
+            { keys: %w[secondary_email secondary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "secondary_email" => "md:col-span-2" } },
+            { keys: %w[mailing_city mailing_state mailing_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
+            { keys: %w[phone phone_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+            { keys: %w[agency_name agency_position], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+            { keys: %w[agency_city agency_state agency_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
+            { keys: %w[number_of_attendees payment_method], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+          ]
+
+          field_key_to_group = {}
+          row_groups.each { |g| g[:keys].each { |k| field_key_to_group[k] = g } }
+
+          fields_by_key = @form_fields.select(&:field_key).index_by(&:field_key)
+          rendered_keys = {}
+        %>
+
+        <% @form_fields.each do |field| %>
+          <% next if field.field_key.present? && rendered_keys[field.field_key] %>
+
+          <% if field.group_header? %>
+            <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
+              <h3 class="text-lg font-semibold text-gray-800"><%= field.question %></h3>
+            </div>
+          <% elsif (group = field.field_key.present? && field_key_to_group[field.field_key]) %>
+            <div class="<%= group[:grid] %>">
+              <% group[:keys].each do |key| %>
+                <% row_field = fields_by_key[key] %>
+                <% next unless row_field %>
+                <% rendered_keys[key] = true %>
+                <% span = group.dig(:spans, key) %>
+                <% submitted_value = params.dig(:public_registration, :form_fields, row_field.id.to_s) %>
+                <% if span %>
+                  <div class="<%= span %>">
+                    <%= render "events/public_registrations/form_field", field: row_field, value: submitted_value %>
+                  </div>
+                <% else %>
+                  <%= render "events/public_registrations/form_field", field: row_field, value: submitted_value %>
+                <% end %>
+              <% end %>
+            </div>
+          <% else %>
+            <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
+            <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+          <% end %>
+        <% end %>
+
+        <div class="pt-6">
+          <%= submit_tag "Register",
+                class: "w-full rounded-md bg-blue-900 px-6 py-3 text-white font-semibold text-lg hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+        </div>
+
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -1,0 +1,92 @@
+<% content_for(:page_bg_class, "admin-or-owner") %>
+
+<div class="max-w-2xl mx-auto py-8 px-4">
+
+  <%# ---- BACK LINK ---- %>
+  <div class="mb-4">
+    <%= link_to event_registration_path(@user_form.user.event_registrations.find_by(event: @event)),
+                class: "text-sm text-gray-500 hover:text-gray-700 inline-flex items-center gap-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Back to Registration
+    <% end %>
+  </div>
+
+  <%# ---- FORM RESPONSES CARD ---- %>
+  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+
+    <%# Card Header %>
+    <div class="bg-blue-900 text-white px-6 py-4">
+      <div class="flex items-center gap-3">
+        <div class="shrink-0">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+        </div>
+        <div class="flex-1">
+          <h1 class="text-xl font-semibold tracking-wide">Registration Details</h1>
+          <p class="text-sm text-blue-200"><%= @event.title %></p>
+        </div>
+      </div>
+    </div>
+
+    <%# Card Body %>
+    <div class="px-6 py-6 space-y-1">
+      <%
+        row_groups = [
+          { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+          { keys: %w[nickname pronouns], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+          { keys: %w[primary_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "primary_email" => "md:col-span-2" } },
+          { keys: %w[secondary_email secondary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "secondary_email" => "md:col-span-2" } },
+          { keys: %w[mailing_city mailing_state mailing_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
+          { keys: %w[phone phone_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+          { keys: %w[agency_name agency_position], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+          { keys: %w[agency_city agency_state agency_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
+          { keys: %w[number_of_attendees payment_method], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
+        ]
+
+        field_key_to_group = {}
+        row_groups.each { |g| g[:keys].each { |k| field_key_to_group[k] = g } }
+
+        fields_by_key = @form_fields.select(&:field_key).index_by(&:field_key)
+        rendered_keys = {}
+      %>
+
+      <% @form_fields.each do |field| %>
+        <% next if field.field_key.present? && rendered_keys[field.field_key] %>
+
+        <% if field.group_header? %>
+          <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
+            <h3 class="text-lg font-semibold text-gray-800"><%= field.question %></h3>
+          </div>
+        <% elsif (group = field.field_key.present? && field_key_to_group[field.field_key]) %>
+          <div class="<%= group[:grid] %>">
+            <% group[:keys].each do |key| %>
+              <% row_field = fields_by_key[key] %>
+              <% next unless row_field %>
+              <% rendered_keys[key] = true %>
+              <% response = @responses[row_field.id] %>
+              <% span = group.dig(:spans, key) %>
+              <div class="<%= span %> py-2">
+                <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= row_field.question %></dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                  <%= display_response_text(row_field, response) %>
+                </dd>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <% response = @responses[field.id] %>
+          <div class="py-2">
+            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= field.question %></dt>
+            <dd class="mt-1 text-sm text-gray-900">
+              <%= display_response_text(field, response) %>
+            </dd>
+          </div>
+        <% end %>
+      <% end %>
+
+      <div class="pt-4 border-t border-gray-200 mt-4">
+        <p class="text-xs text-gray-500">
+          Submitted on <%= @user_form.created_at.strftime("%B %d, %Y at %l:%M %P") %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,6 +10,9 @@
 <div class="flex flex-wrap justify-end gap-2 mb-4">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <% if allowed_to?(:manage?, @event) && @event.object.forms.exists?(name: "Public Registration") %>
+    <%= link_to "Register (as visitor)", new_event_public_registration_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+  <% end %>
   <% if allowed_to?(:edit?, @event) %>
     <%= link_to "Edit", edit_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% end %>

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -22,6 +22,7 @@
                   as: :boolean,
                   label: "Primary",
                   input_html: {
+                    checked: f.object.new_record? || f.object.primary?,
                     class: "mr-2 rounded focus:ring-blue-500 text-blue-600"
                   } %>
     </div>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -71,6 +71,32 @@
     </div>
   </div>
 
+  <!-- Profile-specific Categories (e.g. Workshop Environments) -->
+  <% if @org_categories_grouped.present? %>
+    <div class="form-group space-y-4 mb-8">
+      <% @org_categories_grouped.each do |type, cats| %>
+        <div class="font-semibold text-gray-700 mb-2"><%= type.display_label %></div>
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+          <div class="flex flex-wrap gap-3">
+            <% cats.each do |category| %>
+              <% id = "organization_category_ids_#{category.id}" %>
+              <label for="<%= id %>"
+                     class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                <%= hidden_field_tag "organization[category_ids][]", "" %>
+                <%= check_box_tag "organization[category_ids][]",
+                                  category.id,
+                                  @organization.category_ids.include?(category.id),
+                                  id: id,
+                                  class: "h-4 w-4 text-blue-600 rounded" %>
+                <span class="text-sm text-gray-700 whitespace-nowrap"><%= category.name %></span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
   <!-- Background info -->
   <div class="form-group space-y-4 mb-8">
     <div class="font-semibold text-gray-700 mb-2">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -10,7 +10,7 @@
   <div class="flex flex-col md:flex-row gap-8 items-start">
     <div class="w-full md:w-3/4">
       <div class="space-y-6">
-        <div class="flex flex-col md:flex-row gap-4"><%= f.input :first_name, input_html: { value: f.object.first_name || @user&.first_name } %><%= f.input :last_name, input_html: { value: f.object.last_name || @user&.last_name } %><%= f.input :pronouns %></div>
+        <div class="flex flex-col md:flex-row gap-4"><%= f.input :first_name, input_html: { value: f.object.first_name || @user&.first_name } %><%= f.input :legal_first_name, label: "Legal First Name", hint: "If different from first name" %><%= f.input :last_name, input_html: { value: f.object.last_name || @user&.last_name } %><%= f.input :pronouns %></div>
 
         <% person = f.object.respond_to?(:object) ? f.object.object : f.object %>
         <% decorated = person.decorate %>
@@ -81,6 +81,7 @@
             </div>
             <div class="flex-1">
               <%= f.input :date_of_birth,
+                          label: "Birthday",
                           as: :date,
                           discard_year: true,
                           order: [:month, :day],
@@ -226,6 +227,32 @@
                                   class: "btn btn-secondary-outline" %>
     </div>
   </div>
+
+  <!-- Profile-specific Categories -->
+  <% if @person_categories_grouped.present? %>
+    <div class="form-group space-y-4">
+      <% @person_categories_grouped.each do |type, cats| %>
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+          <h3 class="font-semibold text-gray-700 mb-3"><%= type.display_label %></h3>
+          <div class="flex flex-wrap gap-3">
+            <% cats.each do |category| %>
+              <% id = "person_category_ids_#{category.id}" %>
+              <label for="<%= id %>"
+                     class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                <%= hidden_field_tag "person[category_ids][]", "" %>
+                <%= check_box_tag "person[category_ids][]",
+                                  category.id,
+                                  @person.category_ids.include?(category.id),
+                                  id: id,
+                                  class: "h-4 w-4 text-blue-600 rounded" %>
+                <span class="text-sm text-gray-700 whitespace-nowrap"><%= category.name %></span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
   <!-- Organization Affiliations -->
   <div class="form-group space-y-4">

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -101,5 +101,5 @@
     <% end %>
     <p id="<%= field.html_id %>_error" class="hide">Please select at least one option</p>
   </div>
-  <%= "<br/>".html_safe if field.html_id == 'children_s_ages' && field.form.name.include?('Family Workshop Log') %>
+  <%= "<br/>".html_safe if field.html_id == 'children_s_ages' && field.form.display_name.include?('Family Workshop Log') %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,8 +92,10 @@ Rails.application.routes.draw do
     member do
       get :manage
       patch :preview
+      post :copy_registration_form
     end
     resource :registrations, only: %i[ create destroy ], module: :events, as: :registrant_registration
+    resource :public_registration, only: [ :new, :create, :show ], module: :events
   end
   resources :people do
     collection do

--- a/db/migrate/20260224000002_enhance_forms_for_event_registration.rb
+++ b/db/migrate/20260224000002_enhance_forms_for_event_registration.rb
@@ -1,0 +1,9 @@
+class EnhanceFormsForEventRegistration < ActiveRecord::Migration[8.0]
+  def change
+    add_column :form_fields, :field_key, :string
+    add_column :form_fields, :field_group, :string
+
+    add_index :form_fields, :field_key
+    add_index :form_fields, :field_group
+  end
+end

--- a/db/migrate/20260224000003_add_profile_specific_to_category_types.rb
+++ b/db/migrate/20260224000003_add_profile_specific_to_category_types.rb
@@ -1,0 +1,5 @@
+class AddProfileSpecificToCategoryTypes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :category_types, :profile_specific, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260224000004_add_legal_first_name_to_people.rb
+++ b/db/migrate/20260224000004_add_legal_first_name_to_people.rb
@@ -1,0 +1,5 @@
+class AddLegalFirstNameToPeople < ActiveRecord::Migration[8.0]
+  def change
+    add_column :people, :legal_first_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_24_000004) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -322,6 +322,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
     t.string "display_text"
     t.string "legacy_id"
     t.string "name", null: false
+    t.boolean "profile_specific", default: false, null: false
     t.boolean "published", default: false, null: false
     t.boolean "story_specific", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -484,6 +485,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
     t.integer "answer_datatype"
     t.integer "answer_type"
     t.datetime "created_at", precision: nil, null: false
+    t.string "field_group"
+    t.string "field_key"
     t.integer "form_id", null: false
     t.string "instructional_hint"
     t.boolean "is_required", default: true
@@ -492,6 +495,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
     t.string "question", null: false
     t.integer "status", default: 1
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["field_group"], name: "index_form_fields_on_field_group"
+    t.index ["field_key"], name: "index_form_fields_on_field_key"
     t.index ["form_id"], name: "index_form_fields_on_form_id"
     t.index ["parent_id"], name: "index_form_fields_on_parent_id"
   end
@@ -499,6 +504,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
   create_table "forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_builder_id"
+    t.string "name"
     t.integer "owner_id", null: false
     t.string "owner_type", null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -672,6 +678,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_24_000000) do
     t.string "first_name", null: false
     t.string "instagram_url"
     t.string "last_name", null: false
+    t.string "legal_first_name"
     t.string "linked_in_url"
     t.date "member_since"
     t.text "notes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -249,3 +249,39 @@ story_population_type.update!(display_text: "Who is your story about?", story_sp
   end
   cat.update!(published: true) unless cat.published?
 end
+
+puts "Creating WorkshopEnvironment CategoryType…"
+workshop_env_type = find_or_create_by_name!(CategoryType, "WorkshopEnvironment") do |ct|
+  ct.display_text = "Workshop Environments"
+  ct.story_specific = false
+  ct.profile_specific = true
+  ct.published = true
+end
+workshop_env_type.update!(display_text: "Workshop Environments", story_specific: false, profile_specific: true, published: true)
+
+%w[Shelter School Hospital Community\ Center After-School\ Program Virtual/Online Private\ Practice Other].each do |name|
+  cat = Category.where("LOWER(name) = LOWER(?)", name).first
+  if cat
+    cat.update!(category_type: workshop_env_type) unless cat.category_type_id == workshop_env_type.id
+  else
+    cat = workshop_env_type.categories.create!(name: name, published: true)
+  end
+  cat.update!(published: true) unless cat.published?
+end
+
+puts "Creating registerable Event with registration form…"
+reg_event = Event.find_or_create_by!(title: "AWBW Facilitator Training") do |event|
+  event.start_date = 2.months.from_now
+  event.end_date = 2.months.from_now + 3.hours
+  event.registration_close_date = 2.months.from_now - 1.day
+  event.published = true
+  event.publicly_visible = true
+  event.featured = true
+  event.cost = 150
+  event.created_by = User.find_by(email: "umberto.user@example.com")
+end
+
+unless reg_event.forms.exists?(name: EventRegistrationFormBuilder::FORM_NAME)
+  EventRegistrationFormBuilder.build!(reg_event)
+  puts "  → Registration form created for '#{reg_event.title}'"
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -25,24 +25,32 @@ RSpec.describe Form do
   #   pending("Requires functional owner factory and association uncommented")
   # end
 
-  describe '#name' do
-    # These tests remain relevant
+  describe '#display_name' do
     let(:user_owner) do
       create(:user)
     end
     let(:form) { build(:form, owner: user_owner) }
 
-    context 'when owner is present' do
-      it 'returns owner name Form' do
-        # Need to handle potential nil name from owner.try(:name)
-        owner_name = user_owner.try(:name) || user_owner.email # Or however owner name is derived
-        expect(form.name).to eq("#{owner_name} Form")
+    context 'when name is set' do
+      it 'returns the name' do
+        form.name = "Public Registration"
+        expect(form.display_name).to eq("Public Registration")
       end
     end
-    context 'when owner is nil' do
+
+    context 'when name is blank and owner is present' do
+      it 'returns owner name Form' do
+        form.name = nil
+        owner_name = user_owner.try(:name) || user_owner.email
+        expect(form.display_name).to eq("#{owner_name} Form")
+      end
+    end
+
+    context 'when name is blank and owner is nil' do
       it 'returns New Form' do
+        form.name = nil
         form.owner = nil
-        expect(form.name).to eq('New Form')
+        expect(form.display_name).to eq('New Form')
       end
     end
   end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -160,7 +160,11 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/workshop_ideas/edit.html.erb"           => "admin-only bg-blue-100",
     "app/views/workshop_variation_ideas/edit.html.erb" => "admin-only bg-blue-100",
     "app/views/workshop_variations/edit.html.erb"      => "admin-only bg-blue-100",
-    "app/views/workshops/edit.html.erb"                => "admin-only bg-blue-100"
+    "app/views/workshops/edit.html.erb"                => "admin-only bg-blue-100",
+
+    # ─── public registration ───
+    "app/views/events/public_registrations/new.html.erb"  => "public",
+    "app/views/events/public_registrations/show.html.erb" => "admin-or-owner"
   }.freeze
 
   EXPECTED_MAPPINGS.each do |view_path, expected_bg_class|


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Allow unauthenticated visitors to register for events through a public-facing form
- Collect comprehensive contact, professional, and qualitative information during registration
- Automatically create/link Person, User, Organization, Address, and ContactMethod records
- Enable admins to view submitted registration form responses

### How did you approach the change?

**Refactoring**
- Extracted `TagAssignable` concern from 7 controllers (Events, Stories, StoryIdeas, Resources, Workshops, Tutorials, CommunityNews) to DRY up `assign_associations`

**Form Architecture**
- Added `field_key`, `field_group`, and `name` columns to forms/form_fields
- Built `EventRegistrationFormBuilder` service to seed registration forms with organized field groups (contact, background, professional, qualitative, payment)
- Added form copy feature between events

**Public Registration**
- `Events::PublicRegistrationsController` with `skip_before_action :authenticate_user!` for new/create
- Honeypot field for spam prevention, server-side validation (required fields, email format, integer format)
- State fields render as dropdowns using `GeographyHelper#us_states`
- `PublicRegistration` service handles transactional record creation with duplicate detection:
  - Find-or-create User, Person, Organization, Affiliation
  - Existing addresses/phones kept; new data marks old primary as inactive
  - Sectors and categories assigned to both Person and Organization
  - Sends confirmation + admin FYI notifications

**Model & Display Enhancements**
- Added `legal_first_name` to Person (nickname support: if nickname provided, it becomes `first_name`)
- Added `profile_specific` to CategoryType for person/org-only category tags
- Registration form show page with same multi-column layout as the form, resolving sector/category IDs to names
- Event registration index shows form completion icon per registrant
- Registration ticket show page accessible to unauthenticated users
- Admin can view any registrant's form via `user_id` param

### Anything else to add?

- Auto-signs in the user after public registration so they see the ticket confirmation page
- `field_group` column enables future authenticated-user registration form (skip contact fields already on file)
- 48 files changed, 1317 insertions

## Test plan
- [ ] Run `bin/rails db:migrate` — migrations run cleanly
- [ ] Run `bin/rails db:seed` — seeds create registration form on events
- [ ] Visit `/events/:id/public_registration/new` while logged out — form renders with all field groups
- [ ] Submit form with valid data — creates all records, redirects to ticket page
- [ ] Submit with missing required fields — shows validation errors inline
- [ ] Re-register same email — shows "already registered" error
- [ ] Admin views registration form via "View Registration Form" link — shows correct registrant's responses
- [ ] Checkbox fields (sectors/categories) display names, not IDs
- [ ] Copy registration form from one event to another via event edit page
- [ ] `bundle exec rspec` — existing tests pass
- [ ] `bundle exec rubocop` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)