### PR TITLE
Rename Videos to Video Gallery and fix stale Tutorial seed refs

### DIFF
--- a/app/views/home/_video_recordings.html.erb
+++ b/app/views/home/_video_recordings.html.erb
@@ -1,4 +1,4 @@
-<% title ||= "Videos" %>
+<% title ||= "Video Gallery" %>
 
 <section class="py-10 bg-teal-50">
   <div class="max-w-6xl mx-auto px-4">

--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -1359,7 +1359,7 @@ faqs.each do |faq_data|
   end
 end
 
-puts "Creating Tutorials…"
+puts "Creating Video Recordings…"
 [
   {
     title: "Getting Started: Your First Workshop",
@@ -1425,7 +1425,7 @@ puts "Creating Tutorials…"
     featured: true,
     position: 6,
     is_instructional: false,
-    is_podcast: false
+    is_podcast: true
   }
 ].each do |video_data|
   VideoRecording.where(title: video_data[:title]).first_or_create!(video_data)
@@ -1448,7 +1448,7 @@ if amy && priya
     "Resource"             => Resource.order(:id).limit(2).to_a,
     "Story"                => Story.order(:id).limit(2).to_a,
     "StoryIdea"            => StoryIdea.order(:id).limit(2).to_a,
-    "Tutorial"             => Tutorial.order(:id).limit(2).to_a,
+    "VideoRecording"       => VideoRecording.order(:id).limit(2).to_a,
     "Workshop"             => Workshop.order(:id).limit(2).to_a,
     "WorkshopIdea"         => WorkshopIdea.order(:id).limit(2).to_a,
     "WorkshopLog"          => WorkshopLog.order(:id).limit(2).to_a,
@@ -1518,7 +1518,7 @@ view_targets = {
   "event" => Event.limit(3).to_a,
   "community_news" => CommunityNews.published.limit(3).to_a,
   "workshop_variation" => WorkshopVariation.published.limit(3).to_a,
-  "tutorial" => Tutorial.limit(3).to_a
+  "video_recording" => VideoRecording.limit(3).to_a
 }.reject { |_, v| v.empty? }
 
 # ── view.* events (populates "Content Types People View Most" pie chart) ──

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Home", type: :request do
+  describe "GET /" do
+    it "renders section titles as exactly two words" do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+
+      section_titles = response.body
+        .scan(%r{<h2 class="text-3xl font-semibold text-gray-900">(.*?)</h2>}m)
+        .flatten.map(&:strip)
+      expect(section_titles).not_to be_empty, "Expected to find section titles in h2 tags"
+
+      section_titles.each do |title|
+        words = title.split
+        expect(words.length).to eq(2),
+          "Expected section title \"#{title}\" to be two words, but it has #{words.length}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Rename the home index "Videos" section to "Video Gallery" so it follows the two-word pattern of all other sections (Featured Workshops, Community News, etc.)
- Fix broken `db:dev:seed` caused by stale `Tutorial` references left over from the VideoRecording refactor

### How did you approach the change?
- Changed default title in `_video_recordings.html.erb` from "Videos" to "Video Gallery"
- Replaced three stale `Tutorial` references in `dummy_dev_seeds.rb` with `VideoRecording`
- Made one seed video recording a podcast (`is_podcast: true`) for better type coverage
- Added a request spec that validates all home section titles are exactly two words

### UI Testing Checklist
- [ ] Home page renders "Video Gallery" as the section title
- [ ] `rake db:dev:seed` completes without errors

### Anything else to add?
The `Tutorial` model was renamed to `VideoRecording` in #1228 but these seed references were missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)