### PR TITLE
Filter workshop log orgs by user affiliation

### DIFF
--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -140,7 +140,7 @@ class WorkshopLogsController < ApplicationController
                                 .distinct
                                 .select("users.id, users.email, users.person_id, people.first_name, people.last_name")
                                 .order(Arel.sql("LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email), LOWER(people.email_2), LOWER(people.email)"))
-    @organizations = authorized_scope(Organization.all)
+    @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
     @workshops = Workshop.where(id: @workshop_logs_unpaginated.select(:workshop_id).distinct)
                          .includes(:windows_type)
                          .order(:title)
@@ -202,10 +202,10 @@ class WorkshopLogsController < ApplicationController
     end
 
     @organizations =
-      Organization.where(id: current_user.organizations.select(:id))
-                   .or(Organization.where(id: @workshop_log.organization_id))
-                   .distinct
-                   .order(:name)
+      authorized_scope(Organization.all, as: :affiliated)
+        .or(Organization.where(id: @workshop_log.organization_id))
+        .distinct
+        .order(:name)
     organization = params[:agency_id].present? ? Organization.where(id: params[:agency_id]).last : @organizations.first
     @organization_id = organization.id if organization
   end

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -27,7 +27,7 @@ class OrganizationPolicy < ApplicationPolicy
   end
 
   relation_scope(:affiliated) do |relation|
-    next relation.active if admin?
+    next relation if admin?
     next relation.none unless user&.person_id
 
     relation.joins(:affiliations)

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -36,7 +36,7 @@
       </div>
 
       <div class="flex-1 mb-4 md:mb-0">
-        <% if current_user.person&.affiliations&.count != 1 %>
+        <% if allowed_to?(:index?, Organization) || current_user.person&.affiliations&.count != 1 %>
           <%= f.input :organization_id,
                     as: :select,
                     collection: @organizations,

--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -72,6 +72,45 @@ RSpec.describe "/workshop_logs", type: :request do
       expect(response.body).not_to include("workshop_log_#{other_log.id}")
     end
 
+    context "organization filtering" do
+      it "shows only affiliated organizations for non-admin users" do
+        person = create(:person, user: user)
+        affiliated_org = create(:organization, name: "Affiliated Org")
+        unaffiliated_org = create(:organization, name: "Unaffiliated Org")
+        create(:affiliation, person: person, organization: affiliated_org)
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Affiliated Org")
+        expect(response.body).not_to include("Unaffiliated Org")
+      end
+
+      it "includes organizations from inactive affiliations for non-admin users" do
+        person = create(:person, user: user)
+        inactive_org = create(:organization, name: "Inactive Affiliation Org")
+        create(:affiliation, person: person, organization: inactive_org, inactive: true)
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Inactive Affiliation Org")
+      end
+
+      it "shows all organizations for admin users" do
+        admin = create(:user, :admin)
+        sign_in admin
+        org_a = create(:organization, name: "Org Alpha")
+        org_b = create(:organization, name: "Org Beta")
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Org Alpha")
+        expect(response.body).to include("Org Beta")
+      end
+    end
+
     # TODO use action policy to filter
     xit "populates workshops dropdown with only workshops from visible logs" do
       visible_workshop = create(:workshop)
@@ -90,6 +129,45 @@ RSpec.describe "/workshop_logs", type: :request do
       expect(response.body).to include(hidden_workshop.name)
       expect(response.body).not_to include(unassigned_workshop.name)
       expect(response.body).not_to include(unassigned_hidden_workshop.name)
+    end
+  end
+
+  describe "GET /new" do
+    let!(:combined_windows_type) { create(:windows_type, :combined) }
+    let!(:form_builder) do
+      fb = FormBuilder.create!(windows_type_id: combined_windows_type.id, name: "Combined form")
+      fb.forms.create!
+      fb
+    end
+
+    context "organization filtering" do
+      it "shows only affiliated organizations for non-admin users" do
+        person = create(:person, user: user)
+        affiliated_org = create(:organization, name: "Affiliated Form Org")
+        unaffiliated_org = create(:organization, name: "Unaffiliated Form Org")
+        create(:affiliation, person: person, organization: affiliated_org)
+        create(:affiliation, person: person, organization: create(:organization, name: "Second Affiliated Org"))
+
+        get new_workshop_log_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Affiliated Form Org")
+        expect(response.body).to include("Second Affiliated Org")
+        expect(response.body).not_to include("Unaffiliated Form Org")
+      end
+
+      it "shows all organizations for admin users" do
+        admin = create(:user, :admin)
+        sign_in admin
+        org_a = create(:organization, name: "Admin Form Org A")
+        org_b = create(:organization, name: "Admin Form Org B")
+
+        get new_workshop_log_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Admin Form Org A")
+        expect(response.body).to include("Admin Form Org B")
+      end
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Non-admins were seeing all published organizations on the workshop logs index filter and form dropdown
- They should only see organizations they have affiliations with (active or inactive)
- Admins should continue to see all organizations

### How did you approach the change?

- Updated `OrganizationPolicy`'s `:affiliated` scope so admins get all orgs (previously returned only `.active`)
- Replaced inline org queries in `WorkshopLogsController` with `authorized_scope(Organization.all, as: :affiliated)` in both `set_index_variables` and `set_form_variables`
- Added `allowed_to?(:index?, Organization)` check in the form view so admins always see the org dropdown (even with 1 affiliation)
- Added request specs covering org filtering for non-admins (affiliated only, including inactive affiliations) and admins (all orgs) on both the index and new form

### UI Testing Checklist

- [x] Non-admin with multiple affiliations sees only their affiliated orgs in the index filter dropdown
- [x] Non-admin with multiple affiliations sees only their affiliated orgs in the new/edit form dropdown
- [x] Non-admin with inactive affiliations still sees those orgs
- [x] Admin sees all organizations in both the index filter and form dropdowns
- [x] Admin with exactly 1 affiliation sees the dropdown (not a hidden field) on the form

### Anything else to add?

- The `:affiliated` scope on `OrganizationPolicy` was previously unused, so changing its admin behavior has no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)