### PR TITLE
Reorder invite button on user edit and add invite seed users

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -74,11 +74,6 @@
                               confirm_email_manual_user_path(@user),
                               class: "btn btn-warning-outline text-sm" %>
                 <% end %>
-                <%= button_to "Send reset password email",
-                              send_reset_password_instructions_user_path(@user),
-                              method: :post,
-                              form_class: "inline",
-                              class: "btn btn-secondary-outline text-sm" %>
                 <% unless @user.confirmed_at.present? %>
                   <%= button_to "Resend invite email",
                                 send_welcome_instructions_user_path(@user),
@@ -86,6 +81,11 @@
                                 form_class: "inline",
                                 class: "btn btn-secondary-outline text-sm" %>
                 <% end %>
+                <%= button_to "Send reset password email",
+                              send_reset_password_instructions_user_path(@user),
+                              method: :post,
+                              form_class: "inline",
+                              class: "btn btn-secondary-outline text-sm" %>
                 <% if current_user == @user %>
                   <%= link_to "Change password",
                               change_password_path,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,6 +59,173 @@ User.find_or_create_by!(email: "orphaned_reports@awbw.org") do |user|
   user.confirmed_at = Time.current
 end
 
+# Invited but hasn't clicked the link yet
+invited = User.find_or_create_by!(email: "invited.pending@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless invited.confirmed_at.present?
+  invited.update_columns(
+    confirmed_at: nil,
+    welcome_instructions_token: Devise.friendly_token,
+    welcome_instructions_created_at: 3.days.ago,
+    welcome_instructions_sent_at: 3.days.ago
+  )
+end
+unless invited.person.present?
+  person = Person.create!(
+    first_name: "Invited",
+    last_name: "Pending",
+    email: invited.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  invited.update!(person: person)
+end
+
+# Clicked confirmation link but didn't set password
+confirmed_no_pw = User.find_or_create_by!(email: "confirmed.nopassword@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless confirmed_no_pw.welcome_instructions_token.present?
+  token = Devise.friendly_token
+  confirmed_no_pw.update_columns(
+    confirmed_at: 2.days.ago,
+    welcome_instructions_token: token,
+    welcome_instructions_created_at: 5.days.ago,
+    welcome_instructions_sent_at: 5.days.ago
+  )
+end
+unless confirmed_no_pw.person.present?
+  person = Person.create!(
+    first_name: "Confirmed",
+    last_name: "NoPassword",
+    email: confirmed_no_pw.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  confirmed_no_pw.update!(person: person)
+end
+
+# Locked account (too many failed attempts)
+locked = User.find_or_create_by!(email: "locked.user@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+  user.confirmed_at = 1.month.ago
+end
+unless locked.locked_at.present?
+  locked.update_columns(
+    locked_at: 1.day.ago,
+    failed_attempts: Devise.maximum_attempts
+  )
+end
+unless locked.person.present?
+  person = Person.create!(
+    first_name: "Locked",
+    last_name: "User",
+    email: locked.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  locked.update!(person: person)
+end
+
+# Never invited (created but no confirmation sent)
+never_invited = User.find_or_create_by!(email: "never.invited@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless never_invited.welcome_instructions_sent_at.present?
+  never_invited.update_columns(confirmed_at: nil)
+end
+unless never_invited.person.present?
+  person = Person.create!(
+    first_name: "Never",
+    last_name: "Invited",
+    email: never_invited.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  never_invited.update!(person: person)
+end
+
+# Invited a while ago, never clicked (stale invite)
+stale_invited = User.find_or_create_by!(email: "stale.invite@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless stale_invited.confirmed_at.present?
+  stale_invited.update_columns(
+    confirmed_at: nil,
+    welcome_instructions_token: Devise.friendly_token,
+    welcome_instructions_created_at: 45.days.ago,
+    welcome_instructions_sent_at: 45.days.ago
+  )
+end
+unless stale_invited.person.present?
+  person = Person.create!(
+    first_name: "Stale",
+    last_name: "Invite",
+    email: stale_invited.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  stale_invited.update!(person: person)
+end
+
+# Invited yesterday
+recent_invited = User.find_or_create_by!(email: "recent.invite@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless recent_invited.confirmed_at.present?
+  recent_invited.update_columns(
+    confirmed_at: nil,
+    welcome_instructions_token: Devise.friendly_token,
+    welcome_instructions_created_at: 1.day.ago,
+    welcome_instructions_sent_at: 1.day.ago
+  )
+end
+unless recent_invited.person.present?
+  person = Person.create!(
+    first_name: "Recent",
+    last_name: "Invite",
+    email: recent_invited.email,
+    created_by: admin,
+    updated_by: admin,
+    profile_is_searchable: true
+  )
+  recent_invited.update!(person: person)
+end
+
+# Never invited, no person record either
+User.find_or_create_by!(email: "orphan.uninvited@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end.tap do |u|
+  u.update_columns(confirmed_at: nil) unless u.welcome_instructions_sent_at.present?
+end
+
+# Invited, no person record
+invited_no_person = User.find_or_create_by!(email: "invited.noperson@example.com") do |user|
+  user.password = "password"
+  user.super_user = false
+end
+unless invited_no_person.confirmed_at.present?
+  invited_no_person.update_columns(
+    confirmed_at: nil,
+    welcome_instructions_token: Devise.friendly_token,
+    welcome_instructions_created_at: 10.days.ago,
+    welcome_instructions_sent_at: 10.days.ago
+  )
+end
+
 # Only reset seed-user passwords, not every user in the database
 seed_emails = %w[umberto.user@example.com amy.user@example.com orphaned_reports@awbw.org]
 user_password = Devise::Encryptor.digest(User, "password")

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -579,4 +579,37 @@ RSpec.describe "/users", type: :request do
       end
     end
   end
+
+  # ---------------------------------------
+  # SEND RESET PASSWORD INSTRUCTIONS
+  # ---------------------------------------
+  describe "POST /send_reset_password_instructions" do
+    let(:user) { create(:user) }
+
+    context "as admin" do
+      before { sign_in admin }
+
+      it "sends reset password instructions and redirects with notice" do
+        post send_reset_password_instructions_user_url(user)
+        expect(flash[:notice]).to include("Reset password instructions sent")
+        expect(response).to redirect_to(users_path)
+      end
+    end
+
+    context "as regular_user" do
+      before { sign_in regular_user }
+
+      it "redirects to root" do
+        post send_reset_password_instructions_user_url(user)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as guest" do
+      it "redirects to root" do
+        post send_reset_password_instructions_user_url(user)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins need better visibility into user invite states during development and testing
- The "Resend invite email" button should appear before "Send reset password email" for logical ordering (invite first, then reset)

### How did you approach the change?

- Reordered buttons on user edit page: "Resend invite email" now appears before "Send reset password email"
- Added seed users covering various invite/confirmation states:
  - Invited but hasn't clicked link (3 days ago)
  - Confirmed email but didn't set password
  - Locked account (too many failed attempts)
  - Never invited (no confirmation sent)
  - Stale invite (45 days ago, expired token)
  - Recently invited (yesterday)
  - Uninvited with no person record
  - Invited with no person record
- Added missing request spec for `send_reset_password_instructions` action (admin, regular user, guest)

### UI Testing Checklist

- [x] Visit `/users` as admin — verify various invite states display correctly (clock icons, invite buttons)
- [x] Edit an unconfirmed user — verify "Resend invite email" appears before "Send reset password email"
- [x] Click "Resend invite email" — verify flash notice and redirect

### Anything else to add?

- Seeds are idempotent — safe to run multiple times
- All existing specs pass (58 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)