### PR TITLE
Add missing name column to forms table

### DIFF
--- a/db/migrate/20260224000005_add_name_to_forms.rb
+++ b/db/migrate/20260224000005_add_name_to_forms.rb
@@ -1,0 +1,5 @@
+class AddNameToForms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :forms, :name, :string unless column_exists?(:forms, :name)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_24_000004) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_24_000005) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes [link an issue]

### What is the goal of this PR and why is this important? 
The forms table was created without a name column, but schema.rb and application code reference it. This caused 500 errors on event pages querying forms by name.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

