### PR TITLE
Refresh public event registration UI

### DIFF
--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -1,17 +1,18 @@
   
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
   <!-- Ticket Container -->
-  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
     <!-- Ticket Header -->
-    <div class="bg-blue-900 text-white px-6 py-4">
-      <div class="flex items-center gap-8">
+    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
         <div class="shrink-0">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide">Event Registration</h1>
+          <h1 class="text-xl font-semibold tracking-wide leading-tight">Event registration</h1>
         </div>
       </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
     <!-- Ticket Body -->
     <div class="bg-gray-50 px-6 py-6 space-y-5">

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -2,10 +2,11 @@
 <% return if field.group_header? %>
 
 <% error = @field_errors&.dig(field.id) %>
-<% error_border = error ? "border-red-500" : "border-gray-300" %>
+<% error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30" %>
+<% input_classes = "w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition focus:outline-none focus:ring-2 #{error_border}" %>
 
 <div class="mb-5">
-  <label class="block text-sm font-medium text-gray-700 mb-1" for="public_registration_form_fields_<%= field.id %>">
+  <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="public_registration_form_fields_<%= field.id %>">
     <%= label || field.name %>
     <% if field.required %>
       <span class="text-red-500">*</span>
@@ -13,7 +14,7 @@
   </label>
 
   <% if field.hint_text.present? %>
-    <p class="text-xs text-gray-500 mb-1"><%= field.hint_text %></p>
+    <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>
   <% end %>
 
   <% field_name = "public_registration[form_fields][#{field.id}]" %>
@@ -24,7 +25,7 @@
     <% if field.field_identifier&.end_with?("_state") %>
       <select name="<%= field_name %>"
               id="<%= field_id %>"
-              class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              class="<%= input_classes %>"
               <%= "required" if field.required %>>
         <option value="">Select a state</option>
         <% us_states.each do |name, abbr| %>
@@ -47,7 +48,7 @@
              name="<%= field_name %>"
              id="<%= field_id %>"
              value="<%= value %>"
-             class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+             class="<%= input_classes %>"
              <%= "required" if field.required %>
              <%= raw(extra_attrs.join(" ")) %>>
     <% end %>
@@ -56,13 +57,13 @@
     <textarea name="<%= field_name %>"
               id="<%= field_id %>"
               rows="4"
-              class="w-full rounded-md border <%= error_border %> px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              class="<%= input_classes %>"
               <%= "required" if field.required %>><%= value %></textarea>
 
   <% when "multiple_choice_radio" %>
-    <div class="flex flex-wrap gap-4 mt-1">
+    <div class="flex flex-wrap gap-2.5 mt-1">
       <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
-        <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+        <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <input type="radio"
                  name="<%= field_name %>"
                  value="<%= ffao.answer_option.name %>"
@@ -82,9 +83,9 @@
       <%# Professional fields: render dynamic sector/category options %>
       <% if field.field_identifier == "primary_service_area" %>
         <% options = Sector.published.order(:name) %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
           <% options.each do |sector| %>
-            <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
               <input type="checkbox"
                      name="<%= checkbox_name %>"
                      value="<%= sector.id %>"
@@ -103,9 +104,9 @@
         }[field.field_identifier] %>
         <% ct = CategoryType.find_by(name: category_type_name) %>
         <% options = ct&.categories&.published&.order(:position, :name) || [] %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
           <% options.each do |category| %>
-            <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
               <input type="checkbox"
                      name="<%= checkbox_name %>"
                      value="<%= category.id %>"
@@ -118,9 +119,9 @@
       <% end %>
     <% else %>
       <%# Standard answer options %>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-1">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
         <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
-          <label class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
             <input type="checkbox"
                    name="<%= checkbox_name %>"
                    value="<%= ffao.answer_option.name %>"
@@ -135,6 +136,8 @@
   <% end %>
 
   <% if error %>
-    <p class="text-xs text-red-600 mt-1"><%= field.name %> <%= error %></p>
+    <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
+      <i class="fa-solid fa-circle-exclamation"></i><%= field.name %> <%= error %>
+    </p>
   <% end %>
 </div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -1,57 +1,71 @@
 <% content_for(:page_bg_class, "public") %>
 
-<div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Back to Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% if allowed_to?(:dashboard?, @event) %>
-    <div class="ml-auto flex flex-wrap items-center gap-1">
-      <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-      <%= link_to "Registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-    </div>
-  <% end %>
+<div class="max-w-2xl mx-auto px-4">
+  <div class="flex flex-wrap items-center gap-2 pt-4">
+    <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
+    <% end %>
+    <% if allowed_to?(:dashboard?, @event) %>
+      <div class="ml-auto flex flex-wrap items-center gap-1">
+        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <%= link_to "Registrants", manage_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      </div>
+    <% end %>
+  </div>
 </div>
 
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
 
   <%# ---- EVENT HEADER ---- %>
   <div class="text-center mb-8">
     <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
