### PR TITLE
Add consistent page topper banners across resource views

### DIFF
--- a/app/views/community_news/index.html.erb
+++ b/app/views/community_news/index.html.erb
@@ -1,15 +1,17 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">News</h2>
-        <p class="text-gray-600">Find recent newsletters and other community postings</p>
+<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- News header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:community_news, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:community_news, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:community_news, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:community_news, intensity: 900) %> uppercase tracking-wide">News</span>
       </div>
-
-      <div class="text-right">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, CommunityNews) %>
           <%= link_to "New community news",
                       new_community_news_path,
@@ -17,6 +19,9 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:community_news) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600">Find recent newsletters and other community postings</p>
 
     <%= render "search_boxes" %>
 

--- a/app/views/community_news/show.html.erb
+++ b/app/views/community_news/show.html.erb
@@ -1,11 +1,19 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <% community_news_url   = community_news_url(@community_news) %>
 <% community_news_title = ERB::Util.url_encode(@community_news.title) %>
-<div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Community News header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:community_news, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:community_news, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:community_news, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:community_news, intensity: 900) %> uppercase tracking-wide">Community News</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Community news", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "News", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @community_news) %>
           <%= link_to "Edit", edit_community_news_path(@community_news),
                       class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
@@ -15,7 +23,9 @@
         </span>
         <%= print_button(@community_news, printable_type: "CommunityNews", button_text: "Print page") %>
       </div>
-
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:community_news) %> p-4 sm:p-8 space-y-6">
       <!-- Header Row -->
       <div class="w-full bg-white rounded-lg shadow-md p-6 space-y-6">
         <div class="max-w-3xl mx-auto px-4 py-10 text-gray-800">
@@ -80,4 +90,5 @@
           </div>
         </div>
       </div>
+  </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,18 +1,17 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h1 class="text-2xl font-semibold mb-2">Events</h1>
-
-        <p class="text-gray-600 max-w-2xl">
-          Join us for our virtual events including art workshops, facilitator trainings and other opportunities to create, connect and be in community
-        </p>
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Events header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:events, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:events, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:events, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:events, intensity: 900) %> uppercase tracking-wide">Events</span>
       </div>
-      <div class="text-right text-end">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Event) %>
           <div class="admin-only bg-blue-100">
             <%= link_to "New event",
@@ -22,10 +21,11 @@
         <% end %>
       </div>
     </div>
-    <!-- Divider -->
-    <div class="w-full mt-6">
-      <hr class="border-gray-300 mb-6">
-    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:events) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600 max-w-2xl">
+      Join us for our virtual events including art workshops, facilitator trainings and other opportunities to create, connect and be in community
+    </p>
 
     <% if @events.any? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,22 +6,29 @@
     <button onclick="window.close()" class="btn btn-secondary-outline btn-sm">Close preview</button>
   </div>
 <% else %>
-<!-- Top Right Actions -->
-<div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Back to Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <div class="ml-auto flex flex-wrap gap-2">
-  <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% if allowed_to?(:manage?, @event) && @event.object.event_forms.registration.exists? %>
-    <%= link_to "Register (as visitor)", new_event_public_registration_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-  <% end %>
-  <% if allowed_to?(:edit?, @event) %>
-    <%= link_to "Edit", edit_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% end %>
-  <% if allowed_to?(:manage?, @event) %>
-    <%= link_to "Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-  <% end %>
-  <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
+<!-- Event header banner -->
+<div class="<%= DomainTheme.bg_class_for(:events, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:events, intensity: 300) %> px-8 py-3 mb-4 rounded-xl">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:events, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+      </svg>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:events, intensity: 900) %> uppercase tracking-wide">Event</span>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <% if allowed_to?(:manage?, @event) && @event.object.event_forms.registration.exists? %>
+        <%= link_to "Register (as visitor)", new_event_public_registration_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      <% end %>
+      <% if allowed_to?(:edit?, @event) %>
+        <%= link_to "Edit", edit_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <% end %>
+      <% if allowed_to?(:manage?, @event) %>
+        <%= link_to "Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      <% end %>
+      <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
+    </div>
   </div>
 </div>
 <% end %>

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -1,16 +1,17 @@
 <% content_for(:page_bg_class, "public") %>
 <%= render "shared/public_welcome_banner" %>
 
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-4">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold">FAQs</h2>
-        <p class="text-gray-600 mt-2">Find answers to common questions here. If you don't see what you need, please reach out to us at <%= mail_to ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"), class: "text-blue-600 hover:text-blue-800" %>.</p>
+<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- FAQs header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:faqs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:faqs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:faqs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:faqs, intensity: 900) %> uppercase tracking-wide">FAQs</span>
       </div>
-
-      <div class="text-right text-end">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Faq) %>
           <%= link_to "New FAQ",
                       new_faq_path,
@@ -18,12 +19,15 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:faqs) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600">Find answers to common questions here. If you don't see what you need, please reach out to us at <%= mail_to ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"), class: "text-blue-600 hover:text-blue-800" %>.</p>
 
     <!-- Filter form -->
-    <div class="mt-4"><%= render "search_boxes" %></div>
+    <%= render "search_boxes" %>
 
     <!-- Inner White Card -->
-    <div class="bg-white rounded-lg shadow-md p-6 mt-4">
+    <div class="bg-white rounded-lg shadow-md p-6">
       <div
         class="animate-fade"
         data-controller="sortable"

--- a/app/views/faqs/show.html.erb
+++ b/app/views/faqs/show.html.erb
@@ -1,12 +1,24 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- FAQ header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:faqs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:faqs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:faqs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:faqs, intensity: 900) %> uppercase tracking-wide">FAQ</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "FAQs", faqs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @faq) %>
           <%= link_to "Edit", edit_faq_path(@faq), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
       </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:faqs) %> p-4 sm:p-8 space-y-6">
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">
         <%= @faq.class.model_name.human %>
         Details
@@ -16,4 +28,5 @@
           <%= render @faq, hide_options: true %>
         </div>
       </div>
+  </div>
 </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,17 +1,24 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Header -->
-      <div class="flex flex-col sm:flex-row justify-between items-center mb-6 gap-3">
-        <div id="organization_count">
-          <h1 class="text-2xl font-semibold text-gray-900">Organizations</h1>
-        </div>
+<div class="max-w-7xl mx-auto border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Organizations header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:organizations, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> uppercase tracking-wide">Organizations</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Organization) %>
           <%= link_to "New Organization",
                       new_organization_path,
                       class: "admin-only bg-blue-100 btn btn-primary-outline" %>
         <% end %>
       </div>
-
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:organizations) %> p-4 sm:p-8 space-y-6">
       <!-- Optional filters -->
       <%= render "search_boxes" %>
 
@@ -53,4 +60,5 @@
           <div class="h-8 w-10 bg-gray-200 rounded"></div>
         </div>
       <% end %>
