### PR TITLE
Test workshop log colleague visibility and person dropdown scoping

### DIFF
--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -72,6 +72,91 @@ RSpec.describe "/workshop_logs", type: :request do
       expect(response.body).not_to include("workshop_log_#{other_log.id}")
     end
 
+    context "colleague workshop log visibility" do
+      it "shows workshop logs from colleagues in the same organization" do
+        shared_org = create(:organization, name: "Shared Org")
+        person = create(:person, user: user)
+        create(:affiliation, person: person, organization: shared_org)
+
+        colleague = create(:user)
+        colleague_person = create(:person, user: colleague)
+        create(:affiliation, person: colleague_person, organization: shared_org)
+
+        colleague_log = create(:workshop_log, valid_attributes.merge(
+          created_by_id: colleague.id,
+          organization_id: shared_org.id
+        ))
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("workshop_log_#{colleague_log.id}")
+      end
+
+      it "does not show workshop logs from unaffiliated organizations" do
+        my_org = create(:organization, name: "My Org")
+        person = create(:person, user: user)
+        create(:affiliation, person: person, organization: my_org)
+
+        other_org = create(:organization, name: "Other Org")
+        stranger = create(:user)
+        stranger_person = create(:person, user: stranger)
+        create(:affiliation, person: stranger_person, organization: other_org)
+
+        stranger_log = create(:workshop_log, valid_attributes.merge(
+          created_by_id: stranger.id,
+          organization_id: other_org.id
+        ))
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include("workshop_log_#{stranger_log.id}")
+      end
+    end
+
+    context "person filtering" do
+      it "shows only affiliated colleagues in the person dropdown for non-admin users" do
+        shared_org = create(:organization, name: "Shared Org")
+        person = create(:person, user: user, first_name: "Current", last_name: "Userface")
+        create(:affiliation, person: person, organization: shared_org)
+
+        colleague = create(:user)
+        colleague_person = create(:person, user: colleague, first_name: "Colleague", last_name: "Personface")
+        create(:affiliation, person: colleague_person, organization: shared_org)
+
+        unaffiliated_org = create(:organization, name: "Unaffiliated Org")
+        stranger = create(:user)
+        stranger_person = create(:person, user: stranger, first_name: "Stranger", last_name: "Dangerface")
+        create(:affiliation, person: stranger_person, organization: unaffiliated_org)
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Colleague Personface")
+        expect(response.body).not_to include("Stranger Dangerface")
+      end
+
+      it "shows all people with access for admin users" do
+        admin = create(:user, :admin)
+        sign_in admin
+
+        org_a = create(:organization)
+        person_a = create(:person, user: create(:user), first_name: "Alpha", last_name: "Userton")
+        create(:affiliation, person: person_a, organization: org_a)
+
+        org_b = create(:organization)
+        person_b = create(:person, user: create(:user), first_name: "Beta", last_name: "Userton")
+        create(:affiliation, person: person_b, organization: org_b)
+
+        get workshop_logs_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Alpha Userton")
+        expect(response.body).to include("Beta Userton")
+      end
+    end
+
     context "organization filtering" do
       it "shows only affiliated organizations for non-admin users" do
         person = create(:person, user: user)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Adds test coverage for workshop log index page scoping by organization affiliation
- Verifies that the person dropdown follows the same affiliation rules as the organization dropdown
- Ensures non-admin users only see colleague logs and colleague names from their affiliated organizations

### How did you approach the change?

- Added "colleague workshop log visibility" context with two specs:
  - Logs from colleagues in the same org are visible
  - Logs from unaffiliated orgs are hidden
- Added "person filtering" context with two specs:
  - Person dropdown shows only affiliated colleagues for non-admins
  - Person dropdown shows all people with access for admins
- No code changes needed — existing policy scopes already enforce the correct behavior

### Anything else to add?

- All 17 request specs pass (15 existing + 2 pending xits unchanged)


🤖 Generated with [Claude Code](https://claude.com/claude-code)