### PR TITLE
Group manage registrants header actions into dropdowns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (34) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (35) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -272,6 +272,7 @@ end
 - `prefetch_lazy` — Prefetch lazy-loaded content
 - `print_options` — Print options toggle for analytics
 - `remote_select` — AJAX-powered select dropdown
+- `reveal_section` — Expand a collapsible section and scroll to it when loaded via matching URL hash
 - `rhino_source` — Rich text editor integration
 - `searchable_checkbox` — TomSelect checkbox-style multi-select
 - `searchable_select` — Tom Select autocomplete

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -75,6 +75,9 @@ application.register("prefetch-lazy", PrefetchLazyController)
 import PrintOptionsController from "./print_options_controller"
 application.register("print-options", PrintOptionsController)
 
+import RevealSectionController from "./reveal_section_controller"
+application.register("reveal-section", RevealSectionController)
+
 import RhinoSourceController from "./rhino_source_controller"
 application.register("rhino-source", RhinoSourceController)
 

--- a/app/frontend/javascript/controllers/reveal_section_controller.js
+++ b/app/frontend/javascript/controllers/reveal_section_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Expands a collapsible section and scrolls it into view when the page loads
+// with a matching URL hash — e.g. when linked from another page so the user
+// lands on the section already open rather than collapsed or scrolled past.
+//
+//   <div data-controller="dropdown reveal-section"
+//        data-reveal-section-anchor-value="registration_form_section"
+//        data-reveal-section-target="toggle"> ... the toggle button
+//        data-reveal-section-target="content"> ... the collapsible body
+//
+// The toggle target is clicked (reusing the dropdown controller) only when the
+// content is currently hidden, keeping the dropdown's open/closed state honest.
+export default class extends Controller {
+  static targets = ["toggle", "content"]
+  static values = { anchor: String }
+
+  connect() {
+    if (window.location.hash.slice(1) !== this.anchorValue) return
+    if (this.hasContentTarget && this.contentTarget.classList.contains("hidden")) {
+      this.toggleTarget.click()
+    }
+    this.element.scrollIntoView({ behavior: "smooth", block: "start" })
+  }
+}

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -1,0 +1,18 @@
+<% dropdown_id = "bulk-actions-menu-#{SecureRandom.hex(4)}" %>
+<% item_class = "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
+<div data-controller="dropdown" class="relative">
+  <button type="button"
+          data-action="dropdown#toggle"
+          data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
+          class="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-gray-300 shadow-sm bg-white text-sm text-gray-700 hover:bg-gray-50">
+    <span>Bulk actions</span>
+    <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
+  </button>
+
+  <div id="<%= dropdown_id %>"
+       data-dropdown-target="content"
+       class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
+    <%= link_to "Send reminder", preview_reminder_event_path(@event), class: item_class %>
+    <%= link_to "Download CSV", manage_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } %>
+  </div>
+</div>

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -4,7 +4,7 @@
   <button type="button"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
-          class="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-gray-300 shadow-sm bg-white text-sm text-gray-700 hover:bg-gray-50">
+          class="btn btn-utility-outline">
     <span>Bulk actions</span>
     <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
   </button>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -318,18 +318,21 @@
     </div>
 
     <% if allowed_to?(:manage?, @event) %>
-      <div class="admin-only registration-form-section" data-controller="dropdown">
+      <div class="admin-only registration-form-section"
+           data-controller="dropdown reveal-section"
+           data-reveal-section-anchor-value="registration_form_section">
         <button
           type="button"
           id="registration_form_button"
           class="flex items-center justify-between cursor-pointer w-full bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-t-md"
           data-action="dropdown#toggle"
+          data-reveal-section-target="toggle"
           data-dropdown-payload-param='[{"registration_form_section":"hidden"}, {"registration_form_arrow":"rotate-180"}, {"registration_form_button":"rounded-t-md rounded-md"}]'>
           Registration Form
           <i id="registration_form_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300 rotate-180"></i>
         </button>
 
-        <div id="registration_form_section" class="border border-gray-300 p-4 rounded-b-md">
+        <div id="registration_form_section" class="border border-gray-300 p-4 rounded-b-md" data-reveal-section-target="content">
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <p class="text-sm mb-2">

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -1,11 +1,11 @@
-<% dropdown_id = "forms-menu-#{SecureRandom.hex(4)}" %>
+<% dropdown_id = "form-actions-menu-#{SecureRandom.hex(4)}" %>
 <% item_class = "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
 <div data-controller="dropdown" class="relative">
   <button type="button"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
           class="btn btn-utility-outline">
