### PR TITLE
Exclude unapplied scholarships from the event grand total

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -71,9 +71,12 @@ class EventDashboard
   end
 
   # Everything accounted for: registration fees (received + still owed),
-  # scholarships awarded, and continuing-education fees.
+  # scholarship dollars already applied, and continuing-education fees.
+  # Outstanding scholarships are excluded here: their cost still sits in
+  # outstanding_cents, so adding the award would double-count it and push the
+  # grand total above total_cents.
   def grand_total_cents
-    registration_subtotal_cents + scholarship_total_cents + cont_ed_total_cents
+    registration_subtotal_cents + applied_scholarship_cents + cont_ed_total_cents
   end
 
   def paid_count
@@ -240,6 +243,13 @@ class EventDashboard
 
   def allocated_by_registration
     @allocated_by_registration ||= registration_allocations.group(:allocatable_id).sum(:amount)
+  end
+
+  # Scholarship dollars actually applied to registrations. Outstanding
+  # scholarships have a zero allocation (see Scholarship#sync_allocation_amount),
+  # so this counts only money that has reduced a registrant's balance.
+  def applied_scholarship_cents
+    registration_allocations.where(source_type: "Scholarship").sum(:amount)
   end
 
   def scholarships

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -253,6 +253,33 @@ RSpec.describe EventDashboard do
     end
   end
 
+  # An outstanding scholarship (tasks not yet completed) has a zero allocation,
+  # so the registration's full cost still sits in outstanding_cents. The grand
+  # total must not also add the awarded amount, or it double-counts that cost
+  # and climbs above the full-price total_cents.
+  context "with an outstanding (unapplied) scholarship" do
+    let(:event) { create(:event, cost_cents: 10_000) }
+    let(:recipient) { create(:person) }
+    let!(:registration) { create(:event_registration, event: event, registrant: recipient, status: "registered") }
+
+    before do
+      scholarship = create(:scholarship, recipient: recipient, amount_cents: 10_000, tasks_completed: false)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 0)
+    end
+
+    it "still reports the awarded amount on the scholarship card headline" do
+      expect(dashboard.scholarship_total_cents).to eq(10_000)
+      expect(dashboard.scholarship_total_cents).to eq(
+        dashboard.completed_scholarship_cents + dashboard.outstanding_scholarship_cents
+      )
+    end
+
+    it "does not let the grand total exceed the full-price total" do
+      expect(dashboard.grand_total_cents).to eq(dashboard.total_cents)
+      expect(dashboard.grand_total_cents).to eq(10_000)
+    end
+  end
+
   context "with a free event" do
     let(:event) { create(:event, cost_cents: 0) }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `EventDashboard#grand_total_cents` could exceed the full-price `total_cents` and show scholarship dollars that were never actually applied.
- Root cause: an outstanding scholarship (tasks not yet completed) has its allocation `amount` forced to 0 by `Scholarship#sync_allocation_amount`, so that registration's full cost still sits in `outstanding_cents`. `grand_total_cents` *also* added the awarded amount via `scholarship_total_cents`, double-counting the same cost.
- Surfaced by a Copilot review comment on the dashboard overview.

### How did you approach the change?

- Added a private `applied_scholarship_cents` that sums only scholarship **allocation** amounts (zero for outstanding scholarships), and used it in `grand_total_cents`.
- Deliberately left `scholarship_total_cents` as the **awarded** amount: the dashboard scholarship card headline must equal its Completed + Incomplete breakdown, so it can't become applied-only (which is why Copilot's literal suggestion was adjusted rather than applied as-is).
- Used the allocation amount (not `completed_scholarship_cents`) because existing fixtures can have an applied allocation while `tasks_completed` is still false — the allocation is the source of truth for what's been applied.

### UI Testing Checklist

- [ ] Open an event dashboard with an **outstanding** scholarship (awarded, tasks incomplete): grand total no longer exceeds the full-price total.
- [ ] Scholarship card headline still equals Completed + Incomplete.

### Anything else to add?

- TDD: added a failing spec (`with an outstanding (unapplied) scholarship`) asserting `grand_total_cents == total_cents` and that the headline still equals completed + outstanding, then made it pass. Full `event_dashboard_spec` green (36 examples).
- No migration or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)