### PR TITLE
Hide "Change photo" control on published story view

### DIFF
--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -53,12 +53,6 @@
           <% end %>
         </div>
 
-        <div class="flex justify-end">
-          <%= render "assets/primary_image_picker", owner: @story %>
-        </div>
-        <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
-          <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
-        </div>
         <div id="hero-image">
           <%= render "assets/display_assets", resource: @story, link: true %>
         </div>

--- a/spec/views/stories/show.html.erb_spec.rb
+++ b/spec/views/stories/show.html.erb_spec.rb
@@ -19,4 +19,9 @@ RSpec.describe "stories/show", type: :view do
     expect(rendered).to match(/MyBody/)
     expect(rendered).to match(story.author_credit)
   end
+
+  it "does not render the 'Change photo' control, even for admins" do
+    render
+    expect(rendered).not_to match(/Change photo/)
+  end
 end


### PR DESCRIPTION
Closes #1518

### What is the goal of this PR and why is this important?
- The "Change photo" control on the published story view added right-aligned chrome and vertical whitespace near the top of the page.
- In practice, editors always change a story's primary photo from the **edit** view, so the inline picker on the published page was redundant.

### How did you approach the change?
- Removed the `assets/primary_image_picker` render and its now-orphaned `upload-progress` bar from `app/views/stories/show.html.erb`.
- Kept the `hero-image` display so the photo still renders.
- Left the shared `assets/_primary_image_picker` partial untouched — the workshop and resource show pages still use it (it remains admin-gated via `allowed_to?(:manage?, owner)`).
- Photo editing is preserved via the story edit form (`shared/form_image_fields` with `include_primary_asset: true`).

### UI Testing Checklist
- [ ] Published story page no longer shows the "Change photo" button (admin and non-admin), and the top whitespace is reduced.
- [ ] Story photo still displays on the published page.
- [ ] Workshop and resource show pages still show their "Change photo" picker for admins.
- [ ] Changing a story's primary photo from the edit view still works.

### Anything else to add?
- Added a view spec asserting the published story view does not render the "Change photo" control even for admins (red-green verified).
- Considered restricting the control to admins instead, but it was already admin-only; hiding it entirely resolves the whitespace complaint that motivated the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)