-    <span>Forms</span>
+    <span>Form actions</span>
     <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
   </button>
 

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -12,7 +12,9 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
-    <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <% if @event.scholarship_form %>
+      <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -12,7 +12,9 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <% if @event.event_forms.registration.exists? %>
+      <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <% end %>
     <% if @event.scholarship_form %>
       <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
     <% end %>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -4,7 +4,7 @@
   <button type="button"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
-          class="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-gray-300 shadow-sm bg-white text-sm text-gray-700 hover:bg-gray-50">
+          class="btn btn-utility-outline">
     <span>Forms</span>
     <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
   </button>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -12,11 +12,15 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <% if @event.event_forms.registration.exists? %>
-      <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
-    <% end %>
-    <% if @event.scholarship_form %>
-      <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <% if @event.event_forms.registration.exists? || @event.scholarship_form %>
+      <% if @event.event_forms.registration.exists? %>
+        <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+      <% end %>
+      <% if @event.scholarship_form %>
+        <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+      <% end %>
+    <% else %>
+      <%= link_to "Select a form", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -19,8 +19,10 @@
       <% if @event.scholarship_form %>
         <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
+      <div class="my-1 border-t border-gray-100"></div>
+      <%= link_to "Change base form", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% else %>
-      <%= link_to "Select a form", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
+      <%= link_to "Enable forms", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -12,7 +12,7 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank" %>
-    <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank" %>
+    <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
   </div>
 </div>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -1,0 +1,22 @@
+<% dropdown_id = "forms-menu-#{SecureRandom.hex(4)}" %>
+<% item_class = "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
+<div data-controller="dropdown" class="relative">
+  <button type="button"
+          data-action="dropdown#toggle"
+          data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
+          class="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-gray-300 shadow-sm bg-white text-sm text-gray-700 hover:bg-gray-50">
+    <span>Forms</span>
+    <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
+  </button>
+
+  <div id="<%= dropdown_id %>"
+       data-dropdown-target="content"
+       class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
+    <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: item_class %>
+    <% if @event.event_forms.registration.exists? %>
+      <div class="my-1 border-t border-gray-100"></div>
+      <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank" %>
+      <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/_forms_menu.html.erb
+++ b/app/views/events/_forms_menu.html.erb
@@ -12,11 +12,7 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: item_class %>
-    <% if @event.event_forms.registration.exists? %>
-      <div class="my-1 border-t border-gray-100"></div>
-      <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank" %>
-      <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank" %>
-    <% end %>
+    <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank" %>
+    <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank" %>
   </div>
 </div>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -12,7 +12,10 @@
     </div>
     <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
-        <%= render "forms_menu" %>
+        <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+        <% if @event.event_forms.registration.exists? %>
+          <%= render "forms_menu" %>
+        <% end %>
       <% end %>
       <%= render "bulk_actions_menu" %>
       <% if allowed_to?(:edit?, @event) %>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -12,14 +12,14 @@
     </div>
     <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
-        <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if @event.event_forms.registration.exists? %>
           <%= render "forms_menu" %>
         <% end %>
       <% end %>
       <%= render "bulk_actions_menu" %>
       <% if allowed_to?(:edit?, @event) %>
-        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 border-l border-gray-200 pl-3 ml-1" %>
+        <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
       <% end %>
     </div>
   </div>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -13,7 +13,7 @@
     <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
         <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% if @event.event_forms.registration.exists? %>
+        <% if @event.event_forms.registration.exists? || @event.scholarship_form %>
           <%= render "forms_menu" %>
         <% end %>
       <% end %>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -13,7 +13,7 @@
     <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
         <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= render "forms_menu" %>
+        <%= render "form_actions_menu" %>
       <% end %>
       <%= render "bulk_actions_menu" %>
       <% if allowed_to?(:edit?, @event) %>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -10,19 +10,13 @@
         <%= @event.title %>
       </p>
     </div>
