### PR TITLE
Add copyable shareable links for individual stories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (34) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (35) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -262,6 +262,7 @@ end
 - `column_toggle` — Toggle table column visibility
 - `comment_edit_toggle` — Inline comment editing mode
 - `confirm_email` — Email confirmation UI
+- `copy_link` — Copy a direct shareable URL to the clipboard
 - `dirty_form` — Unsaved changes detection
 - `dismiss` — Dismissable elements
 - `dropdown` — Dropdown menus with keyboard/click-outside handling

--- a/app/frontend/javascript/controllers/copy_link_controller.js
+++ b/app/frontend/javascript/controllers/copy_link_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="copy-link"
+// Copies a direct shareable URL to the clipboard and gives the user feedback.
+export default class extends Controller {
+  static targets = ["input", "label"]
+  static values = { confirmedLabel: { type: String, default: "Copied!" } }
+
+  async copy() {
+    const url = this.inputTarget.value
+
+    try {
+      await navigator.clipboard.writeText(url)
+    } catch {
+      // Fallback for browsers without the async clipboard API
+      this.inputTarget.select()
+      document.execCommand("copy")
+    }
+
+    this.confirm()
+  }
+
+  confirm() {
+    if (!this.hasLabelTarget) return
+
+    const original = this.labelTarget.textContent
+    this.labelTarget.textContent = this.confirmedLabelValue
+
+    if (this.resetTimeout) clearTimeout(this.resetTimeout)
+    this.resetTimeout = setTimeout(() => {
+      this.labelTarget.textContent = original
+    }, 2000)
+  }
+
+  disconnect() {
+    if (this.resetTimeout) clearTimeout(this.resetTimeout)
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -30,6 +30,9 @@ application.register("column-toggle", ColumnToggleController)
 import CommentEditToggleController from "./comment_edit_toggle_controller"
 application.register("comment-edit-toggle", CommentEditToggleController)
 
+import CopyLinkController from "./copy_link_controller"
+application.register("copy-link", CopyLinkController)
+
 import DirtyFormController from "./dirty_form_controller"
 application.register("dirty-form", DirtyFormController)
 

--- a/app/views/stories/_share_links.html.erb
+++ b/app/views/stories/_share_links.html.erb
@@ -1,0 +1,50 @@
+<%# Direct shareable link + social/email share targets for a single story.
+    Locals: story (decorated or plain), url (canonical public share URL string). %>
+<% encoded_url   = CGI.escape(url) %>
+<% encoded_title = CGI.escape(story.title) %>
+<div class="border-t border-gray-300 pt-6 mt-6" data-controller="copy-link">
+  <h3 class="font-semibold text-lg mb-3">Share this story</h3>
+
+  <div class="flex flex-col sm:flex-row gap-2 sm:items-center mb-4">
+    <input
+      type="text"
+      data-copy-link-target="input"
+      value="<%= url %>"
+      readonly
+      aria-label="Direct link to this story"
+      class="w-full sm:max-w-md px-3 py-2 bg-gray-100 border border-gray-300 rounded font-mono text-sm overflow-x-auto whitespace-nowrap cursor-text"
+    >
+    <button type="button" data-action="copy-link#copy" class="btn btn-secondary-outline whitespace-nowrap">
+      <i class="fa-solid fa-link mr-1"></i>
+      <span data-copy-link-target="label">Copy link</span>
+    </button>
+  </div>
+
+  <div class="flex space-x-4">
+    <%= link_to "mailto:?subject=#{encoded_title}&body=#{encoded_url}",
+                class: "text-gray-600 hover:text-gray-800",
+                title: "Share by email" do %>
+      <i class="fa-solid fa-envelope fa-lg"></i>
+    <% end %>
+    <%= link_to "https://www.facebook.com/sharer/sharer.php?u=#{encoded_url}",
+                target: "_blank", rel: "noopener noreferrer",
+                class: "text-blue-600 hover:text-blue-800", title: "Share on Facebook" do %>
+      <i class="fab fa-facebook-square fa-lg"></i>
+    <% end %>
+    <%= link_to "https://twitter.com/intent/tweet?url=#{encoded_url}&text=#{encoded_title}",
+                target: "_blank", rel: "noopener noreferrer",
+                class: "text-sky-500 hover:text-sky-700", title: "Share on X" do %>
+      <i class="fab fa-x-twitter fa-lg"></i>
+    <% end %>
+    <%= link_to "https://www.linkedin.com/sharing/share-offsite/?url=#{encoded_url}",
+                target: "_blank", rel: "noopener noreferrer",
+                class: "text-blue-700 hover:text-blue-900", title: "Share on LinkedIn" do %>
+      <i class="fab fa-linkedin fa-lg"></i>
+    <% end %>
+    <%= link_to "https://pinterest.com/pin/create/button/?url=#{encoded_url}&description=#{encoded_title}",
+                target: "_blank", rel: "noopener noreferrer",
+                class: "text-red-600 hover:text-red-800", title: "Share on Pinterest" do %>
+      <i class="fab fa-pinterest-square fa-lg"></i>
+    <% end %>
+  </div>
+</div>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -1,5 +1,4 @@
-<% story_url   = story_url(@story) %>
-<% story_title = ERB::Util.url_encode(@story.title) %>
+<% share_url = story_share_url(@story) %>
 
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
@@ -69,39 +68,7 @@
         </div>
 
         <!-- Share Section -->
-        <h3 class="font-semibold text-lg mb-3">Share this Story:</h3>
-
-        <div class="flex space-x-4 mb-6">
-
-          <!-- Facebook -->
-          <%= link_to "https://www.facebook.com/sharer/sharer.php?u=#{story_url}",
-                      target: "_blank", rel: "noopener noreferrer",
-                      class: "text-blue-600 hover:text-blue-800" do %>
-            <i class="fab fa-facebook-square fa-lg"></i>
-          <% end %>
-
-          <!-- X / Twitter -->
-          <%= link_to "https://twitter.com/intent/tweet?url=#{story_url}&text=#{story_title}",
-                      target: "_blank", rel: "noopener noreferrer",
-                      class: "text-sky-500 hover:text-sky-700" do %>
-            <i class="fab fa-x-twitter fa-lg"></i>
-          <% end %>
-
-          <!-- LinkedIn -->
-          <%= link_to "https://www.linkedin.com/sharing/share-offsite/?url=#{story_url}",
-                      target: "_blank", rel: "noopener noreferrer",
-                      class: "text-blue-700 hover:text-blue-900" do %>
-            <i class="fab fa-linkedin fa-lg"></i>
-          <% end %>
-
-          <!-- Pinterest -->
-          <%= link_to "https://pinterest.com/pin/create/button/?url=#{story_url}&description=#{story_title}",
-                      target: "_blank", rel: "noopener noreferrer",
-                      class: "text-red-600 hover:text-red-800" do %>
-            <i class="fab fa-pinterest-square fa-lg"></i>
-          <% end %>
-
-        </div>
+        <%= render "stories/share_links", story: @story, url: share_url %>
 
         <div class="text-sm text-gray-500 leading-relaxed border-t border-gray-300 pt-6">
           <%= render "shared/organization_footer" %>

--- a/app/views/story_shares/show.html.erb
+++ b/app/views/story_shares/show.html.erb
@@ -84,6 +84,9 @@
         <%= render "assets/display_assets", resource: @story, link: true %>
       </div>
     <% end %>
+
+    <!-- Share Section -->
+    <%= render "stories/share_links", story: @story, url: story_share_url(@story) %>
   </div>
 </section>
 

--- a/spec/requests/story_share_spec.rb
+++ b/spec/requests/story_share_spec.rb
@@ -103,6 +103,12 @@ RSpec.describe "/story_share", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "renders a copyable direct link to the story" do
+        get story_share_path(public_story)
+        expect(response.body).to include(story_share_url(public_story))
+        expect(response.body).to include("Copy link")
+      end
+
       it "cannot view published-only story" do
         get story_share_path(published_story)
         expect(response).to redirect_to(root_path)


### PR DESCRIPTION
Closes #1523

### What is the goal of this PR and why is this important?
- The story sharing surface previously showed only social share icons and a story count — there was no way to grab the **direct URL** for an individual story to paste into an email, message, or social post.
- Stakeholders requested copy-paste shareable links per story so stories can be circulated easily.

### How did you approach the change?
- Added a reusable `stories/_share_links` partial that renders:
  - the story's direct public URL in a read-only field with a **Copy link** button
  - email + Facebook / X / LinkedIn / Pinterest share targets
- Backed the copy button with a small `copy-link` Stimulus controller (clipboard write with a graceful `execCommand` fallback and a transient "Copied!" confirmation).
- Wired the partial into the public **story share** page (`story_shares/show`), which previously had no share affordance at all.
- Replaced the duplicated inline social markup on the **story show** page with the shared partial, so both surfaces stay in sync and now use the canonical public `story_share_url`.
- Updated `AGENTS.md` (Stimulus controller list + count).

### UI Testing Checklist
- [ ] On a public story share page, the direct URL is shown and **Copy link** copies it to the clipboard (button shows "Copied!").
- [ ] Email / Facebook / X / LinkedIn / Pinterest share links open with the correct pre-filled URL and title.
- [ ] Story show page renders the same share section.

### Anything else to add?
- Added a request spec asserting the share page renders the direct story URL and copy affordance.
- Note: this workspace was missing frontend deps; ran `npm ci` so Vite-built pages render in the test env.
