### PR TITLE
Open gallery attachment links in a new tab to avoid losing edits

### DIFF
--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -80,7 +80,7 @@
       <div data-file-preview-target="filename"
            class="text-center text-sm text-gray-500 break-all max-w-[8rem]">
         <%= if blob.present? && blob.respond_to?(:persisted?) && blob.persisted?
-              link_to(blob.filename.to_s, url_for(file), class: "underline")
+              link_to(blob.filename.to_s, url_for(file), class: "underline", target: "_blank", rel: "noopener")
             else
               "No file selected"
             end

--- a/spec/views/shared/_form_image_field.html.erb_spec.rb
+++ b/spec/views/shared/_form_image_field.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "shared/_form_image_field", type: :view do
+  let(:asset) { create(:gallery_asset, :with_file) }
+  let(:builder) { ActionView::Helpers::FormBuilder.new(:gallery_asset, asset, view, {}) }
+
+  before do
+    render partial: "shared/form_image_field", locals: { f: builder, label: "Gallery 1" }
+  end
+
+  it "links the attached file's name so it opens in a new tab" do
+    expect(rendered).to have_css("a[href][target='_blank'][rel='noopener']", text: asset.file.filename.to_s)
+  end
+end


### PR DESCRIPTION
Closes #1511

### What is the goal of this PR and why is this important?
- Stakeholder report: clicking an image/attachment in the gallery section of an edit form navigated away in the **same tab**, discarding any unsaved form edits.
- Show-page galleries already open full-size images in a new tab (via `DisplayImagePresenter`), but the in-form attachment cards (`shared/_form_image_field`) were missed — their filename link opened in the same tab.
- This makes the in-form behavior consistent and protects in-progress work.

### How did you approach the change?
- Added `target: "_blank", rel: "noopener"` to the persisted-file filename link in `app/views/shared/_form_image_field.html.erb`.
- This partial is shared by every model's edit form (stories, resources, workshop variations, etc.), so the fix applies everywhere the gallery/attachment section appears.
- TDD: added a view spec (`spec/views/shared/_form_image_field.html.erb_spec.rb`) that asserts the filename link opens in a new tab — confirmed it failed before the change and passes after.

### UI Testing Checklist
- [ ] Edit a story (or resource/workshop variation) that has an attached gallery image
- [ ] Click the filename link under an existing attachment → it opens the file in a **new tab**
- [ ] The original edit form remains open with unsaved changes intact

### Anything else to add?
- Scope kept minimal: the filename link was the only element in this section that actually navigated (the thumbnail image itself is not a link), so this is the precise source of the "lost work" behavior.