+  </div>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -2,26 +2,27 @@
 <div class="border border-gray-200 rounded-xl shadow overflow-hidden">
     <!-- Organization header banner -->
     <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:organizations, intensity: 300) %> px-8 py-3">
-      <div class="flex items-center gap-2">
-        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
-        </svg>
-        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> uppercase tracking-wide">Organization Profile</span>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+          </svg>
+          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> uppercase tracking-wide">Organization Profile</span>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Organizations", organizations_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% if allowed_to?(:edit?, @organization) %>
+            <%= link_to "Edit", edit_organization_path(@organization),
+                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% end %>
+          <span class="inline-block text-sm">
+            <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
+          </span>
+        </div>
       </div>
     </div>
     <div class="p-8">
-    <!-- Header actions -->
-    <div class="flex flex-wrap justify-end gap-2 mb-4">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Organizations", organizations_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <% if allowed_to?(:edit?, @organization) %>
-        <%= link_to "Edit", edit_organization_path(@organization),
-                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <% end %>
-      <span class="inline-block text-sm">
-        <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
-      </span>
-    </div>
     <!-- Header: logo + name + badges -->
     <div class="flex flex-col md:flex-row md:items-center gap-6 mb-8">
       <div class="flex-shrink-0 flex justify-center md:justify-start">

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,11 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="community-news-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div id="people_count" class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">People</h2>
+<div class="community-news-index max-w-7xl mx-auto border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- People header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:people, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:people, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:people, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:people, intensity: 900) %> uppercase tracking-wide">People</span>
       </div>
-      <div class="text-right ">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Person) %>
           <%= link_to "New Person",
                       new_person_path,
@@ -13,6 +17,8 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:people) %> p-4 sm:p-8 space-y-6">
     <%= render "search_boxes" %>
 
     <% result_src = people_path + "?" + request.query_string %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -2,36 +2,37 @@
 <div class="admin-or-owner <%#= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow overflow-hidden">
       <!-- Person header banner -->
       <div class="<%= DomainTheme.bg_class_for(:people, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:people, intensity: 300) %> px-8 py-3">
+        <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:people, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
           </svg>
           <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:people, intensity: 900) %> uppercase tracking-wide">Individual Profile</span>
         </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <% unless @person.user %>
+            <div class="admin-only bg-blue-100 p-2">
+              No user!
+              <%= link_to "Create user",
+                          new_user_path(person_id: @person.id),
+                          class: "btn btn-warning px-2 py-1" %>
+            </div>
+          <% end %>
+          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% if allowed_to?(:index?, Person) %>
+            <%= link_to "People", people_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% end %>
+          <% if allowed_to?(:edit?, @person) %>
+            <%= link_to "Edit", edit_person_path(@person),
+                        class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <% end %>
+          <span class="inline-block text-sm">
+            <%= render "bookmarks/editable_bookmark_button", resource: @person.object %>
+          </span>
+        </div>
+      </div>
       </div>
       <div class="p-4 sm:p-8 relative">
-      <!-- Header actions -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <% unless @person.user %>
-          <div class="admin-only bg-blue-100 p-2">
-            No user!
-            <%= link_to "Create user",
-                        new_user_path(person_id: @person.id),
-                        class: "btn btn-warning px-2 py-1" %>
-          </div>
-        <% end %>
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% if allowed_to?(:index?, Person) %>
-          <%= link_to "People", people_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% end %>
-        <% if allowed_to?(:edit?, @person) %>
-          <%= link_to "Edit", edit_person_path(@person),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% end %>
-        <span class="inline-block text-sm">
-          <%= render "bookmarks/editable_bookmark_button", resource: @person.object %>
-        </span>
-      </div>
       <!-- Header: avatar + name + badges -->
       <div class="flex flex-col md:flex-row md:items-center gap-6 mb-8">
         <div class="flex-shrink-0 flex justify-center md:justify-start">

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -1,16 +1,17 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Resources</h2>
-        <p class="text-gray-600">Search for handouts, templates and toolkits to support your work</p>
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Resources header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:resources, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:resources, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:resources, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:resources, intensity: 900) %> uppercase tracking-wide">Resources</span>
       </div>
-
-      <div class="text-right">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Resource) %>
           <%= link_to "New Resource",
                       new_resource_path,
@@ -18,12 +19,12 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:resources) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600">Search for handouts, templates and toolkits to support your work</p>
 
     <!-- Search Form -->
     <div class="w-full"><%= render "search_boxes" %></div>
-
-    <!-- Divider -->
-    <div class="w-full mt-6"><hr class="border-gray-300 mb-6"></div>
 
     <!-- Results Table -->
     <% result_src = resources_path + "?" + request.query_string %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -1,7 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Resource header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:resources, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:resources, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:resources, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:resources, intensity: 900) %> uppercase tracking-wide">Resource</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Resources", resources_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @resource) %>
@@ -17,6 +25,9 @@
                     class: "btn btn-utility",
                     download: true if @resource.downloadable_asset&.file&.attached? %>
       </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:resources) %> p-4 sm:p-8 space-y-6">
       <!-- Resource Card -->
       <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
         <!-- Title -->
@@ -52,4 +63,5 @@
       </div>
       <!-- Mentions -->
       <%= render "show_mentions" %>
+  </div>
 </div>

--- a/app/views/shared/_navbar_menu_mobile.html.erb
+++ b/app/views/shared/_navbar_menu_mobile.html.erb
@@ -136,7 +136,7 @@
         <%= link_to new_workshop_variation_idea_path,
                     class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-layer-group"></i>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path></svg>
           <span class="whitespace-nowrap">New workshop variation idea</span>
         <% end %>
 
@@ -154,14 +154,14 @@
         <%= link_to new_workshop_log_path,
                     class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-clipboard-list"></i>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
           <span>New workshop log</span>
         <% end %>
 
         <%= link_to new_story_idea_path,
                     class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-          <i class="fas fa-book-open"></i>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
           <span>New story idea</span>
         <% end %>
 

--- a/app/views/shared/_navbar_new_button.html.erb
+++ b/app/views/shared/_navbar_new_button.html.erb
@@ -21,7 +21,7 @@
   data-dropdown-target="content">
   <%= link_to new_workshop_variation_idea_path,
               class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-    <i class="fas fa-layer-group"></i>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path></svg>
     <span class="whitespace-nowrap">New workshop variation idea</span>
   <% end %>
 
@@ -37,13 +37,13 @@
 
   <%= link_to new_workshop_log_path,
               class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-    <i class="fas fa-clipboard-list"></i>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path></svg>
     <span>New workshop log</span>
   <% end %>
 
   <%= link_to new_story_idea_path,
               class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
