### PR TITLE
Clarify workshop search prompt on StoryIdea form

### DIFF
--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -68,7 +68,7 @@
               remote_select_model_value: "workshop"
             }
           },
-          prompt: "Type to search workshops",
+          prompt: "Type to search workshops…",
           label: "Workshop",
           label_html: { class: "block font-medium mb-1 text-gray-700 #{ 'readonly' if promoted_to_story }" } %>
 

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -68,7 +68,7 @@
               remote_select_model_value: "workshop"
             }
           },
-          prompt: "Search by title",
+          prompt: "Type to search workshops",
           label: "Workshop",
           label_html: { class: "block font-medium mb-1 text-gray-700 #{ 'readonly' if promoted_to_story }" } %>
 


### PR DESCRIPTION
Closes #1506

### What is the goal of this PR and why is this important?
- Stakeholder (Rachel) reported that the workshop field's "Search by title" prompt was ambiguous about what's being searched
- Per discussion on the issue, we went with the text-change approach rather than pre-fetching a dropdown of unrelated results

### How did you approach the change?
- Changed the prompt on the StoryIdea form's workshop remote-select from "Search by title" to "Type to search workshops"
- Mentions what is being searched (per Justin's feedback that "start typing to search" alone is ambiguous), and "Type to" signals to the user that this is a search input rather than a static dropdown

### UI Testing Checklist
- [ ] Navigate to a new StoryIdea form and verify the workshop field shows "Type to search workshops" as its placeholder
- [ ] Verify typing into the field still surfaces workshop results
- [ ] Verify selecting a workshop saves correctly

### Anything else to add?
- The same "Search by title" prompt also appears on the Story, WorkshopLog, WorkshopVariation, and WorkshopVariationIdea forms. Scoping this PR to the StoryIdea form per the issue title — happy to do a follow-up for the others if we want consistency