### PR TITLE
Fix workshop_logs rake task idempotency and preserve report_id

### DIFF
--- a/lib/tasks/migrate_workshop_logs.rake
+++ b/lib/tasks/migrate_workshop_logs.rake
@@ -8,7 +8,43 @@ namespace :workshop_logs do
       count = ActiveRecord::Base.connection.execute("SELECT COUNT(*) AS c FROM workshop_logs").first
       if count && count[0] > 0
         puts "Clearing #{count[0]} legacy record(s) from workshop_logs..."
-        ActiveRecord::Base.connection.execute("UPDATE report_form_field_answers SET workshop_log_id = NULL WHERE workshop_log_id IS NOT NULL")
+
+        # Clear workshop_log_id from previously migrated report_form_field_answers
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          UPDATE report_form_field_answers
+          SET workshop_log_id = NULL
+          WHERE workshop_log_id IS NOT NULL
+        SQL
+
+        # Revert polymorphic types back to Report for re-migration
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          UPDATE active_storage_attachments
+          SET record_type = 'Report'
+          WHERE record_type = 'WorkshopLog'
+            AND record_id IN (SELECT id FROM workshop_logs)
+        SQL
+
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          UPDATE assets
+          SET owner_type = 'Report'
+          WHERE owner_type = 'WorkshopLog'
+            AND owner_id IN (SELECT id FROM workshop_logs)
+        SQL
+
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          UPDATE quotable_item_quotes
+          SET quotable_type = 'Report'
+          WHERE quotable_type = 'WorkshopLog'
+            AND quotable_id IN (SELECT id FROM workshop_logs)
+        SQL
+
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          UPDATE sectorable_items
+          SET sectorable_type = 'Report'
+          WHERE sectorable_type = 'WorkshopLog'
+            AND sectorable_id IN (SELECT id FROM workshop_logs)
+        SQL
+
         ActiveRecord::Base.connection.execute("DELETE FROM workshop_logs")
       end
 
@@ -50,7 +86,7 @@ namespace :workshop_logs do
         WHERE r.#{wl_condition}
       SQL
 
