### PR TITLE
Show unconfirmed facilitators in story author dropdown

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -131,7 +131,7 @@ class StoriesController < ApplicationController
                             .references(:users)
                             .order(:created_at)
     @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
-    @users = User.has_access.includes(:person).left_joins(:person).order(Arel.sql("people.first_name IS NULL, LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email)"))
+    @users = User.selectable_as_author.includes(:person).left_joins(:person).order(Arel.sql("people.first_name IS NULL, LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email)"))
     @windows_types = WindowsType.all
     @workshops = authorized_scope(Workshop.all).includes(:windows_type).order(:title)
     @categories_grouped =

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,10 @@ class User < ApplicationRecord
   end
 
   scope :has_access, -> { where(locked_at: nil, inactive: [ false, nil ]).where.not(confirmed_at: nil) }
+  # Users selectable as a story/idea author. Unlike has_access, email confirmation
+  # is not required: facilitators are real people who should be creditable
+  # regardless of whether they have confirmed their email.
+  scope :selectable_as_author, -> { where(locked_at: nil, inactive: [ false, nil ]) }
 
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -248,6 +248,25 @@ RSpec.describe User do
     end
   end
 
+  describe ".selectable_as_author" do
+    let!(:confirmed_user) { create(:user) }
+    let!(:unconfirmed_user) { create(:user, :unconfirmed) }
+    let!(:inactive_user) { create(:user, inactive: true) }
+    let!(:locked_user) { create(:user, :locked) }
+
+    it "includes facilitators whose email is not yet confirmed" do
+      expect(User.selectable_as_author).to include(unconfirmed_user)
+    end
+
+    it "includes facilitators with confirmed emails" do
+      expect(User.selectable_as_author).to include(confirmed_user)
+    end
+
+    it "excludes inactive and locked users" do
+      expect(User.selectable_as_author).not_to include(inactive_user, locked_user)
+    end
+  end
+
   describe '.search_by_params' do
     let!(:admin_user) { create(:user, email: 'alice@example.com', super_user: true) }
     let!(:regular_user) { create(:user, email: 'bob@example.com', super_user: false) }


### PR DESCRIPTION
Closes #1515

### What is the goal of this PR and why is this important?
- Facilitators with **unconfirmed emails** were silently missing from the story author dropdown (confirmed examples: Courtney Koczka, Lemny Perez).
- Email confirmation status should not gate whether a facilitator can be credited as a story author — they are real people who do the work regardless of whether they've confirmed their email.

### How did you approach the change?
- The dropdown was built from `User.has_access`, which requires `confirmed_at` to be present — that's the gate that hid these facilitators.
- Added a dedicated `User.selectable_as_author` scope: active + unlocked, **without** the email-confirmation requirement.
- Switched the story form's author collection (`set_form_variables`) to use `selectable_as_author`.
- Left `has_access` untouched so its access-control semantics (used broadly elsewhere) are unchanged.

### Anything else to add?
- The same `has_access`-based author dropdown exists for **story ideas** (`story_ideas_controller`) and a few other forms (workshop ideas, bookmarks, etc.). Those were intentionally left out of scope since the issue is specifically about the story author dropdown — happy to extend `selectable_as_author` to them in a follow-up if the same treatment is wanted.
- Tested via a model spec for the new scope (includes confirmed + unconfirmed, excludes inactive/locked). A request spec for `GET /stories/new` was not added because full-page renders 500 in the test environment (asset/vite related, pre-existing) — existing story request specs only exercise Turbo-frame/redirect paths for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)