### PR TITLE
Respect category position in story idea population categories

### DIFF
--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -125,7 +125,7 @@ class StoryIdeasController < ApplicationController
     @users = users.distinct.order("people.first_name, people.last_name")
 
     @story_population_type = CategoryType.find_by(name: "StoryPopulation")
-    @story_population_categories = @story_population_type&.categories&.published&.order(:name) || []
+    @story_population_categories = @story_population_type&.categories&.published&.ordered_by_position_and_name || []
     @sectors = Sector.published.order(:name)
     submitted_sector_ids = Array(params.dig(:story_idea, :sector_ids)).reject(&:blank?)
     submitted_category_ids = Array(params.dig(:story_idea, :category_ids)).reject(&:blank?)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The simplified story idea form was displaying "Who is this story about?" (StoryPopulation) category checkboxes in alphabetical order, ignoring the per-type ordering set in the admin category index
- The `Category` model already supports per-`category_type` ordering via the `positioned` gem and `ordered_by_position_and_name` scope, and the admin index already has drag-reorder UI wired up — but the simplified-view loader was bypassing it

### How did you approach the change?

- One-line change in `StoryIdeasController#set_form_variables`: switched `.order(:name)` to `.ordered_by_position_and_name` on `@story_population_categories`
- The persisted-view loader (`@categories_grouped`) was already ordering by `:position, :name`, so this brings the simplified view in line

### UI Testing Checklist

- [ ] In the categories admin index, filter by StoryPopulation category type and drag-reorder a couple of rows
- [ ] Open the public/new story idea form and confirm the StoryPopulation checkboxes appear in the admin-set order
- [ ] Confirm the persisted/edit story idea form still orders correctly (no regression)

### Anything else to add?

- `position` is scoped per `category_type_id`, so reorder in the admin index only produces meaningful results when first filtered by a single category type