-      # Update report_form_field_answers to point to workshop_logs
+      # Populate workshop_log_id on report_form_field_answers (keep report_id)
       rffa_count = ActiveRecord::Base.connection.execute(<<~SQL).first[0]
         SELECT COUNT(*) FROM report_form_field_answers
         WHERE report_id IN (SELECT id FROM reports WHERE #{wl_condition})
@@ -58,7 +94,7 @@ namespace :workshop_logs do
       puts "Updating #{rffa_count} report_form_field_answers..."
       ActiveRecord::Base.connection.execute(<<~SQL)
         UPDATE report_form_field_answers
-        SET workshop_log_id = report_id, report_id = NULL
+        SET workshop_log_id = report_id
         WHERE report_id IN (SELECT id FROM reports WHERE #{wl_condition})
       SQL
 

--- a/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
+++ b/spec/lib/tasks/migrate_workshop_logs_rake_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "workshop_logs:migrate_from_reports" do
     # only processes this test's report
     conn.execute("UPDATE report_form_field_answers SET workshop_log_id = NULL WHERE workshop_log_id IS NOT NULL")
     conn.execute("DELETE FROM workshop_logs")
-    conn.execute("UPDATE report_form_field_answers SET report_id = NULL WHERE report_id IN (SELECT id FROM reports WHERE type = 'WorkshopLog')")
     conn.execute("DELETE FROM reports WHERE type = 'WorkshopLog'")
   end
 
@@ -97,8 +96,58 @@ RSpec.describe "workshop_logs:migrate_from_reports" do
 
     rffa = conn.execute("SELECT report_id, workshop_log_id FROM report_form_field_answers WHERE workshop_log_id = #{report_id}").first
     expect(rffa).to be_present
-    expect(rffa[0]).to be_nil # report_id nulled
+    expect(rffa[0]).to eq(report_id) # report_id preserved
     expect(rffa[1]).to eq(report_id) # workshop_log_id set
+  end
+
+  it "does not modify report_id on any associated tables" do
+    report_id = insert_report_as_workshop_log
+    form_field = create(:form_field)
+    answer_option = create(:answer_option)
+    conn.execute(<<~SQL)
+      INSERT INTO report_form_field_answers (report_id, form_field_id, answer_option_id, answer, created_at, updated_at)
+      VALUES (#{report_id}, #{form_field.id}, #{answer_option.id}, 'test answer', NOW(), NOW())
+    SQL
+    blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new("test"), filename: "test.txt")
+    conn.execute(<<~SQL)
+      INSERT INTO active_storage_attachments (name, record_type, record_id, blob_id, created_at)
+      VALUES ('image', 'Report', #{report_id}, #{blob.id}, NOW())
+    SQL
+    conn.execute(<<~SQL)
+      INSERT INTO assets (owner_type, owner_id, type, created_at, updated_at)
+      VALUES ('Report', #{report_id}, 'GalleryAsset', NOW(), NOW())
+    SQL
+    quote = create(:quote)
+    conn.execute(<<~SQL)
+      INSERT INTO quotable_item_quotes (quotable_type, quotable_id, quote_id, created_at, updated_at)
+      VALUES ('Report', #{report_id}, #{quote.id}, NOW(), NOW())
+    SQL
+    conn.execute(<<~SQL)
+      INSERT INTO sectorable_items (sectorable_type, sectorable_id, created_at, updated_at)
+      VALUES ('Report', #{report_id}, NOW(), NOW())
+    SQL
+
+    Rake::Task["workshop_logs:migrate_from_reports"].invoke
+
+    # report_form_field_answers: report_id preserved
+    rffa = conn.execute("SELECT report_id FROM report_form_field_answers WHERE workshop_log_id = #{report_id}").first
+    expect(rffa[0]).to eq(report_id)
+
+    # active_storage_attachments: record_id preserved
+    asa = conn.execute("SELECT record_id FROM active_storage_attachments WHERE record_id = #{report_id} AND name = 'image'").first
+    expect(asa[0]).to eq(report_id)
+
+    # assets: owner_id preserved
+    asset = conn.execute("SELECT owner_id FROM assets WHERE owner_id = #{report_id}").first
+    expect(asset[0]).to eq(report_id)
+
+    # quotable_item_quotes: quotable_id preserved
+    qiq = conn.execute("SELECT quotable_id FROM quotable_item_quotes WHERE quotable_id = #{report_id}").first
+    expect(qiq[0]).to eq(report_id)
+
+    # sectorable_items: sectorable_id preserved
+    si = conn.execute("SELECT sectorable_id FROM sectorable_items WHERE sectorable_id = #{report_id}").first
+    expect(si[0]).to eq(report_id)
   end
 
   it "updates active_storage_attachments record_type" do
@@ -208,13 +257,16 @@ RSpec.describe "workshop_logs:migrate_from_reports" do
     expect(wl_workshop_id).to eq(workshop.id)
   end
 
-  it "does not delete WorkshopLog records from reports table" do
-    insert_report_as_workshop_log
+  it "retains all report records with type WorkshopLog" do
+    ids = 3.times.map { insert_report_as_workshop_log }
 
     Rake::Task["workshop_logs:migrate_from_reports"].invoke
 
-    count = conn.execute("SELECT COUNT(*) FROM reports WHERE type = 'WorkshopLog'").first[0]
-    expect(count).to eq(1)
+    ids.each do |id|
+      row = conn.execute("SELECT id, type FROM reports WHERE id = #{id}").first
+      expect(row).to be_present, "Expected report #{id} to still exist"
+      expect(row[1]).to eq("WorkshopLog")
+    end
   end
 
   it "does not affect non-WorkshopLog reports" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The `workshop_logs:migrate_from_reports` rake task was not idempotent — re-running it on staging showed 0 associated records because the cleanup step didn't revert polymorphic type changes from prior runs
- The task was also nulling `report_id` on `report_form_field_answers`, which is unnecessary — we should keep the FK to reports and just populate `workshop_log_id`

### How did you approach the change?
- Expand the cleanup block to revert polymorphic types (`WorkshopLog` → `Report`) on `active_storage_attachments`, `assets`, `quotable_item_quotes`, and `sectorable_items` before deleting `workshop_logs`
- Change `report_form_field_answers` migration to set `workshop_log_id = report_id` without nulling `report_id`
- Add test that all associated table IDs are preserved after migration
- Add test that all report records are retained with `type = 'WorkshopLog'`

### Anything else to add?
- This was discovered on staging where re-running the task showed 0 for all associated data counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)