### PR TITLE
Handle blocked organization deletion gracefully

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -131,10 +131,10 @@ class OrganizationsController < ApplicationController
     if @organization.destroy
       redirect_to organizations_path, notice: "Organization was successfully destroyed."
     else
-      redirect_to @organization, alert: "Unable to delete this organization: #{@organization.errors.full_messages.to_sentence}."
+      redirect_to edit_organization_path(@organization), alert: "Unable to delete this organization: #{@organization.errors.full_messages.to_sentence}."
     end
   rescue ActiveRecord::InvalidForeignKey
-    redirect_to @organization, alert: "Unable to delete this organization because it has associated records that cannot be removed."
+    redirect_to edit_organization_path(@organization), alert: "Unable to delete this organization because it has associated records that cannot be removed."
   end
 
   def check_duplicates

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -127,8 +127,14 @@ class OrganizationsController < ApplicationController
 
   def destroy
     authorize! @organization
-    @organization.destroy!
-    redirect_to organizations_path, notice: "Organization was successfully destroyed."
+
+    if @organization.destroy
+      redirect_to organizations_path, notice: "Organization was successfully destroyed."
+    else
+      redirect_to @organization, alert: "Unable to delete this organization: #{@organization.errors.full_messages.to_sentence}."
+    end
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to @organization, alert: "Unable to delete this organization because it has associated records that cannot be removed."
   end
 
   def check_duplicates

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -202,7 +202,17 @@ RSpec.describe "/organizations", type: :request do
         }.not_to change(Organization, :count)
 
         expect(response).to redirect_to(organization_url(organization))
-        expect(flash[:alert]).to be_present
+        expect(flash[:alert]).to include("Unable to delete this organization")
+      end
+
+      it "renders the alert on the page after following the redirect" do
+        organization = Organization.create!(valid_attributes)
+        create(:affiliation, organization: organization)
+
+        delete organization_url(organization)
+        follow_redirect!
+
+        expect(response.body).to include("Unable to delete this organization")
       end
     end
 
@@ -216,7 +226,17 @@ RSpec.describe "/organizations", type: :request do
         }.not_to change(Organization, :count)
 
         expect(response).to redirect_to(organization_url(organization))
-        expect(flash[:alert]).to be_present
+        expect(flash[:alert]).to include("associated records that cannot be removed")
+      end
+
+      it "renders the alert on the page after following the redirect" do
+        organization = Organization.create!(valid_attributes)
+        create(:workshop_log, organization: organization, created_by: admin)
+
+        delete organization_url(organization)
+        follow_redirect!
+
+        expect(response.body).to include("associated records that cannot be removed")
       end
     end
   end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -191,6 +191,34 @@ RSpec.describe "/organizations", type: :request do
       delete organization_url(organization)
       expect(response).to redirect_to(organizations_url)
     end
+
+    context "when the organization has affiliations" do
+      it "does not destroy and redirects with an alert" do
+        organization = Organization.create!(valid_attributes)
+        create(:affiliation, organization: organization)
+
+        expect {
+          delete organization_url(organization)
+        }.not_to change(Organization, :count)
+
+        expect(response).to redirect_to(organization_url(organization))
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "when the organization has associated workshop logs" do
+      it "does not destroy and redirects with an alert" do
+        organization = Organization.create!(valid_attributes)
+        create(:workshop_log, organization: organization, created_by: admin)
+
+        expect {
+          delete organization_url(organization)
+        }.not_to change(Organization, :count)
+
+        expect(response).to redirect_to(organization_url(organization))
+        expect(flash[:alert]).to be_present
+      end
+    end
   end
 
   describe "POST /create with duplicate check" do

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -201,13 +201,37 @@ RSpec.describe "/organizations", type: :request do
           delete organization_url(organization)
         }.not_to change(Organization, :count)
 
-        expect(response).to redirect_to(organization_url(organization))
+        expect(response).to redirect_to(edit_organization_url(organization))
         expect(flash[:alert]).to include("Unable to delete this organization")
       end
 
       it "renders the alert on the page after following the redirect" do
         organization = Organization.create!(valid_attributes)
         create(:affiliation, organization: organization)
+
+        delete organization_url(organization)
+        follow_redirect!
+
+        expect(response.body).to include("Unable to delete this organization")
+      end
+    end
+
+    context "when the organization has event registrations" do
+      it "does not destroy and redirects with an alert" do
+        organization = Organization.create!(valid_attributes)
+        create(:event_registration_organization, organization: organization)
+
+        expect {
+          delete organization_url(organization)
+        }.not_to change(Organization, :count)
+
+        expect(response).to redirect_to(edit_organization_url(organization))
+        expect(flash[:alert]).to include("Unable to delete this organization")
+      end
+
+      it "renders the alert on the page after following the redirect" do
+        organization = Organization.create!(valid_attributes)
+        create(:event_registration_organization, organization: organization)
 
         delete organization_url(organization)
         follow_redirect!
@@ -225,7 +249,7 @@ RSpec.describe "/organizations", type: :request do
           delete organization_url(organization)
         }.not_to change(Organization, :count)
 
-        expect(response).to redirect_to(organization_url(organization))
+        expect(response).to redirect_to(edit_organization_url(organization))
         expect(flash[:alert]).to include("associated records that cannot be removed")
       end
 


### PR DESCRIPTION
Closes #1497

### What is the goal of this PR and why is this important?
- Deleting an organization with associated affiliations, event registrations, workshop logs, stories, or other related records previously produced a 500 error
- Admins were unable to understand or recover from the failure

### How did you approach the change?
- `OrganizationsController#destroy` now uses `destroy` (instead of `destroy!`) so `restrict_with_error` validations from `affiliations` and `event_registration_organizations` surface as flash alerts
- Added a `rescue ActiveRecord::InvalidForeignKey` to catch DB-level FK constraint violations from associations not covered by `dependent:` (workshop_logs, reports, stories, story_ideas, community_news, monthly_reports, workshop_variations, workshop_variation_ideas, users)
- On failure, the user is redirected to the **edit** page with an alert explaining the blockage — this is where the delete button lives and where admins manage the associations (affiliations, etc.) that block deletion
- On success, redirect to the index (unchanged)
- Added request specs covering all three failure paths (affiliations, event registrations, workshop logs) plus assertions that the flash alert text renders on the destination page

### UI Testing Checklist
- [ ] As an admin, delete an organization that has no affiliations or other associated records — should redirect to the index with a success notice
- [ ] As an admin, attempt to delete an organization with active affiliations — should redirect to the edit page with an alert
- [ ] As an admin, attempt to delete an organization with event registrations — should redirect to the edit page with an alert
- [ ] As an admin, attempt to delete an organization that has workshop logs — should redirect to the edit page with an alert

### Anything else to add?
- Follows the same redirect-with-flash convention used by `UsersController#destroy` and the Rails scaffold
- Edit-page redirect matches this codebase's convention of placing delete buttons on edit forms