### PR TITLE
Notify old email when email change is requested

### DIFF
--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -11,6 +11,7 @@ class NotificationMailerJob < ApplicationJob
       "workshop_log_submitted"     => ->(n) { NotificationMailer.workshop_log_submitted(n) },
       "workshop_log_submitted_fyi" => ->(n) { NotificationMailer.workshop_log_submitted_fyi(n) },
       "reset_password_fyi"   => ->(n) { NotificationMailer.reset_password_fyi(n) },
+      "account_email_change_requested_notification" => ->(n) { NotificationMailer.account_email_change_requested_notification(n) },
       "event_registration_confirmation" => ->(n) { EventMailer.event_registration_confirmation(n.noticeable) },
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -96,6 +96,16 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
+  def account_email_change_requested_notification(notification)
+    @user = notification.noticeable
+    @new_email = @user.unconfirmed_email
+
+    mail(
+      to: notification.recipient_email,
+      subject: "#{SUBJECT_PREFIX} An email change was requested for your account"
+    )
+  end
+
   def workshop_log_submitted(notification)
     @notification = notification
     @noticeable = notification.noticeable

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@ class Notification < ApplicationRecord
     account_confirmation
     account_confirmation_fyi
     account_email_change_requested
-    account_email_changed
+    account_email_change_requested_notification
     account_confirmed
     account_confirmed_fyi
     account_unlock_fyi
@@ -67,6 +67,7 @@ class Notification < ApplicationRecord
     [ "Idea: confirmation (all)", "has been received" ],
     [ "Idea: confirmation: workshop log", "workshop log has been received" ],
     [ "User: confirm new email", "Confirm your new email address" ],
+    [ "User: email change alert (old address)", "email change was requested" ],
     [ "User: password reset", "Password reset request" ],
     [ "User: unlock instructions", "Unlock instructions" ],
     [ "User: welcome instructions", "Welcome instructions" ]

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -67,7 +67,7 @@ class Notification < ApplicationRecord
     [ "Idea: confirmation (all)", "has been received" ],
     [ "Idea: confirmation: workshop log", "workshop log has been received" ],
     [ "User: confirm new email", "Confirm your new email address" ],
-    [ "User: email change alert (old address)", "email change was requested" ],
+    [ "User: confirm new email (old address)", "email change was requested" ],
     [ "User: password reset", "Password reset request" ],
     [ "User: unlock instructions", "Unlock instructions" ],
     [ "User: welcome instructions", "Welcome instructions" ]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   after_update :track_password_reset_sent
   after_update :track_password_changed
 
-  after_commit :create_email_changed_notification, on: :update
+  after_commit :notify_old_email_of_change_request, on: :update
 
   before_destroy :track_account_deleted
 
@@ -365,17 +365,18 @@ class User < ApplicationRecord
     person.update(email: email)
   end
 
-  def create_email_changed_notification
-    return unless previous_changes.key?("email")
 
-    _from, to = previous_changes["email"]
+  def notify_old_email_of_change_request
+    return unless previous_changes.key?("unconfirmed_email")
+    return if previous_changes["unconfirmed_email"].last.blank?
+
     NotificationServices::CreateNotification.call(
       noticeable: self,
       recipient_role: :person,
-      recipient_email: to,
-      kind: :account_email_changed,
+      recipient_email: email,
+      kind: :account_email_change_requested_notification,
       notification_type: 1,
-      deliver: false
+      deliver: true
     )
   end
 

--- a/app/views/notification_mailer/account_email_change_requested_notification.html.erb
+++ b/app/views/notification_mailer/account_email_change_requested_notification.html.erb
@@ -1,0 +1,31 @@
+<h1>Email change requested</h1>
+
+<div style="text-align: left;">
+  <p>
+    Hello <strong><%= @user.first_name_or_email %></strong>,
+  </p>
+
+  <p>
+    A request was made to change the email address on your AWBW Portal account
+    from <strong><%= @user.email %></strong>
+    to a new address.
+  </p>
+</div>
+
+<div style="
+  background-color:#fef3c7;
+  border-radius:6px;
+  padding:12px;
+  margin:16px 0;
+">
+  <p>
+    If you made this request, no action is needed. A confirmation email was
+    sent to your new address to complete the change.
+  </p>
+
+  <p>
+    If you did <strong>not</strong> request this change, please
+    <%= link_to "contact us", contact_us_url %> immediately so we can
+    secure your account.
+  </p>
+</div>

--- a/spec/jobs/notification_mailer_job_spec.rb
+++ b/spec/jobs/notification_mailer_job_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe NotificationMailerJob, type: :job do
       expect(notification.delivered_at).to be_nil
     end
 
