### PR TITLE
Update remote-select prompts to "Type to search …"

### DIFF
--- a/app/views/people/_affiliation_fields.html.erb
+++ b/app/views/people/_affiliation_fields.html.erb
@@ -20,7 +20,7 @@
               }
             },
             error: "Organization can't be blank",
-            prompt: "Search by name",
+            prompt: "Type to search organizations…",
             label: "Organization",
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 " } %>
         <% end %>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -59,7 +59,7 @@
                       remote_select_model_value: "workshop"
                     }
                   },
-                  prompt: "Search by title",
+                  prompt: "Type to search workshops…",
                   label: "Workshop",
                   label_html: { class: "block font-medium mb-1 text-gray-700" } %>
 
@@ -82,7 +82,7 @@
                       remote_select_model_value: "organization"
                     }
                   },
-                  prompt: "Search by name",
+                  prompt: "Type to search organizations…",
                   label: "Organization",
                   label_html: { class: "block font-medium mb-1 text-gray-700" } %>
     </div>

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -21,7 +21,7 @@
               remote_select_model_value: "workshop"
             }
           },
-          prompt: "Search by title",
+          prompt: "Type to search workshops…",
           label: "Workshop",
           label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
 

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -37,7 +37,7 @@
                 remote_select_model_value: "workshop"
               }
             },
-            prompt: "Search by title",
+            prompt: "Type to search workshops…",
             label: "Workshop" %>
         <% elsif f.object.workshop_id.present? %>
           <%= f.hidden_field :workshop_id, value: f.object.workshop_id %>

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -18,7 +18,7 @@
               remote_select_model_value: "workshop"
             }
           },
-          prompt: "Search by title",
+          prompt: "Type to search workshops…",
           label: "Workshop" %>
       <% elsif @workshop %>
         <%= f.hidden_field :workshop_id, value: @workshop.id %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Applies the same prompt pattern as #1509 (which updated the StoryIdea form) to the remaining views with remote-select fields
- Signals to users that these are remote-search fields rather than static dropdowns, and names what's being searched

### How did you approach the change?
- Changed `"Search by title"` → `"Type to search workshops…"` on the workshop fields in:
  - `stories/_form.html.erb`
  - `workshop_logs/_form.html.erb`
  - `workshop_variations/_form.html.erb`
  - `workshop_variation_ideas/_form.html.erb`
- Changed `"Search by name"` → `"Type to search organizations…"` on the organization fields in:
  - `stories/_form.html.erb`
  - `people/_affiliation_fields.html.erb`

### UI Testing Checklist
- [ ] On a new Story form, confirm the workshop field placeholder reads "Type to search workshops…"
- [ ] On the same Story form, confirm the organization field placeholder reads "Type to search organizations…"
- [ ] On a new WorkshopLog form, confirm the workshop field placeholder reads "Type to search workshops…"
- [ ] On a new WorkshopVariation form (admin), confirm the workshop field placeholder reads "Type to search workshops…"
- [ ] On a new WorkshopVariationIdea form (admin), confirm the workshop field placeholder reads "Type to search workshops…"
- [ ] On a Person's affiliation fields, confirm the organization field placeholder reads "Type to search organizations…"
- [ ] Confirm typing in each field still surfaces results and selection still saves

### Anything else to add?
- Follow-up to #1509, which scoped its text change to StoryIdea only