### PR TITLE
Fix people index for non-admin access (#1490)

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -7,7 +7,7 @@ class Affiliation < ApplicationRecord
 
   scope :active, -> {
     where(inactive: false)
-      .where("end_date IS NULL OR end_date >= ?", Date.current)
+      .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
   }
 
   scope :facilitators, -> { where("title LIKE ?", "%facilitator%") }

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -19,11 +19,18 @@
           </thead>
           <tbody class="divide-y divide-gray-200">
             <% @people.each do |person| %>
-              <% cache [person, current_user.super_user?] do %>
+              <% cache [ person, current_user.super_user?, current_user.person_id == person.id ] do %>
               <tr class="hover:bg-gray-50 transition-colors duration-150 <%= "admin-only bg-blue-100" unless person.published? %>">
                 <td class="px-4 py-2">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
-                  <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
+                  <% if allowed_to?(:show?, person) %>
+                    <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
+                  <% else %>
+                    <span class="font-semibold"><%= person.name %></span>
+                    <% if show_email && person.preferred_email.present? %>
+                      <div class="text-xs text-gray-500"><%= person.preferred_email %></div>
+                    <% end %>
+                  <% end %>
                 </td>
                 <td class="px-4 py-2 text-center text-sm text-gray-800">
                   <%= person.member_since&.year %>
@@ -50,15 +57,25 @@
                   <% if affiliations.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% affiliations.first(3).each do |affiliation| %>
-                        <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
-                            data: { turbo_frame: "_top" },
-                            class: "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}",
-                            style: affiliation.facilitator? ? nil : "border-left: 4px solid #d1d5db" %>
+                        <% org_classes = "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)}" %>
+                        <% org_style = affiliation.facilitator? ? nil : "border-left: 4px solid #d1d5db" %>
+                        <% if allowed_to?(:show?, affiliation.organization) %>
+                          <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
+                              data: { turbo_frame: "_top" },
+                              class: "#{org_classes} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}",
+                              style: org_style %>
+                        <% else %>
+                          <span class="<%= org_classes %>" style="<%= org_style %>"><%= affiliation.organization.name %></span>
+                        <% end %>
                       <% end %>
                       <% if affiliations.size > 3 %>
-                        <%= link_to "+#{affiliations.size - 3}", person_path(person),
-                            data: { turbo_frame: "_top" },
-                            class: "inline-block px-3 py-1 rounded-md text-sm font-medium text-gray-500 hover:text-gray-700" %>
+                        <% if allowed_to?(:show?, person) %>
+                          <%= link_to "+#{affiliations.size - 3}", person_path(person),
+                              data: { turbo_frame: "_top" },
+                              class: "inline-block px-3 py-1 rounded-md text-sm font-medium text-gray-500 hover:text-gray-700" %>
+                        <% else %>
+                          <span class="inline-block px-3 py-1 rounded-md text-sm font-medium text-gray-500">+<%= affiliations.size - 3 %></span>
+                        <% end %>
                       <% end %>
                     </div>
                   <% else %>

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe Affiliation do
     it 'excludes records with past end date' do
       expect(described_class.active).not_to include(inactive_by_end_date)
     end
+
+    it 'qualifies end_date when joined with organizations (which also has end_date)' do
+      expect {
+        described_class.active.joins(:organization).to_a
+      }.not_to raise_error
+    end
   end
 
   describe '#set_inactive_from_dates' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -299,6 +299,12 @@ RSpec.describe Person, type: :model do
       expect(results).to include(person_alice)
       expect(results).not_to include(person_bob)
     end
+
+    it 'chains with_active_affiliations and organization_name without an ambiguous end_date error' do
+      expect {
+        Person.with_active_affiliations.search_by_params(organization_name: 'Alpha').to_a
+      }.not_to raise_error
+    end
   end
 
   describe ".published" do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -132,6 +132,22 @@ RSpec.describe PersonPolicy, type: :policy do
         expect(sql).to include('`affiliations`.`inactive` = FALSE')
         expect(sql).to include('`users`.`locked_at` IS NULL')
       end
+
+      it "excludes people whose user account is locked" do
+        regular = create(:user)
+        searchable = create(:person, profile_is_searchable: true)
+        create(:affiliation, person: searchable, inactive: false, end_date: nil)
+        locked = create(:person, profile_is_searchable: true, user: create(:user, :locked))
+        create(:affiliation, person: locked, inactive: false, end_date: nil)
+        unlinked = create(:person, profile_is_searchable: true, user: nil)
+        create(:affiliation, person: unlinked, inactive: false, end_date: nil)
+
+        policy = described_class.new(Person, user: regular)
+        scope = policy.apply_scope(Person.all, type: :active_record_relation)
+
+        expect(scope).to include(searchable, unlinked)
+        expect(scope).not_to include(locked)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #1490

### What is the goal of this PR and why is this important?
- In preparation for exposing the `Person` profile to non-admins, harden the `/people` index so it doesn't crash on a search filter and renders only links the viewer can follow.

### How did you approach the change?
- **Ambiguous `end_date`**: qualified the column inside `Affiliation.active` (`affiliations.end_date`) so merging it onto a relation that also joins `organizations` (which has its own `end_date`) no longer raises `Trilogy::ProtocolError: 1052: Column 'end_date' in where clause is ambiguous`. Added regression tests that join `:organization` and that chain `Person.with_active_affiliations.search_by_params(organization_name: ...)`.
- **Policy-aware links** in `app/views/people/people_results.html.erb`: gated the person profile button, organization affiliation pills, and the overflow `+N` link with `allowed_to?(:show?, ...)`. When the viewer lacks access, the same content renders as plain text instead of a link. Expanded the fragment-cache key to include whether the viewer owns the row so policy-gated output stays correct.
- Note: the locked-user filter and the index policy change are not in this PR — those landed in #1489 / #1494.

### UI Testing Checklist
- [ ] As an admin, `/people` renders with all existing links (person profile, organization pills, edit, user)
- [ ] As an admin, filtering by `organization_name` no longer 500s (regression check for the ambiguous column)
- [ ] (Once the index opens to non-admins) confirm organization pills render as plain text when `OrganizationPolicy#show?` returns false
- [ ] (Once the index opens to non-admins) confirm an owner sees a working link to their own profile row

### Anything else to add?
- The index controller still uses `PersonPolicy#index?` (admin-only on `main`), so the view changes are dormant until the policy opens up. The third issue checklist item ("check policies for all links in the index results") is addressed defensively rather than waiting for the policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)