### PR TITLE
Hide empty gallery section and exclude primary image

### DIFF
--- a/app/views/workshops/_show_body.html.erb
+++ b/app/views/workshops/_show_body.html.erb
@@ -128,15 +128,12 @@
           </div>
         <% end %>
 
-        <% if workshop.primary_asset&.file&.attached? ||
-          workshop.gallery_assets.any? { |img| img.persisted? && img.file.attached? } %>
+        <% if workshop.gallery_assets.any? { |img| img.persisted? && img.file.attached? } %>
           <div class="workshop-gallery single-workshop-detail mb-4">
             <h3 class="text-lg font-semibold mb-1">Gallery</h3>
             <hr class="border-gray-300 mb-2">
 
             <div class="flex flex-wrap gap-4">
-                <%= render "assets/display_image", item: workshop.primary_asset, item_type: "Main", link: true %>
-
                 <% workshop.gallery_assets.each_with_index do |gallery_assets, idx| %>
                   <%= render "assets/display_image", item: gallery_assets, idx: idx, link: true %>
                 <% end %>

--- a/spec/system/workshops_spec.rb
+++ b/spec/system/workshops_spec.rb
@@ -114,6 +114,36 @@ RSpec.describe "Workshops", type: :system do
         sign_in(create(:user))
 
         workshop = create(:workshop, :published)
+        create(:gallery_asset, :with_file, owner: workshop)
+
+        visit workshop_path(workshop)
+
+        within ".workshop-gallery" do
+          links = all("a.display-image-link")
+          expect(links.length).to be >= 1
+
+          links.each do |link|
+            expect(link[:target]).to eq("_blank")
+            expect(link[:rel]).to include("noopener")
+          end
+        end
+      end
+
+      it "hides the gallery section when there are no gallery images" do
+        sign_in(create(:user))
+
+        workshop = create(:workshop, :published)
+        create(:primary_asset, :with_file, owner: workshop)
+
+        visit workshop_path(workshop)
+
+        expect(page).to have_no_css(".workshop-gallery")
+      end
+
+      it "does not show the primary image in the gallery" do
+        sign_in(create(:user))
+
+        workshop = create(:workshop, :published)
         create(:primary_asset, :with_file, owner: workshop)
         create(:gallery_asset, :with_file, owner: workshop)
 
@@ -121,12 +151,7 @@ RSpec.describe "Workshops", type: :system do
 
         within ".workshop-gallery" do
           links = all("a.display-image-link")
-          expect(links.length).to be >= 2
-
-          links.each do |link|
-            expect(link[:target]).to eq("_blank")
-            expect(link[:rel]).to include("noopener")
-          end
+          expect(links.length).to eq(1)
         end
       end
     end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The gallery section on the workshop show page was displaying even when only a primary image existed (no gallery images uploaded)
- The primary image was being duplicated in the gallery alongside gallery-specific images
- This cleans up the workshop show page by only showing the gallery when there are actual gallery images

### How did you approach the change?

- Removed the primary image condition from the gallery visibility check — now only renders when `gallery_assets` are present
- Removed the primary image render call from inside the gallery section
- Updated the existing gallery system spec to reflect the new behavior
- Added two new system specs: one verifying the gallery is hidden when no gallery images exist, another verifying the primary image is excluded from the gallery

### UI Testing Checklist

- [ ] Workshop show page with gallery images — gallery section visible, only gallery images shown
- [ ] Workshop show page with only a primary image — no gallery section visible
- [ ] Workshop show page with both primary and gallery images — gallery shows only gallery images

### Anything else to add?

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)