### PR TITLE
Fix MissingTemplate error for non-HTML home page requests

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,9 @@ class HomeController < ApplicationController
 
   def index
     authorize! :home
-    render :index
+
+    respond_to do |format|
+      format.html { render :index }
+    end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Bots/crawlers requesting the home page with non-HTML formats (e.g. `Accept: text/plain`) cause a 500 error (`ActionView::MissingTemplate`) because only `index.html.erb` exists
- This wraps the render in `respond_to` so unsupported formats get a `406 Not Acceptable` instead of a 500

### How did you approach the change?

- Added `respond_to` block in `HomeController#index` to explicitly handle only `format.html`
- Non-HTML format requests now return 406 instead of raising an exception

### Anything else to add?

- Other public-facing controllers have the same vulnerability — a follow-up PR could add a global `rescue_from ActionView::MissingTemplate` in `ApplicationController` to handle all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)