### PR TITLE
Show initial-letter avatar when no photo uploaded

### DIFF
--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar-user-button relative" id="avatar" data-controller="dropdown">
   <% user = current_user %>
   <% person = user&.person %>
-  <% avatar_image = person&.avatar&.attached? ? person.avatar.variant(:thumbnail) : "missing.png" %>
+  <% has_avatar = person&.avatar&.attached? %>
 
   <button
     type="button"
@@ -12,9 +12,17 @@
     <span class="sr-only">Open user menu</span>
     <span class="absolute -inset-1.5"></span>
 
-    <%= image_tag avatar_image,
-                  id: "avatar-image",
-                  class: "size-10 rounded-full bg-gray-800 outline -outline-offset-1 outline-white/10" %>
+    <% if has_avatar %>
+      <%= image_tag person.avatar.variant(:thumbnail),
+                    id: "avatar-image",
+                    class: "size-10 rounded-full bg-gray-800 outline -outline-offset-1 outline-white/10" %>
+    <% else %>
+      <span id="avatar-image"
+            class="size-10 rounded-full bg-sky-200 text-sky-700 font-bold text-lg
+                   flex items-center justify-center border border-sky-300 shadow-sm">
+        <%= (person&.first_name.presence || user.first_name.presence || user.email).to_s.first.upcase %>
+      </span>
+    <% end %>
   </button>
 
   <!-- Dropdown menu -->

--- a/spec/system/navbar_avatar_updates_spec.rb
+++ b/spec/system/navbar_avatar_updates_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe "Navbar avatar behavior", type: :system do
       person.reload
       expect(person.avatar).not_to be_attached
 
-      avatar_img = find("#avatar-image")
-      expect(avatar_img[:src]).to include("missing")
+      avatar_el = find("#avatar-image")
+      expect(avatar_el.tag_name).to eq("span")
+      expect(avatar_el.text).to eq(person.first_name.first.upcase)
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Users without an avatar photo saw a generic `missing.png` placeholder in the navbar
- Replace it with a styled circle showing the first letter of their name, which is more personal and visually consistent with the existing `person_profile_button` pattern

### How did you approach the change?

- In `_navbar_user.html.erb`, conditionally render either the attached avatar image or a `<span>` circle with the user's first initial
- Fallback chain: `person.first_name` -> `user.first_name` -> `user.email` so there's always a letter
- Styled with `bg-sky-200 text-sky-700` to match the existing avatar fallback in `person_helper.rb`
- Updated system spec to expect a `<span>` element with the initial instead of an `<img>` with "missing" src

### UI Testing Checklist

- [ ] Log in as a user with an avatar photo — avatar image displays normally
- [ ] Log in as a user without an avatar — sky-blue circle with first initial displays
- [ ] Verify the initial circle looks good on the dark navbar background
- [ ] Click the avatar circle — dropdown menu opens correctly

### Anything else to add?

- The `id="avatar-image"` is preserved on both the `<img>` and `<span>` paths so the dropdown controller continues to work


🤖 Generated with [Claude Code](https://claude.com/claude-code)