### PR TITLE
Keep View registration button lit for public users via reg param

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -80,7 +80,7 @@ module Events
           checkout_session = create_stripe_checkout_session(registration, result.form_submission)
           redirect_to checkout_session.url, allow_other_host: true, status: :see_other
         else
-          redirect_to registration_ticket_path(registration.slug),
+          redirect_to registration_ticket_path(registration.slug, reg: params[:reg].presence),
                       notice: "You have been successfully registered!"
         end
       else
@@ -165,8 +165,8 @@ module Events
           },
           quantity: 1
         } ],
-        success_url: registration_ticket_url(registration.slug, checkout: "success"),
-        cancel_url: registration_ticket_url(registration.slug, checkout: "cancelled")
+        success_url: registration_ticket_url(registration.slug, checkout: "success", reg: params[:reg].presence),
+        cancel_url: registration_ticket_url(registration.slug, checkout: "cancelled", reg: params[:reg].presence)
       )
 
       registration.update!(checkout_session_id: checkout_session.id)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,31 @@
 module EventsHelper
+  # Separates registration slugs packed into a single `?reg=` param so public
+  # (logged-out) users keep the "View registration" button lit across several
+  # events in one session. A period is used because it never appears in a
+  # urlsafe_base64 slug and stays unescaped in a URL, keeping it human-readable.
+  REG_PARAM_DELIMITER = "."
+
+  # The registration slugs carried in the current request's `?reg=` param.
+  def reg_param_slugs
+    params[:reg].to_s.split(REG_PARAM_DELIMITER)
+  end
+
+  # The registration for this event that the visitor has "unlocked" via their
+  # `?reg=` param, if any. Slugs are the authorization token, so no ownership
+  # check is needed. Returns nil when none of the param slugs belong to the event.
+  def reg_param_registration(event)
+    slugs = reg_param_slugs
+    return if slugs.empty?
+    EventRegistration.where(slug: slugs, event_id: event.id).first
+  end
+
+  # The current `?reg=` slug set with `slug` merged in, for forwarding onward
+  # links after a registration so the new event's button stays lit alongside
+  # any events registered earlier this session.
+  def reg_param_with(slug)
+    (reg_param_slugs << slug).uniq.join(REG_PARAM_DELIMITER)
+  end
+
   # Stable anchor id for a registrant's row on the Onboarding matrix, so back-links
   # from detail pages can scroll to (and highlight) the row they came from.
   def onboarding_row_id(record_or_id)

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -24,7 +24,7 @@
 
     <!-- Title + badges -->
     <div class="flex flex-col gap-2 flex-1 min-w-0 pr-1 mr-4 mt-1">
-      <%= link_to event_path(event),
+      <%= link_to event_path(event, reg: params[:reg].presence),
                   class: "hover:underline block leading-tight",
                   data: { turbo_prefetch: false, turbo: false } do %>
         <%= title_with_badges(event).html_safe %>
@@ -34,6 +34,10 @@
 
   <!-- Location + Times + Buttons (bottom-aligned group) -->
   <% registered = current_user && event.actively_registered?(current_user.person) %>
+  <% unless registered
+       slug_registration = reg_param_registration(event)
+       slug_registered = slug_registration&.active?
+     end %>
   <div class="mt-auto flex flex-col gap-4">
     <div class="text-sm text-gray-700 leading-none">
       <% if event.location.present? %>
@@ -58,6 +62,11 @@
                   class: "btn px-3 py-2 text-xs uppercase leading-tight text-white hover:bg-white event-view-registration-btn",
                   style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 2px solid rgb(22, 101, 52);" %>
       <% end %>
+    <% elsif slug_registered %>
+      <%= link_to "View registration", registration_ticket_path(slug_registration.slug),
+                  data: { turbo_frame: "_top" },
+                  class: "btn px-3 py-2 text-xs uppercase leading-tight text-white hover:bg-white event-view-registration-btn",
+                  style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 2px solid rgb(22, 101, 52);" %>
     <% elsif event.ended? %>
       <span class="text-sm text-gray-500 italic">Event ended</span>
       <% if allowed_to?(:manage?, event) %>
