### PR TITLE
Fix 500 on organization show page

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -70,7 +70,7 @@ class OrganizationsController < ApplicationController
     logged_user_ids = workshop_logs.where.not(created_by_id: nil).distinct.pluck(:created_by_id)
     @users = User.where(id: logged_user_ids)
                   .includes(:person)
-                  .select("users.id, users.person_id, people.first_name, people.last_name")
+                  .select("users.id, users.person_id, users.email, people.first_name, people.last_name")
                   .order("people.first_name, people.last_name")
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Fix a production 500 error on `GET /organizations/:id`
- `OrganizationsController#show` was raising `ActiveModel::MissingAttributeError` for `email` on User

### How did you approach the change?
- Added `users.email` to the `.select()` clause in the `@users` query
- The view calls `full_name_with_email` on each user for the person filter dropdown, which requires the `email` attribute
- The same query in `WorkshopLogsController` already included `users.email` — this was just an oversight in the organizations controller

### Anything else to add?
- One-line fix, no behavioral change beyond resolving the 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)