### PR TITLE
Filter four content indexes by organization_id

### DIFF
--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -25,6 +25,7 @@ class CommunityNewsController < ApplicationController
 
       render :index_lazy
     else
+      @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
       render :index
     end
   end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -12,6 +12,7 @@ class EventRegistrationsController < ApplicationController
     @event_registrations_count = filtered.size
     @event_registrations = filtered.includes(registrant: [ :user, { avatar_attachment: :blob } ], event: :event_forms).paginate(page: params[:page], per_page: per_page)
     @events = Event.order(start_date: :desc)
+    @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
     @filtered_event = Event.find_by(id: params[:event_id]) if params[:event_id].present?
     @selected_registrant = Person.find_by(id: params[:registrant_id]) if params[:registrant_id].present?
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -21,6 +21,7 @@ class StoriesController < ApplicationController
 
       render :index_lazy
     else
+      @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
       render :index
     end
   end

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -11,6 +11,7 @@ class StoryIdeasController < ApplicationController
                            .paginate(page: params[:page], per_page: per_page)
                            .decorate
     @story_ideas_count = filtered.count == base_scope.count ? base_scope.count : "#{filtered.count}/#{base_scope.count}"
+    @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
   end
 
   def show

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -66,6 +66,7 @@ class CommunityNews < ApplicationRecord
     community_news = community_news.by_year(params[:year]) if params[:year].present? && params[:year].match?(/\A\d{4}\z/)
     community_news = community_news.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     community_news = community_news.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
+    community_news = community_news.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     community_news
   end
 end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -68,6 +68,11 @@ class EventRegistration < ApplicationRecord
     elsif params[:event_name].present?
       registrations = registrations.event_title(params[:event_name].downcase.strip)
     end
+    if params[:organization_id].present?
+      registrations = registrations.joins(:event_registration_organizations)
+                                   .where(event_registration_organizations: { organization_id: params[:organization_id] })
+                                   .distinct
+    end
     registrations
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -81,6 +81,7 @@ class Story < ApplicationRecord
     stories = stories.facilitator_spotlights(params[:facilitator_spotlights]) if params[:facilitator_spotlights].present?
     stories = stories.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     stories = stories.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
+    stories = stories.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     stories
   end
 

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -8,6 +8,7 @@ class StoryIdea < ApplicationRecord
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.search(params[:query]) if params[:query].present?
+    results = results.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     results
   end
 

--- a/app/views/community_news/_search_boxes.html.erb
+++ b/app/views/community_news/_search_boxes.html.erb
@@ -59,6 +59,19 @@
                  button_text: "All" %>
     </div>
 
+    <!-- ORGANIZATION -->
+    <div class="min-w-[200px] pb-2">
+      <label for="organization_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Organization
+      </label>
+      <%= f.select :organization_id,
+                   options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),
+                   { include_blank: "All organizations" },
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+                           focus:ring-blue-500 focus:border-blue-500",
+                   onchange: "this.form.requestSubmit()" %>
+    </div>
+
     <!-- CLEAR FILTERS -->
     <div class="min-w-[120px] pb-3">
       <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">&nbsp;</label>

--- a/app/views/event_registrations/_search_boxes.html.erb
+++ b/app/views/event_registrations/_search_boxes.html.erb
@@ -25,6 +25,15 @@
                              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
                      onchange: "this.form.submit();" %>
     </div>
+    <div class="w-full md:flex-1">
+      <%= label_tag :organization_id, "Organization", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :organization_id,
+                     options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),
+                     include_blank: "All organizations",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                     onchange: "this.form.submit();" %>
+    </div>
     <!-- Clear filters -->
     <div class="w-full md:w-auto flex justify-end"><%= link_to 'Clear filters', event_registrations_path,
                   class: "btn btn-utility-outline",

--- a/app/views/stories/_search_boxes.html.erb
+++ b/app/views/stories/_search_boxes.html.erb
@@ -61,6 +61,19 @@
                  button_text: "All" %>
     </div>
 
