### PR TITLE
Fix notification error tracking and event re-registration emails

### DIFF
--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -35,5 +35,8 @@ class NotificationMailerJob < ApplicationJob
         mail: mailer
       ) if persist_delivered_email
     end
+  rescue => e
+    notification&.record_error!(e)
+    raise
   end
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -61,9 +61,8 @@ class DeviseMailer < Devise::Mailer
     return unless @mail && @record
 
     kind = notification_kind_for_devise_action[action_name]
-    return unless kind # don't create fyi emails for Devise mailers you don’t care about
+    return unless kind # don’t create fyi emails for Devise mailers you don’t care about
 
-    puts "=====DeviseMailer FYI: #{kind}"
     notification = NotificationServices::CreateNotification.call(
       noticeable: @record,
       recipient_role: :person,
@@ -79,8 +78,10 @@ class DeviseMailer < Devise::Mailer
     )
 
     notify_admin_if_needed(kind)
+  rescue => e
+    Rails.logger.error("DeviseMailer#create_notification_record failed: #{e.message}")
+    notification&.record_error!(e) if notification&.persisted?
   end
-
 
   def notify_admin_if_needed(kind)
     if kind == "reset_password"

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -65,6 +65,18 @@ class Notification < ApplicationRecord
     delivered_at.present?
   end
 
+  def failed?
+    error_at.present? && !delivered?
+  end
+
+  def record_error!(exception)
+    update!(
+      error_message: exception.message.truncate(500),
+      error_class: exception.class.name,
+      error_at: Time.current
+    )
+  end
+
   def resend_count
     # If this notification has a root, use that; otherwise, this IS the root
     root_id = root_notification_id || id

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -30,6 +30,10 @@ module EventRegistrationServices
         existing = @event.event_registrations.find_by(registrant: person)
         if existing
           existing.update!(scholarship_requested: true) if @scholarship_requested
+          if existing.status == "cancelled"
+            existing.update!(status: "registered")
+            send_notifications(existing)
+          end
           update_person_form(person)
           return Result.new(success?: true, event_registration: existing, errors: [])
         end

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -17,8 +17,10 @@
       <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
         <% if notification.delivered_at.present? %>
           <%= time_ago_in_words(notification.delivered_at.in_time_zone("Pacific Time (US & Canada)")) %> ago
+        <% elsif notification.failed? %>
+          <span class="text-red-600 font-medium" title="<%= notification.error_class %>: <%= notification.error_message %>">Failed</span>
         <% else %>
-          <span class="text-red-600 font-medium">Not sent</span>
+          <span class="text-yellow-600 font-medium">Pending</span>
         <% end %>
       </td>
 

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -26,6 +26,11 @@
           <i class="fas fa-check-circle"></i>
           Delivered
         </span>
+      <% elsif @notification.failed? %>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-red-100 text-red-700">
+          <i class="fas fa-exclamation-circle"></i>
+          Failed
+        </span>
       <% else %>
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-yellow-100 text-yellow-700">
           <i class="fas fa-clock"></i>
@@ -88,6 +93,26 @@
               &.strftime("%B %d, %Y %l:%M %p") || "Not sent" %>
         </dd>
       </div>
+
+      <% if @notification.failed? %>
+        <div class="flex items-start gap-4">
+          <dt class="w-28 text-gray-500">Error</dt>
+          <dd class="text-red-700">
+            <span class="font-medium"><%= @notification.error_class %></span>
+            <span class="text-gray-600">—</span>
+            <%= @notification.error_message %>
+          </dd>
+        </div>
+
+        <div class="flex items-start gap-4">
+          <dt class="w-28 text-gray-500">Failed at</dt>
+          <dd class="text-gray-900">
+            <%= @notification.error_at
+                &.in_time_zone("Pacific Time (US & Canada)")
+                &.strftime("%B %d, %Y %l:%M %p") %>
+          </dd>
+        </div>
+      <% end %>
 
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">Noticeable</dt>

--- a/db/migrate/20260302150000_add_error_tracking_to_notifications.rb
+++ b/db/migrate/20260302150000_add_error_tracking_to_notifications.rb
@@ -1,0 +1,7 @@
+class AddErrorTrackingToNotifications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :notifications, :error_message, :text
+    add_column :notifications, :error_class, :string
+    add_column :notifications, :error_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_02_150000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -604,6 +604,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_150000) do
     t.text "email_body_html"
     t.text "email_body_text"
     t.text "email_subject"
+    t.datetime "error_at"
+    t.string "error_class"
+    t.text "error_message"
     t.string "kind", null: false
     t.integer "noticeable_id"
     t.string "noticeable_type"

