### PR TITLE
Fix orphaned created_by_id in workshop_logs migration

### DIFF
--- a/lib/tasks/migrate_workshop_logs.rake
+++ b/lib/tasks/migrate_workshop_logs.rake
@@ -43,6 +43,21 @@ namespace :workshop_logs do
         WHERE r.#{wl_condition}
       SQL
 
+      # Leave a comment on workshop logs with orphaned created_by_id
+      if orphan_count > 0
+        now = Time.current.utc.strftime("%Y-%m-%d %H:%M:%S")
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          INSERT INTO comments (body, commentable_id, commentable_type, created_at, updated_at)
+          SELECT
+            CONCAT('[migration] Original created_by_id was ', r.created_by_id, ' but user no longer exists.'),
+            r.id, 'WorkshopLog', '#{now}', '#{now}'
+          FROM reports r
+          LEFT JOIN users u ON u.id = r.created_by_id
+          WHERE r.#{wl_condition} AND r.created_by_id IS NOT NULL AND u.id IS NULL
+        SQL
+        puts "  Added comments to #{orphan_count} workshop logs with orphaned created_by_id"
+      end
+
       # Update report_form_field_answers to point to workshop_logs
       rffa_count = ActiveRecord::Base.connection.execute(<<~SQL).first[0]
         SELECT COUNT(*) FROM report_form_field_answers


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The `workshop_logs:migrate_from_reports` rake task failed on staging because some reports reference deleted users via `created_by_id`
- The `workshop_logs` table has a FK constraint (`created_by_id` → `users.id`) that the `reports` table lacked, so the INSERT fails for orphaned references

### How did you approach the change?

- LEFT JOIN `users` in the INSERT so orphaned `created_by_id` values are set to NULL instead of failing the FK constraint
- Log the count of orphaned records during migration
- Create a `[migration]` comment on each affected workshop log recording the original `created_by_id` value for audit trail

### Anything else to add?

- This was discovered when running the migration on staging (40,802 records)
- The orphaned user references likely come from users deleted without cascading to their reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)