### PR TITLE
Fix content width inconsistency between logged-in and logged-out (#1102)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,14 +46,10 @@
       <div class="<%= yield(:page_bg_class) if content_for?(:page_bg_class) %> flex-grow">
         <div class="<%= 'mx-auto max-w-7xl px-2 sm:px-6 lg:px-8' unless content_for?(:full_width) %> <%= 'pt-3' unless controller_name == 'home' %>">
           <%# TODO handle printable area %>
-          <% if user_signed_in? %>
-            <div class="signed-in-user <%= 'my-3' unless controller_name == 'home' %>"><%= render "shared/flash_messages" %><%= yield %></div>
-          <% else %>
-            <div class="not-signed-in-user min-h-screen flex flex-col">
-              <%= render "shared/flash_messages" %>
-              <%= yield %>
-            </div>
-          <% end %>
+          <div class="<%= 'my-3' unless controller_name == 'home' %>">
+            <%= render "shared/flash_messages" %>
+            <%= yield %>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION


<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

- This work Closes #1102 

### What is the goal of this PR and why is this important? 
The logged-out wrapper had `min-h-screen flex flex-col` which could cause content to render at a different width than the block-level wrapper used for logged-in users. Unify into a single wrapper for both states and apply my-3 spacing consistently regardless of login state.

### How did you approach the change?
<!-- What did you do? -->

### Anything else to add?
<!-- Any alternative approaches you considered? Any specific questions for reviewers? -->

