### PR TITLE
 Add started_at/ended_at datetime fields to Banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def display_banner
     # Cache banners to avoid repeated queries during page render
-    @banners ||= Banner.published.select("id, content").to_a
+    @banners ||= Banner.active.select("id, content").to_a
     return if @banners.empty?
 
     safe_content_array = @banners.map { |banner|

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -12,4 +12,10 @@ class Banner < ApplicationRecord
   def name
     content.truncate(50)
   end
+
+  scope :active, -> {
+   where(show: true)
+     .where("started_at IS NULL OR started_at <= ?", Time.current)
+     .where("ended_at IS NULL OR ended_at >= ?", Time.current)
+ }
 end

--- a/db/migrate/20260405143000_add_timeto_banner.rb
+++ b/db/migrate/20260405143000_add_timeto_banner.rb
@@ -1,0 +1,6 @@
+class AddTimetoBanner < ActiveRecord::Migration[8.1]
+  def change
+    add_column :banners, :started_at, :datetime
+    add_column :banners, :ended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_05_143000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -213,8 +213,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_120000) do
     t.text "content"
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
+    t.datetime "ended_at"
     t.boolean "published", default: false, null: false
     t.boolean "show"
+    t.datetime "started_at"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "updated_by_id"
     t.index ["created_by_id"], name: "index_banners_on_created_by_id"


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Closes #216

### What is the goal of this PR and why is this important?
Adds support for scheduled banners with start/end dates

### How did you approach the change?
Added started_at/ended_at datetime fields to Banner, created an :active scope to filter by current date, and updated display_banner helper to show all active banners instead of just the last one.

### UI Testing Checklist
<!-- This will be automatically generated based on your changes. -->
<!-- Complete the auto-generated checklist below before marking as ready for review. -->
<!-- Add or remove items as needed for your specific changes. -->

### Anything else to add?
Should I also add the started_at and ended_at fields to the banners/new form? 


