### PR TITLE
Unify event admin navigation around the Dashboard

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -36,7 +36,7 @@ class EventsController < ApplicationController
   end
 
   def dashboard
-    authorize! @event, to: :manage?
+    authorize! @event
     @event = @event.decorate
     @dashboard = EventDashboard.new(@event)
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -33,6 +33,10 @@ class EventPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def dashboard?
+    admin? || owner?
+  end
+
   def preview_reminder?
     manage?
   end

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -12,7 +12,9 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%= link_to "Send reminder", preview_reminder_event_path(@event), class: item_class %>
-    <%= link_to "Download CSV", manage_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } %>
+    <%= link_to "Send reminder emails", preview_reminder_event_path(@event), class: item_class %>
+    <%= link_to manage_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
+      Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>
+    <% end %>
   </div>
 </div>

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -46,9 +46,9 @@
     </div>
 
     <div class="flex items-center gap-3">
-    <% if allowed_to?(:edit?, event) %>
-      <%= link_to "Edit",
-                edit_event_path(event),
+    <% if allowed_to?(:dashboard?, event) %>
+      <%= link_to "Dashboard",
+                dashboard_event_path(event),
                 data: { turbo_frame: "_top" },
                 class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>

--- a/app/views/events/_subnav.html.erb
+++ b/app/views/events/_subnav.html.erb
@@ -1,0 +1,19 @@
+<%# Shared sub-navigation for an event's admin sub-pages.
+    Pass `event:` and `current:` (one of :dashboard, :registrants, :edit, :view).
+    The current page renders as a non-link underlined tab; the rest are muted links. %>
+<nav class="flex flex-wrap items-center gap-1" aria-label="Event views">
+  <% tabs = [
+       { key: :dashboard, label: "Dashboard", path: dashboard_event_path(event), visible: allowed_to?(:dashboard?, event) },
+       { key: :registrants, label: "Registrants", path: manage_event_path(event), visible: allowed_to?(:manage?, event) },
+       { key: :edit, label: "Edit event", path: edit_event_path(event), visible: allowed_to?(:edit?, event) },
+       { key: :view, label: "View event", path: event_path(event), visible: true }
+     ] %>
+  <% tabs.each do |tab| %>
+    <% next unless tab[:visible] %>
+    <% if tab[:key] == current %>
+      <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
+    <% else %>
+      <%= link_to tab[:label], tab[:path], class: "text-sm text-gray-500 hover:text-gray-700 border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
+    <% end %>
+  <% end %>
+</nav>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -2,11 +2,8 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + actions %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
-    <div class="flex gap-2">
-      <%= link_to "Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "View", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    </div>
+    <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
 
   <%# Centered title block %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,9 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-4">
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= render "events/subnav", event: @event, current: :edit %>
   </div>
   <div class="flex items-center justify-between mb-3">
     <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">

--- a/app/views/events/manage.html.erb
+++ b/app/views/events/manage.html.erb
@@ -1,8 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <%# Top bar: eyelash + sub-nav, matching the other event pages %>
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= render "events/subnav", event: @event, current: :registrants %>
+  </div>
+
+  <%# Title row: heading + registrant action controls %>
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
     <div>
-      <%= link_to "← Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
       <h1 class="text-2xl font-semibold text-gray-900">
         Manage registrants
       </h1>
@@ -10,16 +16,14 @@
         <%= @event.title %>
       </p>
     </div>
-    <div class="flex items-center gap-2">
-      <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <div class="flex flex-wrap items-center gap-1">
       <% if allowed_to?(:edit?, @event) %>
-        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= render "form_actions_menu" %>
       <% end %>
       <%= render "bulk_actions_menu" %>
-<% if allowed_to?(:new?, EventRegistration) %>
-  <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-<% end %>
+      <% if allowed_to?(:new?, EventRegistration) %>
+        <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "manage"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -1,9 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <%# Top bar: eyelash + sub-nav, matching the other event pages %>
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+    <%= link_to "← Registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= render "events/subnav", event: @event, current: nil %>
+  </div>
+
   <div class="mb-6">
-    <%= link_to "← Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
     <h1 class="text-2xl font-semibold text-gray-900">
-      Send reminder email
+      Send reminder emails
     </h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -2,6 +2,12 @@
 
 <div class="flex flex-wrap items-center gap-2 mb-4">
   <%= link_to "← Back to Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <% if allowed_to?(:dashboard?, @event) %>
+    <div class="ml-auto flex flex-wrap items-center gap-1">
+      <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      <%= link_to "Registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    </div>
+  <% end %>
 </div>
 
 <div class="max-w-2xl mx-auto py-8 px-4">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,15 +17,14 @@
 <% else %>
 <!-- Top Right Actions -->
 <div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Back to Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <div class="ml-auto flex flex-wrap gap-2">
+  <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <div class="ml-auto flex flex-wrap gap-1">
   <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <%= link_to "Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% if allowed_to?(:edit?, @event) %>
-    <%= link_to "Edit", edit_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <% if allowed_to?(:dashboard?, @event) %>
+    <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <% if allowed_to?(:manage?, @event) %>
-    <%= link_to "Manage registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    <%= link_to "Registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
   </div>

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -126,6 +126,34 @@ RSpec.describe EventPolicy, type: :policy do
     end
   end
 
