### PR TITLE
Show author credit preview on idea show pages

### DIFF
--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -43,6 +43,9 @@
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
           <%= @story_idea.author_credit_preference&.humanize || "—" %>
+          <% if @story_idea.author_credit_preference.present? %>
+            <span class="text-gray-500">(<%= @story_idea.author_credit %>)</span>
+          <% end %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Permission given:</span>

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -32,6 +32,9 @@
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
           <%= @workshop_idea.author_credit_preference&.humanize || "—" %>
+          <% if @workshop_idea.author_credit_preference.present? %>
+            <span class="text-gray-500">(<%= @workshop_idea.author_credit %>)</span>
+          <% end %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Windows audience:</span>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -44,6 +44,9 @@
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
           <%= @workshop_variation_idea.author_credit_preference&.humanize || "—" %>
+          <% if @workshop_variation_idea.author_credit_preference.present? %>
+            <span class="text-gray-500">(<%= @workshop_variation_idea.author_credit %>)</span>
+          <% end %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Permission given:</span>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- When reviewing idea submissions, admins see the author credit preference (e.g. "First name only") but can't tell what the actual display name will be without navigating elsewhere
- This adds the resolved credit name in parentheses so the preview is immediately visible, e.g. `First name only (Priya)`

### How did you approach the change?
- On each idea show page (`story_ideas`, `workshop_ideas`, `workshop_variation_ideas`), added a `<span>` after the humanized preference that calls `author_credit` to show the resolved display name
- Only renders the preview when a preference is actually set

### UI Testing Checklist
- [ ] Visit a story idea show page with an author credit preference set — verify preview appears in parens
- [ ] Visit a workshop idea show page — same check
- [ ] Visit a workshop variation idea show page — same check
- [ ] Visit an idea with no author credit preference — verify just "—" shows with no parens

### Anything else to add?
- The `author_credit` method is defined in the `AuthorCreditable` concern, already included by all three models

🤖 Generated with [Claude Code](https://claude.com/claude-code)