### PR TITLE
Add drag-and-drop ordering for featured stories

### DIFF
--- a/app/controllers/featured_stories_controller.rb
+++ b/app/controllers/featured_stories_controller.rb
@@ -1,0 +1,15 @@
+class FeaturedStoriesController < ApplicationController
+  def index
+    authorize! Story, to: :reorder?
+    # Operate on the full featured set (published or not) so the drag-and-drop
+    # index lines up exactly with the positioning scope (positioned on: :featured).
+    @stories = Story.where(featured: true).order(:position).decorate
+  end
+
+  def update
+    story = Story.find(params[:id])
+    authorize! story, to: :reorder?
+    story.update!(position: params[:position])
+    head :no_content
+  end
+end

--- a/app/controllers/home/stories_controller.rb
+++ b/app/controllers/home/stories_controller.rb
@@ -5,7 +5,7 @@ module Home
     def index
       authorize! :home
       @stories = authorized_scope(Story.published
-                      .order(:title), with: HomePolicy)
+                      .order(:position), with: HomePolicy)
                       .decorate
 
       render "home/stories/index"

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -2,6 +2,12 @@ class Story < ApplicationRecord
   include AuthorCreditable
   include Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
 
+  # Featured stories are curated into a manual order (drag-and-drop) so the
+  # home page can control which stories surface first. Scoping on :featured
+  # keeps a contiguous sequence within the featured set, independent of the
+  # much larger pool of non-featured stories.
+  positioned on: :featured
+
   has_rich_text :rhino_body
 
   belongs_to :created_by, class_name: "User"

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -9,6 +9,10 @@ class StoryPolicy < ApplicationPolicy
     admin? || record.publicly_visible? || (authenticated? && record.published?)
   end
 
+  def reorder?
+    admin?
+  end
+
   # Scoping
   # See https://actionpolicy.evilmartians.io/#/scoping
   #

--- a/app/views/featured_stories/_featured_story.html.erb
+++ b/app/views/featured_stories/_featured_story.html.erb
@@ -1,0 +1,25 @@
+<div
+  id="<%= dom_id story %>"
+  class="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3 hover:bg-gray-50 transition-colors"
+  data-sortable-id="<%= story.id %>">
+  <i class="fa-solid fa-grip-vertical text-gray-400 cursor-move" data-sortable-handle=""></i>
+
+  <div class="w-16 h-12 shrink-0 rounded bg-gray-200 overflow-hidden">
+    <%= render "assets/display_image",
+               resource: story,
+               width: 16, height: 12,
+               link: false,
+               link_to_object: false,
+               file: story.display_image,
+               variant: :gallery %>
+  </div>
+
+  <div class="grow min-w-0">
+    <p class="font-semibold text-gray-900 truncate"><%= story.title %></p>
+    <% unless story.published? %>
+      <span class="text-xs font-medium text-amber-700">Not published — hidden from the home page</span>
+    <% end %>
+  </div>
+
+  <%= link_to "Edit", edit_story_path(story), class: "btn btn-secondary-outline shrink-0" %>
+</div>

--- a/app/views/featured_stories/index.html.erb
+++ b/app/views/featured_stories/index.html.erb
@@ -1,0 +1,29 @@
+<% content_for(:page_bg_class, "public") %>
+<%= render "shared/public_welcome_banner" %>
+
+<div class="w-full max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex items-start justify-between mb-4">
+    <div class="pr-6">
+      <h2 class="text-2xl font-semibold">Reorder featured stories</h2>
+      <p class="text-gray-600 mt-2">Drag the stories into the order they should appear in the highlighted stories section of the home page.</p>
+    </div>
+
+    <div class="text-right text-end">
+      <%= link_to "Back to stories", stories_path, class: "btn btn-primary-outline" %>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-md p-4 mt-4">
+    <% if @stories.present? %>
+      <div
+        class="space-y-2 animate-fade"
+        data-controller="sortable"
+        data-sortable-url-value="<%= featured_story_path(id: ":id") %>"
+        data-testid="featured-story-list">
+        <%= render partial: "featured_story", collection: @stories, as: :story %>
+      </div>
+    <% else %>
+      <p class="text-start text-gray-500 mt-2">No featured stories yet. Mark a story as featured to curate the home page order.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -9,7 +9,12 @@
         <p class="text-gray-600">Check out stories from Windows Facilitators around the world and the healing they make possible through art</p>
       </div>
 
