### PR TITLE
Add PR workflow instructions to AI config files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,9 @@
 # This project is a Ruby on Rails application.
 
+# PRs
+- After completing work, create a pull request using `gh pr create`
+- Once the PR is created, prepend the PR number to the branch name (e.g., rename `maebeale/fix-login` to `maebeale/1234-fix-login`) using `git branch -m` and `git push origin -u` with the new name, then delete the old remote branch
+
 # Code style requirements:
 - Use modern Ruby syntax
 - Prefer early returns and guard clauses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,11 @@ Common factory traits across models:
 
 RuboCop linting on PRs and pushes to main.
 
+## PR Workflow
+
+- After completing work, create a pull request using `gh pr create`
+- Once the PR is created, prepend the PR number to the branch name (e.g., rename `maebeale/fix-login` to `maebeale/1234-fix-login`) using `git branch -m` and `git push origin -u` with the new name, then delete the old remote branch
+
 ## Key Library Usage
 
 | Need | Library |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,8 @@ bundle exec bundle-audit check --update
 
 ## PRs
 
+- After completing work, **create a pull request** using `gh pr create`
+- Once the PR is created, **prepend the PR number to the branch name** (e.g., rename `maebeale/fix-login` to `maebeale/1234-fix-login`) using `git branch -m` and `git push origin -u` with the new name, then delete the old remote branch
 - Use `docs/pull_request_template.md` for PR description structure
 - Use bullet points, not paragraphs, when filling out each section
 - Description must explain why the change was made, not just what


### PR DESCRIPTION
Closes [N/A]

### What is the goal of this PR and why is this important?
- Standardize AI agent workflow so PRs are created automatically and branch names include the PR number for easier tracking

### How did you approach the change?
- Added PR creation and branch renaming instructions to `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`
- Instructions tell agents to: (1) create a PR with `gh pr create`, (2) prepend the PR number to the branch name

### Anything else to add?
- No code changes, only AI instruction files updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)