### PR TITLE
Remove age range tags from workshop index and bookmarks

### DIFF
--- a/app/views/bookmarks/_personal_row.html.erb
+++ b/app/views/bookmarks/_personal_row.html.erb
@@ -82,12 +82,6 @@
       <% else %>
         <%= bookmarkable.created_at.strftime("%B %d, %Y") %>
       <% end %>
-      <% if bookmark.bookmarkable_type == "Workshop" && bookmarkable.age_ranges.any? %>
-        <br>Age ranges: <%= bookmarkable.age_ranges
-                                        .sort_by { |c| [c.position.to_i, c.name.to_s.downcase] }
-                                        .map(&:name)
-                                        .to_sentence %>
-      <% end %>
     </span>
    </div>
  </div>

--- a/app/views/workshops/_index_row.html.erb
+++ b/app/views/workshops/_index_row.html.erb
@@ -76,15 +76,6 @@
 <!--          Led: <%##= workshop.led_count %> <%#= "time".pluralize(workshop.led_count.to_i) %>-->
         <%# end %>
 
-        <!-- Age ranges -->
-        <% if workshop.age_ranges.any? %>
-          <div class="text-sm text-gray-600 leading-tight">
-            Age ranges: <%= workshop.age_ranges
-                                    .sort_by { |c| [c.position.to_i, c.name.to_s.downcase] }
-                                    .map(&:name)
-                                    .to_sentence %>
-          </div>
-        <% end %>
 
       </div>
     </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Remove age range category tags from workshop listing and bookmarks views
- These tags are no longer needed in the index row and personal bookmarks row

### How did you approach the change?

- Removed the age range display block from `app/views/workshops/_index_row.html.erb`
- Removed the age range display block from `app/views/bookmarks/_personal_row.html.erb`
- No test changes needed — no existing tests assert on age range tag rendering in these views

### Anything else to add?

- The age range association and model-level code remain intact for use elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)