### PR TITLE
Add search_by_params tests for 11 models

### DIFF
--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -155,4 +155,57 @@ RSpec.describe CommunityNews, type: :model do
       end
     end
   end
+
+  describe '.search_by_params' do
+    let(:person) { create(:person, first_name: 'John', last_name: 'Doe') }
+    let(:user_with_person) { person.user }
+
+    let!(:news_alpha) do
+      create(:community_news, :published,
+             title: 'Alpha Community Update',
+             author: user_with_person,
+             created_at: Date.new(2025, 6, 15))
+    end
+
+    let!(:news_beta) do
+      create(:community_news,
+             title: 'Beta Draft Article',
+             author: user_with_person,
+             created_at: Date.new(2026, 3, 1))
+    end
+
+    it 'returns all when no params' do
+      results = CommunityNews.search_by_params({})
+      expect(results).to include(news_alpha, news_beta)
+    end
+
+    it 'filters by title' do
+      results = CommunityNews.search_by_params(title: 'Alpha')
+      expect(results).to include(news_alpha)
+      expect(results).not_to include(news_beta)
+    end
+
+    it 'filters by published param' do
+      results = CommunityNews.search_by_params(published: 'true')
+      expect(results).to include(news_alpha)
+      expect(results).not_to include(news_beta)
+    end
+
+    it 'filters by year' do
+      results = CommunityNews.search_by_params(year: '2025')
+      expect(results).to include(news_alpha)
+      expect(results).not_to include(news_beta)
+    end
+
+    it 'ignores invalid year format' do
+      results = CommunityNews.search_by_params(year: 'abc')
+      expect(results).to include(news_alpha, news_beta)
+    end
+
+    it 'chains title and year filters' do
+      results = CommunityNews.search_by_params(title: 'Alpha', year: '2025')
+      expect(results).to include(news_alpha)
+      expect(results).not_to include(news_beta)
+    end
+  end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -8,4 +8,37 @@ RSpec.describe EventRegistration, type: :model do
     it { should belong_to(:registrant).required }
     it { should have_many(:comments).dependent(:destroy) }
   end
+
+  describe '.search_by_params' do
+    let(:person_alice) { create(:person, first_name: 'Alice', last_name: 'Smith') }
+    let(:person_bob) { create(:person, first_name: 'Bob', last_name: 'Jones') }
+    let(:event_art) { create(:event, title: 'Art Workshop') }
+    let(:event_music) { create(:event, title: 'Music Session') }
+
+    let!(:reg_alice_art) { create(:event_registration, registrant: person_alice, event: event_art) }
+    let!(:reg_bob_music) { create(:event_registration, registrant: person_bob, event: event_music) }
+
+    it 'returns all when no params' do
+      results = EventRegistration.search_by_params({})
+      expect(results).to include(reg_alice_art, reg_bob_music)
+    end
+
+    it 'filters by registrant_id' do
+      results = EventRegistration.search_by_params(registrant_id: person_alice.id)
+      expect(results).to include(reg_alice_art)
+      expect(results).not_to include(reg_bob_music)
+    end
+
+    it 'filters by event_id' do
+      results = EventRegistration.search_by_params(event_id: event_music.id)
+      expect(results).to include(reg_bob_music)
+      expect(results).not_to include(reg_alice_art)
+    end
+
+    it 'chains registrant_id and event_id filters' do
+      results = EventRegistration.search_by_params(registrant_id: person_alice.id, event_id: event_art.id)
+      expect(results).to include(reg_alice_art)
+      expect(results).not_to include(reg_bob_music)
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -73,4 +73,31 @@ RSpec.describe Event, type: :model do
       end
     end
   end
+
+  describe '.search_by_params' do
+    let!(:art_event) { create(:event, title: 'Art Workshop Showcase', description: 'Annual art exhibition') }
+    let!(:music_event) { create(:event, title: 'Music Therapy Session', description: 'Healing through music') }
+
+    it 'returns all when no params' do
+      results = Event.search_by_params({})
+      expect(results).to include(art_event, music_event)
+    end
+
+    it 'filters by query matching title' do
+      results = Event.search_by_params(query: 'Art Workshop')
+      expect(results).to include(art_event)
+      expect(results).not_to include(music_event)
+    end
+
+    it 'filters by query matching description' do
+      results = Event.search_by_params(query: 'Healing')
+      expect(results).to include(music_event)
+      expect(results).not_to include(art_event)
+    end
+
+    it 'returns empty for non-matching query' do
+      results = Event.search_by_params(query: 'nonexistent')
+      expect(results).not_to include(art_event, music_event)
+    end
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -89,4 +89,32 @@ RSpec.describe Notification do
       expect(third_resend.resend_number).to eq(3)
     end
   end
