### PR TITLE
Fix show page clickable labels, policy gates, and specs

### DIFF
--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -30,6 +30,21 @@
     <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div>
+          <span class="font-semibold text-gray-700">Story by:</span>
+          <% if @story_idea.created_by&.person && allowed_to?(:show?, @story_idea.created_by.person) %>
+            <%= link_to @story_idea.created_by.name,
+                        person_path(@story_idea.created_by.person),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:people, intensity: 100)} #{DomainTheme.text_class_for(:people)} #{DomainTheme.bg_class_for(:people, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @story_idea.created_by&.name || "—" %>
+          <% end %>
+        </div>
+        <div>
+          <span class="font-semibold text-gray-700">Author credit:</span>
+          <%= @story_idea.author_credit_preference&.humanize || "—" %>
+        </div>
+        <div>
           <span class="font-semibold text-gray-700">Permission given:</span>
           <% if @story_idea.permission_given %>
             <span class="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-700">Yes</span>
@@ -38,21 +53,42 @@
           <% end %>
         </div>
         <div>
-          <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= @story_idea.author_credit_preference&.humanize || "—" %>
+          <span class="font-semibold text-gray-700">Workshop:</span>
+          <% workshop_title = @story_idea.workshop&.title || @story_idea.external_workshop_title %>
+          <% if @story_idea.workshop && allowed_to?(:show?, @story_idea.workshop) %>
+            <%= link_to workshop_title, workshop_path(@story_idea.workshop),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:workshops, intensity: 100)} #{DomainTheme.text_class_for(:workshops)} #{DomainTheme.bg_class_for(:workshops, intensity: 100, hover: true)}" %>
+          <% elsif workshop_title.present? %>
+            <%= workshop_title %>
+          <% else %>
+            —
+          <% end %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Windows audience:</span>
           <%= @story_idea.windows_type&.short_name || "—" %>
         </div>
         <div>
+          <span class="font-semibold text-gray-700">Organization:</span>
+          <% if @story_idea.organization && allowed_to?(:show?, @story_idea.organization) %>
+            <%= link_to @story_idea.organization.name,
+                        organization_path(@story_idea.organization),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @story_idea.organization&.name || "—" %>
+          <% end %>
+        </div>
+        <div class="hidden md:block"></div>
+        <div>
           <span class="font-semibold text-gray-700">Created by:</span>
-          <%= @story_idea.created_by&.full_name %>
+          <%= @story_idea.created_by&.name %>
           <br><span class="text-gray-400"><%= @story_idea.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Updated by:</span>
-          <%= @story_idea.updated_by&.full_name %>
+          <%= @updated_by&.name || "—" %>
           <br><span class="text-gray-400"><%= @story_idea.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
       </div>
@@ -77,21 +113,6 @@
             <% end %>
           </div>
         </div>
-      <% end %>
-    </div>
-
-    <div class="text-sm text-gray-600 space-y-0.5">
-      <p><strong>Story by:</strong> <%= @story_idea.author_credit %></p>
-      <p><strong>Organization:</strong> <%= @story_idea.organization_name %></p>
-      <% workshop_title = @story_idea.workshop&.title || @story_idea.external_workshop_title %>
-      <% if workshop_title.present? %>
-        <p><strong>Workshop:</strong>
-          <% if @story_idea.workshop %>
-            <%= link_to workshop_title, workshop_path(@story_idea.workshop), class: "hover:underline" %>
-          <% else %>
-            <%= workshop_title %>
-          <% end %>
-        </p>
       <% end %>
     </div>
 

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -19,10 +19,11 @@
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div>
           <span class="font-semibold text-gray-700">Submitted by:</span>
-          <% if @workshop_log.created_by && allowed_to?(:show?, @workshop_log.created_by) %>
+          <% if @workshop_log.created_by&.person && allowed_to?(:show?, @workshop_log.created_by.person) %>
             <%= link_to @workshop_log.created_by.name,
-                        @workshop_log.created_by.person ? person_path(@workshop_log.created_by.person) : user_path(@workshop_log.created_by),
-                        class: "hover:underline" %>
+                        person_path(@workshop_log.created_by.person),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:people, intensity: 100)} #{DomainTheme.text_class_for(:people)} #{DomainTheme.bg_class_for(:people, intensity: 100, hover: true)}" %>
           <% else %>
             <%= @workshop_log.created_by&.name || "—" %>
           <% end %>
@@ -32,9 +33,10 @@
           <% if @workshop_log.organization && allowed_to?(:show?, @workshop_log.organization) %>
             <%= link_to @workshop_log.organization.name,
                         organization_path(@workshop_log.organization),
