### PR TITLE
Require AI agents to attribute their GitHub comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,7 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
-- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
+- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user, so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
 
 ## Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -181,6 +181,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
 - **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user, so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
+- **Keep GitHub comments short and to the point** — one or two sentences, stating the key insight directly. Skip preamble, restating the code, and hedging; if a comment needs more than a few lines, it usually belongs in the PR description instead
 
 ## Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,7 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
-- **Attribute every GitHub comment to Claude** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST start with a 🤖 emoji and state it is from Claude. Begin the comment body with `🤖 _From Claude:_` followed by the content
+- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
 
 ## Testing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,6 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
+- **Attribute every GitHub comment to Claude** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST start with a 🤖 emoji and state it is from Claude. Begin the comment body with `🤖 _From Claude:_` followed by the content
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
 - **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user, so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
+- **Keep GitHub comments short and to the point** — one or two sentences, stating the key insight directly. Skip preamble, restating the code, and hedging; if a comment needs more than a few lines, it usually belongs in the PR description instead
 
 ## Ruby Version Manager
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
-- **Attribute every GitHub comment to Claude** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST start with a 🤖 emoji and state it is from Claude. Begin the comment body with `🤖 _From Claude:_` followed by the content
+- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
 
 ## Ruby Version Manager
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
+- **Attribute every GitHub comment to Claude** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST start with a 🤖 emoji and state it is from Claude. Begin the comment body with `🤖 _From Claude:_` followed by the content
 
 ## Ruby Version Manager
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - **On every push**, update the PR title and content to reflect the current diff — preserve any existing images/screenshots in the description
 - **On every push**, update AI instruction files if the diff adds, removes, or renames anything tracked in AGENTS.md — specifically: Stimulus controllers, services, model/controller concerns, mailers, rake tasks, and directory file counts
 - **On every push**, add PR review comments on notable lines of code — decisions, trade-offs, non-obvious logic, or anything a reviewer should understand. Use `gh api` to post line comments on the diff
-- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user (maebeale), so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
+- **Attribute every AI-authored GitHub comment** — `gh` posts as the authenticated user, so any comment you create (PR review comments, issue/PR comments, replies) MUST be prefixed to identify the AI agent that wrote it. Begin the comment body with `🤖 _From <agent>:_` (e.g. `🤖 _From Claude:_` or `🤖 _From Copilot:_`) followed by the content
 
 ## Ruby Version Manager
 


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- `gh` posts comments as the authenticated user, so AI-generated PR/issue comments are indistinguishable from the human's own — this adds a rule requiring the AI agent to clearly attribute its comments.

### How did you approach the change?
- Added a matching bullet to the **PRs** section of both AI instruction files (`CLAUDE.md` and `.github/copilot-instructions.md`, kept in sync) requiring every GitHub comment an AI creates to start with an agent-agnostic `🤖 _From <agent>:_` prefix (e.g. `🤖 _From Claude:_`, `🤖 _From Copilot:_`).

### UI Testing Checklist
- N/A — documentation/instruction files only, no UI or runtime code changed.

### Anything else to add?
- Wording was made agent-agnostic in response to Copilot review feedback so the Copilot instruction file isn't hard-coded to "Claude".