-    <i class="fas fa-book-open"></i>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path></svg>
     <span>New story idea</span>
   <% end %>
 

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,15 +1,17 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="community-news-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Stories</h2>
-        <p class="text-gray-600">Check out stories from Windows Facilitators around the world and the healing they make possible through art</p>
+<div class="community-news-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Stories header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:stories, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:stories, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:stories, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:stories, intensity: 900) %> uppercase tracking-wide">Stories</span>
       </div>
-
-      <div class="text-right text-end">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Story) %>
           <%= link_to "New Story",
                       new_story_path,
@@ -17,6 +19,9 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:stories) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600">Check out stories from Windows Facilitators around the world and the healing they make possible through art</p>
 
     <%= render "search_boxes" %>
 

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -2,9 +2,17 @@
 <% story_title = ERB::Util.url_encode(@story.title) %>
 
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Story header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:stories, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:stories, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:stories, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:stories, intensity: 900) %> uppercase tracking-wide">Story</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @story) %>
@@ -16,7 +24,9 @@
         </span>
         <%= print_button(@story, printable_type: "Story", button_text: "Print page") %>
       </div>
-
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:stories) %> p-4 sm:p-8 space-y-6">
       <!-- Story Card -->
       <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
 
@@ -104,4 +114,5 @@
           <%= render "shared/organization_footer" %>
         </div>
       </div>
+  </div>
 </div>

--- a/app/views/story_ideas/edit.html.erb
+++ b/app/views/story_ideas/edit.html.erb
@@ -1,6 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Story idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:story_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:story_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:story_ideas, intensity: 900) %> uppercase tracking-wide">Edit Story Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if @story_idea.stories.any? %>
@@ -10,12 +19,12 @@
         <% end %>
         <%= link_to "View", story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> p-4 sm:p-8 space-y-6">
 
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", story_idea: @story_idea %>
-          <%= render "shared/audit_info", resource: @story_idea %>
-        </div>
-      </div>
+    <%= render "form", story_idea: @story_idea %>
+    <%= render "shared/audit_info", resource: @story_idea %>
+
+  </div>
 </div>

--- a/app/views/story_ideas/index.html.erb
+++ b/app/views/story_ideas/index.html.erb
@@ -1,88 +1,91 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="space-y-6">
-        <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            <%= StoryIdea.model_name.human.pluralize %> (<%= @story_ideas_count %>)
-          </h1>
-          <div class="flex gap-2">
-            <%= link_to("New #{ StoryIdea.model_name.human.downcase }",
-                        new_story_idea_path,
-                        class: "btn btn-primary-outline") %>
-          </div>
-        </div>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Story idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:story_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:story_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:story_ideas, intensity: 900) %> uppercase tracking-wide">Story Ideas (<%= @story_ideas_count %>)</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to("New #{StoryIdea.model_name.human.downcase}",
+                    new_story_idea_path,
+                    class: "btn btn-primary-outline") %>
+      </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> p-4 sm:p-8 space-y-6">
 
-        <%= render "search_boxes" %>
+    <%= render "search_boxes" %>
 
-        <div class="rounded-xl bg-white p-6">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
-            <tr>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><span class="pl-3">Image</span></th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Author</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Name</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Windows Type</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Workshop</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Organization</th>
-              <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Updated At</th>
-              <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Promoted to Story</th>
-              <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Actions</th>
-            </tr>
-            </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-            <% @story_ideas.each do |story_idea| %>
-              <tr class="hover:bg-gray-50">
-                <td>
-                  <div class="p-3">
-                    <%= render "assets/display_image",
-                               resource: story_idea,
-                               width: 18, height: 14,
-                               variant: :index,
-                               link_to_object: true,
-                               file: story_idea.display_image %>
-                  </div>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.created_by.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800">
-                  <%= link_to story_idea.name, story_idea_path(story_idea),
-                              class: "font-bold hover:text-indigo-800 hover:underline" %>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.windows_type&.short_name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.workshop_title %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.organization&.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
-                  <%= story_idea.updated_at.strftime("%b %d, %Y") %>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
-                  <% if story_idea.stories.any? %>
-                    <%= link_to "Story", story_path(story_idea.stories.last),
-                                class: "btn btn-secondary-outline" %>
-                  <% end %>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
-                  <%= link_to "Edit", edit_story_idea_path(story_idea), class: "btn btn-secondary-outline" %>
-                </td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
-        </div>
-        </div>
-
-
-        <!-- Empty state -->
-        <% unless @story_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
-            No <%= StoryIdea.model_name.human.pluralize.downcase %> found.
-          </p>
+    <div class="rounded-xl bg-white p-6">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+        <tr>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700"><span class="pl-3">Image</span></th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Author</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Name</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Windows Type</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Workshop</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Organization</th>
+          <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Updated At</th>
+          <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Promoted to Story</th>
+          <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Actions</th>
+        </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+        <% @story_ideas.each do |story_idea| %>
+          <tr class="hover:bg-gray-50">
+            <td>
+              <div class="p-3">
+                <%= render "assets/display_image",
+                           resource: story_idea,
+                           width: 18, height: 14,
+                           variant: :index,
+                           link_to_object: true,
+                           file: story_idea.display_image %>
+              </div>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.created_by.name %></td>
+            <td class="px-4 py-2 text-sm text-gray-800">
+              <%= link_to story_idea.name, story_idea_path(story_idea),
+                          class: "font-bold hover:text-indigo-800 hover:underline" %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.windows_type&.short_name %></td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.workshop_title %></td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.organization&.name %></td>
+            <td class="px-4 py-2 text-sm text-gray-500 text-center">
+              <%= story_idea.updated_at.strftime("%b %d, %Y") %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-500 text-center">
+              <% if story_idea.stories.any? %>
+                <%= link_to "Story", story_path(story_idea.stories.last),
+                            class: "btn btn-secondary-outline" %>
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-500 text-center">
+              <%= link_to "Edit", edit_story_idea_path(story_idea), class: "btn btn-secondary-outline" %>
+            </td>
+          </tr>
         <% end %>
+        </tbody>
+      </table>
+    </div>
 
