### PR TITLE
Add admin-only nav options for Story, Workshop Variation, Workshop

### DIFF
--- a/app/views/shared/_navbar_menu_mobile.html.erb
+++ b/app/views/shared/_navbar_menu_mobile.html.erb
@@ -164,6 +164,39 @@
           <i class="fas fa-book-open"></i>
           <span>New story idea</span>
         <% end %>
+
+        <% if allowed_to?(:new?, Story) %>
+          <div class="admin-only bg-blue-100">
+            <%= link_to new_story_path,
+                        class: "flex items-center px-4 py-2 text-sm text-white
+                      hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+              <i class="fas fa-book"></i>
+              <span>New story</span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if allowed_to?(:new?, WorkshopVariation) %>
+          <div class="admin-only bg-blue-100">
+            <%= link_to new_workshop_variation_path,
+                        class: "flex items-center px-4 py-2 text-sm text-white
+                      hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+              <i class="fas fa-swatchbook"></i>
+              <span>New workshop variation</span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if allowed_to?(:new?, Workshop) %>
+          <div class="admin-only bg-blue-100">
+            <%= link_to new_workshop_path,
+                        class: "flex items-center px-4 py-2 text-sm text-white
+                      hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+              <i class="fas fa-chalkboard-teacher"></i>
+              <span>New workshop</span>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
     <% end %>

--- a/app/views/shared/_navbar_new_button.html.erb
+++ b/app/views/shared/_navbar_new_button.html.erb
@@ -46,6 +46,36 @@
     <i class="fas fa-book-open"></i>
     <span>New story idea</span>
   <% end %>
+
+  <% if allowed_to?(:new?, Story) %>
+   <div class="admin-only bg-blue-100">
+      <%= link_to new_story_path,
+                  class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+        <i class="fas fa-book"></i>
+        <span>New story</span>
+      <% end %>
+   </div>
+  <% end %>
+
+  <% if allowed_to?(:new?, WorkshopVariation) %>
+   <div class="admin-only bg-blue-100">
+      <%= link_to new_workshop_variation_path,
+                  class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+        <i class="fas fa-swatchbook"></i>
+        <span>New workshop variation</span>
+      <% end %>
+   </div>
+  <% end %>
+
+  <% if allowed_to?(:new?, Workshop) %>
+   <div class="admin-only bg-blue-100">
+      <%= link_to new_workshop_path,
+                  class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
+        <i class="fas fa-chalkboard-teacher"></i>
+        <span>New workshop</span>
+      <% end %>
+   </div>
+  <% end %>
 </div>
 
   </div>

--- a/spec/views/shared/_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_navbar.html.erb_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe "shared/_navbar", type: :view do
       expect(rendered).not_to include("Admin")
     end
 
+    it "does not show admin-only New dropdown items" do
+      expect(rendered).not_to have_css(".admin-only", text: "New story")
+      expect(rendered).not_to have_css(".admin-only", text: "New workshop variation")
+      expect(rendered).not_to have_css(".admin-only", text: "New workshop")
+    end
+
     it "shows personal menu items" do
       expect(rendered).to include("My bookmarks")
       expect(rendered).to include("My workshop logs")
@@ -76,6 +82,12 @@ RSpec.describe "shared/_navbar", type: :view do
 
     it "shows profile and team links" do
       expect(rendered).to include("My profile")
+    end
+
+    it "shows admin-only New dropdown items" do
+      expect(rendered).to have_css(".admin-only", text: "New story")
+      expect(rendered).to have_css(".admin-only", text: "New workshop variation")
+      expect(rendered).to have_css(".admin-only", text: "New workshop")
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Give admins quick access to create stories, workshop variations, and workshops directly from the "New" button dropdown
- These are admin-only actions that were previously only accessible by navigating to the respective index pages

### How did you approach the change?

- Added three new admin-only links to the New button dropdown in both desktop (`_navbar_new_button.html.erb`) and mobile (`_navbar_menu_mobile.html.erb`) navs
- Each link is gated by its policy's `new?` action (which defaults to `admin?` via `ApplicationPolicy`)
- Styled with the existing `admin-only bg-blue-100` pattern to visually distinguish them
- Used distinct icons: `fa-book` (story), `fa-swatchbook` (workshop variation), `fa-chalkboard-teacher` (workshop)
- Added view spec coverage for both regular user (items hidden) and admin (items visible)

### Anything else to add?

- No policy changes needed — `Story`, `WorkshopVariation`, and `Workshop` all inherit `new? -> admin?` from `ApplicationPolicy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)