### PR TITLE
Send password reset with manual email confirmation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -281,6 +281,7 @@ class UsersController < ApplicationController
     result = UserServices::ProcessEmailManualConfirm.call(
       user: @user,
       action: params[:confirm_action],
+      send_reset_password: params[:send_reset_password] == "1",
       current_user: current_user
     )
 

--- a/app/services/user_services/process_email_manual_confirm.rb
+++ b/app/services/user_services/process_email_manual_confirm.rb
@@ -6,13 +6,14 @@ module UserServices
       end
     end
 
-    def self.call(user:, action:, current_user:)
-      new(user:, action:, current_user:).call
+    def self.call(user:, action:, send_reset_password: false, current_user:)
+      new(user:, action:, send_reset_password:, current_user:).call
     end
 
-    def initialize(user:, action:, current_user:)
+    def initialize(user:, action:, send_reset_password:, current_user:)
       @user = user
       @action = action
+      @send_reset_password = send_reset_password
       @current_user = current_user
       @actions_taken = []
     end
@@ -23,6 +24,7 @@ module UserServices
         resend_confirmation
       when "confirm"
         manually_confirm
+        send_reset_password_instructions if @send_reset_password
       end
 
       Result.new(actions_taken: @actions_taken)
@@ -44,6 +46,11 @@ module UserServices
       else
         @actions_taken << "Email has been manually confirmed"
       end
+    end
+
+    def send_reset_password_instructions
+      @user.send_reset_password_instructions
+      @actions_taken << "Password reset instructions sent to #{@user.email}"
     end
   end
 end

--- a/app/views/users/confirm_email_manual.html.erb
+++ b/app/views/users/confirm_email_manual.html.erb
@@ -83,6 +83,16 @@
             </p>
           </div>
         </button>
+        <label class="flex items-start gap-3 p-3 ml-8 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 cursor-pointer"
+               onclick="event.stopPropagation();">
+          <%= check_box_tag :send_reset_password, "1", true, class: "mt-0.5" %>
+          <div>
+            <span class="text-sm font-medium text-gray-900">Also send password reset email</span>
+            <p class="text-xs text-gray-500">
+              Sends password reset instructions so the user can log in with their new email
+            </p>
+          </div>
+        </label>
       <% end %>
 
       <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">

--- a/spec/services/user_services/process_email_manual_confirm_spec.rb
+++ b/spec/services/user_services/process_email_manual_confirm_spec.rb
@@ -134,6 +134,43 @@ RSpec.describe UserServices::ProcessEmailManualConfirm do
       end
     end
 
+    context "with action 'confirm' and send_reset_password" do
+      let(:user) { create(:user) }
+      let(:new_email) { "newemail@example.com" }
+      let(:mock_mail) { double(deliver_later: true, deliver: true, deliver_now: true) }
+
+      before do
+        user.update_columns(unconfirmed_email: new_email)
+        allow(DeviseMailer).to receive(:reset_password_instructions).and_return(mock_mail)
+      end
+
+      it "confirms the email and sends password reset instructions" do
+        result = described_class.call(
+          user: user,
+          action: "confirm",
+          send_reset_password: true,
+          current_user: admin
+        )
+
+        user.reload
+        expect(user.email).to eq(new_email)
+        expect(DeviseMailer).to have_received(:reset_password_instructions)
+        expect(result.summary).to include("manually confirmed")
+        expect(result.summary).to include("Password reset instructions sent to #{new_email}")
+      end
+
+      it "does not send password reset when send_reset_password is false" do
+        described_class.call(
+          user: user,
+          action: "confirm",
+          send_reset_password: false,
+          current_user: admin
+        )
+
+        expect(DeviseMailer).not_to have_received(:reset_password_instructions)
+      end
+    end
+
     context "with no action" do
       let(:user) { create(:user, confirmed_at: nil) }
 


### PR DESCRIPTION
Closes #1459

### What is the goal of this PR and why is this important?

- When an admin manually confirms an email change, the user still can't log in — their account has a random password from initial setup and the admin has to separately send a password reset email
- This combines both steps into one, reducing admin friction and preventing the "I changed the email but they still can't log in" support loop

### How did you approach the change?

- Added `send_reset_password` option to `ProcessEmailManualConfirm` service (defaults to `false` for backward compatibility)
- Added a default-on checkbox to the manual confirm interstitial so admins can opt into sending password reset instructions alongside confirmation
- Controller passes the new param through to the service
- The checkbox only appears under the "Manually confirm" option (not "Resend confirmation") since resend already sends an email the user acts on

### UI Testing Checklist

- [ ] Change a user's email, go to manual confirm interstitial, verify the "Also send password reset email" checkbox appears under "Manually confirm"
- [ ] Confirm with checkbox checked — verify both confirmation and password reset flash messages appear
- [ ] Confirm with checkbox unchecked — verify only confirmation message appears
- [ ] Resend confirmation — verify password reset checkbox is not involved

### Anything else to add?

- The checkbox is checked by default since the most common scenario is that the user needs both actions