### PR TITLE
Fix personal bookmarks page width

### DIFF
--- a/app/views/bookmarks/personal.html.erb
+++ b/app/views/bookmarks/personal.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 py-8">
-  <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="max-w-6xl mx-auto px-4 py-8">
+  <div class="max-w-6xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
     <h1 class="text-2xl font-semibold text-gray-900 mb-4">
       <%= @viewing_self ? "My" : "#{@user_name}'s" %> Bookmarks (<%= @bookmarks_count %>)
     </h1>


### PR DESCRIPTION
## Summary
- Updated personal bookmarks page max-width from `max-w-5xl` (896px) to `max-w-6xl` (1024px) to match the community news section width

## Test plan
- [x] Visit My Bookmarks page and verify it matches the width of the Community News section on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)