+    <!-- ORGANIZATION -->
+    <div class="min-w-[200px] pb-2">
+      <label for="organization_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+        Organization
+      </label>
+      <%= f.select :organization_id,
+                   options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),
+                   { include_blank: "All organizations" },
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2
+                           focus:ring-blue-500 focus:border-blue-500",
+                   onchange: "this.form.requestSubmit()" %>
+    </div>
+
     <!-- CLEAR FILTERS -->
     <div class="min-w-[120px] pb-3">
       <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">&nbsp;</label>

--- a/app/views/story_ideas/_search_boxes.html.erb
+++ b/app/views/story_ideas/_search_boxes.html.erb
@@ -16,6 +16,17 @@
       </div>
     </div>
 
+    <!-- Organization -->
+    <div class="w-full md:w-auto md:min-w-[220px]">
+      <%= label_tag :organization_id, "Organization", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :organization_id,
+                     options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),
+                     include_blank: "All organizations",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                     onchange: "this.form.submit()" %>
+    </div>
+
     <!-- Clear filters -->
     <div class="w-full md:w-auto">
       <%= link_to "Clear filters", story_ideas_path,

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -207,5 +207,14 @@ RSpec.describe CommunityNews, type: :model do
       expect(results).to include(news_alpha)
       expect(results).not_to include(news_beta)
     end
+
+    it 'filters by organization_id' do
+      organization = create(:organization)
+      org_news = create(:community_news, author: user_with_person, organization: organization)
+
+      results = CommunityNews.search_by_params(organization_id: organization.id)
+      expect(results).to include(org_news)
+      expect(results).not_to include(news_alpha, news_beta)
+    end
   end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -228,6 +228,15 @@ RSpec.describe EventRegistration, type: :model do
       expect(results).to include(reg_alice_art)
       expect(results).not_to include(reg_bob_music)
     end
+
+    it 'filters by organization_id via event_registration_organizations' do
+      organization = create(:organization)
+      create(:event_registration_organization, event_registration: reg_alice_art, organization: organization)
+
+      results = EventRegistration.search_by_params(organization_id: organization.id)
+      expect(results).to include(reg_alice_art)
+      expect(results).not_to include(reg_bob_music)
+    end
   end
 
   describe "cancellation emails" do

--- a/spec/models/story_idea_spec.rb
+++ b/spec/models/story_idea_spec.rb
@@ -65,5 +65,11 @@ RSpec.describe StoryIdea, type: :model do
       results = StoryIdea.search_by_params(query: 'nonexistent')
       expect(results).not_to include(idea_alpha, idea_beta)
     end
+
+    it 'filters by organization_id' do
+      results = StoryIdea.search_by_params(organization_id: idea_alpha.organization_id)
+      expect(results).to include(idea_alpha)
+      expect(results).not_to include(idea_beta)
+    end
   end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -129,5 +129,14 @@ RSpec.describe Story, type: :model do
       expect(results).to include(published_story)
       expect(results).not_to include(draft_story, old_story)
     end
+
+    it 'filters by organization_id' do
+      organization = create(:organization)
+      org_story = create(:story, organization: organization)
+
+      results = Story.search_by_params(organization_id: organization.id)
+      expect(results).to include(org_story)
+      expect(results).not_to include(published_story, draft_story, old_story)
+    end
   end
 end

--- a/spec/requests/community_news_spec.rb
+++ b/spec/requests/community_news_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe "/community_news", type: :request do
       get community_news_index_url
       expect(response).to be_successful
     end
+
+    it "filters by organization_id on lazy turbo-frame request" do
+      org = create(:organization)
+      matching = CommunityNews.create!(valid_attributes.merge(title: "Org Match", organization: org))
+      other    = CommunityNews.create!(valid_attributes.merge(title: "Other Match"))
+
+      get community_news_index_url(organization_id: org.id), headers: { "Turbo-Frame" => "community_news_results" }
+      expect(response).to be_successful
+      expect(response.body).to include(matching.title)
+      expect(response.body).not_to include(other.title)
+    end
   end
 
   describe "GET /show" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response).to have_http_status(:success)
       end
 
