### PR TITLE
Add dependent: :nullify to workshop_variations association

### DIFF
--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -19,7 +19,7 @@ class WorkshopVariationIdea < ApplicationRecord
   belongs_to :windows_type, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :notifications, as: :noticeable, dependent: :destroy
-  has_many :workshop_variations
+  has_many :workshop_variations, dependent: :nullify
 
   # Asset associations
   has_one :primary_asset, -> { where(type: "PrimaryAsset") },


### PR DESCRIPTION

### What is the goal of this PR and why is this important? 
The has_many :workshop_variations on WorkshopVariationIdea was missing a dependent option, causing destroy to fail with ActiveRecord::InvalidForeignKey when any WorkshopVariation referenced the idea. This was the source of a flaky test in the admin DELETE /destroy spec.

Uses :nullify since variations are optional (belongs_to optional: true) and should survive deletion of the original idea.


