### PR TITLE
Remove user avatar, source from person instead

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,6 @@ class UsersController < ApplicationController
     authorize!
     per_page = params[:number_of_items_per_page].presence || 25
     base_scope = authorized_scope(User.includes(:created_by, :updated_by,
-                                                avatar_attachment: :blob,
                                                 person: { avatar_attachment: :blob }))
     filtered = base_scope.search_by_params(params).order(:first_name, :last_name)
     @users_count = filtered.count
@@ -309,7 +308,7 @@ class UsersController < ApplicationController
       :email, :comment, :person_id, :inactive, :locked, :primary_address, :time_zone, :super_user,
 
       ##### legacy to remove later
-      :agency_id, :legacy, :legacy_id, :subscribecode, :avatar, :first_name, :last_name, # legacy to remove later
+      :agency_id, :legacy, :legacy_id, :subscribecode, :first_name, :last_name, # legacy to remove later
       :address, :address2, :city, :city2, :state, :state2, :zip, :zip2, # legacy to remove later
       :phone, :phone2, :phone3, :birthday, :best_time_to_call, :notes, # legacy to remove later
       #####

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -8,7 +8,7 @@ class UserDecorator < ApplicationDecorator
   end
 
   def default_display_image
-    return avatar if respond_to?(:avatar) && avatar&.attached?
+    return person.avatar if person&.avatar&.attached?
     "missing.png"
   end
 

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -19,9 +19,6 @@ module PersonHelper
       avatar = if person.avatar.present?
         image_tag person.avatar.variant(:thumbnail),
                   class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
-      elsif person.user&.avatar.present?
-        image_tag person.user.avatar,
-                  class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
       else
         content_tag(:span, person.name.to_s.first.to_s.upcase,
                     class: "w-10 h-10 rounded-full flex items-center justify-center

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,9 +54,6 @@ class User < ApplicationRecord
   has_many :windows_types, through: :organizations
 
   has_many :user_form_form_fields, through: :user_forms, dependent: :destroy
-  # Images
-  has_one_attached :avatar
-
   # Nested attributes
   accepts_nested_attributes_for :user_forms
   accepts_nested_attributes_for :comments, reject_if: proc { |attrs| attrs["body"].blank? }

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -37,10 +37,6 @@
             <%= image_tag @person.avatar.variant(:thumbnail),
                           id: "person_#{@person.id}_avatar_image",
                           class: "w-28 h-28 rounded-full object-cover border-2 border-gray-200 shadow" %>
-          <% elsif @person.user&.avatar&.attached? %>
-            <%= image_tag @person.user.avatar,
-                          id: "person_#{@person.id}_avatar_image",
-                          class: "w-28 h-28 rounded-full object-cover border-2 border-gray-200 shadow" %>
           <% else %>
             <%= image_tag "missing.png",
                           id: "person_#{@person.id}_avatar_image",

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,8 +52,8 @@
             <% end %>
           </h2>
 
-          <% if @user.avatar.attached? %>
-            <%= image_tag @user.avatar,
+          <% if @user.person&.avatar&.attached? %>
+            <%= image_tag @user.person.avatar,
                           id: "avatar-preview",
                           class: "w-16 h-16 rounded-full object-cover border border-gray-300 shadow-sm" %>
           <% else %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,9 +27,6 @@ RSpec.describe User do
     # it { should have_many(:colleagues).through(:organizations).source(:organization_users) }
     it { should have_many(:notifications) } # As :noticeable
 
-    # Paperclip avatar
-    # it { should have_attached_file(:avatar) }
-
     # Nested Attributes
     it { should accept_nested_attributes_for(:user_forms) }
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The User model had a legacy `has_one_attached :avatar` that duplicated the Person model's avatar
- Views had a fragile fallback chain: person avatar → user avatar → missing.png
- This removes user avatar entirely so avatars are sourced exclusively from Person, the canonical owner

### How did you approach the change?

- Removed `has_one_attached :avatar` from User model
- Updated `UserDecorator#default_display_image` to delegate to `person.avatar`
- Removed `avatar_attachment: :blob` eager-loading and `:avatar` from permitted params in UsersController
- Updated user show view to pull avatar from `@user.person` instead of `@user`
- Removed user avatar fallback branches in person show view and `PersonHelper#person_profile_button`
- Cleaned up commented-out Paperclip avatar test in user spec

### Anything else to add?

- The navbar (`_navbar_user.html.erb`) already used `person.avatar` only — no change needed
- Legacy Paperclip schema columns (`avatar_file_name`, etc.) remain in the DB and can be removed in a follow-up migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)