### PR TITLE
Replace story author dropdown with a search box

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -131,7 +131,6 @@ class StoriesController < ApplicationController
                             .references(:users)
                             .order(:created_at)
     @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
-    @users = User.has_access.includes(:person).left_joins(:person).order(Arel.sql("people.first_name IS NULL, LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email)"))
     @windows_types = WindowsType.all
     @workshops = authorized_scope(Workshop.all).includes(:windows_type).order(:title)
     @categories_grouped =

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -274,18 +274,22 @@
   <div class="flex flex-col md:flex-row md:space-x-4">
     <div class="flex-1 mb-4 md:mb-0">
       <%= f.input :created_by_id,
-                  collection: @users.map { |u| [ u.full_name_with_email, u.id ] },
-                  prompt: "Select an author",
+                  collection: f.object.created_by.present? ? [[ f.object.created_by.remote_search_label[:label], f.object.created_by.id ]] : [],
+                  selected: f.object.created_by_id,
+                  include_blank: true,
                   label: (f.object.created_by&.person ? (
                     link_to "Story author",
                             person_path(f.object.created_by.person),
                             class: "hover:underline") : "Story author").html_safe,
                   label_html: { class: "block font-medium mb-1 text-gray-700" },
                   input_html: {
-                    class: select_caret_class(blank: f.object.created_by_id.blank?),
-                    style: custom_caret_style,
-                    onchange: select_caret_onchange
-                  } %>
+                    class: "w-full px-3 py-2 border border-gray-300 rounded-lg",
+                    data: {
+                      controller: "remote-select",
+                      remote_select_model_value: "user"
+                    }
+                  },
+                  prompt: "Type to search authors…" %>
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">


### PR DESCRIPTION
Closes #1516

### What is the goal of this PR and why is this important?
- The story author field rendered a `<select>` containing every accessible user as an `<option>`
- As the facilitator/user list grows this dropdown becomes unwieldy to scan and bloats the HTML on every story new/edit page
- Replaces it with a type-to-search input so an author can be found quickly

### How did you approach the change?
- Reused the existing `remote-select` Stimulus controller (TomSelect) that already powers the workshop and organization fields on this same form
- The author `created_by_id` field now loads matches on demand from the existing `User` remote-search endpoint (`/search/user`) instead of pre-rendering all users
- For a persisted story, the currently-selected author is seeded as the single initial option (same pattern as workshop/organization) so the existing value displays
- Removed the now-unused `@users` query from `StoriesController#set_form_variables` — it previously loaded and ordered every accessible user just to populate the dropdown
- No backend/authorization changes needed: `User` already implements `remote_search`/`remote_search_label`, `SearchController` already whitelists `user`, and story new/edit/create are admin-only (matching the search endpoint's `admin?` rule)

### UI Testing Checklist
- [ ] On a new story, the "Story author" field shows a "Type to search authors…" search box; typing returns matching users
- [ ] On an existing story, the current author is pre-selected/displayed and can be changed via search
- [ ] Saving a story persists the selected author (`created_by_id`)

### Anything else to add?
- Existing story form view specs (`spec/views/stories/new` and `edit`) still pass — the server-rendered element remains a `<select>` (TomSelect enhances it client-side)
- The sibling "spotlighted facilitator" field still uses a full dropdown; out of scope for this issue but a candidate for the same treatment in a follow-up