### PR TITLE
Fix New variation button to check WorkshopVariation policy

### DIFF
--- a/app/views/workshops/_show_associations.html.erb
+++ b/app/views/workshops/_show_associations.html.erb
@@ -8,7 +8,7 @@
           <h2 class="text-lg font-semibold mb-2">Variations of this Workshop</h2>
         </div>
         <div class="flex gap-2 justify-end">
-          <% if allowed_to?(:new?, WorkshopVariationIdea) && @workshop.persisted? %>
+          <% if allowed_to?(:new?, WorkshopVariation) && @workshop.persisted? %>
             <%= link_to "New variation",
                         new_workshop_variation_path(from: "workshop_show", workshop_id: workshop.id),
                         class: "admin-only bg-blue-100 btn btn-secondary-outline" %>

--- a/spec/views/workshops/_show_associations.html.erb_spec.rb
+++ b/spec/views/workshops/_show_associations.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "workshops/_show_associations", type: :view do
+  let(:user) { create(:user) }
+  let(:workshop) { create(:workshop, created_by: user) }
+
+  before do
+    assign(:workshop, workshop)
+    assign(:workshop_variations, [])
+    assign(:quotes, [])
+    assign(:leader_spotlights, [])
+    assign(:mentions, {})
+  end
+
+  context "when user can manage WorkshopVariation" do
+    before do
+      allow(view).to receive(:allowed_to?).and_return(false)
+      allow(view).to receive(:allowed_to?).with(:new?, WorkshopVariation).and_return(true)
+      render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
+    end
+
+    it "displays the New variation button" do
+      expect(rendered).to have_link("New variation", href: new_workshop_variation_path(from: "workshop_show", workshop_id: workshop.id))
+    end
+  end
+
+  context "when user cannot manage WorkshopVariation" do
+    before do
+      allow(view).to receive(:allowed_to?).and_return(false)
+      render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
+    end
+
+    it "does not display the New variation button" do
+      expect(rendered).not_to have_link("New variation")
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The "New variation" button on the workshop show page was visible to all authenticated users, but creating a workshop variation is an admin-only action
- This fixes the authorization check so only admins can see the button

### How did you approach the change?

- Changed the policy check from `allowed_to?(:new?, WorkshopVariationIdea)` to `allowed_to?(:new?, WorkshopVariation)` in the `_show_associations` partial
- `WorkshopVariationIdea#new?` allows any authenticated user, while `WorkshopVariation` inherits `new?` from `ApplicationPolicy#manage?` which requires `admin?`
- Added view spec to verify the button visibility is gated by `WorkshopVariation` policy

### UI Testing Checklist

- [x] Verify "New variation" button appears for admin users on workshop show page
- [x] Verify "New variation" button is hidden for non-admin authenticated users
- [x] Verify "New variation idea" button still appears for all authenticated users
- [x] Verify no buttons appear for visitors

### Anything else to add?

- The adjacent "New variation idea" button correctly checks `WorkshopVariationIdea` policy and is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)