### PR TITLE
Add Vite CSP hints for future policy enablement

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,15 @@
 #     policy.img_src     :self, :https, :data
 #     policy.object_src  :none
 #     policy.script_src  :self, :https
+#     # Allow @vite/client to hot reload javascript changes in development
+#     # policy.script_src *policy.script_src, :unsafe_eval, "http://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
+#     # You may need to enable this in production as well depending on your setup.
+#     # policy.script_src *policy.script_src, :blob if Rails.env.test?
 #     policy.style_src   :self, :https
+#     # Allow @vite/client to hot reload style changes in development
+#     # policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
+#     # Allow @vite/client to hot reload changes in development
+#     # policy.connect_src *policy.connect_src, "ws://#{ ViteRuby.config.host_with_port }" if Rails.env.development?
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end


### PR DESCRIPTION
## Summary
- Adds commented-out CSP directives from the official `vite_rails` installer (`script_src`, `style_src`, `connect_src`) to `content_security_policy.rb`
- These serve as ready-to-use breadcrumbs for when CSP is enabled, covering Vite HMR in development and blob sources in test
- Inspired by PR #298 but only cherry-picks the CSP comments (includes the `connect_src` websocket hint that #298 missed)

## Test plan
- [ ] Verify app boots without errors (`bin/rails s`)
- [ ] Confirm no functional change — all additions are commented out

🤖 Generated with [Claude Code](https://claude.com/claude-code)