### PR TITLE
Track responded status on contact-us notifications

### DIFF
--- a/ai/server
+++ b/ai/server
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 # Start development services (web + vite).
-# Uses CONDUCTOR_PORT if set, otherwise defaults to 3000.
-# Derives a unique Vite port (CONDUCTOR_PORT + 1) to avoid collisions.
+# Uses CONDUCTOR_PORT (Conductor's assigned workspace port) if set,
+# otherwise probes for a free port starting at 3000.
+# Derives a unique Vite port (server_port + 1) to avoid collisions.
 set -euo pipefail
 source "$(dirname "$0")/.ruby-env"
+
 if [ -n "${CONDUCTOR_PORT:-}" ]; then
-  export VITE_RUBY_PORT=$((CONDUCTOR_PORT + 1))
+  server_port="$CONDUCTOR_PORT"
+else
+  server_port=3000
+  while lsof -iTCP:"$server_port" -sTCP:LISTEN -n -P >/dev/null 2>&1; do
+    server_port=$((server_port + 1))
+  done
+  echo "ai/server: CONDUCTOR_PORT unset, picked free port $server_port"
 fi
-bin/dev -p "${CONDUCTOR_PORT:-3000}"
+
+export VITE_RUBY_PORT=$((server_port + 1))
+bin/dev -p "$server_port"

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,5 @@
 class NotificationsController < ApplicationController
-  before_action :set_notification, only: [ :show, :resend ]
+  before_action :set_notification, only: [ :show, :update, :resend ]
 
   def index
     authorize!
@@ -19,6 +19,12 @@ class NotificationsController < ApplicationController
 
   def show
     authorize! @notification
+  end
+
+  def update
+    authorize! @notification
+    @notification.update!(notification_params)
+    head :ok
   end
 
   def resend
@@ -52,5 +58,9 @@ class NotificationsController < ApplicationController
 
   def set_notification
     @notification = Notification.find(params[:id])
+  end
+
+  def notification_params
+    params.require(:notification).permit(:responded)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -114,6 +114,10 @@ class Notification < ApplicationRecord
     !kind.in?(DEVISE_KINDS)
   end
 
+  def contact_us?
+    kind.in?(%w[contact_us contact_us_fyi])
+  end
+
   def delivered?
     delivered_at.present?
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -94,6 +94,14 @@ class Notification < ApplicationRecord
   scope :record_type, ->(record_type) { where(noticeable_type: record_type.to_s.camelize.titleize.gsub(" ", "")) }
   scope :subject_line, ->(subject) { where("notifications.email_subject LIKE ?", "%#{subject}%") }
   scope :email_topic, ->(topic) { where("notifications.email_subject LIKE ?", "%#{topic}%") }
+  scope :responded_status, ->(status) {
+    case status.to_s
+    when "yes" then where(kind: "contact_us_fyi", responded: true)
+    when "no"  then where(kind: "contact_us_fyi", responded: false)
+    when "na"  then where.not(kind: "contact_us_fyi")
+    else all
+    end
+  }
 
   def self.email_topic_phrase(label)
     EMAIL_TOPICS.assoc(label)&.last
@@ -107,6 +115,7 @@ class Notification < ApplicationRecord
     topic_phrase = email_topic_phrase(params[:email_topic]) if params[:email_topic].present?
     stories = stories.email_topic(topic_phrase) if topic_phrase.present?
     stories = stories.record_type(params[:record_type]) if params[:record_type].present?
+    stories = stories.responded_status(params[:responded_status]) if params[:responded_status].present?
     stories
   end
 
@@ -114,8 +123,8 @@ class Notification < ApplicationRecord
     !kind.in?(DEVISE_KINDS)
   end
 
-  def contact_us?
-    kind.in?(%w[contact_us contact_us_fyi])
+  def requires_response?
+    kind == "contact_us_fyi"
   end
 
   def delivered?

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -9,6 +9,10 @@ class NotificationPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def update?
+    admin?
+  end
+
   def resend?
     admin? && record.resendable?
   end

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -58,7 +58,7 @@
           data-autosave-url-value="<%= notification_path(notification) %>"
           data-autosave-id-value="<%= notification.id %>"
           data-action="change->autosave#save">
