### PR TITLE
Migrate user_permissions to user comments via rake task

### DIFF
--- a/lib/tasks/legacy_user_permissions_to_comments.rake
+++ b/lib/tasks/legacy_user_permissions_to_comments.rake
@@ -41,4 +41,3 @@ namespace :legacy do
     say.call "Created #{processed} comments on users (skipped #{skipped})."
   end
 end
-

--- a/spec/tasks/legacy_user_permissions_to_comments_spec.rb
+++ b/spec/tasks/legacy_user_permissions_to_comments_spec.rb
@@ -52,4 +52,3 @@ RSpec.describe "legacy:user_permissions_to_comments" do
     expect(user.comments.count).to eq(first_count)
   end
 end
-


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Closes [#1343 ]

### What is the goal of this PR and why is this important?
Ahead of dropping the users_permissions table, we'll use this rake task to migrate any permissions info into user comments

### How did you approach the change?
Adds rake task and corresponding spec