@@ -82,7 +91,7 @@
         <% end %>
       <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
         <%= link_to "Register",
-                    new_event_public_registration_path(event),
+                    new_event_public_registration_path(event, reg: params[:reg].presence),
                     data: { turbo_frame: "_top" },
                     class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
       <% end %>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -1,7 +1,7 @@
 <% instance ||= 1 %>
 <% button_text ||= "Register" %>
 <% registered = event.actively_registered?(current_user&.person) %>
-<% slug_registration = params[:reg].present? ? EventRegistration.find_by(slug: params[:reg], event_id: event.id) : nil %>
+<% slug_registration = reg_param_registration(event) %>
 <% slug_registered = slug_registration&.active? %>
 <% slug_cancelled = slug_registration.present? && slug_registration.status == "cancelled" %>
 <%= tag.div id: dom_id(event.object, "registration_section_#{instance}"), class: "registration-section flex flex-col items-center gap-4 mb-6" do %>
@@ -29,13 +29,13 @@
                           style: "font-family: 'Telefon Bold', sans-serif;" %>
           <% else %>
             <%= link_to button_text,
-                        new_event_public_registration_path(event),
+                        new_event_public_registration_path(event, reg: params[:reg].presence),
                         class: "btn btn-accent px-10 py-2 text-2xl uppercase",
                         style: "font-family: 'Telefon Bold', sans-serif;" %>
           <% end %>
         <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
           <%= link_to button_text,
-                      new_event_public_registration_path(event),
+                      new_event_public_registration_path(event, reg: params[:reg].presence),
                       class: "btn btn-accent px-10 py-2 text-2xl uppercase",
                       style: "font-family: 'Telefon Bold', sans-serif;" %>
         <% end %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -94,7 +94,7 @@
         </div>
       <% end %>
 
-      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2", data: { turbo: !@event.cost_cents.to_i.positive? } do |f| %>
+      <%= form_with url: event_public_registration_path(@event, reg: params[:reg].presence), method: :post, local: true, class: "space-y-2", data: { turbo: !@event.cost_cents.to_i.positive? } do |f| %>
 
         <% if @scholarship %>
           <input type="hidden" name="scholarship_requested" value="true">

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "public") %>
 <div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
-  <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+  <%= link_to event_path(@event_registration.event, reg: reg_param_with(@event_registration.slug)), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
   <% end %>
   <div class="ml-auto flex gap-2">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,7 +17,7 @@
 <% else %>
 <!-- Top Right Actions -->
 <div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <%= link_to "← Events", events_path(reg: params[:reg].presence), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <div class="ml-auto flex flex-wrap gap-1">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% if @event.event_registrations.active.exists? %>

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe "Events::Registrations", type: :request do
         get registration_ticket_path(registration.slug)
         expect(response).to have_http_status(:success)
       end
+
+      it "merges this slug into the reg param on the back-to-event link" do
+        prior = create(:event_registration, registrant: create(:person))
+        get registration_ticket_path(registration.slug, reg: prior.slug)
+        expect(response.body).to include("reg=#{prior.slug}.#{registration.slug}")
+      end
     end
 
     context "as an admin" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -36,6 +36,33 @@ RSpec.describe "Events", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "shows a View registration link on the card when an active reg param is present" do
