### PR TITLE
Add submitter confirmation email to WorkshopIdea

### DIFF
--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -28,6 +28,12 @@ class WorkshopIdeasController < ApplicationController
     if @workshop_idea.save
       NotificationServices::CreateNotification.call(
         noticeable: @workshop_idea,
+        kind: :idea_submitted,
+        recipient_role: :person,
+        recipient_email: @workshop_idea.created_by.email,
+        notification_type: 0)
+      NotificationServices::CreateNotification.call(
+        noticeable: @workshop_idea,
         kind: :idea_submitted_fyi,
         recipient_role: :admin,
         recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),

--- a/spec/requests/workshop_ideas_spec.rb
+++ b/spec/requests/workshop_ideas_spec.rb
@@ -79,6 +79,23 @@ RSpec.describe "/workshop_ideas", type: :request do
         expect(response).to redirect_to(workshop_idea_path(WorkshopIdea.last))
       end
 
+      it "sends admin and submitter notifications" do
+        expect(NotificationServices::CreateNotification).to receive(:call).with(
+          hash_including(
+            kind: :idea_submitted,
+            recipient_role: :person
+          )
+        )
+        expect(NotificationServices::CreateNotification).to receive(:call).with(
+          hash_including(
+            kind: :idea_submitted_fyi,
+            recipient_role: :admin
+          )
+        )
+
+        post workshop_ideas_path, params: { workshop_idea: valid_attributes }
+      end
+
       it "handles RecordNotUnique gracefully" do
         allow_any_instance_of(WorkshopIdea).to receive(:save).and_raise(
           ActiveRecord::RecordNotUnique.new("Duplicate entry")


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- WorkshopIdea was the only submission model missing a submitter confirmation email
- All other submission models (StoryIdea, WorkshopVariationIdea, WorkshopLog, EventRegistration) already send both a submitter email and an admin FYI
- This aligns WorkshopIdea with the established pattern

### How did you approach the change?
- Added `idea_submitted` notification call in `WorkshopIdeasController#create`, before the existing `idea_submitted_fyi` admin notification
- Uses the same `idea_submitted` kind already used by StoryIdea and WorkshopVariationIdea — the mailer method and templates already exist
- Added request spec verifying both notifications are sent on create (matching the pattern in `workshop_variation_ideas_spec.rb`)

### UI Testing Checklist
- [ ] Create a new WorkshopIdea as a regular user — verify submitter receives confirmation email
- [ ] Verify admin still receives FYI notification email
- [ ] Verify email subject reads "AWBW Portal: Your workshop idea has been received"

### Anything else to add?
- No new mailer methods or templates needed — the existing `NotificationMailer#idea_submitted` handles all idea types polymorphically via `model_name.human`

🤖 Generated with [Claude Code](https://claude.com/claude-code)