+      it "filters registrations by organization_id" do
+        organization = create(:organization)
+        matching_reg = create(:event_registration)
+        create(:event_registration_organization, event_registration: matching_reg, organization: organization)
+
+        get event_registrations_path(organization_id: organization.id)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(matching_reg.registrant.first_name)
+        expect(response.body).not_to include(existing_registration.registrant.first_name)
+      end
+
       it "exports CSV with headers and data only (no captions)" do
         get event_registrations_path, params: { format: :csv }
 

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe "/stories", type: :request do
         expect(response.body).to include(private_story.title)
       end
 
+      it "filters by organization_id on lazy turbo-frame request" do
+        other_org = create(:organization)
+        story_in_other_org = Story.create!(base_attributes.merge(
+          title: "Other Org Story #{SecureRandom.hex(4)}",
+          organization_id: other_org.id,
+          published: true
+        ))
+
+        get stories_url(organization_id: organization.id), headers: { "Turbo-Frame" => "story_results" }
+        expect(response.body).to include(published_story.title)
+        expect(response.body).not_to include(story_in_other_org.title)
+      end
+
       describe "external link handling" do
         let(:turbo_headers) { { "Turbo-Frame" => "story_results" } }
 

--- a/spec/requests/story_ideas_spec.rb
+++ b/spec/requests/story_ideas_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe "/story_ideas", type: :request do
         get story_ideas_url
         expect(response).to be_successful
       end
+
+      it "filters story ideas by organization_id" do
+        org = create(:organization)
+        matching = create(:story_idea, organization: org)
+        excluded = create(:story_idea)
+
+        get story_ideas_url(organization_id: org.id)
+        expect(response).to be_successful
+        expect(response.body).to include(story_idea_path(matching))
+        expect(response.body).not_to include(story_idea_path(excluded))
+      end
     end
 
     describe "GET /show" do

--- a/spec/views/story_ideas/index.html.erb_spec.rb
+++ b/spec/views/story_ideas/index.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "story_ideas/index", type: :view do
     # Simulate a single page of paginated results
     assign(:story_ideas,
            StoryIdeaDecorator.decorate_collection(paginated([ story_idea1, story_idea2 ])))
+    assign(:organizations, [])
   end
 
   it "renders a list of story_ideas" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- This is building up to a new update to Organization form and Organization Profile (show)
- Make four model indexes — CommunityNews, EventRegistrations, Stories, StoryIdeas — filterable by \`organization_id\`.
- Reachable from each index's filter bar via a new Organization \`<select>\`, or directly via \`?organization_id=<id>\` query param.

### How did you approach the change?
- Added an \`organization_id\` clause to each model's \`search_by_params\`.
  - \`EventRegistration\` joins through \`event_registration_organizations\`.
  - \`StoryIdea\`, \`Story\`, \`CommunityNews\` use the direct \`organization_id\` column.
- In each index action, loaded \`@organizations\` from the affiliated authorized scope and added an Organization \`<select>\` to the corresponding \`_search_boxes.html.erb\`, defaulting to "All organizations".
- Added model specs covering the new filter on each model.
- Added a request spec on each index confirming \`?organization_id=<id>\` returns only matching records and excludes others.

### UI Testing Checklist
- [ ] Visit \`/community_news\`, \`/event_registrations\`, \`/stories\`, \`/story_ideas\` — confirm the new "Organization" dropdown appears and defaults to "All organizations".
- [ ] Pick an org from the dropdown and confirm the listing narrows to records for that org only.
- [ ] Visit each index with \`?organization_id=<id>\` in the URL and confirm the same filtering.

### Anything else to add?
- Supersedes #1531. A separate PR will add an "Associated records" section to the Organization edit page consuming these filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)