-        <% if notification.contact_us? %>
+        <% if notification.requires_response? %>
           <input type="hidden" name="notification[responded]" value="0">
           <input type="checkbox"
                  name="notification[responded]"

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -6,6 +6,7 @@
     <th class="px-4 py-3 text-left font-medium text-gray-600">Recipient</th>
     <th class="px-4 py-3 text-left font-medium text-gray-600">Subject</th>
     <th class="px-4 py-3 text-left font-medium text-gray-600">Record</th>
+    <th class="px-4 py-3 text-center font-medium text-gray-600">Responded</th>
     <th class="px-4 py-3 text-right font-medium text-gray-600"></th>
   </tr>
   </thead>
@@ -48,6 +49,25 @@
                       class: "btn btn-secondary-outline" %>
         <% else %>
           <span class="text-gray-400">—</span>
+        <% end %>
+      </td>
+
+      <!-- Responded -->
+      <td class="px-4 py-3 text-center"
+          data-controller="autosave"
+          data-autosave-url-value="<%= notification_path(notification) %>"
+          data-autosave-id-value="<%= notification.id %>"
+          data-action="change->autosave#save">
+        <% if notification.contact_us? %>
+          <input type="hidden" name="notification[responded]" value="0">
+          <input type="checkbox"
+                 name="notification[responded]"
+                 value="1"
+                 <%= "checked" if notification.responded? %>
+                 class="w-5 h-5 rounded border-gray-300 text-green-600 accent-green-600 focus:ring-green-500 cursor-pointer"
+                 title="Responded to by staff">
+        <% else %>
+          <span class="text-gray-300">—</span>
         <% end %>
       </td>
 

--- a/app/views/notifications/_search_boxes.html.erb
+++ b/app/views/notifications/_search_boxes.html.erb
@@ -51,6 +51,17 @@
                        oninput: "this.form.requestSubmit()" %>
     </div>
 
+    <div>
+      <%= f.label :responded_status, "Responded",
+                  class: "block text-sm font-medium text-gray-500 mb-1" %>
+
+      <%= f.select :responded_status,
+                   options_for_select([ [ "Yes", "yes" ], [ "No", "no" ], [ "N/A", "na" ] ], params[:responded_status]),
+                   { include_blank: "All" },
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+                             focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
     <!-- Clear -->
     <div>
       <span class="block text-sm mb-1">&nbsp;</span>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex justify-between items-center mb-6">
-        <section class="pl-8">
+        <section class="w-full">
           <div class="flex flex-col items-start mb-4">
             <h1 class="text-3xl font-bold text-gray-900 my-2">System notifications</h1>
           </div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -57,6 +57,24 @@
         </div>
       <% end %>
 
+      <% if @notification.requires_response? && allowed_to?(:update?, @notification) %>
+        <div class="flex items-center justify-end gap-2"
+             data-controller="autosave"
+             data-autosave-url-value="<%= notification_path(@notification) %>"
+             data-autosave-id-value="<%= @notification.id %>"
+             data-action="change->autosave#save">
+          <label class="inline-flex items-center gap-2 px-2 py-1 rounded bg-gray-50 hover:bg-gray-100 cursor-pointer">
+            <input type="hidden" name="notification[responded]" value="0">
+            <input type="checkbox"
+                   name="notification[responded]"
+                   value="1"
+                   <%= "checked" if @notification.responded? %>
+                   class="w-4 h-4 rounded border-gray-300 text-green-600 accent-green-600 focus:ring-green-500">
+            <span class="text-gray-700">Responded</span>
+          </label>
+        </div>
+      <% end %>
+
       <% if allowed_to?(:resend?, @notification) %>
         <%= button_to "Resend Email",
                       resend_notification_path(@notification),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,7 +120,7 @@ Rails.application.routes.draw do
     resources :comments, only: [ :index, :create ]
   end
   resources :faqs
-  resources :notifications, only: [ :index, :show ] do
+  resources :notifications, only: [ :index, :show, :update ] do
     member do
       post :resend
     end

--- a/db/migrate/20260417120000_add_responded_to_notifications.rb
+++ b/db/migrate/20260417120000_add_responded_to_notifications.rb
@@ -1,0 +1,9 @@
+class AddRespondedToNotifications < ActiveRecord::Migration[8.1]
+  def up
+    add_column :notifications, :responded, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :notifications, :responded, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_12_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_120000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -614,6 +614,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_12_120000) do
     t.integer "parent_notification_id"
     t.string "recipient_email", null: false
     t.string "recipient_role", null: false
