### PR TITLE
Fix bookmark display for Person and VideoRecording

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -7,7 +7,7 @@ class BookmarksController < ApplicationController
     authorize!
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
-      base_scope = authorized_scope(Bookmark.includes(bookmarkable: [ :primary_asset, :gallery_assets, :windows_type ]))
+      base_scope = authorized_scope(Bookmark.includes(:bookmarkable))
       filtered = base_scope.search(params)
       @sort = VALID_SORTS.include?(params[:sort]) ? params[:sort] : "created_at"
       @sort_direction = params[:direction] == "asc" ? "asc" : "desc"
@@ -30,7 +30,7 @@ class BookmarksController < ApplicationController
 
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
-      base_scope = authorized_scope(Bookmark.includes(bookmarkable: [ :primary_asset, :gallery_assets, :windows_type ]))
+      base_scope = authorized_scope(Bookmark.includes(:bookmarkable))
       filtered = base_scope.search(params, user: user)
       @sort = VALID_SORTS.include?(params[:sort]) ? params[:sort] : "created_at"
       @sort_direction = params[:direction] == "asc" ? "asc" : "desc"

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -195,6 +195,27 @@ RSpec.describe "Bookmarks", type: :request do
         }.to change(Bookmark, :count).by(-1)
       end
     end
+
+    context "with person and video_recording bookmarks" do
+      let(:person) { create(:person) }
+      let(:video_recording) { create(:video_recording, :published) }
+      let!(:person_bookmark) { create(:bookmark, user: regular_user, bookmarkable: person) }
+      let!(:video_bookmark) { create(:bookmark, user: regular_user, bookmarkable: video_recording) }
+
+      it "renders personal bookmarks with person bookmark via turbo frame" do
+        get personal_bookmarks_path,
+            headers: { "Turbo-Frame" => "personal_bookmarks_results" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(person.first_name)
+      end
+
+      it "renders personal bookmarks with video_recording bookmark via turbo frame" do
+        get personal_bookmarks_path,
+            headers: { "Turbo-Frame" => "personal_bookmarks_results" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(video_recording.title)
+      end
+    end
   end
 
   # ============================================================
@@ -296,6 +317,27 @@ RSpec.describe "Bookmarks", type: :request do
         expect {
           delete bookmark_path(video_recording_bookmark)
         }.to change(Bookmark, :count).by(-1)
+      end
+    end
+
+    context "with person and video_recording bookmarks" do
+      let(:person) { create(:person) }
+      let(:video_recording) { create(:video_recording, :published) }
+      let!(:person_bookmark) { create(:bookmark, user: regular_user, bookmarkable: person) }
+      let!(:video_bookmark) { create(:bookmark, user: admin, bookmarkable: video_recording) }
+
+      it "renders admin index with person bookmark via turbo frame" do
+        get bookmarks_path,
+            headers: { "Turbo-Frame" => "bookmarks_results" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(person.first_name)
+      end
+
+      it "renders admin index with video_recording bookmark via turbo frame" do
+        get bookmarks_path,
+            headers: { "Turbo-Frame" => "bookmarks_results" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(video_recording.title)
       end
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Fix broken bookmark display pages when Person or VideoRecording bookmarks exist
- The controller was eager loading `:primary_asset`, `:gallery_assets`, and `:windows_type` through the polymorphic `bookmarkable` association, which fails for types that lack those associations (Person has none; VideoRecording lacks `:windows_type`)

### How did you approach the change?

- Simplified `Bookmark.includes(bookmarkable: [:primary_asset, :gallery_assets, :windows_type])` to `Bookmark.includes(:bookmarkable)` in both `index` and `personal` actions
- Added request specs verifying Person and VideoRecording bookmarks render correctly in both admin and personal turbo frame views

### UI Testing Checklist

- [ ] Bookmark a Person, visit My Bookmarks — page renders without error
- [ ] Bookmark a VideoRecording, visit My Bookmarks — page renders without error
- [ ] Admin bookmarks index renders with mixed bookmarkable types
- [ ] Sorting and keyword filtering still work on both views

### Anything else to add?

- Nested `includes` through a polymorphic `belongs_to` causes Rails to call e.g. `Person.includes(:primary_asset)`, which raises `ActiveRecord::AssociationNotFoundError` since Person doesn't have that association
- The paginated results (25 per page) mean the N+1 trade-off from dropping nested includes is minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)