### PR TITLE
Match WindowsType seed names to production (title case)

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -119,7 +119,7 @@ class BookmarksController < ApplicationController
   private
 
   def set_index_variables
-    @sortable_fields = WindowsType.where("name NOT LIKE ?", "%COMBINED%")
+    @sortable_fields = WindowsType.where.not(name: "Combined")
     @windows_types_array = WindowsType::TYPES
     @bookmarkable_types = Bookmark.bookmarkable_type_options
     @workshops = authorized_scope(Workshop.where("led_count > 0")).order(led_count: :desc)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -133,18 +133,12 @@ class Bookmark < ApplicationRecord
 
   def self.windows_type(windows_type)
     return all unless windows_type.present?
-    case windows_type.downcase
-    when /adult/
-      normalized = "ADULT WORKSHOP"
-    when /child/
-      normalized = "CHILDREN WORKSHOP"
-    when /combined/
-      normalized = "COMBINED"
-    else
-      normalized = windows_type
+    normalized = case windows_type.downcase
+    when /adult/    then "Adult"
+    when /child/    then "Children"
+    when /combined/ then "Combined"
+    else windows_type
     end
-
-    pattern = "%#{normalized}%"
 
     # Use aliased table names to avoid conflicts with title scope's LEFT JOINs
     joins(<<~SQL)
@@ -161,7 +155,7 @@ class Bookmark < ApplicationRecord
       LEFT JOIN windows_types AS wt_ws_types
         ON wt_ws_types.id = wt_workshops.windows_type_id
     SQL
-    .where("wt_res_types.name LIKE :pattern OR wt_ws_types.name LIKE :pattern", pattern: pattern)
+    .where("wt_res_types.name = :name OR wt_ws_types.name = :name", name: normalized)
   end
 
   def self.user_name(user_name)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -129,9 +129,9 @@ class Report < ApplicationRecord
 
   def form_builder
     if type and type.include? "Monthly"
-      if windows_type and windows_type.name == "ADULT WORKSHOP LOG"
+      if windows_type and windows_type.name == "Adult"
         FormBuilder.find(4)
-      elsif windows_type and windows_type.name == "CHILDREN WORKSHOP LOG"
+      elsif windows_type and windows_type.name == "Children"
         FormBuilder.find(2)
       end
     elsif owner and owner_type.include? "FormBuilder"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -262,11 +262,11 @@ user_password = Devise::Encryptor.digest(User, "password")
 User.where(email: seed_emails).update_all(encrypted_password: user_password)
 
 puts "Creating WindowsTypes…"
-adult_type = WindowsType.where(name: "ADULT WINDOWS")
+adult_type = WindowsType.where(name: "Adult")
                         .first_or_create!(legacy_id: 1, short_name: "Adult")
-childrens_type = WindowsType.where(name: "CHILDREN'S WINDOWS")
+childrens_type = WindowsType.where(name: "Children")
                             .first_or_create!(legacy_id: 2, short_name: "Children")
-combined_type = WindowsType.where(name: "ADULT & CHILDREN COMBINED (FAMILY) WINDOWS")
+combined_type = WindowsType.where(name: "Combined")
                            .first_or_create!(legacy_id: 3, short_name: "Combined")
 
 puts "Creating FormBuilders…"

--- a/spec/factories/windows_types.rb
+++ b/spec/factories/windows_types.rb
@@ -4,17 +4,17 @@ FactoryBot.define do
     sequence(:short_name) { |n| "Short Name #{n}" }
 
     trait :adult do
-      name { "ADULT WINDOWS" }
+      name { "Adult" }
       short_name { "Adult" }
     end
 
     trait :children do
-      name { "CHILDREN'S WINDOWS" }
+      name { "Children" }
       short_name { "Children" }
     end
 
     trait :combined do
-      name { "ADULT & CHILDREN COMBINED (FAMILY) WINDOWS" }
+      name { "Combined" }
       short_name { "Combined" }
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Bring our `WindowsType` seeds and factory in line with what actually lives in production.
- In production, the three `WindowsType` rows are `Adult` / `Children` / `Combined` (title case, single word) — both the `name` and `short_name` columns. Our seeds and factory were still creating them with the older verbose names (`ADULT WINDOWS`, `CHILDREN'S WINDOWS`, `ADULT & CHILDREN COMBINED (FAMILY) WINDOWS`), which haven't matched prod for some time.
- That drift silently breaks code that looks up a `WindowsType` by `name`, for example `WindowsType.find_by(name: "Combined")` in the workshop_variation form, which currently returns nil against the older seed data.

### How did you approach the change?
- `db/seeds.rb`: create the three `WindowsType` rows with `name` set to the same title-case value as `short_name`.
- `spec/factories/windows_types.rb`: update the `:adult`, `:children`, `:combined` traits to use the new names so factory-built records mirror prod.
- `app/controllers/bookmarks_controller.rb`: switch from a case-sensitive `LIKE "%COMBINED%"` exclusion to a direct `where.not(name: "Combined")` now that the name is a stable single word.
- Leaving `app/models/concerns/reportable.rb` alone for now — its `form_builder` method also compares against the old `"ADULT WORKSHOP LOG"` / `"CHILDREN WORKSHOP LOG"` strings, but that file only exists on the `monthly-reports-index` branch (PR #1530). A 1-line follow-up will update it once #1530 merges.

### UI Testing Checklist
- [ ] Run `bin/rails db:seed` on a fresh DB and confirm the three `WindowsType` rows have `name`/`short_name` set to `Adult` / `Children` / `Combined`.
- [ ] On an existing dev DB, manually update the three `WindowsType` rows to match (or wipe and reseed).
- [ ] WorkshopVariation form: confirm the windows-type dropdown defaults to `Combined` (was previously broken because `find_by(name: "Combined")` returned nil).
- [ ] Bookmarks index: sortable fields still exclude `Combined`.

### Anything else to add?
- This is a pure naming-alignment PR; no behavior changes were intended beyond fixing the lookups that were already supposed to work.