### PR TITLE
Add Ahoy tracking to FAQ searches and views

### DIFF
--- a/app/controllers/faqs_controller.rb
+++ b/app/controllers/faqs_controller.rb
@@ -1,4 +1,5 @@
 class FaqsController < ApplicationController
+  include AhoyTracking
   skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_faq, only: [ :show, :edit, :update, :destroy ]
 
@@ -8,10 +9,12 @@ class FaqsController < ApplicationController
     @faqs = faqs.search_by_params(params.to_unsafe_h.slice("query", "published"))
               .by_position
               .page(params[:page])
+    track_index_intent(Faq, @faqs, params)
   end
 
   def show
     authorize! @faq
+    track_view(@faq)
   end
 
   def new

--- a/spec/requests/faqs_spec.rb
+++ b/spec/requests/faqs_spec.rb
@@ -23,6 +23,38 @@ RSpec.describe "/faqs", type: :request do
   let!(:unpublished_faq) { create(:faq, question: "Unpublished FAQ", answer: "Unpublished FAQ Body") }
   let!(:public_faq) { create(:faq, :published, question: "Public FAQ", answer: "Public FAQ Body", publicly_visible: true) }
 
+  describe "Ahoy tracking" do
+    before { sign_in admin }
+
+    describe "GET /index" do
+      it "tracks a search event when a query param is present" do
+        expect(Analytics::AhoyTracker).to receive(:track_index_intent).with(
+          anything, Faq, params: anything, result_count: anything
+        )
+
+        get faqs_path, params: { query: "Published" }
+      end
+
+      it "calls track_index_intent even without search params" do
+        expect(Analytics::AhoyTracker).to receive(:track_index_intent).with(
+          anything, Faq, params: anything, result_count: anything
+        )
+
+        get faqs_path
+      end
+    end
+
+    describe "GET /show" do
+      it "tracks a view event" do
+        expect(Analytics::AhoyTracker).to receive(:track).with(
+          anything, :view, published_faq
+        )
+
+        get faq_path(published_faq)
+      end
+    end
+  end
+
   describe "GET /index" do
     context "as an admin" do
       before { sign_in admin }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- FAQ searches and page views were not being captured as Ahoy events
- Every other public-facing controller (Resources, Workshops, Tutorials, Events, etc.) already tracks these, so FAQs were a gap in analytics

### How did you approach the change?

- Added `include AhoyTracking` to `FaqsController`
- Added `track_index_intent(Faq, @faqs, params)` in the `index` action to capture search queries and result counts
- Added `track_view(@faq)` in the `show` action to capture individual FAQ views
- Added request specs verifying the tracking calls

### UI Testing Checklist

- [x] Visit /faqs and verify page still loads
- [x] Search for a FAQ and verify results still appear
- [x] Click into a FAQ and verify the show page loads

### Anything else to add?

- Follows the exact pattern used in `ResourcesController`, `WorkshopsController`, `TutorialsController`, etc.
- No UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)