### PR TITLE
Decouple workspace port from Conductor via WORKSPACE_PORT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,12 @@ A [staging environment](https://awbw-staging-xzek4.ondigitalocean.app/) is also 
 <details>
 <summary><strong>Conductor (parallel AI workspaces)</strong></summary>
 
-This project supports [Conductor](https://conductor.build) for running multiple coding agents in parallel. Each workspace gets its own port, database, and session cookie automatically.
+[Conductor](https://conductor.build) is an optional macOS platform for running multiple coding agents in parallel, each in its own git worktree. You don't need it to work on this project — it's just one supported way to run isolated workspaces. When used, each workspace gets its own port, database, and session cookie automatically.
+
+The app itself only depends on the generic `WORKSPACE_PORT` environment variable for this isolation. The `bin/conductor-*` scripts derive `WORKSPACE_PORT` from Conductor's `CONDUCTOR_PORT`, but any other system (or a manual setup) can achieve the same result by exporting `WORKSPACE_PORT` itself.
 
 1. Open the project in Conductor — it will run `bin/conductor-setup` to symlink config files and set up a workspace-specific database.
-2. The dev server starts on the port assigned by Conductor (via `CONDUCTOR_PORT`).
+2. The dev server starts on the port assigned to the workspace.
 3. When a workspace is archived, `bin/conductor-archive` stops the running server.
 
 Configuration lives in `conductor.json` at the project root.

--- a/ai/server
+++ b/ai/server
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # Start development services (web + vite).
-# Uses CONDUCTOR_PORT (Conductor's assigned workspace port) if set,
-# otherwise probes for a free port starting at 3000.
+# Uses WORKSPACE_PORT (the workspace's assigned port) if set, otherwise probes
+# for a free port starting at 3000.
 # Derives a unique Vite port (server_port + 1) to avoid collisions.
 set -euo pipefail
 source "$(dirname "$0")/.ruby-env"
 
-if [ -n "${CONDUCTOR_PORT:-}" ]; then
-  server_port="$CONDUCTOR_PORT"
+if [ -n "${WORKSPACE_PORT:-}" ]; then
+  server_port="$WORKSPACE_PORT"
 else
   server_port=3000
   while lsof -iTCP:"$server_port" -sTCP:LISTEN -n -P >/dev/null 2>&1; do
     server_port=$((server_port + 1))
   done
-  echo "ai/server: CONDUCTOR_PORT unset, picked free port $server_port"
+  echo "ai/server: WORKSPACE_PORT unset, picked free port $server_port"
 fi
 
 export VITE_RUBY_PORT=$((server_port + 1))

--- a/bin/conductor-archive
+++ b/bin/conductor-archive
@@ -7,7 +7,10 @@
 set -e
 cd $(dirname "$0")/..
 
-PORT=${CONDUCTOR_PORT:-${PORT:-3000}}
+# CONDUCTOR_PORT is Conductor-specific. Expose it under the generic
+# WORKSPACE_PORT name so the rest of the app never references Conductor directly.
+export WORKSPACE_PORT=${WORKSPACE_PORT:-${CONDUCTOR_PORT:-}}
+PORT=${WORKSPACE_PORT:-${PORT:-3000}}
 
 echo "Archiving Conductor workspace (port ${PORT})..."
 
@@ -21,7 +24,7 @@ for p in "$PORT" "$((PORT + 36))"; do
 done
 
 # Drop workspace-specific databases
-if [ -n "$CONDUCTOR_PORT" ]; then
+if [ -n "$WORKSPACE_PORT" ]; then
   echo "Dropping workspace databases..."
   bin/rails db:drop 2>/dev/null || true
   RAILS_ENV=test bin/rails db:drop 2>/dev/null || true

--- a/bin/conductor-server
+++ b/bin/conductor-server
@@ -2,14 +2,18 @@
 #/ Usage: bin/conductor-server
 #/
 #/ Start all development processes for a Conductor workspace.
-#/ Uses CONDUCTOR_PORT if set, otherwise PORT, defaulting to 3000.
+#/ Uses WORKSPACE_PORT if set, otherwise PORT, defaulting to 3000.
 #/ Sets VITE_RUBY_PORT to PORT + 36 to avoid port conflicts.
 
 set -e
 cd $(dirname "$0")/..
 
-# Use CONDUCTOR_PORT if set, otherwise PORT, defaulting to 3000
-export PORT=${CONDUCTOR_PORT:-${PORT:-3000}}
+# CONDUCTOR_PORT is Conductor-specific. Expose it under the generic
+# WORKSPACE_PORT name so the rest of the app never references Conductor directly.
+export WORKSPACE_PORT=${WORKSPACE_PORT:-${CONDUCTOR_PORT:-}}
+
+# Use WORKSPACE_PORT if set, otherwise PORT, defaulting to 3000
+export PORT=${WORKSPACE_PORT:-${PORT:-3000}}
 export VITE_RUBY_PORT=$((PORT + 36))
 
 echo "Starting on http://awbw.local:${PORT} (Vite on :${VITE_RUBY_PORT})"

--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -16,6 +16,12 @@ elif [ -x /opt/homebrew/bin/mise ]; then
   eval "$(/opt/homebrew/bin/mise activate sh)"
 fi
 
+# CONDUCTOR_PORT is Conductor-specific. Expose it under the generic
+# WORKSPACE_PORT name so the rest of the app (database.yml, initializers,
+# bin/setup) only references WORKSPACE_PORT. Export it before bin/setup runs
+# so the per-workspace database is created with the right suffix.
+export WORKSPACE_PORT=${WORKSPACE_PORT:-${CONDUCTOR_PORT:-}}
+
 if [ -z "$CONDUCTOR_ROOT_PATH" ]; then
   echo "Not running inside Conductor. Falling back to normal setup..."
 
@@ -97,9 +103,9 @@ npm ci
 # Run full setup (database drop, create, migrate, seed)
 bin/setup --skip-server
 
-PORT=${CONDUCTOR_PORT:-${PORT:-3000}}
+PORT=${WORKSPACE_PORT:-${PORT:-3000}}
 echo ""
 echo "Conductor setup complete!"
 echo "App will run at http://localhost:${PORT}"
 echo "Vite dev server at http://localhost:$((PORT + 36))"
-echo "Database: awbw_development_${CONDUCTOR_PORT}"
+echo "Database: awbw_development_${WORKSPACE_PORT}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@
 #
 # WORKSPACE_PORT gives each parallel workspace its own database. Under Conductor
 # it is derived from CONDUCTOR_PORT by the bin/conductor-* scripts.
-<% workspace_port = ENV["WORKSPACE_PORT"] %>
+<% workspace_port = ENV["WORKSPACE_PORT"].presence %>
 
 base: &base
   adapter: trilogy

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,10 @@
 #
 # The encoding and collation settings ensure consistent UTF-8 handling across
 # Mac and Linux environments, preventing schema.rb merge conflicts.
+#
+# WORKSPACE_PORT gives each parallel workspace its own database. Under Conductor
+# it is derived from CONDUCTOR_PORT by the bin/conductor-* scripts.
+<% workspace_port = ENV["WORKSPACE_PORT"] %>
 
 base: &base
   adapter: trilogy
@@ -22,7 +26,7 @@ base: &base
 development:
   primary: &primary_development
     <<: *base
-    database: awbw_development<%= "_#{ENV['CONDUCTOR_PORT']}" if ENV['CONDUCTOR_PORT'] %>
+    database: awbw_development<%= "_#{workspace_port}" if workspace_port %>
 #  queue:
 #    <<: *primary_development
 #    database: awbw_development_queue
@@ -37,7 +41,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *base
-  database: awbw_test<%= "_#{ENV['CONDUCTOR_PORT']}" if ENV['CONDUCTOR_PORT'] %>
+  database: awbw_test<%= "_#{workspace_port}" if workspace_port %>
 
 staging:
   primary: &primary_staging

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -7,9 +7,10 @@
 
 if Rails.env.development?
   port = ENV.fetch("PORT", 3000)
-  workspace_port = ENV["WORKSPACE_PORT"]
-  # Use awbw.local in a workspace so browsers treat all workspaces as the
-  # same origin — passwords and cookies carry over regardless of port.
+  workspace_port = ENV["WORKSPACE_PORT"].presence
+  # Use awbw.local in a workspace so all workspaces share the same hostname
+  # (site) — saved passwords and cookies carry over across ports, since they
+  # are scoped by host rather than full origin.
   # Requires 127.0.0.1 awbw.local in /etc/hosts.
   hostname = workspace_port ? "awbw.local" : "localhost"
   default_host = "#{hostname}:#{port}"

--- a/config/initializers/default_host.rb
+++ b/config/initializers/default_host.rb
@@ -1,15 +1,17 @@
-# Derive the default host from PORT so Conductor workspaces each get
-# their own URL automatically. CONDUCTOR_PORT is set by Conductor and
-# flows into PORT via bin/conductor-server.
+# Derive the default host from PORT so parallel workspaces each get
+# their own URL automatically. WORKSPACE_PORT identifies a workspace and
+# flows into PORT via bin/conductor-server. Under Conductor, WORKSPACE_PORT
+# is derived from CONDUCTOR_PORT by the bin/conductor-* scripts.
 #
 # In production, APP_HOST is set explicitly in the environment.
 
 if Rails.env.development?
   port = ENV.fetch("PORT", 3000)
-  # Use awbw.local when running in Conductor so browsers treat all
-  # workspaces as the same origin — passwords and cookies carry over
-  # regardless of port. Requires 127.0.0.1 awbw.local in /etc/hosts.
-  hostname = ENV["CONDUCTOR_PORT"] ? "awbw.local" : "localhost"
+  workspace_port = ENV["WORKSPACE_PORT"]
+  # Use awbw.local in a workspace so browsers treat all workspaces as the
+  # same origin — passwords and cookies carry over regardless of port.
+  # Requires 127.0.0.1 awbw.local in /etc/hosts.
+  hostname = workspace_port ? "awbw.local" : "localhost"
   default_host = "#{hostname}:#{port}"
 
   Rails.application.routes.default_url_options[:host] = default_host

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# Append port to cookie name so Conductor workspaces don't share sessions.
-port_suffix = ENV["CONDUCTOR_PORT"] ? "_#{ENV['CONDUCTOR_PORT']}" : ""
+# Append port to cookie name so parallel workspaces don't share sessions.
+# Under Conductor, WORKSPACE_PORT is derived from CONDUCTOR_PORT by the
+# bin/conductor-* scripts.
+workspace_port = ENV["WORKSPACE_PORT"]
+port_suffix = workspace_port ? "_#{workspace_port}" : ""
 Rails.application.config.session_store :cookie_store, key: "_awbw_session#{port_suffix}"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,6 +3,6 @@
 # Append port to cookie name so parallel workspaces don't share sessions.
 # Under Conductor, WORKSPACE_PORT is derived from CONDUCTOR_PORT by the
 # bin/conductor-* scripts.
-workspace_port = ENV["WORKSPACE_PORT"]
+workspace_port = ENV["WORKSPACE_PORT"].presence
 port_suffix = workspace_port ? "_#{workspace_port}" : ""
 Rails.application.config.session_store :cookie_store, key: "_awbw_session#{port_suffix}"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The per-workspace port — used for the workspace database name, session cookie, and dev host — was read directly from Conductor's `CONDUCTOR_PORT`, hardcoding a dependency on one specific tool.
- This makes the parallel-worktree isolation mechanism generic so it works for anyone running multiple local instances, not just Conductor users.

### How did you approach the change?
- The app now reads a generic `WORKSPACE_PORT` env var everywhere (`config/database.yml`, `config/initializers/session_store.rb`, `config/initializers/default_host.rb`, `ai/server`).
- The Conductor entry scripts (`bin/conductor-setup`, `bin/conductor-server`, `bin/conductor-archive`) are now the **only** place `CONDUCTOR_PORT` is referenced — each exports `WORKSPACE_PORT=${WORKSPACE_PORT:-${CONDUCTOR_PORT:-}}` near the top, so everything they spawn inherits it.
- This matches reality: `CONDUCTOR_PORT` is only injected into those three script processes, not the interactive terminal — so translating it once, upstream, is the natural seam.
- In `bin/conductor-setup` the export happens before `bin/setup` runs so the per-workspace database is created with the right suffix.
- Documented the contract in `CONTRIBUTING.md`: Conductor is one optional platform; any other setup can get the same isolation by exporting `WORKSPACE_PORT`.

### Verification
Confirmed via `bin/rails runner` that the resolved database/cookie are correct in each case:

| Scenario | Database / cookie |
|---|---|
| `WORKSPACE_PORT=4567` (any system) | `awbw_development_4567` / `_awbw_session_4567` |
| Conductor: `CONDUCTOR_PORT` → script exports `WORKSPACE_PORT` | suffixed correctly |
| Raw `CONDUCTOR_PORT` with no translation | correctly **ignored** by app code |
| Nothing set | base `awbw_development` |

Shell scripts pass `sh -n`; Rubocop clean on changed Ruby files.

### Anything else to add?
- Trade-off: there's no implicit `CONDUCTOR_PORT` fallback in the app anymore, so a non-Conductor user must export `WORKSPACE_PORT` themselves to get an isolated DB/port. This is the intended decoupling and matches prior behavior in the interactive terminal (where `CONDUCTOR_PORT` was never present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