-        <!-- Pagination -->
-        <div class="mt-6 flex justify-center">
-          <div class="pagination mt-6">
-            <%= tailwind_paginate @story_ideas %>
-          </div>
-        </div>
+    <!-- Empty state -->
+    <% unless @story_ideas.any? %>
+      <p class="text-gray-500 text-center py-6">
+        No <%= StoryIdea.model_name.human.pluralize.downcase %> found.
+      </p>
+    <% end %>
+
+    <!-- Pagination -->
+    <div class="mt-6 flex justify-center">
+      <div class="pagination mt-6">
+        <%= tailwind_paginate @story_ideas %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/story_ideas/new.html.erb
+++ b/app/views/story_ideas/new.html.erb
@@ -1,30 +1,35 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-2xl font-semibold text-gray-900">New <%= @story_idea.class.model_name.human.downcase %></h1>
-  </div>
-
-  <div class="mb-6 text-gray-700 leading-relaxed">
-    At A Window Between Worlds, we value every story you share. Your voice helps paint a picture of the positive impact
-    of art on people and communities, inspiring others to use art in similarly powerful and far reaching ways.
-    <br><br>
-    Thank you for considering submitting to our
-    <%= link_to "Story Share", "https://www.awbw.org/stories",
-                target: "_blank", class: "text-blue-600 hover:text-blue-800" %>.
-    Stories are typically short (200-400 words) and describe an art workshop you did and the impact it had on someone.
-    You can write about art workshops you've done with clients, family, friends, colleagues, community members,
-    volunteers, and yourself. To help your stories make the greatest impact, check out these
-    <%= link_to "tips for stories", resource_path(1011), class: "text-blue-600 hover:text-blue-800" %>
-    <br><br>
-    <span class="italic">
-      Please note: edits may be made, and not all stories
-      will be published to the site, but may still be used in other places.
-    </span>
-  </div>
-
-  <div class="space-y-6">
-    <div class="mt-4">
-      <%= render "form", story_idea: @story_idea %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Story idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:story_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:story_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+      </svg>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:story_ideas, intensity: 900) %> uppercase tracking-wide">New Story Idea</span>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> p-4 sm:p-8 space-y-6">
+
+    <div class="text-gray-700 leading-relaxed">
+      At A Window Between Worlds, we value every story you share. Your voice helps paint a picture of the positive impact
+      of art on people and communities, inspiring others to use art in similarly powerful and far reaching ways.
+      <br><br>
+      Thank you for considering submitting to our
+      <%= link_to "Story Share", "https://www.awbw.org/stories",
+                  target: "_blank", class: "text-blue-600 hover:text-blue-800" %>.
+      Stories are typically short (200-400 words) and describe an art workshop you did and the impact it had on someone.
+      You can write about art workshops you've done with clients, family, friends, colleagues, community members,
+      volunteers, and yourself. To help your stories make the greatest impact, check out these
+      <%= link_to "tips for stories", resource_path(1011), class: "text-blue-600 hover:text-blue-800" %>
+      <br><br>
+      <span class="italic">
+        Please note: edits may be made to your story idea, and not all stories
+        will be published to the site, but may still be used in other places.
+      </span>
+    </div>
+
+    <%= render "form", story_idea: @story_idea %>
+
   </div>
 </div>

--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -1,14 +1,26 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% if allowed_to?(:index?, StoryIdea) %>
-      <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
-    <% if allowed_to?(:edit?, @story_idea) %>
-      <%= link_to "Edit", edit_story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Story idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:story_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:story_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:story_ideas, intensity: 900) %> uppercase tracking-wide">Story Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, StoryIdea) %>
+          <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @story_idea) %>
+          <%= link_to "Edit", edit_story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+      </div>
+    </div>
   </div>
+  <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> p-4 sm:p-8 space-y-6">
 
   <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
     <div class="font-semibold text-gray-900 mb-2">
@@ -121,5 +133,7 @@
     <div class="mb-10">
       <%= @story_idea.rhino_body %>
     </div>
+  </div>
+
   </div>
 </div>

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -1,24 +1,17 @@
 <% content_for(:page_bg_class, "public") %>
 <%= render "shared/public_welcome_banner" %>
 
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:tutorials) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">
-          <%= Tutorial.model_name.human(count: 2) %>
-        </h2>
-
-        <p class="text-gray-600 max-w-2xl">
-          <% if user_signed_in? %>
-            Our library of step-by-step tutorials and informational videos designed to support your journey
-          <% else %>
-            A library of videos designed to introduce you to our work and the real-world impact shared by the community we serve
-          <% end %>
-        </p>
+<div class="w-full max-w-7xl mx-auto border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Tutorials header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:tutorials, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:tutorials, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:tutorials, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:tutorials, intensity: 900) %> uppercase tracking-wide">Tutorials</span>
       </div>
-
-      <div class="text-right">
+      <div class="flex flex-wrap gap-2">
         <% if allowed_to?(:new?, Tutorial) %>
           <%= link_to "New #{Tutorial.model_name.human.downcase}",
                        new_tutorial_path,
@@ -26,6 +19,15 @@
         <% end %>
       </div>
     </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:tutorials) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-600 max-w-2xl">
+      <% if user_signed_in? %>
+        Our library of step-by-step tutorials and informational videos designed to support your journey
+      <% else %>
+        A library of videos designed to introduce you to our work and the real-world impact shared by the community we serve
+      <% end %>
+    </p>
 
     <%= render "search_boxes" %>
 

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,7 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Tutorial header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:tutorials, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:tutorials, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:tutorials, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664zM21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:tutorials, intensity: 900) %> uppercase tracking-wide">Tutorial</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to Tutorial.model_name.human(count: 2), tutorials_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @tutorial) %>
@@ -12,7 +20,9 @@
           <%= render "bookmarks/editable_bookmark_button", resource: @tutorial.object %>
         </span>
       </div>
-
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:tutorials) %> p-4 sm:p-8 space-y-6">
       <!-- Resource Card -->
       <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
 
@@ -45,4 +55,5 @@
         </div>
 
       </div>
+  </div>
 </div>

--- a/app/views/workshop_ideas/edit.html.erb
+++ b/app/views/workshop_ideas/edit.html.erb
@@ -1,16 +1,25 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 900) %> uppercase tracking-wide">Edit Workshop Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "View", workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> p-4 sm:p-8 space-y-6">
 
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", workshop_idea: @workshop_idea %>
-          <%= render "shared/audit_info", resource: @workshop_idea %>
-        </div>
-      </div>
+    <%= render "form", workshop_idea: @workshop_idea %>
+    <%= render "shared/audit_info", resource: @workshop_idea %>
+
+  </div>
 </div>

--- a/app/views/workshop_ideas/index.html.erb
+++ b/app/views/workshop_ideas/index.html.erb
@@ -1,82 +1,87 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="space-y-6">
-        <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            <%= WorkshopIdea.model_name.human.pluralize %> (<%= @workshop_ideas_count %>)
-          </h1>
-          <div class="flex gap-2">
-            <%= link_to "New #{WorkshopIdea.model_name.human.downcase}",
-                        new_workshop_idea_path,
-                        class: "btn btn-primary-outline" %>
-          </div>
-        </div>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 900) %> uppercase tracking-wide"><%= WorkshopIdea.model_name.human.pluralize %> (<%= @workshop_ideas_count %>)</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "New #{WorkshopIdea.model_name.human.downcase}",
+                    new_workshop_idea_path,
+                    class: "btn btn-primary-outline" %>
+      </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> p-4 sm:p-8 space-y-6">
 
