### PR TITLE
Add magnifying glass icon to remote-select inputs

### DIFF
--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
           .catch(() => callback());
       },
     });
+    this.addSearchIcon();
     // Inject CSS to remove some default tom-select styles -might be a better way to do this.
     const style = document.createElement("style");
     style.textContent = `
@@ -38,10 +39,21 @@ export default class extends Controller {
         padding: 0 !important;           /* Remove padding from input */
         margin: 0 !important;            /* Remove margin if any */
       }
+      .ts-wrapper {
+        position: relative;
+      }
+      .ts-wrapper .remote-select-icon {
+        position: absolute;
+        left: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        color: #9ca3af;
+        pointer-events: none;
+      }
       .ts-control {
         border: none !important;
         box-shadow: none !important;
-        padding: 0 !important;           /* Remove padding from container */
+        padding: 0 0 0 1.25rem !important;  /* Left padding for search icon */
         margin: 0 !important;
         min-height: 0 !important;        /* Remove min-height TomSelect sets */
       }
@@ -51,6 +63,15 @@ export default class extends Controller {
       }
     `;
     document.head.appendChild(style);
+  }
+
+  addSearchIcon() {
+    const wrapper = this.select.wrapper;
+    if (!wrapper || wrapper.querySelector(".remote-select-icon")) return;
+    const icon = document.createElement("i");
+    icon.className = "fa-solid fa-magnifying-glass remote-select-icon";
+    icon.setAttribute("aria-hidden", "true");
+    wrapper.prepend(icon);
   }
 
   disconnect() {

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -39,21 +39,27 @@ export default class extends Controller {
         padding: 0 !important;           /* Remove padding from input */
         margin: 0 !important;            /* Remove margin if any */
       }
-      .ts-wrapper {
+      .remote-select-container {
         position: relative;
       }
-      .ts-wrapper .remote-select-icon {
+      .remote-select-container .remote-select-icon {
         position: absolute;
-        left: 0.25rem;
+        left: 0.75rem;
         top: 50%;
         transform: translateY(-50%);
         color: #9ca3af;
+        font-size: 0.875rem;
+        line-height: 1;
         pointer-events: none;
+        z-index: 1;
+      }
+      .remote-select-container .ts-control {
+        padding-left: 1.5rem !important;  /* Make room for the search icon */
       }
       .ts-control {
         border: none !important;
         box-shadow: none !important;
-        padding: 0 0 0 1.5rem !important;  /* Left padding for search icon */
+        padding: 0 !important;           /* Remove padding from container */
         margin: 0 !important;
         min-height: 0 !important;        /* Remove min-height TomSelect sets */
       }
@@ -67,11 +73,15 @@ export default class extends Controller {
 
   addSearchIcon() {
     const wrapper = this.select.wrapper;
-    if (!wrapper || wrapper.querySelector(".remote-select-icon")) return;
+    if (!wrapper || wrapper.parentElement?.classList.contains("remote-select-container")) return;
+    const container = document.createElement("div");
+    container.className = "remote-select-container";
+    wrapper.parentNode.insertBefore(container, wrapper);
+    container.appendChild(wrapper);
     const icon = document.createElement("i");
     icon.className = "fa-solid fa-magnifying-glass remote-select-icon";
     icon.setAttribute("aria-hidden", "true");
-    wrapper.prepend(icon);
+    container.appendChild(icon);
   }
 
   disconnect() {

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -44,7 +44,7 @@ export default class extends Controller {
       }
       .ts-wrapper .remote-select-icon {
         position: absolute;
-        left: 0;
+        left: 0.25rem;
         top: 50%;
         transform: translateY(-50%);
         color: #9ca3af;
@@ -53,7 +53,7 @@ export default class extends Controller {
       .ts-control {
         border: none !important;
         box-shadow: none !important;
-        padding: 0 0 0 1.25rem !important;  /* Left padding for search icon */
+        padding: 0 0 0 1.5rem !important;  /* Left padding for search icon */
         margin: 0 !important;
         min-height: 0 !important;        /* Remove min-height TomSelect sets */
       }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Per Justin's comment on #1506, a small UI tweak (in addition to the text changes in #1509 / #1527) would help users tell remote search fields apart from regular dropdowns
- Regular selects show a chevron caret on the right; remote-search fields had no distinguishing visual

### How did you approach the change?
- Added a magnifying glass icon on the left of every `remote-select` field, injected by the existing Stimulus controller so all uses get it consistently
- Left placement (rather than right) creates a stronger structural distinction from the chevron-on-the-right selects nearby, and matches the convention from most search inputs (Google, GitHub, macOS)
- Wraps the Tom Select element in a `.remote-select-container` div the controller creates, so the icon positions against a container with predictable dimensions (positioning against `.ts-wrapper` directly was rendering clipped)
- Added left padding to the Tom Select control so typed text doesn't overlap the icon

### UI Testing Checklist
- [ ] Visit a new StoryIdea form and confirm the workshop field shows a magnifying glass on the left
- [ ] Confirm the workshop field looks visually distinct from the Windows audience and Organization selects on either side
- [ ] Type into the workshop field and confirm typed text does not overlap the icon and the icon renders fully inside the rounded border
- [ ] Spot-check other remote-select fields (Story, WorkshopLog, WorkshopVariation, WorkshopVariationIdea, person/org affiliation fields, event registrations) — confirm the icon appears and search still works

### Anything else to add?
- Affects all 8 views that use `remote-select`
- Companion to #1509 (merged) and #1527 (prompt-text changes for the remaining views)