### PR TITLE
Clean up event registration show page layout

### DIFF
--- a/app/views/event_registrations/show.html.erb
+++ b/app/views/event_registrations/show.html.erb
@@ -37,36 +37,26 @@
 
       <!-- Ticket Body -->
       <div class="bg-gray-50 px-6 py-6 space-y-5">
-        <!-- Event Image + Registrant -->
-        <div class="flex items-center gap-4">
-          <div class="shrink-0">
+
+        <!-- Event Image + Title -->
+        <div class="text-center space-y-4">
+          <div class="inline-block rounded-lg overflow-hidden border border-gray-200 shadow-sm">
             <%= render "assets/display_image",
                        resource: @event_registration.event,
-                       width: 32, height: 24,
+                       width: 48, height: 32,
                        variant: :index,
                        link_to_object: true,
                        file: @event_registration.event.decorate.display_image %>
           </div>
-          <div class="flex flex-col justify-center min-w-0 flex-1 ml-[4rem]">
-            <p class="text-gray-500 uppercase tracking-wide text-xs">Registrant</p>
-            <p class="font-medium text-gray-900 text-lg">
-              <% if user_signed_in? %>
-                <%= link_to @event_registration.registrant.full_name, person_path(@event_registration.registrant), class: "text-blue-700 hover:text-blue-900 underline" %>
-              <% else %>
-                <%= @event_registration.registrant.full_name %>
-              <% end %>
-            </p>
-          </div>
-        </div>
 
-        <!-- Event Name -->
-        <div class="text-center">
-          <% if @event_registration.event.respond_to?(:pre_title) && @event_registration.event.pre_title.present? %>
-            <p class="text-base font-semibold text-gray-700 mb-1" style="font-family: 'Telefon Bold', sans-serif"><%= @event_registration.event.pre_title %></p>
-          <% end %>
-          <h2 class="text-3xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif">
-            <%= link_to @event_registration.event.title, event_path(@event_registration.event), class: "hover:underline" %>
-          </h2>
+          <div>
+            <% if @event_registration.event.respond_to?(:pre_title) && @event_registration.event.pre_title.present? %>
+              <p class="text-base font-semibold text-gray-700 mb-1" style="font-family: 'Telefon Bold', sans-serif"><%= @event_registration.event.pre_title %></p>
+            <% end %>
+            <h2 class="text-3xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif">
+              <%= link_to @event_registration.event.title, event_path(@event_registration.event), class: "hover:underline" %>
+            </h2>
+          </div>
         </div>
 
         <!-- Divider (perforation style) -->
@@ -74,6 +64,18 @@
           <div class="border-t border-dashed border-gray-300"></div>
           <div class="absolute -left-3 top-1/2 -translate-y-1/2 w-6 h-6 bg-gray-100 rounded-full"></div>
           <div class="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 bg-gray-100 rounded-full"></div>
+        </div>
+
+        <!-- Registrant -->
+        <div class="text-center">
+          <p class="text-gray-500 uppercase tracking-wide text-xs">Registrant</p>
+          <p class="font-medium text-gray-900 text-lg">
+            <% if user_signed_in? %>
+              <%= link_to @event_registration.registrant.full_name, person_path(@event_registration.registrant), class: "text-blue-700 hover:text-blue-900 underline" %>
+            <% else %>
+              <%= @event_registration.registrant.full_name %>
+            <% end %>
+          </p>
         </div>
 
         <!-- Event Details -->
@@ -101,12 +103,6 @@
 
           <%= render "events/videoconference_link", event: @event_registration.event.decorate, joinable: @event_registration.joinable? %>
 
-          <% if @event_registration.event.registration_close_date %>
-            <div class="text-base text-gray-700">
-              <% reg_tz_abbr = @event_registration.event.start_date.in_time_zone(Time.zone).strftime("%Z") %>
-              Registration closes <%= @event_registration.event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %l:%M %P") %> <%= reg_tz_abbr %>
-            </div>
-          <% end %>
 
         </div>
 
@@ -126,35 +122,30 @@
         <!-- Divider -->
         <div class="border-t border-gray-200"></div>
 
-        <!-- Status + Meta -->
-        <div class="flex items-center justify-between mt-4">
-          <div>
-            <% if @event_registration.checked_in? %>
-              <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                Checked In
-              </span>
-            <% elsif @event_registration.respond_to?(:canceled?) && @event_registration.canceled? %>
-              <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                Canceled
-              </span>
-            <% end %>
-          </div>
+        <!-- Status -->
+        <div class="mt-4 text-center space-y-2">
+          <% if @event_registration.checked_in? %>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+              Checked In
+            </span>
+          <% elsif @event_registration.respond_to?(:canceled?) && @event_registration.canceled? %>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800">
+              Canceled
+            </span>
+          <% else %>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+              Registered on <%= @event_registration.created_at.strftime("%B %-d, %Y") %>
+            </span>
+          <% end %>
 
-          <p class="text-xs text-gray-500">
-            Registered on <%= @event_registration.created_at.strftime("%B %d, %Y") %>
-          </p>
-
-        </div>
-
-        <!-- Registration actions -->
-        <div class="mt-4 flex flex-wrap items-center justify-center gap-3">
-          <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">You are registered!</span>
           <% if user_signed_in? %>
-            <%= button_to "De-register",
-                          event_registrant_registration_path(event_id: @event_registration.event),
-                          method: :delete,
-                          data: { turbo_confirm: "Are you sure?" },
-                          class: "btn btn-secondary-outline text-sm" %>
+            <div>
+              <%= button_to "De-register",
+                            event_registrant_registration_path(event_id: @event_registration.event),
+                            method: :delete,
+                            data: { turbo_confirm: "Are you sure?" },
+                            class: "btn btn-secondary-outline text-sm" %>
+            </div>
           <% end %>
         </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,9 @@
   </div>
 <% else %>
 <!-- Top Right Actions -->
-<div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="flex flex-wrap items-center gap-2 mb-4">
+  <%= link_to "← Back to Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <div class="ml-auto flex flex-wrap gap-2">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% if allowed_to?(:manage?, @event) && @event.object.forms.exists?(name: "Public Registration") %>
@@ -20,6 +22,7 @@
     <%= link_to "Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
+  </div>
 </div>
 <% end %>
 


### PR DESCRIPTION
## Summary
- Restructures the registration confirmation ticket: event image and title displayed at top, registrant name below the perforation divider
- Combines the "You are registered!" badge and "Registered on" date into a single centered status badge
- Removes redundant registration close date from the confirmation page (not relevant post-registration)
- Adds "← Back to Events" navigation link to the event show page

## Test plan
- [x] View an event registration confirmation page and verify layout: image + title at top, perforation divider, registrant name, event details, status badge
- [x] Verify "Registered on [date]" badge displays correctly for normal registrations
- [ ] Verify "Checked In" and "Canceled" badges still display correctly
- [x] Verify "De-register" button appears for signed-in users
- [x] Verify "← Back to Events" link appears on event show page and navigates correctly
- [x] Verify existing nav links (Home, Events, admin links) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)