### PR TITLE
Add calendar header, back links, and pronoun fix to event pages

### DIFF
--- a/app/services/event_registration_form_builder.rb
+++ b/app/services/event_registration_form_builder.rb
@@ -64,7 +64,7 @@ class EventRegistrationFormBuilder
                          key: "last_name", group: "contact", required: true)
     position = add_field(form, position, "Preferred Nickname", :free_form_input_one_line,
                          key: "nickname", group: "contact", required: false)
-    position = add_field(form, position, "Preferred Pronouns", :free_form_input_one_line,
+    position = add_field(form, position, "Pronouns", :free_form_input_one_line,
                          key: "pronouns", group: "contact", required: false)
     position = add_field(form, position, "Primary Email", :free_form_input_one_line,
                          key: "primary_email", group: "contact", required: true)

--- a/app/views/event_registrations/show.html.erb
+++ b/app/views/event_registrations/show.html.erb
@@ -7,6 +7,12 @@
 </div>
   <div class="max-w-lg mx-auto">
 
+    <div class="mb-4">
+      <%= link_to event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        &larr; Back to Event
+      <% end %>
+    </div>
+
     <!-- Ticket Container -->
     <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
 
@@ -130,6 +136,16 @@
             Registered on <%= @event_registration.created_at.strftime("%B %d, %Y") %>
           </p>
 
+        </div>
+
+        <!-- CALENDAR LINKS -->
+        <div class="flex flex-col items-center mt-4 pt-3 border-t border-gray-100">
+          <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
+            Add to Your Calendar
+          </p>
+          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium">
+            <%= @event_registration.event.decorate.calendar_links %>
+          </div>
         </div>
 
         <% registration_form = @event_registration.event.forms.find_by(name: "Public Registration") %>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -55,6 +55,11 @@
     <% end %>
 
     <!-- CALENDAR LINKS -->
-    <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links %></div>
+    <div class="flex flex-col items-center">
+      <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
+        Add to Your Calendar
+      </p>
+      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links %></div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -7,7 +7,7 @@
     <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
       <p class="text-base font-semibold text-gray-700 mb-2" style="font-family: 'Telefon Bold', sans-serif; font-size: 42px"><%= @event.pre_title %></p>
     <% end %>
-    <h1 class="font-bold text-green-800 mb-4" style="font-family: Lato, sans-serif; font-size: 53px"><%= @event.title %></h1>
+    <h1 class="font-bold text-green-800 mb-4" style="font-family: Lato, sans-serif; font-size: 53px"><%= link_to @event.title, event_path(@event), class: "hover:underline" %></h1>
 
     <div class="text-center space-y-2">
       <div class="font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif; font-size: 35px">
@@ -22,6 +22,12 @@
         <div class="text-base text-gray-700"><%= @event.location.name %></div>
       <% end %>
     </div>
+  </div>
+
+  <div class="mb-4">
+    <%= link_to event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      &larr; Back to Event
+    <% end %>
   </div>
 
   <%# ---- REGISTRATION FORM CARD ---- %>

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Event registration show page", type: :system do
+  let(:user) { create(:user, :with_person, time_zone: "Pacific Time (US & Canada)") }
+
+  let(:event) do
+    create(
+      :event,
+      :published,
+      title: "My Event",
+      start_date: 2.days.from_now.change(hour: 10),
+      end_date: 2.days.from_now.change(hour: 12)
+    )
+  end
+
+  let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+
+  before { driven_by(:rack_test) }
+
+  describe "back to event link" do
+    it "shows a back link to the event page" do
+      sign_in(user)
+      visit event_registration_path(registration)
+
+      expect(page).to have_link("Back to Event", href: event_path(event))
+    end
+  end
+
+  describe "event title link" do
+    it "links the event title back to the event page" do
+      sign_in(user)
+      visit event_registration_path(registration)
+
+      within("h2") do
+        expect(page).to have_link(event.title, href: event_path(event))
+      end
+    end
+  end
+
+  describe "calendar links" do
+    it "shows Add to Your Calendar header and calendar links" do
+      sign_in(user)
+      visit event_registration_path(registration)
+
+      expect(page).to have_text("Add to Your Calendar")
+      expect(page).to have_link("Google")
+      expect(page).to have_link("Office 365")
+    end
+  end
+end

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe "Event show page", type: :system do
 
         expect(page).to have_button("De-register")
         expect(page).to have_text("You are registered!")
+        expect(page).to have_text("Add to Your Calendar")
         expect(page).to have_text("Google")
         expect(page).to have_text("Office 365")
       end

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Public registration new page", type: :system do
+  let(:event) do
+    create(
+      :event,
+      :published,
+      :publicly_visible,
+      title: "My Event",
+      start_date: 2.days.from_now.change(hour: 10),
+      end_date: 2.days.from_now.change(hour: 12)
+    )
+  end
+
+  before do
+    driven_by(:rack_test)
+    EventRegistrationFormBuilder.build!(event)
+  end
+
+  describe "back to event link" do
+    it "shows a back link to the event page" do
+      visit new_event_public_registration_path(event)
+
+      expect(page).to have_link("Back to Event", href: event_path(event))
+    end
+  end
+
+  describe "event title link" do
+    it "links the event title back to the event page" do
+      visit new_event_public_registration_path(event)
+
+      within("h1") do
+        expect(page).to have_link(event.title, href: event_path(event))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Improve navigation and consistency across event pages
- Make calendar links more discoverable with a clear header
- Update outdated "Preferred Pronouns" label to just "Pronouns"

### How did you approach the change?

- Added "Add to Your Calendar" header above calendar links on the event show page (`_registration_section.html.erb`) and registration ticket page (`event_registrations/show.html.erb`) to match the existing event card style
- Added calendar links with header to the registration ticket page (previously had none)
- Added "← Back to Event" link above the card on both the public registration form and registration ticket pages
- Linked the event title on the public registration form back to the event show page
- Renamed "Preferred Pronouns" to "Pronouns" in `EventRegistrationFormBuilder`
- Added system tests for back links, title links, and calendar header display

### Anything else to add?

- Existing form fields in production need a console migration: `FormField.where(question: "Preferred Pronouns").update_all(question: "Pronouns")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)