-        <!-- Filter form -->
-        <%= render "search_boxes" %>
+    <!-- Filter form -->
+    <%= render "search_boxes" %>
 
-        <div class="rounded-xl bg-white p-6">
-          <div class="overflow-x-auto">
-          <table class="w-full border-collapse border border-gray-200">
-            <thead class="bg-gray-100">
-            <tr>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Main Image</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Title</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Timeframe</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Author</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Promoted?</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+    <div class="rounded-xl bg-white p-6">
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse border border-gray-200">
+          <thead class="bg-gray-100">
+          <tr>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Main Image</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Title</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Timeframe</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Author</th>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Promoted?</th>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+          </tr>
+          </thead>
+
+          <tbody class="divide-y divide-gray-200">
+          <% @workshop_ideas.each do |workshop_idea| %>
+            <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <td>
+                <div class="p-3">
+                  <%= render "assets/display_image",
+                             resource: workshop_idea,
+                             width: 18, height: 14,
+                             variant: :index,
+                             link_to_object: true,
+                             file: workshop_idea.display_image %>
+                </div>
+              </td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.title %></td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.time_frame_total %></td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.created_by.name %></td>
+              <td class="px-4 py-2 text-sm text-gray-800 text-center">
+                <% if workshop_idea.workshops.any? %>
+                  <span class='fa fa-check-circle text-green-500'></span>
+                <% else %>
+                  <span>--</span>
+                <% end %>
+              </td>
+
+              <!-- Actions -->
+              <td class="px-4 py-2 flex justify-center gap-2">
+                <%= link_to 'Edit', edit_workshop_idea_path(workshop_idea), class: "btn btn-secondary-outline" %>
+              </td>
             </tr>
-            </thead>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
 
-            <tbody class="divide-y divide-gray-200">
-            <% @workshop_ideas.each do |workshop_idea| %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
-                <td>
-                  <div class="p-3">
-                    <%= render "assets/display_image",
-                               resource: workshop_idea,
-                               width: 18, height: 14,
-                               variant: :index,
-                               link_to_object: true,
-                               file: workshop_idea.display_image %>
-                  </div>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.title %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.time_frame_total %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.created_by.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800 text-center">
-                  <% if workshop_idea.workshops.any? %>
-                    <span class='fa fa-check-circle text-green-500'></span>
-                  <% else %>
-                    <span>--</span>
-                  <% end %>
-                </td>
+    <!-- Empty state -->
+    <% unless @workshop_ideas.any? %>
+      <p class="text-gray-500 text-center py-6">
+        No <%= WorkshopIdea.model_name.human.pluralize.downcase %> found.
+      </p>
+    <% end %>
 
-                <!-- Actions -->
-                <td class="px-4 py-2 flex justify-center gap-2">
-                  <%= link_to 'Edit', edit_workshop_idea_path(workshop_idea), class: "btn btn-secondary-outline" %>
-                </td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
-        </div>
-        </div>
-
-        <!-- Empty state -->
-        <% unless @workshop_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
-            No <%= WorkshopIdea.model_name.human.pluralize.downcase %> found.
-          </p>
-        <% end %>
-
-        <!-- Pagination -->
-        <div class="mt-6 flex justify-center">
-          <div class="pagination">
-            <%= tailwind_paginate @workshop_ideas %>
-          </div>
-        </div>
+    <!-- Pagination -->
+    <div class="mt-6 flex justify-center">
+      <div class="pagination">
+        <%= tailwind_paginate @workshop_ideas %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/workshop_ideas/new.html.erb
+++ b/app/views/workshop_ideas/new.html.erb
@@ -1,18 +1,27 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">
-          New Workshop Idea
-        </h1>
-        <p>We encourage you to create your own workshop or a
-          <%= link_to "variation of an existing workshop",
-                      new_workshop_variation_idea_path,
-                      class: "text-blue-500 hover:underline" %>.
-          <br>Please enter the details of your creation below. Most fields are optional.</p>
-      </div>
-      <div class="space-y-6">
-        <div class="bg-white rounded mt-4 p-6">
-          <%= render "form" %>
-        </div>
-      </div>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+      </svg>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 900) %> uppercase tracking-wide">New Workshop Idea</span>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> p-4 sm:p-8 space-y-6">
+
+    <p class="text-gray-700 leading-relaxed">
+      We encourage you to create your own workshop or a
+      <%= link_to "variation of an existing workshop",
+                  new_workshop_variation_idea_path,
+                  class: "text-blue-500 hover:underline" %>.
+      Please enter the details of your creation below. Most fields are optional.
+    </p>
+
+    <div class="bg-white rounded mt-4 p-6">
+      <%= render "form" %>
+    </div>
+
+  </div>
 </div>

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -1,14 +1,26 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% if allowed_to?(:index?, WorkshopIdea) %>
-      <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
-    <% if allowed_to?(:edit?, @workshop_idea) %>
-      <%= link_to "Edit", edit_workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_ideas, intensity: 900) %> uppercase tracking-wide">Workshop Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopIdea) %>
+          <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_idea) %>
+          <%= link_to "Edit", edit_workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+      </div>
+    </div>
   </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> p-4 sm:p-8 space-y-6">
 
   <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
     <div class="font-semibold text-gray-900 mb-2">
@@ -94,5 +106,7 @@
         </div>
       <% end %>
     <% end %>
+  </div>
+
   </div>
 </div>

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -23,7 +23,7 @@
           },
           prompt: "Search by title",
           label: "Workshop",
-          label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+          label_html: { class: "block font-medium text-gray-700 mb-1" } %>
 
         <%= f.input :external_workshop_title,
                   as: :text,
@@ -32,7 +32,7 @@
                     rows: 1,
                     class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                   },
-                  label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+                  label_html: { class: "block font-medium text-gray-700 mb-1" } %>
       </div>
 
       <div class="flex-1 mb-4 md:mb-0">
