### PR TITLE
Show FileMaker code instead of internal ID on org form

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -178,7 +178,7 @@ end
   def organization_params
     params.require(:organization).permit(
       :name, :description, :start_date, :end_date, :mission_vision_values,
-      :agency_type, :agency_type_other, :internal_id, :logo, :notes, :email, :website_url,
+      :agency_type, :agency_type_other, :filemaker_code, :logo, :notes, :email, :website_url,
       :organization_status_id, :location_id, :windows_type_id,
       :profile_show_sectors, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -199,8 +199,8 @@
 
     <% if allowed_to?(:manage?, Organization) %>
       <div class="admin-only bg-blue-100">
-        <%= f.input :internal_id,
-                    label: "Internal Organization ID",
+        <%= f.input :filemaker_code,
+                    label: "FileMaker Project ID",
                     input_html: {
                       class: "rounded-md border-gray-300 bg-blue-100 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                     } %>

--- a/lib/tasks/migrate_internal_id_to_filemaker_code.rake
+++ b/lib/tasks/migrate_internal_id_to_filemaker_code.rake
@@ -1,0 +1,38 @@
+namespace :organizations do
+  desc "Migrate internal_id to filemaker_code for organizations"
+  task migrate_internal_id_to_filemaker_code: :environment do
+    puts "Starting migration of internal_id to filemaker_code..."
+    puts "Environment: #{Rails.env}"
+    puts "==============================================="
+
+    migrated_count = 0
+    commented_count = 0
+    skipped_count = 0
+
+    Organization.where.not(internal_id: [ nil, "" ]).find_each do |org|
+      internal_stripped = org.internal_id.strip
+      filemaker_stripped = org.filemaker_code&.strip
+
+      if !filemaker_stripped.present? && internal_stripped.present?
+        org.update!(filemaker_code: internal_stripped)
+        migrated_count += 1
+        puts "Migrated org #{org.id} (#{org.name}): filemaker_code set to '#{internal_stripped}'"
+      elsif internal_stripped != filemaker_stripped
+        org.comments.create!(
+          body: "Data migration note: internal_id '#{org.internal_id}' did not match filemaker_code '#{org.filemaker_code}'"
+        )
+        commented_count += 1
+        puts "Mismatch org #{org.id} (#{org.name}): internal_id='#{org.internal_id}' vs filemaker_code='#{org.filemaker_code}' — comment added"
+      else
+        skipped_count += 1
+        puts "Skipped org #{org.id} (#{org.name}): values already match"
+      end
+    end
+
+    puts "==============================================="
+    puts "Migration complete!"
+    puts "Migrated: #{migrated_count}"
+    puts "Mismatches commented: #{commented_count}"
+    puts "Skipped (already matching): #{skipped_count}"
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Replace the internal ID field with the FileMaker code field on the organization form so admins can view/edit the FileMaker Project ID directly
- Add a data migration rake task to move existing internal_id values into filemaker_code

### How did you approach the change?
- Swapped `internal_id` for `filemaker_code` in the org form (admin-only field) with label "FileMaker Project ID"
- Updated strong params to permit `filemaker_code` instead of `internal_id`
- Added `rake organizations:migrate_internal_id_to_filemaker_code` which:
  - Copies stripped `internal_id` into `filemaker_code` when filemaker_code is blank and internal_id is present
  - Adds a comment to the organization when both fields have values that don't match after stripping
  - Skips records where values already match

### UI Testing Checklist
- [x] Verify "FileMaker Project ID" field appears on org edit form for admin users
- [x] Verify field is hidden for non-admin users
- [x] Verify saving a value to the field persists correctly

### Anything else to add?
- Run `rake organizations:migrate_internal_id_to_filemaker_code` in production after deploy to migrate existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)