### PR TITLE
Add dynamic search and filtering to account activity

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,23 +23,21 @@ class UsersController < ApplicationController
   def show
     authorize! @user
     @user = User.find(params[:id]).decorate
+
+    if turbo_frame_request? && params[:section] == "account_activity"
+      @account_events = account_events_for(@user, search: params[:search], by_user_id: params[:by_user_id])
+                          .paginate(page: params[:page], per_page: 10)
+      by_user_options = account_event_user_options(@user)
+      render partial: "users/sections/account_activity",
+             locals: { user: @user, account_events: @account_events, by_user_options: by_user_options }
+      return
+    end
+
     @comments = @user.comments.includes(:created_by).newest_first.paginate(page: params[:comments_page], per_page: 5)
 
-    user_auth_events = Ahoy::Event
-      .where("name LIKE 'auth.%' OR name LIKE 'update.user'")
-      .where(
-        "(CAST(JSON_EXTRACT(properties, '$.record_id') AS UNSIGNED) = :id AND JSON_UNQUOTE(JSON_EXTRACT(properties, '$.record_type')) = 'User') OR " \
-        "(CAST(JSON_EXTRACT(properties, '$.resource_id') AS UNSIGNED) = :id AND JSON_UNQUOTE(JSON_EXTRACT(properties, '$.resource_type')) = 'User')",
-        id: @user.id
-      )
-
+    user_auth_events = user_auth_events_base(@user)
     @last_admin_event = user_auth_events.where(name: %w[auth.admin_granted auth.admin_revoked]).order(time: :desc).first
     @last_lock_event = user_auth_events.where(name: %w[auth.account_locked auth.account_unlocked]).order(time: :desc).first
-
-    @account_events = user_auth_events
-      .includes(:user)
-      .order(time: :desc)
-      .paginate(page: params[:page], per_page: 10)
 
     # Fall back to ahoy events for created_by/updated_by if not set on the model
     unless @user.created_by
@@ -270,6 +268,32 @@ class UsersController < ApplicationController
     @user.person.affiliations.first || @user.person.affiliations.build if @user.person
     organizations = authorized_scope(Organization.all)
     @organizations_array = organizations.order(:name).pluck(:name, :id)
+  end
+
+  def user_auth_events_base(user)
+    Ahoy::Event
+      .where("name LIKE 'auth.%' OR name LIKE 'update.user'")
+      .where(
+        "(CAST(JSON_EXTRACT(properties, '$.record_id') AS UNSIGNED) = :id AND JSON_UNQUOTE(JSON_EXTRACT(properties, '$.record_type')) = 'User') OR " \
+        "(CAST(JSON_EXTRACT(properties, '$.resource_id') AS UNSIGNED) = :id AND JSON_UNQUOTE(JSON_EXTRACT(properties, '$.resource_type')) = 'User')",
+        id: user.id
+      )
+  end
+
+  def account_events_for(user, search: nil, by_user_id: nil)
+    scope = user_auth_events_base(user).includes(:user).order(time: :desc)
+    if search.present?
+      q = "%#{search}%"
+      scope = scope.where("ahoy_events.name LIKE :q OR CAST(ahoy_events.properties AS CHAR) LIKE :q", q: q)
+    end
+    scope = scope.where(user_id: by_user_id) if by_user_id.present?
+    scope
+  end
+
+  def account_event_user_options(user)
+    User.where(super_user: true).or(User.where(id: user.id))
+        .order(:first_name, :last_name)
+        .map { |u| [ u.name, u.id ] }
   end
 
   def password_param

