### PR TITLE
Fix workshop_id population in workshop_logs migration

### DIFF
--- a/lib/tasks/migrate_workshop_logs.rake
+++ b/lib/tasks/migrate_workshop_logs.rake
@@ -35,7 +35,8 @@ namespace :workshop_logs do
         SELECT
           r.id,
           CASE WHEN u.id IS NOT NULL THEN r.created_by_id ELSE #{orphaned_user.id} END,
-          r.organization_id, r.windows_type_id, r.workshop_id,
+          r.organization_id, r.windows_type_id,
+          COALESCE(r.workshop_id, CASE WHEN r.owner_type = 'Workshop' THEN r.owner_id END),
           r.date, r.rating, COALESCE(r.external_workshop_title, r.workshop_name),
           r.children_first_time, r.children_ongoing,
           r.teens_first_time, r.teens_ongoing, r.adults_first_time, r.adults_ongoing,

--- a/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
+++ b/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
@@ -142,6 +142,33 @@ RSpec.describe "workshop_logs:migrate_from_reports" do
     expect(qiq[0]).to eq("WorkshopLog")
   end
 
+  it "populates workshop_id from owner_id when owner_type is Workshop" do
+    report_id = insert_report_as_workshop_log(
+      workshop_id: nil,
+      owner_type: "Workshop",
+      owner_id: workshop.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to eq(workshop.id)
+  end
+
+  it "prefers workshop_id over owner_id when both are present" do
+    other_workshop = create(:workshop)
+    report_id = insert_report_as_workshop_log(
+      workshop_id: workshop.id,
+      owner_type: "Workshop",
+      owner_id: other_workshop.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to eq(workshop.id)
+  end
+
   it "does not delete WorkshopLog records from reports table" do
     insert_report_as_workshop_log
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The `workshop_logs:migrate_from_reports` rake task wasn't populating `workshop_id` for reports that stored the workshop association via `owner_type`/`owner_id` instead of `workshop_id`
- This left migrated workshop_logs with NULL `workshop_id`, breaking workshop associations

### How did you approach the change?

- Used `COALESCE(r.workshop_id, CASE WHEN r.owner_type = 'Workshop' THEN r.owner_id END)` so the migration prefers `workshop_id` when present and falls back to `owner_id` for polymorphic associations
- Added two specs: one for the `owner_id` fallback case, one verifying `workshop_id` takes precedence when both are present

### Anything else to add?

- The rake task already clears existing workshop_logs before re-inserting, so re-running it will fix previously migrated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)