### PR TITLE
Make FAQs bookmarkable

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -2,7 +2,7 @@ class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :bookmarkable, polymorphic: true
 
-  BOOKMARKABLE_MODELS = %w[CommunityNews Event Organization Person Report Resource Story StoryIdea
+  BOOKMARKABLE_MODELS = %w[CommunityNews Event Faq Organization Person Report Resource Story StoryIdea
                            Tutorial Workshop WorkshopIdea WorkshopLog WorkshopVariation WorkshopVariationIdea].freeze
 
   DROPDOWN_MODELS = (BOOKMARKABLE_MODELS - %w[Report]).freeze
@@ -62,6 +62,7 @@ class Bookmark < ApplicationRecord
     bookmarks = self.joins(<<~SQL)
       LEFT JOIN community_news      AS st_cn  ON st_cn.id  = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'CommunityNews'
       LEFT JOIN events              AS st_ev  ON st_ev.id  = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Event'
+      LEFT JOIN faqs                AS st_faq ON st_faq.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Faq'
       LEFT JOIN organizations       AS st_org ON st_org.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Organization'
       LEFT JOIN people              AS st_ppl ON st_ppl.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Person'
       LEFT JOIN resources           AS st_res ON st_res.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Resource'
@@ -80,6 +81,7 @@ class Bookmark < ApplicationRecord
         COALESCE(
           st_cn.title,
           st_ev.title,
+          st_faq.question,
           CONCAT(st_ppl.first_name, ' ', st_ppl.last_name),
           st_org.name,
           st_rpt.type,
@@ -106,6 +108,7 @@ class Bookmark < ApplicationRecord
     bookmarks = bookmarks.joins(<<~SQL)
       LEFT JOIN community_news ON community_news.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'CommunityNews'
       LEFT JOIN events         ON events.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Event'
+      LEFT JOIN faqs           ON faqs.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Faq'
       LEFT JOIN organizations  ON organizations.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Organization'
       LEFT JOIN people         ON people.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Person'
       LEFT JOIN resources      ON resources.id = bookmarks.bookmarkable_id AND bookmarks.bookmarkable_type = 'Resource'
@@ -121,7 +124,7 @@ class Bookmark < ApplicationRecord
     SQL
 
     bookmarks.where(
-      "community_news.title LIKE :title OR events.title LIKE :title OR people.first_name LIKE :title OR
+      "community_news.title LIKE :title OR events.title LIKE :title OR faqs.question LIKE :title OR people.first_name LIKE :title OR
        people.last_name LIKE :title OR organizations.name LIKE :title OR resources.title LIKE :title OR
        reports.type LIKE :title OR
        stories.title LIKE :title OR workshops.title LIKE :title OR workshop_ideas.title LIKE :title OR

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -2,6 +2,8 @@ class Faq < ApplicationRecord
   include Publishable
   positioned
 
+  has_many :bookmarks, as: :bookmarkable, dependent: :destroy
+
   # Validations
   validates_presence_of :question, :answer
 

--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -100,6 +100,8 @@
         </div>
       <% end %>
 
+      <%= render "bookmarks/editable_bookmark_icon", resource: faq %>
+
       <button
         type="button"
         class="py-5 font-medium text-left cursor-pointer"

--- a/spec/models/faq_spec.rb
+++ b/spec/models/faq_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Faq do
   # let(:faq) { build(:faq) } # Keep if needed
 
   describe "associations" do
-    # Add association tests if any
+    it { should have_many(:bookmarks).dependent(:destroy) }
   end
 
   describe "validations" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Allow users to bookmark individual FAQs, just like workshops, resources, events, etc.
- FAQ appears as a filterable type in bookmark index/personal page dropdowns

### How did you approach the change?
- Added `has_many :bookmarks, as: :bookmarkable` to the FAQ model
- Added `"Faq"` to `BOOKMARKABLE_MODELS` in Bookmark (auto-included in `DROPDOWN_MODELS`)
- Added FAQ joins to `sort_by_title` and `title` search scopes in Bookmark
- Rendered `editable_bookmark_icon` partial in the FAQ accordion view
- Added association spec to FAQ model test

### UI Testing Checklist
- [x] Bookmark icon appears next to each FAQ for authenticated users
- [x] Clicking bookmark icon bookmarks/unbookmarks the FAQ
- [x] FAQ appears in the type dropdown on bookmarks personal page
- [x] FAQ appears in the type dropdown on bookmarks index page (admin)
- [x] Bookmarked FAQs appear in personal bookmarks list
- [x] Title search works for bookmarked FAQs
- [x] Sort by title works for bookmarked FAQs

### Anything else to add?
- Follows the exact same polymorphic bookmark pattern used by all other bookmarkable models

🤖 Generated with [Claude Code](https://claude.com/claude-code)