### PR TITLE
Send cancellation emails when event registration is cancelled

### DIFF
--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -12,7 +12,9 @@ class NotificationMailerJob < ApplicationJob
       "workshop_log_submitted_fyi" => ->(n) { NotificationMailer.workshop_log_submitted_fyi(n) },
       "reset_password_fyi"   => ->(n) { NotificationMailer.reset_password_fyi(n) },
       "event_registration_confirmation" => ->(n) { EventMailer.event_registration_confirmation(n.noticeable) },
-      "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) }
+      "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
+      "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
+      "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) }
     }
 
     mailer = mailer_map[notification.kind]&.call(notification)

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -18,4 +18,23 @@ class EventMailer < ApplicationMailer
       subject: "AWBW Portal: Event registration confirmed for #{@event.title}"
     )
   end
+
+  def event_registration_cancelled(event_registration)
+    @event_registration = event_registration
+    @event = event_registration.event.decorate
+    @person = event_registration.registrant
+
+    @notification_type = "Event registration cancellation"
+
+    @time_zone = @person.user&.time_zone || Time.zone.name
+    @event_url = event_url(@event, reg: @event_registration.slug)
+    @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+
+    mail(
+      to: @person.preferred_email,
+      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      subject: "AWBW Portal: Event registration cancelled for #{@event.title}"
+    )
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -16,6 +16,16 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
+  def event_registration_cancelled_fyi(notification)
+    @event_registration = notification.noticeable
+    @event = @event_registration.event.decorate
+    @person = @event_registration.registrant
+    @notification_type = "Event registration cancellation"
+
+    mail(
+      subject: "#{FYI_PREFIX} Event registration cancelled by #{@person.full_name} for #{@event.title}"
+    )
+  end
 
   def idea_submitted(notification)
     @notification = notification

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -10,6 +10,7 @@ class EventRegistration < ApplicationRecord
   accepts_nested_attributes_for :comments, reject_if: proc { |attrs| attrs["body"].blank? }
 
   before_create :generate_slug
+  after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance ].freeze
   INACTIVE_STATUSES = %w[ cancelled no_show ].freeze
@@ -145,5 +146,30 @@ class EventRegistration < ApplicationRecord
       self.slug = SecureRandom.urlsafe_base64(16)
       break unless EventRegistration.exists?(slug: slug)
     end
+  end
+
+  def status_changed_to_cancelled?
+    saved_change_to_status? && status == "cancelled"
+  end
+
+  def send_cancellation_emails
+    email = registrant&.preferred_email
+    return if email.blank?
+
+    NotificationServices::CreateNotification.call(
+      noticeable: self,
+      kind: "event_registration_cancelled",
+      recipient_role: :person,
+      recipient_email: email,
+      notification_type: 1
+    )
+
+    NotificationServices::CreateNotification.call(
+      noticeable: self,
+      kind: "event_registration_cancelled_fyi",
+      recipient_role: :admin,
+      recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      notification_type: 1
+    )
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,6 +21,8 @@ class Notification < ApplicationRecord
 
     event_registration_confirmation
     event_registration_confirmation_fyi
+    event_registration_cancelled
+    event_registration_cancelled_fyi
     idea_submitted
     idea_submitted_fyi
     report_submitted

--- a/app/views/event_mailer/event_registration_cancelled.html.erb
+++ b/app/views/event_mailer/event_registration_cancelled.html.erb
@@ -1,0 +1,41 @@
+<h1>Event registration cancelled</h1>
+
+<div style="margin-top: 36px; text-align: left;">
+  <p>
+    Hello <strong><%= @person.full_name %></strong>,
+  </p>
+
+  <p>
+    Your registration for the following <%= @organization_name %> event has been cancelled:
+  </p>
+
+  <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+    <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+      <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+        <%= @event.pre_title %>
+      </p>
+    <% end %>
+
+    <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+      <%= @event.title %>
+    </h2>
+
+    <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
+    </p>
+
+    <% if @event.location.present? %>
+      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+        <%= @event.location.name %>
+      </p>
+    <% end %>
+  </div>
+
+  <p>
+    If you cancelled by mistake, you can re-register on the event page.
+  </p>
+</div>
+
+<p>
+  <a href="<%= @event_url %>" class="button">View event</a>
+</p>

--- a/app/views/event_mailer/event_registration_cancelled.text.erb
+++ b/app/views/event_mailer/event_registration_cancelled.text.erb
@@ -1,0 +1,20 @@
+Event registration cancelled
+
+Hello <%= @person.full_name %>,
+
+Your registration for the following event has been cancelled:
+
+<% if @event.respond_to?(:pre_title) && @event.pre_title.present? %><%= @event.pre_title %>
+<% end %><%= @event.title %>
+<% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
+
+<% if @event.location.present? %>
+Location: <%= @event.location.name %>
+<% end %>
+
+If you cancelled by mistake, you can re-register on the event page:
+<%= @event_url %>
+
+--
+This is an automated message from <%= @organization_name %>.
+If you did not expect this message, you may ignore it.

