### PR TITLE
Send confirmation to pending email with reconfirmation-specific copy

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -22,9 +22,14 @@ class DeviseMailer < Devise::Mailer
     @record = record
     @token  = token
     @user = record
+    @reconfirmation = record.pending_reconfirmation?
 
-    opts[:subject] = "AWBW Portal: Welcome instructions for #{record.full_name}"
-    @mail   = super
+    opts[:subject] = if @reconfirmation
+      "AWBW Portal: Confirm your new email address"
+    else
+      "AWBW Portal: Welcome instructions for #{record.full_name}"
+    end
+    @mail = super
   end
 
   def unlock_instructions(record, token, opts = {})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -197,6 +197,16 @@ class User < ApplicationRecord
     []
   end
 
+  # Override Devise to always send confirmation to the pending email when present.
+  # Devise's default checks `pending_reconfirmation?` but can still route to the
+  # current email in some flows. This ensures the confirmation always targets the
+  # unconfirmed (new) email address.
+  def send_confirmation_instructions
+    generate_confirmation_token! unless @raw_confirmation_token
+    target = unconfirmed_email.presence || email
+    send_devise_notification(:confirmation_instructions, @raw_confirmation_token, to: target)
+  end
+
   def set_welcome_instructions_token!
     loop do
       self.welcome_instructions_token = Devise.friendly_token

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,50 +1,109 @@
-<h1>Welcome to the AWBW Portal!</h1>
+<% if @reconfirmation %>
+  <h1>Confirm your new email</h1>
 
-<div style="text-align: left;">
-  <p>
-    Hello <strong><%= @user.first_name_or_email %></strong>,
-  </p>
+  <div style="text-align: left;">
+    <p>
+      Hello <strong><%= @user.first_name_or_email %></strong>,
+    </p>
 
-  <p>
-    We invite you to join our Portal. Set your password below to log in and unlock our full library of curriculum and resources. Until you're logged in, only our public content will be visible.
-  </p>
-</div>
+    <p>
+      We received a request to change your AWBW Portal email address
+      to <strong><%= @user.unconfirmed_email %></strong>.
+    </p>
+  </div>
 
-<div style="
-background-color:#f3f4f6;
-  border-radius:6px;
-  padding:12px;
-  margin:16px 0;
-">
-  <p>
-    To get started, click the button below to set your password:
-  </p>
+  <div style="
+  background-color:#f3f4f6;
+    border-radius:6px;
+    padding:12px;
+    margin:16px 0;
+  ">
+    <p>
+      Click the button below to confirm this change:
+    </p>
 
-  <p>
-    <%= link_to "Set your password",
-                confirm_url(confirmation_token: @token),
-                target: "_blank",
-                style: "display:inline-block;
-                        padding:10px 16px;
-                        background:#2563eb;
-                        color:#ffffff;
-                        text-decoration:none;
-                        border-radius:6px;
-                        font-weight:bold;" %>
-  </p>
-</div>
+    <p>
+      <%= link_to "Confirm new email",
+                  confirm_url(confirmation_token: @token),
+                  target: "_blank",
+                  style: "display:inline-block;
+                          padding:10px 16px;
+                          background:#2563eb;
+                          color:#ffffff;
+                          text-decoration:none;
+                          border-radius:6px;
+                          font-weight:bold;" %>
+    </p>
+  </div>
 
-<div style="text-align: left;">
-  <p>
-    This invitation link will expire in 30 days and can only be used once.
-  </p>
+  <div style="text-align: left;">
+    <p>
+      If you did not request this change, you can safely ignore this email.
+      Your email address will remain unchanged.
+    </p>
 
-  <p>
-    If you have any questions, please visit our
-    <%= link_to "Contact us", contact_us_url %> page to connect with our staff.
-  </p>
-</div>
+    <p>
+      This link will expire in <%= distance_of_time_in_words(Devise.confirm_within) %>.
+    </p>
 
