### PR TITLE
HOLD UNTIL PROFILES LAUNCH: Allow authenticated users to access the people index and search

### DIFF
--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -2,7 +2,7 @@ class PersonPolicy < ApplicationPolicy
   # See https://actionpolicy.evilmartians.io/#/writing_policies
 
   def index?
-    admin?
+    authenticated?
   end
 
   def show?
@@ -26,7 +26,7 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def search?
-    admin?
+    authenticated?
   end
 
   # Scoping

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PersonPolicy, type: :policy do
     context "with regular user" do
       subject { policy_for(user: regular_user) }
 
-      it { is_expected.not_to be_allowed_to(:index?) }
+      it { is_expected.to be_allowed_to(:index?) }
     end
 
     context "with no user" do

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "People authorization", type: :request do
     context "as a regular user" do
       before { sign_in regular_user }
 
-      it "redirects to root" do
+      it "renders successfully" do
         get people_path
-        expect(response).to redirect_to(root_path)
+        expect(response).to have_http_status(:ok)
       end
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Open up the People index (`GET /people`) and people typeahead search to all authenticated users
- Previously both were admin-only; we want regular users to be able to find other community members
- Visibility filters that govern *which* people show up (searchable flag, active affiliations, locked user accounts) are tracked separately — see follow-up PR #1489

### How did you approach the change?

- `PersonPolicy#index?` and `PersonPolicy#search?` now allow any authenticated user instead of only admins
- The existing non-admin `relation_scope` already filters to `searchable` people with active affiliations, so non-admins still don't see opted-out profiles or people with no active affiliation
- `show?`, `edit?`, `update?`, and `destroy?` remain admin-only (or owner for `show?`)
- Updated the `PersonPolicy` spec so a regular user is expected to be allowed `:index?`
- Updated the people authorization request spec to expect a 200 (instead of redirect to root) for a regular user hitting `/people`

### UI Testing Checklist

- [ ] Sign in as a regular user, visit `/people`, confirm the index loads (200)
- [ ] Confirm regular users still cannot view individual person `show`/`edit`/`update` pages unless they own them
- [ ] Confirm admins still see all people on the index
- [ ] Confirm people typeahead (`/search?model=person&q=...`) returns results for a regular user

### Anything else to add?

- Stacked PR: #1489 builds on this to also exclude people whose user account is locked