### PR TITLE
Clarify sector/category checkbox headings on story and video forms

### DIFF
--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -24,7 +24,8 @@ class Sector < ApplicationRecord
     "Other"
   ]
 
-  STORY_DISPLAY_TEXT = "Which sectors apply?"
+  STORY_DISPLAY_TEXT = "Which sectors does this story fit into?"
+  VIDEO_DISPLAY_TEXT = "Which sectors apply?"
 
   has_many :sectorable_items, dependent: :destroy
   has_many :workshops, through: :sectorable_items,

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -103,6 +103,7 @@
   <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6 mt-6">
     <h3 class="text-base font-semibold text-gray-800 mb-3">
       <%= Sector::STORY_DISPLAY_TEXT %>
+      <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
     </h3>
 
     <div class="flex flex-wrap gap-3">
@@ -129,7 +130,10 @@
 
   <% story_specific_categories.each do |type, cats| %>
     <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
-      <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type.display_label %></h3>
+      <h3 class="text-base font-semibold text-gray-800 mb-3">
+        <%= type.display_label %>
+        <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
+      </h3>
 
       <div class="flex flex-wrap gap-3">
         <% cats.each do |category| %>

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -153,6 +153,7 @@
             <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
               <h3 class="text-base font-semibold text-gray-800 mb-3">
                 <%= Sector::STORY_DISPLAY_TEXT %>
+                <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
               </h3>
 
               <div class="flex flex-wrap gap-3">
@@ -180,7 +181,10 @@
             <div class="form-group space-y-6">
               <% @categories_grouped.each do |type, cats| %>
                 <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-                  <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type.display_label %></h3>
+                  <h3 class="text-base font-semibold text-gray-800 mb-3">
+                    <%= type.display_label %>
+                    <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
+                  </h3>
 
                   <div class="flex flex-wrap gap-3">
                     <% cats.each do |category| %>
@@ -213,6 +217,7 @@
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
         <h3 class="text-base font-semibold text-gray-800 mb-3">
           <%= Sector::STORY_DISPLAY_TEXT %>
+          <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
         </h3>
 
         <div class="flex flex-wrap gap-3">
@@ -241,6 +246,7 @@
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
           <h3 class="text-base font-semibold text-gray-800 mb-3">
             <%= @story_population_type.display_label %>
+            <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
           </h3>
 
           <div class="flex flex-wrap gap-3">

--- a/app/views/video_recordings/_form.html.erb
+++ b/app/views/video_recordings/_form.html.erb
@@ -77,7 +77,10 @@
         <div id="tags" class="border border-gray-300 p-4 rounded-b-md">
           <!-- Sectors -->
           <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
-            <h3 class="text-base font-semibold text-gray-800 mb-3">Which sectors apply?</h3>
+            <h3 class="text-base font-semibold text-gray-800 mb-3">
+              <%= Sector::VIDEO_DISPLAY_TEXT %>
+              <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
+            </h3>
 
             <div class="flex flex-wrap gap-3">
               <% @sectors.each do |sector| %>
@@ -105,7 +108,10 @@
           <div class="form-group space-y-6">
             <% @categories_grouped.each do |type, cats| %>
               <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-                <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type.display_label %></h3>
+                <h3 class="text-base font-semibold text-gray-800 mb-3">
+                  <%= type.display_label %>
+                  <span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>
+                </h3>
 
                 <div class="flex flex-wrap gap-3">
                   <% cats.each do |category| %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The sector-list heading on stories and videos was the same generic "Which sectors apply?" — the story context benefits from naming the noun ("this story") so the prompt reads less like a checklist label and more like a question
- The category/sector checkbox groups are all multi-select, but nothing in the UI hinted at that — users could reasonably pick only one. Adding "(check all that apply)" makes the affordance explicit

### How did you approach the change?

- Split `Sector::STORY_DISPLAY_TEXT` (now "Which sectors does this story fit into?") from a new `Sector::VIDEO_DISPLAY_TEXT` ("Which sectors apply?"), and pointed the video form at the new constant
- Added a small italic gray inline `<span class="text-sm font-normal italic text-gray-500 ml-1">(check all that apply)</span>` next to every multi-select tag heading on:
  - `app/views/stories/_form.html.erb` — sector heading and per-`category_type` heading
  - `app/views/story_ideas/_form.html.erb` — sector heading (admin & simplified), per-`category_type` heading, and `@story_population_type` heading
  - `app/views/video_recordings/_form.html.erb` — sector heading and per-`category_type` heading
- Kept the hint visually subordinate (smaller, italic, gray) so it reads as a parenthetical, not a competing label

### UI Testing Checklist

- [ ] Open `/stories/new` and confirm "Which sectors does this story fit into? (check all that apply)" appears, with the parenthetical in a lighter italic style
- [ ] Open `/story_ideas/new` (simplified view) and confirm the same heading + hint on sectors, and "(check all that apply)" on the StoryPopulation group
- [ ] Open `/story_ideas/:id/edit` (admin/persisted view) and confirm the sector heading and each category-type heading show the hint
- [ ] Open `/video_recordings/new` and confirm "Which sectors apply? (check all that apply)"
- [ ] Confirm the hint wraps reasonably at narrow widths and doesn't dominate the heading

### Anything else to add?

- The existing spec at `spec/views/stories/new.html.erb_spec.rb:204` asserts against `Sector::STORY_DISPLAY_TEXT`, so it picks up the new wording automatically
- I considered scoping the "(check all that apply)" hint to just the StoryPopulation heading (which is what prompted this), but every group rendered by these loops is a checkbox multi-select, so applying it uniformly is consistent. Easy to narrow with a conditional if reviewers prefer