### PR TITLE
Add publishing test results to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
 
-      - name: Run tests
-        run: bundle exec rspec
+      - name: Run tests and publish results
+        run: bundle exec rspec --format progress --format json --out tmp/rspec_results.json
         env:
           RAILS_ENV: test
           # AWS credentials
@@ -85,3 +85,10 @@ jobs:
           SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           CI: "true"
+
+      - name: Publish test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: rspec-results
+          path: tmp/rspec_results.json

--- a/.github/workflows/sanity-check-main.yml
+++ b/.github/workflows/sanity-check-main.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           RAILS_ENV: test
           CI: "true"
-        run: bundle exec rspec --format progress --format json --out tmp/rspec_results.json
+        run: bundle exec rspec
 
       - name: Generate coverage badge
         run: ruby bin/coverage_badge.rb coverage/summary.json coverage_badge.svg
@@ -68,10 +68,3 @@ jobs:
           publish_files: coverage_badge.svg
           destination_dir: badges/main
           keep_files: true
-
-      - name: Publish test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: rspec-results
-          path: tmp/rspec_results.json


### PR DESCRIPTION
Added publishing of test results to workflow

<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Closes #594 

### What is the goal of this PR and why is this important?
As part of discussions regarding #594, it was agreed that we publish test results as part of AWBW's CI pipeline runs.
Code coverage results are being published as a result of merging #110 and this PR builds on that work.

### How did you approach the change?
I did some research regarding how publishing of test results is handled in other open source Rails projects and picked what I thought would work for the project at its current stage. Some notes regarding what I didn't include:

1. Publishing of Capybara reports
I haven't added Capybara because it presently isn't being run in the current pipeline. 
Would we want to save screenshots of failed feature tests? In which case I would be happy to add running them to the pipeline and saving the screenshot results as part of the workflow.

2. In #55 (parent of #594), there is the following to-do item
> - [ ]  Runs the tests in an environment as similar to production as possible (e.g. if CD results in Docker images being deployed then try to run the tests inside of a similar Docker image)

From looking at the current codebase, I saw a a [`Capfile`](https://github.com/rubyforgood/awbw/blob/main/Capfile), a [`Dockerfile`](https://github.com/rubyforgood/awbw/blob/main/Dockerfile) and a [`Procfile`](https://github.com/rubyforgood/awbw/blob/main/Procfile.dev) for development. With this under consideration, what would "an environment as similar to production as possible" mean?

It may be that current pipeline suffices and we can validate as we go depending on need e.g. having a workflow for building and publishing a `Dockerfile`.

### Anything else to add?
<!-- Any alternative approaches you considered? Special notes for reviewers? -->
**Reviewer's Note**: I put the changes in the `sanity-check-main.yml` file since that's where the code coverage job is but most projects seem to put it in `ci.yml`. Let me know if I should keep the changes as is or move them to `ci.yml`.

Thanks in advance for the review :pray: :blush: 
