### PR TITLE
Show event times and public registration on cards for visitors

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -45,19 +45,17 @@
   </div>
 
   <!-- END title row -->
-  <%# disabled until we add visitor registration %>
-  <% if current_user %>
-    <% registered = event.actively_registered?(current_user.person) %>
-    <!-- 2️⃣ TIMES + BUTTONS IN ONE ROW -->
-    <div class="times-and-buttons flex flex-wrap items-center justify-between w-full gap-4">
-      <!-- LEFT: Times -->
-      <div class="text-sm text-gray-700 leading-tight whitespace-pre-line">
-        <%= event.times(display_day: true, display_date: true).html_safe %>
-      </div>
+  <!-- 2️⃣ TIMES + BUTTONS IN ONE ROW -->
+  <div class="times-and-buttons flex flex-wrap items-center justify-between w-full gap-4">
+    <!-- LEFT: Times -->
+    <div class="text-sm text-gray-700 leading-tight whitespace-pre-line">
+      <%= event.times(display_day: true, display_date: true).html_safe %>
+    </div>
 
-      <!-- RIGHT: Buttons + Registered -->
-
-      <div class="flex items-center gap-3">
+    <!-- RIGHT: Buttons + Registered -->
+    <div class="flex items-center gap-3">
+      <% if current_user %>
+        <% registered = event.actively_registered?(current_user.person) %>
         <% if allowed_to?(:edit?, event) %>
           <%= link_to "Edit",
                     edit_event_path(event),
@@ -66,11 +64,9 @@
         <% end %>
 
         <% if registered %>
-          <%= button_to "De-register",
-                      event_registrant_registration_path(event_id: event),
-                      method: :delete,
-                      data: { turbo_confirm: "Are you sure?" },
-                      class: "btn btn-secondary-outline" %>
+          <% registration = event.active_registration_for(current_user.person) %>
+          <%= link_to "View your registration", registration_ticket_path(registration.slug),
+                      class: "text-sm text-green-700 hover:text-green-900 underline" %>
         <% elsif event.ended? %>
           <span class="text-sm text-gray-500 italic">Event ended</span>
           <% if allowed_to?(:manage?, event) %>
@@ -88,11 +84,16 @@
           <span class="text-sm text-gray-500 italic">Registration closed</span>
         <% end %>
 
-        <% if registered %>
-          <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full"> Registered </span>
-        <% end %>
-      </div>
+      <% elsif event.registerable? && event.object.forms.exists?(name: "Public Registration") %>
+        <%= link_to "Register",
+                    new_event_public_registration_path(event),
+                    data: { turbo_frame: "_top" },
+                    class: "btn btn-primary-outline" %>
+      <% end %>
     </div>
+  </div>
+  <% if current_user %>
+    <% registered ||= event.actively_registered?(current_user.person) %>
     <!-- 4️⃣ FULL-WIDTH CALENDAR LINKS ROW -->
     <% if registered %>
       <div class="flex flex-col items-center mt-4 pt-3 border-t border-gray-100">


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Event cards previously hid date/time and registration buttons from public (non-logged-in) visitors
- Public visitors couldn't see when events were happening or register for publicly registerable events from the card view

### How did you approach the change?

- Moved event times display outside the `current_user` conditional so all visitors can see event dates
- Added a "Register" link for public visitors when the event is registerable and has a "Public Registration" form, linking to the public registration page
- Replaced the "De-register" button with a "View your registration" link for registered users, matching the pattern on the event show page
- Added `turbo_frame: "_top"` to the public Register link to prevent turbo frame mismatch errors when cards are rendered inside a turbo frame (e.g., home page)

### UI Testing Checklist

- [ ] Public visitor sees event date/time on event cards
- [ ] Public visitor sees "Register" button on events with public registration enabled
- [ ] Clicking "Register" as public visitor navigates to the public registration form
- [ ] Logged-in registered user sees "View your registration" link instead of "De-register"
- [ ] Logged-in unregistered user still sees "Register" button
- [ ] Admin "Edit" button still appears for authorized users
- [ ] Calendar links still appear for registered logged-in users

### Anything else to add?

- The public Register link uses `link_to` (GET) to the public registration form, consistent with `_registration_section.html.erb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)