### PR TITLE
Rebalance published story image sizing (#1519)

### DIFF
--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -2,11 +2,11 @@
 
 class DisplayImagePresenter
   WIDTH_CLASSES = {
-    "18" => "w-18", "24" => "w-24", "32" => "w-32", "full" => "w-full"
+    "18" => "w-18", "24" => "w-24", "32" => "w-32", "48" => "w-48", "full" => "w-full"
   }.freeze
 
   HEIGHT_CLASSES = {
-    "14" => "h-14", "18" => "h-18", "24" => "h-24", "32" => "h-32", "full" => "h-full"
+    "14" => "h-14", "18" => "h-18", "24" => "h-24", "32" => "h-32", "48" => "h-48", "full" => "h-full"
   }.freeze
 
   PDF_PREVIEW_SIZES = { hero: [ 1200, 1200 ], gallery: [ 300, 300 ], index: [ 300, 300 ] }.freeze

--- a/app/views/assets/_display_assets.html.erb
+++ b/app/views/assets/_display_assets.html.erb
@@ -1,4 +1,7 @@
+<% hero_extra_classes ||= "" %>
+<% gallery_width ||= "32" %>
+<% gallery_height ||= gallery_width %>
 <div class="assets">
-  <%= render "assets/display_image", resource: resource, file: (defined?(file) ? file : nil), variant: (defined?(variant) ? variant : :hero), link: (defined?(link) ? link : nil) %>
-  <%= render "assets/display_gallery_media", resource: resource, link: (defined?(link) ? link : nil), align: (defined?(align) ? align : nil) %>
+  <%= render "assets/display_image", resource: resource, file: (defined?(file) ? file : nil), variant: (defined?(variant) ? variant : :hero), link: (defined?(link) ? link : nil), extra_image_classes: hero_extra_classes %>
+  <%= render "assets/display_gallery_media", resource: resource, link: (defined?(link) ? link : nil), align: (defined?(align) ? align : nil), width: gallery_width, height: gallery_height %>
 </div>

--- a/app/views/assets/_display_gallery_media.html.erb
+++ b/app/views/assets/_display_gallery_media.html.erb
@@ -1,11 +1,13 @@
 <!-- Gallery Media -->
 <% gallery_assets = resource.gallery_assets.select { |img| img.file.attached? } %>
 <% align = (defined?(align) && align.present?) ? align.to_s : "center" %>
+<% width ||= "32" %>
+<% height ||= width %>
 <% if gallery_assets.any? %>
   <div class="<%= resource.class.table_name %>-gallery text-<%= align %> mb-4">
     <div class="flex flex-wrap justify-<%= align %> gap-4 <%= 'mx-auto' if align == 'center' %> max-w-4xl">
       <% gallery_assets.each_with_index do |gallery_assets, idx| %>
-        <%= render "assets/display_image", item: gallery_assets, idx: idx, variant: :gallery, link: (defined?(link) ? link : nil) %>
+        <%= render "assets/display_image", item: gallery_assets, idx: idx, variant: :gallery, width: width, height: height, link: (defined?(link) ? link : nil) %>
       <% end %>
     </div>
   </div>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -60,7 +60,8 @@
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
         <div id="hero-image">
-          <%= render "assets/display_assets", resource: @story, link: true %>
+          <%= render "assets/display_assets", resource: @story, link: true,
+                     hero_extra_classes: "max-w-2xl mx-auto", gallery_width: "48", gallery_height: "48" %>
         </div>
 
         <!-- Story Body Text -->

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe DisplayImagePresenter do
         expect(result.image_classes).to include("h-32")
       end
 
+      it "maps width and height of 48 to w-48 and h-48" do
+        result = described_class.call(file: "test.jpg", variant: :gallery, width: "48", height: "48", view_context: view_context)
+        expect(result.image_classes).to include("w-48")
+        expect(result.image_classes).to include("h-48")
+      end
+
       it "builds index wrapper classes with dimensions" do
         result = described_class.call(file: "test.jpg", variant: :index, width: "24", height: "24", view_context: view_context)
         expect(result.wrapper_classes).to include("index-size")

--- a/spec/views/stories/show.html.erb_spec.rb
+++ b/spec/views/stories/show.html.erb_spec.rb
@@ -19,4 +19,29 @@ RSpec.describe "stories/show", type: :view do
     expect(rendered).to match(/MyBody/)
     expect(rendered).to match(story.author_credit)
   end
+
+  context "with primary and gallery images" do
+    let(:story_with_images) do
+      created = create(:story, created_by: user, updated_by: user)
+      create(:primary_asset, :with_file, owner: created)
+      create(:gallery_asset, :with_file, owner: created)
+      created.reload
+    end
+
+    before do
+      assign(:story, story_with_images.decorate)
+    end
+
+    it "constrains and centers the primary image so it does not render too large" do
+      render
+      expect(rendered).to include("max-w-2xl")
+      expect(rendered).to include("mx-auto")
+    end
+
+    it "renders gallery images at the enlarged size" do
+      render
+      expect(rendered).to include("w-48")
+      expect(rendered).to include("h-48")
+    end
+  end
 end


### PR DESCRIPTION
Closes #1519

### What is the goal of this PR and why is this important?
- On published story pages the **primary image rendered too large** (full card width) while the **secondary/gallery images rendered too small** (fixed 128px), so the relative sizing felt off.
- This rebalances the two so they read as an intentional pair, per the stakeholder request.

### How did you approach the change?
- **Shrink + center the primary:** the hero image is capped to `max-w-2xl` and centered with `mx-auto` instead of spanning the full card width.
- **Enlarge the secondary:** gallery thumbnails go from `w-32 h-32` (128px) to `w-48 h-48` (192px); still within the 256px `:thumbnail` variant, so no upscaling/blur.
- **Scoped to stories:** sizing is threaded through the shared `assets/_display_assets` and `assets/_display_gallery_media` partials via backward-compatible params (`hero_extra_classes`, `gallery_width`, `gallery_height`). All other consumers (workshops, events, ideas, etc.) keep their existing defaults.
- Added `48` entries to `DisplayImagePresenter`'s width/height maps (the `w-48`/`h-48` utilities are already emitted by other views, so Tailwind generates them).

### Tests
- Followed red→green: added failing specs first, then the fix.
- `DisplayImagePresenter` spec: `48` maps to `w-48`/`h-48`.
- `stories/show` view spec: primary image is constrained/centered; gallery images render at the enlarged size.

### UI Testing Checklist
- [ ] Open a published story with a primary image and at least one gallery image — confirm the primary is noticeably smaller/centered and the gallery thumbnails are larger.
- [ ] Confirm a story with only a primary image (no gallery) still looks correct.
- [ ] Spot-check a workshop/event show page to confirm their image sizing is unchanged.

### Anything else to add?
- Screenshots to follow.