-      <p class="text-base font-semibold text-gray-700 mb-2" style="font-family: 'Telefon Bold', sans-serif; font-size: 42px"><%= @event.pre_title %></p>
+      <p class="text-lg sm:text-xl font-bold uppercase tracking-[0.2em] text-accent mb-3" style="font-family: 'Telefon Bold', sans-serif"><%= @event.pre_title %></p>
     <% end %>
-    <h1 class="font-bold text-green-800 mb-4" style="font-family: Lato, sans-serif; font-size: 53px"><%= link_to @event.title, event_path(@event), class: "hover:underline" %></h1>
+    <h1 class="font-black text-green-800 leading-tight text-4xl sm:text-5xl mb-5" style="font-family: Lato, sans-serif">
+      <%= link_to @event.title, event_path(@event), class: "hover:underline decoration-2 underline-offset-4" %>
+    </h1>
 
-    <div class="text-center space-y-2">
-      <div class="font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif; font-size: 35px">
-        <%= @event.times(display_day: true, display_date: true, styled: true) %>
-      </div>
+    <div class="font-bold text-blue-900 uppercase text-2xl sm:text-3xl mb-4" style="font-family: Lato, sans-serif">
+      <%= @event.times(display_day: true, display_date: true, styled: true) %>
+    </div>
 
+    <div class="flex flex-wrap items-center justify-center gap-2.5">
       <% if @event.labelled_cost.present? %>
-        <div class="text-xl font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif"><%= @event.labelled_cost %></div>
+        <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-1.5 text-sm font-semibold text-blue-900 ring-1 ring-blue-100">
+          <i class="fa-solid fa-ticket text-blue-500"></i><%= @event.labelled_cost %>
+        </span>
       <% end %>
-
       <% if @event.location.present? %>
-        <div class="text-base text-gray-700"><%= @event.location.name %></div>
+        <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-1.5 text-sm font-semibold text-blue-900 ring-1 ring-blue-100">
+          <i class="fa-solid fa-location-dot text-blue-500"></i><%= @event.location.name %>
+        </span>
       <% end %>
     </div>
   </div>
 
   <%# ---- REGISTRATION FORM CARD ---- %>
-  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <div class="bg-blue-900 text-white px-6 py-4">
-      <div class="flex items-center gap-8">
+    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
         <div class="shrink-0">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
-        <h2 class="text-xl font-semibold tracking-wide">Registration</h2>
+        <div>
+          <h2 class="text-xl font-semibold tracking-wide leading-tight">Registration</h2>
+          <p class="text-sm text-blue-200">Reserve your spot — it only takes a minute.</p>
+        </div>
       </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <%# Card Body %>
-    <div class="px-6 py-6">
+    <div class="px-6 sm:px-8 py-7">
       <% if flash[:alert] %>
-        <div class="bg-red-50 border border-red-300 text-red-800 rounded-lg px-4 py-3 mb-6">
-          <%= flash[:alert] %>
+        <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">
+          <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
+          <span><%= flash[:alert] %></span>
         </div>
       <% end %>
 
@@ -112,8 +126,10 @@
           <% next if field.field_identifier.present? && rendered_ids[field.field_identifier] %>
 
           <% if field.group_header? %>
-            <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-              <h3 class="text-lg font-semibold text-gray-800"><%= field.name %></h3>
+            <div class="pt-7 pb-4">
+              <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900">
+                <span class="h-5 w-1 rounded-full bg-accent"></span><%= field.name %>
+              </h3>
             </div>
           <% elsif (group = field.field_identifier.present? && identifier_to_group[field.field_identifier]) %>
             <div class="<%= group[:grid] %>">
@@ -143,8 +159,10 @@
         <% end %>
 
         <% if @scholarship_form && @scholarship_form.form_fields.any? %>
-          <div class="pt-8 pb-4 border-t border-gray-200">
-            <h3 class="text-lg font-semibold text-blue-900 mb-4">Scholarship Application</h3>
+          <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">
+            <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900 mb-5">
+              <i class="fa-solid fa-hand-holding-heart text-accent"></i>Scholarship application
+            </h3>
             <div class="space-y-4">
               <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% next if field.group_header? %>
@@ -155,9 +173,14 @@
           </div>
         <% end %>
 