@@ -49,7 +49,7 @@
                     selected: (params[:organization_id].presence || (f.object.organization_id || (@organizations.count == 1 ? @organizations.first.id : nil))),
                     input_html: { value: params[:organization_id].presence || f.object.organization_id || @organization_id,
                                   class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+                    label_html: { class: "block font-medium text-gray-700 mb-1" } %>
         <% else current_user.person&.affiliations&.count == 1 %>
           <%= f.hidden_field :organization_id,
                            value: f.object.organization_id || current_user.person.primary_organization&.id %>
@@ -63,7 +63,7 @@
                   required: true,
                   input_html: { type: 'date', value: f.object.date&.strftime('%Y-%m-%d'),
                                 class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" },
-                  label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+                  label_html: { class: "block font-medium text-gray-700 mb-1" } %>
       </div>
     </div>
 
@@ -74,7 +74,7 @@
 
     <!-- Ongoing Participants -->
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-700 mb-2">Ongoing participants <span class="text-xs text-gray-500">(have attended an AWBW workshop before)</span></label>
+      <label class="block font-medium text-gray-700 mb-2">Ongoing participants <span class="text-xs text-gray-500">(have attended an AWBW workshop before)</span></label>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
         <%= f.input :children_ongoing, as: :integer, label: "Children (0–12)",
@@ -96,7 +96,7 @@
 
     <!-- First-Time Participants -->
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-700 mb-2">First-time participants <span class="text-xs text-gray-500">(have never attended an AWBW workshop)</span></label>
+      <label class="block font-medium text-gray-700 mb-2">First-time participants <span class="text-xs text-gray-500">(have never attended an AWBW workshop)</span></label>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
         <%= f.input :children_first_time, as: :integer, label: "Children (0–12)", input_html: { min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" } %>

--- a/app/views/workshop_logs/_index.html.erb
+++ b/app/views/workshop_logs/_index.html.erb
@@ -11,19 +11,21 @@
    ) || [0, 0, 0, 0, 0, 0] %>
 
       <div class="space-y-6">
-        <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            <%= WorkshopLog.model_name.human.pluralize %> (<%= number_with_delimiter(workshop_logs_count) %>)
-          </h1>
-          <div class="flex gap-2">
-            <%= link_to "New #{WorkshopLog.model_name.human.downcase}",
-                        new_workshop_log_path(organization_id: params[:organization_id],
-                                              workshop_id: params[:workshop_id],
-                                              created_by_id: current_user.id),
-                        class: "btn btn-primary" %>
+        <% unless local_assigns[:hide_header] %>
+          <!-- Header -->
+          <div class="flex items-center justify-between mb-6">
+            <h1 class="text-2xl font-semibold text-gray-900">
+              <%= WorkshopLog.model_name.human.pluralize %> (<%= number_with_delimiter(workshop_logs_count) %>)
+            </h1>
+            <div class="flex gap-2">
+              <%= link_to "New #{WorkshopLog.model_name.human.downcase}",
+                          new_workshop_log_path(organization_id: params[:organization_id],
+                                                workshop_id: params[:workshop_id],
+                                                created_by_id: current_user.id),
+                          class: "btn btn-primary" %>
+            </div>
           </div>
-        </div>
+        <% end %>
 
         <!-- Filter form -->
         <%= render "workshop_logs/search_boxes" %>

--- a/app/views/workshop_logs/edit.html.erb
+++ b/app/views/workshop_logs/edit.html.erb
@@ -1,16 +1,25 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop log header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_logs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> uppercase tracking-wide">Edit Workshop Log</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "View", workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> p-4 sm:p-8 space-y-6">
 
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", workshop_log: @workshop_log %>
-          <%= render "shared/audit_info", resource: @workshop_log %>
-        </div>
-      </div>
+    <%= render "form", workshop_log: @workshop_log %>
+    <%= render "shared/audit_info", resource: @workshop_log %>
+
+  </div>
 </div>

--- a/app/views/workshop_logs/index.html.erb
+++ b/app/views/workshop_logs/index.html.erb
@@ -1,6 +1,26 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="rounded-xl bg-white p-6">
-    <%= render "index" %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop log header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_logs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> uppercase tracking-wide">Workshop Logs</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "New workshop log",
+                    new_workshop_log_path(organization_id: params[:organization_id],
+                                          workshop_id: params[:workshop_id],
+                                          created_by_id: current_user.id),
+                    class: "btn btn-primary" %>
+      </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> p-4 sm:p-8 space-y-6">
+    <div class="rounded-xl bg-white p-6">
+      <%= render "index", hide_header: true %>
+    </div>
   </div>
 </div>

--- a/app/views/workshop_logs/new.html.erb
+++ b/app/views/workshop_logs/new.html.erb
@@ -1,38 +1,41 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop log header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_logs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+      </svg>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> uppercase tracking-wide">New Workshop Log</span>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> p-4 sm:p-8 space-y-6">
 
-      <!-- Header -->
-      <div class="mb-8 space-y-4">
-        <!-- Alert -->
-        <div id="notification_monthly"
-             class="hidden relative rounded-md border border-green-300 bg-green-50 text-green-800 px-4 py-3 text-sm flex items-start justify-between">
-          <span>
-            A monthly report has already been submitted for this month.
-            To submit an additional workshop log, please contact your program manager.
-          </span>
-          <button type="button"
-                  class="text-green-700 hover:text-green-900 font-semibold ml-4"
-                  data-dismiss="alert"
-                  aria-label="Close">
-            &times;
-          </button>
-        </div>
+    <!-- Alert -->
+    <div id="notification_monthly"
+         class="hidden relative rounded-md border border-green-300 bg-green-50 text-green-800 px-4 py-3 text-sm flex items-start justify-between">
+      <span>
+        A monthly report has already been submitted for this month.
+        To submit an additional workshop log, please contact your program manager.
+      </span>
+      <button type="button"
+              class="text-green-700 hover:text-green-900 font-semibold ml-4"
+              data-dismiss="alert"
+              aria-label="Close">
+        &times;
+      </button>
+    </div>
 
-        <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
-          New <%= @workshop_log.class.model_name.human.downcase %>
-        </h1>
+    <!-- Description -->
+    <p class="text-gray-700 leading-relaxed">
+      An optional tool to track data from your art workshops.
+      <br>
+      If you don't see the workshop you facilitated listed in the dropdown menu, you can type in a new title in the field below.
+    </p>
 
-        <!-- Description -->
-        <p class="text-gray-700 leading-relaxed">
-          An optional tool to track data from your art workshops. If you don't see the workshop you facilitated listed in the dropdown menu, you can type in a new title in the field below.
-        </p>
-      </div>
+    <div class="bg-white rounded mt-4 p-6">
+      <%= render "form" %>
+    </div>
 
-      <div class="space-y-6">
-        <div class="bg-white rounded mt-4 p-6">
-          <%= render "form" %>
-        </div>
-      </div>
-
+  </div>
 </div>

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -1,14 +1,26 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-member") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% if allowed_to?(:index?, WorkshopLog) %>
-      <%= link_to "My Workshop Logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
-    <% if allowed_to?(:edit?, @workshop_log) %>
-      <%= link_to "Edit", edit_workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop log header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_logs, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> uppercase tracking-wide">Workshop Log</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopLog) %>
+          <%= link_to "My Workshop Logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_log) %>
+          <%= link_to "Edit", edit_workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+      </div>
+    </div>
   </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> p-4 sm:p-8 space-y-6">
 
   <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
     <div class="font-semibold text-gray-900 mb-2">
@@ -184,5 +196,7 @@
         </div>
       </div>
     <% end %>
+  </div>
+
   </div>
 </div>

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -46,7 +46,7 @@
           },
           prompt: "Search by title",
           label: "Workshop",
-          label_html: { class: "block text-sm font-medium text-gray-700 mb-1 #{ 'readonly' if promoted_to_variation}" } %>
+          label_html: { class: "block font-medium text-gray-700 mb-1 #{ 'readonly' if promoted_to_variation}" } %>
       </div>
       <div>
         <%= f.input :windows_type_id,
@@ -75,7 +75,7 @@
                       selected: (params[:organization_id].presence || (f.object.organization_id || (@organizations.count == 1 ? @organizations.first.id : nil))),
                       input_html: { value: params[:organization_id].presence || f.object.organization_id || @organization_id,
                                     class: "#{ "readonly" if promoted_to_variation } block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" },
-                      label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+                      label_html: { class: "block font-medium text-gray-700 mb-1" } %>
         <% else %>
           <%= f.hidden_field :organization_id,
                              value: f.object.organization_id || current_user.person.primary_organization&.id %>

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -1,6 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop variation idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 900) %> uppercase tracking-wide">Edit Workshop Variation Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if @workshop_variation_idea.workshop_variations.any? %>
           <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