-<% content_for :fallback_url do %>
-  <%= confirm_url(confirmation_token: @token) %>
+    <p>
+      If you have any questions, please visit our
+      <%= link_to "Contact us", contact_us_url %> page to connect with our staff.
+    </p>
+  </div>
+
+  <% content_for :fallback_url do %>
+    <%= confirm_url(confirmation_token: @token) %>
+  <% end %>
+<% else %>
+  <h1>Welcome to the AWBW Portal!</h1>
+
+  <div style="text-align: left;">
+    <p>
+      Hello <strong><%= @user.first_name_or_email %></strong>,
+    </p>
+
+    <p>
+      We invite you to join our Portal. Set your password below to log in and unlock our full library of curriculum and resources. Until you're logged in, only our public content will be visible.
+    </p>
+  </div>
+
+  <div style="
+  background-color:#f3f4f6;
+    border-radius:6px;
+    padding:12px;
+    margin:16px 0;
+  ">
+    <p>
+      To get started, click the button below to set your password:
+    </p>
+
+    <p>
+      <%= link_to "Set your password",
+                  confirm_url(confirmation_token: @token),
+                  target: "_blank",
+                  style: "display:inline-block;
+                          padding:10px 16px;
+                          background:#2563eb;
+                          color:#ffffff;
+                          text-decoration:none;
+                          border-radius:6px;
+                          font-weight:bold;" %>
+    </p>
+  </div>
+
+  <div style="text-align: left;">
+    <p>
+      This invitation link will expire in 30 days and can only be used once.
+    </p>
+
+    <p>
+      If you have any questions, please visit our
+      <%= link_to "Contact us", contact_us_url %> page to connect with our staff.
+    </p>
+  </div>
+
+  <% content_for :fallback_url do %>
+    <%= confirm_url(confirmation_token: @token) %>
+  <% end %>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,3 +1,21 @@
+<% if @reconfirmation %>
+Confirm your new email
+======================
+
+Hello <%= @user.first_name_or_email %>,
+
+We received a request to change your AWBW Portal email address to <%= @user.unconfirmed_email %>.
+
+Confirm this change:
+<%= confirm_url(confirmation_token: @token) %>
+
+If you did not request this change, you can safely ignore this email. Your email address will remain unchanged.
+
+This link will expire in <%= distance_of_time_in_words(Devise.confirm_within) %>.
+
+If you have any questions, please visit our Contact us page to connect with our staff:
+<%= contact_us_url %>
+<% else %>
 Welcome to the AWBW Portal!
 ==========================
 
@@ -12,3 +30,4 @@ This invitation link will expire in 30 days and can only be used once.
 
 If you have any questions regarding this invitation, please visit our Contact us page to connect with our staff:
 <%= contact_us_url %>
+<% end %>

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -51,6 +51,50 @@ RSpec.describe DeviseMailer, type: :mailer do
     # so user_unlock_url route doesn't exist and the view can't render
   end
 
+  describe "#confirmation_instructions" do
+    context "when sending for initial signup (no pending reconfirmation)" do
+      it "uses the welcome subject line" do
+        mail = described_class.confirmation_instructions(user, token)
+
+        expect(mail.subject).to eq("AWBW Portal: Welcome instructions for #{user.full_name}")
+      end
+
+      it "includes welcome copy and password setup CTA" do
+        mail = described_class.confirmation_instructions(user, token)
+
+        expect(mail.body.encoded).to include("Welcome to the AWBW Portal!")
+        expect(mail.body.encoded).to include("Set your password")
+      end
+    end
+
+    context "when sending for email change (reconfirmation)" do
+      before do
+        user.skip_confirmation_notification!
+        user.update!(email: "new@example.com")
+      end
+
+      it "uses the email change subject line" do
+        mail = described_class.confirmation_instructions(user, token)
+
+        expect(mail.subject).to eq("AWBW Portal: Confirm your new email address")
+      end
+
+      it "includes email change copy instead of welcome copy" do
+        mail = described_class.confirmation_instructions(user, token)
+
+        expect(mail.body.encoded).to include("Confirm your new email")
+        expect(mail.body.encoded).not_to include("Welcome to the AWBW Portal!")
+        expect(mail.body.encoded).not_to include("Set your password")
+      end
+
+      it "shows the new email address in the body" do
+        mail = described_class.confirmation_instructions(user, token)
+
+        expect(mail.body.encoded).to include(user.unconfirmed_email)
+      end
+    end
+  end
+
   describe "#create_notification_record" do
     let(:notification) { build(:notification) }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- When an admin changes a user's email, the confirmation email was sent to the old email instead of the new (pending) one
- The confirmation email used welcome/invite copy ("Set your password") even for existing users confirming an email change — confusing for the recipient

### How did you approach the change?

- Override `send_confirmation_instructions` on User to always route to `unconfirmed_email` when present, rather than relying on Devise's `pending_reconfirmation?` check
- Branch the DeviseMailer `confirmation_instructions` subject line: welcome vs reconfirmation
- Branch the HTML and text email templates with appropriate copy for each scenario:
  - **Welcome invite** (new users): unchanged — "Welcome to the AWBW Portal!", "Set your password"
  - **Reconfirmation** (email change): "Confirm your new email", shows the new email address, safe-to-ignore note
- Add mailer specs covering both branches (subject, body content, new email shown)

### UI Testing Checklist

- [ ] Create a new user → they receive the welcome invite email with "Set your password"
- [ ] Change an existing confirmed user's email → confirmation email goes to the **new** email with "Confirm your new email" copy
- [ ] Use "Resend confirmation email" on confirm_email_manual page for a pending email change → email goes to the pending email
- [ ] Use the interstitial "Continue" button after email change → email goes to the pending email

### Anything else to add?

- The `ProcessEmailManualConfirm` and `ProcessEmailChange` services both call `send_confirmation_instructions`, so the User model override fixes both flows in one place


🤖 Generated with [Claude Code](https://claude.com/claude-code)