### PR TITLE
Rescue RecordNotUnique in controllers with ActionText fields

### DIFF
--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -71,7 +71,7 @@ class CommunityNewsController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Community news create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -95,7 +95,7 @@ class CommunityNewsController < ApplicationController
         assign_associations(@community_news)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Community news update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -75,7 +75,7 @@ class EventsController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Event create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -105,7 +105,7 @@ class EventsController < ApplicationController
       else
         raise ActiveRecord::Rollback
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Event update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -73,7 +73,7 @@ class ResourcesController < ApplicationController
         assign_associations(@resource)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Resource create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -99,7 +99,7 @@ class ResourcesController < ApplicationController
         assign_associations(@resource)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Resource update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -75,7 +75,7 @@ class StoriesController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Story create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -101,7 +101,7 @@ class StoriesController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Story update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -59,7 +59,7 @@ class StoryIdeasController < ApplicationController
           notification_type: 0)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "StoryIdea create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -88,7 +88,7 @@ class StoryIdeasController < ApplicationController
         assign_associations(@story_idea)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "StoryIdea update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -51,7 +51,7 @@ class TutorialsController < ApplicationController
         assign_associations(@tutorial)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Tutorial create failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end
@@ -75,7 +75,7 @@ class TutorialsController < ApplicationController
         assign_associations(@tutorial)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       Rails.logger.error "Tutorial update failed: #{e.class} - #{e.message}"
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -43,6 +43,11 @@ class WorkshopIdeasController < ApplicationController
       set_form_variables
       render :new, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    Rails.logger.error "WorkshopIdea create failed: #{e.class} - #{e.message}"
+    @workshop_idea.errors.add(:base, "could not be saved due to a conflict. Please try again.")
+    set_form_variables
+    render :new, status: :unprocessable_content
   end
 
   def edit
@@ -59,6 +64,11 @@ class WorkshopIdeasController < ApplicationController
       set_form_variables
       render :edit, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    Rails.logger.error "WorkshopIdea update failed: #{e.class} - #{e.message}"
+    @workshop_idea.errors.add(:base, "could not be saved due to a conflict. Please try again.")
+    set_form_variables
+    render :edit, status: :unprocessable_content
   end
 
   def destroy

--- a/app/controllers/workshop_variation_ideas_controller.rb
+++ b/app/controllers/workshop_variation_ideas_controller.rb
@@ -70,6 +70,11 @@ class WorkshopVariationIdeasController < ApplicationController
       set_form_variables
       render :new, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    Rails.logger.error "WorkshopVariationIdea create failed: #{e.class} - #{e.message}"
+    @workshop_variation_idea.errors.add(:base, "could not be saved due to a conflict. Please try again.")
+    set_form_variables
+    render :new, status: :unprocessable_content
   end
 
   def update
@@ -80,6 +85,11 @@ class WorkshopVariationIdeasController < ApplicationController
       set_form_variables
       render :edit, status: :unprocessable_content
     end
+  rescue ActiveRecord::RecordNotUnique => e
+    Rails.logger.error "WorkshopVariationIdea update failed: #{e.class} - #{e.message}"
+    @workshop_variation_idea.errors.add(:base, "could not be saved due to a conflict. Please try again.")
+    set_form_variables
+    render :edit, status: :unprocessable_content
   end
 
   def destroy

--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -35,7 +35,7 @@ class WorkshopVariationsController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       log_workshop_error("creation", e)
       raise ActiveRecord::Rollback
     end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -100,7 +100,7 @@ class WorkshopsController < ApplicationController
         end
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       log_workshop_error("creation", e)
       raise ActiveRecord::Rollback
     end
@@ -158,7 +158,7 @@ class WorkshopsController < ApplicationController
         assign_associations(@workshop)
         success = true
       end
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
       log_workshop_error("update", e)
       raise ActiveRecord::Rollback
     end

--- a/spec/requests/workshop_ideas_spec.rb
+++ b/spec/requests/workshop_ideas_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe "/workshop_ideas", type: :request do
 
         expect(response).to redirect_to(workshop_idea_path(WorkshopIdea.last))
       end
