### PR TITLE
Fix calendar links using user's time zone instead of UTC

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -22,8 +22,8 @@ class EventDecorator < ApplicationDecorator
   end
 
   def calendar_links
-    start_time   = object.start_date.strftime("%Y%m%dT%H%M%SZ")
-    end_time     = object.end_date.strftime("%Y%m%dT%H%M%SZ")
+    start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
+    end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
     title_encoded = ERB::Util.url_encode(object.title)
 
     has_url      = object.videoconference_url.present?

--- a/spec/system/person_adds_event_to_calendar_test.rb
+++ b/spec/system/person_adds_event_to_calendar_test.rb
@@ -36,8 +36,8 @@ RSpec.describe "People can register for an event" do
 
       describe "Calendar links after registration" do
         let(:title_encoded) { ERB::Util.url_encode(@event.title) }
-        let(:start_time) { @event.start_date.strftime("%Y%m%dT%H%M%SZ") }
-        let(:end_time) { @event.end_date.strftime("%Y%m%dT%H%M%SZ") }
+        let(:start_time) { @event.start_date.utc.strftime("%Y%m%dT%H%M%SZ") }
+        let(:end_time) { @event.end_date.utc.strftime("%Y%m%dT%H%M%SZ") }
 
         before do
           visit events_path


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- "Add to Your Calendar" links on event pages were creating calendar events at the wrong time
- The times were off by the user's UTC offset (e.g., 7-8 hours for Pacific users)

### How did you approach the change?
- `EventDecorator#calendar_links` formatted times with a `Z` suffix (meaning UTC) but didn't actually convert to UTC first
- The `around_action :set_time_zone_from_user` in `ApplicationController` sets `Time.zone` to the user's time zone (defaulting to Pacific), so `object.start_date.strftime(...)` formatted the local time, not UTC
- Added `.utc` before `.strftime` so the value is properly converted to UTC to match the `Z` suffix
- Updated the corresponding system test expectations

### Anything else to add?
- Example of the bug: a 3:00 PM Pacific event was formatted as `T150000Z`, which calendar apps interpreted as 3:00 PM UTC = 8:00 AM Pacific

🤖 Generated with [Claude Code](https://claude.com/claude-code)