@@ -17,12 +26,12 @@
         <%= link_to "View", workshop_variation_idea_path(@workshop_variation_idea),
                     class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit workshop variation idea</h1>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 sm:p-8 space-y-6">
 
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
-          <%= render "shared/audit_info", resource: @workshop_variation_idea %>
-        </div>
-      </div>
+    <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
+    <%= render "shared/audit_info", resource: @workshop_variation_idea %>
+
+  </div>
 </div>

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -1,81 +1,86 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="space-y-6">
-        <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
-            Workshop Variation Ideas (<%= @workshop_variation_ideas_count %>)
-          </h1>
-          <div class="flex gap-2">
-            <%= link_to "New workshop variation idea",
-                        new_workshop_variation_idea_path,
-                        class: "btn btn-primary-outline" %>
-          </div>
-        </div>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop variation idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 900) %> uppercase tracking-wide">Workshop Variation Ideas (<%= @workshop_variation_ideas_count %>)</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "New workshop variation idea",
+                    new_workshop_variation_idea_path,
+                    class: "btn btn-primary-outline" %>
+      </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 sm:p-8 space-y-6">
 
-        <%= render "search_boxes" %>
+    <%= render "search_boxes" %>
 
-        <div class="rounded-xl bg-white p-6">
-          <div class="overflow-x-auto">
-          <table class="w-full border-collapse border border-gray-200">
-            <thead class="bg-gray-100">
-            <tr>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Main Image</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Name</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">Workshop</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Author</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Promoted?</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+    <div class="rounded-xl bg-white p-6">
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse border border-gray-200">
+          <thead class="bg-gray-100">
+          <tr>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Main Image</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Name</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">Workshop</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Author</th>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Promoted?</th>
+            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+          </tr>
+          </thead>
+
+          <tbody class="divide-y divide-gray-200">
+          <% @workshop_variation_ideas.each do |workshop_variation_idea| %>
+            <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <td>
+                <div class="p-3">
+                  <%= render "assets/display_image",
+                             resource: workshop_variation_idea,
+                             width: 18, height: 14,
+                             variant: :index,
+                             link_to_object: true,
+                             file: workshop_variation_idea.display_image %>
+                </div>
+              </td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.name %></td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.workshop.title %></td>
+              <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.created_by.name %></td>
+              <td class="px-4 py-2 text-sm text-gray-800 text-center">
+                <% if workshop_variation_idea.workshop_variations.any? %>
+                  <span class='fa fa-check-circle text-green-500'></span>
+                <% else %>
+                  <span>--</span>
+                <% end %>
+              </td>
+
+              <!-- Actions -->
+              <td class="px-4 py-2 flex justify-center gap-2">
+                <%= link_to 'Edit', edit_workshop_variation_idea_path(workshop_variation_idea), class: "btn btn-secondary-outline" %>
+              </td>
             </tr>
-            </thead>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
 
-            <tbody class="divide-y divide-gray-200">
-            <% @workshop_variation_ideas.each do |workshop_variation_idea| %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
-                <td>
-                  <div class="p-3">
-                    <%= render "assets/display_image",
-                               resource: workshop_variation_idea,
-                               width: 18, height: 14,
-                               variant: :index,
-                               link_to_object: true,
-                               file: workshop_variation_idea.display_image %>
-                  </div>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.workshop.title %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_variation_idea.created_by.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800 text-center">
-                  <% if workshop_variation_idea.workshop_variations.any? %>
-                    <span class='fa fa-check-circle text-green-500'></span>
-                  <% else %>
-                    <span>--</span>
-                  <% end %>
-                </td>
+    <!-- Empty state -->
+    <% unless @workshop_variation_ideas.any? %>
+      <p class="text-gray-500 text-center py-6">
+        No workshop variation ideas found.
+      </p>
+    <% end %>
 
-                <!-- Actions -->
-                <td class="px-4 py-2 flex justify-center gap-2">
-                  <%= link_to 'Edit', edit_workshop_variation_idea_path(workshop_variation_idea), class: "btn btn-secondary-outline" %>
-                </td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
-        </div>
-        </div>
-
-        <!-- Empty state -->
-        <% unless @workshop_variation_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
-            No workshop variation ideas found.
-          </p>
-        <% end %>
-
-        <!-- Pagination -->
-        <div class="mt-6 flex justify-center">
-          <div class="pagination">
-            <%= tailwind_paginate @workshop_variation_ideas %>
-          </div>
-        </div>
+    <!-- Pagination -->
+    <div class="mt-6 flex justify-center">
+      <div class="pagination">
+        <%= tailwind_paginate @workshop_variation_ideas %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/workshop_variation_ideas/new.html.erb
+++ b/app/views/workshop_variation_ideas/new.html.erb
@@ -1,17 +1,23 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">New workshop variation idea</h1>
-      </div>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop variation idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path>
+      </svg>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 900) %> uppercase tracking-wide">New Workshop Variation Idea</span>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 sm:p-8 space-y-6">
 
-      <p class="text-gray-700 leading-relaxed mb-4">
-        Sharing your unique workshop variations strengthens our curriculum for our entire community.
-        We deeply value your innovations and welcome your feedback anytime.
-      </p>
+    <p class="text-gray-700 leading-relaxed">
+      Sharing your unique workshop variations strengthens our curriculum for our entire community.
+      <br>
+      We deeply value your innovations and welcome your feedback anytime.
+    </p>
 
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
-        </div>
-      </div>
+    <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
+
+  </div>
 </div>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -1,15 +1,27 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% if allowed_to?(:index?, WorkshopVariationIdea) %>
