### PR TITLE
Fix duplicate .sorted() call causing double joins on bookmarks page

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -5,7 +5,7 @@ class BookmarksController < ApplicationController
     authorize!
     per_page = params[:number_of_items_per_page] || 25
     base_scope = authorized_scope(Bookmark.includes(bookmarkable: [ :primary_asset, :gallery_assets, :windows_type ]))
-    filtered = base_scope.search(params).sorted(params[:sort])
+    filtered = base_scope.search(params)
 
     @bookmarks = filtered.paginate(page: params[:page], per_page: per_page).decorate
     @bookmarks_count = base_scope.length
@@ -26,7 +26,7 @@ class BookmarksController < ApplicationController
     @viewing_self = user == current_user
 
     base_scope = authorized_scope(Bookmark.includes(bookmarkable: [ :primary_asset, :gallery_assets, :windows_type ]))
-    filtered = base_scope.search(params, user: user).sorted(params[:sort])
+    filtered = base_scope.search(params, user: user)
 
     @bookmarks_count = filtered.length
     @bookmarks = filtered.paginate(page: params[:page], per_page: per_page)

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Bookmark, type: :model do
     end
 
     it "includes tutorial bookmarks when sorting by title" do
-      result = Bookmark.search({}).sorted("title")
+      result = Bookmark.sorted("title")
       expect(result).to include(tutorial_bookmark)
     end
   end
@@ -161,7 +161,7 @@ RSpec.describe Bookmark, type: :model do
     end
   end
 
-  describe '.search' do
+  describe ".search" do
     let(:user) { create(:user) }
     let!(:workshop1) { create(:workshop, title: "Alpha", led_count: 15) }
     let!(:workshop2) { create(:workshop, title: "Bravo", led_count: 10) }
@@ -173,33 +173,90 @@ RSpec.describe Bookmark, type: :model do
       create_list(:bookmark, 7, bookmarkable: workshop2, created_at: 4.days.ago)
     end
 
-    it 'sorts by newest-bookmarked by default' do
-      params = {}
-      result = Bookmark.search(params)
-      result = result.sorted(params[:sort])
+    it "sorts by newest-bookmarked by default" do
+      result = Bookmark.search({})
       expect(result.first.bookmarkable.title).to eq("Bravo")
     end
 
-    it 'sorts by title when sort=title' do
-      params = { sort: "title" }
-      result = Bookmark.search(params)
-      result = result.sorted(params[:sort])
+    it "sorts by title when sort=title" do
+      result = Bookmark.search({ sort: "title" })
       expect(result.first.bookmarkable).to eq(workshop1)
     end
 
-    it 'sorts by led count when sort=popularity' do
-      params = { sort: "popularity" }
-      result = Bookmark.search(params)
-      result = result.sorted(params[:sort])
+    it "sorts by popularity when sort=popularity" do
+      result = Bookmark.search({ sort: "popularity" })
       expect(result.first.bookmarkable).to eq(workshop2)
     end
 
-    it 'sorts by created_at when sort=newest' do
-      params = { sort: "newest" }
-      result = Bookmark.search(params)
-      result = result.sorted(params[:sort])
+    it "sorts by created_at when sort=newest" do
+      result = Bookmark.search({ sort: "newest" })
       expect(result.first.created_at).to eq(bookmark2.created_at)
       expect(result.first.bookmarkable).to eq(workshop2)