--- a/app/views/users/sections/_account_activity.html.erb
+++ b/app/views/users/sections/_account_activity.html.erb
@@ -1,0 +1,93 @@
+<%= turbo_frame_tag "account_activity_section" do %>
+  <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+    <div class="flex items-center justify-between mb-3">
+      <h4 class="text-sm font-semibold uppercase text-gray-700">Account activity</h4>
+      <%= link_to "See all user activity",
+                  admin_activities_events_path(user_id: user.id),
+                  class: "text-xs text-gray-500 hover:text-blue-600",
+                  data: { turbo_frame: "_top" } %>
+    </div>
+
+    <%= form_tag(user_path(user), method: :get,
+      data: { controller: "collection", turbo_frame: "account_activity_section" },
+      autocomplete: "off",
+      class: "mb-4") do %>
+      <%= hidden_field_tag :section, "account_activity" %>
+      <div class="flex items-center gap-3">
+        <div class="relative flex-1 max-w-sm">
+          <%= text_field_tag :search, params[:search],
+                             class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 shadow-sm
+                                   focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                             placeholder: "Search events..." %>
+          <button type="submit"
+                  class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-blue-600">
+            <i class="fa fa-search text-sm"></i>
+          </button>
+        </div>
+        <%= select_tag :by_user_id,
+                       options_for_select(by_user_options, params[:by_user_id]),
+                       include_blank: "By: All users",
+                       class: "rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 shadow-sm
+                              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+        <% if params[:search].present? || params[:by_user_id].present? %>
+          <%= link_to "Clear", user_path(user, section: "account_activity"),
+                      class: "text-sm text-gray-500 hover:text-blue-600",
+                      data: { action: "collection#clearAndSubmit" } %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if account_events.any? %>
+      <div class="blur-on-submit">
+        <table class="w-full border-collapse text-sm">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-2 text-left font-semibold text-gray-700">Event</th>
+              <th class="px-4 py-2 text-left font-semibold text-gray-700">Changes</th>
+              <th class="px-4 py-2 text-left font-semibold text-gray-700">Time</th>
+              <th class="px-4 py-2 text-left font-semibold text-gray-700">By</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <% account_events.each do |event| %>
+              <tr class="hover:bg-gray-50">
+                <td class="px-4 py-2 text-gray-900">
+                  <% if event.name.start_with?("auth.") %>
+                    <%= event.name.sub(/\Aauth\./, "").titleize %>
+                  <% else %>
+                    <%= event.name.split(".").first.titleize %>
+                  <% end %>
+                </td>
+                <td class="px-4 py-2 text-gray-500 text-xs">
+                  <% changes = event.properties["changes"] %>
+                  <% assoc_changes = event.properties["association_changes"] %>
+                  <% if changes.present? %>
+                    <% changes.each do |attr, vals| %>
+                      <div><span class="font-medium"><%= attr.titleize %></span>: <%= vals["after"] %></div>
+                    <% end %>
+                  <% end %>
+                  <% if assoc_changes.present? %>
+                    <% assoc_changes.each do |assoc_name, records| %>
+                      <% Array(records).each do |record| %>
+                        <div><span class="font-medium"><%= assoc_name.to_s.titleize %></span>: <%= record["action"] %></div>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td class="px-4 py-2 text-gray-500"><%= l(event.time, format: :long) %></td>
+                <td class="px-4 py-2 text-gray-500"><%= event.user&.name.presence || "—" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <div class="mt-4 flex justify-center">
+        <%= tailwind_paginate account_events, params: { section: "account_activity", search: params[:search], by_user_id: params[:by_user_id] } %>
+      </div>
+    <% else %>
+      <p class="text-gray-500 italic text-sm">
+        <%= (params[:search].present? || params[:by_user_id].present?) ? "No matching events found." : "No account activity recorded." %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -180,54 +180,10 @@
       </div>
 
       <!-- Account activity -->
-      <% if @account_events.any? %>
-        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-          <h4 class="text-sm font-semibold uppercase text-gray-700 mb-3">Account activity</h4>
-          <table class="w-full border-collapse text-sm">
-            <thead class="bg-gray-50">
-              <tr>
-                <th class="px-4 py-2 text-left font-semibold text-gray-700">Event</th>
-                <th class="px-4 py-2 text-left font-semibold text-gray-700">Changes</th>
-                <th class="px-4 py-2 text-left font-semibold text-gray-700">Time</th>
-                <th class="px-4 py-2 text-left font-semibold text-gray-700">By</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100">
-              <% @account_events.each do |event| %>
-                <tr class="hover:bg-gray-50">
-                  <td class="px-4 py-2 text-gray-900">
-                    <% if event.name.start_with?("auth.") %>
-                      <%= event.name.sub(/\Aauth\./, "").titleize %>
-                    <% else %>
-                      <%= event.name.split(".").first.titleize %>
-                    <% end %>
-                  </td>
-                  <td class="px-4 py-2 text-gray-500 text-xs">
-                    <% changes = event.properties["changes"] %>
-                    <% assoc_changes = event.properties["association_changes"] %>
-                    <% if changes.present? %>
-                      <% changes.each do |attr, vals| %>
-                        <div><span class="font-medium"><%= attr.titleize %></span>: <%= vals["after"] %></div>
-                      <% end %>
-                    <% end %>
-                    <% if assoc_changes.present? %>
-                      <% assoc_changes.each do |assoc_name, records| %>
-                        <% Array(records).each do |record| %>
-                          <div><span class="font-medium"><%= assoc_name.to_s.titleize %></span>: <%= record["action"] %></div>
-                        <% end %>
-                      <% end %>
-                    <% end %>
-                  </td>
-                  <td class="px-4 py-2 text-gray-500"><%= l(event.time, format: :long) %></td>
-                  <td class="px-4 py-2 text-gray-500"><%= event.user&.name.presence || "—" %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-          <div class="mt-4 flex justify-center">
-            <%= tailwind_paginate @account_events %>
-          </div>
-        </div>
+      <%= turbo_frame_tag "account_activity_section",
+                          src: user_path(@user, section: "account_activity"),
+                          loading: :lazy do %>
+        <p class="text-gray-500 italic text-sm p-6">Loading account activity...</p>
       <% end %>
 
       <!-- Comments Section -->


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Account activity on the user show page was a static paginated table requiring full page reloads
- Adds real-time search and filtering without leaving the page
- Makes it easy to find specific events in a user's activity history

### How did you approach the change?

- Extracted account activity table into a lazy-loading Turbo Frame partial (`users/sections/_account_activity`)
- Added text search that filters by event name and properties (JSON content)
- Added a "By" dropdown to filter events by the user who performed them (admins + the account owner)
- Reused existing `collection` Stimulus controller for debounced auto-submit and blur-on-submit loading feedback
- Extracted `user_auth_events_base` private method to DRY up the Ahoy event query used by both the turbo frame branch and the status/audit queries
- Added "See all user activity" link to the admin activities page filtered by user

### Anything else to add?

- No new JavaScript — the existing `collection_controller.js` handles text input debounce, select change auto-submit, clear-and-submit, and blur-on-submit
- Pagination preserves search and filter params

🤖 Generated with [Claude Code](https://claude.com/claude-code)