### PR TITLE
Improve activities stat boxes layout

### DIFF
--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -30,22 +30,20 @@
             View counts
           </h2>
 
-          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-5 gap-y-2 gap-x-2">
+          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
             <% @summary.each do |label, data| %>
               <%= link_to polymorphic_path(label.to_s.classify.constantize), class: "block group" do %>
                 <div class="<%= DomainTheme.bg_class_for(label) %> border border-gray-200 rounded-xl p-5
-                shadow-sm hover:shadow-md transition min-h-[130px]">
-                  <div class="flex items-start justify-between">
-                    <div class="text-xs font-semibold tracking-wide uppercase text-gray-500">
-                      <%= label.to_s.humanize %>
-                    </div>
-
-                    <div class="text-3xl font-bold text-gray-900 group-hover:text-blue-600 leading-none tabular-nums transition-colors">
-                      <%= number_with_delimiter(data[:views]) %>
-                    </div>
+                shadow-sm hover:shadow-md transition min-h-[120px]">
+                  <div class="text-xs font-semibold tracking-wide uppercase text-gray-500">
+                    <%= label.to_s.humanize %>
                   </div>
 
-                  <div class="mt-3 space-y-1 text-xs text-gray-600 flex flex-col items-end">
+                  <div class="text-3xl font-bold text-gray-900 group-hover:text-blue-600 leading-none tabular-nums transition-colors mt-2">
+                    <%= number_with_delimiter(data[:views]) %>
+                  </div>
+
+                  <div class="mt-2 space-y-1 text-xs text-gray-600">
                     <% if data[:prints].to_i > 0 %>
                       <div class="flex items-center gap-1">
                         <span class="tabular-nums"><%= number_with_delimiter(data[:prints]) %></span>
@@ -144,7 +142,7 @@
           <h2 class="text-lg font-semibold text-gray-800 mb-4">Stories</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <%= render "admin/analytics/popular_list",
-                       title: "Stories",
+                       title: "Most viewed",
                        records: @most_viewed_stories,
                        path_method: :story_path,
                        metric: :view_count,


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The stat boxes on the Activities > Counts page had inconsistent visual sizing because the label and number were laid out side-by-side, causing long labels like "Organizations" and "Workshop Variations" to look cramped
- The Stories popular list section was incorrectly titled "Stories" instead of "Most viewed"

### How did you approach the change?
- Switched stat box layout from side-by-side (label left, number right) to stacked (label on top, number below) — the standard stat card pattern that accommodates any label length
- Changed the xl grid from 6 columns to 5, creating two even rows of 5 instead of an unbalanced 6+4
- Normalized gap spacing to a uniform `gap-3`
- Fixed Stories popular list title from "Stories" to "Most viewed" to match other sections

### UI Testing Checklist
- [x] Visit `/admin/activities/counts` and verify all 10 stat boxes display with consistent sizing
- [x] Verify long labels (Organizations, Workshop Variations, Community News) display without cramping
- [x] Check responsive behavior at different breakpoints (2/3/4/5 columns)
- [x] Verify the Stories section shows "Most viewed" as the first list title

### Anything else to add?
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)