### PR TITLE
Populate workshop_id from owner_id in workshop_logs migration

### DIFF
--- a/lib/tasks/migrate_workshop_logs.rake
+++ b/lib/tasks/migrate_workshop_logs.rake
@@ -39,7 +39,8 @@ namespace :workshop_logs do
         SELECT
           r.id,
           CASE WHEN u.id IS NOT NULL THEN r.created_by_id ELSE #{orphaned_user.id} END,
-          r.organization_id, r.windows_type_id, r.workshop_id,
+          r.organization_id, r.windows_type_id,
+          CASE WHEN r.workshop_id IS NOT NULL AND r.workshop_id != 0 THEN r.workshop_id WHEN r.owner_type = 'Workshop' AND r.owner_id IS NOT NULL THEN r.owner_id ELSE NULL END,
           r.date, r.rating, COALESCE(r.external_workshop_title, r.workshop_name),
           r.children_first_time, r.children_ongoing,
           r.teens_first_time, r.teens_ongoing, r.adults_first_time, r.adults_ongoing,

--- a/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
+++ b/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
@@ -142,6 +142,72 @@ RSpec.describe "workshop_logs:migrate_from_reports" do
     expect(qiq[0]).to eq("WorkshopLog")
   end
 
+  it "populates workshop_id from owner_id when workshop_id is null and owner_type is Workshop" do
+    report_id = insert_report_as_workshop_log(
+      workshop_id: nil,
+      owner_type: "Workshop",
+      owner_id: workshop.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to eq(workshop.id)
+  end
+
+  it "falls back to owner_id when workshop_id is zero" do
+    report_id = insert_report_as_workshop_log(
+      workshop_id: 0,
+      owner_type: "Workshop",
+      owner_id: workshop.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to eq(workshop.id)
+  end
+
+  it "does not use owner_id when owner_type is not Workshop" do
+    report_id = insert_report_as_workshop_log(
+      workshop_id: nil,
+      owner_type: "Organization",
+      owner_id: organization.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to be_nil
+  end
+
+  it "sets workshop_id to null when workshop_id is absent and no workshop owner" do
+    report_id = insert_report_as_workshop_log(
+      workshop_id: nil,
+      owner_type: nil,
+      owner_id: nil
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to be_nil
+  end
+
+  it "preserves valid integer workshop_id over owner_id" do
+    other_workshop = create(:workshop)
+    report_id = insert_report_as_workshop_log(
+      workshop_id: workshop.id,
+      owner_type: "Workshop",
+      owner_id: other_workshop.id
+    )
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    wl_workshop_id = conn.execute("SELECT workshop_id FROM workshop_logs WHERE id = #{report_id}").first[0]
+    expect(wl_workshop_id).to eq(workshop.id)
+  end
+
   it "does not delete WorkshopLog records from reports table" do
     insert_report_as_workshop_log
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The workshop_logs migration rake task was copying `workshop_id` directly from the reports table, but only 5 of ~40k records had it populated
- The actual workshop association for most WorkshopLog reports was stored via the polymorphic owner (`owner_type='Workshop'`, `owner_id`), not `workshop_id`
- This fix correctly backfills ~34k workshop_log records with their workshop association

### How did you approach the change?

- Updated the `INSERT INTO workshop_logs` SQL in the rake task to use a `CASE` expression:
  1. Use `workshop_id` if non-null and non-zero
  2. Fall back to `owner_id` when `owner_type = 'Workshop'` and `owner_id` is present
  3. Otherwise `NULL` (valid per model — `belongs_to :workshop, optional: true`)
- Added 5 test cases covering: owner_id fallback, zero workshop_id fallback, non-Workshop owner_type ignored, null fallback, and workshop_id preserved over owner_id

### Anything else to add?

- ~6,548 records have neither `workshop_id` nor a Workshop owner — these will get `NULL`, which is valid per the model's `workshop_or_external_title_present` validation (they should have an `external_workshop_title` instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)