### PR TITLE
Fix NoMethodError in QuotePolicy#show?

### DIFF
--- a/app/policies/quote_policy.rb
+++ b/app/policies/quote_policy.rb
@@ -6,7 +6,7 @@ class QuotePolicy < ApplicationPolicy
   end
 
   def show?
-    admin? || owner?
+    admin? || (authenticated? && record.published?)
   end
 
   # Scoping
@@ -19,11 +19,5 @@ class QuotePolicy < ApplicationPolicy
     else
       relation.none
     end
-  end
-
-  private
-
-  def owner?
-    record.recipient_email == user.email
   end
 end

--- a/spec/policies/quote_policy_spec.rb
+++ b/spec/policies/quote_policy_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe QuotePolicy, type: :policy do
+  let(:admin_user) { build_stubbed :user, :admin }
+  let(:regular_user) { build_stubbed :user }
+  let(:published_quote) { build_stubbed :quote, published: true }
+  let(:unpublished_quote) { build_stubbed :quote, published: false }
+
+  def policy_for(record: nil, user:)
+    described_class.new(record, user: user)
+  end
+
+  describe "#index?" do
+    context "with admin user" do
+      subject { policy_for(user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:index?) }
+    end
+
+    context "with regular user" do
+      subject { policy_for(user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:index?) }
+    end
+  end
+
+  describe "#show?" do
+    context "with admin user" do
+      subject { policy_for(record: unpublished_quote, user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:show?) }
+    end
+
+    context "with authenticated user and published quote" do
+      subject { policy_for(record: published_quote, user: regular_user) }
+
+      it { is_expected.to be_allowed_to(:show?) }
+    end
+
+    context "with authenticated user and unpublished quote" do
+      subject { policy_for(record: unpublished_quote, user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:show?) }
+    end
+
+    context "with no user and published quote" do
+      subject { policy_for(record: published_quote, user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:show?) }
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Fixes a production `NoMethodError: undefined method 'recipient_email' for an instance of QuoteDecorator` reported by Honeybadger
- Non-admin users hitting `QuotesController#show` would crash because `QuotePolicy#owner?` called `recipient_email`, which doesn't exist on Quote

### How did you approach the change?

- The `owner?` method was copy-pasted from `NotificationPolicy` but Quote has no `recipient_email` column — it's publishable content, not user-owned
- Replaced `admin? || owner?` with `admin? || (authenticated? && record.published?)` to match the existing `relation_scope` logic and the pattern used by other publishable models (Resource, Workshop, Story, etc.)
- Removed the dead `owner?` private method
- Added `QuotePolicy` spec covering admin, authenticated+published, authenticated+unpublished, and unauthenticated access

### UI Testing Checklist

- [ ] Visit a published quote as a non-admin user — should render without error
- [ ] Visit an unpublished quote as a non-admin user — should be denied

### Anything else to add?

- No migration or schema change needed — this was purely a policy bug