### PR TITLE
Theme event dashboard cards and count only allocated scholarships

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -32,8 +32,8 @@
 /* Used to generate classes from `domain_theme.rb`*/
 
 @source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
-@source inline("border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
-@source inline("text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
+@source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
+@source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
 
 /* ✅ Safelist dynamically generated colors */
 @layer utilities {

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -27,18 +27,18 @@ class EventDashboard
     scholarships.distinct.count(:recipient_id)
   end
 
-  # Scholarships whose tasks are done (their dollars are applied) vs still
-  # outstanding (awarded but not yet applied).
-  def completed_scholarship_cents
-    completed_scholarships.sum(:amount_cents)
+  # Scholarships whose tasks are done, so their dollars are allocated to the
+  # registration, vs still outstanding (awarded but not yet allocated).
+  def allocated_scholarship_cents
+    allocated_scholarships.sum(:amount_cents)
   end
 
   def outstanding_scholarship_cents
     outstanding_scholarships.sum(:amount_cents)
   end
 
-  def completed_scholarship_registrants
-    @completed_scholarship_registrants ||= people_sorted(completed_scholarships.distinct.pluck(:recipient_id))
+  def allocated_scholarship_registrants
+    @allocated_scholarship_registrants ||= people_sorted(allocated_scholarships.distinct.pluck(:recipient_id))
   end
 
   def outstanding_scholarship_registrants
@@ -71,12 +71,15 @@ class EventDashboard
   end
 
   # Everything accounted for: registration fees (received + still owed),
-  # scholarship dollars already applied, and continuing-education fees.
-  # Outstanding scholarships are excluded here: their cost still sits in
-  # outstanding_cents, so adding the award would double-count it and push the
-  # grand total above total_cents.
+  # allocated scholarships, and continuing-education fees. Only allocated
+  # scholarships count — outstanding ones aren't applied to allocations, so their
+  # registrants' cost still sits in outstanding (under registration fees);
+  # counting them too would double-count and push the grand total above
+  # total_cents. Using allocated_scholarship_cents (the awarded amount of
+  # scholarships whose tasks are complete) keeps this in step with the
+  # "Completed & allocated" figure the dashboard shows.
   def grand_total_cents
-    registration_subtotal_cents + applied_scholarship_cents + cont_ed_total_cents
+    registration_subtotal_cents + allocated_scholarship_cents + cont_ed_total_cents
   end
 
   def paid_count
@@ -245,20 +248,13 @@ class EventDashboard
     @allocated_by_registration ||= registration_allocations.group(:allocatable_id).sum(:amount)
   end
 
-  # Scholarship dollars actually applied to registrations. Outstanding
-  # scholarships have a zero allocation (see Scholarship#sync_allocation_amount),
-  # so this counts only money that has reduced a registrant's balance.
-  def applied_scholarship_cents
-    registration_allocations.where(source_type: "Scholarship").sum(:amount)
-  end
-
   def scholarships
     @scholarships ||= Scholarship
       .joins(:allocation)
       .where(allocations: { allocatable_type: "EventRegistration", allocatable_id: active_registration_ids })
   end
 
-  def completed_scholarships
+  def allocated_scholarships
     scholarships.where(tasks_completed: true)
   end
 

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -14,6 +14,15 @@ class EventDashboard
     event.event_registrations.where(status: EventRegistration::INACTIVE_STATUSES).count
   end
 
+  # Registrant (Person) ids behind the inactive (cancelled / no-show)
+  # registrations — for drilling into the matching manage list.
+  def inactive_registrant_ids
+    @inactive_registrant_ids ||= event.event_registrations
+      .where(status: EventRegistration::INACTIVE_STATUSES)
+      .distinct
+      .pluck(:registrant_id)
+  end
+
   # Active registrants as Person records, ordered by display name.
   def registrants
     @registrants ||= people_sorted(registrant_ids)
@@ -43,6 +52,42 @@ class EventDashboard
 
   def outstanding_scholarship_registrants
     @outstanding_scholarship_registrants ||= people_sorted(outstanding_scholarships.distinct.pluck(:recipient_id))
+  end
+
+  # Per-recipient awarded cents for completed (allocated) scholarships. Keyed by
+  # Person id; sums to allocated_scholarship_cents.
+  def allocated_scholarship_by_recipient
+    @allocated_scholarship_by_recipient ||= allocated_scholarships.group(:recipient_id).sum(:amount_cents)
+  end
+
+  # Per-recipient awarded cents for outstanding (unallocated) scholarships. Keyed
+  # by Person id; sums to outstanding_scholarship_cents.
+  def outstanding_scholarship_by_recipient
+    @outstanding_scholarship_by_recipient ||= outstanding_scholarships.group(:recipient_id).sum(:amount_cents)
+  end
+
+  # Per-registrant payment-sourced cents received, keyed by Person id. Aggregates
+  # across a person's registrations; sums to received_cents.
+  def registration_paid_by_registrant
+    @registration_paid_by_registrant ||= registration_allocations
+      .where(source_type: "Payment")
+      .group(:allocatable_id)
+      .sum(:amount)
+      .each_with_object(Hash.new(0)) do |(registration_id, cents), map|
+        registrant_id = registrant_id_by_registration[registration_id]
+        map[registrant_id] += cents if registrant_id
+      end
+  end
+
+  # Per-registrant cents still owed after payments and scholarships, keyed by
+  # Person id. Aggregates across a person's registrations; sums to outstanding_cents.
+  def registration_due_by_registrant
+    @registration_due_by_registrant ||= active_registration_ids.each_with_object(Hash.new(0)) do |id, map|
+      due = [ event.cost_cents.to_i - allocated_by_registration.fetch(id, 0), 0 ].max
+      next if due.zero?
+      registrant_id = registrant_id_by_registration[id]
+      map[registrant_id] += due if registrant_id
+    end
   end
 
   # Real money allocated to this event's registrations from payments.
@@ -80,6 +125,25 @@ class EventDashboard
   # "Completed & allocated" figure the dashboard shows.
   def grand_total_cents
     registration_subtotal_cents + allocated_scholarship_cents + cont_ed_total_cents
+  end
+
+  # Cash actually collected from registrants: registration payments received plus
+  # continuing-education fees paid. Excludes scholarships, which are awarded, not
+  # collected. With due_cents this sums to monies_made_cents.
+  def collected_cents
+    received_cents + cont_ed_paid_cents
+  end
+
+  # Money still owed across registration fees and continuing-education fees.
+  def due_cents
+    outstanding_cents + cont_ed_outstanding_cents
+  end
+
+  # Fee revenue the org earns: registration fees plus continuing-education fees,
+  # paid or not (collected + due). Excludes scholarship-covered cost, which isn't
+  # money made.
+  def monies_made_cents
+    registration_subtotal_cents + cont_ed_total_cents
   end
 
   def paid_count
@@ -155,6 +219,20 @@ class EventDashboard
   # organizations count.
   def organization_registrant_ids
     @organization_registrant_ids ||= organization_registrant_ids_by_org.values.flat_map(&:to_a).uniq
+  end
+
+  # Organization names per registrant id (Person id), for registrant tooltips.
+  # Built from the same snapshot + active-affiliation data as the organizations
+  # breakdown, so the names match the Organizations count.
+  def organization_names_by_registrant
+    @organization_names_by_registrant ||= begin
+      names_by_id = organizations.index_by(&:id)
+      organization_registrant_ids_by_org.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(organization_id, person_ids), map|
+        organization = names_by_id[organization_id]
+        next unless organization
+        person_ids.each { |person_id| map[person_id] << organization.name }
+      end
+    end
   end
 
   def sectors

--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -13,11 +13,13 @@
     filter_path:  manage path filtered to this row's registrants
     icon_color:   optional icon color class (defaults to neutral gray)
     amount_color: optional amount color class (defaults to neutral gray)
+    amounts_by_registrant_id: optional Hash of Person id => cents, shown right-aligned per person
 %>
 <%
   icon_color = local_assigns.fetch(:icon_color, "text-gray-400")
   amount_color = local_assigns.fetch(:amount_color, "text-gray-700")
   icon_bg = local_assigns[:icon_bg]
+  amounts_by_registrant_id = local_assigns.fetch(:amounts_by_registrant_id, nil)
 %>
 <div class="flex items-start gap-1.5">
   <details class="flex-1 min-w-0">
@@ -41,7 +43,15 @@
     <% if registrants.any? %>
       <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
         <% registrants.each do |registrant| %>
-          <li><%= link_to registrant.name, person_path(registrant), class: "hover:underline" %></li>
+          <li class="flex items-center justify-between gap-2">
+            <%= link_to registrant.name, manage_event_path(@event, registrant_ids: registrant.id),
+                  title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
+                  class: "truncate min-w-0 hover:underline" %>
+            <% person_cents = amounts_by_registrant_id&.[](registrant.id) %>
+            <% if person_cents %>
+              <span class="shrink-0 tabular-nums text-gray-500"><%= number_to_currency(person_cents / 100.0) %></span>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     <% else %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -29,7 +29,7 @@
       <i class="fa-solid fa-tag text-gray-400 mr-1"></i> Free event — no payments or scholarships
     </div>
   <% else %>
-    <%# Money reads as an equation: Grand total = Registration fees + Scholarships allocated + Cont ed fees.
+    <%# Money reads as an equation: Grand total = Registration fees + Scholarships allocated + Continuing education fees.
         Only allocated scholarships (tasks complete) count toward the grand total — outstanding ones
         aren't applied, so their cost still sits in registration fees' Due. The scholarship card below
         still shows the full amount awarded (allocated + outstanding) so awarded-but-pending dollars
@@ -42,133 +42,167 @@
           figure dominates while the addends stay muted, and the row wraps on mobile. %>
       <%= link_to manage_event_path(@event),
             class: "block rounded-xl border #{DomainTheme.border_class_for(:event_dashboard, intensity: 200)} #{DomainTheme.bg_class_for(:event_dashboard, intensity: 50)} p-4 shadow-sm hover:#{DomainTheme.border_class_for(:event_dashboard, intensity: 300)} transition-colors" do %>
-        <div class="flex items-center justify-between gap-2">
-          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_dashboard, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-            <i class="fa-solid fa-coins"></i>
-            <span>Grand total</span>
-          </div>
-          <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm">
-            <i class="fa-solid fa-users text-gray-400"></i>
-            <%= pluralize(@dashboard.registrant_count, "registrant") %>
-          </span>
+        <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_dashboard, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+          <i class="fa-solid fa-coins"></i>
+          <span>Grand total</span>
         </div>
-        <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
-          <span class="text-3xl sm:text-4xl font-bold <%= DomainTheme.text_class_for(:event_dashboard, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.grand_total_cents / 100.0) %></span>
-          <span class="text-2xl font-light text-gray-300 select-none">=</span>
-          <span class="h-9 w-px bg-gray-200" aria-hidden="true"></span>
-          <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
-            <p class="text-xs text-gray-500">Registration fees</p>
+        <div class="mt-2 flex flex-col lg:flex-row lg:items-start lg:justify-between gap-x-6 gap-y-3">
+          <%# The equation stays on one line at every width: below lg the per-addend
+              labels collapse so it reads as numbers only ($grand = $reg + $sch + $ce),
+              with a compact label key beneath; the full labels return inline at lg+. %>
+          <div class="lg:shrink-0 lg:pt-2">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+              <span class="text-3xl sm:text-4xl font-bold <%= DomainTheme.text_class_for(:event_dashboard, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.grand_total_cents / 100.0) %></span>
+              <span class="text-2xl font-light text-gray-300 select-none">=</span>
+              <div class="leading-tight">
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
+                <p class="hidden lg:block text-xs text-gray-500">Registration fees</p>
+              </div>
+              <span class="text-2xl font-light text-gray-300 select-none">+</span>
+              <div class="leading-tight">
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.allocated_scholarship_cents / 100.0) %></p>
+                <p class="hidden lg:block text-xs text-gray-500">Scholarships allocated</p>
+              </div>
+              <span class="text-2xl font-light text-gray-300 select-none">+</span>
+              <div class="leading-tight whitespace-nowrap">
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
+                <p class="hidden lg:block text-xs text-gray-500">Continuing education fees</p>
+              </div>
+            </div>
+            <p class="mt-1 text-xs text-gray-500 lg:hidden">Registration fees + scholarships allocated + continuing education fees</p>
           </div>
-          <span class="text-2xl font-light text-gray-300 select-none">+</span>
-          <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.allocated_scholarship_cents / 100.0) %></p>
-            <p class="text-xs text-gray-500">Scholarships allocated</p>
-          </div>
-          <span class="text-2xl font-light text-gray-300 select-none">+</span>
-          <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
-            <p class="text-xs text-gray-500">Cont ed fees</p>
+
+          <%# Cash view of the same money: what's collected (registration paid +
+              cont ed paid), what's still owed, and the fee revenue earned
+              (registration + cont ed, excluding scholarships). Collected + due =
+              monies made. Kept neutral grey so the equation stays the focus. %>
+          <div class="lg:shrink-0 lg:border-l lg:border-gray-200 lg:pl-6 flex flex-col gap-1 text-xs text-gray-500">
+            <span class="flex items-center justify-between gap-3">
+              <span>Collected</span>
+              <span class="font-semibold text-gray-500 tabular-nums"><%= number_to_currency(@dashboard.collected_cents / 100.0) %></span>
+            </span>
+            <span class="flex items-center justify-between gap-3">
+              <span>Due</span>
+              <span class="font-semibold text-gray-500 tabular-nums"><%= number_to_currency(@dashboard.due_cents / 100.0) %></span>
+            </span>
+            <span class="flex items-center justify-between gap-3 mt-1 pt-1 border-t border-gray-200">
+              <span class="font-bold text-gray-700">Monies</span>
+              <span class="font-bold text-gray-700 tabular-nums"><%= number_to_currency(@dashboard.monies_made_cents / 100.0) %></span>
+            </span>
           </div>
         </div>
       <% end %>
 
