### PR TITLE
Bump swiper to ^12.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "from": "^0.1.7",
         "rhino-editor": "^0.18.0",
         "sortablejs": "^1.15.6",
-        "swiper": "^12.0.3",
+        "swiper": "^12.2.0",
         "tailwindcss": "^4.1.13",
         "tippy.js": "^6.3.7",
         "tom-select": "^2.4.6",
@@ -3157,17 +3157,17 @@
       }
     },
     "node_modules/swiper": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.0.3.tgz",
-      "integrity": "sha512-BHd6U1VPEIksrXlyXjMmRWO0onmdNPaTAFduzqR3pgjvi7KfmUCAm/0cj49u2D7B0zNjMw02TSeXfinC1hDCXg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
+      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "from": "^0.1.7",
     "rhino-editor": "^0.18.0",
     "sortablejs": "^1.15.6",
-    "swiper": "^12.0.3",
+    "swiper": "^12.2.0",
     "tailwindcss": "^4.1.13",
     "tippy.js": "^6.3.7",
     "tom-select": "^2.4.6",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Bumps the `swiper` carousel dependency from `^12.0.3` to `^12.2.0`
- Keeps us on a current, patched release within the 12.x line

### How did you approach the change?
- Updated the version range in `package.json` and refreshed `package-lock.json`
- Stays within the same major (`12.x`), so no breaking changes expected

### Anything else to add?
- No source changes — dependency bump only