### PR TITLE
Hide best time to call unless value present or admin

### DIFF
--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -164,7 +164,9 @@
       </div>
 
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 mb-4 shadow-sm">
-        <%= f.input :best_time_to_call %>
+        <% if @person.best_time_to_call.present? || params[:admin] == "true" %>
+          <%= f.input :best_time_to_call %>
+        <% end %>
 
         <%= f.simple_fields_for :contact_methods do |f| %>
           <%= render "contact_methods/contact_method_fields", f: f %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The "Best time to call" field adds clutter to the person form for most users
- Hide it unless there's already a value saved or the user accesses the form with `?admin=true`

### How did you approach the change?

- Wrapped the `best_time_to_call` input in a conditional in `app/views/people/_form.html.erb`
- Shows the field when `@person.best_time_to_call` is present (preserves existing data)
- Shows the field when `params[:admin] == "true"` (allows admins to set it when needed)

### UI Testing Checklist

- [ ] Visit person edit page — "Best time to call" field should be hidden
- [ ] Visit person edit page with `?admin=true` — field should appear
- [ ] Edit a person who has a "best time to call" value — field should appear

### Anything else to add?

Nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)