### PR TITLE
Allow unauthenticated access to sectors and categories tag pages

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,5 +1,5 @@
 class TagsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :index ]
+  skip_before_action :authenticate_user!, only: [ :index, :sectors, :categories ]
 
   def index
     authorize!


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Sectors and categories are public-facing tag browsing pages, like the tags index
- Guests should be able to view them without signing in

### How did you approach the change?
- Added `:sectors` and `:categories` to `TagsController`'s `skip_before_action :authenticate_user!`
- Split out from #1449 where it was incorrectly bundled with an unrelated bug fix

### Anything else to add?
- Note: `authorize!` is still called in both actions — guest access depends on the policy allowing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)