### PR TITLE
Allow clearing story author on edit form

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -275,7 +275,7 @@
     <div class="flex-1 mb-4 md:mb-0">
       <%= f.input :created_by_id,
                   collection: @users.map { |u| [ u.full_name_with_email, u.id ] },
-                  prompt: "Select an author",
+                  include_blank: "Select an author",
                   label: (f.object.created_by&.person ? (
                     link_to "Story author",
                             person_path(f.object.created_by.person),

--- a/spec/views/stories/edit.html.erb_spec.rb
+++ b/spec/views/stories/edit.html.erb_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe "stories/edit", type: :view do
     end
   end
 
+  it "renders a blank author option so an already-set author can be cleared" do
+    render
+
+    assert_select "select[name=?]", "story[created_by_id]" do
+      assert_select "option[value=?]", "", text: "Select an author"
+    end
+  end
+
   it "does not render the Website button when website_url is nil" do
     story.update(website_url: nil)
     assign(:story, story.decorate)


### PR DESCRIPTION
Closes #1517

### What is the goal of this PR and why is this important?
- On an existing (unpublished) story, the **Story author** field could not be cleared back to the "Select an author" placeholder — the deselect behavior only worked on the new-story form.
- This was a stakeholder-reported bug; editors need to be able to unset the author and re-choose.

### How did you approach the change?
- The author select used simple_form's `prompt:` option, which only renders the placeholder `<option>` when **no** value is selected. On an existing story the author is already set, so the blank option was never rendered and there was nothing to select to clear the field.
- Switched `prompt: "Select an author"` to `include_blank: "Select an author"`, which always renders the blank option. This matches how `workshop_id` and `organization_id` already behave on the same form, and leaves the new-story form unchanged.
- The existing `select-placeholder` styling and `onchange` handler already react to an empty value, so clearing now correctly re-applies the gray placeholder style.

### Testing
- Added a view spec asserting the edit form renders a blank `option` for `story[created_by_id]` (red before the fix, green after).
- `spec/views/stories/edit.html.erb_spec.rb` and `new.html.erb_spec.rb` pass (23 examples, 0 failures).

### Anything else to add?
- The adjacent **Story spotlighted facilitator** field (`spotlighted_facilitator_id`) has the identical `prompt:` pattern and the same limitation. It's out of scope for issue #1517, but happy to fix it in this PR or a follow-up if desired.
