### PR TITLE
Add test for organization sectors

### DIFF
--- a/spec/system/organization_sectors_spec.rb
+++ b/spec/system/organization_sectors_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Navbar avatar behavior", type: :system do
+RSpec.describe "Organization sector displays", type: :system do
   let!(:organization) do
     direct_sector_1 = create(:sector, name: "Direct Sector 1")
     direct_sector_2 = create(:sector, name: "Direct Sector 2")


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->


### What is the goal of this PR and why is this important?
This PR adds system tests for sector visibility on the organization show page and populations served page. The tests verify that:
- On the organization show page, sectors are displayed with proper truncation when there are more than 3 sectors
- On the populations served page, all sectors are displayed with correct counts for affiliated sectors. 

### How did you approach the change?
The tests follow the existing logic defined in `organization.rb` for direct and affiliated sectors, and mirror the behavior implemented in the organizations controller.

### UI Testing Checklist
<!-- This will be automatically generated based on your changes. -->
<!-- Complete the auto-generated checklist below before marking as ready for review. -->
<!-- Add or remove items as needed for your specific changes. -->

### Anything else to add?
Nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

