### PR TITLE
Fix Conductor workspace port wiring (ai/* scripts) and archive DB cleanup

### DIFF
--- a/ai/.ruby-env
+++ b/ai/.ruby-env
@@ -1,3 +1,12 @@
+# Under Conductor, the workspace's assigned port arrives in the terminal as
+# CONDUCTOR_PORT. Expose it under the generic WORKSPACE_PORT name so ai/* scripts
+# and the Rails app (database.yml, session_store, default_host) select the
+# per-workspace database, session, port, and host. Mirrors bin/conductor-{setup,server},
+# which set this for their own entry points but not for interactive ai/* runs.
+if [ -n "${CONDUCTOR_PORT:-}" ]; then
+  export WORKSPACE_PORT="${WORKSPACE_PORT:-$CONDUCTOR_PORT}"
+fi
+
 # Ensure the correct Ruby version is available via mise or rbenv
 if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"

--- a/bin/conductor-archive
+++ b/bin/conductor-archive
@@ -7,6 +7,17 @@
 set -e
 cd $(dirname "$0")/..
 
+# Activate mise so bin/rails resolves to the project's Ruby. This script runs
+# under /bin/sh, which does not source ~/.zshenv, so without this the db:drop
+# below silently fails (swallowed by `|| true`) and the workspace databases are
+# never dropped. Mirrors bin/conductor-setup; use shims (a single POSIX
+# `export PATH=...` line) so it works under any /bin/sh, including dash on Linux.
+if command -v mise > /dev/null 2>&1; then
+  eval "$(mise activate bash --shims)"
+elif [ -x /opt/homebrew/bin/mise ]; then
+  eval "$(/opt/homebrew/bin/mise activate bash --shims)"
+fi
+
 # CONDUCTOR_PORT is Conductor-specific. Expose it under the generic
 # WORKSPACE_PORT name so the rest of the app never references Conductor directly.
 export WORKSPACE_PORT=${WORKSPACE_PORT:-${CONDUCTOR_PORT:-}}
@@ -23,11 +34,13 @@ for p in "$PORT" "$((PORT + 36))"; do
   fi
 done
 
-# Drop workspace-specific databases
+# Drop workspace-specific databases. Keep `|| true` so a drop failure never
+# aborts archiving, but let stderr through so failures are visible in the log
+# rather than silently leaving an orphaned database behind.
 if [ -n "$WORKSPACE_PORT" ]; then
   echo "Dropping workspace databases..."
-  bin/rails db:drop 2>/dev/null || true
-  RAILS_ENV=test bin/rails db:drop 2>/dev/null || true
+  bin/rails db:drop || true
+  RAILS_ENV=test bin/rails db:drop || true
 fi
 
 echo "Archive complete."


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

Two related fixes to Conductor workspace port/database wiring:

**1. `ai/*` scripts ignored the workspace's assigned port**
- `ai/server` was probing for a free port instead of using the Conductor-assigned one (e.g. `WORKSPACE_PORT unset, picked free port 3001`).
- Root cause: the `CONDUCTOR_PORT` → `WORKSPACE_PORT` translation only lived in `bin/conductor-setup` and `bin/conductor-server`. Interactive `ai/*` scripts source `ai/.ruby-env`, where it was absent — so in a Conductor terminal `CONDUCTOR_PORT` is set but `WORKSPACE_PORT` is not.
- Beyond the wrong port, `ai/console` / `ai/test` / `ai/db-migrate` connected to the **base** `awbw_development` / `awbw_test` DBs instead of the per-workspace `*_<port>` DBs, and `session_store` / `default_host` used the wrong session key and host.

**2. `bin/conductor-archive` silently failed to drop workspace databases**
- The archive hook is supposed to drop the workspace's dev+test DBs, but orphaned `awbw_*_<port>` databases were piling up from retired workspaces.
- Root cause: `conductor-archive` runs under `/bin/sh`, which doesn't source the shell rc, so **mise was never activated** — `bin/rails` resolved to no/wrong Ruby and `db:drop` failed. The failure was hidden by `2>/dev/null || true`, so each archive silently left its databases behind.

### How did you approach the change?

- **`ai/.ruby-env`**: added the `CONDUCTOR_PORT` → `WORKSPACE_PORT` translation once (sourced by every `ai/*` script), guarded on `CONDUCTOR_PORT` being present so non-Conductor runs keep the free-port-probe fallback.
- **`bin/conductor-archive`**: activate mise via shims (matching `bin/conductor-setup`) so `bin/rails` works, and stop swallowing stderr so any future `db:drop` failure is visible in the archive log instead of orphaning a database.
- Verified: mise shims resolve Ruby under plain `sh`; the script passes `sh -n`; inside Conductor `WORKSPACE_PORT` derives from `CONDUCTOR_PORT`, outside it stays unset.

### Anything else to add?

- These are tracked files, so existing workspaces only pick up the fixes after merging to `main` and pulling.
- The archive fix prevents *future* orphans; the existing pile of orphaned `awbw_*_<port>` DBs was cleaned up separately/manually.
- Note the hook only runs when a workspace is archived through Conductor — manually deleting a worktree still bypasses it.