### PR TITLE
Fix stale bookmark state after unbookmarking via turbo_stream

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -90,6 +90,7 @@ class BookmarksController < ApplicationController
     authorize! @bookmark
     if @bookmark
       @bookmark.destroy
+      current_user.bookmarks.reload
       @bookmarkable = @bookmark.bookmarkable
       respond_to do |format|
         format.html {

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe "Bookmarks", type: :request do
       }.to change(Bookmark, :count).by(-1)
     end
 
+    it "renders unbookmarked state in turbo_stream after destroy" do
+      delete bookmark_path(bookmark), headers: turbo_headers
+
+      expect(response.body).to include("far fa-bookmark")
+      expect(response.body).not_to include("fas fa-bookmark")
+    end
+
     it "cannot destroy another user's bookmark" do
       expect {
         delete bookmark_path(other_bookmark)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Fix unbookmarking a story on the home index (and any turbo_stream bookmark destroy) rendering the bookmarked state again instead of the unbookmarked state
- Without this fix, the bookmark icon flips back to "bookmarked" after confirming removal, and a second attempt raises `RecordNotFound`

### How did you approach the change?
- `ApplicationController#preload_current_user_associations` eagerly loads `current_user.bookmarks` for in-memory lookups via `bookmark_for`
- `BookmarksController#destroy` loaded the bookmark independently via `Bookmark.find`, so destroying it only marked that Ruby object as `destroyed?` — the preloaded collection kept a stale copy
- When the turbo_stream response re-rendered the bookmark icon partial, `bookmark_for` found the stale copy and rendered the "bookmarked" state
- Added `current_user.bookmarks.reload` after destroy to sync the preloaded collection with the database
- Added a request spec asserting the turbo_stream response contains the unbookmarked icon (`far fa-bookmark`) and not the bookmarked icon (`fas fa-bookmark`)

### UI Testing Checklist
- [ ] Bookmark a story, then unbookmark it from the home page — icon should stay in unbookmarked state
- [ ] Unbookmark from a story show page — same correct behavior
- [ ] Re-bookmark after unbookmarking — works without errors

### Anything else to add?
- The root cause affects any turbo_stream bookmark destroy, not just stories on the home page


🤖 Generated with [Claude Code](https://claude.com/claude-code)