### PR TITLE
Harden event registration filter scopes against invalid params

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -85,6 +85,7 @@ class EventRegistration < ApplicationRecord
     when "yes" then with_scholarship
     when "complete" then scholarship_tasks_completed
     when "incomplete" then scholarship_tasks_incomplete
+    else all
     end
   }
   scope :paid_in_full, -> {
@@ -116,6 +117,7 @@ class EventRegistration < ApplicationRecord
     case value
     when "paid" then paid_in_full
     when "unpaid" then not_paid_in_full
+    else all
     end
   }
   scope :keyword, ->(term) {

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -166,14 +166,14 @@
                   amount_cents: @dashboard.allocated_scholarship_cents,
                   count: @dashboard.allocated_scholarship_registrants.size, registrants: @dashboard.allocated_scholarship_registrants,
                   amounts_by_registrant_id: @dashboard.allocated_scholarship_by_recipient,
-                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.allocated_scholarship_registrants.map(&:id).join("-")) %>
+                  filter_path: manage_event_path(@event, scholarship: "complete") %>
             <%= render "dashboard_money_row", label: "Incomplete & unallocated", icon: "fa-hourglass-half",
                   icon_color: @dashboard.outstanding_scholarship_registrants.any? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.outstanding_scholarship_registrants.any? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.outstanding_scholarship_cents,
                   count: @dashboard.outstanding_scholarship_registrants.size, registrants: @dashboard.outstanding_scholarship_registrants,
                   amounts_by_registrant_id: @dashboard.outstanding_scholarship_by_recipient,
-                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.outstanding_scholarship_registrants.map(&:id).join("-")) %>
+                  filter_path: manage_event_path(@event, scholarship: "incomplete") %>
           </div>
         </details>
 
@@ -205,13 +205,13 @@
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.cont_ed_paid_cents,
                   count: @dashboard.cont_ed_paid_count, registrants: @dashboard.cont_ed_paid_registrants,
-                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.cont_ed_paid_registrants.map(&:id).join("-")) %>
+                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.cont_ed_paid_registrants.map(&:id).join("-").presence || "0") %>
             <%= render "dashboard_money_row", label: "Due", icon: "fa-hourglass-half",
                   icon_color: @dashboard.cont_ed_unpaid_count.positive? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.cont_ed_unpaid_count.positive? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.cont_ed_outstanding_cents,
                   count: @dashboard.cont_ed_unpaid_count, registrants: @dashboard.cont_ed_unpaid_registrants,
-                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.cont_ed_unpaid_registrants.map(&:id).join("-")) %>
+                  filter_path: manage_event_path(@event, registrant_ids: @dashboard.cont_ed_unpaid_registrants.map(&:id).join("-").presence || "0") %>
           </div>
         </details>
       </div>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe EventRegistration, type: :model do
         expect(EventRegistration.scholarship_status("incomplete")).to include(incomplete_scholarship_reg)
         expect(EventRegistration.scholarship_status("incomplete")).not_to include(scholarship_reg)
       end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.scholarship_status("bogus")).to include(scholarship_reg, incomplete_scholarship_reg, paid_reg, unpaid_reg)
+      end
     end
 
     describe ".payment_status" do
@@ -164,6 +168,10 @@ RSpec.describe EventRegistration, type: :model do
       it "maps 'unpaid' to not_paid_in_full" do
         expect(EventRegistration.payment_status("unpaid")).to include(unpaid_reg)
         expect(EventRegistration.payment_status("unpaid")).not_to include(paid_reg)
+      end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.payment_status("bogus")).to include(paid_reg, unpaid_reg)
       end
     end
   end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -280,6 +280,20 @@ RSpec.describe "Events", type: :request do
 
     before { sign_in admin }
 
+    context "with unknown filter params" do
+      it "does not crash on an invalid payment_status" do
+        get manage_event_path(event, payment_status: "bogus")
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not crash on an invalid scholarship status" do
+        get manage_event_path(event, scholarship: "bogus")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context "confirmed column toggle" do
       it "renders the slide toggle for confirmed column" do
         get manage_event_path(event)


### PR DESCRIPTION
## Why

Addresses Copilot review findings on the event management dashboard PR (now on `main`).

The `manage` action chains filters directly onto the relation:

```ruby
scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?
scope = scope.scholarship_status(params[:scholarship]) if params[:scholarship].present?
```

Both scopes used a bare `case` with no `else`, so an unknown value (e.g. `?payment_status=foo` or `?scholarship=foo`) returned `nil`, broke the chain, and 500'd the page. The dashboard drill-in links also had two correctness gaps.

## What

- **`payment_status` / `scholarship_status` scopes** — add `else all` so unknown values return an unfiltered relation instead of `nil`.
- **Scholarship drill-ins** — use the `scholarship=complete` / `scholarship=incomplete` filters instead of a hyphenated `registrant_ids` list, so the link stays correct even when there are zero recipients (a blank id list otherwise resolves to the unfiltered view).
- **Cont-ed drill-ins** — fall back to `registrant_ids: "0"` when the (currently always-empty, stubbed) list is blank, so an empty list matches the $0 row rather than showing all registrants.

## Testing

- Model specs: unknown values return an unfiltered relation for both scopes.
- Request specs: `GET /manage` with invalid `payment_status` / `scholarship` params returns 200 instead of 500.
- `ai/lint` clean on Ruby files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)