-      <%= link_to "Workshop Variation Ideas", workshop_variation_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
-    <% if allowed_to?(:edit?, @workshop_variation_idea) %>
-      <%= link_to "Edit", edit_workshop_variation_idea_path(@workshop_variation_idea),
-                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop variation idea header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 900) %> uppercase tracking-wide">Workshop Variation Idea</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:index?, WorkshopVariationIdea) %>
+          <%= link_to "Workshop Variation Ideas", workshop_variation_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:edit?, @workshop_variation_idea) %>
+          <%= link_to "Edit", edit_workshop_variation_idea_path(@workshop_variation_idea),
+                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+      </div>
+    </div>
   </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 sm:p-8 space-y-6">
 
   <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
     <div class="font-semibold text-gray-900 mb-2">
@@ -103,5 +115,7 @@
     <div class="mb-10">
       <%= @workshop_variation_idea.rhino_body %>
     </div>
+  </div>
+
   </div>
 </div>

--- a/app/views/workshop_variations/index.html.erb
+++ b/app/views/workshop_variations/index.html.erb
@@ -1,18 +1,22 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="space-y-6">
-    <!-- Header -->
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-semibold text-gray-900">
-        <%= WorkshopVariation.model_name.human.pluralize %> (<%= @workshop_variations_count %>)
-      </h1>
-      <div class="flex gap-2">
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop variations header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variations, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variations, intensity: 900) %> uppercase tracking-wide">Workshop Variations (<%= @workshop_variations_count %>)</span>
+      </div>
+      <div class="flex flex-wrap gap-2">
         <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
                     new_workshop_variation_path,
                     class: "btn btn-primary-outline" %>
       </div>
     </div>
-
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> p-4 sm:p-8 space-y-6">
     <%= render "search_boxes" %>
 
     <div class="rounded-xl bg-white p-6">
@@ -86,4 +90,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -1,17 +1,26 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
-
-    <div class="flex flex-wrap justify-end gap-2 mb-4">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Workshop", workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
-                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <% if allowed_to?(:edit?, @workshop_variation) %>
-        <%= link_to "Edit", edit_workshop_variation_path(@workshop_variation),
-                    class: "#{ "admin-only bg-blue-100 " if allowed_to?(:manage?, WorkshopVariation) }text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <% end %>
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshop Variation header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_variations, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_variations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_variations, intensity: 900) %> uppercase tracking-wide">Workshop Variation</span>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Workshop", workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
+                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% if allowed_to?(:edit?, @workshop_variation) %>
+          <%= link_to "Edit", edit_workshop_variation_path(@workshop_variation),
+                      class: "#{ "admin-only bg-blue-100 " if allowed_to?(:manage?, WorkshopVariation) }text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <% end %>
+      </div>
     </div>
-
-
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> p-4 sm:p-8 space-y-6">
     <!-- Resource Card -->
     <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
       <div class="workshop">
@@ -67,4 +76,5 @@
       <!-- Main Text -->
       <%= @workshop_variation.rhino_body %>
     </div>
+  </div>
 </div>

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -1,33 +1,34 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="workshops-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Workshops</h2>
-
-        <p class="text-gray-700">
-          Search by emotional theme, materials needed, ease of set-up, and more.
-          <br>
-          We encourage Windows Facilitator creativity and innovation. If you adapt and improve workshops, please <%= link_to "share your ideas with us", new_workshop_variation_idea_path, class: "text-blue-500" %>!
-        </p>
+<div class="workshops-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow overflow-hidden">
+  <!-- Workshops header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshops, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshops, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshops, intensity: 900) %> uppercase tracking-wide">Workshops</span>
       </div>
-
-      <% if allowed_to?(:new?, Workshop) %>
-        <%= link_to "New workshop",
-                    new_workshop_path,
-                    class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-      <% end %>
+      <div class="flex flex-wrap gap-2">
+        <% if allowed_to?(:new?, Workshop) %>
+          <%= link_to "New workshop",
+                      new_workshop_path,
+                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+        <% end %>
+      </div>
     </div>
   </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshops) %> p-4 sm:p-8 space-y-6">
+    <p class="text-gray-700">
+      Search by emotional theme, materials needed, ease of set-up, and more.
+      <br>
+      We encourage Windows Facilitator creativity and innovation. If you adapt and improve workshops, please <%= link_to "share your ideas with us", new_workshop_variation_idea_path, class: "text-blue-500" %>!
+    </p>
 
-  <!-- Divider -->
-  <div class="w-full"><hr class="border-gray-300 mb-6"></div>
-
-  <!-- Search Form -->
-  <div class="w-full">
+    <!-- Search Form -->
+    <div class="w-full">
     <%= form_tag(workshops_path, method: :get,
                  data: {turbo_stream: true, turbo_frame: "workshop_results",
                         controller: "collection share-url"}, autocomplete: "off", class: "space-y-6") do %>
@@ -113,5 +114,6 @@
         </div>
       </div>
     <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -1,5 +1,17 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="workshop-show max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6 print:border-none print:shadow-none">
+<div class="workshop-show max-w-7xl mx-auto border border-gray-200 rounded-xl shadow overflow-hidden print:border-none print:shadow-none">
+  <!-- Workshop header banner -->
+  <div class="<%= DomainTheme.bg_class_for(:workshops, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshops, intensity: 300) %> px-8 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"></path>
+        </svg>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshops, intensity: 900) %> uppercase tracking-wide">Workshop</span>
+      </div>
+    </div>
+  </div>
+  <div class="<%= DomainTheme.bg_class_for(:workshops) %> p-6 print:border-none print:shadow-none">
   <div class="flex flex-col gap-6">
     <!-- Main Workshop Show -->
     <div id="show" class="flex-1">
@@ -19,5 +31,6 @@
         }, { once: true });
       </script>
     </div>
+  </div>
   </div>
 </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Adds a consistent **page topper** header banner across the app's index and show views (events, workshops, stories, resources, FAQs, people, organizations, community news, and the various idea/log views).
- Gives users a unified visual anchor and clearer hierarchy on every resource page, instead of the ad-hoc header rows each view previously rolled on its own.

### How did you approach the change?

- Replaced per-view header markup with domain-themed banner headers using `DomainTheme` background/border/text helpers at consistent intensities.
- Swapped FontAwesome (`<i class="fas ...">`) icons for inline SVG icons in the navbar "New" menu and across views, removing the FontAwesome dependency from these templates and keeping icon styling under Tailwind control.
- Normalized label typography in workshop log forms (dropped redundant `text-sm` on field labels).

### UI Testing Checklist

- [ ] Index pages render the new banner header with correct domain theming and "New" action buttons.
- [ ] Show pages render the new banner header.
- [ ] Navbar "New" dropdown icons render as SVGs (no broken FontAwesome glyphs).
- [ ] Workshop log form labels display correctly.
- [ ] Mobile navbar menu renders correctly.

### Anything else to add?

- View-only changes; no model, controller, or routing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
