### PR TITLE
Upgrade puma to 7.2.1 (fix High-severity PROXY protocol CVEs)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "devise", "~> 5.0.4"
 gem "draper"
 gem "aws-sdk-s3"
 
-gem "puma", "~> 6.0" # Add Puma as the web server
+gem "puma", "~> 7.2" # Add Puma as the web server
 
 gem "cocoon", "~> 1.2.6"
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "devise", "~> 5.0.4"
 gem "draper"
 gem "aws-sdk-s3"
 
-gem "puma", "~> 7.2" # Add Puma as the web server
+gem "puma", "~> 7.2", ">= 7.2.1" # Add Puma as the web server
 
 gem "cocoon", "~> 1.2.6"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,7 +557,7 @@ GEM
       date
       stringio
     public_suffix (7.0.2)
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -818,7 +818,7 @@ DEPENDENCIES
   premailer-rails
   pry-coolline
   pry-rails
-  puma (~> 6.0)
+  puma (~> 7.2)
   rack-mini-profiler (~> 4.0)
   rails (~> 8.1.0)
   receipts (~> 2.4)
@@ -1047,7 +1047,7 @@ CHECKSUMS
   pry-rails (0.3.11) sha256=a69e28e24a34d75d1f60bcf241192a54253f8f7ef8a62cba1e75750a9653593d
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
-  puma (6.6.1) sha256=b9b56e4a4ea75d1bfa6d9e1972ee2c9f43d0883f011826d914e8e37b3694ea1e
+  puma (7.2.1) sha256=d7bf0e9cabd532e0d401e142cd94e3ac531e993610e2d80e6fbf9c26961414b0
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -818,7 +818,7 @@ DEPENDENCIES
   premailer-rails
   pry-coolline
   pry-rails
-  puma (~> 7.2)
+  puma (~> 7.2, >= 7.2.1)
   rack-mini-profiler (~> 4.0)
   rails (~> 8.1.0)
   receipts (~> 2.4)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `bundler-audit` (and CI) flags Puma 6.6.1 for two **High**-severity vulnerabilities in the PROXY protocol v1 parser:
  - [CVE-2026-47736](https://www.cve.org/CVERecord?id=CVE-2026-47736) — remote memory exhaustion via crafted PROXY v1 headers
  - [CVE-2026-47737](https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737) — PROXY v1 repeated-header acceptance on persistent connections
- The advisory's fix is `~> 7.2.1` or `>= 8.0.2`. This upgrades to the **7.2 line** (7.2.1), a single major-version bump that includes the hardened PROXY parser.

### How did you approach the change?

- Bumped `gem "puma"` from `~> 6.0` → `~> 7.2`; `bundle update puma` resolved to **7.2.1**.
- Verified `bin/bundler-audit check --update` now reports **No vulnerabilities found**.
- Reviewed Puma 6→7 breaking changes against this app — no app changes required:
  - **Ruby 4.0.1** is well above Puma 7's new **Ruby 3.0** minimum.
  - **Rails 8.1 / Rack 3.2.6** are compatible.
  - `config/puma.rb` uses only stable DSL (`threads`, `port`, `plugin :tmp_restart`, `plugin :solid_queue`, `solid_queue_mode`, `pidfile`) — the `tmp_restart`/`solid_queue` plugin APIs are unchanged in 7.x.
  - No `on_worker_boot`/`on_*` callback hooks anywhere (those were renamed to `before_*`/`after_*` in 7.0, but old names still alias), so nothing to rename.
  - No `workers`/`WEB_CONCURRENCY` config and no PROXY-protocol usage in the repo, so the `preload_app!` default flip and stricter PROXY parsing have no effect here.

### Anything else to add?

- Puma 7 raises the default `persistent_timeout` to 65s and lowercases response headers. Neither affects this app's code; the two `Content-Disposition` assertions in `spec/requests/event_registrations_spec.rb` run through the ActionDispatch stack (Puma not involved), so header casing is unaffected.
- **Deploy note:** this is a major version jump — worth a smoke test in staging on boot. If a proxy/LB sits in front, confirm its upstream idle timeout exceeds 65s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)