### PR TITLE
Add 50 seed people with realistic configurations

### DIFF
--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -745,7 +745,7 @@ puts "Creating CommunityNews…"
                 )
 end
 
-puts "Creating new StoryIdeas…"
+puts "Creating StoryIdeas…"
 10.times do |i|
   body_content = Faker::Lorem.paragraph(sentence_count: 10)
   StoryIdea.create!(
@@ -917,7 +917,7 @@ end
 
 
 
-puts "Creating new Resources…"
+puts "Creating Resources…"
 10.times do |i|
   kind = Resource::PUBLISHED_KINDS.sample
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Adds 50 people to dev seeds with similar names in clusters (Johnson, Garcia, Smith, Williams, Brown, Davis, De La Cruz) for realistic search/dropdown testing
- Includes a mix of configurations: some with `profile_is_searchable: false`, some without user accounts, varying numbers of affiliations, and various email setups

### How did you approach the change?

- Added 50 test people in `dummy_dev_seeds.rb` with realistic name clusters and cross-cluster similar names
- Set `confirmed_at` on seed users to suppress Devise confirmation emails
- Used valid `Affiliation#position` enum values (`default`, `liaison`, `leader`, `assistant`)
- Added realistic facilitator-related titles to affiliations (Facilitator, Lead Facilitator, Co-Facilitator, etc.)
- Fixed Rails 8.1 compatibility: `Person.where(...).exists?` instead of `Person.exists?(sql, args)`
- Cleaned up seed `puts` statements for consistency

### Anything else to add?

- 8 of 50 people have `profile_is_searchable: false`
- 16 of 50 do not have associated user accounts
- Affiliation counts range from 0-3 per person

🤖 Generated with [Claude Code](https://claude.com/claude-code)