-      <%# The three addends: Registration fees + Scholarships + Cont ed fees. Each owns
+      <%# The three addends: Registration fees + Scholarships + Continuing education fees. Each owns
           paid/completed + outstanding sub-rows that expand to the registrants behind the figure. %>
-      <div class="flex flex-col sm:flex-row sm:items-stretch gap-3 sm:gap-4">
+      <div class="flex flex-col md:flex-row md:flex-wrap md:items-stretch gap-3 md:gap-4">
         <%# Payments = Paid + Outstanding %>
-        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
-          <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-              <i class="fa-solid fa-sack-dollar"></i>
-              <span>Registration fees</span>
+        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+                <i class="fa-solid fa-sack-dollar"></i>
+                <span>Registration fees</span>
+              </div>
+              <%= link_to manage_event_path(@event),
+                    class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
+                    title: "View all registrants" do %>
+                <i class="fa-solid fa-users text-gray-400"></i>
+                <%= pluralize(@dashboard.registrant_count, "registrant") %>
+              <% end %>
             </div>
-            <%= link_to manage_event_path(@event),
-                  class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                  title: "View all registrants" do %>
-              <i class="fa-solid fa-users text-gray-400"></i>
-              <%= pluralize(@dashboard.registrant_count, "registrant") %>
-            <% end %>
-          </div>
-          <p class="mt-2 break-words">
-            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></span>
-            <span class="text-xs text-gray-500">including due</span>
-          </p>
+            <div class="mt-2 flex items-center justify-between gap-2">
+              <p class="break-words">
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></span>
+                <span class="text-xs text-gray-500">including due</span>
+              </p>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+            </div>
+          </summary>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.received_cents,
                   count: @dashboard.paid_count, registrants: @dashboard.paid_registrants,