-        <div class="pt-6">
-          <%= submit_tag "Register",
-                class: "w-full rounded-md bg-blue-900 px-6 py-3 text-white font-semibold text-lg hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+        <div class="pt-7">
+          <%= button_tag type: "submit",
+                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-blue-900 px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-blue-900/20 transition hover:bg-blue-800 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer" do %>
+            <i class="fa-regular fa-circle-check"></i>Register
+          <% end %>
+          <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">
+            <i class="fa-solid fa-lock"></i>Your information is kept private. Fields marked <span class="text-red-500 font-medium">*</span> are required.
+          </p>
         </div>
 
       <% end %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -2,30 +2,35 @@
 
 <% reg = @form_submission.person.event_registrations.find_by(event: @event) %>
 <% back_path = reg&.slug.present? ? registration_ticket_path(reg.slug) : event_path(@event) %>
-<div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Back to Registration", back_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+<div class="max-w-2xl mx-auto px-4 pt-4">
+  <div class="flex flex-wrap items-center gap-2">
+    <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Back to registration
+    <% end %>
+  </div>
 </div>
 
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
 
   <%# ---- FORM RESPONSES CARD ---- %>
-  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <div class="bg-blue-900 text-white px-6 py-4">
-      <div class="flex items-center gap-8">
+    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
         <div class="shrink-0">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide">Registration Details</h1>
+          <h1 class="text-xl font-semibold tracking-wide leading-tight">Registration details</h1>
           <p class="text-sm text-blue-200"><%= @event.title %></p>
         </div>
       </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <%# Card Body %>
-    <div class="px-6 py-6 space-y-1">
+    <div class="px-6 sm:px-8 py-7 space-y-1">
       <%
         row_groups = [
           { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Back to Event", event_path(@event_registration.event, reg: @event_registration.slug), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+<div class="max-w-2xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
+  <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
+  <% end %>
   <div class="ml-auto flex gap-2">
     <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   <% if allowed_to?(:index?, EventRegistration) %>

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Event registration show page", type: :system do
       sign_in(user)
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_link("Back to Event", href: event_path(event, reg: registration.slug))
+      expect(page).to have_link("Back to event", href: event_path(event, reg: registration.slug))
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe "Event registration show page", type: :system do
     it "allows guests to view the ticket via slug" do
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_text("Event Registration")
+      expect(page).to have_text("Event registration")
       expect(page).to have_text(registration.registrant.full_name)
     end
   end

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Public registration new page", type: :system do
     it "shows a back link to the event page" do
       visit new_event_public_registration_path(event)
 
-      expect(page).to have_link("Back to Event", href: event_path(event))
+      expect(page).to have_link("Back to event", href: event_path(event))
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The public event registration flow rendered as a plain form on a white page — functional but unbranded and a bit flat.
- This makes registering feel more inviting and trustworthy, which matters because it's a public, conversion-sensitive page.
- It also unifies the visual language across the three public-facing registration screens (form, submitted details, ticket).

### How did you approach the change?

- **Shared card style** across the registration form, details page, and ticket: `rounded-2xl` card with a gradient header bar and an accent stripe.
- **Registration form** (`public_registrations/new`): accent-colored eyebrow for the pre-title, responsive hero title, and cost/location shown as icon pills instead of stacked text. Added a subtitle, an icon submit button with hover-lift, and a privacy/required-fields helper line. The scholarship section now sits in its own tinted panel.
- **Form fields** (`_form_field`): larger rounded inputs with clearer hover/focus/error states; radio and checkbox options render as selectable cards (`has-[:checked]` highlight); inline errors get an icon.
- All existing field-grouping/grid Ruby logic was left untouched — only surrounding markup changed.
- Switched back-link/header labels to sentence case ("Back to event", "Event registration", "Registration details") per the project convention, and updated the two system specs that asserted the old title-case text.
- Kept `content_for(:page_bg_class, ...)` exactly `"public"` to stay aligned with `page_bg_class_alignment_spec` (the token maps to an authorization level), so the visual lift comes from the card/header/fields rather than a page background change.

### UI Testing Checklist

- [ ] Public registration form renders with the new header, pills, and card styling
- [ ] Required-field validation errors still display correctly (red borders + inline messages)
- [ ] Radio/checkbox options highlight when selected
- [ ] Scholarship application section appears in its tinted panel when applicable
- [ ] Submitted-details page and registration ticket share the refreshed card style
- [ ] Layout holds up on mobile widths

### Anything else to add?

- Rebased onto latest `main`; the registration views had no conflicts.
- Verified via the registration system + request specs and `page_bg_class_alignment_spec` (all green), plus RuboCop (clean).
- Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)