+  describe "#dashboard?" do
+    let(:owned_event) { build_stubbed :event, created_by: regular_user }
+
+    context "with admin user" do
+      subject { policy_for(record: published_event, user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:dashboard?) }
+    end
+
+    context "with owner" do
+      subject { policy_for(record: owned_event, user: regular_user) }
+
+      it { is_expected.to be_allowed_to(:dashboard?) }
+    end
+
+    context "with non-owner regular user" do
+      subject { policy_for(record: published_event, user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:dashboard?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(record: published_event, user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:dashboard?) }
+    end
+  end
+
   describe "aliases to :manage?" do
     let(:policy) { policy_for(user: admin_user) }
 

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -107,18 +107,20 @@ RSpec.describe "Event show page", type: :system do
   # --------------------------------------------------
 
   describe "admin buttons" do
-    it "shows Edit for admin" do
+    it "shows admin controls for admin" do
       sign_in(admin)
       visit event_path(event)
 
-      expect(page).to have_link("Edit", href: edit_event_path(event))
+      expect(page).to have_link("Dashboard", href: dashboard_event_path(event))
+      expect(page).to have_link("Registrants", href: manage_event_path(event))
     end
 
-    it "hides Edit for regular users" do
+    it "hides admin controls for regular users" do
       sign_in(user)
       visit event_path(event)
 
-      expect(page).not_to have_link("Edit")
+      expect(page).not_to have_link("Dashboard")
+      expect(page).not_to have_link("Registrants")
     end
   end
 

--- a/spec/views/events/edit.html.erb_spec.rb
+++ b/spec/views/events/edit.html.erb_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "events/edit", type: :view do
     assign(:categories_grouped, [])
     allow(view).to receive(:current_user).and_return(build_stubbed(:user, :admin))
     allow(view).to receive(:allowed_to?).with(:manage?, event).and_return(true)
+    allow(view).to receive(:allowed_to?).with(:dashboard?, event).and_return(true)
+    allow(view).to receive(:allowed_to?).with(:edit?, event).and_return(true)
     allow(view).to receive(:allowed_to?).with(:index?, Event).and_return(true)
     allow(view).to receive(:allowed_to?).with(:destroy?, event).and_return(true)
     allow(view).to receive(:allowed_to?).with(:google_analytics?, event).and_return(true)
@@ -41,7 +43,9 @@ RSpec.describe "events/edit", type: :view do
   it "renders action links" do
     render
 
-    expect(rendered).to have_link("View", href: event_path(event))
+    expect(rendered).to have_link("View event", href: event_path(event))
+    expect(rendered).to have_link("Dashboard", href: dashboard_event_path(event))
+    expect(rendered).to have_link("Registrants", href: manage_event_path(event))
   end
 
   it "renders submit button" do

--- a/spec/views/events/index.html.erb_spec.rb
+++ b/spec/views/events/index.html.erb_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "events/index", type: :view do
       expect(rendered).to include("Closed Event")
     end
 
-    it "renders edit links when allowed" do
-      expect(rendered).to have_link("Edit", href: edit_event_path(event_open))
+    it "renders dashboard links when allowed" do
+      expect(rendered).to have_link("Dashboard", href: dashboard_event_path(event_open))
     end
 
     it "renders New Event link" do
@@ -51,8 +51,8 @@ RSpec.describe "events/index", type: :view do
       render
     end
 
-    it "does not render edit link" do
-      expect(rendered).not_to have_link("Edit")
+    it "does not render dashboard link" do
+      expect(rendered).not_to have_link("Dashboard")
     end
 
     it "does not render New Event link" do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe "events/show", type: :view do
   it "renders action links" do
     render
 
-    expect(rendered).to have_link("Edit", href: edit_event_path(event))
+    expect(rendered).to have_link("Dashboard", href: dashboard_event_path(event))
+    expect(rendered).to have_link("Registrants", href: manage_event_path(event))
     expect(rendered).to have_link("Events", href: events_path)
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins manage events from the **Dashboard**, not the public event show page — but navigation didn't reflect that.
- Each event sub-page had a different back link and an inconsistent set of action links; **editing** was reachable from everywhere except a clear hub.
- Goal: one consistent, predictable navigation model across every event admin surface, with a clear "you are here" cue.

### How did you approach the change?
- **New shared partial `events/_subnav.html.erb`** renders one tab set — `Dashboard | Registrants | Edit event | View event` — used by dashboard, registrants (manage), edit, and send-reminder pages. The current page is shown bold + underlined (`aria-current="page"`); the rest are muted links. Permission-gated per tab.
- **Event cards** now link to **Dashboard** instead of Edit (admins enter at the hub).
- **Event show** (public-first): dropped the redundant `Events` right link and `Edit`; added admin **Dashboard** + **Registrants** escape hatches (gated by policy). Kept `Home`.
- **Registration form** (`public_registrations/new`): added the same admin Dashboard + Registrants links.
- **Manage page** restructured to match the others: eyelash + sub-nav in the top row; heading with the dropdowns / Add registrant right-aligned in the title row.
- **Send reminder**: gained the sub-nav (no active tab); dropdown link + page title aligned to "Send reminder emails".
- **Download CSV** in the bulk-actions menu now shows a download icon.
- **Authorization:** added a dedicated `dashboard?` rule to `EventPolicy`; the `dashboard` action and all Dashboard links use it instead of piggybacking on `manage?`.

### UI Testing Checklist
- [ ] From the events index, a card's **Dashboard** button opens that event's dashboard
- [ ] On dashboard/registrants/edit, the sub-nav shows the current page underlined and the others as links
- [ ] Manage page: dropdowns + Add registrant are right-aligned in the title row; sub-nav is in the top row
- [ ] Event show + registration form show **Dashboard** and **Registrants** only to admins/owners
- [ ] Send reminder page shows the sub-nav with no active tab; menu link and title both read "Send reminder emails"
- [ ] Bulk actions → "Download CSV" shows a download icon

### Anything else to add?
- Tests updated: new `#dashboard?` policy specs; events show/index/edit view specs and the events show system spec updated for the new links.
- Behavior is preserved for non-admins (all admin links are policy-gated).