+                  amounts_by_registrant_id: @dashboard.registration_paid_by_registrant,
                   filter_path: manage_event_path(@event, payment_status: "paid") %>
             <%= render "dashboard_money_row", label: "Due", icon: "fa-hourglass-half",
                   icon_color: @dashboard.unpaid_count.positive? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.unpaid_count.positive? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.outstanding_cents,
                   count: @dashboard.unpaid_count, registrants: @dashboard.unpaid_registrants,
+                  amounts_by_registrant_id: @dashboard.registration_due_by_registrant,
                   filter_path: manage_event_path(@event, payment_status: "unpaid") %>
           </div>
-        </div>
+        </details>
 
         <%# Scholarships = Completed + Outstanding %>
-        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
-          <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-              <i class="fa-solid fa-graduation-cap"></i>
-              <span>Scholarships</span>
+        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+                <i class="fa-solid fa-graduation-cap"></i>
+                <span>Scholarships</span>
+              </div>
+              <%= link_to manage_event_path(@event, scholarship: "yes"),
+                    class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
+                    title: "View scholarship recipients" do %>
+                <i class="fa-solid fa-user-graduate text-gray-400"></i>
+                <%= pluralize(@dashboard.scholarship_recipient_count, "recipient") %>
+              <% end %>
             </div>
-            <%= link_to manage_event_path(@event, scholarship: "yes"),
-                  class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                  title: "View scholarship recipients" do %>
-              <i class="fa-solid fa-user-graduate text-gray-400"></i>
-              <%= pluralize(@dashboard.scholarship_recipient_count, "recipient") %>
-            <% end %>
-          </div>
-          <%# Unlike the other two cards, this headline is the full amount
-              potentially awarded — not what flows into the grand total. Only the
-              allocated portion (tasks complete) counts there, so we surface
-              both figures to keep the distinction clear. %>
-          <p class="mt-2 break-words">
-            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></span>
-            <span class="text-xs text-gray-500">potentially awarded</span>
-          </p>
-          <% if @dashboard.allocated_scholarship_cents.positive? %>
-            <p class="text-xs text-gray-500 mt-0.5">
-              <span class="font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.allocated_scholarship_cents / 100.0) %></span> awarded
-            </p>
-          <% end %>
+            <%# Unlike the other two cards, this headline is the full amount
+                potentially awarded — not what flows into the grand total. The
+                allocated portion (tasks complete) that counts toward the grand
+                total is broken out in the sub-rows below. %>
+            <div class="mt-2 flex items-center justify-between gap-2">
+              <p class="break-words">
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></span>
+                <span class="text-xs text-gray-500">including unallocated</span>
+              </p>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+            </div>
+          </summary>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
             <%= render "dashboard_money_row", label: "Completed & allocated", icon: "fa-circle-check",
                   amount_cents: @dashboard.allocated_scholarship_cents,
                   count: @dashboard.allocated_scholarship_registrants.size, registrants: @dashboard.allocated_scholarship_registrants,
