### PR TITLE
Stop submitting registration_form_id as an unpermitted event param

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -219,7 +219,7 @@ class EventsController < ApplicationController
   end
 
   def assign_event_forms(event)
-    form_id = params.dig(:event, :registration_form_id)
+    form_id = params[:registration_form_id]
     return unless form_id
 
     if form_id.blank?

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -368,7 +368,7 @@
                                    else
                                      @registration_forms.find { |rf| rf.name == ShortEventRegistrationFormBuilder::FORM_NAME }&.id
                                    end %>
-              <select name="event[registration_form_id]" class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
+              <select name="registration_form_id" class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
                 <option value="">No registration form</option>
                 <% @registration_forms.each do |reg_form| %>
                   <% label = case reg_form.name

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -378,6 +378,49 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "registration form selection" do
+    let(:reg_form) { create(:form, :standalone, name: "Short Registration") }
+
+    before { sign_in admin }
+
+    def unpermitted_params_during
+      captured = []
+      subscriber = ActiveSupport::Notifications.subscribe("unpermitted_parameters.action_controller") do |*args|
+        captured.concat(args.last[:keys])
+      end
+      yield
+      captured
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "links the selected registration form on create without an unpermitted param" do
+      unpermitted = unpermitted_params_during do
+        post events_path, params: valid_params.merge(registration_form_id: reg_form.id)
+      end
+
+      expect(unpermitted).not_to include(:registration_form_id)
+      expect(Event.last.registration_form).to eq(reg_form)
+    end
+
+    it "links the selected registration form on update without an unpermitted param" do
+      unpermitted = unpermitted_params_during do
+        patch event_path(event), params: { event: { title: "Updated" }, registration_form_id: reg_form.id }
+      end
+
+      expect(unpermitted).not_to include(:registration_form_id)
+      expect(event.reload.registration_form).to eq(reg_form)
+    end
+
+    it "removes the registration form when blank is submitted" do
+      create(:event_form, event: event, form: reg_form, role: "registration")
+
+      patch event_path(event), params: { event: { title: "Updated" }, registration_form_id: "" }
+
+      expect(event.reload.registration_form).to be_nil
+    end
+  end
+
   describe "Google Analytics snippets" do
     context "as admin" do
       before { sign_in admin }


### PR DESCRIPTION
Closes #1536

### What is the goal of this PR and why is this important?

- The event form posted the registration-form selector as `event[registration_form_id]`, but `registration_form_id` is **not** an Event attribute.
- The registration form is persisted through the `event_forms` join (see `EventsController#assign_event_forms`), not via mass assignment.
- Because the field was nested under `event[...]`, strong params rejected it as an **unpermitted parameter** and logged a warning on every event create/update — which is exactly what the issue flagged ("Why is this submitted and do we need it?").

We do need the value (it drives which registration form gets linked) — it just shouldn't live inside the `event[...]` namespace.

### How did you approach the change?

- Renamed the select from `event[registration_form_id]` to a top-level `registration_form_id` in `app/views/events/_form.html.erb`.
- Updated `assign_event_forms` to read `params[:registration_form_id]` instead of `params.dig(:event, :registration_form_id)`.
- No behavior change for users: selecting a form still links it, and selecting "No registration form" still removes it.

### Anything else to add?

- Added request specs covering create/update/blank that assert the form is linked **and** that `registration_form_id` is no longer reported via the `unpermitted_parameters.action_controller` notification.
- Note: a few unrelated event view-rendering specs (`GET /index`, `/new`, `/show`) currently return 500 in this local environment even on a clean `main` checkout (asset/CSP rendering), so they are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)