### PR TITLE
Fix TomSelect input rounding and height on video filters

### DIFF
--- a/app/frontend/javascript/controllers/searchable_checkbox_controller.js
+++ b/app/frontend/javascript/controllers/searchable_checkbox_controller.js
@@ -16,6 +16,9 @@ export default class extends Controller {
         onChange: () => {
           this.element.requestSubmit();
         },
+        onInitialize() {
+          this.control.classList.add("!rounded-lg", "!py-2");
+        },
       });
     });
   }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The Categories and Sectors TomSelect dropdowns on the video recordings filter had less rounding and were shorter than the adjacent standard form inputs
- This makes the filter form visually consistent

### How did you approach the change?
- Added `onInitialize` callback to TomSelect config in `searchable_checkbox_controller.js`
- Applies Tailwind `!rounded-lg` and `!py-2` classes to the TomSelect control element to match standard input styling

### UI Testing Checklist
- [ ] Video recordings index filter: Categories and Sectors dropdowns match height and rounding of the search text input and Video type select

### Anything else to add?
- Uses Tailwind important modifier (`!`) to override TomSelect's default inline styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)