+
+  describe '.search_by_params' do
+    let!(:notification_alice) { create(:notification, recipient_email: 'alice@example.com', email_subject: 'Welcome to AWBW') }
+    let!(:notification_bob) { create(:notification, recipient_email: 'bob@example.com', email_subject: 'Password Reset') }
+
+    it 'returns all when no params' do
+      results = Notification.search_by_params({})
+      expect(results).to include(notification_alice, notification_bob)
+    end
+
+    it 'filters by email' do
+      results = Notification.search_by_params(email: 'alice')
+      expect(results).to include(notification_alice)
+      expect(results).not_to include(notification_bob)
+    end
+
+    it 'filters by subject_line' do
+      results = Notification.search_by_params(subject_line: 'Welcome')
+      expect(results).to include(notification_alice)
+      expect(results).not_to include(notification_bob)
+    end
+
+    it 'chains email and subject_line filters' do
+      results = Notification.search_by_params(email: 'alice', subject_line: 'Welcome')
+      expect(results).to include(notification_alice)
+      expect(results).not_to include(notification_bob)
+    end
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -255,6 +255,52 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '.search_by_params' do
+    let(:org_alpha) { create(:organization, name: "Alpha Center") }
+    let(:org_beta) { create(:organization, name: "Beta Foundation") }
+
+    let!(:person_alice) do
+      create(:person, first_name: 'Alice', last_name: 'Smith', email: 'alice@example.com').tap do |p|
+        create(:affiliation, person: p, organization: org_alpha)
+      end
+    end
+
+    let!(:person_bob) do
+      create(:person, first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com').tap do |p|
+        create(:affiliation, person: p, organization: org_beta)
+      end
+    end
+
+    it 'returns all when no params' do
+      results = Person.search_by_params({})
+      expect(results).to include(person_alice, person_bob)
+    end
+
+    it 'filters by contact_info matching name' do
+      results = Person.search_by_params(contact_info: 'Alice')
+      expect(results).to include(person_alice)
+      expect(results).not_to include(person_bob)
+    end
+
+    it 'filters by contact_info matching email' do
+      results = Person.search_by_params(contact_info: 'bob@example')
+      expect(results).to include(person_bob)
+      expect(results).not_to include(person_alice)
+    end
+
+    it 'filters by organization_name' do
+      results = Person.search_by_params(organization_name: 'Alpha')
+      expect(results).to include(person_alice)
+      expect(results).not_to include(person_bob)
+    end
+
+    it 'chains contact_info and organization_name' do
+      results = Person.search_by_params(contact_info: 'Alice', organization_name: 'Alpha')
+      expect(results).to include(person_alice)
+      expect(results).not_to include(person_bob)
+    end
+  end
+
   describe ".published" do
     let!(:searchable_with_active) do
       person = create(:person, profile_is_searchable: true)

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -46,4 +46,33 @@ RSpec.describe Quote do
   it 'is valid with valid attributes' do
     expect(build(:quote)).to be_valid
   end
+
+  describe '.search_by_params' do
+    let!(:published_quote) { create(:quote, :published, quote: 'Art heals the soul', speaker_name: 'Jane') }
+    let!(:another_published) { create(:quote, :published, quote: 'Creativity is freedom', speaker_name: 'Bob') }
+    let!(:draft_quote) { create(:quote, quote: 'Unpublished thought', speaker_name: 'Carol') }
+
+    it 'returns all when no params' do
+      results = Quote.search_by_params({})
+      expect(results).to include(published_quote, another_published, draft_quote)
+    end
+
+    it 'filters by query' do
+      results = Quote.search_by_params(query: 'heals')
+      expect(results).to include(published_quote)
+      expect(results).not_to include(another_published, draft_quote)
+    end
+
+    it 'filters by published' do
+      results = Quote.search_by_params(published: 'true')
+      expect(results).to include(published_quote, another_published)
+      expect(results).not_to include(draft_quote)
+    end
+
+    it 'chains query and published filters' do
+      results = Quote.search_by_params(query: 'freedom', published: 'true')
+      expect(results).to include(another_published)
+      expect(results).not_to include(published_quote, draft_quote)
+    end
+  end
 end

--- a/spec/models/story_idea_spec.rb
+++ b/spec/models/story_idea_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe StoryIdea, type: :model do
+  describe '.search_by_params' do
+    let!(:idea_alpha) { create(:story_idea, title: 'Art Healing Journey') }
+    let!(:idea_beta) { create(:story_idea, title: 'Community Impact Report') }
+
+    it 'returns all when no params' do
+      results = StoryIdea.search_by_params({})
+      expect(results).to include(idea_alpha, idea_beta)
+    end
+
+    it 'filters by query matching title' do
+      results = StoryIdea.search_by_params(query: 'Art Healing')
+      expect(results).to include(idea_alpha)
+      expect(results).not_to include(idea_beta)
+    end
+
+    it 'returns empty for non-matching query' do
+      results = StoryIdea.search_by_params(query: 'nonexistent')
+      expect(results).not_to include(idea_alpha, idea_beta)
+    end
+  end
+end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -42,4 +42,43 @@ RSpec.describe Story, type: :model do
       end
     end
   end
+
+  describe '.search_by_params' do
+    let!(:published_story) { create(:story, :published, title: 'Healing Through Art') }
+    let!(:draft_story) { create(:story, title: 'Unpublished Draft', published: false) }
+    let!(:old_story) do
+      create(:story, :published, title: 'Last Year Story').tap do |s|
+        s.update_columns(created_at: Date.new(2025, 5, 1))
+      end
+    end
+
+    it 'returns all when no params' do
+      results = Story.search_by_params({})
+      expect(results).to include(published_story, draft_story, old_story)
+    end
+
+    it 'filters by title' do
+      results = Story.search_by_params(title: 'Healing')
+      expect(results).to include(published_story)
+      expect(results).not_to include(draft_story)
+    end
+
+    it 'filters by published param' do
+      results = Story.search_by_params(published: 'true')
+      expect(results).to include(published_story, old_story)
+      expect(results).not_to include(draft_story)
+    end
+
+    it 'filters by year' do
+      results = Story.search_by_params(year: '2025')
+      expect(results).to include(old_story)
+      expect(results).not_to include(published_story)
+    end
+
+    it 'chains title and published filters' do
+      results = Story.search_by_params(title: 'Healing', published: 'true')
+      expect(results).to include(published_story)
+      expect(results).not_to include(draft_story, old_story)
+    end
+  end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.search_by_params' do
+    let!(:published_tutorial) { create(:tutorial, :published, title: 'Getting Started Guide', body: 'Welcome to AWBW') }
+    let!(:draft_tutorial) { create(:tutorial, title: 'Advanced Workshop Tips', body: 'For experienced facilitators') }
+
+    it 'returns all when no params' do
+      results = Tutorial.search_by_params({})
+      expect(results).to include(published_tutorial, draft_tutorial)
+    end
+
+    it 'filters by search (title or body)' do
+      results = Tutorial.search_by_params(search: 'Getting Started')
+      expect(results).to include(published_tutorial)
+      expect(results).not_to include(draft_tutorial)
+    end
+
+    it 'filters by search matching body content' do
+      results = Tutorial.search_by_params(search: 'facilitators')
+      expect(results).to include(draft_tutorial)
+      expect(results).not_to include(published_tutorial)
+    end
+
+    it 'filters by title only' do
+      results = Tutorial.search_by_params(title: 'Advanced')
+      expect(results).to include(draft_tutorial)
+      expect(results).not_to include(published_tutorial)
+    end
+
+    it 'filters by published param' do
+      results = Tutorial.search_by_params(published: 'true')
+      expect(results).to include(published_tutorial)
+      expect(results).not_to include(draft_tutorial)
+    end
+
+    it 'chains search and published filters' do
+      results = Tutorial.search_by_params(search: 'Guide', published: 'true')
+      expect(results).to include(published_tutorial)
+      expect(results).not_to include(draft_tutorial)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -266,4 +266,52 @@ RSpec.describe User do
       expect(user.first_name_or_email).to eq(user.email)
     end
   end
+
+  describe '.search_by_params' do
+    let!(:admin_user) { create(:user, first_name: 'Alice', last_name: 'Admin', email: 'alice@example.com', super_user: true) }
+    let!(:regular_user) { create(:user, first_name: 'Bob', last_name: 'Regular', email: 'bob@example.com', super_user: false) }
+    let!(:inactive_user) { create(:user, first_name: 'Carol', last_name: 'Inactive', email: 'carol@example.com', inactive: true) }
+    let!(:locked_user) { create(:user, first_name: 'Dave', last_name: 'Locked', email: 'dave@example.com', locked_at: Time.current) }
+
+    it 'returns all when no params' do
+      results = User.search_by_params({})
+      expect(results).to include(admin_user, regular_user, inactive_user, locked_user)
+    end
+
+    it 'filters by search term matching name' do
+      results = User.search_by_params(search: 'Alice')
+      expect(results).to include(admin_user)
+      expect(results).not_to include(regular_user)
+    end
+
+    it 'filters by search term matching email' do
+      results = User.search_by_params(search: 'bob@example')
+      expect(results).to include(regular_user)
+      expect(results).not_to include(admin_user)
+    end
+
+    it 'filters by super_user' do
+      results = User.search_by_params(super_user: 'true')
+      expect(results).to include(admin_user)
+      expect(results).not_to include(regular_user)
+    end
+
+    it 'filters by access true (has access)' do
+      results = User.search_by_params(access: 'true')
+      expect(results).to include(admin_user, regular_user)
+      expect(results).not_to include(inactive_user, locked_user)
+    end
+
+    it 'filters by access false (no access)' do
+      results = User.search_by_params(access: 'false')
+      expect(results).to include(inactive_user, locked_user)
+      expect(results).not_to include(admin_user, regular_user)
+    end
+
+    it 'chains search and super_user filters' do
+      results = User.search_by_params(search: 'Alice', super_user: 'true')
+      expect(results).to include(admin_user)
+      expect(results).not_to include(regular_user, inactive_user)
+    end
+  end
 end

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -17,4 +17,25 @@ RSpec.describe WorkshopVariation do
   #   # expect(build(:workshop_variation)).to be_valid
   #   pending("Requires functional workshop factory and association uncommented")
   # end
+
+  describe '.search_by_params' do
+    let!(:variation_a) { create(:workshop_variation, name: 'Watercolor Technique') }
+    let!(:variation_b) { create(:workshop_variation, name: 'Clay Sculpting') }
+
+    it 'returns all when no params' do
+      results = WorkshopVariation.search_by_params({})
+      expect(results).to include(variation_a, variation_b)
+    end
+
+    it 'filters by query matching name' do
+      results = WorkshopVariation.search_by_params(query: 'Watercolor')
+      expect(results).to include(variation_a)
+      expect(results).not_to include(variation_b)
+    end
+
+    it 'returns empty for non-matching query' do
+      results = WorkshopVariation.search_by_params(query: 'nonexistent')
+      expect(results).not_to include(variation_a, variation_b)
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Most models with `search_by_params` methods had zero test coverage for their filtering logic
- These tests ensure each search box filter works correctly and won't silently break during refactors

### How did you approach the change?
- Added `.search_by_params` model specs to 11 models that were missing them:
  - **CommunityNews** — title, published, year, invalid year, chained filters
  - **Story** — title, published, year, chained filters
  - **Tutorial** — search (title+body), title, published, chained filters
  - **User** — search (name/email), super_user, access true/false, chained filters
  - **Person** — contact_info (name/email), organization_name, chained filters
  - **Notification** — email, subject_line, chained filters
  - **Quote** — query, published, chained filters
  - **Event** — query (title/description), non-matching query
  - **EventRegistration** — registrant_id, event_id, chained filters
  - **WorkshopVariation** — query, non-matching query
  - **StoryIdea** — query, non-matching query (new spec file)
- Each test verifies: no-params returns all, individual filters narrow correctly, filters chain together
- All 51 new tests pass; only pre-existing unrelated failure in `events/registrations_spec.rb`

### Anything else to add?
- Follows existing patterns from `faq_spec.rb` and `organization_spec.rb`
- Skipped `featured` filter for Quote since the model lacks that column (dead code in `search_by_params`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)