-      <div class="text-right text-end">
+      <div class="text-right text-end space-y-2">
+        <% if allowed_to?(:reorder?, Story) %>
+          <%= link_to "Reorder featured",
+                      featured_stories_path,
+                      class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+        <% end %>
         <% if allowed_to?(:new?, Story) %>
           <%= link_to "New Story",
                       new_story_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Rails.application.routes.draw do
   get "search/:model", to: "search#index"
   resources :story_ideas
   resources :stories
+  resources :featured_stories, only: [ :index, :update ]
   resources :story_shares, only: [ :index, :show ]
   resources :video_recordings
   resources :user_forms

--- a/db/migrate/20260604143000_add_position_to_stories.rb
+++ b/db/migrate/20260604143000_add_position_to_stories.rb
@@ -1,0 +1,24 @@
+class AddPositionToStories < ActiveRecord::Migration[8.1]
+  def up
+    add_column :stories, :position, :integer
+    add_index :stories, [ :featured, :position ]
+
+    # Backfill a contiguous 1..n sequence within each featured group so the
+    # positioning gem (scoped on :featured) has a valid starting state.
+    execute <<~SQL.squish
+      UPDATE stories s
+      JOIN (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY featured ORDER BY created_at, id) AS rn
+        FROM stories
+      ) ranked ON ranked.id = s.id
+      SET s.position = ranked.rn
+    SQL
+
+    change_column_null :stories, :position, false
+  end
+
+  def down
+    remove_index :stories, [ :featured, :position ], if_exists: true
+    remove_column :stories, :position, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_155200) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_143000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -906,6 +906,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_155200) do
     t.boolean "featured", default: false, null: false
     t.integer "organization_id"
     t.boolean "permission_given"
+    t.integer "position", null: false
     t.boolean "publicly_featured", default: false, null: false
     t.boolean "publicly_visible", default: false, null: false
     t.boolean "published", default: false, null: false
@@ -919,6 +920,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_155200) do
     t.integer "workshop_id"
     t.string "youtube_url"
     t.index ["created_by_id"], name: "index_stories_on_created_by_id"
+    t.index ["featured", "position"], name: "index_stories_on_featured_and_position"
     t.index ["organization_id"], name: "index_stories_on_organization_id"
     t.index ["published"], name: "index_stories_on_published"
     t.index ["spotlighted_facilitator_id"], name: "index_stories_on_spotlighted_facilitator_id"

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -139,4 +139,41 @@ RSpec.describe Story, type: :model do
       expect(results).not_to include(published_story, draft_story, old_story)
     end
   end
+
+  describe "positioning of featured stories" do
+    it "assigns sequential positions within the featured set as stories are created" do
+      first = create(:story, :featured)
+      second = create(:story, :featured)
+
+      expect([ first.position, second.position ]).to eq([ 1, 2 ])
+    end
+
+    it "scopes positions to featured, so non-featured stories keep their own sequence" do
+      featured = create(:story, :featured)
+      non_featured = create(:story)
+
+      expect(featured.position).to eq(1)
+      expect(non_featured.position).to eq(1)
+    end
+
+    it "reorders the featured set when a position is assigned" do
+      first = create(:story, :featured)
+      second = create(:story, :featured)
+      third = create(:story, :featured)
+
+      third.update!(position: 1)
+
+      expect(first.reload.position).to eq(2)
+      expect(second.reload.position).to eq(3)
+      expect(third.reload.position).to eq(1)
+    end
+
+    it "orders the featured scope by position" do
+      first = create(:story, :featured, :published)
+      second = create(:story, :featured, :published)
+      second.update!(position: 1)
+
+      expect(Story.featured.order(:position)).to eq([ second, first ])
+    end
+  end
 end

