### PR TITLE
Show story idea body as required and humanize its error

### DIFF
--- a/app/helpers/rhino_editor_helper.rb
+++ b/app/helpers/rhino_editor_helper.rb
@@ -1,16 +1,17 @@
 module RhinoEditorHelper
   # custom rhino editor with stimulus controller attached to edit raw source html
-  def rhino_editor(form, base_attribute_name, label: nil, hint: nil)
+  def rhino_editor(form, base_attribute_name, label: nil, hint: nil, required: false)
     rhino_attr = :"rhino_#{base_attribute_name}"
     field_id = form.field_id(rhino_attr)
     value = form.object.public_send(rhino_attr)
 
     label_tag =
       if label.present?
+        label_content = required ? safe_join([ label, " ", content_tag(:abbr, "*", title: "required", class: "text-red-600 no-underline") ]) : label
         form.label(
           base_attribute_name,
-          label,
-          class: "block font-medium mb-1 text-gray-700 text optional"
+          label_content,
+          class: "block font-medium mb-1 text-gray-700 text #{required ? "required" : "optional"}"
         )
       end
 

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -111,6 +111,7 @@
     <% else %>
       <div class="form-group <%= 'has-error' if f.object.errors[:rhino_body].present? %>">
         <%= rhino_editor(f, :body,
+                      required: true,
                       label: "Please share details about your participant(s) (while maintaining confidentiality)
                       and their workshop goals, including what happened during the workshop, and how creating made an impact.
                       Include direct quotes whenever possible.",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
   hello: "Hello world"
   activerecord:
     attributes:
+      story_idea:
+        rhino_body: "Body"
       workshop_variation:
         rhino_body: "Details"
       workshop_variation_idea:

--- a/spec/requests/story_ideas_spec.rb
+++ b/spec/requests/story_ideas_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe "/story_ideas", type: :request do
         post story_ideas_url, params: { story_idea: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_content)
       end
+
+      it "labels the body error as 'Body', not 'Rhino body'" do
+        post story_ideas_url, params: { story_idea: invalid_attributes }
+        expect(response.body).to include("Body can&#39;t be blank")
+        expect(response.body).not_to include("Rhino body")
+      end
     end
 
     describe "PATCH /update" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The story idea body field gave submitters no visual cue that it was required.
- When the body was left blank, the public-facing validation error exposed the internal attribute name "Rhino body" (e.g. "Rhino body can't be blank"), which is confusing to users.

### How did you approach the change?

- Added an optional `required:` keyword to the `rhino_editor` helper that switches the label to the `required` class and appends a red `*` marker. Defaulted to `false` so the helper's other ~40 usages (workshops, events, etc.) are unaffected.
- Passed `required: true` to the body field on the story idea form.
- Added `activerecord.attributes.story_idea.rhino_body: "Body"` to `en.yml` (matching the existing `workshop_variation` pattern) so the error reads "Body can't be blank".
- Added a request spec asserting the invalid-create response says "Body can't be blank" and not "Rhino body".

### UI Testing Checklist

- [ ] Story idea form (new): body label shows a red `*` required marker
- [ ] Submitting the form with a blank body shows "Body can't be blank" (not "Rhino body")

### Anything else to add?

- The shared `rhino_editor` helper change is scoped behind a parameter, so no other forms change behavior.