### PR TITLE
Add Lograge structured logging and Honeybadger deploy notifications

### DIFF
--- a/.github/workflows/honeybadger-deploy.yml
+++ b/.github/workflows/honeybadger-deploy.yml
@@ -1,0 +1,19 @@
+name: Notify Honeybadger deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  honeybadger-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Honeybadger of deploy
+        env:
+          HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
+        run: |
+          curl --silent --show-error --fail \
+            -X POST https://api.honeybadger.io/v1/deploys \
+            -H "X-API-Key: $HONEYBADGER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"deploy\":{\"environment\":\"production\",\"revision\":\"${{ github.sha }}\",\"repository\":\"${{ github.repository }}\",\"local_username\":\"${{ github.actor }}\"}}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,10 @@ RuboCop linting on PRs and pushes to main.
 | Rich text | ActionText + Rhino editor (TipTap-based) |
 | File uploads | ActiveStorage (DigitalOcean Spaces) + legacy Paperclip |
 | Feature flags | FeatureFlipper |
+| Error monitoring | Honeybadger |
+| Observability | OpenTelemetry (Honeycomb via OTLP exporter) |
 | Analytics | Ahoy (events + visits), Chartkick, Groupdate, Blazer |
+| Audit/change logging | Approximated via Ahoy (may adopt PaperTrail or Audited in the future) |
 | Geocoding | Geocoder + MaxMind GeoIP2 |
 | Email styling | Premailer-rails (inline CSS) |
 | Positioning | Positioning gem for ordered records |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ RuboCop linting on PRs and pushes to main.
 | Feature flags | FeatureFlipper |
 | Error monitoring | Honeybadger |
 | Observability | OpenTelemetry (Honeycomb via OTLP exporter) |
+| Structured logging | Lograge (JSON format, production-only) |
 | Analytics | Ahoy (events + visits), Chartkick, Groupdate, Blazer |
 | Audit/change logging | Approximated via Ahoy (may adopt PaperTrail or Audited in the future) |
 | Geocoding | Geocoder + MaxMind GeoIP2 |

--- a/Gemfile
+++ b/Gemfile
@@ -112,3 +112,6 @@ gem "opentelemetry-instrumentation-all"
 
 # Error monitoring (production-only via initializer guard)
 gem "honeybadger", "~> 6.4"
+
+# Structured request logging (production-only via initializer guard)
+gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,11 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -818,6 +823,7 @@ DEPENDENCIES
   kt-paperclip (~> 7.1.1)
   launchy
   listen
+  lograge
   maxmind-geoip2 (~> 1.5, >= 1.5.1)
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
@@ -959,6 +965,7 @@ CHECKSUMS
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   llhttp-ffi (0.5.1) sha256=9a25a7fc19311f691a78c9c0ac0fbf4675adbd0cca74310228fdf841018fa7bc
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  lograge (0.14.0) sha256=42371a75823775f166f727639f5ddce73dd149452a55fc94b90c303213dc9ae1
   loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,30 @@
+unless Rails.env.local?
+  Rails.application.configure do
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Json.new
+
+    config.lograge.ignore_custom = lambda do |event|
+      event.payload[:path] == "/up"
+    end
+
+    config.lograge.custom_options = lambda do |event|
+      exceptions = %w[controller action format id]
+      params = event.payload[:params]&.except(*exceptions) || {}
+
+      {
+        request_id: event.payload[:headers]&.fetch("action_dispatch.request_id", nil),
+        user_id: event.payload[:user_id],
+        remote_ip: event.payload[:remote_ip],
+        params: params,
+        time: Time.current.iso8601(3)
+      }.compact
+    end
+
+    config.lograge.custom_payload do |controller|
+      {
+        user_id: controller.current_user&.id,
+        remote_ip: controller.request.remote_ip
+      }
+    end
+  end
+end

--- a/config/vector/vector.yaml
+++ b/config/vector/vector.yaml
@@ -1,0 +1,32 @@
+# Vector configuration for forwarding Rails lograge JSON to Honeybadger Insights.
+# This is a reference config — not loaded by Rails.
+# Deploy to /etc/vector/vector.yaml on the server running Vector.
+
+sources:
+  app:
+    type: "file"
+    include: ["/home/app/shared/log/*.log"]
+
+transforms:
+  parse_logs:
+    type: "remap"
+    inputs: ["app"]
+    source: |
+      payload, err = parse_json(string!(.message))
+      if err == null {
+        .payload = payload
+        del(.message)
+      }
+
+sinks:
+  honeybadger_events:
+    type: "http"
+    inputs: ["parse_logs"]
+    uri: "https://api.honeybadger.io/v1/events"
+    request:
+      headers:
+        X-API-Key: "PROJECT_API_KEY"
+    encoding:
+      codec: "json"
+    framing:
+      method: "newline_delimited"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Production currently lacks queryable request logs and any signal for *when* a deploy happened, making it hard to correlate errors (now captured via Honeybadger) to a specific release.
- This adds structured logging and deploy markers so request behavior and release boundaries are both visible in Honeybadger Insights.

### How did you approach the change?
- Added the `lograge` gem and a `config/initializers/lograge.rb` initializer that emits one JSON line per request, guarded to non-local environments (`unless Rails.env.local?`).
- Enriched each log line with `request_id`, `user_id`, `remote_ip`, filtered `params`, and an ISO8601 timestamp; health-check requests to `/up` are ignored.
- Added `config/vector/vector.yaml` as a reference Vector config (not loaded by Rails) that tails the app log and forwards parsed JSON to the Honeybadger Insights events endpoint.
- Added `.github/workflows/honeybadger-deploy.yml` to notify Honeybadger's deploy API on every push to `main`.
- Updated `AGENTS.md` to document Lograge under structured logging.

### Anything else to add?
- The Vector config and the deploy workflow rely on `HONEYBADGER_API_KEY` being configured on the server / in repo secrets respectively.
- No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)