### PR TITLE
Fix email protected on users index

### DIFF
--- a/app/views/users/users_results.html.erb
+++ b/app/views/users/users_results.html.erb
@@ -19,7 +19,7 @@
         <% @users.each do |user| %>
           <tr class="hover:bg-gray-50 transition-colors duration-150">
             <!-- Email -->
-            <td class="px-4 py-2 text-gray-800 font-semibold break-words"><%= user.email %></td>
+            <td class="px-4 py-2 text-gray-800 font-semibold break-words"><!--email_off--><%= user.email %><!--email_on--></td>
 
             <!-- Person -->
             <td class="px-4 py-2 text-left">


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Email addresses on the users admin index show as `[email protected]` in production due to email obfuscation
- This matches the fix already applied on the people index

### How did you approach the change?

- Wrapped `user.email` with `<!--email_off-->` / `<!--email_on-->` HTML comments in `users_results.html.erb`
- This is the same pattern used in the `person_profile_button` helper (`app/helpers/person_helper.rb`)

### Anything else to add?

- One-line change, no risk of regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)