+    end
+
+    context "with title filter and title sort combined" do
+      it "does not produce duplicate table joins" do
+        expect {
+          Bookmark.search({ title: "Alpha", sort: "title" }).to_a
+        }.not_to raise_error
+      end
+
+      it "filters and sorts correctly" do
+        result = Bookmark.search({ title: "Alpha", sort: "title" })
+        expect(result.map(&:bookmarkable).uniq).to eq([ workshop1 ])
+      end
+    end
+
+    context "with title filter and newest sort" do
+      it "filters by title and sorts by newest" do
+        result = Bookmark.search({ title: "Bravo", sort: "newest" })
+        expect(result.map(&:bookmarkable).uniq).to eq([ workshop2 ])
+      end
+    end
+
+    context "with title filter and popularity sort" do
+      it "does not raise" do
+        expect {
+          Bookmark.search({ title: "Alpha", sort: "popularity" }).to_a
+        }.not_to raise_error
+      end
+    end
+
+    context "scoped to a user" do
+      it "returns only that user's bookmarks" do
+        result = Bookmark.search({}, user: user)
+        expect(result).to contain_exactly(bookmark1, bookmark2)
+      end
+
+      it "does not produce duplicate joins with title sort" do
+        expect {
+          Bookmark.search({ sort: "title" }, user: user).to_a
+        }.not_to raise_error
+      end
+
+      it "does not produce duplicate joins with title filter and title sort" do
+        expect {
+          Bookmark.search({ title: "Alpha", sort: "title" }, user: user).to_a
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe ".sorted" do
+    let(:user) { create(:user) }
+    let!(:workshop1) { create(:workshop, title: "Zebra") }
+    let!(:workshop2) { create(:workshop, title: "Apple") }
+    let!(:bookmark1) { create(:bookmark, user: user, bookmarkable: workshop1, created_at: 2.days.ago) }
+    let!(:bookmark2) { create(:bookmark, user: user, bookmarkable: workshop2, created_at: 1.day.ago) }
+
+    it "defaults to newest" do
+      result = Bookmark.sorted
+      expect(result.first).to eq(bookmark2)
+    end
+
+    it "sorts by title" do
+      result = Bookmark.sorted("title")
+      expect(result.first.bookmarkable).to eq(workshop2) # Apple before Zebra
     end
   end
 end

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe "Bookmarks", type: :request do
       expect(response.body).to include(Tutorial.model_name.human)
     end
 
+    it "can access personal bookmarks sorted by title" do
+      get personal_bookmarks_path, params: { sort: "title" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can access personal bookmarks with title filter and title sort" do
+      get personal_bookmarks_path, params: { sort: "title", title: "test" }
+      expect(response).to have_http_status(:ok)
+    end
+
     it "cannot access tally index" do
       get tally_bookmarks_path
       expect(response).to redirect_to(root_path)
@@ -170,6 +180,16 @@ RSpec.describe "Bookmarks", type: :request do
 
     it "can access global index" do
       get bookmarks_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can access global index sorted by title" do
+      get bookmarks_path, params: { sort: "title" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can access global index with title filter and title sort" do
+      get bookmarks_path, params: { sort: "title", title: "test" }
       expect(response).to have_http_status(:ok)
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Fixes a production Honeybadger crash: `ActiveRecord::StatementInvalid: Trilogy::ProtocolError: 1066: Not unique table/alias: 'community_news'` on `BookmarksController#personal`
- `Bookmark.search` already calls `.sorted()` internally, but both controller actions were calling `.sorted()` again on the result, doubling the SQL joins

### How did you approach the change?

- **Removed duplicate `.sorted()` calls** from `BookmarksController#index` and `#personal` — `Bookmark.search` already calls `.sorted()` internally, so calling it again joined the aliased tables a second time
- Fixed existing model specs that replicated the same double-sort bug pattern
- Added model specs covering sort + filter combos (title filter + title/newest/popularity sort, user-scoped + title sort)
- Added request specs for personal and global index with `sort=title` and `title=` filter params

### UI Testing Checklist

- [ ] Verify bookmarks personal page loads without error
- [ ] Verify bookmarks personal page with sort=title works
- [ ] Verify bookmarks global index (admin) with sort=title works
- [ ] Verify bookmarks global index with title search + sort=title works

### Anything else to add?

- The aliased table approach (`st_` prefix in `sort_by_title`, `wt_` prefix in `windows_type`) already on main prevents join conflicts between filter and sort scopes — this PR just removes the redundant second `.sorted()` call that duplicated the aliased joins


🤖 Generated with [Claude Code](https://claude.com/claude-code)