### PR TITLE
Load full dev seeds in Conductor workspaces via --seed-dev

### DIFF
--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -99,14 +99,17 @@ if [ -d "$CONDUCTOR_ROOT_PATH/.bundle" ]; then
   ln -sf "$CONDUCTOR_ROOT_PATH/.bundle" .bundle
 fi
 
-# Install deps before bin/setup so they're available when Rails env loads
+# Install gems before bin/setup so they're available when it loads the Rails
+# env (bin/setup requires config/environment before it runs bundle itself).
+# npm packages aren't needed to boot Rails, so leave `npm ci` to bin/setup
+# instead of running it twice.
 echo ""
 echo "== Installing dependencies =="
 bundle check > /dev/null 2>&1 || bundle install
-npm ci
 
-# Run full setup (database drop, create, migrate, seed)
-bin/setup --skip-server
+# Run full setup (database drop, create, migrate, seed). Conductor workspaces
+# are always dev, so load the full dev sample dataset via --seed-dev.
+bin/setup --skip-server --seed-dev
 
 PORT=${WORKSPACE_PORT:-${PORT:-3000}}
 echo ""

--- a/bin/setup
+++ b/bin/setup
@@ -60,7 +60,13 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Running Rails migrations and seeds =="
   system! "bin/rails db:migrate"
-  system! "bin/rails db:seed"
+  # --seed-dev loads the full dev sample dataset (db:seed:dev chains the base
+  # db:seed first); plain db:seed stays the default for CI and lean setups.
+  if ARGV.include?("--seed-dev")
+    system! "bin/rails db:seed:dev"
+  else
+    system! "bin/rails db:seed"
+  end
 
   puts "\n== Preparing test database =="
   system! "RAILS_ENV=test bin/rails db:drop"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Conductor workspaces came up with an **empty UI** — none of the dev sample data (workshops, events, analytics, profiles, payments, etc.) was present
- Root cause: `bin/setup` hardcoded `bin/rails db:seed`, which only loads the minimal base seeds (`db/seeds.rb`). The rich dev dataset lives behind the `db:seed:dev` rake task, and nothing ever invoked it
- Recent refactors (#1573, #1574, #1576) built out `db:seed:dev` / `db:seed:users` and the per-domain dev seed files, but stopped short of wiring setup to call them

### How did you approach the change?
- Added a `--seed-dev` flag to `bin/setup`: when present it runs `db:seed:dev` (which chains the base `db:seed` first); otherwise it stays on plain `db:seed` so CI and lean setups are unaffected
- Pass `--seed-dev` from `bin/conductor-setup`, since Conductor workspaces are always dev
- Dropped the redundant `npm ci` from `bin/conductor-setup` (`bin/setup` already runs it) and clarified the surrounding comment

### Anything else to add?
- Existing workspaces won't backfill automatically — run `bin/rails db:seed:dev` once to populate, or re-run setup
- `db:seed:dev` is dev-only by design; the default `db:seed` path is preserved for production-style and CI runs