### PR TITLE
Filter admin activity pages by audience and default to past month

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -45,14 +45,7 @@ module Admin
       end
 
       # Audience filter
-      case params[:audience]
-      when "visitors"
-        scope = scope.where(user_id: nil)
-      when "users"
-        scope = scope.joins(:user).where(users: { super_user: false })
-      when "staff"
-        scope = scope.joins(:user).where(users: { super_user: true })
-      end
+      scope = apply_audience_filter(scope)
 
       # Filter by resource type and ID
       if params[:resource_type].present?
@@ -94,6 +87,12 @@ module Admin
       if params[:visit_id].present?
         scope = scope.where(id: params[:visit_id])
       end
+
+      # Time period filter
+      scope = scope.where(started_at: time_range) if time_range
+
+      # Audience filter
+      scope = apply_audience_filter(scope)
 
       # Date filtering
       if params[:from].present?
@@ -273,7 +272,7 @@ module Admin
         .first(10).to_h
 
       # User signup trend
-      signup_range = time_range || 6.months.ago..Time.current
+      signup_range = time_range || (6.months.ago..Time.current)
       @user_signup_trend = User.where(created_at: signup_range).group_by_week(:created_at).count
 
       # Search-to-view conversion
@@ -345,40 +344,45 @@ module Admin
       end.reject { |s| s[:data].empty? }
     end
 
+    def selected_audiences
+      @selected_audiences ||= Array(params[:audience]).reject(&:blank?).presence || %w[visitors users]
+    end
+
     def scoped_visits
       scope = Ahoy::Visit.all
       scope = scope.where(started_at: time_range) if time_range
-
-      case params[:audience]
-      when "visitors"
-        scope = scope.where(user_id: nil)
-      when "users"
-        scope = scope.includes(:user).joins(:user).where(users: { super_user: false })
-      when "staff"
-        scope = scope.includes(:user).joins(:user).where(users: { super_user: true })
-      end
-
-      scope
+      apply_audience_filter(scope)
     end
 
     def scoped_events
       scope = Ahoy::Event.all
       scope = scope.where(time: time_range) if time_range
+      apply_audience_filter(scope)
+    end
 
-      case params[:audience]
-      when "visitors"
-        scope = scope.where(user_id: nil)
-      when "users"
-        scope = scope.includes(:user).joins(:user).where(users: { super_user: false })
-      when "staff"
-        scope = scope.includes(:user).joins(:user).where(users: { super_user: true })
+    def apply_audience_filter(scope)
+      audiences = selected_audiences
+      return scope if (audiences & %w[visitors users staff]).size == 3
+
+      allowed_user_ids = []
+      allowed_user_ids << nil if audiences.include?("visitors")
+
+      if audiences.include?("users")
+        allowed_user_ids.concat(User.where(super_user: false).pluck(:id))
       end
 
-      scope
+      if audiences.include?("staff")
+        allowed_user_ids.concat(User.where(super_user: true).pluck(:id))
+      end
+
+      return scope.none if allowed_user_ids.empty?
+
+      scope.where(user_id: allowed_user_ids)
     end
 
     def time_range
-      case params[:time_period]
+      period = params[:time_period].presence || "past_month"
+      case period
       when "past_day"
         1.day.ago..Time.current
       when "past_week"
@@ -387,8 +391,8 @@ module Admin
         1.month.ago..Time.current
       when "past_year"
         1.year.ago..Time.current
-      else
-        nil # all_time
+      when "all_time"
+        nil
       end
     end
 

--- a/app/controllers/admin/analytics_controller.rb
+++ b/app/controllers/admin/analytics_controller.rb
@@ -5,6 +5,7 @@ module Admin
 
     def index
       authorize! :analytics, to: :index?
+      @selected_audiences = Array(params[:audience]).reject(&:blank?).presence || %w[visitors users]
       time_scope = apply_time_filter(params[:time_period])
 
       # Query Ahoy events for view counts within the time period
@@ -35,7 +36,7 @@ module Admin
       @zero_engagement_resources = zero_engagement_for_model(Resource, time_scope).limit(10).decorate
 
       # Single query to get all event counts grouped by name
