### PR TITLE
Add responsive card layout to admin activity events table

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -255,6 +255,49 @@ textarea.comment-truncated:focus {
   color: white !important;
 }
 
+/* Responsive table: Kevin Powell card-based approach for small screens */
+@media (max-width: 767px) {
+  .responsive-table thead {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+
+  .responsive-table tbody {
+    display: block;
+  }
+
+  .responsive-table tr {
+    display: block;
+    border-bottom: 2px solid #e5e7eb;
+    padding: 0.75rem 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .responsive-table td {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    gap: 0.5rem;
+    padding: 0.35rem 1rem;
+    text-align: left;
+    border: none;
+  }
+
+  .responsive-table td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
 /* Turbo progress bar */
 .turbo-progress-bar {
   height: 7px;

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -113,8 +113,8 @@
       </div>
 
       <!-- Events Table -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm">
-        <table class="min-w-full divide-y divide-gray-200 text-sm">
+      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
+        <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
           <thead class="bg-gray-50 text-gray-600 uppercase tracking-wider text-xs">
           <tr>
             <th class="px-4 py-3 text-left rounded-tl-xl">Time</th>
@@ -129,19 +129,19 @@
           <tbody class="divide-y divide-gray-100">
           <% @events.each do |event| %>
             <tr class="hover:bg-gray-50 transition">
-              <td class="px-4 py-3 whitespace-nowrap text-gray-500">
+              <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
                 <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
               </td>
 
-              <td class="px-4 py-3 font-medium text-gray-900">
+              <td data-label="Event" class="px-4 py-3 font-medium text-gray-900">
                 <%= event.name %>
               </td>
 
-              <td class="px-4 py-3 text-gray-500">
+              <td data-label="Resource" class="px-4 py-3 text-gray-500">
                 <%= event.properties["resource_title"].presence || "—" %>
               </td>
 
-              <td class="px-4 py-3 text-gray-600">
+              <td data-label="User" class="px-4 py-3 text-gray-600">
                 <% if event.user %>
                   <%= link_to event.user.full_name,
                               user_path(event.user),
@@ -151,11 +151,11 @@
                 <% end %>
               </td>
 
-              <td class="px-4 py-3 text-gray-500">
+              <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
                 <%= event.visit_id %>
               </td>
 
-              <td class="px-4 py-3 text-gray-500 relative group">
+              <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
                 <% if event.properties.present? && event.properties.any? %>
                   <%= link_to admin_activities_event_path(event),
                               class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Make the admin activity events table usable on small screens
- On mobile (<768px), table rows collapse into stacked cards with labeled fields instead of requiring horizontal scrolling

### How did you approach the change?
- Applied [Kevin Powell's responsive table technique](https://www.youtube.com/watch?v=czZ1PvNW5hk): visually hide `<thead>`, convert each `<tr>` to a block-level card, and use `td::before { content: attr(data-label) }` to show column headers inline
- Added `data-label` attributes to each `<td>` in the events table
- Added a reusable `.responsive-table` CSS class in `application.tailwind.css`

**Why custom CSS instead of Tailwind utilities?** The responsive card pattern requires the same set of styles on every `<td>` (display, grid, `::before` pseudo-element with `content: attr(data-label)`, etc.). Doing this with Tailwind utilities would mean repeating ~10 utility classes on every single `<td>` across every row. A single `.responsive-table` CSS class keeps the HTML clean and DRY — the only addition to each `<td>` is the `data-label` attribute.

### UI Testing Checklist
- [ ] View admin activity events page on desktop — table should look unchanged
- [ ] View on mobile / narrow browser (<768px) — rows should display as stacked cards with labeled fields
- [ ] Verify properties hover tooltip still works on desktop

### Anything else to add?
- The `.responsive-table` class is reusable for other tables in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)