### PR TITLE
Fix nil slug crash on event registration ticket link

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -51,10 +51,12 @@
 
     <% if registered %>
       <% registration = event.active_registration_for(current_user.person) %>
+      <% if registration&.slug.present? %>
       <%= link_to "View registration", registration_ticket_path(registration.slug),
                   data: { turbo_frame: "_top" },
                   class: "btn px-3 py-2 text-xs uppercase leading-tight text-white hover:bg-white event-view-registration-btn",
                   style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 2px solid rgb(22, 101, 52);" %>
+      <% end %>
     <% elsif event.ended? %>
       <span class="text-sm text-gray-500 italic">Event ended</span>
       <% if allowed_to?(:manage?, event) %>

--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -1068,6 +1068,11 @@ registrations_data.each do |data|
   )
 end
 
+# Backfill slugs for any registrations created before the generate_slug callback existed
+EventRegistration.where(slug: nil).find_each do |reg|
+  reg.update!(slug: SecureRandom.urlsafe_base64(16))
+end
+
 puts "Creating Registration Form Submissions…"
 # Create person_form records linking registrants to their event's registration form.
 # This simulates people who filled out the registration form.


### PR DESCRIPTION
## Summary
- Guard against nil `slug` in `events/_card.html.erb` to prevent `ActionController::UrlGenerationError` when a registration's slug is nil
- Backfill slugs in dev seeds for registrations created before the `generate_slug` callback existed

## Context
- The home page "Upcoming Events" section crashed with `No route matches {action: "show", controller: "events/registrations", slug: nil}` because some event registrations had nil slugs
- The `before_create :generate_slug` callback on `EventRegistration` generates slugs for new records, but older seeded records pre-date this callback

## Test plan
- [x] Verify home page loads without error when events have registrations with nil slugs
- [x] Verify "View registration" link still works for registrations that have slugs
- [x] Run `bin/setup` or `rails db:seed` and confirm all registrations get slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)