### PR TITLE
Remove display limits on featured home index items

### DIFF
--- a/app/views/home/community_news/index.html.erb
+++ b/app/views/home/community_news/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "home_community_news" do %>
   <% if @community_news&.any? %>
     <div class="space-y-4">
-      <% @community_news.first(3).each do |news| %>
+      <% @community_news.each do |news| %>
         <%= render "community_news/community_news_card", news: news %>
       <% end %>
     </div>

--- a/app/views/home/events/index.html.erb
+++ b/app/views/home/events/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "home_events" do %>
   <% if @events&.any? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-      <% @events.first(4).each do |event| %>
+      <% @events.each do |event| %>
         <%= render "events/card", event: event %>
       <% end %>
     </div>

--- a/app/views/home/stories/index.html.erb
+++ b/app/views/home/stories/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "home_stories" do %>
   <% if @stories&.any? %>
     <div class="space-y-4">
-      <% @stories.first(3).each do |story| %>
+      <% @stories.each do |story| %>
         <%= render "stories/story_card", story: story %>
       <% end %>
     </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins can now feature as many items as they want on the home page without hitting a display cap
- Previously, community news (3), events (4), and stories (3) had hardcoded `.first(N)` limits that silently hid featured items

### How did you approach the change?
- Removed `.first(3)` from community news view
- Removed `.first(4)` from events view
- Removed `.first(3)` from stories view
- The `HomePolicy` scope already correctly filters by `featured` (logged in) or `publicly_featured` (visitors), so no controller or policy changes needed

### UI Testing Checklist
- [ ] Verify home page displays all featured community news when logged in
- [ ] Verify home page displays all featured events when logged in
- [ ] Verify home page displays all featured stories when logged in
- [ ] Verify home page displays only publicly featured items when logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)