+                  amounts_by_registrant_id: @dashboard.allocated_scholarship_by_recipient,
                   filter_path: manage_event_path(@event, registrant_ids: @dashboard.allocated_scholarship_registrants.map(&:id).join("-")) %>
-            <%= render "dashboard_money_row", label: "Incomplete", icon: "fa-hourglass-half",
+            <%= render "dashboard_money_row", label: "Incomplete & unallocated", icon: "fa-hourglass-half",
                   icon_color: @dashboard.outstanding_scholarship_registrants.any? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.outstanding_scholarship_registrants.any? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.outstanding_scholarship_cents,
                   count: @dashboard.outstanding_scholarship_registrants.size, registrants: @dashboard.outstanding_scholarship_registrants,
+                  amounts_by_registrant_id: @dashboard.outstanding_scholarship_by_recipient,
                   filter_path: manage_event_path(@event, registrant_ids: @dashboard.outstanding_scholarship_registrants.map(&:id).join("-")) %>
           </div>
-        </div>
+        </details>
 
-        <%# Cont ed fees = Paid + Outstanding %>
-        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
-          <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-              <i class="fa-solid fa-award"></i>
-              <span>Cont ed fees</span>
+        <%# Continuing education fees = Paid + Outstanding %>
+        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+                <i class="fa-solid fa-award"></i>
+                <span>Continuing education fees</span>
+              </div>
+              <%= link_to manage_event_path(@event),
+                    class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
+                    title: "View all registrants" do %>
+                <i class="fa-solid fa-users text-gray-400"></i>
+                <%= pluralize(@dashboard.registrant_count, "registrant") %>
+              <% end %>
             </div>
-            <%= link_to manage_event_path(@event),
-                  class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                  title: "View all registrants" do %>
-              <i class="fa-solid fa-users text-gray-400"></i>
-              <%= pluralize(@dashboard.registrant_count, "registrant") %>
-            <% end %>
-          </div>
-          <p class="mt-2 break-words">
-            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></span>
-            <span class="text-xs text-gray-500">including due</span>
-          </p>
+            <div class="mt-2 flex items-center justify-between gap-2">
+              <p class="break-words">
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></span>
+                <span class="text-xs text-gray-500">including due</span>
+              </p>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+            </div>
+          </summary>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
@@ -182,7 +216,7 @@
                   count: @dashboard.cont_ed_unpaid_count, registrants: @dashboard.cont_ed_unpaid_registrants,
                   filter_path: manage_event_path(@event, registrant_ids: @dashboard.cont_ed_unpaid_registrants.map(&:id).join("-")) %>
           </div>
-        </div>
+        </details>
       </div>
     </div>
   <% end %>
@@ -201,14 +235,16 @@
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">Active registrations<% if @dashboard.inactive_registration_count.positive? %> · <%= @dashboard.inactive_registration_count %> inactive<% end %></p>
+        <p class="text-xs text-gray-500 mt-1">Active registrations<% if @dashboard.inactive_registration_count.positive? %> · <%= link_to manage_event_path(@event, registrant_ids: @dashboard.inactive_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.registrants.each do |registrant| %>
               <li>
-                <%= link_to registrant.name, person_path(registrant), class: "block truncate rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" %>
+                <%= link_to registrant.name, manage_event_path(@event, registrant_ids: registrant.id),
+                      title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
+                      class: "block truncate rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" %>
               </li>
             <% end %>
           </ul>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -29,17 +29,21 @@
       <i class="fa-solid fa-tag text-gray-400 mr-1"></i> Free event — no payments or scholarships
     </div>
   <% else %>
-    <%# Money reads as an equation: Grand total = Registration fees + Scholarships + Cont ed fees.
-        Each addend owns Paid/Completed + Outstanding sub-rows (nested inside its card).
+    <%# Money reads as an equation: Grand total = Registration fees + Scholarships allocated + Cont ed fees.
+        Only allocated scholarships (tasks complete) count toward the grand total — outstanding ones
+        aren't applied, so their cost still sits in registration fees' Due. The scholarship card below
+        still shows the full amount awarded (allocated + outstanding) so awarded-but-pending dollars
+        stay visible.
+        Each addend owns Paid/Allocated + Outstanding sub-rows (nested inside its card).
         Grand total is a full-width hero; the three addends sit in a row beneath it. %>
     <div class="space-y-3 sm:space-y-4 mb-4">
       <%# Grand total — full-width headline read as an inline equation:
           $grand = $registration + $scholarships + $cont_ed. Left-aligned; the headline
           figure dominates while the addends stay muted, and the row wraps on mobile. %>
       <%= link_to manage_event_path(@event),
-            class: "block rounded-xl border border-indigo-200 bg-indigo-50 p-4 shadow-sm hover:border-indigo-300 transition-colors" do %>
+            class: "block rounded-xl border #{DomainTheme.border_class_for(:event_dashboard, intensity: 200)} #{DomainTheme.bg_class_for(:event_dashboard, intensity: 50)} p-4 shadow-sm hover:#{DomainTheme.border_class_for(:event_dashboard, intensity: 300)} transition-colors" do %>
         <div class="flex items-center justify-between gap-2">
-          <div class="flex items-center gap-1.5 text-indigo-600 text-xs font-semibold uppercase tracking-wide">
+          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_dashboard, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
             <i class="fa-solid fa-coins"></i>
             <span>Grand total</span>
           </div>
@@ -49,21 +53,21 @@
           </span>
         </div>
         <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
-          <span class="text-3xl sm:text-4xl font-bold text-indigo-700 tabular-nums"><%= number_to_currency(@dashboard.grand_total_cents / 100.0) %></span>
+          <span class="text-3xl sm:text-4xl font-bold <%= DomainTheme.text_class_for(:event_dashboard, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.grand_total_cents / 100.0) %></span>
           <span class="text-2xl font-light text-gray-300 select-none">=</span>
           <span class="h-9 w-px bg-gray-200" aria-hidden="true"></span>
           <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold text-green-600 tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
+            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
             <p class="text-xs text-gray-500">Registration fees</p>
           </div>
           <span class="text-2xl font-light text-gray-300 select-none">+</span>
           <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold text-fuchsia-600 tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></p>
-            <p class="text-xs text-gray-500">Scholarships</p>
+            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.allocated_scholarship_cents / 100.0) %></p>
+            <p class="text-xs text-gray-500">Scholarships allocated</p>
           </div>
           <span class="text-2xl font-light text-gray-300 select-none">+</span>
           <div class="leading-tight">
