### PR TITLE
Route event registration emails through notification system

### DIFF
--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -11,7 +11,7 @@ module Events
 
     def resend_confirmation
       authorize! @event_registration, to: :show_public?
-      EventMailer.event_registration_confirmation(@event_registration).deliver_later
+      send_registration_notifications(@event_registration)
       redirect_to registration_ticket_path(@event_registration.slug), notice: "Confirmation email sent."
     end
 
@@ -43,6 +43,7 @@ module Events
       if existing&.status == "cancelled"
         authorize! existing
         existing.update!(status: "registered")
+        send_registration_notifications(existing)
         success = "Your registration has been reactivated."
         respond_to do |format|
           format.turbo_stream { flash.now[:notice] = success }
@@ -55,6 +56,7 @@ module Events
       authorize! @event_registration
 
       if @event_registration.save
+        send_registration_notifications(@event_registration)
         success = "You have successfully registered for this event."
         respond_to do |format|
           format.turbo_stream { flash.now[:notice] = success }
@@ -100,6 +102,27 @@ module Events
     end
 
     private
+
+    def send_registration_notifications(event_registration)
+      registrant_email = event_registration.registrant.preferred_email
+      return if registrant_email.blank?
+
+      NotificationServices::CreateNotification.call(
+        noticeable: event_registration,
+        kind: :event_registration_confirmation,
+        recipient_role: :person,
+        recipient_email: registrant_email,
+        notification_type: 0
+      )
+
+      NotificationServices::CreateNotification.call(
+        noticeable: event_registration,
+        kind: :event_registration_confirmation_fyi,
+        recipient_role: :admin,
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+        notification_type: 0
+      )
+    end
 
     def set_event
       @event = Event.find(params[:event_id])

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -58,11 +58,14 @@ RSpec.describe "Events::Registrations", type: :request do
   describe "POST /registration/:slug/resend_confirmation" do
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
-    it "sends confirmation email and redirects back" do
+    it "creates notification records and redirects back" do
       expect {
         post registration_resend_confirmation_path(registration.slug)
-      }.to have_enqueued_mail(EventMailer, :event_registration_confirmation)
+      }.to change(Notification, :count).by(2)
 
+      expect(Notification.last(2).map(&:kind)).to match_array(
+        %w[event_registration_confirmation event_registration_confirmation_fyi]
+      )
       expect(response).to redirect_to(registration_ticket_path(registration.slug))
       expect(flash[:notice]).to eq("Confirmation email sent.")
     end
@@ -70,10 +73,10 @@ RSpec.describe "Events::Registrations", type: :request do
     context "as a guest" do
       before { sign_out user }
 
-      it "sends confirmation email (slug is authorization)" do
+      it "creates notification records (slug is authorization)" do
         expect {
           post registration_resend_confirmation_path(registration.slug)
-        }.to have_enqueued_mail(EventMailer, :event_registration_confirmation)
+        }.to change(Notification, :count).by(2)
 
         expect(response).to redirect_to(registration_ticket_path(registration.slug))
       end
@@ -193,6 +196,17 @@ RSpec.describe "Events::Registrations", type: :request do
         expect(response.media_type).to eq("text/vnd.turbo-stream.html")
         expect(flash.now[:notice]).to eq("You have successfully registered for this event.")
       end
+
+      it "creates notification records" do
+        expect {
+          post event_registrant_registration_path(event_id: event.id),
+            headers: turbo_headers
+        }.to change(Notification, :count).by(2)
+
+        expect(Notification.last(2).map(&:kind)).to match_array(
+          %w[event_registration_confirmation event_registration_confirmation_fyi]
+        )
+      end
     end
 
     context "when a cancelled registration exists" do
@@ -209,6 +223,17 @@ RSpec.describe "Events::Registrations", type: :request do
         expect(cancelled_registration.reload.status).to eq("registered")
         expect(response).to have_http_status(:ok)
         expect(flash.now[:notice]).to eq("Your registration has been reactivated.")
+      end
+
+      it "creates notification records on reactivation" do
+        expect {
+          post event_registrant_registration_path(event_id: event.id),
+            headers: turbo_headers
+        }.to change(Notification, :count).by(2)
+
+        expect(Notification.last(2).map(&:kind)).to match_array(
+          %w[event_registration_confirmation event_registration_confirmation_fyi]
+        )
       end
 
       it "reactivates via HTML format and redirects to ticket" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Event registration confirmation emails sent from `Events::RegistrationsController` were not creating `Notification` records, making them invisible in the admin notification log
- `resend_confirmation` called `EventMailer.deliver_later` directly, bypassing the notification system entirely
- `create` (authenticated self-registration) never sent confirmation emails at all — for both new registrations and reactivated cancelled ones

### How did you approach the change?

- Added `send_registration_notifications` private method to `Events::RegistrationsController` that calls `NotificationServices::CreateNotification` for both the registrant confirmation and admin FYI — matching the pattern used by `PublicRegistration` and `ProcessConfirmation` services
- `resend_confirmation` now routes through this method instead of calling `EventMailer` directly
- `create` now sends notifications after both new registrations and reactivated cancelled registrations
- Updated existing specs and added new specs to verify `Notification` records are created

### UI Testing Checklist

- [ ] Register for an event as a logged-in user → confirm notification records created
- [ ] Reactivate a cancelled registration → confirm notification records created
- [ ] Resend confirmation from ticket page → confirm notification records created
- [ ] Verify emails are still delivered as expected

### Anything else to add?

- The `PublicRegistration` service and `ProcessConfirmation` service already used `NotificationServices::CreateNotification` correctly — this fix brings the authenticated registration controller in line with those patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)