### PR TITLE
Remove false-positive empty body warning from NotificationMailerJob

### DIFF
--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -26,10 +26,6 @@ class NotificationMailerJob < ApplicationJob
 
       mailer.deliver_now
 
-      if mailer.body.blank?
-        Rails.logger.warn("WARNING: Mailer body is empty for Notification #{notification.id} (#{notification.kind})")
-      end
-
       NotificationServices::PersistDeliveredEmail.call(
         notification: notification,
         mail: mailer


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Eliminates noisy false-positive "Mailer body is empty" warnings that fire on every notification email
- These warnings were cluttering logs and obscuring real issues

### How did you approach the change?

- All notification emails produce multipart messages (both `.html.erb` and `.text.erb` templates), so the top-level `Mail::Message#body` is always empty — content lives in `html_part` and `text_part`
- The `mailer.body.blank?` check was therefore true for every email, despite the emails having real content
- Real delivery failures (missing templates, rendering errors) already raise exceptions caught by the existing `rescue` block, which records the error via `notification.record_error!`
- Removed the check entirely since it provided no signal

### Anything else to add?

- `PersistDeliveredEmail` already handles multipart correctly via `mail.multipart?` / `mail.html_part` / `mail.text_part`
- No behavior change — emails continue to be sent and persisted exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)