### PR TITLE
Fix workshop_logs rake task on unseeded environments

### DIFF
--- a/lib/tasks/migrate_workshop_logs.rake
+++ b/lib/tasks/migrate_workshop_logs.rake
@@ -17,7 +17,11 @@ namespace :workshop_logs do
         "SELECT COUNT(*) AS c FROM reports WHERE #{wl_condition}"
       ).first[0]
       # Reassign orphaned created_by_id to the "Orphaned Reports" user
-      orphaned_user = User.find_by!(email: "orphaned_reports@awbw.org")
+      orphaned_user = User.find_or_create_by!(email: "orphaned_reports@awbw.org") do |u|
+        u.first_name = "Orphaned Reports"
+        u.last_name = "User"
+        u.password = SecureRandom.hex(20)
+      end
       orphan_count = ActiveRecord::Base.connection.execute(
         "SELECT COUNT(*) FROM reports r LEFT JOIN users u ON u.id = r.created_by_id WHERE r.#{wl_condition} AND r.created_by_id IS NOT NULL AND u.id IS NULL"
       ).first[0]


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The `workshop_logs:migrate_from_reports` rake task fails on staging because it uses `find_by!` for the `orphaned_reports@awbw.org` user, which doesn't exist in unseeded environments

### How did you approach the change?

- Changed `User.find_by!` to `User.find_or_create_by!` so the task creates the orphaned reports user if it doesn't already exist
- Matches the same pattern already used in `db/seeds.rb`

### Anything else to add?

- No UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)