### PR TITLE
Fix case/whitespace sensitivity in duplicate label detection

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -336,8 +336,9 @@ class Workshop < ApplicationRecord
   end
 
   def self.resolve_duplicate_labels(labels)
-    dupes = labels.group_by { |l| l[:label] }.select { |_, v| v.size > 1 }.keys.to_set
-    labels.each { |l| l[:label] = "#{l[:label]} ##{l[:id]}" if dupes.include?(l[:label]) }
+    normalize = ->(s) { s.squish.downcase }
+    dupes = labels.group_by { |l| normalize[l[:label]] }.select { |_, v| v.size > 1 }.flat_map(&:last).to_set
+    labels.each { |l| l[:label] = "#{l[:label]} ##{l[:id]}" if dupes.include?(l) }
     labels
   end
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -133,6 +133,32 @@ RSpec.describe Workshop do
         { id: w3.id, label: "Music Therapy (ADULT)" }
       )
     end
+
+    it "treats labels as duplicates regardless of case" do
+      wt = create(:windows_type, :adult)
+      w1 = create(:workshop, title: "Art Therapy", windows_type: wt)
+      w2 = create(:workshop, title: "art therapy", windows_type: wt)
+
+      labels = Workshop.resolve_duplicate_labels([ w1, w2 ].map(&:remote_search_label))
+
+      expect(labels).to contain_exactly(
+        { id: w1.id, label: "Art Therapy (ADULT) ##{w1.id}" },
+        { id: w2.id, label: "art therapy (ADULT) ##{w2.id}" }
+      )
+    end
+
+    it "treats labels as duplicates regardless of extra whitespace" do
+      wt = create(:windows_type, :adult)
+      w1 = create(:workshop, title: "Art Therapy", windows_type: wt)
+      w2 = create(:workshop, title: "Art  Therapy", windows_type: wt)
+
+      labels = Workshop.resolve_duplicate_labels([ w1, w2 ].map(&:remote_search_label))
+
+      expect(labels).to contain_exactly(
+        { id: w1.id, label: "Art Therapy (ADULT) ##{w1.id}" },
+        { id: w2.id, label: "Art  Therapy (ADULT) ##{w2.id}" }
+      )
+    end
   end
 
   describe ".remote_search" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `resolve_duplicate_labels` used exact Ruby string comparison to detect duplicate workshop labels in remote-select dropdowns
- Workshops with the same name but different casing (e.g. "Art Therapy" vs "art therapy") or extra whitespace would not get IDs appended, making them indistinguishable in the dropdown

### How did you approach the change?

- Normalize labels with `.squish.downcase` for grouping/comparison, while preserving the original label text for display
- Added specs for case-insensitive and whitespace-insensitive duplicate detection

### Anything else to add?

- Also confirmed that all workshop search paths (remote search, title scope, full-text, author) are case insensitive via MySQL `utf8mb4_unicode_ci` collation

🤖 Generated with [Claude Code](https://claude.com/claude-code)