### PR TITLE
Add Spanish translations for categories, sectors, and workshop titles

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -99,7 +99,7 @@ class CategoriesController < ApplicationController
   def category_params
     if params[:category]
       params.require(:category).permit(
-        :name, :category_type_id, :published, :position
+        :name, :name_spanish, :category_type_id, :published, :position
       )
     else
       params.permit(:position)

--- a/app/controllers/category_types_controller.rb
+++ b/app/controllers/category_types_controller.rb
@@ -59,6 +59,6 @@ class CategoryTypesController < ApplicationController
   end
 
   def category_type_params
-    params.require(:category_type).permit(:name, :display_text, :published, :story_specific, :profile_specific)
+    params.require(:category_type).permit(:name, :name_spanish, :display_text, :published, :story_specific, :profile_specific)
   end
 end

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -75,7 +75,7 @@ class SectorsController < ApplicationController
   # Strong parameters
   def sector_params
     params.require(:sector).permit(
-      :name, :published
+      :name, :name_spanish, :published
     )
   end
 end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -219,7 +219,7 @@ class WorkshopsController < ApplicationController
 
   def workshop_params
     params.require(:workshop).permit(
-      :title, :featured, :published,
+      :title, :title_spanish, :featured, :published,
       :full_name, :created_by_id, :windows_type_id, :workshop_idea_id, :author_credit_preference,
       :month, :year,
       :publicly_visible,

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -3,7 +3,16 @@ class CategoryDecorator < ApplicationDecorator
     name
   end
 
+  def title_spanish
+    name_spanish.presence || name
+  end
+
   def detail(length: nil)
     "#{category_type.name}: #{name}"
+  end
+
+  def detail_spanish(length: nil)
+    type_label = category_type.name_spanish.presence || category_type.name
+    "#{type_label}: #{name_spanish.presence || name}"
   end
 end

--- a/app/decorators/category_type_decorator.rb
+++ b/app/decorators/category_type_decorator.rb
@@ -3,6 +3,10 @@ class CategoryTypeDecorator < ApplicationDecorator
     name.titleize
   end
 
+  def title_spanish
+    name_spanish.presence&.titleize || name.titleize
+  end
+
   def detail(length: nil)
   end
 end

--- a/app/decorators/workshop_decorator.rb
+++ b/app/decorators/workshop_decorator.rb
@@ -19,7 +19,7 @@ class WorkshopDecorator < ApplicationDecorator
   end
 
   def has_spanish_fields?
-    spanish_field_values.any?
+    title_spanish.present? || spanish_field_values.any?
   end
 
   def new?

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -15,6 +15,13 @@
                     input_html: { class: "form-control" } %>
       </div>
 
+      <!-- Name (Spanish) -->
+      <div class="flex-1 min-w-[220px]">
+        <%= f.input :name_spanish,
+                    label: "Name (Spanish)",
+                    input_html: { class: "form-control" } %>
+      </div>
+
       <!-- Category Type -->
       <div class="flex-1 min-w-[220px]">
         <%= f.input :category_type_id,

--- a/app/views/categories/_tagging_label.html.erb
+++ b/app/views/categories/_tagging_label.html.erb
@@ -1,5 +1,7 @@
 <% category ||= nil %>
 
+<% spanish ||= false %>
+
 <% name_only ||= false %>
 
 <% bg_color ||= DomainTheme.bg_class_for(:sectors) %>
@@ -9,6 +11,8 @@
 <% bg_hover_color ||= "bg-lime-200" %>
 
 <% if category %>
+  <% display_name = spanish ? (category.name_spanish.presence || category.name) : category.name %>
+  <% display_type = spanish ? (category.category_type&.name_spanish.presence || category.category_type&.name) : category.category_type&.name %>
   <%= link_to taggings_path(category_names_all: category.name),
     data: { turbo_frame: "_top", category_name: category.name, controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
               class: "inline-flex items-center
@@ -19,7 +23,7 @@
                       px-3 py-1
                       text-sm font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text"><%= "#{category.category_type&.name}: " if !name_only && category.category_type %><%= category.name %></span>
+    <span data-tag-link-loading-target="text"><%= "#{display_type}: " if !name_only && display_type %><%= display_name %></span>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -20,6 +20,10 @@
                 <p class="text-gray-900"><%= @category.name %></p>
               </div>
               <div class="mb-3">
+                <p class="font-bold text-gray-700">Name (Spanish):</p>
+                <p class="text-gray-900"><%= @category.name_spanish.presence || "--" %></p>
+              </div>
+              <div class="mb-3">
                 <p class="font-bold text-gray-700">Category type:</p>
                 <p class="text-gray-900"><%= @category.category_type.name %></p>
               </div>

--- a/app/views/category_types/_form.html.erb
+++ b/app/views/category_types/_form.html.erb
@@ -8,6 +8,9 @@
                   label: "Name",
                   input_html: { class: "form-control" },
                   required: true %>
+      <%= f.input :name_spanish,
+                  label: "Name (Spanish)",
+                  input_html: { class: "form-control" } %>
       <%= f.input :display_text,
                   label: "Display Text",
                   hint: "For display on story idea form",

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -41,6 +41,10 @@
           <span class="font-bold">Display text:</span>
           <span class="ml-1"><%= @category_type.display_text %></span>
         </p>
+        <p class="text-gray-700">
+          <span class="font-bold">Name (Spanish):</span>
+          <span class="ml-1"><%= @category_type.name_spanish.presence || "--" %></span>
+        </p>
       </div>
 
       <!-- Associated Categories -->

--- a/app/views/sectors/_form.html.erb
+++ b/app/views/sectors/_form.html.erb
@@ -14,6 +14,13 @@
                     input_html: { class: "form-control" } %>
       </div>
 
+      <!-- Name (Spanish) -->
+      <div class="flex-1 min-w-[220px]">
+        <%= f.input :name_spanish,
+                    label: "Name (Spanish)",
+                    input_html: { class: "form-control" } %>
+      </div>
+
       <div class="flex items-center min-w-[150px] pt-6">
         <%= f.input :published,
                     as: :boolean,

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -1,5 +1,7 @@
 <% sector ||= nil %>
 
+<% spanish ||= false %>
+
 <% is_leader ||= false %>
 
 <% display_leader ||= false %>
@@ -11,6 +13,7 @@
 <% bg_hover_color ||= "bg-lime-200" %>
 
 <% if sector %>
+  <% display_name = spanish ? (sector.name_spanish.presence || sector.name) : sector.name %>
   <%= link_to taggings_path(sector_names_all: sector.name),
     data: { turbo_frame: "_top", sector_name: sector.name, controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
               class: "inline-flex items-center
@@ -21,7 +24,7 @@
                       px-3 py-1
                       text-sm font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text"><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
+    <span data-tag-link-loading-target="text"><%= display_name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/app/views/sectors/show.html.erb
+++ b/app/views/sectors/show.html.erb
@@ -20,6 +20,10 @@
                 <p class="text-gray-900"><%= @sector.name %></p>
               </div>
               <div class="mb-3">
+                <p class="font-bold text-gray-700">Name (Spanish):</p>
+                <p class="text-gray-900"><%= @sector.name_spanish.presence || "--" %></p>
+              </div>
+              <div class="mb-3">
                 <p class="font-bold text-gray-700">Published:</p>
                 <p class="text-gray-900"><%= @sector.published? %></p>
               </div>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -369,6 +369,11 @@
         </button>
 
         <div id="translations" class="hidden border border-gray-300 p-4 rounded-b-md">
+          <div class="mb-4">
+            <%= f.input :title_spanish,
+                        label: "Title (Spanish)",
+                        input_html: { class: "form-control" } %>
+          </div>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <% @workshop.decorate.display_spanish_fields.each do |field| %>
               <%= rhino_editor(f, field, label: field.to_s.humanize) %>

--- a/app/views/workshops/_show_body.html.erb
+++ b/app/views/workshops/_show_body.html.erb
@@ -90,6 +90,8 @@
     <div class="mt-4 ml-2 default-link">
       <!-- English / Details -->
       <div id="english-content" data-tabs-target="tabContent">
+        <%= render "show_tags", workshop: workshop, spanish: false %>
+
         <% if content_has_value?(workshop.rhino_extra_field) %>
           <div class="text-sm mb-4"><%= workshop.rhino_extra_field %></div>
         <% end %>
@@ -154,6 +156,12 @@
       <% if workshop.has_spanish_fields? %>
         <!-- Spanish -->
         <div id="spanish-content" data-tabs-target="tabContent" class="hidden">
+          <% if workshop.title_spanish.present? %>
+            <h2 class="text-2xl font-bold text-gray-900 mb-4"><%= workshop.title_spanish %></h2>
+          <% end %>
+
+          <%= render "show_tags", workshop: workshop, spanish: true %>
+
           <% workshop_sections_spanish = { "Objetivo" => workshop.rhino_objective_spanish,
                                            "Rango de edad" => workshop.age_range_spanish,
                                            "Materiales" => workshop.rhino_materials_spanish,

--- a/app/views/workshops/_show_lazy.html.erb
+++ b/app/views/workshops/_show_lazy.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "show_lazy" do %>
-  <%= render "show_tags", workshop: workshop %>
   <%= render "show_body", workshop: workshop %>
   <%= render "show_associations", workshop: workshop %>
 <% end %>

--- a/app/views/workshops/_show_tags.html.erb
+++ b/app/views/workshops/_show_tags.html.erb
@@ -1,22 +1,23 @@
+<% spanish ||= false %>
 <% tag_count = workshop.sectors.published.count + workshop.categories.published.count %>
 <div class="tags-section print:hidden p-2 mb-4" data-controller="dropdown">
   <button
     type="button"
     class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition"
     data-action="dropdown#toggle"
-    data-dropdown-payload-param='[{"workshop_tags_content":"hidden"}, {"workshop_tags_show_label":"hidden"}, {"workshop_tags_hide_label":"hidden"}, {"workshop_tags_chevron":"rotate-180"}]'>
-    <i id="workshop_tags_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 rotate-180"></i>
-    <span id="workshop_tags_show_label" class="hidden">Show tags (<%= tag_count %>)</span>
-    <span id="workshop_tags_hide_label">Hide tags (<%= tag_count %>)</span>
+    data-dropdown-payload-param='[{"workshop_tags_content<%= "_spanish" if spanish %>":"hidden"}, {"workshop_tags_show_label<%= "_spanish" if spanish %>":"hidden"}, {"workshop_tags_hide_label<%= "_spanish" if spanish %>":"hidden"}, {"workshop_tags_chevron<%= "_spanish" if spanish %>":"rotate-180"}]'>
+    <i id="workshop_tags_chevron<%= "_spanish" if spanish %>" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 rotate-180"></i>
+    <span id="workshop_tags_show_label<%= "_spanish" if spanish %>" class="hidden"><%= spanish ? "Mostrar etiquetas" : "Show tags" %> (<%= tag_count %>)</span>
+    <span id="workshop_tags_hide_label<%= "_spanish" if spanish %>"><%= spanish ? "Ocultar etiquetas" : "Hide tags" %> (<%= tag_count %>)</span>
   </button>
 
-  <div id="workshop_tags_content" class="mt-4 flex flex-wrap gap-2">
+  <div id="workshop_tags_content<%= "_spanish" if spanish %>" class="mt-4 flex flex-wrap gap-2">
     <% workshop.sectors.published.order(:name).each do |sector| %>
-      <%= render "sectors/tagging_label", sector: sector %>
+      <%= render "sectors/tagging_label", sector: sector, spanish: spanish %>
     <% end %>
     <% workshop.categories.includes(:category_type).published
          .order(Arel.sql("category_types.name, categories.position, categories.name")).each do |category| %>
-      <%= render "categories/tagging_label", category: category %>
+      <%= render "categories/tagging_label", category: category, spanish: spanish %>
     <% end %>
   </div>
 

--- a/db/migrate/20260307143000_add_name_spanish_to_categories_sectors_category_types.rb
+++ b/db/migrate/20260307143000_add_name_spanish_to_categories_sectors_category_types.rb
@@ -1,0 +1,7 @@
+class AddNameSpanishToCategoriesSectorsCategoryTypes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :categories, :name_spanish, :string
+    add_column :sectors, :name_spanish, :string
+    add_column :category_types, :name_spanish, :string
+  end
+end

--- a/db/migrate/20260307143100_add_title_spanish_to_workshops.rb
+++ b/db/migrate/20260307143100_add_title_spanish_to_workshops.rb
@@ -1,0 +1,5 @@
+class AddTitleSpanishToWorkshops < ActiveRecord::Migration[8.1]
+  def change
+    add_column :workshops, :title_spanish, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_02_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_07_143000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -299,6 +299,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_02_150000) do
     t.datetime "created_at", precision: nil, null: false
     t.integer "legacy_id"
     t.string "name", null: false
+    t.string "name_spanish"
     t.integer "position", null: false
     t.boolean "published", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -322,6 +323,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_02_150000) do
     t.string "display_text"
     t.string "legacy_id"
     t.string "name", null: false
+    t.string "name_spanish"
     t.boolean "profile_specific", default: false, null: false
     t.boolean "published", default: false, null: false
     t.boolean "story_specific", default: false, null: false
@@ -889,6 +891,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_02_150000) do
   create_table "sectors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "name", null: false
+    t.string "name_spanish"
     t.boolean "published", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_sectors_on_name", unique: true

--- a/spec/views/categories/_tagging_label.html.erb_spec.rb
+++ b/spec/views/categories/_tagging_label.html.erb_spec.rb
@@ -17,4 +17,25 @@ RSpec.describe "categories/_tagging_label", type: :view do
 
     expect(rendered).not_to include("Theme:")
   end
+
+  context "when spanish is true" do
+    it "shows Spanish name when present" do
+      category.update!(name_spanish: "Resiliencia")
+      type.update!(name_spanish: "Tema")
+
+      render partial: "categories/tagging_label",
+             locals: { category: category, spanish: true }
+
+      expect(rendered).to include("Tema:")
+      expect(rendered).to include("Resiliencia")
+    end
+
+    it "falls back to English name when Spanish name is blank" do
+      render partial: "categories/tagging_label",
+             locals: { category: category, spanish: true }
+
+      expect(rendered).to include("Theme:")
+      expect(rendered).to include("Resilience")
+    end
+  end
 end

--- a/spec/views/sectors/_tagging_label.html.erb_spec.rb
+++ b/spec/views/sectors/_tagging_label.html.erb_spec.rb
@@ -9,4 +9,23 @@ RSpec.describe "sectors/_tagging_label", type: :view do
     expect(rendered).to include("Survivors")
     expect(rendered).to include("sector_names_all=Survivors")
   end
+
+  context "when spanish is true" do
+    it "shows Spanish name when present" do
+      sector.update!(name_spanish: "Sobrevivientes")
+
+      render partial: "sectors/tagging_label",
+             locals: { sector: sector, spanish: true }
+
+      expect(rendered).to include("Sobrevivientes")
+      expect(rendered).not_to include(">Survivors<")
+    end
+
+    it "falls back to English name when Spanish name is blank" do
+      render partial: "sectors/tagging_label",
+             locals: { sector: sector, spanish: true }
+
+      expect(rendered).to include("Survivors")
+    end
+  end
 end

--- a/spec/views/workshops/_show_body.html.erb_spec.rb
+++ b/spec/views/workshops/_show_body.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "workshops/_show_body", type: :view do
+  let(:user) { create(:user) }
+  let(:workshop) { create(:workshop, created_by: user) }
+
+  before do
+    assign(:quotes, [])
+    assign(:leader_spotlights, [])
+  end
+
+  context "when workshop has no Spanish fields" do
+    before do
+      render partial: "workshops/show_body",
+             locals: { workshop: workshop.decorate }
+    end
+
+    it "shows Details tab instead of English" do
+      expect(rendered).to include("Details")
+      expect(rendered).not_to include("Español")
+    end
+
+    it "does not render the Spanish content tab" do
+      expect(rendered).not_to have_css("#spanish-content")
+    end
+  end
+
+  context "when workshop has title_spanish" do
+    before do
+      workshop.update!(title_spanish: "Taller de Arte")
+      render partial: "workshops/show_body",
+             locals: { workshop: workshop.decorate }
+    end
+
+    it "shows English and Español tabs" do
+      expect(rendered).to include("English")
+      expect(rendered).to include("Español")
+    end
+
+    it "renders the Spanish title in the Spanish tab" do
+      expect(rendered).to have_css("#spanish-content h2", text: "Taller de Arte")
+    end
+  end
+
+  context "when workshop has Spanish rich text content but no title_spanish" do
+    before do
+      workshop.update!(rhino_objective_spanish: "Un objetivo en español")
+      render partial: "workshops/show_body",
+             locals: { workshop: workshop.decorate }
+    end
+
+    it "shows English and Español tabs" do
+      expect(rendered).to include("English")
+      expect(rendered).to include("Español")
+    end
+
+    it "does not render a Spanish title heading" do
+      expect(rendered).not_to have_css("#spanish-content h2")
+    end
+  end
+end

--- a/spec/views/workshops/_show_tags.html.erb_spec.rb
+++ b/spec/views/workshops/_show_tags.html.erb_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe "workshops/_show_tags", type: :view do
+  let(:user) { create(:user) }
+  let(:workshop) { create(:workshop, created_by: user) }
+  let(:type) { create(:category_type, :published, name: "Theme") }
+  let(:category) { create(:category, :published, name: "Resilience", category_type: type) }
+  let(:sector) { create(:sector, :published, name: "Education") }
+
+  before do
+    workshop.categories << category
+    workshop.sectors << sector
+  end
+
+  context "when spanish is false" do
+    before do
+      render partial: "workshops/show_tags",
+             locals: { workshop: workshop, spanish: false }
+    end
+
+    it "shows English tag labels" do
+      expect(rendered).to include("Show tags")
+      expect(rendered).to include("Hide tags")
+    end
+
+    it "shows English category and sector names" do
+      expect(rendered).to include("Resilience")
+      expect(rendered).to include("Education")
+      expect(rendered).to include("Theme:")
+    end
+  end
+
+  context "when spanish is true" do
+    before do
+      category.update!(name_spanish: "Resiliencia")
+      type.update!(name_spanish: "Tema")
+      sector.update!(name_spanish: "Educación")
+
+      render partial: "workshops/show_tags",
+             locals: { workshop: workshop, spanish: true }
+    end
+
+    it "shows Spanish tag labels" do
+      expect(rendered).to include("Mostrar etiquetas")
+      expect(rendered).to include("Ocultar etiquetas")
+    end
+
+    it "shows Spanish category and sector names" do
+      expect(rendered).to include("Resiliencia")
+      expect(rendered).to include("Educación")
+      expect(rendered).to include("Tema:")
+    end
+  end
+
+  context "when spanish is true but no Spanish translations exist" do
+    before do
+      render partial: "workshops/show_tags",
+             locals: { workshop: workshop, spanish: true }
+    end
+
+    it "falls back to English names" do
+      expect(rendered).to include("Resilience")
+      expect(rendered).to include("Education")
+      expect(rendered).to include("Theme:")
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Workshop tags (categories, sectors) and titles currently only display in English, even when viewing the Spanish tab
- This adds `name_spanish` to categories, sectors, and category_types, and `title_spanish` to workshops
- When a workshop is viewed in Spanish mode, tags and title now display their Spanish translations (falling back to English when blank)

### How did you approach the change?

- Added `name_spanish` column to categories, sectors, and category_types tables
- Added `title_spanish` column to workshops table
- Updated admin forms and show pages to expose the new Spanish fields
- Updated tagging label partials to accept a `spanish` flag and conditionally display the Spanish name
- Moved tag rendering from above the English/Spanish tabs into each tab's content div, so switching tabs naturally shows the correct language
- Spanish title renders as an `<h2>` inside the Spanish tab content (only when present)
- Updated decorators with `title_spanish` / `detail_spanish` methods that fall back to English
- Updated `has_spanish_fields?` to also check `title_spanish`
- All strong params updated across controllers

### UI Testing Checklist

- [ ] Workshop show page: verify tags appear inside the English tab
- [ ] Workshop show page: switch to Español tab and verify Spanish tags and title display
- [ ] Workshop show page: verify fallback to English when no Spanish translations exist
- [ ] Category admin: verify Name (Spanish) field on new/edit forms and show page
- [ ] Sector admin: verify Name (Spanish) field on new/edit forms and show page
- [ ] Category type admin: verify Name (Spanish) field on new/edit forms and show page
- [ ] Workshop edit: verify Title (Spanish) field in the Spanish Translations section

### Anything else to add?

- Consistent with existing `_spanish` suffix column pattern used by workshop content fields
- No data migration needed — all Spanish fields are nullable and fall back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)