--- a/spec/jobs/notification_mailer_job_spec.rb
+++ b/spec/jobs/notification_mailer_job_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe NotificationMailerJob, type: :job do
+  describe "#perform" do
+    let(:notification) { create(:notification, kind: "reset_password_fyi") }
+
+    it "delivers the email and persists it" do
+      expect {
+        described_class.new.perform(notification.id)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      notification.reload
+      expect(notification.delivered_at).to be_present
+      expect(notification.email_subject).to be_present
+    end
+
+    it "skips already-delivered notifications" do
+      notification.update!(delivered_at: Time.current)
+
+      expect {
+        described_class.new.perform(notification.id)
+      }.not_to change { ActionMailer::Base.deliveries.count }
+    end
+
+    it "records error on the notification when delivery fails" do
+      allow(NotificationMailer).to receive(:reset_password_fyi)
+        .and_raise(Net::SMTPServerBusy, "450 Too many connections")
+
+      expect {
+        described_class.new.perform(notification.id)
+      }.to raise_error(Net::SMTPServerBusy)
+
+      notification.reload
+      expect(notification.error_class).to eq("Net::SMTPServerBusy")
+      expect(notification.error_message).to include("Too many connections")
+      expect(notification.error_at).to be_present
+      expect(notification.delivered_at).to be_nil
+    end
+
+    it "raises for unknown notification kinds" do
+      notification.update_column(:kind, "reset_password") # valid kind but no mailer mapping
+
+      expect {
+        described_class.new.perform(notification.id)
+      }.to raise_error(/Unknown notification kind/)
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -90,6 +90,49 @@ RSpec.describe Notification do
     end
   end
 
+  describe "#failed?" do
+    it "returns true when error_at is present and not delivered" do
+      notification = create(:notification, error_at: Time.current, delivered_at: nil)
+
+      expect(notification.failed?).to be true
+    end
+
+    it "returns false when delivered even with error_at" do
+      notification = create(:notification, error_at: Time.current, delivered_at: Time.current)
+
+      expect(notification.failed?).to be false
+    end
+
+    it "returns false when no error_at" do
+      notification = create(:notification, error_at: nil, delivered_at: nil)
+
+      expect(notification.failed?).to be false
+    end
+  end
+
+  describe "#record_error!" do
+    it "stores exception details on the notification" do
+      notification = create(:notification)
+      error = StandardError.new("SMTP connection refused")
+
+      notification.record_error!(error)
+      notification.reload
+
+      expect(notification.error_message).to eq("SMTP connection refused")
+      expect(notification.error_class).to eq("StandardError")
+      expect(notification.error_at).to be_present
+    end
+
+    it "truncates long error messages" do
+      notification = create(:notification)
+      error = StandardError.new("x" * 600)
+
+      notification.record_error!(error)
+
+      expect(notification.error_message.length).to be <= 500
+    end
+  end
+
   describe '.search_by_params' do
     let!(:notification_alice) { create(:notification, recipient_email: 'alice@example.com', email_subject: 'Welcome to AWBW') }
     let!(:notification_bob) { create(:notification, recipient_email: 'bob@example.com', email_subject: 'Password Reset') }

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe EventRegistrationServices::PublicRegistration do
+  let(:event) { create(:event, :published, :publicly_visible) }
+  let(:form) { ExtendedEventRegistrationFormBuilder.build!(event) }
+
+  def field_id(key)
+    form.form_fields.find_by!(field_key: key).id.to_s
+  end
+
+  def base_form_params(first_name:, last_name:, email:)
+    {
+      field_id("first_name") => first_name,
+      field_id("last_name") => last_name,
+      field_id("primary_email") => email,
+      field_id("primary_email_type") => "personal"
+    }
+  end
+
+  describe "re-registration after cancellation" do
+    let(:person) { create(:person, first_name: "Jane", last_name: "Doe", email: "jane@example.com") }
+    let!(:cancelled_registration) do
+      create(:event_registration, event: event, registrant: person, status: "cancelled")
+    end
+
+    it "reactivates a cancelled registration" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Jane", last_name: "Doe", email: "jane@example.com")
+      )
+
+      expect(result.success?).to be true
+      expect(result.event_registration).to eq(cancelled_registration)
+      expect(cancelled_registration.reload.status).to eq("registered")
+    end
+
+    it "sends confirmation and FYI notifications on re-registration" do
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation, recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation_fyi, recipient_role: :admin)
+      )
+
+      described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Jane", last_name: "Doe", email: "jane@example.com")
+      )
+    end
+
+    it "does not send notifications for an already-active registration" do
+      cancelled_registration.update!(status: "registered")
+
+      expect(NotificationServices::CreateNotification).not_to receive(:call)
+
+      described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Jane", last_name: "Doe", email: "jane@example.com")
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Users reported that registration emails were not always going out, and the notification log showed "Not sent" with no explanation of why
- When a user cancelled their event registration and re-registered, no confirmation or FYI emails were sent

### How did you approach the change?

- Added `error_message`, `error_class`, `error_at` columns to notifications so failed deliveries capture what went wrong
- Added `rescue` in `DeviseMailer#create_notification_record` so after-action errors (from `create!`/`update!`) don't block Devise from delivering the actual email — this was the root cause of some "Not sent" entries
- `NotificationMailerJob` now records errors on the notification before re-raising for SolidQueue retry
- Updated notification index and show views to distinguish Failed (red) vs Pending (yellow) states, with error details on hover and in the detail view
- Fixed `PublicRegistration` service to reactivate cancelled event registrations and send both confirmation + FYI emails on re-registration

### UI Testing Checklist

- [ ] Trigger a notification email and verify it shows as "Delivered" in the notifications list
- [ ] Cancel an event registration, re-register the same person, and verify both confirmation and FYI emails are sent
- [ ] Simulate a failed email (see PR description) and verify the notification shows "Failed" with error details

### Anything else to add?

To test a failed email in dev, temporarily point ActionMailer at a bad SMTP server in the Rails console:
```ruby
ActionMailer::Base.delivery_method = :smtp
ActionMailer::Base.smtp_settings = { address: "localhost", port: 19999 }
ActionMailer::Base.raise_delivery_errors = true
n = Notification.create!(noticeable: User.first, kind: "reset_password_fyi", notification_type: 1, recipient_role: "admin", recipient_email: "test@example.com")
NotificationMailerJob.perform_now(n.id)
n.reload.error_message # => shows the error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)