### PR TITLE
Collapse double-height empty paragraphs in story editor (#1521)

### DIFF
--- a/app/frontend/javascript/rhino/custom-editor.css
+++ b/app/frontend/javascript/rhino/custom-editor.css
@@ -44,6 +44,24 @@ custom-rhino-editor table .column-resize-handle {
 custom-rhino-editor table p {
   margin: 0;
 }
+/*
+ * Issue #1521: collapse double-height empty paragraphs in the editor.
+ *
+ * Empty spacer paragraphs (`<p><br></p>`, common in legacy/imported stories)
+ * are parsed by ProseMirror as a paragraph containing a hard break, and then a
+ * `ProseMirror-trailingBreak` <br> is appended for editing. The two <br>s render
+ * as two blank lines, doubling the gap between paragraphs and making published
+ * stories hard to read while editing.
+ *
+ * Hide the redundant content break so the editor shows a single blank line. The
+ * <br> is only hidden (still in the DOM), so saved content and the published
+ * view are unchanged. Scoped to a content <br> that is immediately followed by
+ * the trailing break, so intentional in-paragraph line breaks are untouched.
+ */
+custom-rhino-editor .trix-content p > br:first-child:not(.ProseMirror-trailingBreak):has(+ br.ProseMirror-trailingBreak:last-child) {
+  display: none;
+}
+
 custom-rhino-editor a {
   text-decoration: underline;
   color: #2563eb; /* Tailwind blue-600 */

--- a/spec/system/stories_spec.rb
+++ b/spec/system/stories_spec.rb
@@ -135,6 +135,42 @@ RSpec.describe "Stories", type: :system do
         expect(page).to have_current_path(story_path(story))
         expect(page).to have_content("A New Title")
       end
+
+      # Issue #1521: legacy empty spacer paragraphs (`<p><br></p>`) were rendered
+      # by the editor as double-height blank lines, making stories hard to read
+      # while editing. They should collapse to a single blank line.
+      it "renders empty spacer paragraphs as a single blank line in the editor" do
+        user = create(:user, :admin)
+        sign_in(user)
+        story = create(
+          :story,
+          created_by: user,
+          rhino_body: "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>"
+        )
+
+        visit edit_story_path(story)
+
+        expect(page).to have_css(".trix-content p", minimum: 3, wait: 10)
+        expect(page).to have_css(".trix-content p", text: "First paragraph.")
+
+        heights = page.evaluate_script(<<~JS)
+          (() => {
+            const ps = Array.from(document.querySelectorAll(".trix-content p"));
+            const textP = ps.find(p => p.textContent.trim().length > 0);
+            const emptyP = ps.find(p => p.textContent.trim().length === 0);
+            return {
+              text: textP ? textP.getBoundingClientRect().height : null,
+              empty: emptyP ? emptyP.getBoundingClientRect().height : null
+            };
+          })()
+        JS
+
+        expect(heights["text"]).to be > 0
+        expect(heights["empty"]).to be > 0
+        # A single blank line ≈ one text line. Before the fix the spacer was two
+        # lines tall (a content <br> plus ProseMirror's trailing break).
+        expect(heights["empty"]).to be <= heights["text"] * 1.5
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #1521

### What is the goal of this PR and why is this important?
- When editing a published story, empty spacer paragraphs rendered with a **double-height** blank line, so the gap between paragraphs looked far larger than in the published view and made stories hard to read while editing.
- Stakeholder request: stories should be readable in edit mode without manually deleting blank lines.

### How did you approach the change?
- **Root cause:** Legacy/imported stories separate paragraphs with empty `<p><br></p>` paragraphs. ProseMirror (rhino-editor) parses the lone `<br>` as a hard break **and then appends its own `ProseMirror-trailingBreak` `<br>` for editing**. The two `<br>`s render as two blank lines (~56px instead of ~28px), doubling every inter-paragraph gap.
- **Fix:** one editor-scoped CSS rule in `custom-editor.css` that hides the redundant content `<br>` when it is immediately followed by the trailing break, so spacers collapse to a single blank line.
- **Why CSS, not content rewriting:** the `<br>` is only hidden, not removed — it stays in the DOM and in the serialized HTML. Verified via a save round-trip that empty spacers and intentional in-paragraph breaks are both preserved byte-for-byte, so **stored content and the published view are unchanged**. Rewriting `<p><br></p>` to an empty `<p>` would have shrunk spacing in the published view on the next save, so it was avoided.
- The selector is deliberately narrow (`br:first-child` directly followed by `br.ProseMirror-trailingBreak:last-child`), so intentional in-paragraph line breaks (`Line one<br>line two`) and multi-line spacers are left untouched.

### UI Testing Checklist
- [x] Empty spacer paragraphs render as a single blank line in the editor (was double)
- [x] Intentional in-paragraph line breaks are preserved (still two lines)
- [x] Saving with no edits preserves stored content (`<p><br></p>` round-trips)
- [x] Published story view is unchanged
- [x] Added a system spec (red→green verified) asserting the spacer height ≈ one text line

### Anything else to add?
- New spec: `spec/system/stories_spec.rb` — "renders empty spacer paragraphs as a single blank line in the editor". It uses a **relative** height assertion (empty ≤ 1.5× a single text line) so it is robust to font/line-height differences across environments. Confirmed failing before the fix (empty = 56px vs 42px threshold) and passing after.

_Before (doubled gaps) and after (single blank line) screenshots from a local published story are available — happy to attach._
