### PR TITLE
Add Instructional badge to video cards

### DIFF
--- a/app/helpers/title_display_helper.rb
+++ b/app/helpers/title_display_helper.rb
@@ -55,6 +55,17 @@ module TitleDisplayHelper
       )
     end
 
+    # --- Instructional badge ---
+    if record.respond_to?(:is_instructional) && record.is_instructional?
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-graduation-cap"), class: "inline-flex justify-center w-5")
+      fragments << content_tag(
+        :span,
+        icon + content_tag(:span, "Instructional", class: "ml-1"),
+        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
+              text-sm font-medium bg-teal-100 text-teal-800 whitespace-nowrap"
+      )
+    end
+
     # --- Promoted from story idea badge ---
     if record.respond_to?(:story_idea) && record.story_idea.present?
       icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-arrow-up-from-bracket"), class: "inline-flex justify-center w-5")

--- a/spec/helpers/title_display_helper_spec.rb
+++ b/spec/helpers/title_display_helper_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe TitleDisplayHelper, type: :helper do
+  before do
+    allow(helper).to receive(:controller_name).and_return("video_recordings")
+    allow(helper).to receive(:controller_path).and_return("video_recordings")
+    allow(helper).to receive(:user_signed_in?).and_return(false)
+  end
+
+  describe "#title_with_badges" do
+    context "when record is instructional" do
+      let(:record) { build(:video_recording, title: "Test Video", is_instructional: true) }
+
+      it "includes the Instructional badge" do
+        result = helper.title_with_badges(record)
+        expect(result).to include("Instructional")
+        expect(result).to include("fa-graduation-cap")
+      end
+    end
+
+    context "when record is not instructional" do
+      let(:record) { build(:video_recording, title: "Test Video", is_instructional: false) }
+
+      it "does not include the Instructional badge" do
+        result = helper.title_with_badges(record)
+        expect(result).not_to include("Instructional")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Video cards on the index page now show an "Instructional" badge when `is_instructional` is true
- Helps users quickly distinguish instructional videos from other content without opening them

### How did you approach the change?
- Added an "Instructional" badge to the shared `title_with_badges` helper using the existing badge pattern
- Teal color (`bg-teal-100 text-teal-800`) with a `fa-graduation-cap` icon
- Uses `respond_to?` guard so it only appears on models with the `is_instructional` attribute
- Added helper spec covering both instructional and non-instructional cases

### UI Testing Checklist
- [ ] Visit video recordings index — instructional videos show the teal badge
- [ ] Non-instructional videos do not show the badge
- [ ] Badge renders correctly alongside other badges (Unpublished, Public, Featured)

### Anything else to add?
- No migration needed — `is_instructional` already exists on `video_recordings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)