### PR TITLE
Remove branch rename instruction from AI files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,7 +172,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 - **Push to a draft PR early** — push commits and create a draft PR (`gh pr create --draft`) as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
 - After completing work, **mark the PR ready** using `gh pr ready`
-- Once the PR is created, **prepend the PR number to the branch name** (e.g., rename `maebeale/fix-login` to `maebeale/1234-fix-login`) using `git branch -m` and `git push origin -u` with the new name, then delete the old remote branch
+- **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
 - Use bullet points, not paragraphs, when filling out each section
 - Description must explain why the change was made, not just what

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 - **Push to a draft PR early** — push commits and create a draft PR (`gh pr create --draft`) as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
 - After completing work, **mark the PR ready** using `gh pr ready`
-- Once the PR is created, **prepend the PR number to the branch name** (e.g., rename `maebeale/fix-login` to `maebeale/1234-fix-login`) using `git branch -m` and `git push origin -u` with the new name, then delete the old remote branch
+- **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
 - Use bullet points, not paragraphs, when filling out each section
 - Description must explain why the change was made, not just what


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The AI instruction files told agents to rename branches to prepend the PR number after creating a PR
- This doesn't work — deleting the old remote branch auto-closes the PR on GitHub, and the head ref can't be changed after creation
- There are lots of closed copies of PR's now where AI was trying to get the pr number in the branch name, causing a chicken and egg situation

### How did you approach the change?

- Replaced the branch rename instruction with a note not to rename branches after PR creation
- Updated both `CLAUDE.md` and `.github/copilot-instructions.md` to stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)