### PR TITLE
Check all event forms for registration icon

### DIFF
--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -42,16 +42,18 @@
                 </tr>
                 </thead>
 
+                <% all_event_form_ids = @event_registrations.flat_map { |er| er.event.event_forms.map(&:form_id) }.uniq %>
+                <% submitted_pairs = all_event_form_ids.any? ? PersonForm.where(form_id: all_event_form_ids, person_id: @event_registrations.map(&:registrant_id).uniq).pluck(:person_id, :form_id).to_set : Set.new %>
                 <tbody class="divide-y divide-gray-200">
                   <% @event_registrations.each do |event_registration| %>
                     <tr id="<%= dom_id(event_registration) %>" class="hover:bg-gray-50 transition-colors duration-150">
                       <td class="px-4 py-2 text-sm text-gray-800 align-top">
                         <div class="flex items-center gap-2">
                           <%= person_profile_button(event_registration.registrant) %>
-                          <% reg_form = event_registration.event.registration_form %>
-                          <% if reg_form && reg_form.person_forms.exists?(person: event_registration.registrant) %>
+                          <% er_form_ids = event_registration.event.event_forms.map(&:form_id) %>
+                          <% if er_form_ids.any? && er_form_ids.any? { |fid| submitted_pairs.include?([ event_registration.registrant_id, fid ]) } %>
                             <i class="fa-solid fa-file-lines text-green-600 shrink-0" title="Completed registration form"></i>
-                          <% elsif reg_form %>
+                          <% elsif er_form_ids.any? %>
                             <i class="fa-regular fa-file-lines text-gray-300 shrink-0" title="No registration form submitted"></i>
                           <% end %>
                         </div>

--- a/app/views/events/_manage_results.html.erb
+++ b/app/views/events/_manage_results.html.erb
@@ -3,8 +3,8 @@
     <p class="text-sm text-gray-500 px-6 py-4 border-b border-gray-100">
       <%= @event_registrations.size %> registrant<%= "s" if @event_registrations.size != 1 %>
     </p>
-    <% reg_form = @event.registration_form %>
-    <% form_submissions = reg_form ? reg_form.person_forms.where(person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at).to_h : {} %>
+    <% event_form_ids = @event.form_ids %>
+    <% form_submissions = event_form_ids.any? ? PersonForm.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
     <% if @event_registrations.any? %>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse border border-gray-200">
@@ -28,17 +28,18 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
                   <div class="flex items-center gap-1">
                     <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
-                    <% if reg_form && form_submissions.key?(person.id) %>
-                      <% submitted_at = form_submissions[person.id] %>
+                    <% if event_form_ids.any? && (submissions = form_submissions[person.id]) %>
                       <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
+                      <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
+                      <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
                       <%= link_to event_public_registration_path(@event, **form_show_params),
                                   class: "text-green-600 hover:text-green-800",
-                                  title: "#{reg_form.name} — Submitted #{submitted_at.strftime('%B %d, %Y at %l:%M %P')}#{' — Scholarship requested' if registration.scholarship_requested?}",
+                                  title: tooltip_parts.join("\n"),
                                   target: "_blank",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fa-solid fa-file-lines"></i>
                       <% end %>
-                    <% elsif reg_form %>
+                    <% elsif event_form_ids.any? %>
                       <i class="fa-regular fa-file-lines text-gray-300" title="No registration form submitted"></i>
                     <% end %>
                     <% if registration.comments.any? %>

--- a/spec/factories/person_forms.rb
+++ b/spec/factories/person_forms.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :person_form do
+    association :person
+    association :form
+  end
+end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -49,6 +49,46 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(data_rows).to include(expected_row)
       end
 
+      context "registration form icon" do
+        let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
+        let(:person) { existing_registration.registrant }
+
+        it "shows green icon when person submitted the current registration form" do
+          create(:event_form, event: event, form: reg_form, role: "registration")
+          create(:person_form, person: person, form: reg_form)
+
+          get event_registrations_path
+
+          expect(response.body).to include("fa-solid fa-file-lines")
+        end
+
+        it "shows gray icon when person has not submitted any form" do
+          create(:event_form, event: event, form: reg_form, role: "registration")
+
+          get event_registrations_path
+
+          expect(response.body).to include("fa-regular fa-file-lines")
+        end
+
+        it "shows green icon when person submitted a non-registration form for the event" do
+          scholarship_form = create(:form, :standalone, name: "Scholarship Form")
+          create(:event_form, event: event, form: reg_form, role: "registration")
+          create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+          create(:person_form, person: person, form: scholarship_form)
+
+          get event_registrations_path
+
+          expect(response.body).to include("fa-solid fa-file-lines")
+          expect(response.body).not_to include("fa-regular fa-file-lines")
+        end
+
+        it "does not show any form icon when event has no forms" do
+          get event_registrations_path
+
+          expect(response.body).not_to include("fa-file-lines")
+        end
+      end
+
       it "paginates results" do
         additional = create_list(:event_registration, 3)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -242,4 +242,54 @@ RSpec.describe "Events", type: :request do
       end
     end
   end
+
+  describe "GET /events/:id/manage" do
+    let(:person) { create(:person) }
+    let!(:registration) { create(:event_registration, event: event, registrant: person) }
+
+    before { sign_in admin }
+
+    context "registration form icon" do
+      let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
+
+      it "shows green icon when person submitted the current registration form" do
+        create(:event_form, event: event, form: reg_form, role: "registration")
+        create(:person_form, person: person, form: reg_form)
+
+        get manage_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('fa-solid fa-file-lines')
+      end
+
+      it "shows gray icon when person has not submitted any form" do
+        create(:event_form, event: event, form: reg_form, role: "registration")
+
+        get manage_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('fa-regular fa-file-lines')
+      end
+
+      it "shows green icon when person submitted a non-registration form for the event" do
+        scholarship_form = create(:form, :standalone, name: "Scholarship Form")
+        create(:event_form, event: event, form: reg_form, role: "registration")
+        create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+        create(:person_form, person: person, form: scholarship_form)
+
+        get manage_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('fa-solid fa-file-lines')
+        expect(response.body).not_to include('fa-regular fa-file-lines')
+      end
+
+      it "does not show any form icon when event has no forms" do
+        get manage_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('fa-file-lines')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The form submission icon on manage registrations and event registrations index pages only checked the form currently tagged as "registration" role
- If an event's registration form was swapped, people who submitted the old form lost their green icon
- This ensures the icon reflects any form submission for the event, not just the currently selected registration form

### How did you approach the change?

- **`_manage_results.html.erb`**: Changed from querying `@event.registration_form` (single form) to `@event.form_ids` (all forms linked to the event). Joins `forms` table to include form names in the tooltip for each submission
- **`event_registrations/index.html.erb`**: Batch-loads all form submissions upfront as a `Set` of `[person_id, form_id]` pairs, then checks against all event forms per row. Also fixes N+1 queries (previously called `.exists?` per row)
- Added `PersonForm` factory and 8 request spec tests (4 per page) covering: submitted current form, submitted non-registration form, no submission, and no forms linked

### UI Testing Checklist

- [x] Visit manage registrations page for an event with a registration form — green icon shows for people who submitted it
- [x] Visit manage registrations page for an event where a person submitted a scholarship form but not the registration form — green icon still shows
- [x] Visit event registrations index — same behavior as above
- [x] Tooltip on green icon shows form name(s) and submission timestamp(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)