### PR TITLE
Add vite test asset build to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -67,6 +67,9 @@ FileUtils.chdir APP_ROOT do
   system! "RAILS_ENV=test bin/rails db:create"
   system! "RAILS_ENV=test bin/rails db:migrate"
 
+  puts "\n== Building Vite test assets =="
+  system! "RAILS_ENV=test npx vite build --mode test"
+
   puts "\n== Cleaning logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
## Summary
- Adds `npx vite build --mode test` step to `bin/setup` so system specs work on a fresh setup without manually building test assets first

## Test plan
- [ ] Run `bin/setup` on a fresh clone and verify vite test assets are built
- [ ] Run system specs after setup and verify they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)