### PR TITLE
Add display author to public content forms

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -222,6 +222,9 @@ class EventsController < ApplicationController
         .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
+    @authors = authorized_scope(User.has_access.or(User.where(id: @event.author_id)))
+                   .includes(:person)
+                   .map { |u| [ u.full_name, u.id ] }.sort_by(&:first)
   end
 
   def set_event
@@ -230,6 +233,7 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:cost,
+                                  :author_id,
                                   :created_by_id,
                                   :location_id,
                                   :title,

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -149,10 +149,9 @@ class ResourcesController < ApplicationController
     @resource.build_downloadable_asset if @resource.downloadable_asset.blank?
     @resource.gallery_assets.build
     @windows_types = WindowsType.all
-    @authors = authorized_scope(User.has_access.or(User.where(id: @resource.created_by_id)))
+    @authors = authorized_scope(User.has_access.or(User.where(id: @resource.author_id)))
                    .includes(:person)
-                   .order("people.first_name, people.last_name")
-                   .map { |u| [ u.full_name, u.id ] }
+                   .map { |u| [ u.full_name, u.id ] }.sort_by(&:first)
     @categories_grouped =
       Category
         .includes(:category_type)
@@ -171,7 +170,7 @@ class ResourcesController < ApplicationController
   def resource_params
     params.require(:resource).permit(
       :rhino_body, :kind, :male, :female, :title, :featured, :published, :publicly_visible, :publicly_featured,
-      :agency, :author, :filemaker_code, :windows_type_id, :position,
+      :agency, :author, :author_id, :filemaker_code, :windows_type_id, :position,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       downloadable_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -9,7 +9,7 @@ class StoriesController < ApplicationController
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 12
       base_scope = authorized_scope(Story.includes(:windows_type, :organization, :workshop,
-                                                   :created_by, :bookmarks, :primary_asset,
+                                                   :author, :created_by, :bookmarks, :primary_asset,
                                                    :story_idea))
       filtered = base_scope.search_by_params(params)
       sortable = %w[title updated_at created_at windows_type workshop author organization]
@@ -131,6 +131,9 @@ class StoriesController < ApplicationController
                             .order(:created_at)
     @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
     @users = User.has_access.includes(:person).left_joins(:person).order(Arel.sql("people.first_name IS NULL, LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email)"))
+    @authors = authorized_scope(User.has_access.or(User.where(id: @story.author_id)))
+                   .includes(:person)
+                   .map { |u| [ u.full_name, u.id ] }.sort_by(&:first)
     @windows_types = WindowsType.all
     @workshops = authorized_scope(Workshop.all).includes(:windows_type).order(:title)
     @categories_grouped =
@@ -173,7 +176,7 @@ class StoriesController < ApplicationController
       scope.left_joins(:workshop)
            .reorder(Workshop.arel_table[:title].public_send(dir))
     when "author"
-      scope.left_joins(created_by: :person)
+      scope.left_joins(author: :person)
            .reorder(Person.arel_table[:first_name].public_send(dir))
     when "organization"
       scope.left_joins(:organization)
@@ -188,7 +191,7 @@ class StoriesController < ApplicationController
     params.require(:story).permit(
       :title, :rhino_body, :featured, :published, :publicly_visible, :publicly_featured, :youtube_url, :website_url,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
-      :created_by_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
+      :author_id, :created_by_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -42,6 +42,7 @@ class TutorialsController < ApplicationController
 
   def create
     @tutorial = Tutorial.new(tutorial_params)
+    @tutorial.created_by ||= current_user
     authorize! @tutorial
 
     success = false
@@ -108,6 +109,9 @@ class TutorialsController < ApplicationController
         .select { |type, _| type.nil? || type.published? }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
+    @authors = authorized_scope(User.has_access.or(User.where(id: @tutorial.author_id)))
+                   .includes(:person)
+                   .map { |u| [ u.full_name, u.id ] }.sort_by(&:first)
   end
 
   private
@@ -120,6 +124,7 @@ class TutorialsController < ApplicationController
   def tutorial_params
     params.require(:tutorial).permit(
       :title, :body, :rhino_body, :position, :youtube_url,
+      :author_id, :created_by_id,
       :featured, :published, :publicly_visible, :publicly_featured,
       category_ids: [],
       sector_ids: [],

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ApplicationRecord
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
+  belongs_to :author, class_name: "User", optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :location, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -14,6 +14,7 @@ class Resource < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :author, class_name: "User", optional: true
   belongs_to :created_by, class_name: "User"
   belongs_to :workshop, optional: true
   belongs_to :windows_type, optional: true

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -4,6 +4,7 @@ class Story < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :author, class_name: "User", optional: true
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"
   belongs_to :windows_type
@@ -48,7 +49,7 @@ class Story < ApplicationRecord
     attributes person_first: "people.first_name", person_last: "people.last_name"
     options :all, type: :text, default: true, default_operator: :or
 
-    scope { join_rich_texts.left_joins(created_by: :person) }
+    scope { join_rich_texts.left_joins(author: :person) }
     attributes action_text_body: "action_text_rich_texts.plain_text_body"
     options :action_text_body, type: :text, default: true, default_operator: :or
   end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -3,6 +3,9 @@ class Tutorial < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :author, class_name: "User", optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -411,8 +411,20 @@
     <% end %>
   </div>
 
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
+    <%= f.input :author_id,
+                as: :select,
+                label: "Display author",
+                collection: @authors,
+                selected: f.object.author_id || current_user&.id,
+                input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
+    <div class="text-sm text-gray-500 self-end pb-2">
+      <%= "Created by: #{f.object.created_by.name}" if f.object.created_by %>
+    </div>
+  </div>
+
   <div class="flex items-center justify-between gap-4">
-    <div><%= "Created by: #{f.object.created_by.name}" if f.object.created_by %></div>
+    <div></div>
 
     <div class="action-buttons mt-8 flex justify-center gap-3">
       <% if allowed_to?(:destroy?, f.object) %>

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -70,6 +70,14 @@
                   input_html: { class: "w-full rounded border-gray-300 px-2 py-1", min: 1, step: 1 },
                   label_html: { class: "font-medium mb-1 block" } %>
     </div>
+    <div class="flex-1 min-w-[200px]">
+      <%= f.input :author_id,
+                  as: :select,
+                  label: "Display author",
+                  collection: @authors,
+                  selected: f.object.author_id || f.object.created_by_id || current_user&.id,
+                  input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
+    </div>
   </div>
 
   <!-- Third Row -->

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -262,6 +262,15 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4">
     <div class="flex-1 mb-4 md:mb-0">
+      <%= f.input :author_id,
+                  as: :select,
+                  label: "Display author",
+                  collection: @authors,
+                  selected: f.object.author_id || current_user&.id,
+                  input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
+    </div>
+
+    <div class="flex-1 mb-4 md:mb-0">
       <%= f.input :created_by_id,
                   collection: @users.map { |u| [ u.full_name_with_email, u.id ] },
                   prompt: "Select an author",

--- a/app/views/tutorials/_form.html.erb
+++ b/app/views/tutorials/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for(@tutorial, html: { multipart: true }) do |f| %>
+  <%= f.hidden_field :created_by_id, value: f.object.created_by_id || current_user&.id %>
   <%= render 'shared/errors', resource: @tutorial if @tutorial.errors.any? %>
 
   <div class="p-3">
@@ -27,6 +28,14 @@
         <%= f.input :position,
                     as: :integer,
                     hint: "Order to display videos in (lower numbers display first)" %>
+      </div>
+      <div class="flex-1">
+        <%= f.input :author_id,
+                    as: :select,
+                    label: "Display author",
+                    collection: @authors,
+                    selected: f.object.author_id || current_user&.id,
+                    input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
       </div>
     </div>
 

--- a/db/migrate/20260308143000_add_author_to_public_forms.rb
+++ b/db/migrate/20260308143000_add_author_to_public_forms.rb
@@ -1,0 +1,9 @@
+class AddAuthorToPublicForms < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :stories, :author, foreign_key: { to_table: :users }, null: true
+    add_reference :events, :author, foreign_key: { to_table: :users }, null: true
+    add_reference :resources, :author, foreign_key: { to_table: :users }, null: true
+    add_reference :tutorials, :author, foreign_key: { to_table: :users }, null: true
+    add_reference :tutorials, :created_by, foreign_key: { to_table: :users }, null: true
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :event do
+    association :author, factory: :user
     association :created_by, factory: :user
     title { "sample title" }
     description { "sample description" }

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :resource do
+    association :author, factory: :user
     association :created_by, factory: :user
     title { Faker::Lorem.sentence }
     kind { Resource::PUBLISHED_KINDS.sample }

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :windows_type
     association :organization
     association :workshop
+    association :author, factory: :user
     association :created_by, factory: :user
     association :updated_by, factory: :user
     sequence(:title) { |n| "Story #{n}" }

--- a/spec/factories/tutorials.rb
+++ b/spec/factories/tutorials.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :tutorial do
+    association :author, factory: :user
+    association :created_by, factory: :user
     title { "MyString" }
     body { "MyText" }
     featured { false }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Public-facing **stories, events, resources, and tutorials** need a byline that can be attributed to a chosen author, independently of who actually created the record in the Portal.
- Previously the displayed author was tied to `created_by`, so the public byline could not differ from the internal creator. This adds a dedicated **"Display author"** so editors control attribution directly.

### How did you approach the change?

- Added a nullable `author` reference (→ `users`) to `stories`, `events`, `resources`, and `tutorials`, plus a `created_by` reference to `tutorials` (it previously had none).
- Added `belongs_to :author, class_name: "User", optional: true` to each model.
- Added a **"Display author"** select to each public form, defaulting to the existing author/creator or the current user.
- Switched Story search and the author sort column to use the new `author` association instead of `created_by`.
- Permitted `author_id` (and `created_by_id` where needed) in the controllers and updated factories.

### UI Testing Checklist

- [ ] Story form: "Display author" select appears, saves, and drives the displayed byline
- [ ] Event form: "Display author" select appears and saves; "Created by" still shown
- [ ] Resource form: "Display author" select appears and saves
- [ ] Tutorial form: "Display author" select appears and saves; `created_by` set on create
- [ ] Stories index: author column sort works against the new association

### Anything else to add?

- The branch is based on a commit ~127 behind `main`; the PR diff is clean (only the author changes) since the base is a direct ancestor, but a rebase before merge may be worth it. Screenshots to be added for the four forms.
