### PR TITLE
Add mise activation to ai scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,14 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
 
+## Ruby Version Manager
+
+This project uses [mise](https://mise.jdx.dev/) to manage the Ruby version. Before running any `bundle exec` or Ruby command, activate mise:
+```bash
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
+```
+The `ai/` scripts include this automatically.
+
 ## Quick Commands
 
 See `ai/` directory for executable scripts:

--- a/ai/console.txt
+++ b/ai/console.txt
@@ -5,4 +5,5 @@
 #   ai/console
 #   ai/console --sandbox
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 bundle exec rails console "$@"

--- a/ai/db-migrate.txt
+++ b/ai/db-migrate.txt
@@ -5,4 +5,5 @@
 #   ai/db-migrate                    # migrate
 #   ai/db-migrate VERSION=0          # rollback all
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 bundle exec rails db:migrate "$@"

--- a/ai/lint.txt
+++ b/ai/lint.txt
@@ -5,6 +5,7 @@
 #   ai/lint           # check all files
 #   ai/lint --fix     # auto-fix
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 if [[ "${1:-}" == "--fix" ]]; then
   shift
   bundle exec rubocop -a "$@"

--- a/ai/routes.txt
+++ b/ai/routes.txt
@@ -6,4 +6,5 @@
 #   ai/routes -g workshops     # routes matching "workshops"
 #   ai/routes -g events        # routes matching "events"
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 bundle exec rails routes "$@"

--- a/ai/server.txt
+++ b/ai/server.txt
@@ -5,4 +5,5 @@
 # Usage:
 #   ai/server
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 bin/dev

--- a/ai/test.txt
+++ b/ai/test.txt
@@ -7,4 +7,5 @@
 #   ai/test spec/models/user_spec.rb:42          # specific line
 #   ai/test --fail-fast                          # stop on first failure
 set -euo pipefail
+eval "$(command /opt/homebrew/bin/mise activate zsh)"
 bundle exec rspec "$@"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- AI agents (Claude Code, Conductor) inherit system Ruby (2.6) instead of the project's mise-managed Ruby (4.0.1), causing `bundle exec` to fail with bundler version errors
- Scripts and docs need to explicitly activate mise so agents can run tests, lint, and other Ruby commands

### How did you approach the change?
- Added `eval "$(command /opt/homebrew/bin/mise activate zsh)"` to all 6 ai/ scripts (test, lint, console, db-migrate, routes, server)
- Added a "Ruby Version Manager" section to CLAUDE.md documenting the mise activation command

### UI Testing Checklist
- [ ] N/A — no UI changes

### Anything else to add?
- This only affects AI agent environments; human developers already have mise activated via their shell profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)