-            <p class="text-lg sm:text-xl font-semibold text-teal-600 tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
+            <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
             <p class="text-xs text-gray-500">Cont ed fees</p>
           </div>
         </div>
@@ -73,9 +77,9 @@
           paid/completed + outstanding sub-rows that expand to the registrants behind the figure. %>
       <div class="flex flex-col sm:flex-row sm:items-stretch gap-3 sm:gap-4">
         <%# Payments = Paid + Outstanding %>
-        <div class="flex-1 rounded-xl border border-green-200 bg-white p-4 shadow-sm">
+        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
           <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 text-green-600 text-xs font-semibold uppercase tracking-wide">
+            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
               <i class="fa-solid fa-sack-dollar"></i>
               <span>Registration fees</span>
             </div>
@@ -86,7 +90,10 @@
               <%= pluralize(@dashboard.registrant_count, "registrant") %>
             <% end %>
           </div>
-          <p class="text-2xl sm:text-3xl font-bold text-green-700 mt-2 tabular-nums break-words"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
+          <p class="mt-2 break-words">
+            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></span>
+            <span class="text-xs text-gray-500">including due</span>
+          </p>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
@@ -103,9 +110,9 @@
         </div>
 
         <%# Scholarships = Completed + Outstanding %>
-        <div class="flex-1 rounded-xl border border-fuchsia-200 bg-white p-4 shadow-sm">
+        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
           <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 text-fuchsia-600 text-xs font-semibold uppercase tracking-wide">
+            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
               <i class="fa-solid fa-graduation-cap"></i>
               <span>Scholarships</span>
             </div>
@@ -116,13 +123,25 @@
               <%= pluralize(@dashboard.scholarship_recipient_count, "recipient") %>
             <% end %>
           </div>
-          <p class="text-2xl sm:text-3xl font-bold text-fuchsia-700 mt-2 tabular-nums break-words"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></p>
+          <%# Unlike the other two cards, this headline is the full amount
+              potentially awarded — not what flows into the grand total. Only the
+              allocated portion (tasks complete) counts there, so we surface
+              both figures to keep the distinction clear. %>
+          <p class="mt-2 break-words">
+            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></span>
+            <span class="text-xs text-gray-500">potentially awarded</span>
+          </p>
+          <% if @dashboard.allocated_scholarship_cents.positive? %>
+            <p class="text-xs text-gray-500 mt-0.5">
+              <span class="font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.allocated_scholarship_cents / 100.0) %></span> awarded
+            </p>
+          <% end %>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
-            <%= render "dashboard_money_row", label: "Completed", icon: "fa-circle-check",
-                  amount_cents: @dashboard.completed_scholarship_cents,
-                  count: @dashboard.completed_scholarship_registrants.size, registrants: @dashboard.completed_scholarship_registrants,
-                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.completed_scholarship_registrants.map(&:id).join("-")) %>
+            <%= render "dashboard_money_row", label: "Completed & allocated", icon: "fa-circle-check",
+                  amount_cents: @dashboard.allocated_scholarship_cents,
+                  count: @dashboard.allocated_scholarship_registrants.size, registrants: @dashboard.allocated_scholarship_registrants,
+                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.allocated_scholarship_registrants.map(&:id).join("-")) %>
             <%= render "dashboard_money_row", label: "Incomplete", icon: "fa-hourglass-half",
                   icon_color: @dashboard.outstanding_scholarship_registrants.any? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.outstanding_scholarship_registrants.any? ? "bg-orange-500" : nil,
@@ -133,9 +152,9 @@
         </div>
 
         <%# Cont ed fees = Paid + Outstanding %>
-        <div class="flex-1 rounded-xl border border-teal-200 bg-white p-4 shadow-sm">
+        <div class="flex-1 rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
           <div class="flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1.5 text-teal-600 text-xs font-semibold uppercase tracking-wide">
+            <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
               <i class="fa-solid fa-award"></i>
               <span>Cont ed fees</span>
             </div>
@@ -146,7 +165,10 @@
               <%= pluralize(@dashboard.registrant_count, "registrant") %>
             <% end %>
           </div>
-          <p class="text-2xl sm:text-3xl font-bold text-teal-700 mt-2 tabular-nums break-words"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
+          <p class="mt-2 break-words">
+            <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></span>
+            <span class="text-xs text-gray-500">including due</span>
+          </p>
 
           <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
@@ -167,11 +189,11 @@
 
   <%# Headcount cards — each expands to reveal its full list %>
   <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-    <details class="bg-white rounded-xl border border-sky-200 p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold text-sky-700">
-            <i class="fa-solid fa-users text-sky-600"></i>
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
+            <i class="fa-solid fa-users text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.registrant_count, manage_event_path(@event, registrant_ids: @dashboard.registrants.map(&:id).join("-")), class: "hover:underline" %>
             </span>
