### PR TITLE
Hide locked users' profiles from the non-admin people index

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -98,6 +98,11 @@ class Person < ApplicationRecord
       .merge(Affiliation.active)
       .distinct
   }
+  scope :where_user_not_locked, -> {
+    left_joins(:user).where(users: { locked_at: nil }).or(
+      left_joins(:user).where(users: { id: nil })
+    )
+  }
   scope :organization_name, ->(organization_name) {
     return all if organization_name.blank?
     left_joins(affiliations: :organization)

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -34,7 +34,7 @@ class PersonPolicy < ApplicationPolicy
 
   relation_scope do |relation|
     next relation if admin?
-    relation.searchable.with_active_affiliations
+    relation.searchable.with_active_affiliations.where_user_not_locked
   end
 
   private

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -124,11 +124,13 @@ RSpec.describe PersonPolicy, type: :policy do
     context "with regular user" do
       let(:policy) { policy_for(record: Person, user: regular_user) }
 
-      it "filters to searchable people with active affiliations" do
+      it "filters to searchable people with active affiliations and unlocked users" do
         scope = policy.apply_scope(Person.all, type: :active_record_relation)
-        expect(scope.to_sql).to include('`people`.`profile_is_searchable` = TRUE')
-        expect(scope.to_sql).to include('INNER JOIN `affiliations`')
-        expect(scope.to_sql).to include('`affiliations`.`inactive` = FALSE')
+        sql = scope.to_sql
+        expect(sql).to include('`people`.`profile_is_searchable` = TRUE')
+        expect(sql).to include('INNER JOIN `affiliations`')
+        expect(sql).to include('`affiliations`.`inactive` = FALSE')
+        expect(sql).to include('`users`.`locked_at` IS NULL')
       end
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Once non-admin users can see the People index (see #1494), they will not see profiles whose user is locked
- Locked accounts have had access revoked; their profile should not be discoverable by facilitators on people index
- Admins are unaffected — they continue to see all people, locked or not
- NOTE: this code doesn't do anything rn bc facilitators don't have the People index permission yet, but, adding this logic now before we forget this additional condition

### How did you approach the change?

- Added a `Person.where_user_not_locked` scope: `left_joins(:user)` so people with no user record are still included, then keeps only rows where `users.locked_at IS NULL`
- Chained `.where_user_not_locked` onto the non-admin branch of `PersonPolicy`'s `relation_scope`, after the existing `searchable.with_active_affiliations` filters
- Updated the policy spec to assert the generated SQL also includes `users.locked_at IS NULL`

### UI Testing Checklist

- [ ] Sign in as a regular user. Lock a user account that has a Person with an active affiliation and `profile_is_searchable: true`. Confirm that profile no longer appears on `/people`
- [ ] Confirm a Person with no associated user but an active affiliation still appears for regular users
- [ ] Confirm an admin viewing `/people` still sees locked users' profiles

### Anything else to add?

- This is a no-op for end users until #1494 merges, since regular users cannot reach `/people` yet. Keeping them split so the policy change and the visibility-filter change can be reviewed independently