### PR TITLE
Add inline gallery controls to set featured image and remove images

### DIFF
--- a/app/controllers/gallery_assets_controller.rb
+++ b/app/controllers/gallery_assets_controller.rb
@@ -1,0 +1,31 @@
+class GalleryAssetsController < ApplicationController
+  before_action :set_asset, only: [ :destroy, :make_primary ]
+
+  # Remove an image from the gallery
+  def destroy
+    authorize! @asset.owner, to: :manage? # check the policy of the record that owns the asset
+    @asset.destroy!
+
+    redirect_back_or_to polymorphic_path(@asset.owner), notice: "Image removed."
+  end
+
+  # Promote an existing gallery image to be the featured (primary) image
+  def make_primary
+    authorize! @asset.owner, to: :manage?
+    ActiveRecord::Base.transaction do
+      if existing_primary = @asset.owner.assets.find_by(type: "PrimaryAsset")
+        existing_primary.update!(type: "GalleryAsset")
+      end
+
+      @asset.update!(type: "PrimaryAsset")
+    end
+
+    redirect_back_or_to polymorphic_path(@asset.owner), notice: "Featured image updated."
+  end
+
+  private
+
+  def set_asset
+    @asset = GalleryAsset.find(params[:id])
+  end
+end

--- a/app/views/assets/_display_gallery_media.html.erb
+++ b/app/views/assets/_display_gallery_media.html.erb
@@ -2,10 +2,18 @@
 <% gallery_assets = resource.gallery_assets.select { |img| img.file.attached? } %>
 <% align = (defined?(align) && align.present?) ? align.to_s : "center" %>
 <% if gallery_assets.any? %>
+  <% can_manage = allowed_to?(:manage?, resource) %>
   <div class="<%= resource.class.table_name %>-gallery text-<%= align %> mb-4">
     <div class="flex flex-wrap justify-<%= align %> gap-4 <%= 'mx-auto' if align == 'center' %> max-w-4xl">
-      <% gallery_assets.each_with_index do |gallery_assets, idx| %>
-        <%= render "assets/display_image", item: gallery_assets, idx: idx, variant: :gallery, link: (defined?(link) ? link : nil) %>
+      <% gallery_assets.each_with_index do |gallery_asset, idx| %>
+        <% if can_manage %>
+          <div class="relative group">
+            <%= render "assets/display_image", item: gallery_asset, idx: idx, variant: :gallery, link: (defined?(link) ? link : nil) %>
+            <%= render "assets/gallery_item_controls", asset: gallery_asset %>
+          </div>
+        <% else %>
+          <%= render "assets/display_image", item: gallery_asset, idx: idx, variant: :gallery, link: (defined?(link) ? link : nil) %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/assets/_gallery_item_controls.html.erb
+++ b/app/views/assets/_gallery_item_controls.html.erb
@@ -1,0 +1,16 @@
+<div class="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition">
+  <%= button_to make_primary_gallery_asset_path(asset),
+                method: :post,
+                class: "bg-white text-gray-700 rounded-full w-8 h-8 flex items-center justify-center shadow hover:bg-gray-100 transition",
+                title: "Set as featured image",
+                data: { turbo_confirm: "Make this the featured image?" } do %>
+    <i class="fa-solid fa-star"></i>
+  <% end %>
+  <%= button_to gallery_asset_path(asset),
+                method: :delete,
+                class: "bg-white text-red-600 rounded-full w-8 h-8 flex items-center justify-center shadow hover:bg-gray-100 transition",
+                title: "Remove image",
+                data: { turbo_confirm: "Remove this image from the gallery?" } do %>
+    <i class="fa-solid fa-trash"></i>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
   # end
   resources :primary_assets
   resources :rich_text_assets
+  resources :gallery_assets, only: [ :destroy ] do
+    member do
+      post :make_primary
+    end
+  end
 
   namespace :images do
     resources :primary_images, only: [ :show ]

