### PR TITLE
HOLD: Widen registrants list and slim states card on event dashboard

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -221,17 +221,18 @@ class EventDashboard
     @organization_registrant_ids ||= organization_registrant_ids_by_org.values.flat_map(&:to_a).uniq
   end
 
-  # Organization names per registrant id (Person id), for registrant tooltips.
-  # Built from the same snapshot + active-affiliation data as the organizations
-  # breakdown, so the names match the Organizations count.
+  # Organization names per registrant id (Person id), for labeling and tooltips
+  # in the registrant list. Built from the same snapshot + active-affiliation data
+  # as the organizations breakdown, so the names match the Organizations count.
+  # Names are deduped and sorted; registrants with multiple orgs get all of them.
   def organization_names_by_registrant
     @organization_names_by_registrant ||= begin
-      names_by_id = organizations.index_by(&:id)
+      names_by_org = organizations.index_by(&:id)
       organization_registrant_ids_by_org.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(organization_id, person_ids), map|
-        organization = names_by_id[organization_id]
-        next unless organization
-        person_ids.each { |person_id| map[person_id] << organization.name }
-      end
+        name = names_by_org[organization_id]&.name
+        next unless name
+        person_ids.each { |person_id| map[person_id] << name }
+      end.transform_values { |names| names.uniq.sort }
     end
   end
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -219,8 +219,8 @@
   <% end %>
 
   <%# Headcount cards — each expands to reveal its full list %>
-  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
+  <div class="grid grid-cols-2 lg:grid-cols-12 gap-3 sm:gap-4">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm lg:col-span-4">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
@@ -238,10 +238,11 @@
         <% if @dashboard.registrants.any? %>
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.registrants.each do |registrant| %>
+              <% org_names = @dashboard.organization_names_by_registrant[registrant.id] %>
               <li>
-                <%= link_to registrant.name, manage_event_path(@event, registrant_ids: registrant.id),
-                      title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                      class: "block truncate rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" %>
+                <%= link_to manage_event_path(@event, registrant_ids: registrant.id), class: "block truncate rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: [ registrant.name, org_names.present? ? "(#{org_names.join(", ")})" : nil ].compact.join(" ") do %>
+                  <%= registrant.name %><% if org_names.present? %> <span class="text-gray-400">(<%= org_names.join(", ") %>)</span><% end %>
+                <% end %>
               </li>
             <% end %>
           </ul>
@@ -251,7 +252,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm lg:col-span-3">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
@@ -286,7 +287,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm lg:col-span-3">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
@@ -318,7 +319,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
+    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm lg:col-span-2">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -150,10 +150,11 @@ RSpec.describe EventDashboard do
         expect(map[org_c.id].to_a).to contain_exactly(person2.id)
       end
 
-      it "maps each registrant id to its organization names (for tooltips)" do
-        map = dashboard.organization_names_by_registrant
-        expect(map[person1.id]).to contain_exactly("Alpha Org", "Beta Org")
-        expect(map[person2.id]).to contain_exactly("Gamma Org")
+      it "maps each registrant to its organization names, deduped and sorted" do
+        names = dashboard.organization_names_by_registrant
+        expect(names[person1.id]).to eq([ "Alpha Org", "Beta Org" ])
+        expect(names[person2.id]).to eq([ "Gamma Org" ])
+        expect(names).not_to have_key(cancelled_person.id)
       end
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The four headcount cards on the event dashboard (Registrants, Organizations, Sectors, States) were equal width.
- The registrants list — the longest, most-read list — was cramped and truncated names early, while the short States list had width to spare.

### How did you approach the change?
- Switched the card row to a 12-column grid on `lg` and reallocated widths: Registrants `col-span-4` (wider), Organizations/Sectors `col-span-3` (unchanged), States `col-span-2` (thinner).
- Added each registrant's organization name(s) in muted parens next to their name, truncated to fit.
- The full "Name (Org)" string is preserved in the link `title`, so hovering still surfaces both the registrant name and organization name even when the line is truncated.
- Added `EventDashboard#organization_names_by_registrant` (deduped, sorted, multi-org aware) to back the labels, with a spec.

### Anything else to add?
- Org names reuse the existing snapshot + active-affiliation data already computed for the Organizations card, so no extra queries beyond the org lookup.
- Mobile layout (2-up grid) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)