### PR TITLE
Add explicit rubocop-rails-omakase rules to AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,6 @@
 
 # Code style requirements:
 - Use modern Ruby syntax
-- Follow RuboCop (with  rubocop-rails-omakase and rubocop-rails and rubocop-performance)
 - Prefer early returns and guard clauses
 - Avoid unnecessary and/or complex conditionals
 - Prefer enums and scopes over magic strings
@@ -13,3 +12,41 @@
 - Prefer service objects under app/services
 - Prefer POROs over concerns when possible
 - Use `after_commit` instead of `after_save` for side effects
+
+# RuboCop (rubocop-rails-omakase)
+This project uses rubocop-rails-omakase. All code MUST follow these rules:
+
+## Strings
+- Always use double quotes: `"foo"` not `'foo'`
+
+## Spacing
+- Spaces inside array brackets: `[ a, b, c ]` not `[a, b, c]` (empty arrays: `[]`)
+- Spaces inside hash braces: `{ a: 1, b: 2 }` not `{a: 1}` (empty hashes: `{}`)
+- Spaces inside block braces: `foo { bar }` not `foo {bar}` (empty blocks: `foo { }`)
+- No spaces inside parens: `foo(bar)` not `foo( bar )`
+- No spaces inside reference brackets: `hash[:key]` not `hash[ :key ]`
+- Space before block braces: `foo { }` not `foo{ }`
+
+## Commas
+- No trailing commas in arrays, hashes, or method arguments
+
+## Indentation
+- 2-space indentation, no tabs
+- Consistent indentation at normal level — do NOT indent methods under `private`/`protected`
+- Align `end` with the variable in assignments
+- Align `when` with `end`, not with `case`
+
+## Whitespace
+- No trailing whitespace on any line
+- No trailing blank lines at end of file
+- No empty lines inside class, module, method, or block bodies
+
+## Syntax
+- Use `%w[]` and `%i[]` with square bracket delimiters (not parens)
+- Use modern hash syntax: `{ key: value }` not `{ :key => value }`
+- No redundant returns — omit `return` on last expression
+- Use `flat_map` instead of `.map { }.flatten`
+- No redundant `.to_s` inside string interpolation
+- Use `Foo.method` not `Foo::method` for method calls
+- No parentheses around conditions: `if foo` not `if (foo)`
+- No semicolons to separate statements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,6 @@ npm ci
 
 ## Code Style
 
-- Follow RuboCop with rubocop-rails-omakase
 - Use modern Ruby syntax
 - Prefer early returns and guard clauses
 - Avoid unnecessary and/or complex conditionals
@@ -45,6 +44,50 @@ npm ci
 - Prefer service objects under app/services/
 - Prefer POROs over concerns when possible
 - Use `after_commit` instead of `after_save` for side effects
+
+## RuboCop (rubocop-rails-omakase)
+
+This project uses rubocop-rails-omakase. All code MUST follow these rules:
+
+### Strings
+- **Always use double quotes** for strings: `"foo"` not `'foo'`
+
+### Spacing
+- **Spaces inside array brackets:** `[ a, b, c ]` not `[a, b, c]` (empty arrays: `[]`)
+- **Spaces inside hash braces:** `{ a: 1, b: 2 }` not `{a: 1}` (empty hashes: `{}`)
+- **Spaces inside block braces:** `foo { bar }` not `foo {bar}` (empty blocks: `foo { }`)
+- **No spaces inside parens:** `foo(bar)` not `foo( bar )`
+- **No spaces inside reference brackets:** `hash[:key]` not `hash[ :key ]`
+- **Space before block braces:** `foo { }` not `foo{ }`
+
+### Commas
+- **No trailing commas** in arrays, hashes, or method arguments
+
+### Indentation
+- **2-space indentation**, no tabs
+- **Consistent indentation** at normal level — do NOT indent methods under `private`/`protected`
+- **Align `end` with the variable** in assignments:
+  ```ruby
+  result = if condition
+    value
+  end
+  ```
+- **Align `when` with `end`**, not with `case`
+
+### Whitespace
+- **No trailing whitespace** on any line
+- **No trailing blank lines** at end of file
+- **No empty lines** inside class, module, method, or block bodies
+
+### Syntax
+- **Use `%w[]` and `%i[]`** with square bracket delimiters (not parens)
+- **Use modern hash syntax:** `{ key: value }` not `{ :key => value }`
+- **No redundant returns** — omit `return` on last expression
+- **Use `flat_map`** instead of `.map { }.flatten`
+- **No redundant `.to_s`** inside string interpolation
+- **Use `Foo.method`** not `Foo::method` for method calls
+- **No parentheses around conditions:** `if foo` not `if (foo)`
+- **No semicolons** to separate statements
 
 ## Related Files
 


### PR DESCRIPTION
## Summary
- Expands the vague "Follow RuboCop with rubocop-rails-omakase" instruction into specific, actionable rules in both `CLAUDE.md` and `.github/copilot-instructions.md`
- Covers strings (double quotes), spacing (array brackets, hash braces, block braces), commas (no trailing), indentation (2-space, align `end` with variable), whitespace (no trailing), and syntax (`%w[]`, modern hash syntax, no redundant returns, `flat_map`)
- Rules are derived directly from the rubocop-rails-omakase gem config plus this project's `.rubocop.yml` overrides

## Test plan
- [ ] Verify `CLAUDE.md` renders correctly and rules are clear
- [ ] Verify `.github/copilot-instructions.md` renders correctly
- [ ] Confirm rules match the project's `.rubocop.yml` and rubocop-rails-omakase gem config

🤖 Generated with [Claude Code](https://claude.com/claude-code)