### PR TITLE
Add searchable image gallery with editable titles (#1512)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,10 +57,10 @@ This codebase (Rails 8.1)
 
 | Directory | Purpose | Count |
 |---|---|---|
-| `app/controllers/` | Rails controllers (admin/, events/) | ~63 files |
+| `app/controllers/` | Rails controllers (admin/, events/) | ~64 files |
 | `app/views/` | ERB templates | ~465 files |
 | `app/decorators/` | Draper decorators for view logic | ~36 files |
-| `app/policies/` | ActionPolicy authorization rules | ~44 files |
+| `app/policies/` | ActionPolicy authorization rules | ~45 files |
 | `app/presenters/` | Presentation objects | 1 file |
 | `app/helpers/` | View helpers | ~19 files |
 | `app/mailers/` | ActionMailer classes | 6 files |

--- a/app/controllers/gallery_assets_controller.rb
+++ b/app/controllers/gallery_assets_controller.rb
@@ -1,0 +1,33 @@
+class GalleryAssetsController < ApplicationController
+  before_action :set_gallery_asset, only: :update
+
+  def index
+    authorize! GalleryAsset
+    @query = params[:query].to_s.strip
+
+    scope = authorized_scope(GalleryAsset.images.with_attached_file.includes(:owner))
+    scope = scope.search_metadata(@query) if @query.present?
+    scope = scope.order(created_at: :desc)
+
+    @count = scope.count
+    @gallery_assets = scope.paginate(page: params[:page], per_page: 24)
+
+    render :results if turbo_frame_request?
+  end
+
+  def update
+    authorize! @gallery_asset
+    @gallery_asset.update(gallery_asset_params)
+    render partial: "gallery_assets/card", locals: { gallery_asset: @gallery_asset }
+  end
+
+  private
+
+  def set_gallery_asset
+    @gallery_asset = GalleryAsset.find(params[:id])
+  end
+
+  def gallery_asset_params
+    params.expect(gallery_asset: [ :title ])
+  end
+end

--- a/app/models/gallery_asset.rb
+++ b/app/models/gallery_asset.rb
@@ -1,2 +1,20 @@
 class GalleryAsset < Asset
+  # Only gallery assets whose attached file is an image. Joins the blob so the
+  # gallery can be searched/filtered in SQL and used as an image database.
+  scope :images, -> {
+    joins(file_attachment: :blob)
+      .where("active_storage_blobs.content_type LIKE ?", "image/%")
+  }
+
+  # Free-text search across the editable title, the owning record type, and the
+  # original filename — the metadata the team tags images with (org, workshop, etc.).
+  scope :search_metadata, ->(query) {
+    next all if query.blank?
+
+    term = "%#{sanitize_sql_like(query)}%"
+    where(
+      "assets.title LIKE :term OR assets.owner_type LIKE :term OR active_storage_blobs.filename LIKE :term",
+      term: term
+    )
+  }
 end

--- a/app/policies/gallery_asset_policy.rb
+++ b/app/policies/gallery_asset_policy.rb
@@ -1,0 +1,10 @@
+class GalleryAssetPolicy < ApplicationPolicy
+  # The gallery image database is an internal admin tool for tagging and finding images.
+  def index?  = admin?
+  def update? = admin?
+
+  relation_scope do |relation|
+    next relation if admin?
+    relation.none
+  end
+end

--- a/app/views/gallery_assets/_card.html.erb
+++ b/app/views/gallery_assets/_card.html.erb
@@ -1,0 +1,34 @@
+<%= turbo_frame_tag dom_id(gallery_asset) do %>
+  <div class="flex flex-col bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+    <a href="<%= url_for(gallery_asset.file) %>" target="_blank" rel="noopener" class="block bg-gray-50">
+      <% if gallery_asset.file.variable? %>
+        <%= image_tag gallery_asset.file.variant(:thumbnail),
+              alt: gallery_asset.title.presence || gallery_asset.file.filename.to_s,
+              loading: "lazy",
+              class: "w-full h-40 object-cover" %>
+      <% else %>
+        <%= image_tag gallery_asset.file,
+              alt: gallery_asset.title.presence || gallery_asset.file.filename.to_s,
+              loading: "lazy",
+              class: "w-full h-40 object-cover" %>
+      <% end %>
+    </a>
+
+    <div class="p-3 flex flex-col gap-2">
+      <%= form_with model: gallery_asset, url: gallery_asset_path(gallery_asset), method: :patch,
+            class: "flex items-center gap-2" do |f| %>
+        <%= f.text_field :title, value: gallery_asset.title,
+              placeholder: "Add a title…",
+              class: "min-w-0 flex-1 bg-white border border-gray-300 rounded-md px-2 py-1 text-sm
+                      focus:ring-blue-500 focus:border-blue-500" %>
+        <%= f.submit "Save", class: "btn btn-primary-outline text-xs px-2 py-1 whitespace-nowrap" %>
+      <% end %>
+
+      <% if gallery_asset.owner.present? %>
+        <p class="text-xs text-gray-500 truncate">
+          <i class="fa-regular fa-folder mr-1"></i><%= gallery_asset.owner_type.underscore.humanize %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/gallery_assets/_search.html.erb
+++ b/app/views/gallery_assets/_search.html.erb
@@ -1,0 +1,23 @@
+<%= form_tag gallery_assets_path, method: :get,
+      data: { controller: "collection", turbo_frame: "gallery_results" },
+      autocomplete: "off",
+      class: "w-full" do %>
+  <label for="query" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">
+    Search images
+  </label>
+
+  <div class="flex items-end gap-3">
+    <div class="relative flex-1">
+      <%= text_field_tag :query, params[:query],
+            placeholder: "Title, organization, workshop, filename…",
+            class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 pr-10
+                    focus:ring-blue-500 focus:border-blue-500" %>
+
+      <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700">
+        <i class="fa fa-search"></i>
+      </button>
+    </div>
+
+    <%= link_to "Clear", gallery_assets_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
+  </div>
+<% end %>

--- a/app/views/gallery_assets/index.html.erb
+++ b/app/views/gallery_assets/index.html.erb
@@ -1,0 +1,27 @@
+<div class="max-w-7xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex items-start justify-between mb-6">
+    <div class="pr-6">
+      <h1 class="text-2xl font-semibold mb-2">Image gallery</h1>
+      <p class="text-gray-600">Search every gallery image and tag it with a title (organization, workshop, etc.) to find it again.</p>
+    </div>
+  </div>
+
+  <%= render "search" %>
+
+  <div class="w-full mt-6"><hr class="border-gray-300 mb-6"></div>
+
+  <% result_src = gallery_assets_path + "?" + request.query_string %>
+  <%= turbo_frame_tag :gallery_results, src: result_src, data: { turbo: "temporary" } do %>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 animate-pulse">
+      <% 8.times do %>
+        <div class="bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <div class="w-full h-40 bg-gray-200"></div>
+          <div class="p-3 space-y-2">
+            <div class="h-8 bg-gray-200 rounded"></div>
+            <div class="h-3 w-1/2 bg-gray-200 rounded"></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/gallery_assets/results.html.erb
+++ b/app/views/gallery_assets/results.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag :gallery_results do %>
+  <p class="text-sm text-gray-500 mb-4">
+    <%= pluralize(@count, "image") %><%= " matching “#{@query}”" if @query.present? %>
+  </p>
+
+  <% if @gallery_assets.any? %>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 animate-fade">
+      <% @gallery_assets.each do |gallery_asset| %>
+        <%= render "gallery_assets/card", gallery_asset: gallery_asset %>
+      <% end %>
+    </div>
+
+    <div class="pagination flex justify-center mt-6 w-full"><%= tailwind_paginate @gallery_assets %></div>
+  <% else %>
+    <p class="text-gray-500 text-center py-10">No images match your search. Try a different term.</p>
+  <% end %>
+<% end %>

--- a/app/views/shared/_navbar_menu.html.erb
+++ b/app/views/shared/_navbar_menu.html.erb
@@ -40,6 +40,14 @@
         <i class="fas fa-tag"></i>
         <span>Tags</span>
       <% end %>
+
+      <% if allowed_to?(:index?, GalleryAsset) %>
+        <%= link_to gallery_assets_path,
+                    class: "admin-only bg-blue-100 flex items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+          <i class="fas fa-images"></i>
+          <span>Image gallery</span>
+        <% end %>
+      <% end %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
     resources :comments, only: [ :index, :create ]
   end
   resources :faqs
+  resources :gallery_assets, only: [ :index, :update ]
   resources :notifications, only: [ :index, :show, :update ] do
     member do
       post :resend

--- a/spec/models/gallery_asset_spec.rb
+++ b/spec/models/gallery_asset_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe GalleryAsset, type: :model do
+  describe ".images" do
+    it "returns only gallery assets with an attached image file" do
+      with_image = create(:gallery_asset, :with_file)
+      create(:gallery_asset) # no file attached
+
+      expect(described_class.images).to contain_exactly(with_image)
+    end
+  end
+
+  describe ".search_metadata" do
+    let!(:tagged)   { create(:gallery_asset, :with_file, title: "Sunrise Workshop") }
+    let!(:other)    { create(:gallery_asset, :with_file, title: "Evening Class") }
+
+    it "matches on the editable title (case-insensitive)" do
+      expect(described_class.images.search_metadata("sunrise")).to contain_exactly(tagged)
+    end
+
+    it "matches on the owner type" do
+      workshop = create(:workshop)
+      owned = create(:gallery_asset, :with_file, owner: workshop, title: "Untitled")
+
+      expect(described_class.images.search_metadata("workshop")).to include(owned)
+    end
+
+    it "returns the full scope when the query is blank" do
+      expect(described_class.images.search_metadata("")).to contain_exactly(tagged, other)
+    end
+  end
+end

--- a/spec/policies/gallery_asset_policy_spec.rb
+++ b/spec/policies/gallery_asset_policy_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe GalleryAssetPolicy, type: :policy do
+  let(:admin_user)   { build_stubbed(:user, super_user: true) }
+  let(:regular_user) { build_stubbed(:user, super_user: false) }
+  let(:guest_user)   { nil }
+
+  def policy_for(record:, user:)
+    described_class.new(record, user: user)
+  end
+
+  describe "#index?" do
+    it "allows admin" do
+      expect(policy_for(record: GalleryAsset, user: admin_user)).to be_allowed_to(:index?)
+    end
+
+    it "denies regular user" do
+      expect(policy_for(record: GalleryAsset, user: regular_user)).not_to be_allowed_to(:index?)
+    end
+
+    it "denies guest" do
+      expect(policy_for(record: GalleryAsset, user: guest_user)).not_to be_allowed_to(:index?)
+    end
+  end
+
+  describe "#update?" do
+    let(:gallery_asset) { build_stubbed(:gallery_asset) }
+
+    it "allows admin" do
+      expect(policy_for(record: gallery_asset, user: admin_user)).to be_allowed_to(:update?)
+    end
+
+    it "denies regular user" do
+      expect(policy_for(record: gallery_asset, user: regular_user)).not_to be_allowed_to(:update?)
+    end
+  end
+end

--- a/spec/requests/gallery_assets_spec.rb
+++ b/spec/requests/gallery_assets_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "/gallery_assets", type: :request do
+  let(:admin)        { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+  let!(:gallery_asset) { create(:gallery_asset, :with_file, title: "Sunrise Workshop") }
+
+  describe "GET /gallery_assets" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the gallery" do
+        get gallery_assets_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Image gallery")
+      end
+
+      it "filters by the search query in a turbo frame request" do
+        create(:gallery_asset, :with_file, title: "Evening Class")
+
+        get gallery_assets_path, params: { query: "sunrise" },
+            headers: { "Turbo-Frame" => "gallery_results" }
+
+        expect(response.body).to include("Sunrise Workshop")
+        expect(response.body).not_to include("Evening Class")
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in regular_user }
+
+      it "is not authorized and redirects" do
+        get gallery_assets_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed out" do
+      it "redirects to sign in" do
+        get gallery_assets_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /gallery_assets/:id" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "updates the editable title" do
+        patch gallery_asset_path(gallery_asset), params: { gallery_asset: { title: "Tagged: Org A" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(gallery_asset.reload.title).to eq("Tagged: Org A")
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in regular_user }
+
+      it "is not authorized and does not change the title" do
+        patch gallery_asset_path(gallery_asset), params: { gallery_asset: { title: "Hacked" } }
+
+        expect(response).to redirect_to(root_path)
+        expect(gallery_asset.reload.title).to eq("Sunrise Workshop")
+      end
+    end
+  end
+end

--- a/spec/routing/gallery_assets_routing_spec.rb
+++ b/spec/routing/gallery_assets_routing_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe GalleryAssetsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/gallery_assets").to route_to("gallery_assets#index")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/gallery_assets/1").to route_to("gallery_assets#update", id: "1")
+    end
+
+    it "does not route to #show" do
+      expect(get: "/gallery_assets/1").not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
Closes #1512

### What is the goal of this PR and why is this important?
- The team wants to use the portal's gallery images as an **image database**, but there was no way to browse or find them.
- There was no gallery page, no search, and image titles could not be edited — so images couldn't be tagged with their organization, workshop, etc.
- This adds an admin-only **Image gallery** so images can be tagged with meaningful titles and found again later.

### How did you approach the change?
- **New `GalleryAssetsController`** (`index`, `update`), reachable from the **Curriculum → Image gallery** nav item (admin-only).
- **`index`** lists every gallery asset whose attached file is an image, newest first, paginated (24/page).
- **Search box** debounces into a Turbo frame (reusing the existing `collection` Stimulus controller) and matches on the editable **title**, the **owner type** (Workshop, Story, …), and the original **filename**, via new `GalleryAsset.images` / `GalleryAsset.search_metadata` scopes.
- **Editable titles**: each image card has an inline title field that PATCHes to `update`; the response re-renders just that card's Turbo frame, so tagging an image never reloads the page.
- **Authorization**: `GalleryAssetPolicy` restricts both actions to admins (super users), consistent with the default policy; non-admins are redirected like elsewhere in the app.

### Anything else to add?
- Titles are intentionally free-text so the team can tag with whatever metadata is useful (org, workshop, program). Search matches that text plus owner type and filename.
- Specs added: model (scopes), request (auth + search + inline edit), policy, and routing. All green locally (`18 examples, 0 failures`).
- Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)