+    t.boolean "responded", default: false, null: false
     t.integer "root_notification_id"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["kind"], name: "index_notifications_on_kind"

--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -1544,6 +1544,68 @@ if amy && aisha
   puts "  #{shared.size} bookmarks shared between both users"
 end
 
+puts "Creating Notifications…"
+contact_us_samples = [
+  { from: "jordan.hayes@example.com", subject: "Question about facilitating Comfort Journals" },
+  { from: "priya.patel@example.com",  subject: "Interested in starting a chapter" },
+  { from: "sam.wong@example.com",     subject: "Press inquiry — Survivor Voices article" },
+  { from: "lee.morgan@example.com",   subject: "Donation receipt request" },
+  { from: "chris.alvarez@example.com", subject: "Workshop materials availability" },
+  { from: "robin.singh@example.com",  subject: "Volunteer opportunities" }
+]
+
+reply_to_email = ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+sample_user = User.where.not(person_id: nil).first
+
+contact_us_samples.each_with_index do |sample, i|
+  delivered_at = (contact_us_samples.size - i).days.ago
+
+  Notification.find_or_create_by!(
+    recipient_email: sample[:from],
+    email_subject: "We received your message",
+    kind: "contact_us"
+  ) do |n|
+    n.noticeable = sample_user&.person
+    n.recipient_role = "person"
+    n.notification_type = 0
+    n.delivered_at = delivered_at
+  end
+
+  Notification.find_or_create_by!(
+    recipient_email: reply_to_email,
+    email_subject: "[FYI] New contact form submission from #{sample[:from]}: #{sample[:subject]}",
+    kind: "contact_us_fyi"
+  ) do |n|
+    n.noticeable = sample_user&.person
+    n.recipient_role = "admin"
+    n.notification_type = 0
+    n.delivered_at = delivered_at
+    # Mark older submissions as already responded so the green checks are visible
+    n.responded = i < (contact_us_samples.size / 2)
+  end
+end
+
+# A few non-contact-us notifications so the em-dash rendering is visible too
+[
+  { kind: "event_registration_confirmation_fyi", subject: "[FYI] New event registration" },
+  { kind: "idea_submitted_fyi", subject: "[FYI] New story idea submission by a contributor" },
+  { kind: "workshop_log_submitted_fyi", subject: "New WorkshopLog submission" }
+].each_with_index do |attrs, i|
+  Notification.find_or_create_by!(
+    recipient_email: reply_to_email,
+    email_subject: attrs[:subject],
+    kind: attrs[:kind]
+  ) do |n|
+    n.noticeable = sample_user&.person
+    n.recipient_role = "admin"
+    n.notification_type = 0
+    n.delivered_at = (i + 1).days.ago
+  end
+end
+
+puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications " \
+     "(#{Notification.where(kind: 'contact_us_fyi', responded: true).count} marked responded)"
+
 # ─── Ahoy visits & events (analytics charts) ───────────────────────────
 if Ahoy::Visit.any?
   puts "Skipping Ahoy seed data (#{Ahoy::Visit.count} visits already exist)"

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe Notification do
     end
   end
 
+  describe "#contact_us?" do
+    it "returns true for contact_us kind" do
+      expect(build(:notification, kind: "contact_us").contact_us?).to be true
+    end
+
+    it "returns true for contact_us_fyi kind" do
+      expect(build(:notification, kind: "contact_us_fyi").contact_us?).to be true
+    end
+
+    it "returns false for other kinds" do
+      expect(build(:notification, kind: "reset_password_fyi").contact_us?).to be false
+    end
+  end
+
   describe '#resend?' do
     it 'returns true when notification has a parent' do
       parent = create(:notification)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -44,17 +44,41 @@ RSpec.describe Notification do
     end
   end
 
-  describe "#contact_us?" do
-    it "returns true for contact_us kind" do
-      expect(build(:notification, kind: "contact_us").contact_us?).to be true
+  describe ".responded_status" do
+    let!(:fyi_responded)     { create(:notification, kind: "contact_us_fyi", responded: true) }
+    let!(:fyi_not_responded) { create(:notification, kind: "contact_us_fyi", responded: false) }
+    let!(:contact_us)        { create(:notification, kind: "contact_us") }
+    let!(:other)             { create(:notification, kind: "reset_password_fyi") }
+
+    it "returns only responded contact_us_fyi notifications for 'yes'" do
+      expect(Notification.responded_status("yes")).to contain_exactly(fyi_responded)
     end
 
+    it "returns only unresponded contact_us_fyi notifications for 'no'" do
+      expect(Notification.responded_status("no")).to contain_exactly(fyi_not_responded)
+    end
+
+    it "returns notifications other than contact_us_fyi for 'na'" do
+      expect(Notification.responded_status("na")).to contain_exactly(contact_us, other)
+    end
+
+    it "returns all notifications for blank/unknown values" do
+      expect(Notification.responded_status("")).to contain_exactly(fyi_responded, fyi_not_responded, contact_us, other)
+      expect(Notification.responded_status("bogus")).to contain_exactly(fyi_responded, fyi_not_responded, contact_us, other)
+    end
+  end
+
+  describe "#requires_response?" do
     it "returns true for contact_us_fyi kind" do
-      expect(build(:notification, kind: "contact_us_fyi").contact_us?).to be true
+      expect(build(:notification, kind: "contact_us_fyi").requires_response?).to be true
+    end
+
+    it "returns false for contact_us kind (auto-confirmation to submitter)" do
+      expect(build(:notification, kind: "contact_us").requires_response?).to be false
     end
 
     it "returns false for other kinds" do
-      expect(build(:notification, kind: "reset_password_fyi").contact_us?).to be false
+      expect(build(:notification, kind: "reset_password_fyi").requires_response?).to be false
     end
   end
 

--- a/spec/policies/notification_policy_spec.rb
+++ b/spec/policies/notification_policy_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe NotificationPolicy, type: :policy do
     end
   end
 
+  describe "#update?" do
+    context "with admin user" do
+      subject { policy_for(record: notification, user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:update?) }
+    end
+
+    context "with owner user" do
+      subject { policy_for(record: notification, user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:update?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(record: notification, user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:update?) }
+    end
+  end
+
   describe "#resend?" do
     context "with admin user" do
       subject { policy_for(record: notification, user: admin_user) }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -25,9 +25,69 @@ RSpec.describe "Notifications", type: :request do
       expect(response.body).not_to include(user_notification.recipient_email)
     end
 
+    context "filtering by responded_status" do
+      let!(:fyi_responded)     { create(:notification, kind: "contact_us_fyi", responded: true,  recipient_email: "yes-fyi@example.com") }
+      let!(:fyi_not_responded) { create(:notification, kind: "contact_us_fyi", responded: false, recipient_email: "no-fyi@example.com") }
+      let!(:user_confirmation) { create(:notification, kind: "contact_us",                       recipient_email: "confirm@example.com") }
+
+      it "yes returns only responded contact_us_fyi notifications" do
+        get notifications_path, params: { responded_status: "yes" }, headers: turbo_headers
+        expect(response.body).to include(fyi_responded.recipient_email)
+        expect(response.body).not_to include(fyi_not_responded.recipient_email)
+        expect(response.body).not_to include(user_confirmation.recipient_email)
+      end
+
+      it "no returns only unresponded contact_us_fyi notifications" do
+        get notifications_path, params: { responded_status: "no" }, headers: turbo_headers
+        expect(response.body).to include(fyi_not_responded.recipient_email)
+        expect(response.body).not_to include(fyi_responded.recipient_email)
+        expect(response.body).not_to include(user_confirmation.recipient_email)
+      end
+
+      it "na excludes contact_us_fyi notifications" do
+        get notifications_path, params: { responded_status: "na" }, headers: turbo_headers
+        expect(response.body).to include(user_confirmation.recipient_email)
+        expect(response.body).not_to include(fyi_responded.recipient_email)
+        expect(response.body).not_to include(fyi_not_responded.recipient_email)
+      end
+    end
+
     it "wraps results in a turbo frame" do
       get notifications_path, headers: turbo_headers
       expect(response.body).to include('id="notifications_results"')
+    end
+
+    context "responded checkbox rendering" do
+      let!(:fyi)             { create(:notification, kind: "contact_us_fyi", responded: false, recipient_email: "fyi@example.com") }
+      let!(:fyi_done)        { create(:notification, kind: "contact_us_fyi", responded: true,  recipient_email: "done@example.com") }
+      let!(:user_confirm)    { create(:notification, kind: "contact_us",                      recipient_email: "confirm@example.com") }
+      let!(:other)           { create(:notification, kind: "reset_password_fyi",              recipient_email: "other@example.com") }
+
+      it "renders an unchecked checkbox for unresponded contact_us_fyi rows" do
+        get notifications_path, params: { email: "fyi@example.com" }, headers: turbo_headers
+
+        expect(response.body).to match(/name="notification\[responded\]"[^>]*value="1"(?![^>]*checked)/)
+      end
+
+      it "renders a checked checkbox for responded contact_us_fyi rows" do
+        get notifications_path, params: { email: "done@example.com" }, headers: turbo_headers
+
+        expect(response.body).to match(/name="notification\[responded\]"[^>]*value="1"[^>]*checked/)
+      end
+
+      it "renders an em-dash placeholder (no checkbox) for contact_us auto-confirmations" do
+        get notifications_path, params: { email: "confirm@example.com" }, headers: turbo_headers
+
+        expect(response.body).to include(user_confirm.recipient_email)
+        expect(response.body).not_to match(/<input[^>]*name="notification\[responded\]"/)
+      end
+
+      it "renders an em-dash placeholder (no checkbox) for other kinds" do
+        get notifications_path, params: { email: "other@example.com" }, headers: turbo_headers
+
+        expect(response.body).to include(other.recipient_email)
+        expect(response.body).not_to match(/<input[^>]*name="notification\[responded\]"/)
+      end
     end
   end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -31,6 +31,49 @@ RSpec.describe "Notifications", type: :request do
     end
   end
 
+  describe "PATCH /notifications/:id" do
+    let(:contact_notification) { create(:notification, kind: "contact_us_fyi", recipient_email: regular_user.email) }
+
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "marks the notification as responded" do
+        patch notification_path(contact_notification), params: { notification: { responded: "1" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(contact_notification.reload.responded).to be(true)
+      end
+
+      it "marks the notification as not responded" do
+        contact_notification.update!(responded: true)
+
+        patch notification_path(contact_notification), params: { notification: { responded: "0" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(contact_notification.reload.responded).to be(false)
+      end
+    end
+
+    context "as a regular user" do
+      before { sign_in regular_user }
+
+      it "does not allow updating" do
+        patch notification_path(contact_notification), params: { notification: { responded: "1" } }
+
+        expect(contact_notification.reload.responded).to be(false)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as a guest" do
+      it "redirects to sign in" do
+        patch notification_path(contact_notification), params: { notification: { responded: "1" } }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
   describe "POST /notifications/:id/resend" do
     context "as an admin" do
       before { sign_in admin }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -91,6 +91,46 @@ RSpec.describe "Notifications", type: :request do
     end
   end
 
+  describe "GET /notifications/:id" do
+    let(:fyi)          { create(:notification, kind: "contact_us_fyi") }
+    let(:user_confirm) { create(:notification, kind: "contact_us") }
+    let(:other)        { create(:notification, kind: "reset_password_fyi") }
+
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the responded checkbox for contact_us_fyi" do
+        get notification_path(fyi)
+
+        expect(response.body).to match(/<input[^>]*name="notification\[responded\]"[^>]*value="1"/)
+      end
+
+      it "does not render the responded checkbox for contact_us (auto-confirmation)" do
+        get notification_path(user_confirm)
+
+        expect(response.body).not_to match(/<input[^>]*name="notification\[responded\]"/)
+      end
+
+      it "does not render the responded checkbox for other kinds" do
+        get notification_path(other)
+
+        expect(response.body).not_to match(/<input[^>]*name="notification\[responded\]"/)
+      end
+    end
+
+    context "as a non-admin owner" do
+      let(:fyi) { create(:notification, kind: "contact_us_fyi", recipient_email: regular_user.email) }
+
+      before { sign_in regular_user }
+
+      it "does not render the responded checkbox even on contact_us_fyi" do
+        get notification_path(fyi)
+
+        expect(response.body).not_to match(/<input[^>]*name="notification\[responded\]"/)
+      end
+    end
+  end
+
   describe "PATCH /notifications/:id" do
     let(:contact_notification) { create(:notification, kind: "contact_us_fyi", recipient_email: regular_user.email) }
 

--- a/spec/system/notification_responded_toggle_spec.rb
+++ b/spec/system/notification_responded_toggle_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Notification responded toggle", type: :system, js: true do
+  let(:admin) { create(:user, :admin) }
+  let!(:fyi) { create(:notification, kind: "contact_us_fyi", responded: false, recipient_email: "fyi@example.com") }
+
+  before { sign_in admin }
+
+  def responded_checkbox
+    find("input[type='checkbox'][name='notification[responded]']")
+  end
+
+  describe "on the index page" do
+    it "auto-saves when an admin checks the box" do
+      visit notifications_path
+
+      expect(responded_checkbox).not_to be_checked
+
+      responded_checkbox.check
+
+      expect(page).to have_css("input[name='notification[responded]'].ring-green-300", wait: 5)
+      expect(fyi.reload.responded).to be(true)
+    end
+
+    it "auto-saves when an admin unchecks the box" do
+      fyi.update!(responded: true)
+
+      visit notifications_path
+
+      expect(responded_checkbox).to be_checked
+
+      responded_checkbox.uncheck
+
+      expect(page).to have_css("input[name='notification[responded]'].ring-green-300", wait: 5)
+      expect(fyi.reload.responded).to be(false)
+    end
+  end
+
+  describe "on the show page" do
+    it "auto-saves when an admin checks the box" do
+      visit notification_path(fyi)
+
+      expect(responded_checkbox).not_to be_checked
+
+      responded_checkbox.check
+
+      expect(page).to have_css("input[name='notification[responded]'].ring-green-300", wait: 5)
+      expect(fyi.reload.responded).to be(true)
+    end
+
+    it "auto-saves when an admin unchecks the box" do
+      fyi.update!(responded: true)
+
+      visit notification_path(fyi)
+
+      expect(responded_checkbox).to be_checked
+
+      responded_checkbox.uncheck
+
+      expect(page).to have_css("input[name='notification[responded]'].ring-green-300", wait: 5)
+      expect(fyi.reload.responded).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Staff need a way to track which contact-us submissions have been replied to.
- Currently there's no signal in the notifications index — admins have to remember (or open each notification) to know what's outstanding.

### How did you approach the change?

**Schema + model**
- Added a `responded:boolean` column to `notifications` (default `false`, non-null). Migration is reversible.
- Predicate `Notification#requires_response?` returns true only for `contact_us_fyi` (the staff-facing FYI). The user-facing `contact_us` auto-confirmation is an automated receipt to the submitter — staff don't "respond" to it — so it renders an em-dash like any other kind.
- New `Notification.responded_status` scope wired into `search_by_params` for the filter dropdown.

**Index** (`/notifications`)
- New "Responded" column. For `contact_us_fyi` rows it renders an inline checkbox; for everything else it shows "—".
- New "Responded" filter dropdown (All / Yes / No / N/A) so staff can quickly surface what's outstanding.
- Fixed a left-padding asymmetry on the index header (inner `<section>` had `pl-8` on top of the outer `p-6`).

**Show** (`/notifications/:id`)
- Same Responded toggle surfaced in the top-right status column alongside Delivered/Failed badges and Resend controls, so admins can mark a contact submission handled without bouncing back to the list.

**Plumbing**
- The checkbox uses the existing `autosave` Stimulus controller — toggling fires a PATCH to `notifications#update`, no submit button, no page reload.
- `NotificationPolicy#update?` is admin-only (matches the index permission).
- Dev seeds add 6 fake `contact_us` + `contact_us_fyi` notification pairs (older half pre-marked responded) plus a few non-contact FYIs so the em-dash rendering is visible too.

**Unrelated bundled change**
- `ai/server` now probes upward from 3000 for a free port when `CONDUCTOR_PORT` is unset, instead of failing with EADDRINUSE.

### UI Testing Checklist

- [ ] Sign in as admin → visit `/notifications`
- [ ] Filter to a `contact_us_fyi` row → checkbox renders unchecked
- [ ] Tick the checkbox → green ring flashes (autosave success), refresh → still checked
- [ ] Untick → state persists after refresh
- [ ] `contact_us` (user-facing) and unrelated rows show "—" in the Responded column
- [ ] Open a `contact_us_fyi` show page → toggle in top-right works and persists
- [ ] "Responded" filter: Yes / No / N/A return the expected slices
- [ ] Sign in as a non-admin → `PATCH /notifications/:id` is denied; show page does not render the checkbox

### Anything else to add?

- Started with a boolean rather than `responded_at` datetime — YAGNI; we can layer a timestamp later if audit needs it.
- Specs added: model (predicate + scope), request (index render, show render, filter, PATCH auth), system (autosave on index + show).

🤖 Generated with [Claude Code](https://claude.com/claude-code)