### PR TITLE
Add confirmed column with toggle to manage registrants

### DIFF
--- a/app/frontend/javascript/controllers/column_toggle_controller.js
+++ b/app/frontend/javascript/controllers/column_toggle_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="column-toggle"
+// Toggles visibility of table columns marked with a data attribute.
+
+export default class extends Controller {
+  static targets = ["toggle", "track", "knob"]
+
+  toggle() {
+    const checked = this.toggleTarget.checked
+    this.element.querySelectorAll("[data-column-toggle-col]").forEach((el) => {
+      el.classList.toggle("hidden", !checked)
+    })
+
+    if (this.hasTrackTarget) {
+      this.trackTarget.classList.toggle("bg-gray-300", !checked)
+      this.trackTarget.classList.toggle("bg-blue-600", checked)
+    }
+    if (this.hasKnobTarget) {
+      this.knobTarget.style.transform = checked ? "translateX(16px)" : ""
+    }
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -24,6 +24,9 @@ application.register("collection", CollectionController)
 import ConfirmEmailController from "./confirm_email_controller"
 application.register("confirm-email", ConfirmEmailController)
 
+import ColumnToggleController from "./column_toggle_controller"
+application.register("column-toggle", ColumnToggleController)
+
 import CommentEditToggleController from "./comment_edit_toggle_controller"
 application.register("comment-edit-toggle", CommentEditToggleController)
 

--- a/app/views/events/_manage_results.html.erb
+++ b/app/views/events/_manage_results.html.erb
@@ -1,8 +1,18 @@
 <%= turbo_frame_tag :manage_results do %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit">
-    <p class="text-sm text-gray-500 px-6 py-4 border-b border-gray-100">
-      <%= @event_registrations.size %> registrant<%= "s" if @event_registrations.size != 1 %>
-    </p>
+  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-controller="column-toggle">
+    <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+      <p class="text-sm text-gray-500">
+        <%= @event_registrations.size %> registrant<%= "s" if @event_registrations.size != 1 %>
+      </p>
+      <label class="inline-flex items-center gap-2 cursor-pointer select-none">
+        <span class="text-sm text-gray-500">Confirmed</span>
+        <input type="checkbox" data-column-toggle-target="toggle" data-action="column-toggle#toggle" class="sr-only">
+        <span class="relative inline-block w-9 h-5">
+          <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
+          <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+        </span>
+      </label>
+    </div>
     <% event_form_ids = @event.form_ids %>
     <% form_submissions = event_form_ids.any? ? PersonForm.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
     <% if @event_registrations.any? %>
@@ -16,6 +26,7 @@
               <% if @event.cost_cents.to_i > 0 %>
                 <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Payment status</th>
               <% end %>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col>Confirmed</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Attendance status</th>
               <th class="px-4 py-2"></th>
             </tr>
@@ -101,6 +112,16 @@
                     <% end %>
                   </td>
                 <% end %>
+                <td class="px-4 py-2 text-center align-top hidden" data-column-toggle-col>
+                  <% if person.user.present? %>
+                    <%= render "users/confirmed_status", user: person.user, invite_params: {} %>
+                  <% else %>
+                    <%= link_to "Create user",
+                                new_user_path(person_id: person.id),
+                                class: "btn btn-secondary-outline",
+                                data: { turbo_frame: "_top" } %>
+                  <% end %>
+                </td>
                 <td class="px-4 py-2 text-sm text-nowrap">
                   <%= render "event_registrations/attendance_status_badge", registration: registration %>
                 </td>

--- a/app/views/users/_confirmed_status.html.erb
+++ b/app/views/users/_confirmed_status.html.erb
@@ -1,0 +1,15 @@
+<% if user.confirmed_at.present? %>
+  <span class="fa fa-check-circle text-gray-300" title="Confirmed <%= l(user.confirmed_at, format: :long) %>"></span>
+<% elsif user.welcome_instructions_sent_at.present? %>
+  <% sent_info = "Confirmation instructions sent #{l(user.welcome_instructions_sent_at, format: :long)}"
+     sent_info += " by #{user.updated_by.name}" if user.updated_by.present? %>
+  <i class="fa-solid fa-clock text-warning" title="<%= sent_info %>"></i>
+<% else %>
+  <%= link_to "Invite",
+              send_welcome_instructions_user_path(user, **(invite_params || {})),
+              class: "btn btn-secondary-outline",
+              data: { turbo_method: :post, turbo_frame: "_top" } %>
+<% end %>
+<% if user.unconfirmed_email.present? %>
+  <i class="fa-solid fa-triangle-exclamation text-warning" title="Email change pending: <%= user.unconfirmed_email %>"></i>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
       <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8 space-y-6">
 
       <!-- Top links -->
-      <div class="flex flex-wrap justify-end gap-2">
+      <div class="flex flex-wrap justify-end items-center gap-2">
         <% unless @user.person %>
           <div class="admin-only bg-blue-100 p-2">
             Not associated with a person
@@ -20,6 +20,13 @@
                         new_person_path(user_id: @user.id),
                         class: "btn btn-warning px-2 py-1" %>
           </div>
+        <% end %>
+        <% unless @user.confirmed_at.present? %>
+          <%= button_to "Invite",
+                        send_welcome_instructions_user_path(@user),
+                        method: :post,
+                        form_class: "inline",
+                        class: "btn btn-secondary-outline" %>
         <% end %>
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:index?, User) %>

--- a/app/views/users/users_results.html.erb
+++ b/app/views/users/users_results.html.erb
@@ -38,27 +38,13 @@
 
             <!-- Confirmed -->
             <td class="px-4 py-2 text-center">
-              <% if user.confirmed_at.present? %>
-                <span class="fa fa-check-circle text-gray-300" title="Confirmed <%= l(user.confirmed_at, format: :long) %>"></span>
-              <% elsif user.welcome_instructions_sent_at.present? %>
-                <% sent_info = "Confirmation instructions sent #{l(user.welcome_instructions_sent_at, format: :long)}"
-                   sent_info += " by #{user.updated_by.name}" if user.updated_by.present? %>
-                <i class="fa-solid fa-clock text-warning" title="<%= sent_info %>"></i>
-              <% else %>
-                <%= link_to "Invite",
-                            send_welcome_instructions_user_path(user,
-                                                                search: params[:search],
-                                                                super_user: params[:super_user],
-                                                                access: params[:access],
-                                                                page: params[:page],
-                                                                number_of_items_per_page:
-                                                                  params[:number_of_items_per_page]),
-                            class: "btn btn-secondary-outline",
-                            data: { turbo_method: :post, turbo_frame: "_top" } %>
-              <% end %>
-              <% if user.unconfirmed_email.present? %>
-                <i class="fa-solid fa-triangle-exclamation text-warning" title="Email change pending: <%= user.unconfirmed_email %>"></i>
-              <% end %>
+              <%= render "users/confirmed_status", user: user, invite_params: {
+                search: params[:search],
+                super_user: params[:super_user],
+                access: params[:access],
+                page: params[:page],
+                number_of_items_per_page: params[:number_of_items_per_page]
+              } %>
             </td>
 
             <!-- Access -->

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -249,6 +249,60 @@ RSpec.describe "Events", type: :request do
 
     before { sign_in admin }
 
+    context "confirmed column toggle" do
+      it "renders the slide toggle for confirmed column" do
+        get manage_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('data-controller="column-toggle"')
+        expect(response.body).to include("Confirmed")
+      end
+
+      it "renders confirmed column header hidden by default" do
+        get manage_event_path(event)
+
+        expect(response.body).to include("data-column-toggle-col")
+      end
+
+      context "when registrant has a confirmed user" do
+        it "shows confirmed check icon" do
+          get manage_event_path(event)
+
+          expect(response.body).to include("fa-check-circle")
+        end
+      end
+
+      context "when registrant has an unconfirmed user with invite sent" do
+        let(:person) { create(:person, user: create(:user, :unconfirmed, welcome_instructions_sent_at: 1.day.ago)) }
+
+        it "shows clock icon" do
+          get manage_event_path(event)
+
+          expect(response.body).to include("fa-solid fa-clock")
+        end
+      end
+
+      context "when registrant has an unconfirmed user without invite" do
+        let(:person) { create(:person, user: create(:user, :unconfirmed)) }
+
+        it "shows invite button" do
+          get manage_event_path(event)
+
+          expect(response.body).to include("Invite")
+        end
+      end
+
+      context "when registrant has no user" do
+        let(:person) { create(:person, user: nil) }
+
+        it "shows create user link" do
+          get manage_event_path(event)
+
+          expect(response.body).to include("Create user")
+        end
+      end
+    end
+
     context "registration form icon" do
       let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
 

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -59,6 +59,43 @@ RSpec.describe "users/show", type: :view do
   end
 
   # --------------------------------------------------
+  # INVITE BUTTON
+  # --------------------------------------------------
+  context "when user is unconfirmed" do
+    let(:admin) { create(:user, :admin) }
+    let(:unconfirmed_user) do
+      create(:user, :unconfirmed, email: "unconfirmed@example.com")
+    end
+
+    before do
+      assign(:user, unconfirmed_user)
+      assign(:account_events, Ahoy::Event.none.paginate(page: 1))
+      assign(:comments, unconfirmed_user.comments.none.paginate(page: 1))
+      allow(view).to receive(:current_user).and_return(admin)
+      allow(view).to receive(:allowed_to?).and_return(true)
+      render
+    end
+
+    it "shows invite button" do
+      expect(rendered).to have_button("Invite")
+    end
+  end
+
+  context "when user is confirmed" do
+    let(:admin) { create(:user, :admin) }
+
+    before do
+      allow(view).to receive(:current_user).and_return(admin)
+      allow(view).to receive(:allowed_to?).and_return(true)
+      render
+    end
+
+    it "does not show invite button" do
+      expect(rendered).not_to have_button("Invite")
+    end
+  end
+
+  # --------------------------------------------------
   # NON-ADMIN VIEW
   # --------------------------------------------------
   context "when current user is not an admin" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Adds a toggleable "Confirmed" column to the event manage registrants page so admins can quickly see user confirmation status without leaving the page
- Extracts confirmed status display into a shared partial to eliminate duplication between users index and manage registrants
- Adds an Invite button to the user show page for unconfirmed users, matching what was already on the edit page

### How did you approach the change?

- Created a new Stimulus `column-toggle` controller that toggles visibility of columns marked with `data-column-toggle-col`
- Added a slide toggle switch (defaulted to off) in the manage registrants table header
- Extracted `users/_confirmed_status.html.erb` shared partial showing: check icon (confirmed), clock icon (invite sent), Invite button (user exists, not confirmed), or "Create user" link (no user account)
- Replaced inline confirmed status logic in `users/users_results.html.erb` with the shared partial
- Added Invite button to `users/show.html.erb` for unconfirmed users
- Added request specs for the confirmed column toggle on manage registrants
- Added view specs for the invite button on user show page

### UI Testing Checklist

- [ ] Visit event manage registrants page — slide toggle should be visible, column hidden by default
- [ ] Click toggle — Confirmed column appears with correct status icons
- [ ] Verify confirmed user shows check icon, invited user shows clock icon, uninvited user shows Invite button, person without user shows "Create user" link
- [ ] Visit users index — confirmed column still works with shared partial
- [ ] Visit user show page for unconfirmed user — Invite button visible
- [ ] Visit user show page for confirmed user — no Invite button

### Anything else to add?

- The Stimulus controller uses JS-driven toggle visuals (track color + knob transform) rather than CSS `peer` modifiers, since the toggle and columns are not siblings in the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)