### PR TITLE
Fix calendar links to use event rich text description

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -37,18 +37,20 @@ class EventDecorator < ApplicationDecorator
     # If both: URL in location field, physical location in description
     # If only URL: URL in location field
     # If only location: location in location field
+    event_description = object.rhino_description.to_plain_text
+
     if has_url && has_location
       cal_location = object.videoconference_url
-      description  = "#{location_name}\n\n#{object.description}"
+      description  = "#{location_name}\n\n#{event_description}"
     elsif has_url
       cal_location = object.videoconference_url
-      description  = object.description.to_s
+      description  = event_description
     elsif has_location
       cal_location = location_name
-      description  = object.description.to_s
+      description  = event_description
     else
       cal_location = nil
-      description  = object.description.to_s
+      description  = event_description
     end
 
     desc_encoded     = ERB::Util.url_encode(description)

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -44,4 +44,33 @@ RSpec.describe EventDecorator do
       expect(event.labelled_cost).to eq("Cost: $25.05")
     end
   end
+
+  describe "#calendar_links" do
+    it "includes rhino_description plain text in all calendar links" do
+      event = create(:event)
+      event.update!(rhino_description: "<div>Join us for healing through art</div>")
+      decorated = event.decorate
+
+      html = decorated.calendar_links
+      doc = Nokogiri::HTML.fragment(html)
+      links = doc.css("a")
+
+      desc_encoded = ERB::Util.url_encode("Join us for healing through art")
+
+      google = links.find { |a| a.text == "Google" }
+      expect(google["href"]).to include("details=#{desc_encoded}")
+
+      apple = links.find { |a| a.text == "Apple" }
+      expect(apple["href"]).to include("DESCRIPTION:Join us for healing through art")
+
+      outlook = links.find { |a| a.text == "Outlook" }
+      expect(outlook["href"]).to include("body=#{desc_encoded}")
+
+      office365 = links.find { |a| a.text == "Office 365" }
+      expect(office365["href"]).to include("body=#{desc_encoded}")
+
+      yahoo = links.find { |a| a.text == "Yahoo" }
+      expect(yahoo["href"]).to include("desc=#{desc_encoded}")
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Calendar links (Google, Apple, Outlook, Office 365, Yahoo) were showing stale placeholder text instead of the actual event description
- The `calendar_links` decorator method was reading from the plain `description` database column, but the event form edits `rhino_description` (ActionText rich text)

### How did you approach the change?

- Switched `EventDecorator#calendar_links` to use `object.rhino_description.to_plain_text` instead of `object.description`
- Added spec that verifies the rich text description appears in all five calendar link types

### Anything else to add?

- The plain `description` column is still used by SearchCop for search indexing — that was left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)