+
+      it "handles RecordNotUnique gracefully" do
+        allow_any_instance_of(WorkshopIdea).to receive(:save).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        expect {
+          post workshop_ideas_path, params: { workshop_idea: valid_attributes }
+        }.not_to change(WorkshopIdea, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
     end
 
     describe "PATCH /update" do
@@ -89,6 +101,19 @@ RSpec.describe "/workshop_ideas", type: :request do
 
         expect(idea.reload.title).to eq("Updated Title")
         expect(response).to redirect_to(workshop_idea_path(idea))
+      end
+
+      it "handles RecordNotUnique gracefully" do
+        idea = create(:workshop_idea, valid_attributes)
+
+        allow_any_instance_of(WorkshopIdea).to receive(:update).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        patch workshop_idea_path(idea),
+              params: { workshop_idea: { title: "Updated Title" } }
+
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/workshop_variation_ideas_spec.rb
+++ b/spec/requests/workshop_variation_ideas_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe "/workshop_variation_ideas", type: :request do
           expect(response).to have_http_status(:unprocessable_content)
         end
       end
+
+      context "when RecordNotUnique is raised" do
+        it "handles it gracefully" do
+          allow_any_instance_of(WorkshopVariationIdea).to receive(:save).and_raise(
+            ActiveRecord::RecordNotUnique.new("Duplicate entry")
+          )
+
+          expect {
+            post workshop_variation_ideas_path, params: { workshop_variation_idea: valid_attributes }
+          }.not_to change(WorkshopVariationIdea, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
     end
 
     describe "PATCH /update" do
@@ -120,6 +134,19 @@ RSpec.describe "/workshop_variation_ideas", type: :request do
 
         expect(idea.reload.name).to eq("Updated Name")
         expect(response).to redirect_to(workshop_variation_idea_path(idea))
+      end
+
+      it "handles RecordNotUnique gracefully" do
+        idea = create(:workshop_variation_idea, valid_attributes)
+
+        allow_any_instance_of(WorkshopVariationIdea).to receive(:update).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        patch workshop_variation_idea_path(idea),
+              params: { workshop_variation_idea: { name: "Updated Name" } }
+
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/workshops_spec.rb
+++ b/spec/requests/workshops_spec.rb
@@ -100,4 +100,45 @@ RSpec.describe "/workshops", type: :request do
       end
     end
   end
+
+  # --- RECORD NOT UNIQUE HANDLING -----------------------------------------------
+  describe "RecordNotUnique handling" do
+    let(:admin) { create(:user, :admin) }
+
+    before { sign_in admin }
+
+    describe "POST /create" do
+      it "handles RecordNotUnique gracefully" do
+        allow_any_instance_of(Workshop).to receive(:save).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        expect {
+          post workshops_url, params: {
+            workshop: { title: "Test Workshop", category_ids: [ "" ] }
+          }
+        }.not_to change(Workshop, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Unable to save the workshop")
+      end
+    end
+
+    describe "PATCH /update" do
+      it "handles RecordNotUnique gracefully" do
+        workshop = create(:workshop)
+
+        allow_any_instance_of(Workshop).to receive(:update).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        patch workshop_url(workshop), params: {
+          workshop: { title: "Updated Title", category_ids: [ "" ] }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Unable to update the workshop")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Fix a production 500 error (`ActiveRecord::RecordNotUnique`) when updating workshops with rich text fields
- The `action_text_rich_texts` uniqueness index violation was not being rescued, causing the error to propagate as an unhandled crash
- Root cause is a race condition (likely double form submission) where ActionText tries to INSERT a rich text record that already exists

### How did you approach the change?

- Added `ActiveRecord::RecordNotUnique` to the rescue clauses in all 10 controllers that save models with `has_rich_text` fields
- **8 controllers** (workshops, stories, resources, tutorials, community_news, story_ideas, events, workshop_variations) already had transaction + rescue blocks — added `RecordNotUnique` to the existing rescue list
- **2 controllers** (workshop_ideas, workshop_variation_ideas) had bare `save`/`update` calls with no rescue — added method-level `rescue RecordNotUnique` blocks that log the error and re-render the form with a 422 status
- Added request specs for workshops, workshop_ideas, and workshop_variation_ideas to verify graceful handling

### UI Testing Checklist

- [ ] Submit a workshop edit form — should save normally
- [ ] Rapidly double-click a workshop save button — should not produce a 500 error

### Anything else to add?

- The error was only observed on workshop update, but the same vulnerability existed across all ActionText-backed controllers
- The fix is defensive — the first request succeeds and the second gets a user-friendly error instead of a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)