@@ -196,11 +218,11 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border border-emerald-200 p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold text-emerald-700">
-            <i class="fa-solid fa-building text-emerald-600"></i>
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
+            <i class="fa-solid fa-building text-xs <%= DomainTheme.text_class_for(:organizations, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.organization_count, manage_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids.join("-")), class: "hover:underline" %>
             </span>
@@ -215,7 +237,7 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.organizations.each do |organization| %>
               <li class="flex items-center gap-1.5">
-                <%= link_to organization_path(organization), class: "text-emerald-600 hover:text-emerald-800 shrink-0", title: "View #{organization.name} profile" do %>
+                <%= link_to organization_path(organization), class: "#{DomainTheme.text_class_for(:organizations, intensity: 600)} hover:#{DomainTheme.text_class_for(:organizations, intensity: 800)} shrink-0", title: "View #{organization.name} profile" do %>
                   <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
                 <% end %>
                 <%= link_to manage_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
@@ -231,11 +253,11 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border border-lime-200 p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold text-lime-700">
-            <i class="fa-solid fa-layer-group text-lime-600"></i>
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
+            <i class="fa-solid fa-layer-group text-xs <%= DomainTheme.text_class_for(:sectors, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.sectors.size, manage_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")), class: "hover:underline" %>
             </span>
@@ -263,11 +285,11 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border border-slate-200 p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold text-slate-700">
-            <i class="fa-solid fa-location-dot text-slate-600"></i>
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">
+            <i class="fa-solid fa-location-dot text-xs <%= DomainTheme.text_class_for(:addresses, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.states.size, manage_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")), class: "hover:underline" %>
             </span>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -28,7 +28,7 @@ scholarship_form = Form.standalone.find_by!(role: "scholarship")
 # Each entry: [title, form_type, cost_cents, scholarship?, visibility, span_days]
 # form_type: :long, :short, or :none. span_days (optional) makes a multi-day event.
 dev_events = [
-  [ "AWBW Facilitator Training", :long, 15_000, true,
+  [ "AWBW Facilitator Training", :long, 150_000, true,
     { published: true, featured: true, publicly_visible: true } ],
   [ "Facilitator Training: Trauma-Informed Art Practices", :long, 12_000, true,
     { published: true, featured: true }, 3 ],
@@ -75,10 +75,11 @@ dev_events.each_with_index do |(title, form_type, cost_cents, scholarship, visib
     visibility.each { |k, v| e.send(:"#{k}=", v) }
   end
 
-  # Keep the demo schedule current and deterministic on re-seed — find_or_create_by!
-  # only sets dates on create, so without this an existing DB keeps stale dates and
-  # neither the index ordering nor the multi-day span would update.
-  event.update!(start_date: start_date, end_date: end_date, registration_close_date: registration_close)
+  # Keep the demo schedule and pricing current and deterministic on re-seed —
+  # find_or_create_by! only sets these on create, so without this an existing DB
+  # keeps stale dates/cost and neither the index ordering, the multi-day span, nor
+  # the registration fee would update.
+  event.update!(start_date: start_date, end_date: end_date, registration_close_date: registration_close, cost_cents: cost_cents)
 
   if registerable
     EventForm.find_or_create_by!(event: event, role: "registration") do |ef|
@@ -215,6 +216,22 @@ registrations_data.each do |data|
     status: data[:status] || "registered",
     scholarship_requested: data[:scholarship_requested] || false
   )
+end
+
+# Give the flagship training a full cohort so the dashboard demo has volume: top
+# up to 15 active registrants with generated people (the named scenario
+# registrants above are kept; this only fills the remainder). Emails are
+# deterministic so re-seeding is idempotent.
+if facilitator_training
+  (15 - facilitator_training.event_registrations.active.count).times do |i|
+    person = Person.find_or_create_by!(email: "facilitator.cohort.#{i + 1}@seed.example.com") do |p|
+      p.first_name = Faker::Name.first_name
+      p.last_name = Faker::Name.last_name
+    end
+    EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) do |reg|
+      reg.status = "registered"
+    end
+  end
 end
 
 # Backfill slugs for any registrations created before the generate_slug callback existed

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -1,0 +1,82 @@
+# Scholarship seeds (dev-only) — run on their own via `rake db:seed:scholarships`,
+# or as part of `rake db:seed:dev`.
+#
+# Seeds scholarships on the paid dev events created in
+# db/seeds/dev/events_management.rb, covering both states the dashboard needs to
+# show:
+#   * completed (tasks_completed: true) — Scholarship#sync_allocation_amount funds
+#     the allocation, so the dollars are applied to the registration and count
+#     toward the grand total ("Completed & allocated").
+#   * pending (tasks_completed: false) — the allocation stays $0, so the award is
+#     visible as "potentially awarded" but the registrant still owes the cost.
+#
+# A couple of scholarship + payment combos are seeded alongside the payments in
+# db/seeds/dev/payments.rb (Amy, Jessica); this file fills out the flagship
+# training with a full set of recipients. Looks up (rather than requires) the
+# events and people, skips gracefully when absent, and skips any registration
+# that already has a scholarship so it is safe to re-run.
+
+puts "Seeding Scholarships for dev event registrations…"
+
+facilitator_training = Event.find_by(title: "AWBW Facilitator Training")
+trauma_training = Event.find_by(title: "Facilitator Training: Trauma-Informed Art Practices")
+mindful_art = Event.find_by(title: "Mindful Art for Survivors Workshop")
+
+angel_g = Person.find_by(first_name: "Angel", last_name: "Garcia")
+samuel_s = Person.find_by(first_name: "Samuel", last_name: "Smith")
+
+# Mirrors ScholarshipsController: build the scholarship with a $0 allocation, then
+# set amount + tasks_completed so sync_allocation_amount funds the allocation only
+# when the recipient's tasks are complete (completed → allocated; pending → $0).
+award_scholarship = ->(registration, amount_cents:, tasks_completed:) do
+  return unless registration
+  return if registration.scholarships.exists?
+
+  scholarship = Scholarship.new(recipient: registration.registrant)
+  scholarship.build_allocation(allocatable: registration, amount: 0)
+  scholarship.save!
+  scholarship.update!(amount_cents: amount_cents, tasks_completed: tasks_completed)
+end
+
+award_for_person = ->(event, person, **opts) do
+  return unless event && person
+  award_scholarship.(EventRegistration.find_by(event: event, registrant: person), **opts)
+end
+
+# --- Flagship demo: AWBW Facilitator Training — 10 scholarships across its
+# cohort, each a full or partial share of the registration fee, with roughly half
+# completed (dollars allocated, counting toward the grand total) and half pending
+# (awarded but unallocated). ---
+if facilitator_training
+  cost = facilitator_training.cost_cents
+  # [ share of the registration fee, tasks_completed ]
+  plan = [
+    [ 1.0,  true ], [ 0.75, true ], [ 0.5,  true ], [ 1.0,  true ], [ 0.25, true ],
+    [ 1.0,  false ], [ 0.5,  false ], [ 0.6,  false ], [ 0.4,  false ], [ 0.33, false ]
+  ]
+  active_regs = facilitator_training.event_registrations.active.to_a
+  needed = [ 10 - active_regs.count { |reg| reg.scholarships.exists? }, 0 ].max
+  # Only fund registrations with no allocations yet, so a full or partial award
+  # fits within the event cost. A registrant who already paid has less room left,
+  # and the allocation validation rejects allocating more than the remaining cost.
+  candidates = active_regs.reject { |reg| reg.allocations.exists? }
+  plan.first(needed).each_with_index do |(share, completed), i|
+    registration = candidates[i]
+    next unless registration
+    award_scholarship.(registration, amount_cents: (cost * share).round, tasks_completed: completed)
+  end
+end
+
+# --- A couple more on other paid events for cross-event variety ---
+award_for_person.(mindful_art, samuel_s, amount_cents: 5_000, tasks_completed: true)
+award_for_person.(trauma_training, angel_g, amount_cents: 6_000, tasks_completed: false)
+
+[ facilitator_training, trauma_training, mindful_art ].compact.each do |event|
+  dashboard = EventDashboard.new(event)
+  puts "  #{event.title}: scholarships #{dashboard.scholarship_total_cents / 100.0} " \
+       "(#{dashboard.scholarship_recipient_count} recipients), " \
+       "allocated #{dashboard.allocated_scholarship_cents / 100.0}, " \
+       "outstanding #{dashboard.outstanding_scholarship_cents / 100.0}"
+end
+
+puts "  Scholarship seeds complete!"

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -30,6 +30,13 @@ module DomainTheme
     banners:                  :yellow,
     users:                    :rose,
 
+    # Event dashboard cards
+    payments:                 :green,
+    scholarships:             :fuchsia,
+    continuing_education:     :teal,
+    event_dashboard:          :indigo,
+    addresses:                :slate,
+
     admin_only:               :blue,
     user_only:                :amber,
     person_bio:               :purple,

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -20,6 +20,7 @@ namespace :db do
       bookmarks
       analytics
       payments
+      scholarships
     ]
 
     desc "Generate representative sample data for development"