-                        class: "hover:underline" %>
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}" %>
           <% else %>
-            —
+            <%= @workshop_log.organization&.name || "—" %>
           <% end %>
         </div>
         <div>
@@ -42,17 +44,24 @@
           <%= @workshop_log.workshop&.windows_type&.short_name || "—" %>
         </div>
         <div>
-          <span class="font-semibold text-gray-700">Workshop date:</span>
-          <%= @workshop_log.date&.strftime("%B %d, %Y") || "—" %>
+          <span class="font-semibold text-gray-700">Workshop:</span>
+          <% if @workshop_log.workshop && allowed_to?(:show?, @workshop_log.workshop) %>
+            <%= link_to @workshop_log.workshop.title, workshop_path(@workshop_log.workshop),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:workshops, intensity: 100)} #{DomainTheme.text_class_for(:workshops)} #{DomainTheme.bg_class_for(:workshops, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @workshop_log.workshop&.title || "—" %>
+          <% end %>
+          <br><span class="text-gray-400"><%= @workshop_log.date&.strftime("%B %d, %Y") || "—" %></span>
         </div>
         <div>
-          <span class="font-semibold text-gray-700">Created:</span>
-          <%= @workshop_log.created_by&.full_name %>
+          <span class="font-semibold text-gray-700">Created by:</span>
+          <%= @workshop_log.created_by&.name %>
           <br><span class="text-gray-400"><%= @workshop_log.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Updated by:</span>
-          <%= @updated_by&.full_name || "—" %>
+          <%= @updated_by&.name || "—" %>
           <br><span class="text-gray-400"><%= @workshop_log.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
       </div>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -31,6 +31,21 @@
     <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div>
+          <span class="font-semibold text-gray-700">Submitted by:</span>
+          <% if @workshop_variation_idea.created_by&.person && allowed_to?(:show?, @workshop_variation_idea.created_by.person) %>
+            <%= link_to @workshop_variation_idea.created_by.name,
+                        person_path(@workshop_variation_idea.created_by.person),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:people, intensity: 100)} #{DomainTheme.text_class_for(:people)} #{DomainTheme.bg_class_for(:people, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @workshop_variation_idea.created_by&.name || "—" %>
+          <% end %>
+        </div>
+        <div>
+          <span class="font-semibold text-gray-700">Author credit:</span>
+          <%= @workshop_variation_idea.author_credit_preference&.humanize || "—" %>
+        </div>
+        <div>
           <span class="font-semibold text-gray-700">Permission given:</span>
           <% if @workshop_variation_idea.permission_given %>
             <span class="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-700">Yes</span>
@@ -39,8 +54,14 @@
           <% end %>
         </div>
         <div>
-          <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= @workshop_variation_idea.author_credit_preference&.humanize || "—" %>
+          <span class="font-semibold text-gray-700">Workshop:</span>
+          <% if @workshop_variation_idea.workshop && allowed_to?(:show?, @workshop_variation_idea.workshop) %>
+            <%= link_to @workshop_variation_idea.workshop.title, workshop_path(@workshop_variation_idea.workshop),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:workshops, intensity: 100)} #{DomainTheme.text_class_for(:workshops)} #{DomainTheme.bg_class_for(:workshops, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @workshop_variation_idea.workshop&.title || "—" %>
+          <% end %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Windows audience:</span>
@@ -48,33 +69,34 @@
         </div>
         <div>
           <span class="font-semibold text-gray-700">Organization:</span>
-          <%= @workshop_variation_idea.organization&.name || "—" %>
+          <% if @workshop_variation_idea.organization && allowed_to?(:show?, @workshop_variation_idea.organization) %>
+            <%= link_to @workshop_variation_idea.organization.name,
+                        organization_path(@workshop_variation_idea.organization),
+                        data: { turbo_frame: "_top" },
+                        class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}" %>
+          <% else %>
+            <%= @workshop_variation_idea.organization&.name || "—" %>
+          <% end %>
         </div>
+        <div class="hidden md:block"></div>
         <div>
           <span class="font-semibold text-gray-700">Created by:</span>
-          <%= @workshop_variation_idea.created_by&.full_name %>
+          <%= @workshop_variation_idea.created_by&.name %>
           <br><span class="text-gray-400"><%= @workshop_variation_idea.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Updated by:</span>
-          <%= @workshop_variation_idea.updated_by&.full_name %>
+          <%= @updated_by&.name || "—" %>
           <br><span class="text-gray-400"><%= @workshop_variation_idea.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
       </div>
     </div>
 