+    it "delivers the account_email_change_requested_notification email" do
+      user = create(:user, email: "old@example.com")
+      user.update_columns(unconfirmed_email: "new@example.com")
+      notif = create(:notification,
+        kind: "account_email_change_requested_notification",
+        noticeable: user,
+        recipient_role: "person",
+        recipient_email: "old@example.com")
+
+      expect {
+        described_class.new.perform(notif.id)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      notif.reload
+      expect(notif.delivered_at).to be_present
+      expect(notif.email_subject).to include("email change was requested")
+    end
+
     it "raises for unknown notification kinds" do
       notification.update_column(:kind, "reset_password") # valid kind but no mailer mapping
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -210,6 +210,38 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
   end
 
+  describe "#account_email_change_requested_notification" do
+    let(:user) { create(:user, email: "old@example.com") }
+    let(:notification) do
+      create(:notification,
+        kind: "account_email_change_requested_notification",
+        noticeable: user,
+        recipient_role: "person",
+        recipient_email: "old@example.com")
+    end
+
+    before { user.update_columns(unconfirmed_email: "new@example.com") }
+
+    subject(:mail) { described_class.account_email_change_requested_notification(notification) }
+
+    it "sends to the old email address" do
+      expect(mail.to).to eq([ "old@example.com" ])
+    end
+
+    it "includes a warning about the email change" do
+      expect(mail.body.encoded).to include("Email change requested")
+      expect(mail.body.encoded).to include("old@example.com")
+    end
+
+    it "includes contact information for unauthorized changes" do
+      expect(mail.body.encoded).to include("contact us")
+    end
+
+    it "renders without raising" do
+      expect { mail.deliver_now }.not_to raise_error
+    end
+  end
+
   describe "#reset_password_fyi" do
     let(:user) { create(:user, email: "user@example.com") }
     let(:notification) { create(:notification, kind: "reset_password_fyi", noticeable: user) }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Notification do
       expect(Notification::KINDS).to include("account_email_change_requested")
     end
 
-    it "includes account_email_changed" do
-      expect(Notification::KINDS).to include("account_email_changed")
+    it "includes account_email_change_requested_notification" do
+      expect(Notification::KINDS).to include("account_email_change_requested_notification")
     end
 
     it "validates account_email_change_requested as a valid kind" do
@@ -22,8 +22,8 @@ RSpec.describe Notification do
       expect(notification).to be_valid
     end
 
-    it "validates account_email_changed as a valid kind" do
-      notification = build(:notification, kind: "account_email_changed", recipient_role: "person")
+    it "validates account_email_change_requested_notification as a valid kind" do
+      notification = build(:notification, kind: "account_email_change_requested_notification", recipient_role: "person")
       expect(notification).to be_valid
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -316,25 +316,34 @@ RSpec.describe User do
     end
   end
 
-  describe "#create_email_changed_notification" do
+  describe "#notify_old_email_of_change_request" do
     let(:user) { create(:user, email: "old@example.com") }
 
-    it "creates an account_email_changed notification when email changes" do
-      user.skip_reconfirmation!
+    it "creates a notification to the old email when an email change is requested" do
+      user.email = "new@example.com"
+      user.skip_confirmation_notification!
 
       expect {
-        user.update!(email: "changed@example.com")
+        user.save!
       }.to change(Notification, :count).by(1)
 
       notification = Notification.last
-      expect(notification.kind).to eq("account_email_changed")
+      expect(notification.kind).to eq("account_email_change_requested_notification")
       expect(notification.recipient_role).to eq("person")
-      expect(notification.recipient_email).to eq("changed@example.com")
+      expect(notification.recipient_email).to eq("old@example.com")
       expect(notification.noticeable).to eq(user)
-      expect(notification.delivered_at).to be_nil
     end
 
-    it "does not create notification when email does not change" do
+    it "does not create notification when unconfirmed_email is cleared" do
+      user.update_columns(unconfirmed_email: "pending@example.com")
+
+      user.skip_reconfirmation!
+      expect {
+        user.update!(email: "pending@example.com")
+      }.not_to change(Notification.where(kind: "account_email_change_requested_notification"), :count)
+    end
+
+    it "does not create notification when other fields change" do
       expect {
         user.update!(first_name: "Updated")
       }.not_to change(Notification, :count)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Security measure: alert the user's current (old) email address when an email change is requested
- Allows account holders to flag unauthorized email changes immediately
- Follows the same pattern used by other major platforms (GitHub, Google, etc.)

### How did you approach the change?

- Added `account_email_change_requested_notification` notification kind
- Created `NotificationMailer#account_email_change_requested_notification` with a template that warns the old email and links to contact support
- Wired it up via `after_commit :notify_old_email_of_change_request` on User, triggered when `unconfirmed_email` is set
- Registered the new kind in `NotificationMailerJob`'s mailer map
- Removed the unused `account_email_changed` notification kind — it had `deliver: false` (no email sent), and the same moment is already tracked via Ahoy (`auth.email_changed`)

### UI Testing Checklist

- [ ] Change email on a user account, verify old email receives the alert
- [ ] Verify new email still receives the Devise confirmation email
- [ ] Verify the notification record is created and visible in admin notifications
- [ ] Verify no notification is created for non-email updates

### Anything else to add?

- The email template uses a warm-colored warning box to draw attention
- `account_email_changed` was removed because notifications represent emails sent, and this kind never sent one — the Ahoy event `auth.email_changed` already covers audit needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)