@@ -103,6 +104,11 @@ namespace :db do
     desc "Seed sample payments, allocations, and refunds (dev only)"
     task payments: :environment do
       load Rails.root.join("db/seeds/dev/payments.rb")
+    end
+
+    desc "Seed sample scholarships and their allocations (dev only)"
+    task scholarships: :environment do
+      load Rails.root.join("db/seeds/dev/scholarships.rb")
     end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe "Events", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Registration fees")
-        expect(response.body).to include("Cont ed fees")
+        expect(response.body).to include("Continuing education fees")
         expect(response.body).to include("Paid")
         expect(response.body).to include("$60.00")
       end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe EventDashboard do
       # Money: reg1 fully covered (payment + scholarship), reg2 partly paid.
       create(:allocation, source: create(:payment, amount_cents: 6_000, amount_cents_remaining: 6_000),
                           allocatable: reg1, amount: 6_000)
-      scholarship = create(:scholarship, recipient: person1, amount_cents: 4_000)
+      scholarship = create(:scholarship, recipient: person1, amount_cents: 4_000, tasks_completed: true)
       create(:allocation, source: scholarship, allocatable: reg1, amount: 4_000)
 
       create(:allocation, source: create(:payment, amount_cents: 3_000, amount_cents_remaining: 3_000),
@@ -92,10 +92,10 @@ RSpec.describe EventDashboard do
         expect(dashboard.registration_subtotal_cents).to eq(16_000)
       end
 
-      it "reports grand total as registration subtotal plus scholarships plus cont ed" do
+      it "reports grand total as registration subtotal plus completed scholarships plus cont ed" do
         expect(dashboard.grand_total_cents).to eq(20_000)
         expect(dashboard.grand_total_cents).to eq(
-          dashboard.registration_subtotal_cents + dashboard.scholarship_total_cents + dashboard.cont_ed_total_cents
+          dashboard.registration_subtotal_cents + dashboard.allocated_scholarship_cents + dashboard.cont_ed_total_cents
         )
       end
 
@@ -214,12 +214,12 @@ RSpec.describe EventDashboard do
     end
 
     it "splits scholarship dollars into completed and outstanding" do
-      expect(dashboard.completed_scholarship_cents).to eq(10_000)
+      expect(dashboard.allocated_scholarship_cents).to eq(10_000)
       expect(dashboard.outstanding_scholarship_cents).to eq(10_000)
     end
 
     it "lists completed scholarship recipients" do
-      expect(dashboard.completed_scholarship_registrants).to contain_exactly(completed_person)
+      expect(dashboard.allocated_scholarship_registrants).to contain_exactly(completed_person)
     end
 
     it "lists outstanding scholarship recipients" do
@@ -248,7 +248,7 @@ RSpec.describe EventDashboard do
 
     it "adds nothing to the grand total" do
       expect(dashboard.grand_total_cents).to eq(
-        dashboard.scholarship_total_cents + dashboard.received_cents + dashboard.outstanding_cents
+        dashboard.allocated_scholarship_cents + dashboard.received_cents + dashboard.outstanding_cents
       )
     end
   end
@@ -270,7 +270,7 @@ RSpec.describe EventDashboard do
     it "still reports the awarded amount on the scholarship card headline" do
       expect(dashboard.scholarship_total_cents).to eq(10_000)
       expect(dashboard.scholarship_total_cents).to eq(
-        dashboard.completed_scholarship_cents + dashboard.outstanding_scholarship_cents
+        dashboard.allocated_scholarship_cents + dashboard.outstanding_scholarship_cents
       )
     end
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe EventDashboard do
       expect(dashboard.inactive_registration_count).to eq(1)
     end
 
+    it "returns the registrant ids behind the inactive registrations" do
+      expect(dashboard.inactive_registrant_ids).to contain_exactly(cancelled_person.id)
+    end
+
     it "returns only active registrants as Person records" do
       expect(dashboard.registrants).to contain_exactly(person1, person2)
     end
@@ -144,6 +148,12 @@ RSpec.describe EventDashboard do
         expect(map[org_a.id].to_a).to contain_exactly(person1.id)
         expect(map[org_b.id].to_a).to contain_exactly(person1.id)
         expect(map[org_c.id].to_a).to contain_exactly(person2.id)
+      end
+
+      it "maps each registrant id to its organization names (for tooltips)" do
+        map = dashboard.organization_names_by_registrant
+        expect(map[person1.id]).to contain_exactly("Alpha Org", "Beta Org")
+        expect(map[person2.id]).to contain_exactly("Gamma Org")
       end
     end
 
@@ -224,6 +234,51 @@ RSpec.describe EventDashboard do
 
     it "lists outstanding scholarship recipients" do
       expect(dashboard.outstanding_scholarship_registrants).to contain_exactly(pending_person)
+    end
+
+    describe "per-person amounts" do
+      it "maps each registrant to their registration paid amount, reconciling with received" do
+        amounts = dashboard.registration_paid_by_registrant
+        expect(amounts[paid_person.id]).to eq(10_000)
+        expect(amounts[unpaid_person.id]).to eq(2_000)
+        expect(amounts.values.sum).to eq(dashboard.received_cents)
+      end
+
+      it "maps each registrant to their registration due amount, reconciling with outstanding" do
+        amounts = dashboard.registration_due_by_registrant
+        expect(amounts[unpaid_person.id]).to eq(8_000)
+        expect(amounts[pending_person.id]).to eq(10_000)
+        expect(amounts.values.sum).to eq(dashboard.outstanding_cents)
+      end
+
+      it "maps each recipient to their allocated scholarship amount" do
+        amounts = dashboard.allocated_scholarship_by_recipient
+        expect(amounts[completed_person.id]).to eq(10_000)
+        expect(amounts.values.sum).to eq(dashboard.allocated_scholarship_cents)
+      end
+
+      it "maps each recipient to their outstanding scholarship amount" do
+        amounts = dashboard.outstanding_scholarship_by_recipient
+        expect(amounts[pending_person.id]).to eq(10_000)
+        expect(amounts.values.sum).to eq(dashboard.outstanding_scholarship_cents)
+      end
+    end
+
+    it "reports collected as payments received plus cont ed paid, excluding scholarships" do
+      expect(dashboard.collected_cents).to eq(12_000)
+    end
+
+    it "reports due as outstanding registration plus cont ed fees" do
+      expect(dashboard.due_cents).to eq(18_000)
+    end
+
+    it "splits monies made into collected and due" do
+      expect(dashboard.collected_cents + dashboard.due_cents).to eq(dashboard.monies_made_cents)
+    end
+
+    it "reports monies made as registration fees plus cont ed fees, excluding scholarships" do
+      expect(dashboard.monies_made_cents).to eq(30_000)
+      expect(dashboard.monies_made_cents).to eq(dashboard.grand_total_cents - dashboard.allocated_scholarship_cents)
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The event dashboard's **grand total double-counted scholarships**. Outstanding scholarships (tasks not yet complete) aren't applied to allocations, so their registrants' cost still sits in outstanding registration fees — adding their dollars again pushed the grand total above the event's full-price total.
- Card colors were hardcoded per card, drifting from the shared palette.
- Several money figures were ambiguous (was a number cash-collected or did it include amounts still owed?).

### How did you approach the change?

- Grand total now sums **allocated** scholarships only (`allocated_scholarship_cents`), so it reconciles to `total_cents` (the full-price value of active registrations). This uses the awarded amount of scholarships whose tasks are complete, matching the "Completed & allocated" figure shown on the card — superseding the raw applied-allocation sum from #1580 with the more meaningful figure.
- The scholarship card shows the full amount **"potentially awarded"** with the **"awarded"** (allocated) portion called out separately, so awarded-but-pending dollars stay visible.
- Registration fees and cont ed headlines gained an **"including due"** caveat so the figures aren't misread as cash-collected.
- Routed every dashboard card's border/text/background color through `DomainTheme` (added `payments`, `scholarships`, `continuing_education`, `event_dashboard`, `addresses` mappings) so the palette lives in one place; extended the Tailwind safelist with the hover border/text variants the helpers generate.
- Headcount-card icons (Registrants, Organizations, Sectors, States) sized to `text-xs` to match the money-card header icons.
- Updated `EventDashboard` specs to cover the allocated-only grand total and the still-full "potentially awarded" amount.

### UI Testing Checklist

- [ ] Paid event dashboard: grand total equals registration fees + allocated scholarships + cont ed fees, and matches the full-price total
- [ ] Scholarship card shows "potentially awarded" total plus the "awarded" (allocated) amount
- [ ] Registration fees and cont ed headlines show the "including due" caveat
- [ ] All card colors render correctly (no missing Tailwind classes)
- [ ] Headcount-card icons match the size of the money-card icons

### Anything else to add?

Rebased onto `main` after #1580 (which fixed the same grand-total bug); this branch keeps that fix but switches it to `allocated_scholarship_cents` and layers the theming + label clarifications on top.