-    <div class="text-sm text-gray-600 space-y-0.5">
-      <p><strong>Workshop:</strong>
-        <% if @workshop_variation_idea.workshop %>
-          <%= link_to @workshop_variation_idea.workshop.title, workshop_path(@workshop_variation_idea.workshop), class: "hover:underline" %>
-        <% else %>
-          —
-        <% end %>
-      </p>
-      <% if @workshop_variation_idea.youtube_url.present? %>
-        <p><strong>YouTube:</strong> <%= @workshop_variation_idea.youtube_url %></p>
-      <% end %>
-    </div>
+    <% if @workshop_variation_idea.youtube_url.present? %>
+      <div class="text-sm text-gray-600">
+        <strong>YouTube:</strong> <%= @workshop_variation_idea.youtube_url %>
+      </div>
+    <% end %>
 
     <%= render "assets/display_assets", resource: @workshop_variation_idea, link: true, align: :start %>
 

--- a/spec/system/person_views_story_idea_spec.rb
+++ b/spec/system/person_views_story_idea_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Viewing a story idea", type: :system do
+  let(:windows_type) { create(:windows_type, :combined) }
+  let(:organization) { create(:organization, name: "Community Arts Project", windows_type_id: windows_type.id) }
+  let(:workshop) { create(:workshop, :published, title: "Healing Through Art", windows_type: windows_type) }
+
+  describe "as the owner" do
+    let(:user) { create(:user) }
+    let(:person) { create(:person, user: user) }
+    let!(:story_idea) do
+      create(:story_idea,
+             created_by: user,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before do
+      person # ensure person is created
+      sign_in user
+    end
+
+    it "displays the organization as plain text (non-admin)" do
+      visit story_idea_path(story_idea)
+
+      expect(page).to have_text(organization.name)
+      expect(page).not_to have_link(organization.name)
+    end
+
+    it "displays the creator as a clickable label" do
+      visit story_idea_path(story_idea)
+
+      expect(page).to have_link(user.name, href: person_path(person))
+    end
+  end
+
+  describe "as the owner without a person record" do
+    let(:user) { create(:user) }
+    let!(:story_idea) do
+      create(:story_idea,
+             created_by: user,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before { sign_in user }
+
+    it "displays the creator as plain text" do
+      visit story_idea_path(story_idea)
+
+      expect(page).to have_text(user.name)
+      expect(page).not_to have_link(user.name)
+    end
+  end
+
+  describe "as an admin" do
+    let(:admin) { create(:user, :admin) }
+    let(:creator) { create(:user) }
+    let(:creator_person) { create(:person, user: creator) }
+    let!(:story_idea) do
+      create(:story_idea,
+             created_by: creator,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before do
+      creator_person # ensure person is created
+      sign_in admin
+    end
+
+    it "displays the organization as a clickable label" do
+      visit story_idea_path(story_idea)
+
+      expect(page).to have_link(organization.name, href: organization_path(organization))
+    end
+
+    it "displays the creator as a clickable label" do
+      visit story_idea_path(story_idea)
+
+      expect(page).to have_link(creator.name, href: person_path(creator_person))
+    end
+  end
+end

--- a/spec/system/person_views_workshop_log_spec.rb
+++ b/spec/system/person_views_workshop_log_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "Viewing a workshop log", type: :system do
+  let(:windows_type) { create(:windows_type, :combined) }
+  let(:organization) { create(:organization, name: "Community Arts Project", windows_type_id: windows_type.id) }
+  let(:workshop) { create(:workshop, :published, title: "Healing Through Art", windows_type: windows_type) }
+
+  describe "as a regular user" do
+    let(:user) { create(:user) }
+    let(:person) { create(:person, user: user) }
+    let!(:affiliation) { create(:affiliation, person: person, organization: organization) }
+    let!(:workshop_log) do
+      create(:workshop_log,
+             created_by: user,
+             organization: organization,
+             owner: workshop,
+             workshop: workshop,
+             windows_type: windows_type,
+             date: 1.day.ago)
+    end
+
+    before { sign_in user }
+
+    it "displays the organization as plain text (non-admin)" do
+      visit workshop_log_path(workshop_log)
+
+      expect(page).to have_text("Community Arts Project")
+      expect(page).not_to have_link("Community Arts Project")
+    end
+
+    it "displays the creator as a clickable label" do
+      visit workshop_log_path(workshop_log)
+
+      expect(page).to have_link(user.name, href: person_path(person))
+    end
+  end
+
+  describe "as a user without a person record" do
+    let(:user) { create(:user) }
+    let!(:workshop_log) do
+      create(:workshop_log,
+             created_by: user,
+             organization: organization,
+             owner: workshop,
+             workshop: workshop,
+             windows_type: windows_type,
+             date: 1.day.ago)
+    end
+
+    before { sign_in user }
+
+    it "displays the creator as plain text" do
+      visit workshop_log_path(workshop_log)
+
+      expect(page).to have_text(user.name)
+      expect(page).not_to have_link(user.name)
+    end
+  end
+
+  describe "as an admin" do
+    let(:admin) { create(:user, :admin) }
+    let(:person) { create(:person, user: admin) }
+    let!(:affiliation) { create(:affiliation, person: person, organization: organization) }
+    let!(:workshop_log) do
+      create(:workshop_log,
+             created_by: admin,
+             organization: organization,
+             owner: workshop,
+             workshop: workshop,
+             windows_type: windows_type,
+             date: 1.day.ago)
+    end
+
+    before { sign_in admin }
+
+    it "displays the organization as a clickable label" do
+      visit workshop_log_path(workshop_log)
+
+      expect(page).to have_link("Community Arts Project", href: organization_path(organization))
+    end
+
+    it "displays the creator as a clickable label" do
+      visit workshop_log_path(workshop_log)
+
+      expect(page).to have_link(admin.name, href: person_path(person))
+    end
+  end
+end

--- a/spec/system/person_views_workshop_variation_idea_spec.rb
+++ b/spec/system/person_views_workshop_variation_idea_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Viewing a workshop variation idea", type: :system do
+  let(:windows_type) { create(:windows_type, :combined) }
+  let(:organization) { create(:organization, name: "Community Arts Project", windows_type_id: windows_type.id) }
+  let(:workshop) { create(:workshop, :published, title: "Healing Through Art", windows_type: windows_type) }
+
+  describe "as the owner" do
+    let(:user) { create(:user) }
+    let(:person) { create(:person, user: user) }
+    let!(:idea) do
+      create(:workshop_variation_idea,
+             created_by: user,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before do
+      person # ensure person is created
+      sign_in user
+    end
+
+    it "displays the organization as plain text (non-admin)" do
+      visit workshop_variation_idea_path(idea)
+
+      expect(page).to have_text(organization.name)
+      expect(page).not_to have_link(organization.name)
+    end
+
+    it "displays the creator as a clickable label" do
+      visit workshop_variation_idea_path(idea)
+
+      expect(page).to have_link(user.name, href: person_path(person))
+    end
+  end
+
+  describe "as the owner without a person record" do
+    let(:user) { create(:user) }
+    let!(:idea) do
+      create(:workshop_variation_idea,
+             created_by: user,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before { sign_in user }
+
+    it "displays the creator as plain text" do
+      visit workshop_variation_idea_path(idea)
+
+      expect(page).to have_text(user.name)
+      expect(page).not_to have_link(user.name)
+    end
+  end
+
+  describe "as an admin" do
+    let(:admin) { create(:user, :admin) }
+    let(:creator) { create(:user) }
+    let(:creator_person) { create(:person, user: creator) }
+    let!(:idea) do
+      create(:workshop_variation_idea,
+             created_by: creator,
+             organization: organization,
+             workshop: workshop,
+             windows_type: windows_type)
+    end
+
+    before do
+      creator_person # ensure person is created
+      sign_in admin
+    end
+
+    it "displays the organization as a clickable label" do
+      visit workshop_variation_idea_path(idea)
+
+      expect(page).to have_link(organization.name, href: organization_path(organization))
+    end
+
+    it "displays the creator as a clickable label" do
+      visit workshop_variation_idea_path(idea)
+
+      expect(page).to have_link(creator.name, href: person_path(creator_person))
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Follow-up to #1246 which was merged before these fixes landed
- The 5 CI failures from #1246 are addressed here: clickable labels were missing ActionPolicy gates, `full_name` was used instead of `name`, and specs expected links where policy returns plain text

### How did you approach the change?
- Gate all linked labels (person, organization, workshop) behind `allowed_to?(:show?, resource)` — non-admin users see plain text for organizations since `OrganizationPolicy#show?` is admin-only
- Use `name` instead of `full_name` consistently across all three show pages (workshop logs, story ideas, workshop variation ideas)
- Fix specs: org label tests for non-admins now expect plain text, "without person" tests use `user.name` to match view output
- Add DomainTheme-colored clickable label styling with `turbo_frame: "_top"`

### Anything else to add?
- Fixes all 5 CI failures from the previous PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)