### PR TITLE
Update login heading to "Welcome to our Portal"

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <%= render "layouts/mailer/logo" %>
 
     <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">
-      Log in to our Portal
+      Welcome to our Portal
     </h2>
 
     <%= simple_form_for(resource, url: session_path(resource_name)) do |f| %>


### PR DESCRIPTION
Closes #1464

### What is the goal of this PR and why is this important?

- The login page heading "Log in to our Portal" felt stiff and unfriendly
- "Welcome to our Portal" is warmer and works for both new and returning users

### How did you approach the change?

- Updated the `<h2>` text in `app/views/devise/sessions/new.html.erb`

### Anything else to add?

- One-line change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)