-    <div class="flex gap-2">
-      <%= link_to "Send reminder", preview_reminder_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Download CSV", manage_event_path(@event, format: :csv), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1", data: { turbo_frame: "_top" } %>
-      <%= link_to "View", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
-        <%= link_to "Edit", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "New registration", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% if @event.event_forms.registration.exists? %>
-          <%= link_to "Public registration", new_event_public_registration_path(@event, as_visitor: true), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1", target: "_blank" %>
-          <% if @event.scholarship_form %>
-            <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1", target: "_blank" %>
-          <% end %>
-        <% end %>
+        <%= render "forms_menu" %>
+      <% end %>
+      <%= render "bulk_actions_menu" %>
+      <% if allowed_to?(:edit?, @event) %>
+        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 border-l border-gray-200 pl-3 ml-1" %>
       <% end %>
     </div>
   </div>

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -16,9 +16,9 @@
         <%= render "form_actions_menu" %>
       <% end %>
       <%= render "bulk_actions_menu" %>
-      <% if allowed_to?(:edit?, @event) %>
-        <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-      <% end %>
+<% if allowed_to?(:new?, EventRegistration) %>
+  <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+<% end %>
     </div>
   </div>
 

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -13,9 +13,7 @@
     <div class="flex items-center gap-2">
       <% if allowed_to?(:edit?, @event) %>
         <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <% if @event.event_forms.registration.exists? || @event.scholarship_form %>
-          <%= render "forms_menu" %>
-        <% end %>
+        <%= render "forms_menu" %>
       <% end %>
       <%= render "bulk_actions_menu" %>
       <% if allowed_to?(:edit?, @event) %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

The action bar on the **Manage registrants** page (`events/manage`) had grown to 7 flat, identically-styled links with no hierarchy — hard to scan and only getting longer as more form entry points are added.

- Surfaces the **primary action** (`Add registrant`) as a real button, placed far right per the app's index convention.
- Collapses the secondary actions into **scoped dropdowns**, so the header stays usable as it grows.
- Groups by *what each control acts on* and orders by *increasing emphasis*, making the bar self-explanatory.

### How did you approach the change?

New layout (emphasis increases left → right, ending on the primary):

```
Edit event   Forms ▾   Bulk actions ▾        Add registrant
```

- **Edit event** — quiet "navigate away" text link (tertiary), far left — mirrors the `Events` link position on `event_registrations/index`.
- **Forms ▾** — links to the *public* registration form: `Public registration`, `Scholarship version` (open in a new tab). Renders only when a registration form exists (otherwise both items are gated away and the menu would be empty).
- **Bulk actions ▾** — collection-level actions: `Send reminder`, `Download CSV`.
- **Add registrant** — the primary write action, far right, styled `admin-only bg-blue-100 btn btn-primary-outline` to match the "New event registration" button on `event_registrations/index`.

This matches the established index convention: `event_registrations`, `organizations`, and `events` indexes all place the primary new/add button at the far right, with secondary/navigation actions to its left.

Details:
- Dropdown triggers use the `btn btn-utility-outline` design-system variant (not ad-hoc classes), so their height / radius / padding / shadow match the primary button and they read as a subordinate neutral tier.
- Reuses the existing `dropdown` Stimulus controller and mirrors the `admin/shared/_audience_dropdown` partial pattern — **no new JS**.
- Two new partials: `events/_forms_menu` and `events/_bulk_actions_menu`.
- Permission gating preserved: Bulk actions show at manage access; Add registrant / Forms / Edit event only with `:edit?`.
- Removed the redundant **View** link (it pointed to the same place as the existing `← Event` back link).
- Relabeled for clarity: **Edit → Edit event**, **New registration → Add registrant** (verb-led CTA; "Add" = insert into the list you're viewing; "registrant" matches the page title and mental model).

### UI Testing Checklist

- [ ] Header reads left→right: `Edit event`, `Forms ▾`, `Bulk actions ▾`, `Add registrant` (primary, far right); no standalone `View`
- [ ] `Add registrant` opens the new-registration form in-frame
- [ ] The two dropdowns match the primary button's height/radius (no shorter triggers)
- [ ] Each dropdown opens on click and closes on outside-click / `Esc`
- [ ] Forms: `Public registration` and `Scholarship version` open in a new tab
- [ ] Bulk actions: `Send reminder` opens the preview page; `Download CSV` downloads (top-level navigation)
- [ ] Event with no registration form → `Forms ▾` is hidden; `Add registrant` still shown
- [ ] As a non-editor (no `:edit?`) → `Edit event`, `Forms ▾`, `Add registrant` absent; `Bulk actions ▾` still present

### Anything else to add?

View-only change — no model/controller/route/migration changes. Scope was deliberately limited to the header bar; search/filters and the results table were left untouched.
