### PR TITLE
Add resend confirmation link to unconfirmed login flash

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -27,7 +27,8 @@ class ConfirmationsController < Devise::ConfirmationsController
     email = session.delete(:unconfirmed_email)
 
     if email.present?
-      resource_class.send_confirmation_instructions(email: email)
+      user = resource_class.send_confirmation_instructions(email: email)
+      create_resend_notification(user) if user.errors.empty?
     end
 
     redirect_to new_user_session_path,
@@ -66,5 +67,17 @@ class ConfirmationsController < Devise::ConfirmationsController
 
   def email_not_found?
     resource.errors.any? { |e| e.attribute == :email && e.type == :not_found }
+  end
+
+  def create_resend_notification(user)
+    NotificationServices::CreateNotification.call(
+      noticeable: user,
+      recipient_role: :person,
+      recipient_email: user.email,
+      kind: "account_confirmation",
+      notification_type: 1,
+      deliver: false,
+      persist_delivered_email: false
+    )
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -22,6 +22,18 @@ class ConfirmationsController < Devise::ConfirmationsController
   end
 
 
+  # GET /users/confirmation/resend — one-click resend from the login flash
+  def resend
+    email = session.delete(:unconfirmed_email)
+
+    if email.present?
+      resource_class.send_confirmation_instructions(email: email)
+    end
+
+    redirect_to new_user_session_path,
+                notice: "If your email exists in our system, you will receive confirmation instructions shortly."
+  end
+
   # POST /users/confirmation (resend)
   def create
     self.resource = resource_class.send_confirmation_instructions(resource_params)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,6 +251,17 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  # Store the attempted email in the session when login fails because the
+  # account is unconfirmed, so the resend-confirmation link in the flash
+  # can send the email without an intermediate form.
+  Warden::Manager.before_failure do |env, opts|
+    if opts[:message] == :unconfirmed
+      request = Rack::Request.new(env)
+      email = request.params.dig("user", "email")
+      env["rack.session"]["unconfirmed_email"] = email if email.present?
+    end
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -15,7 +15,7 @@ en:
       not_found_in_database: "Invalid email or password. Please contact us for assistance."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: 'You have to confirm your email address before continuing. <a href="/users/confirmation/new" class="underline font-semibold">Resend confirmation email</a>'
+      unconfirmed: 'You have to confirm your email address before continuing. <a href="/users/confirmation/resend" class="underline font-semibold">Resend confirmation email</a>'
     mailer:
       confirmation_instructions:
         subject: "AWBW portal: Welcome instructions"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -15,7 +15,7 @@ en:
       not_found_in_database: "Invalid email or password. Please contact us for assistance."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
+      unconfirmed: 'You have to confirm your email address before continuing. <a href="/users/confirmation/new" class="underline font-semibold">Resend confirmation email</a>'
     mailer:
       confirmation_instructions:
         subject: "AWBW portal: Welcome instructions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
                             unlocks: "unlocks" }
   devise_scope :user do
     get "/confirm/:confirmation_token", to: "confirmations#show", as: :confirm
+    get "/users/confirmation/resend", to: "confirmations#resend", as: :resend_user_confirmation
   end
   get "users/change_password", to: "users#change_password", as: "change_password"
   post "users/update_password", to: "users#update_password", as: "update_password"

--- a/spec/requests/unconfirmed_login_spec.rb
+++ b/spec/requests/unconfirmed_login_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe "Unconfirmed user login", type: :request do
       expect(session[:unconfirmed_email]).to be_nil
     end
 
+    it "creates a system notification" do
+      post user_session_path, params: { user: { email: user.email, password: "password123" } }
+
+      expect {
+        get resend_user_confirmation_path
+      }.to change { Notification.where(kind: "account_confirmation").count }.by(1)
+    end
+
+    it "does not create a notification when no email is in session" do
+      expect {
+        get resend_user_confirmation_path
+      }.not_to change { Notification.count }
+    end
+
     it "redirects gracefully when no email is in session" do
       get resend_user_confirmation_path
 

--- a/spec/requests/unconfirmed_login_spec.rb
+++ b/spec/requests/unconfirmed_login_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Unconfirmed user login", type: :request do
+  let(:user) { create(:user, :unconfirmed, password: "password123") }
+
+  it "includes a resend confirmation link in the flash message" do
+    post user_session_path, params: { user: { email: user.email, password: "password123" } }
+
+    expect(response).to redirect_to(new_user_session_path)
+    follow_redirect!
+
+    expect(response.body).to include("Resend confirmation email")
+    expect(response.body).to include("/users/confirmation/new")
+  end
+end

--- a/spec/requests/unconfirmed_login_spec.rb
+++ b/spec/requests/unconfirmed_login_spec.rb
@@ -10,6 +10,39 @@ RSpec.describe "Unconfirmed user login", type: :request do
     follow_redirect!
 
     expect(response.body).to include("Resend confirmation email")
-    expect(response.body).to include("/users/confirmation/new")
+    expect(response.body).to include("/users/confirmation/resend")
+  end
+
+  it "stores the attempted email in the session" do
+    post user_session_path, params: { user: { email: user.email, password: "password123" } }
+
+    expect(session[:unconfirmed_email]).to eq(user.email)
+  end
+
+  describe "GET /users/confirmation/resend" do
+    it "sends confirmation instructions and redirects to login" do
+      post user_session_path, params: { user: { email: user.email, password: "password123" } }
+
+      expect {
+        get resend_user_confirmation_path
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(response).to redirect_to(new_user_session_path)
+      follow_redirect!
+      expect(response.body).to include("you will receive confirmation instructions")
+    end
+
+    it "clears the session email after resending" do
+      post user_session_path, params: { user: { email: user.email, password: "password123" } }
+      get resend_user_confirmation_path
+
+      expect(session[:unconfirmed_email]).to be_nil
+    end
+
+    it "redirects gracefully when no email is in session" do
+      get resend_user_confirmation_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
   end
 end


### PR DESCRIPTION
Closes #1455

### What is the goal of this PR and why is this important?

- When unconfirmed users try to log in, the error flash says "confirm your email" but doesn't tell them how to get a new confirmation email
- The resend link exists in the shared links section but is easy to miss
- This is especially relevant for users arriving via the lock icon on awbw.org

### How did you approach the change?

- Added a direct "Resend confirmation email" link inline in the Devise `unconfirmed` flash message (`config/locales/devise.en.yml`)
- The flash partial already calls `html_safe`, so the link renders correctly with no view changes needed
- One locale string change, one new request spec

### Anything else to add?

- The existing "Didn't receive confirmation instructions?" link in shared links still works — this just makes the path more obvious from the flash itself