### PR TITLE
add org selection for pending orgs on event registration

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -151,10 +151,7 @@ class EventRegistrationsController < ApplicationController
     @event_registration.event_registration_organizations
       .find_or_create_by!(organization: organization)
 
-    redirect_to params[:return_to] == "manage" ?
-      manage_event_path(@event_registration.event) :
-      registration_ticket_path(@event_registration.slug),
-      notice: "Organization linked successfully."
+    redirect_to manage_event_path(@event_registration.event), notice: "Organization linked successfully."
   end
 
   def destroy
@@ -241,5 +238,4 @@ class EventRegistrationsController < ApplicationController
         form_field_id: field.id
       )&.text
   end
-
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -128,6 +128,35 @@ class EventRegistrationsController < ApplicationController
     end
   end
 
+  def link_organization
+    @event_registration = EventRegistration.includes(:event, registrant: :person_forms).find(params[:id])
+    authorize! @event_registration, to: :link_organization?
+    @person = @event_registration.registrant
+    @submitted_org_name = find_submitted_agency_name(@event_registration)
+    @potential_matches = if @submitted_org_name.present?
+      Organization.remote_search(@submitted_org_name).limit(10)
+    else
+      Organization.none
+    end
+  end
+
+  def select_organization
+    @event_registration = EventRegistration.find(params[:id])
+    authorize! @event_registration, to: :select_organization?
+    @person = @event_registration.registrant
+    organization = Organization.find(params[:organization_id])
+
+    Affiliation.find_or_create_by!(person: @person, organization: organization)
+
+    @event_registration.event_registration_organizations
+      .find_or_create_by!(organization: organization)
+
+    redirect_to params[:return_to] == "manage" ?
+      manage_event_path(@event_registration.event) :
+      registration_ticket_path(@event_registration.slug),
+      notice: "Organization linked successfully."
+  end
+
   def destroy
     authorize! @event_registration
     event = @event_registration.event
@@ -197,4 +226,20 @@ class EventRegistrationsController < ApplicationController
       end
     end
   end
+
+  def find_submitted_agency_name(registration)
+    form = registration.event.registration_form
+    return nil unless form
+
+    field = form.form_fields.find_by(field_key: "agency_name")
+    return nil unless field
+
+    PersonFormFormField
+      .joins(person_form: :person)
+      .find_by(
+        person_forms: { person_id: registration.registrant_id, form_id: form.id },
+        form_field_id: field.id
+      )&.text
+  end
+
 end

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -11,6 +11,8 @@ class EventRegistrationPolicy < ApplicationPolicy
   def show_public? = true
   def confirm? = admin?
   def process_confirm? = admin?
+  def link_organization? = admin?
+  def select_organization? = admin?
 
 
   relation_scope do |relation|

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -1,0 +1,61 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="max-w-2xl mx-auto py-8 px-4">
+  <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+    <div class="mb-6">
+      <%= link_to "← Back to manage", manage_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    </div>
+
+    <h1 class="text-xl font-semibold text-gray-900 mb-2">Link Organization</h1>
+    <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
+
+    <% if @submitted_org_name.present? %>
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
+        <p class="text-sm text-gray-500 mb-1">Submitted organization name on registration form:</p>
+        <p class="text-base font-medium text-gray-800"><%= @submitted_org_name %></p>
+      </div>
+    <% else %>
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
+        <p class="text-sm text-gray-500">No organization was submitted on the registration form.</p>
+      </div>
+    <% end %>
+
+    <% if @potential_matches.any? %>
+      <h2 class="text-lg font-semibold text-gray-800 mb-3">Potential matches</h2>
+      <div class="space-y-2 mb-8">
+        <% @potential_matches.each do |org| %>
+          <%= form_with url: select_organization_event_registration_path(@event_registration),
+                        method: :post,
+                        data: { turbo_frame: "_top" },
+                        class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
+            <%= hidden_field_tag :organization_id, org.id %>
+            <%= hidden_field_tag :return_to, params[:return_to] %>
+            <div>
+              <p class="font-medium text-gray-800"><%= org.name %></p>
+              <p class="text-xs text-gray-500"><%= org.city_state %></p>
+            </div>
+            <%= submit_tag "Select", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <h2 class="text-lg font-semibold text-gray-800 mb-3">Or search all organizations</h2>
+    <%= form_with url: select_organization_event_registration_path(@event_registration),
+                  method: :post,
+                  data: { turbo_frame: "_top" },
+                  class: "space-y-4" do %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
+      <div>
+        <%= label_tag :organization_id, "Organization", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= select_tag :organization_id,
+                       options_from_collection_for_select([], :id, :name),
+                       include_blank: true,
+                       class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                       data: { controller: "remote-select", remote_select_model_value: "organization" },
+                       prompt: "Type to search organizations…" %>
+      </div>
+      <%= submit_tag "Link organization",
+                     class: "rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/_manage_results.html.erb
+++ b/app/views/events/_manage_results.html.erb
@@ -70,7 +70,11 @@
                       <% end %>
                     </ul>
                   <% else %>
-                    <span class="text-gray-400">—</span>
+                    <%= link_to link_organization_event_registration_path(registration, return_to: "manage"),
+                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
+                                data: { turbo_frame: "_top" } do %>
+                      <span>Pending</span>
+                    <% end %>
                   <% end %>
                 </td>
                 <td class="px-4 py-2 text-sm">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,8 @@ Rails.application.routes.draw do
     member do
       get :confirm
       post :process_confirm
+      get :link_organization
+      post :select_organization
     end
     resources :comments, only: [ :index, :create ]
   end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -172,6 +172,7 @@ RSpec.describe "page_bg_class alignment with policies" do
 
     # ─── admin-only confirm/interstitial ───
     "app/views/event_registrations/confirm.html.erb"     => "admin-only bg-blue-100",
+    "app/views/event_registrations/link_organization.html.erb" => "admin-only bg-blue-100",
     "app/views/users/confirm_email_change.html.erb"      => "admin-only bg-blue-100",
     "app/views/users/confirm_email_manual.html.erb"      => "admin-only bg-blue-100"
   }.freeze


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
<!-- What are you trying to achieve? Why does this matter? -->
People have a free text input when submitting their registration form for the Organization. Exact matches will add the org association to the person. If there is not an exact match, this adds a pending flag to the manage registrants index. Click pending and view potential matches. Selecting the correct org creates the association.

### How did you approach the change?
<!-- What did you do and why? -->

### UI Testing Checklist
<!-- This will be automatically generated based on your changes. -->
<!-- Complete the auto-generated checklist below before marking as ready for review. -->
<!-- Add or remove items as needed for your specific changes. -->

### Anything else to add?
<!-- Any alternative approaches you considered? Special notes for reviewers? -->


https://github.com/user-attachments/assets/44340d3c-924f-4809-bb2e-9b2424686d26


