### PR TITLE
Add system test for workshop log save flow

### DIFF
--- a/spec/system/person_saves_workshop_log_spec.rb
+++ b/spec/system/person_saves_workshop_log_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe "Saving a workshop log", type: :system do
+  def select_tom_select_option(hidden_select_id, value, label)
+    page.execute_script(<<~JS)
+      var el = document.getElementById('#{hidden_select_id}');
+      var ts = el.tomselect;
+      ts.addOption({id: '#{value}', label: '#{label}'});
+      ts.setValue('#{value}');
+    JS
+  end
+
+  shared_context "workshop log form setup" do
+    let(:windows_type) { create(:windows_type, :combined) }
+    let!(:form_builder) do
+      fb = FormBuilder.create!(windows_type_id: windows_type.id, name: "Combined form")
+      fb.forms.create!
+      fb
+    end
+    let!(:workshop) do
+      create(:workshop, :published, title: "Healing Through Art", windows_type: windows_type)
+    end
+    let(:organization) do
+      create(:organization, name: "Community Arts Project", windows_type_id: windows_type.id)
+    end
+
+    def fill_and_submit_workshop_log
+      visit new_workshop_log_path
+
+      expect(page).to have_content("New workshop log")
+
+      # Select workshop via TomSelect
+      select_tom_select_option("workshop_log_workshop_id", workshop.id, workshop.title)
+
+      # Fill in workshop date (JS to reliably set HTML5 date input)
+      page.execute_script(
+        "document.getElementById('workshop_log_date').value = '#{1.day.ago.strftime('%Y-%m-%d')}'"
+      )
+
+      # Fill in participant counts
+      fill_in "workshop_log_children_ongoing", with: "3"
+      fill_in "workshop_log_teens_ongoing", with: "2"
+      fill_in "workshop_log_adults_ongoing", with: "8"
+      fill_in "workshop_log_children_first_time", with: "1"
+      fill_in "workshop_log_teens_first_time", with: "0"
+      fill_in "workshop_log[adults_first_time]", with: "5"
+
+      click_button "Submit"
+    end
+  end
+
+  describe "as a regular user" do
+    include_context "workshop log form setup"
+
+    let(:user) { create(:user) }
+    let(:person) { create(:person, user: user) }
+
+    before do
+      create(:affiliation, person: person, organization: organization)
+      sign_in user
+    end
+
+    it "successfully saves a workshop log" do
+      fill_and_submit_workshop_log
+
+      expect(page).to have_content("Thank you for submitting a workshop log")
+      expect(WorkshopLog.count).to eq(1)
+
+      log = WorkshopLog.last
+      expect(log.workshop).to eq(workshop)
+      expect(log.organization).to eq(organization)
+      expect(log.created_by).to eq(user)
+      expect(log.children_ongoing).to eq(3)
+      expect(log.teens_ongoing).to eq(2)
+      expect(log.adults_ongoing).to eq(8)
+      expect(log.children_first_time).to eq(1)
+      expect(log.teens_first_time).to eq(0)
+      expect(log.adults_first_time).to eq(5)
+      expect(log.total_attendance).to eq(19)
+    end
+  end
+
+  describe "as an admin" do
+    include_context "workshop log form setup"
+
+    let(:admin) { create(:user, :admin) }
+    let(:person) { create(:person, user: admin) }
+
+    before do
+      create(:affiliation, person: person, organization: organization)
+      sign_in admin
+    end
+
+    it "successfully saves a workshop log" do
+      fill_and_submit_workshop_log
+
+      expect(page).to have_content("Thank you for submitting a workshop log")
+      expect(WorkshopLog.count).to eq(1)
+
+      log = WorkshopLog.last
+      expect(log.workshop).to eq(workshop)
+      expect(log.organization).to eq(organization)
+      expect(log.created_by).to eq(admin)
+      expect(log.children_ongoing).to eq(3)
+      expect(log.adults_first_time).to eq(5)
+      expect(log.total_attendance).to eq(19)
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admin reported workshop logs aren't working — this adds system test coverage to validate the save flow
- Tests both admin and regular user roles to pinpoint where the issue is (both pass, so the core save works)

### How did you approach the change?

- Added `spec/system/person_saves_workshop_log_spec.rb` with two test cases (regular user + admin)
- Uses `execute_script` to interact with TomSelect (workshop dropdown) and HTML5 date input, since Capybara's native methods don't work reliably with these controls in headless Chrome
- Shared context handles common setup (windows type, form builder, workshop, organization)
- Verifies flash message and all database fields after save

### Anything else to add?

- The existing test in `person_submits_workshop_log_test.rb` uses `select` for the workshop dropdown, which likely doesn't work anymore since it was changed to TomSelect with remote search
- Both roles pass — the reported issue may be environment-specific or related to a different flow (e.g., the wizard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)