### PR TITLE
Align select and remote-select heights with input height

### DIFF
--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -30,24 +30,28 @@ export default class extends Controller {
     const style = document.createElement("style");
     style.textContent = `
       /* Remove border and shadow */
-      .ts-control .ts-input {
+      .ts-control .ts-input,
+      .ts-control input {
         border: none !important;
         box-shadow: none !important;
         outline: none !important;
         background: transparent !important;
         padding: 0 !important;           /* Remove padding from input */
         margin: 0 !important;            /* Remove margin if any */
+        line-height: 1.5rem !important;  /* Match the line-height of a native input so heights align */
       }
       .ts-control {
         border: none !important;
         box-shadow: none !important;
         padding: 0 !important;           /* Remove padding from container */
         margin: 0 !important;
-        min-height: 0 !important;        /* Remove min-height TomSelect sets */
+        min-height: 1.5rem !important;   /* Match a single line of text so empty state matches selected state */
+        line-height: 1.5rem !important;
       }
       .ts-control .item {
         margin: 0 !important;            /* Remove padding/margin from selected items */
         padding: 0 !important;
+        line-height: 1.5rem !important;
       }
     `;
     document.head.appendChild(style);

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -104,6 +104,7 @@
 select.select-placeholder {
   color: #9ca3af !important;
   font-size: 0.875rem !important;
+  line-height: 1.5rem !important;
 }
 
 .is-active {


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the new story idea form, the three controls in the first row rendered at three different heights: the empty native ``Windows audience`` select was shortest, the ``Workshop`` TomSelect was slightly taller, and the populated ``Organization`` select was the tallest. They should all match the standard input height.

### How did you approach the change?
- Pinned ``line-height: 1.5rem`` on ``select.select-placeholder`` so the smaller placeholder font (``0.875rem``) no longer collapses the box, keeping empty selects the same height as populated ones.
- In ``remote_select_controller.js``, replaced the ``min-height: 0`` reset on ``.ts-control`` with ``min-height: 1.5rem`` and pinned ``line-height: 1.5rem`` on the control, the inner input, and ``.item`` so TomSelect's content box matches a single line of ``text-base``. Combined with the wrapper's existing ``py-2`` and border, total height ends up at the same 42px as a native input.

### UI Testing Checklist
- [ ] On ``/story_ideas/new``, the ``Windows audience``, ``Workshop`` (TomSelect), and ``Organization`` controls all sit at the same height as the surrounding text inputs, both empty and after a value is selected.
- [ ] Other forms that use ``remote-select`` (event registrations, workshop variations, story form, people/organization affiliations) still render correctly.
- [ ] Other native selects with the placeholder caret styling render at full input height when empty.

### Anything else to add?
- The line-height was the missing piece — without it, both the smaller-font placeholder and TomSelect's default sizing produce a shorter box. Pinning it keeps the placeholder visually smaller without affecting layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)