### PR TITLE
HOLD: Allow workshop log owners to edit their logs (waiting for workshop_log refactor)

### DIFF
--- a/app/policies/workshop_log_policy.rb
+++ b/app/policies/workshop_log_policy.rb
@@ -13,6 +13,10 @@ class WorkshopLogPolicy < ApplicationPolicy
     authenticated?
   end
 
+  def edit?
+    admin? || owner?
+  end
+
   def update?
     admin? || owner?
   end

--- a/spec/policies/workshop_log_policy_spec.rb
+++ b/spec/policies/workshop_log_policy_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe WorkshopLogPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, :admin) }
+  let(:owner_user) { build_stubbed(:user) }
+  let(:other_user) { build_stubbed(:user) }
+
+  let(:workshop_log) { build_stubbed(:workshop_log, created_by: owner_user) }
+
+  def policy_for(record: workshop_log, user:)
+    described_class.new(record, user: user)
+  end
+
+  describe "#edit?" do
+    context "with admin user" do
+      subject { policy_for(user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:edit?) }
+    end
+
+    context "with owner user" do
+      subject { policy_for(user: owner_user) }
+
+      it { is_expected.to be_allowed_to(:edit?) }
+    end
+
+    context "with other user" do
+      subject { policy_for(user: other_user) }
+
+      it { is_expected.not_to be_allowed_to(:edit?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:edit?) }
+    end
+  end
+
+  describe "#update?" do
+    context "with admin user" do
+      subject { policy_for(user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:update?) }
+    end
+
+    context "with owner user" do
+      subject { policy_for(user: owner_user) }
+
+      it { is_expected.to be_allowed_to(:update?) }
+    end
+
+    context "with other user" do
+      subject { policy_for(user: other_user) }
+
+      it { is_expected.not_to be_allowed_to(:update?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:update?) }
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Workshop log creators (owners) could not see the Edit button or access the edit form on the index, org show, or show views
- The `edit?` policy action was missing from `WorkshopLogPolicy`, so it fell through to `ApplicationPolicy#manage?` which is admin-only
- The `update?` action already allowed owners, creating an inconsistency

### How did you approach the change?

- Added `edit?` method to `WorkshopLogPolicy` with the same `admin? || owner?` rule as `update?`
- No view changes needed — all three views (index, show, org show) already gate the Edit button on `allowed_to?(:edit?, log)`
- Added `WorkshopLogPolicy` spec covering `edit?` and `update?` for admin, owner, other user, and anonymous contexts

### UI Testing Checklist

- [ ] Log in as a non-admin user who has created a workshop log
- [ ] Verify Edit button appears on workshop logs index
- [ ] Verify Edit button appears on workshop log show page
- [ ] Verify Edit button appears on organization show page (workshop logs section)
- [ ] Verify clicking Edit opens the edit form and saves successfully
- [ ] Verify non-owner, non-admin users do NOT see the Edit button

### Anything else to add?

- The views already had `allowed_to?(:edit?, ...)` guards — this was purely a policy gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)