### PR TITLE
Add colored left border to distinguish facilitator vs non-facilitator affiliations

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -23,6 +23,10 @@ class Affiliation < ApplicationRecord
   after_destroy :sync_organization_affiliation_dates
 
   # Methods
+  def facilitator?
+    title.to_s.downcase.include?("facilitator")
+  end
+
   def name
     "#{person.name}" if person
   end

--- a/app/views/organizations/_affiliation_fields.html.erb
+++ b/app/views/organizations/_affiliation_fields.html.erb
@@ -1,6 +1,7 @@
 <% if allowed_to?(:manage?, Organization) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
   <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-end mb-4 rounded-lg border p-3 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : 'bg-white border-gray-200' %>"
+       style="border-left: 4px solid <%= f.object.facilitator? ? '#e879f9' : '#d1d5db' %>"
        <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
        data-controller="inactive-toggle">
     <div style="width: 350px; min-width: 350px; flex-shrink: 0;">

--- a/app/views/people/_affiliation_fields.html.erb
+++ b/app/views/people/_affiliation_fields.html.erb
@@ -1,6 +1,7 @@
 <% if allowed_to?(:manage?, Person) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
   <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-end mb-4 rounded-lg border p-3 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : 'bg-white border-gray-200' %>"
+       style="border-left: 4px solid <%= f.object.facilitator? ? '#e879f9' : '#d1d5db' %>"
        data-controller="inactive-toggle">
     <div style="width: 350px; min-width: 350px; flex-shrink: 0;">
       <% if f.object.persisted? && f.object.organization.present? %>


### PR DESCRIPTION



### What is the goal of this PR and why is this important? 
On admin edit forms for people and organizations, affiliation rows now have a fuchsia left border for facilitator roles and a gray left border for non-facilitator roles, making it easy to visually scan affiliation type.