--- a/spec/requests/featured_stories_spec.rb
+++ b/spec/requests/featured_stories_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "/featured_stories", type: :request do
+  let(:admin)        { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+
+  let!(:first_story)  { create(:story, :featured, :published, title: "First featured") }
+  let!(:second_story) { create(:story, :featured, :published, title: "Second featured") }
+
+  describe "GET /index" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the reorder page with featured stories" do
+        get featured_stories_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("First featured")
+        expect(response.body).to include("Second featured")
+      end
+    end
+
+    context "as a non-admin user" do
+      before { sign_in regular_user }
+
+      it "redirects away from the reorder page" do
+        get featured_stories_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as a guest" do
+      it "redirects to sign in" do
+        get featured_stories_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PUT /update" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "moves the story to the requested position" do
+        put featured_story_path(second_story), params: { position: 1 }, as: :json
+
+        expect(response).to have_http_status(:no_content)
+        expect(second_story.reload.position).to eq(1)
+        expect(first_story.reload.position).to eq(2)
+      end
+    end
+
+    context "as a non-admin user" do
+      before { sign_in regular_user }
+
+      it "is not authorized and leaves the order unchanged" do
+        put featured_story_path(second_story), params: { position: 1 }, as: :json
+
+        expect(response).to redirect_to(root_path)
+        expect(second_story.reload.position).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/home/stories_spec.rb
+++ b/spec/requests/home/stories_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "/home/stories", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "GET /home/stories" do
+    it "lists featured stories in their curated position order" do
+      first = create(:story, :featured, :published, title: "Alpha story")
+      second = create(:story, :featured, :published, title: "Bravo story")
+      # Curate Bravo ahead of Alpha despite alphabetical order.
+      second.update!(position: 1)
+
+      get home_stories_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index(second.title)).to be < response.body.index(first.title)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1522

### What is the goal of this PR and why is this important?
- The home page "Highlighted stories" section showed featured stories ordered by title, with no way to curate which story leads.
- Stakeholders requested control over the display order so they can promote specific stories on the home page.

### How did you approach the change?
- Added a `position` column to `stories`, scoped via the `positioning` gem to the featured set (`positioned on: :featured`), so featured stories keep a contiguous, independently-curated order.
- Backfilled existing rows with a contiguous per-group sequence in the migration so the gem has a valid starting state.
- Added an admin-only **Reorder featured stories** page (`/featured_stories`) that reuses the existing `sortable` Stimulus controller + SortableJS drag-and-drop, mirroring the FAQ/Category pattern already in the app.
- The reorder list intentionally shows the full featured set (published or not) so the drag index lines up exactly with the positioning scope; unpublished stories are flagged as hidden from the home page.
- Updated `Home::StoriesController` to order by `position` instead of `title`, so both the authenticated (`featured`) and public (`publicly_featured`) home views respect the curated order.
- Added an admin-only "Reorder featured" link on the stories index header.

### Anything else to add?
- Authorization reuses `StoryPolicy` via a new `reorder?` rule (super users only); non-admins are redirected to root, consistent with the app's `ActionPolicy::Unauthorized` handling.
- The public (anonymous) home page draws from `publicly_featured`; those stories follow the same `position` column, so curation carries over for stories that are both featured and publicly featured.
- Tests: model positioning specs, request specs for the reorder controller (authorization + reordering), and a home stories ordering spec — all green.

### UI Testing Checklist
- [ ] As a super user, visit Stories → "Reorder featured", drag a story to the top, and confirm the new order persists after reload.
- [ ] Confirm the home page "Highlighted stories" section reflects the curated order.
- [ ] Confirm non-admins cannot access `/featured_stories`.