-      all_counts = time_scope.call(Ahoy::Event.all).group(:name).count
+      all_counts = time_scope.call(events_base_scope).group(:name).count
 
       @summary = {
         workshops: {
@@ -107,6 +108,25 @@ module Admin
 
     private
 
+    def events_base_scope
+      return Ahoy::Event.all if (@selected_audiences & %w[visitors users staff]).size == 3
+
+      allowed_user_ids = []
+      allowed_user_ids << nil if @selected_audiences.include?("visitors")
+
+      if @selected_audiences.include?("users")
+        allowed_user_ids.concat(User.where(super_user: false).pluck(:id))
+      end
+
+      if @selected_audiences.include?("staff")
+        allowed_user_ids.concat(User.where(super_user: true).pluck(:id))
+      end
+
+      return Ahoy::Event.none if allowed_user_ids.empty?
+
+      Ahoy::Event.where(user_id: allowed_user_ids)
+    end
+
     def apply_time_filter(time_period)
       time_ago = case time_period
       when "past_day"
@@ -148,7 +168,7 @@ module Admin
       event_name = "#{action}.#{model_class.table_name.singularize}"
       rid_sql = "JSON_UNQUOTE(JSON_EXTRACT(properties, '$.resource_id'))"
 
-      rows = time_scope.call(Ahoy::Event.where(name: event_name))
+      rows = time_scope.call(events_base_scope.where(name: event_name))
         .select(Arel.sql("#{rid_sql} AS rid, COUNT(*) AS cnt"))
         .group(Arel.sql(rid_sql))
         .order(Arel.sql("cnt DESC"))
@@ -173,7 +193,7 @@ module Admin
       table_name_singular = model_class.table_name.singularize
       event_name = "view.#{table_name_singular}"
       # Get IDs of resources that have been viewed in the time period
-      viewed_ids = Ahoy::Event
+      viewed_ids = events_base_scope
         .where(name: event_name)
         .then { |query| time_scope.call(query) }
         .distinct

--- a/app/views/admin/ahoy_activities/charts.html.erb
+++ b/app/views/admin/ahoy_activities/charts.html.erb
@@ -4,35 +4,24 @@
         <h1 class="text-2xl font-semibold text-gray-900">Activities</h1>
         <%= form_with url: admin_activities_charts_path, method: :get, local: true,
                       class: "flex items-center gap-4" do %>
+          <%= render "admin/shared/audience_dropdown" %>
 
-          <label class="text-sm font-medium text-gray-700">Audience:</label>
-          <%= select_tag :audience,
-                         options_for_select(
-                           [
-                             ["All", "all"],
-                             ["Visitors (anon)", "visitors"],
-                             ["Users", "users"],
-                             ["Admins (staff)", "staff"]
-                           ],
-                           params[:audience] || "all"
-                         ),
-                         class: "px-3 py-2 rounded-md border-gray-300 shadow-sm",
-                         onchange: "this.form.submit()" %>
-
-          <label class="text-sm font-medium text-gray-700">Time period:</label>
-          <%= select_tag :time_period,
-                         options_for_select(
-                           [
-                             ['All time', 'all_time'],
-                             ['Past day', 'past_day'],
-                             ['Past week', 'past_week'],
-                             ['Past month', 'past_month'],
-                             ['Past year', 'past_year']
-                           ],
-                           params[:time_period] || 'all_time'
-                         ),
-                         class: "px-3 py-2 rounded-md border-gray-300 shadow-sm",
-                         onchange: "this.form.submit()" %>
+          <div class="flex items-center gap-2">
+            <label class="text-sm font-medium text-gray-700">Time period:</label>
+            <%= select_tag :time_period,
+                           options_for_select(
+                             [
+                               ['All time', 'all_time'],
+                               ['Past day', 'past_day'],
+                               ['Past week', 'past_week'],
+                               ['Past month', 'past_month'],
+                               ['Past year', 'past_year']
+                             ],
+                             params[:time_period] || 'past_month'
+                           ),
+                           class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+                           onchange: "this.form.submit()" %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -49,15 +49,7 @@
 
             <!-- Audience -->
             <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
-                Audience
-              </label>
-              <%= select_tag :audience,
-                             options_for_select(
-                               [["All", "all"], ["Visitors (anon)", "visitors"], ["Users", "users"], ["Admins (staff)", "staff"]],
-                               params[:audience] || "all"
-                             ),
-                             class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
             </div>
 
             <!-- Time Period -->
@@ -68,7 +60,7 @@
               <%= select_tag :time_period,
                              options_for_select(
                                [["All time", "all_time"], ["Past day", "past_day"], ["Past week", "past_week"], ["Past month", "past_month"], ["Past year", "past_year"]],
-                               params[:time_period] || "all_time"
+                               params[:time_period] || "past_month"
                              ),
                              class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -31,6 +31,24 @@
                              class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
+            <!-- Audience -->
+            <div class="flex-1 min-w-0">
+              <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
+            </div>
+
+            <!-- Time Period -->
+            <div class="flex-1 min-w-0">
+              <label class="block text-sm font-medium text-gray-600 mb-1">
+                Time Period
+              </label>
+              <%= select_tag :time_period,
+                             options_for_select(
+                               [["All time", "all_time"], ["Past day", "past_day"], ["Past week", "past_week"], ["Past month", "past_month"], ["Past year", "past_year"]],
+                               params[:time_period] || "past_month"
+                             ),
+                             class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+            </div>
+
             <!-- Date From -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -3,19 +3,23 @@
   <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-semibold text-gray-900">Activities</h1>
 
-        <%= form_with url: admin_activities_counts_path, method: :get, local: true, class: "flex items-center gap-2" do |f| %>
-          <%= f.label :time_period, "Time period:", class: "text-sm font-medium text-gray-700" %>
-          <%= f.select :time_period,
-                       options_for_select([
-                         ['All time', 'all_time'],
-                         ['Past day', 'past_day'],
-                         ['Past week', 'past_week'],
-                         ['Past month', 'past_month'],
-                         ['Past year', 'past_year']
-                       ], params[:time_period] || 'all_time'),
-                       {},
-                       class: "px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500",
-                       onchange: "this.form.submit()" %>
+        <%= form_with url: admin_activities_counts_path, method: :get, local: true, class: "flex items-center gap-4" do |f| %>
+          <%= render "admin/shared/audience_dropdown" %>
+
+          <div class="flex items-center gap-2">
+            <%= f.label :time_period, "Time period:", class: "text-sm font-medium text-gray-700" %>
+            <%= f.select :time_period,
+                         options_for_select([
+                           ['All time', 'all_time'],
+                           ['Past day', 'past_day'],
+                           ['Past week', 'past_week'],
+                           ['Past month', 'past_month'],
+                           ['Past year', 'past_year']
+                         ], params[:time_period] || 'past_month'),
+                         {},
+                         class: "px-3 py-2 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm text-gray-700",
+                         onchange: "this.form.submit()" %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -1,18 +1,23 @@
 <%
-  time_label = case params[:time_period]
+  time_period = params[:time_period].presence || "past_month"
+  time_label = case time_period
                when "past_day"   then "Past day"
                when "past_week"  then "Past week"
                when "past_month" then "Past month"
                when "past_year"  then "Past year"
                end
 
-  audience_label = case params[:audience]
-                   when "visitors" then "Visitors (anon)"
-                   when "users"    then "Users"
-                   when "staff"    then "Admins (staff)"
-                   end
+  audience_labels_map = {
+    "visitors" => "Visitors",
+    "users"    => "Users",
+    "staff"    => "Admins"
+  }
+
+  default_audiences = %w[visitors users]
+  audience_values = Array(params[:audience]).reject(&:blank?).presence || default_audiences
+  audience_labels = audience_values.filter_map { |v| audience_labels_map[v] }
 %>
-<% if time_label || audience_label %>
+<% if time_label || audience_labels.any? %>
   <div class="flex items-center gap-2 mb-4 text-sm">
     <span class="text-gray-500">Filtering:</span>
     <% if time_label %>
@@ -20,9 +25,9 @@
         <%= time_label %>
       </span>
     <% end %>
-    <% if audience_label %>
-      <span class="inline-flex items-center px-3 py-1 rounded-full bg-indigo-100 text-indigo-800 font-medium">
-        <%= audience_label %>
+    <% audience_labels.each do |label| %>
+      <span class="inline-flex items-center px-3 py-1 rounded-full bg-pink-100 text-pink-800 font-medium">
+        <%= label %>
       </span>
     <% end %>
   </div>

--- a/app/views/admin/shared/_audience_dropdown.html.erb
+++ b/app/views/admin/shared/_audience_dropdown.html.erb
@@ -1,0 +1,41 @@
+<%
+  default_audiences = %w[visitors users]
+  selected = Array(params[:audience]).reject(&:blank?).presence || default_audiences
+  auto_submit = local_assigns.fetch(:auto_submit, true)
+  stacked = local_assigns.fetch(:stacked, false)
+
+  labels_map = { "visitors" => "Visitors", "users" => "Users", "staff" => "Admins" }
+  button_label = if (selected & labels_map.keys).size == labels_map.size
+                   "All"
+                 else
+                   selected.filter_map { |v| labels_map[v] }.join(", ")
+                 end
+  dropdown_id = "audience-dropdown-#{SecureRandom.hex(4)}"
+%>
+<div class="<%= stacked ? "" : "flex items-center gap-2" %>">
+  <label class="<%= stacked ? "block text-sm font-medium text-gray-600 mb-1" : "text-sm font-medium text-gray-700" %>"><%= stacked ? "Audience" : "Audience:" %></label>
+  <div data-controller="dropdown" class="relative">
+    <button type="button"
+            data-action="dropdown#toggle"
+            data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
+            class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 bg-transparent text-sm text-gray-700">
+      <span><%= button_label %></span>
+      <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </button>
+
+    <div id="<%= dropdown_id %>"
+         data-dropdown-target="content"
+         class="hidden absolute z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg p-3 min-w-[160px]">
+      <% labels_map.each do |value, label| %>
+        <label class="flex items-center gap-2 cursor-pointer py-1">
+          <%= check_box_tag "audience[]", value, selected.include?(value),
+                            onchange: (auto_submit ? "this.closest('form').submit()" : nil),
+                            class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500" %>
+          <span class="text-sm text-gray-700"><%= label %></span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -103,6 +103,29 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
   context "as an admin" do
     before { sign_in admin }
 
+    describe "default filters" do
+      it "shows Past month chip and Audience chips on events page" do
+        get index_path
+        expect(response.body).to include("Past month")
+        expect(response.body).to include("Visitors")
+        expect(response.body).to include("Users")
+      end
+
+      it "shows Past month chip and Audience chips on visits page" do
+        get visits_path
+        expect(response.body).to include("Past month")
+        expect(response.body).to include("Visitors")
+        expect(response.body).to include("Users")
+      end
+
+      it "shows Past month chip and Audience chips on charts page" do
+        get charts_path
+        expect(response.body).to include("Past month")
+        expect(response.body).to include("Visitors")
+        expect(response.body).to include("Users")
+      end
+    end
+
     describe "GET /admin/activities" do
       it "renders ok" do
         get index_path

--- a/spec/requests/admin/analytics_spec.rb
+++ b/spec/requests/admin/analytics_spec.rb
@@ -130,6 +130,18 @@ RSpec.describe "Admin::Analytics", type: :request do
         get index_path
         expect(response).to have_http_status(:ok)
       end
+
+      it "shows Past month chip and Audience chips by default" do
+        get index_path
+        expect(response.body).to include("Past month")
+        expect(response.body).to include("Visitors")
+        expect(response.body).to include("Users")
+      end
+
+      it "renders successfully with audience filter" do
+        get index_path, params: { audience: %w[visitors users] }
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     describe "POST /admin/activities/counts/print" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admin activity pages (events, visits, charts, counts) lacked consistent filtering controls
- The audience filter was a single-select dropdown that couldn't combine visitor types
- All pages defaulted to "all time" which made initial page loads slow and data noisy

### How did you approach the change?

- Created a shared `_audience_dropdown` partial with multi-select checkboxes (Visitors, Users, Admins) replacing the old single-select
- Added `stacked` layout option to the partial so it matches the vertical filter style on events/visits pages while staying inline on charts/counts
- Added audience and time period filters to the visits page (previously had neither)
- Added audience filtering to the counts page controller (`events_base_scope`)
- Unified audience filtering logic into `apply_audience_filter` in the ahoy activities controller
- Defaulted time period to "past month" across all 4 pages (views and controller)
- Updated `_active_filters_subheader` to show chips reflecting defaults when no params are provided
- Reordered dropdowns: audience first, then time period on all pages
- Added request specs verifying default filter chips appear on all 4 pages

### UI Testing Checklist

- [x] Events page: audience dropdown shows "Visitors, Users" by default, time period shows "Past month"
- [x] Visits page: audience and time period filters appear in filter section
- [x] Charts page: audience dropdown appears before time period in header bar
- [x] Counts page: audience dropdown appears before time period in header bar
- [x] All pages: "Past month", "Visitors", "Users" chips visible in subheader by default
- [x] Selecting "All time" explicitly works and removes time filter
- [x] Multi-selecting audience checkboxes filters data correctly

### Anything else to add?

- The `stacked` option on the audience dropdown partial controls layout: `stacked: true` for filter sections (label on top), `false` (default) for inline header bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)