--- a/spec/requests/gallery_assets_spec.rb
+++ b/spec/requests/gallery_assets_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "/gallery_assets", type: :request do
+  let(:admin)        { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+  let(:story)        { create(:story) }
+
+  describe "DELETE /gallery_assets/:id" do
+    let!(:gallery_asset) { create(:gallery_asset, :with_file, owner: story) }
+
+    context "as admin" do
+      before { sign_in admin }
+
+      it "removes the gallery image" do
+        expect {
+          delete gallery_asset_url(gallery_asset)
+        }.to change(Asset, :count).by(-1)
+
+        expect(response).to redirect_to(story_url(story))
+        expect(Asset.exists?(gallery_asset.id)).to be(false)
+      end
+    end
+
+    context "as a non-admin user" do
+      before { sign_in regular_user }
+
+      it "does not remove the image" do
+        expect {
+          delete gallery_asset_url(gallery_asset)
+        }.not_to change(Asset, :count)
+      end
+    end
+
+    context "when signed out" do
+      it "does not remove the image" do
+        expect {
+          delete gallery_asset_url(gallery_asset)
+        }.not_to change(Asset, :count)
+      end
+    end
+  end
+
+  describe "POST /gallery_assets/:id/make_primary" do
+    let!(:gallery_asset) { create(:gallery_asset, :with_file, owner: story) }
+
+    context "as admin" do
+      before { sign_in admin }
+
+      it "promotes the gallery image to the featured image" do
+        post make_primary_gallery_asset_url(gallery_asset)
+
+        expect(response).to redirect_to(story_url(story))
+        expect(Asset.find(gallery_asset.id).type).to eq("PrimaryAsset")
+      end
+
+      it "demotes the existing featured image to the gallery" do
+        existing_primary = create(:primary_asset, :with_file, owner: story)
+
+        post make_primary_gallery_asset_url(gallery_asset)
+
+        expect(Asset.find(existing_primary.id).type).to eq("GalleryAsset")
+        expect(Asset.find(gallery_asset.id).type).to eq("PrimaryAsset")
+        expect(story.assets.where(type: "PrimaryAsset").count).to eq(1)
+      end
+    end
+
+    context "as a non-admin user" do
+      before { sign_in regular_user }
+
+      it "does not change the asset type" do
+        post make_primary_gallery_asset_url(gallery_asset)
+
+        expect(Asset.find(gallery_asset.id).type).to eq("GalleryAsset")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1510

### What is the goal of this PR and why is this important?
- Stakeholders asked for an easier way to manage gallery images directly from the story (gallery) view, rather than going into the edit form
- Adds two inline, one-click controls on each gallery image: **set as featured** and **remove**
- Reduces friction for the common "change the hero image" and "drop a bad photo" tasks

### How did you approach the change?
- Added a `GalleryAssetsController` with `destroy` (remove an image) and `make_primary` (promote a gallery image to the featured/primary image) actions
- `make_primary` reuses the same `PrimaryAsset` ⇄ `GalleryAsset` STI swap the existing "Change photo" picker already uses, so there is one definition of what "featured" means — the old featured image is demoted back into the gallery
- Controls are rendered by a new `assets/_gallery_item_controls` partial, overlaid on each image and revealed on hover; they only render for users who can `manage?` the owning record (via `allowed_to?`), and every action re-checks the owner's policy server-side
- Because the controls hang off the shared `assets/_display_gallery_media` partial, this works for any asset owner (stories, story ideas, workshops, events, etc.), not just stories
- Routed under `/gallery_assets` rather than `/assets` to avoid colliding with the Rails asset-pipeline URL prefix (which 405s non-GET requests)

### UI Testing Checklist
- [ ] As an admin, hover a gallery image on a story show page and confirm the ⭐ and 🗑 controls appear
- [ ] Click ⭐ to promote a gallery image — it becomes the hero and the previous hero moves into the gallery
- [ ] Click 🗑 (confirm the prompt) to remove a gallery image
- [ ] As a signed-out / non-admin visitor, confirm no controls are shown

### Anything else to add?
- Request specs cover both actions, including authorization (admins act, non-admins/anonymous are blocked) and the featured-image swap
- Verified the controls render for admins and are hidden from anonymous visitors via request specs, and confirmed the overlay visually with a system screenshot (below)