--- a/app/views/notification_mailer/event_registration_cancelled_fyi.html.erb
+++ b/app/views/notification_mailer/event_registration_cancelled_fyi.html.erb
@@ -1,0 +1,55 @@
+<% profile_url = person_url(@person) %>
+
+<p style="margin-bottom: 6px;">
+  Event Registration Cancelled
+</p>
+
+<h1 style="margin: 0;">
+  <strong><%= @person.full_name %></strong>
+  (<%= @person.preferred_email %>)
+</h1>
+
+<p style="margin: 4px 0 16px; font-size: 13px; color: #6b7280;">
+  Cancelled on
+  <%= Time.current
+                   .in_time_zone("Pacific Time (US & Canada)")
+                   .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
+</p>
+
+<div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+  <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+    <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+      <%= @event.pre_title %>
+    </p>
+  <% end %>
+
+  <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+    <%= @event.title %>
+  </h2>
+
+  <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+    <%= @event.times(display_day: true, display_date: true) %>
+  </p>
+
+  <% if @event.location.present? %>
+    <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+      <%= @event.location.name %>
+    </p>
+  <% end %>
+</div>
+
+<p>
+  <a href="<%= profile_url %>"
+     style="display:inline-block;background:#e5e7eb;color:#111827;
+       text-decoration:none;padding:10px 16px;border-radius:6px;
+       font-weight:bold;">
+    View profile
+  </a>
+
+  <a href="<%= event_url(@event) %>"
+     style="display:inline-block;background:#e5e7eb;color:#111827;
+       text-decoration:none;padding:10px 16px;border-radius:6px;
+       font-weight:bold;">
+    View event
+  </a>
+</p>

--- a/app/views/notification_mailer/event_registration_cancelled_fyi.text.erb
+++ b/app/views/notification_mailer/event_registration_cancelled_fyi.text.erb
@@ -1,0 +1,32 @@
+<% profile_url = person_url(@person) %>
+
+Event Registration Cancelled
+==========================
+
+<%= @person.full_name %> (<%= @person.preferred_email %>)
+
+Cancelled on
+<%= Time.current
+                 .in_time_zone("Pacific Time (US & Canada)")
+                 .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
+
+------------------------------------------------------------
+
+Event
+<%= @event.title %>
+
+Event date
+<%= @event.times(display_day: true, display_date: true) %>
+
+<% if @event.location.present? %>
+  Location
+  <%= @event.location.name %>
+<% end %>
+
+------------------------------------------------------------
+
+View profile:
+<%= profile_url %>
+
+View event:
+<%= event_url(@event) %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -228,6 +228,37 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "cancellation emails" do
+    it "sends cancellation emails when status changes to cancelled" do
+      reg = create(:event_registration, status: "registered")
+
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: "event_registration_cancelled", recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: "event_registration_cancelled_fyi", recipient_role: :admin)
+      )
+
+      reg.update!(status: "cancelled")
+    end
+
+    it "does not send emails when status changes to something other than cancelled" do
+      reg = create(:event_registration, status: "registered")
+
+      expect(NotificationServices::CreateNotification).not_to receive(:call)
+
+      reg.update!(status: "attended")
+    end
+
+    it "does not send emails when a non-status attribute changes" do
+      reg = create(:event_registration, status: "cancelled")
+
+      expect(NotificationServices::CreateNotification).not_to receive(:call)
+
+      reg.update!(scholarship_recipient: true)
+    end
+  end
+
   describe "slug" do
     it "generates a slug on create" do
       registration = create(:event_registration)

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -4,6 +4,12 @@ class EventMailerPreview < ActionMailer::Preview
     EventMailer.event_registration_confirmation(event_registration)
   end
 
+  def event_registration_cancelled
+    event_registration = sample_event_registration
+    event_registration.status = "cancelled"
+    EventMailer.event_registration_cancelled(event_registration)
+  end
+
   private
 
   def sample_event_registration

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -19,6 +19,26 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.event_registration_confirmation_fyi(notification)
   end
 
+  def event_registration_cancelled_fyi
+    event_registration =
+      EventRegistration.first ||
+        EventRegistration.create!(
+          event: Event.first || raise("Need an Event"),
+          registrant: User.first || raise("Need a User")
+        )
+
+    notification = find_valid_notification("event_registration_cancelled_fyi") ||
+      Notification.create!(
+        noticeable: event_registration,
+        notification_type: 1,
+        kind: "event_registration_cancelled_fyi",
+        recipient_role: "admin",
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+      )
+
+    NotificationMailer.event_registration_cancelled_fyi(notification)
+  end
+
   def idea_submitted
     noticeable = StoryIdea.first || WorkshopVariationIdea.first
     user = noticeable&.created_by || User.first


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- When a registration is cancelled, neither the registrant nor the admin receives any notification
- This adds automatic emails to both parties so the registrant has confirmation and the admin has visibility into cancellations

### How did you approach the change?

- Added an `after_commit` callback on `EventRegistration` that fires when `status` changes to `"cancelled"`
- Sends two emails through the existing `NotificationServices::CreateNotification` pipeline:
  - **Registrant email** (`EventMailer#event_registration_cancelled`) — confirms cancellation with event details and a link back to re-register
  - **Admin FYI email** (`NotificationMailer#event_registration_cancelled_fyi`) — notifies admin who cancelled and for which event
- Covers both cancellation paths: user self-cancel and admin status update
- Added `event_registration_cancelled` and `event_registration_cancelled_fyi` notification kinds
- Added mailer previews for both emails
- Added model specs for the callback behavior

### UI Testing Checklist

- [ ] Cancel a registration as a user and verify both emails are sent
- [ ] Change a registration status to cancelled via admin form and verify both emails are sent
- [ ] Verify cancellation email includes event details and re-register link
- [ ] Verify admin FYI email includes registrant info and event details
- [ ] Preview emails at `/rails/mailers/event_mailer/event_registration_cancelled` and `/rails/mailers/notification_mailer/event_registration_cancelled_fyi`

### Anything else to add?

- Email templates follow the same styling patterns as the existing registration confirmation emails
- The `after_commit` approach ensures emails are only sent after the transaction commits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)