### PR TITLE
Fix Conductor workspace setup: mise activation and git hooks

### DIFF
--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -10,10 +10,15 @@ cd $(dirname "$0")/..
 # Activate mise so the project's Ruby/Node are on PATH. This script runs
 # under /bin/sh, which does not source ~/.zshenv, so the shims-in-zshenv
 # install documented in CONTRIBUTING.md does not apply here.
+# Use shims (not the activate hook): the shims output is a single POSIX
+# `export PATH=...` line, so it runs under any /bin/sh — including dash on
+# Linux — whereas `mise activate <shell>` emits shell-specific code that only
+# works in that exact shell. The script's interpreter, not the developer's
+# login shell, is what matters here.
 if command -v mise > /dev/null 2>&1; then
-  eval "$(mise activate sh)"
+  eval "$(mise activate bash --shims)"
 elif [ -x /opt/homebrew/bin/mise ]; then
-  eval "$(/opt/homebrew/bin/mise activate sh)"
+  eval "$(/opt/homebrew/bin/mise activate bash --shims)"
 fi
 
 # CONDUCTOR_PORT is Conductor-specific. Expose it under the generic

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
-eval "$(command /opt/homebrew/bin/mise activate zsh)"
+# Put mise's tools (Ruby, gems) on PATH. Resolve mise from PATH first so this
+# works off macOS/Homebrew too, falling back to the Homebrew location. Shims
+# mode emits a single POSIX `export PATH=...`, activating regardless of shell.
+mise_bin="$(command -v mise || true)"
+if [ -z "$mise_bin" ] && [ -x /opt/homebrew/bin/mise ]; then
+  mise_bin=/opt/homebrew/bin/mise
+fi
+[ -n "$mise_bin" ] && eval "$("$mise_bin" activate bash --shims)"
 
-# Run rubocop on all Ruby files
+# Run rubocop on all Ruby files. Use the binstub (not `bundle exec`) so it
+# resolves the gem reliably — matches ai/security.
 echo "Running rubocop..."
-bundle exec rubocop || exit 1
+bin/rubocop || exit 1
 
 # Run brakeman security scan
 echo "Running brakeman security scan..."
-bundle exec brakeman --no-pager -q || exit 1
+bin/brakeman --no-pager -q || exit 1

--- a/bin/setup
+++ b/bin/setup
@@ -71,10 +71,15 @@ FileUtils.chdir APP_ROOT do
   system! "RAILS_ENV=test npx vite build --mode test"
 
   puts "\n== Installing git hooks =="
-  system! 'cp bin/pre-commit .git/hooks/pre-commit'
-  system! 'chmod +x .git/hooks/pre-commit'
-  system! 'cp bin/pre-push .git/hooks/pre-push'
-  system! 'chmod +x .git/hooks/pre-push'
+  # Resolve the hooks dir via git so this works in worktrees too, where .git is
+  # a gitdir-pointer file and hooks live in the shared common dir.
+  hooks_dir = `git rev-parse --git-path hooks`.strip
+  FileUtils.mkdir_p(hooks_dir)
+  %w[pre-commit pre-push].each do |hook|
+    dest = File.join(hooks_dir, hook)
+    FileUtils.cp("bin/#{hook}", dest)
+    FileUtils.chmod(0o755, dest)
+  end
   puts "\n== Cleaning logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

`bin/conductor-setup` was failing before it could install deps, create the database, or run migrations — so new Conductor workspaces came up broken. The fixes also make setup work for plain dev environments, Linux, and git worktrees, not just macOS Conductor.

Root causes (each blocked the next):

- **mise never activated** — `mise activate sh` is rejected by current mise (`sh` is no longer a valid shell type). The failure was silent inside `$(…)`, so setup fell back to **system Ruby 2.6** and crashed loading Rails.
- **git hooks install failed in worktrees** — `cp … .git/hooks/…` assumed `.git` is a directory, but in a Conductor worktree it is a gitdir-pointer *file*; hooks live in the shared common dir.
- **pre-push hook was broken** — it ran `mise activate zsh` under a bash shebang (zsh-only syntax → activation error → rubocop on Ruby 2.6), and `bundle exec brakeman` couldn't locate the gem's executable.

### How did you approach the change?

- Use `mise activate bash --shims` in the non-interactive scripts. Shims mode emits a single POSIX `export PATH=…`, so it works under any `/bin/sh` (including **dash** on Linux) and regardless of the developer's login shell — unlike the shell-specific activate-hook output, which is full of bashisms.
- Resolve the hooks directory via `git rev-parse --git-path hooks`, correct for both **normal clones** (`.git/hooks`) and **worktrees** (shared common dir).
- In `bin/pre-push`, resolve `mise` from `PATH` first (Homebrew path as fallback) and run the `bin/rubocop` / `bin/brakeman` binstubs instead of `bundle exec`, matching `ai/security`.

### Anything else to add?

Verified end-to-end: full `bin/conductor-setup` run (bundle, npm ci, db create/migrate/seed, vite build, hooks) and a real `git push` exercising the pre-push hook (rubocop 1113 files clean, brakeman no warnings). Confirmed the hooks logic works in both a fresh normal clone and this worktree, and that the shims output is POSIX-clean.