+      published_event = create(:event, :published)
+      sign_in user
+      registration = create(:event_registration, event: published_event, registrant: create(:person))
+      get events_path(reg: registration.slug)
+      expect(response.body).to include("href=\"#{registration_ticket_path(registration.slug)}\"")
+    end
+
+    it "does not show a View registration link for a cancelled reg param" do
+      published_event = create(:event, :published)
+      sign_in user
+      registration = create(:event_registration, event: published_event, registrant: create(:person), status: "cancelled")
+      get events_path(reg: registration.slug)
+      expect(response.body).not_to include("href=\"#{registration_ticket_path(registration.slug)}\"")
+    end
+
+    it "shows View registration links for several events packed into one reg param" do
+      event_a = create(:event, :published)
+      event_b = create(:event, :published)
+      sign_in user
+      reg_a = create(:event_registration, event: event_a, registrant: create(:person))
+      reg_b = create(:event_registration, event: event_b, registrant: create(:person))
+      get events_path(reg: "#{reg_a.slug}.#{reg_b.slug}")
+      expect(response.body).to include("href=\"#{registration_ticket_path(reg_a.slug)}\"")
+      expect(response.body).to include("href=\"#{registration_ticket_path(reg_b.slug)}\"")
+    end
+
     context "when user time_zone is set" do
       # 19:00 UTC = 12:00 noon PT = 15:00 (3 pm) ET (June 15, 2031 with DST)
       let(:utc_start) { Time.utc(2031, 6, 15, 19, 0, 0) }
@@ -71,6 +98,22 @@ RSpec.describe "Events", type: :request do
   end
 
   describe "GET /show" do
+    it "shows a View registration link when an active reg param is present" do
+      published_event = create(:event, :published)
+      sign_in user
+      registration = create(:event_registration, event: published_event, registrant: create(:person))
+      get event_path(published_event, reg: registration.slug)
+      expect(response.body).to include("href=\"#{registration_ticket_path(registration.slug)}\"")
+    end
+
+    it "does not show a View registration link for a cancelled reg param" do
+      published_event = create(:event, :published)
+      sign_in user
+      registration = create(:event_registration, event: published_event, registrant: create(:person), status: "cancelled")
+      get event_path(published_event, reg: registration.slug)
+      expect(response.body).not_to include("href=\"#{registration_ticket_path(registration.slug)}\"")
+    end
+
     context "when event has ended" do
       let(:ended_event) { create(:event, :published, :ended) }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Public (non-authenticated) users who register for events lose the "View registration" button as soon as they navigate away
- They have no logged-in identity to look the registration up by, so once the `?reg=` slug drops off the URL the button disappears on the events index and on event pages
- This keeps the button lit for the current browsing session, including for someone who registers for 2–3 events in a row

### How did you approach the change?

- Threads the registration slug through the URL as a `?reg=` param instead of persisting anything server-side
- Multiple slugs are packed into one param, period-delimited (`?reg=slugA.slugB`) — a period never occurs in a `urlsafe_base64` slug, so the URL stays clean and collision-free
- `EventsHelper` parses the param, matches a registration per event, and merges a new slug in after registering so earlier events stay lit
- The param is forwarded across the "← Events" / card / register links and the ticket page, and survives the Stripe checkout round-trip for paid events

### Why URL param instead of session?

- **Privacy on shared devices** — nothing is stored server-side, so the next person on a library/public computer never sees a prior visitor's "View registration" button (a session would have leaked it until expiry)
- **Simplicity** — no session state machine to store/clear/expire; the URL is the single source of truth and is naturally ephemeral (close the tab, it's gone)

### Trade-offs

- The button only persists along links that forward the param — a bookmark, the Home link, or a return visit tomorrow won't show it. This is intended for a single browsing session, and is arguably correct for anonymous users
- Cancelling/reactivating doesn't re-thread the full param set (rare action); the ticket page still shows the correct state

### UI Testing Checklist

- [ ] Register as public user → visit ticket → "← Events" → "View registration" appears on that event's card
- [ ] Click into the event from the index → button still visible
- [ ] Register for a second event in the same session → both cards show "View registration" on the index
- [ ] Paid event: register → pay via Stripe → return to ticket → button persists
- [ ] Cancelled registration → card shows "Register again", not "View registration"
- [ ] Logged-in user registration flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
