### PR TITLE
Fix flaky people_search_spec empty response body

### DIFF
--- a/spec/requests/people_search_spec.rb
+++ b/spec/requests/people_search_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "People search", type: :request do
   let(:admin) { create(:user, :admin) }
-  let(:turbo_headers) { { "Turbo-Frame" => "people_results" } }
+  let(:turbo_headers) { { "Turbo-Frame" => "people_results", "Accept" => "text/html" } }
 
   before { sign_in admin }
 
@@ -17,12 +17,14 @@ RSpec.describe "People search", type: :request do
 
     it "returns all people when no filters are applied" do
       get people_path, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include("Alice")
       expect(response.body).to include("Bob")
     end
 
     it "filters by contact_info" do
       get people_path, params: { contact_info: "Alice" }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include("Alice")
       expect(response.body).not_to include("Bob")
     end
@@ -32,6 +34,7 @@ RSpec.describe "People search", type: :request do
       create(:affiliation, person: person_alice, organization: org)
 
       get people_path, params: { organization_name: "Unique Org" }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include("Alice")
       expect(response.body).not_to include("Bob")
     end


### PR DESCRIPTION
Closes #1469

### What is the goal of this PR and why is this important?

- Fix intermittently failing `people_search_spec.rb` test that produces an empty response body (`""`) when run in the full suite
- The flakiness causes CI failures that are unrelated to actual code changes

### How did you approach the change?

- Added explicit `Accept: text/html` header to turbo frame test requests — without it, format negotiation pollution from preceding specs could cause Rails to look for a non-HTML template, hit `ActionView::MissingTemplate`, and return an empty `head :not_acceptable` (406) response
- Added `have_http_status(:ok)` assertions before body content checks so future failures produce clearer error messages

### Anything else to add?

- The test passes reliably in isolation; the failure only occurs with certain test orderings in the full suite
- Other turbo frame request specs (bookmarks, stories) may benefit from the same `Accept` header addition as a preventive measure