### PR TITLE
Forms Part 2: Extract registration form-name constants to a single source of truth

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -149,7 +149,7 @@ class Event < ApplicationRecord
   def build_public_registration_form
     return if event_forms.registration.exists?
 
-    form_name = title&.match?(/training/i) ? "Extended Event Registration" : "Short Event Registration"
+    form_name = title&.match?(/training/i) ? FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME : FormBuilderService::SHORT_REGISTRATION_FORM_NAME
     form = Form.standalone.find_by(name: form_name)
     return unless form
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -1,4 +1,7 @@
 class FormBuilderService
+  SHORT_REGISTRATION_FORM_NAME = "Short Event Registration"
+  EXTENDED_REGISTRATION_FORM_NAME = "Extended Event Registration"
+
   SECTIONS = {
     person_identifier: { label: "Person identifier", method: :build_person_identifier_fields },
     person_contact_info: { label: "Person contact info", method: :build_person_contact_info_fields },

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -386,16 +386,16 @@
               <% default_form_id = if current_reg_form
                                      current_reg_form.id
                                    elsif @event.title&.match?(/training/i)
-                                     @registration_forms.find { |rf| rf.name == "Extended Event Registration" }&.id
+                                     @registration_forms.find { |rf| rf.name == FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME }&.id
                                    else
-                                     @registration_forms.find { |rf| rf.name == "Short Event Registration" }&.id
+                                     @registration_forms.find { |rf| rf.name == FormBuilderService::SHORT_REGISTRATION_FORM_NAME }&.id
                                    end %>
               <select name="event[registration_form_id]" class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
                 <option value="">No registration form</option>
                 <% @registration_forms.each do |reg_form| %>
                   <% label = case reg_form.name
-                             when "Extended Event Registration", "Public Registration" then "Extended registration form"
-                             when "Short Event Registration", "Short Registration" then "Short registration form"
+                             when FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME, "Public Registration" then "Extended registration form"
+                             when FormBuilderService::SHORT_REGISTRATION_FORM_NAME, "Short Registration" then "Short registration form"
                              else reg_form.name
                              end %>
                   <option value="<%= reg_form.id %>" <%= "selected" if reg_form.id == default_form_id %>><%= label %> (<%= reg_form.form_fields.size %> fields)</option>

--- a/db/seeds/dummy_dev_seeds.rb
+++ b/db/seeds/dummy_dev_seeds.rb
@@ -918,16 +918,16 @@ end
 
 
 puts "Creating standalone registration forms…"
-unless Form.standalone.exists?(name: "Short Event Registration")
+unless Form.standalone.exists?(name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME)
   FormBuilderService.new(
-    name: "Short Event Registration",
+    name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME,
     sections: %i[person_identifier consent marketing scholarship]
   ).call
 end
 
-unless Form.standalone.exists?(name: "Extended Event Registration")
+unless Form.standalone.exists?(name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME)
   FormBuilderService.new(
-    name: "Extended Event Registration",
+    name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
     sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
   ).call
 end
@@ -942,8 +942,8 @@ end
 
 puts "Creating Events with shared forms…"
 admin_user = User.find_by(email: "umberto.user@example.com")
-long_form = Form.standalone.find_by!(name: "Extended Event Registration")
-short_form = Form.standalone.find_by!(name: "Short Event Registration")
+long_form = Form.standalone.find_by!(name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME)
+short_form = Form.standalone.find_by!(name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME)
 scholarship_form = Form.standalone.scholarship_application.first!
 
 # Each entry: [title, form_type, cost_cents, scholarship?, visibility]

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe Event, type: :model do
   end
 
   describe "#build_public_registration_form" do
-    let!(:default_form) { create(:form, name: "Short Event Registration") }
-    let!(:extended_form) { create(:form, name: "Extended Event Registration") }
+    let!(:default_form) { create(:form, name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME) }
+    let!(:extended_form) { create(:form, name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME) }
 
     it "links the default registration form by default" do
       event = create(:event, public_registration_enabled: true)

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "Events::Registrations", type: :request do
 
     before do
       form = FormBuilderService.new(
-        name: "Extended Event Registration",
+        name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
         sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
       ).call
       EventForm.create!(event: event, form: form, role: "registration")

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
   let(:event) { create(:event, :published, :publicly_visible) }
   let(:form) do
     f = FormBuilderService.new(
-      name: "Extended Event Registration",
+      name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
       sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
     ).call
     event.event_forms.create!(form: f, role: "registration")

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe FormBuilderService do
     context "with multiple sections (short event registration)" do
       let(:form) do
         described_class.new(
-          name: "Short Event Registration",
+          name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME,
           sections: %i[person_identifier consent marketing scholarship]
         ).call
       end
@@ -108,7 +108,7 @@ RSpec.describe FormBuilderService do
     context "with multiple sections (extended event registration)" do
       let(:form) do
         described_class.new(
-          name: "Extended Event Registration",
+          name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
           sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
         ).call
       end

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Event registration show page", type: :system do
   describe "view registration form link" do
     it "links to form show with slug param" do
       FormBuilderService.new(
-        name: "Extended Event Registration",
+        name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
         sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
       ).call.tap { |form| EventForm.create!(event: event, form: form, role: "registration") }
       form = event.registration_form

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Event show page", type: :system do
 
     context "when event has a public registration form" do
       before do
-        create(:form, name: "Short Event Registration")
+        create(:form, name: FormBuilderService::SHORT_REGISTRATION_FORM_NAME)
         event.update!(public_registration_enabled: true)
       end
 

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Public registration new page", type: :system do
   before do
     driven_by(:rack_test)
     form = FormBuilderService.new(
-      name: "Extended Event Registration",
+      name: FormBuilderService::EXTENDED_REGISTRATION_FORM_NAME,
       sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
     ).call
     EventForm.create!(event: event, form: form, role: "registration")


### PR DESCRIPTION
> Stacked on #1301 (`maebeale/shared-form-builder`). Review/merge that first; this PR's base is the 1301 branch, not `main`.

### What is the goal of this PR and why is this important?

- Addresses review item #5 from #1301: the registration form-name "magic strings"
- `"Short Event Registration"` and `"Extended Event Registration"` were typed as bare literals in ~10 places (model, event form view, dev seeds, 7 spec files)
- `Event#build_public_registration_form` looks up the form by exact name match — so a rename in any single location silently breaks the lookup (no form attached, no error)
- The pre-refactor code avoided this with a builder constant; that constant disappeared when the three builders were consolidated into `FormBuilderService`

### How did you approach the change?

- Added two constants to `FormBuilderService`:
  - `SHORT_REGISTRATION_FORM_NAME`
  - `EXTENDED_REGISTRATION_FORM_NAME`
- Replaced every literal in app code, dev seeds, and specs with the constants
- Behavior is unchanged — this is a pure refactor to a single source of truth
- Legacy label aliases (`"Public Registration"`, `"Short Registration"`) in the event form `case` are intentionally left as literals; they're historical names, not the canonical ones

### Scope note (Option A vs Option B)

This is the **safe, mechanical fix (Option A)**: make the coupling explicit and grep-able. It does **not** remove the deeper design smell — that `build_public_registration_form` couples an event's *title* (`/training/i`) to a form's *name*. Removing the name-based auto-selection entirely (letting admins explicitly pick the registration form) is a behavior/product change worth its own issue/PR, deliberately out of scope here.

### Testing

- `event_spec`, `form_builder_service_spec`, and `public_registration_spec` (the specs that exercise the form-name lookup) pass
- Rubocop clean on all changed files
- The 6 failures in `registrations_spec` are pre-existing full-page-render 500s caused by Vite not resolving in a fresh worktree (no `node_modules`), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)