### PR TITLE
Add shared author_creditable tests for all AuthorCreditable models

### DIFF
--- a/spec/models/story_idea_spec.rb
+++ b/spec/models/story_idea_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe StoryIdea, type: :model do
+  it_behaves_like "author_creditable", factory: :story_idea
+
   describe "#workshop_title" do
     it "returns workshop title when only workshop is present" do
       workshop = create(:workshop, title: "Healing Art")

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,47 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Story, type: :model do
-  describe "#author_credit" do
-    let(:user) { create(:user, :with_person) }
-    let(:person) { user.person }
-    let(:story) { create(:story, created_by: user) }
-
-    context "when author_credit_preference is full name" do
-      it "returns the person's full name" do
-        story.update!(author_credit_preference: "full_name")
-        expect(story.author_credit).to eq(person.full_name)
-      end
-    end
-
-    context "when author_credit_preference is first name only" do
-      it "returns the person's first name" do
-        story.update!(author_credit_preference: "first_name_only")
-        expect(story.author_credit).to eq(person.first_name)
-      end
-    end
-
-    context "when author_credit_preference is anonymous" do
-      it "returns Anonymous" do
-        story.update!(author_credit_preference: "anonymous")
-        expect(story.author_credit).to eq("Anonymous")
-      end
-    end
-
-    context "when author_credit_preference is nil" do
-      it "falls back to the person's display name preference" do
-        expect(story.author_credit_preference).to be_nil
-        expect(story.author_credit).to eq(person.name)
-      end
-    end
-
-    context "when user has no person" do
-      let(:user) { create(:user, person: nil) }
-
-      it "returns Anonymous" do
-        expect(story.author_credit).to eq("Anonymous")
-      end
-    end
-  end
+  it_behaves_like "author_creditable", factory: :story
 
   describe '.search_by_params' do
     let!(:published_story) { create(:story, :published, title: 'Healing Through Art') }

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe WorkshopIdea, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it_behaves_like "author_creditable", factory: :workshop_idea
 end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -89,35 +89,7 @@ RSpec.describe Workshop do
     end
   end
 
-  describe "#author_credit" do
-    let(:user) { create(:user, :with_person) }
-    let(:person) { user.person }
-    let(:workshop) { create(:workshop, created_by: user) }
-
-    it "returns the person's full name when preference is full_name" do
-      workshop.update!(author_credit_preference: "full_name")
-      expect(workshop.author_credit).to eq(person.full_name)
-    end
-
-    it "returns the person's first name when preference is first_name_only" do
-      workshop.update!(author_credit_preference: "first_name_only")
-      expect(workshop.author_credit).to eq(person.first_name)
-    end
-
-    it "returns Anonymous when preference is anonymous" do
-      workshop.update!(author_credit_preference: "anonymous")
-      expect(workshop.author_credit).to eq("Anonymous")
-    end
-
-    it "falls back to person's display name when preference is nil" do
-      expect(workshop.author_credit).to eq(person.name)
-    end
-
-    it "returns Anonymous when user has no person" do
-      workshop.update!(created_by: create(:user, person: nil))
-      expect(workshop.author_credit).to eq("Anonymous")
-    end
-  end
+  it_behaves_like "author_creditable", factory: :workshop
 
   # Add tests for scopes, methods like #rating, #log_count, SearchCop etc.
 end

--- a/spec/models/workshop_variation_idea_spec.rb
+++ b/spec/models/workshop_variation_idea_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe WorkshopVariationIdea, type: :model do
+  it_behaves_like "author_creditable", factory: :workshop_variation_idea
+end

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe WorkshopVariation do
+  it_behaves_like "author_creditable", factory: :workshop_variation
+
   describe 'associations' do
     it { should belong_to(:workshop).optional }
   end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,0 +1,57 @@
+RSpec.shared_examples "author_creditable" do |factory:|
+  describe "#author_credit" do
+    let(:author_user) { create(:user, :with_person) }
+    let(:person) { author_user.person }
+    let(:record) { create(factory, created_by: author_user) }
+
+    context "when author_credit_preference is full_name" do
+      it "returns the person's full name" do
+        record.update!(author_credit_preference: "full_name")
+        expect(record.author_credit).to eq(person.full_name)
+      end
+    end
+
+    context "when author_credit_preference is first_name_last_initial" do
+      it "returns first name and last initial with period" do
+        record.update!(author_credit_preference: "first_name_last_initial")
+        expect(record.author_credit).to eq("#{person.first_name} #{person.last_name.first}.")
+      end
+    end
+
+    context "when author_credit_preference is first_name_only" do
+      it "returns the person's first name" do
+        record.update!(author_credit_preference: "first_name_only")
+        expect(record.author_credit).to eq(person.first_name)
+      end
+    end
+
+    context "when author_credit_preference is last_name_only" do
+      it "returns the person's last name" do
+        record.update!(author_credit_preference: "last_name_only")
+        expect(record.author_credit).to eq(person.last_name)
+      end
+    end
+
+    context "when author_credit_preference is anonymous" do
+      it "returns Anonymous" do
+        record.update!(author_credit_preference: "anonymous")
+        expect(record.author_credit).to eq("Anonymous")
+      end
+    end
+
+    context "when author_credit_preference is nil", unless: described_class.validators_on(:author_credit_preference).any? { |v| v.is_a?(ActiveModel::Validations::PresenceValidator) } do
+      it "falls back to the person's display name" do
+        record.update!(author_credit_preference: nil)
+        expect(record.author_credit).to eq(person.name)
+      end
+    end
+
+    context "when user has no person" do
+      it "returns Anonymous" do
+        user_without_person = create(:user, person: nil)
+        record.update!(created_by: user_without_person)
+        expect(record.author_credit).to eq("Anonymous")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The `AuthorCreditable` concern (`#author_credit`) formats author names based on preference (full name, first name + last initial, first name only, last name only, anonymous)
- Only 2 of 6 models using this concern had tests, and those were missing coverage for `first_name_last_initial` and `last_name_only` preferences
- This PR ensures all name display preferences are tested across every model that uses the concern

### How did you approach the change?

- Created a shared example (`spec/support/shared_examples/author_creditable.rb`) following the existing `featureable` and `mentioner` shared example patterns
- Tests all 7 scenarios: full_name, first_name_last_initial, first_name_only, last_name_only, anonymous, nil fallback, and no-person fallback
- Automatically skips the nil fallback test for models that validate presence of `author_credit_preference` (StoryIdea, WorkshopVariationIdea)
- Replaced inline tests in Story and Workshop specs with the shared example
- Added shared example to StoryIdea, WorkshopIdea, WorkshopVariation specs
- Created new spec file for WorkshopVariationIdea

### Anything else to add?

- 141 examples, 0 failures across all 7 affected spec files
- Net effect: -71 lines of duplicated tests, +69 lines of shared + comprehensive coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)