### PR TITLE
Add Grant model with scholarships, funder display, and budget guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ This codebase (Rails 8.1)
 | `Resource` | Handouts, toolkits, templates with downloadable assets |
 | `Person` | Organization affiliates with contacts, addresses, sectors |
 | `Organization` | Groups with affiliations, addresses, logos via ActiveStorage |
+| `Grant` | Donated funds (polymorphic `donor`: Organization or Person) with eligibility criteria, tasks, deadlines; parent of `Scholarship`. Scholarship totals cannot exceed the grant amount |
+| `Scholarship` | Award to a `Person`; optionally drawn from a `Grant`, syncs to event registration `Allocation` |
 | `Report` | STI base class for MonthlyReport |
 | `WorkshopLog` | Standalone model for workshop log submissions (attendance, form fields) |
 
@@ -110,6 +112,7 @@ This codebase (Rails 8.1)
 ### Polymorphic Associations
 
 - **Bookmarks** (`bookmarkable`): Workshop, Event, Resource, etc.
+- **Grant donor** (`donor`): Organization, Person
 - **Assets** (`owner`): Workshop, Story, Resource, Report, etc.
 - **Comments** (`commentable`): User, Person, Organization, etc.
 - **Categorizable/Sectorable** items: Workshop, Story, Resource, etc.
@@ -206,7 +209,7 @@ All inherit from `ApplicationDecorator` which provides:
 - `display_image` — selects primary/gallery/downloadable asset intelligently
 - `link_target` — polymorphic path generation
 
-Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator.
+Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator, GrantDecorator.
 
 ## Policies (ActionPolicy)
 

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -1,0 +1,95 @@
+class GrantsController < ApplicationController
+  include AhoyTracking
+  before_action :set_grant, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    authorize!
+    @grants = authorized_scope(Grant.all)
+                .includes(:donor)
+                .by_deadline
+                .page(params[:page])
+    track_index_intent(Grant, @grants, params)
+  end
+
+  def show
+    authorize! @grant
+    set_scholarships
+    track_view(@grant)
+  end
+
+  def new
+    @grant = Grant.new
+    authorize! @grant
+    set_form_variables
+  end
+
+  def edit
+    authorize! @grant
+    set_scholarships
+    set_form_variables
+  end
+
+  def create
+    @grant = Grant.new(grant_params)
+    @grant.created_by = current_user
+    @grant.updated_by = current_user
+    authorize! @grant
+
+    if @grant.save
+      redirect_to @grant, notice: "Grant was successfully created."
+    else
+      set_form_variables
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    authorize! @grant
+    @grant.updated_by = current_user
+
+    if @grant.update(grant_params)
+      redirect_to @grant, notice: "Grant was successfully updated.", status: :see_other
+    else
+      set_scholarships
+      set_form_variables
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    authorize! @grant
+
+    if @grant.destroy
+      redirect_to grants_path, notice: "Grant was successfully destroyed."
+    else
+      redirect_to @grant, alert: "Can't delete a grant that has associated scholarships. Remove its scholarships first.", status: :see_other
+    end
+  end
+
+  def set_form_variables
+    @donor_options = {
+      "Organizations" => Organization.order(:name).map { |o| [ o.name, o.to_signed_global_id.to_s ] },
+      "People" => Person.order(:last_name, :first_name).map { |p| [ p.full_name, p.to_signed_global_id.to_s ] }
+    }
+  end
+
+  private
+
+  def set_grant
+    @grant = Grant.find(params[:id])
+  end
+
+  def set_scholarships
+    @scholarships = @grant.scholarships
+                          .includes(:recipient)
+                          .order(created_at: :desc)
+                          .paginate(page: params[:page], per_page: 10)
+  end
+
+  def grant_params
+    params.require(:grant).permit(
+      :name, :description, :amount_dollars, :amount_cents, :donor_sgid,
+      :application_deadline, :funds_received_on, :eligibility_criteria, :tasks
+    )
+  end
+end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -1,5 +1,6 @@
 class ScholarshipsController < ApplicationController
   before_action :set_scholarship, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_grant, only: [ :new, :create ]
 
   def show
     @scholarship = Scholarship.find(params[:id])
@@ -7,15 +8,34 @@ class ScholarshipsController < ApplicationController
   end
 
   def new
+    if @grant
+      @scholarship = Scholarship.new(grant: @grant)
+      authorize! @scholarship
+      return
+    end
+
     @allocatable = locate_allocatable
-    redirect_to allocations_path, alert: "Allocatable not found." unless @allocatable
+    redirect_to allocations_path, alert: "Allocatable not found." and return unless @allocatable
 
     @scholarship = Scholarship.new(recipient: @allocatable.registrant)
     @scholarship.build_allocation(allocatable: @allocatable, amount: 0)
+    @grants = Grant.by_deadline
     authorize! @scholarship
   end
 
   def create
+    if @grant
+      @scholarship = Scholarship.new(scholarship_params.merge(grant: @grant))
+      authorize! @scholarship
+
+      if @scholarship.save
+        redirect_to grant_return_path, notice: "Scholarship created."
+      else
+        render :new, status: :unprocessable_content
+      end
+      return
+    end
+
     @allocatable = locate_allocatable
     redirect_to allocations_path, alert: "Allocatable not found." and return unless @allocatable
 
@@ -26,12 +46,14 @@ class ScholarshipsController < ApplicationController
     if @scholarship.save
       redirect_to edit_scholarship_path(@scholarship), notice: "Scholarship created."
     else
+      @grants = Grant.by_deadline
       render :new, status: :unprocessable_content
     end
   end
 
   def edit
     @allocatable = @scholarship.allocation&.allocatable
+    @grants = Grant.by_deadline
     authorize! @scholarship
     load_scholarship_submission
   end
@@ -41,8 +63,9 @@ class ScholarshipsController < ApplicationController
     authorize! @scholarship
 
     if @scholarship.update(scholarship_params)
-      redirect_to edit_scholarship_path(@scholarship), notice: "Scholarship updated."
+      redirect_to scholarship_save_path, notice: "Scholarship updated."
     else
+      @grants = Grant.by_deadline
       render :edit, status: :unprocessable_content
     end
   end
@@ -50,17 +73,40 @@ class ScholarshipsController < ApplicationController
   def destroy
     @allocatable = @scholarship.allocation&.allocatable
     authorize! @scholarship
+    grant = @scholarship.grant
     @scholarship.destroy!
 
     event = @allocatable.try(:event)
-    redirect_to event ? manage_event_path(event) : scholarships_path,
-                notice: "Scholarship removed."
+    destination = if event
+      manage_event_path(event)
+    elsif grant
+      params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)
+    else
+      root_path
+    end
+    redirect_to destination, notice: "Scholarship removed."
   end
 
   private
 
   def set_scholarship
     @scholarship = Scholarship.find(params[:id])
+  end
+
+  def set_grant
+    @grant = Grant.find(params[:grant_id]) if params[:grant_id].present?
+  end
+
+  # After saving a grant-funded scholarship, return to the grant the user came
+  # from (its show or edit page, respectively).
+  def grant_return_path
+    params[:return_to] == "grant_edit" ? edit_grant_path(@scholarship.grant) : grant_path(@scholarship.grant)
+  end
+
+  def scholarship_save_path
+    return grant_return_path if @scholarship.grant && params[:return_to].in?(%w[ grant_show grant_edit ])
+
+    edit_scholarship_path(@scholarship)
   end
 
   # Pull the recipient's scholarship-section answers from the event's
@@ -88,6 +134,6 @@ class ScholarshipsController < ApplicationController
   end
 
   def scholarship_params
-    params.require(:scholarship).permit(:amount_dollars, :amount_cents, :tasks_completed)
+    params.require(:scholarship).permit(:amount_dollars, :amount_cents, :tasks_completed, :grant_id, :recipient_id)
   end
 end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -1,0 +1,25 @@
+class GrantDecorator < ApplicationDecorator
+  def amount
+    h.number_to_currency(object.amount_dollars)
+  end
+
+  def allocated
+    h.number_to_currency(object.scholarships_total_cents.to_d / 100)
+  end
+
+  def remaining
+    h.number_to_currency(object.remaining_dollars)
+  end
+
+  def application_deadline
+    object.application_deadline&.strftime("%B %-d, %Y") || "—"
+  end
+
+  def funds_received_on
+    object.funds_received_on&.strftime("%B %-d, %Y") || "—"
+  end
+
+  def fully_allocated?
+    object.remaining_cents <= 0
+  end
+end

--- a/app/helpers/grant_helper.rb
+++ b/app/helpers/grant_helper.rb
@@ -1,0 +1,19 @@
+module GrantHelper
+  # Renders a grant's funder (donor) as an icon + name: a person icon tinted
+  # in the people theme color, or a building icon tinted in the organizations
+  # theme color.
+  def grant_donor_badge(grant)
+    return "" unless grant&.donor
+
+    person = grant.donor.is_a?(Person)
+    icon_name = person ? "fa-user" : "fa-building"
+    color_key = person ? :people : :organizations
+
+    tag.span(class: "inline-flex items-center gap-2") do
+      safe_join([
+        tag.i(class: "fa-solid #{icon_name} #{DomainTheme.text_class_for(color_key)}", aria: { hidden: "true" }),
+        tag.span(grant.funder_name)
+      ])
+    end
+  end
+end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,0 +1,67 @@
+class Grant < ApplicationRecord
+  belongs_to :donor, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
+  has_many :scholarships, dependent: :restrict_with_error
+
+  DONOR_TYPES = %w[Organization Person].freeze
+
+  validates :name, presence: true
+  validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :donor_type, inclusion: { in: DONOR_TYPES }
+
+  scope :by_deadline, -> { order(Arel.sql("application_deadline IS NULL, application_deadline ASC")) }
+
+  # Money is stored in cents; expose a dollar-based accessor for forms and display.
+  def amount_dollars
+    amount_cents.to_d / 100 if amount_cents
+  end
+
+  def amount_dollars=(value)
+    self.amount_cents = (value.to_d * 100).to_i if value.present?
+  end
+
+  # Resolve the polymorphic donor from a signed global id, mirroring the
+  # GlobalID pattern used for scholarship allocatables.
+  def donor_sgid
+    donor&.to_signed_global_id&.to_s
+  end
+
+  def donor_sgid=(sgid)
+    self.donor = GlobalID::Locator.locate_signed(sgid) if sgid.present?
+  end
+
+  # The donor is the funder of any scholarships drawn from the grant.
+  def funder_name
+    donor&.try(:full_name) || donor&.try(:name) || donor&.to_s
+  end
+
+  def scholarships_total_cents
+    scholarships.sum(:amount_cents)
+  end
+
+  def remaining_cents
+    amount_cents.to_i - scholarships_total_cents
+  end
+
+  def remaining_dollars
+    remaining_cents.to_d / 100
+  end
+
+  # Criteria and tasks are stored as newline-separated text; expose them as
+  # trimmed lists for display.
+  def eligibility_criteria_list
+    text_to_list(eligibility_criteria)
+  end
+
+  def task_list
+    text_to_list(tasks)
+  end
+
+  private
+
+  def text_to_list(text)
+    text.to_s.split("\n").map(&:strip).reject(&:blank?)
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -14,6 +14,7 @@ class Organization < ApplicationRecord
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :reports
   has_many :workshop_logs
+  has_many :grants, as: :donor, dependent: :destroy
 
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, as: :sectorable, dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -23,6 +23,7 @@ class Person < ApplicationRecord
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :scholarships, foreign_key: :recipient_id, dependent: :destroy
+  has_many :grants, as: :donor, dependent: :destroy
   has_many :events, through: :event_registrations
   has_many :categories, through: :categorizable_items
   has_many :sectors, through: :sectorable_items

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -1,9 +1,11 @@
 class Scholarship < ApplicationRecord
   belongs_to :recipient, class_name: "Person"
+  belongs_to :grant, optional: true
   has_one :allocation, as: :source, dependent: :destroy
 
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
   validate :recipient_must_match_allocation_registrant
+  validate :within_grant_budget, if: :grant
 
   after_update :sync_allocation_amount, if: -> { saved_change_to_tasks_completed? || saved_change_to_amount_cents? }
 
@@ -18,6 +20,15 @@ class Scholarship < ApplicationRecord
   end
 
   private
+
+  def within_grant_budget
+    return unless amount_cents
+
+    others_total = grant.scholarships.where.not(id: id).sum(:amount_cents)
+    if others_total + amount_cents > grant.amount_cents
+      errors.add(:amount_cents, "would exceed the grant's available funds")
+    end
+  end
 
   def recipient_must_match_allocation_registrant
     return unless allocation&.allocatable.respond_to?(:registrant)

--- a/app/policies/grant_policy.rb
+++ b/app/policies/grant_policy.rb
@@ -1,0 +1,9 @@
+class GrantPolicy < ApplicationPolicy
+  # Grants are an admin-only resource; all default rules resolve to manage? (admin?).
+
+  relation_scope do |relation|
+    next relation if admin?
+
+    relation.none
+  end
+end

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -1,0 +1,89 @@
+<%= simple_form_for(@grant) do |f| %>
+  <%= f.error_notification %>
+  <%= render "shared/errors", resource: @grant if @grant.errors.any? %>
+
+  <div class="space-y-6">
+    <div>
+      <%= f.input :name,
+                  label: "Grant name",
+                  input_html: { class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+    </div>
+
+    <div>
+      <%= f.label :donor_sgid, "Donor", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag "grant[donor_sgid]",
+                     grouped_options_for_select(@donor_options, @grant.donor_sgid),
+                     include_blank: "Select an organization or person",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+      <p class="mt-1 text-xs text-gray-500">The organization or person donating the funds.</p>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <%= f.label :amount_dollars, "Donation amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <div class="relative">
+          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">$</span>
+          <%= f.number_field :amount_dollars, step: 0.01, value: @grant.amount_dollars,
+                             class: "pl-7 w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+        </div>
+        <p class="mt-1 text-xs text-gray-500">Total scholarship amounts awarded from this grant cannot exceed this.</p>
+      </div>
+      <div>
+        <%= f.input :funds_received_on,
+                    label: "Funds received on",
+                    as: :string,
+                    input_html: {
+                      type: "date",
+                      value: @grant.funds_received_on&.strftime("%Y-%m-%d"),
+                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
+                    } %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.input :application_deadline,
+                  as: :string,
+                  input_html: {
+                    type: "date",
+                    value: @grant.application_deadline&.strftime("%Y-%m-%d"),
+                    class: "w-full sm:w-1/2 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
+                  } %>
+    </div>
+
+    <div>
+      <%= f.input :description,
+                  as: :text,
+                  input_html: { rows: 4, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+    </div>
+
+    <div>
+      <%= f.input :eligibility_criteria,
+                  label: "Eligibility criteria",
+                  hint: "One criterion per line.",
+                  as: :text,
+                  input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+    </div>
+
+    <div>
+      <%= f.input :tasks,
+                  label: "Tasks to complete",
+                  hint: "One task per line.",
+                  as: :text,
+                  input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+    </div>
+  </div>
+
+  <div class="action-buttons mt-8 flex justify-center gap-3">
+    <% if allowed_to?(:destroy?, f.object) %>
+      <% if f.object.scholarships.exists? %>
+        <span class="btn btn-danger-outline opacity-50 cursor-not-allowed"
+              title="Remove its scholarships before deleting this grant">Delete</span>
+      <% else %>
+        <%= link_to "Delete", @grant, class: "btn btn-danger-outline",
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this grant?" } %>
+      <% end %>
+    <% end %>
+    <%= link_to "Cancel", grants_path, class: "btn btn-secondary-outline" %>
+    <%= f.button :submit, class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -1,0 +1,21 @@
+<% grant = grant.decorate %>
+<tr class="hover:bg-gray-50 transition-colors duration-150">
+  <td class="px-4 py-2 text-sm text-gray-900">
+    <%= link_to grant.name, grant_path(grant), class: "font-medium text-blue-700 hover:underline" %>
+  </td>
+  <td class="px-4 py-2 text-sm text-gray-800"><%= grant_donor_badge(grant) %></td>
+  <td class="px-4 py-2 text-sm text-gray-800 text-right"><%= grant.amount %></td>
+  <td class="px-4 py-2 text-sm text-gray-800 text-right"><%= grant.allocated %></td>
+  <td class="px-4 py-2 text-sm text-right <%= grant.fully_allocated? ? "text-red-600 font-medium" : "text-green-700" %>">
+    <%= grant.remaining %>
+  </td>
+  <td class="px-4 py-2 text-sm text-gray-800"><%= grant.application_deadline %></td>
+  <td class="px-4 py-2 text-sm text-center">
+    <div class="flex gap-2 justify-center">
+      <%= link_to "View", grant_path(grant), class: "btn btn-secondary-outline" %>
+      <% if allowed_to?(:edit?, grant.object) %>
+        <%= link_to "Edit", edit_grant_path(grant), class: "btn btn-secondary-outline" %>
+      <% end %>
+    </div>
+  </td>
+</tr>

--- a/app/views/grants/_scholarships.html.erb
+++ b/app/views/grants/_scholarships.html.erb
@@ -1,0 +1,60 @@
+<div class="bg-white rounded-lg shadow p-5">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-lg font-semibold text-gray-900">
+      Scholarships (<%= scholarships.total_entries %>)
+    </h2>
+    <%= link_to new_scholarship_path(grant_id: grant.id, return_to: return_to),
+                class: "inline-flex items-center gap-1.5 text-sm font-medium text-blue-700 hover:text-blue-900" do %>
+      <i class="fa-solid fa-plus text-xs"></i>
+      Add scholarship
+      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
+    <% end %>
+  </div>
+
+  <% if scholarships.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Recipient</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
+            <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Tasks completed</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% scholarships.each do |scholarship| %>
+            <tr class="hover:bg-gray-50">
+              <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900">
+                <%= scholarship.recipient&.full_name || "Unknown recipient" %>
+              </td>
+              <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900 text-right">
+                <%= number_to_currency(scholarship.amount_dollars) %>
+              </td>
+              <td class="px-4 py-2 whitespace-nowrap text-sm text-center">
+                <% if scholarship.tasks_completed? %>
+                  <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-3 py-0.5 bg-green-50 text-green-700 border-green-200">
+                    <i class="fa-solid fa-graduation-cap text-xs"></i>
+                    Yes
+                  </span>
+                <% else %>
+                  <span class="text-gray-400">No</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-2 whitespace-nowrap text-sm text-right">
+                <%= link_to "Edit", edit_scholarship_path(scholarship, return_to: return_to),
+                            class: "text-blue-600 hover:text-blue-800" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <% if scholarships.total_pages > 1 %>
+      <div class="pagination flex justify-center mt-4"><%= tailwind_paginate scholarships %></div>
+    <% end %>
+  <% else %>
+    <p class="text-sm text-gray-500">No scholarships have been awarded from this grant yet.</p>
+  <% end %>
+</div>

--- a/app/views/grants/edit.html.erb
+++ b/app/views/grants/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Grants", grants_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "View", grant_path(@grant), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  </div>
+  <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+    Edit <%= Grant.model_name.human.downcase %>
+  </h1>
+
+  <div class="bg-white rounded p-6">
+    <div class="mt-4">
+      <%= render "form" %>
+      <%= render "shared/audit_info", resource: @grant %>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <%= render "scholarships", grant: @grant, scholarships: @scholarships, return_to: "grant_edit" %>
+  </div>
+</div>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="grants-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="w-full">
+    <div class="flex items-start justify-between mb-6">
+      <div class="pr-6">
+        <h2 class="text-2xl font-semibold mb-2">
+          <%= Grant.model_name.human.pluralize %>
+          (<%= @grants.total_entries %>)
+        </h2>
+        <p class="text-gray-600">Funds donated by organizations and people, from which scholarships are awarded.</p>
+      </div>
+
+      <div class="text-right text-end">
+        <% if allowed_to?(:new?, Grant) %>
+          <%= link_to "New #{Grant.model_name.human.downcase}",
+                      new_grant_path,
+                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @grants.any? %>
+      <div class="overflow-x-auto bg-white rounded-lg shadow-md p-2">
+        <table class="w-full border-collapse">
+          <thead class="bg-gray-100">
+            <tr>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Donor</th>
+              <th class="px-4 py-2 text-right text-sm font-semibold text-gray-700">Amount</th>
+              <th class="px-4 py-2 text-right text-sm font-semibold text-gray-700">Allocated</th>
+              <th class="px-4 py-2 text-right text-sm font-semibold text-gray-700">Remaining</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Deadline</th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <%= render partial: "grant", collection: @grants, as: :grant %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="pagination flex justify-center mt-12"><%= tailwind_paginate @grants %></div>
+    <% else %>
+      <p class="text-gray-500 text-center py-6">No grants found.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/grants/new.html.erb
+++ b/app/views/grants/new.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex items-center justify-between mb-3">
+    <h1 class="text-2xl font-semibold text-gray-900">
+      New <%= Grant.model_name.human.downcase %>
+    </h1>
+  </div>
+
+  <div class="bg-white rounded p-6">
+    <div class="mt-4">
+      <%= render "form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -1,0 +1,89 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% grant = @grant.decorate %>
+
+<div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6 space-y-6">
+  <div class="flex items-start justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
+      <p class="text-gray-600 mt-1"><%= grant_donor_badge(grant) %></p>
+    </div>
+    <div class="flex items-center gap-2">
+      <%= link_to "Grants", grants_path, class: "btn btn-secondary-outline" %>
+      <% if allowed_to?(:edit?, @grant) %>
+        <%= link_to "Edit", edit_grant_path(@grant), class: "btn btn-primary-outline" %>
+      <% end %>
+    </div>
+  </div>
+
+  <!-- Budget summary -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Donation amount</dt>
+        <dd class="mt-1 text-xl font-semibold text-gray-900"><%= grant.amount %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Awarded in scholarships</dt>
+        <dd class="mt-1 text-xl font-semibold text-gray-900"><%= grant.allocated %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Remaining</dt>
+        <dd class="mt-1 text-xl font-semibold <%= grant.fully_allocated? ? "text-red-600" : "text-green-700" %>">
+          <%= grant.remaining %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+
+  <!-- Details -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Application deadline</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= grant.application_deadline %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Funds received on</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= grant.funds_received_on %></dd>
+      </div>
+    </dl>
+
+    <% if @grant.description.present? %>
+      <div class="mt-4">
+        <dt class="text-sm font-medium text-gray-500">Description</dt>
+        <dd class="mt-1 text-sm text-gray-900 whitespace-pre-line"><%= @grant.description %></dd>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- Eligibility criteria -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-2">Eligibility criteria</h2>
+    <% if @grant.eligibility_criteria_list.any? %>
+      <ul class="list-disc pl-5 space-y-1 text-sm text-gray-800">
+        <% @grant.eligibility_criteria_list.each do |criterion| %>
+          <li><%= criterion %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-gray-500">No criteria listed.</p>
+    <% end %>
+  </div>
+
+  <!-- Tasks -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-2">Tasks to complete</h2>
+    <% if @grant.task_list.any? %>
+      <ul class="list-disc pl-5 space-y-1 text-sm text-gray-800">
+        <% @grant.task_list.each do |task| %>
+          <li><%= task %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-gray-500">No tasks listed.</p>
+    <% end %>
+  </div>
+
+  <!-- Scholarships -->
+  <%= render "scholarships", grant: @grant, scholarships: @scholarships, return_to: "grant_show" %>
+</div>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -1,3 +1,5 @@
+<% grant = @grant || f.object.grant %>
+<% grant_funded = @allocatable.blank? && grant.present? %>
 <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
          data-controller="scholarship-preview"
          data-scholarship-preview-event-cost-value="<%= @allocatable.respond_to?(:event) ? @allocatable.event.cost_cents.to_i : 0 %>"
@@ -35,7 +37,31 @@
       </dl>
     <% end %>
 
+    <% if grant_funded %>
+      <% donor_icon = grant.donor.is_a?(Person) ? "fa-user #{DomainTheme.text_class_for(:people)}" : "fa-building #{DomainTheme.text_class_for(:organizations)}" %>
+      <div>
+        <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Funder</dt>
+        <dd class="mt-1 text-sm text-gray-900 flex items-center gap-2">
+          <i class="fa-solid <%= donor_icon %>" aria-hidden="true"></i>
+          <%= link_to grant.funder_name, grant_path(grant), class: "text-blue-700 hover:underline" %>
+        </dd>
+      </div>
+      <%= f.hidden_field :grant_id, value: grant.id %>
+    <% end %>
+
     <div class="flex flex-wrap items-start gap-x-10 gap-y-6">
+      <% if grant_funded %>
+        <div>
+          <%= f.label :recipient_id, "Recipient", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.collection_select :recipient_id,
+                (f.object.recipient.present? ? [ f.object.recipient ] : []),
+                :id, :full_name,
+                { include_blank: "Search for a person…" },
+                { required: true, class: "w-64 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm",
+                  data: { controller: "remote-select", remote_select_model_value: "person" } } %>
+        </div>
+      <% end %>
+
       <div>
         <%= f.label :amount_dollars, "Scholarship amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
         <div class="relative w-48">
@@ -54,14 +80,30 @@
         </label>
       </div>
     </div>
+
+    <% unless grant_funded %>
+      <div>
+        <%= f.label :grant_id, "Funded by grant", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.collection_select :grant_id, @grants || Grant.by_deadline, :id, :name,
+                                { include_blank: "None" },
+                                class: "w-72 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+        <p class="mt-1 text-xs text-gray-500">Optional. Scholarship totals cannot exceed the grant's donation amount.</p>
+      </div>
+    <% end %>
   </div>
 </section>
 
 <%# ---- Footer actions ---- %>
-<% cancel_path = @allocatable.respond_to?(:event) ? manage_event_path(@allocatable.event) : scholarships_path %>
+<% cancel_path = if grant_funded
+     params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)
+   elsif @allocatable.respond_to?(:event)
+     manage_event_path(@allocatable.event)
+   else
+     root_path
+   end %>
 <div class="flex items-center gap-3 border-t border-gray-200 pt-6">
   <% if f.object.persisted? %>
-    <%= link_to scholarship_path(f.object),
+    <%= link_to scholarship_path(f.object, return_to: params[:return_to].presence),
                 class: "btn btn-danger-outline",
                 data: { turbo_method: :delete, turbo_confirm: "Remove this scholarship?" } do %>
       <i class="fa-solid fa-trash-can"></i>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -1,9 +1,16 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% grant = @scholarship.grant %>
+<% grant_funded = @allocatable.blank? && grant.present? %>
+<% theme = grant_funded ? :grants : :scholarships %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:scholarships) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <% if @allocatable.respond_to?(:event) %>
+    <% if grant_funded %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Grant
+      <% end %>
+    <% elsif @allocatable.respond_to?(:event) %>
       <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
@@ -25,7 +32,7 @@
              event: (@allocatable.event if @allocatable.respond_to?(:event)),
              person: @scholarship.recipient %>
 
-  <%= form_with model: @scholarship, class: "space-y-6" do |f| %>
+  <%= form_with model: @scholarship, url: scholarship_path(@scholarship, return_to: params[:return_to].presence), class: "space-y-6" do |f| %>
     <%= render "form", f: f %>
   <% end %>
 

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -1,9 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% theme = @grant ? :grants : :scholarships %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:scholarships) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <% if @allocatable.respond_to?(:event) %>
+    <% if @grant %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Grant
+      <% end %>
+    <% elsif @allocatable.respond_to?(:event) %>
       <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
@@ -24,7 +29,8 @@
              event: (@allocatable.event if @allocatable.respond_to?(:event)),
              person: @scholarship.recipient %>
 
-  <%= form_with model: @scholarship, url: scholarships_path(allocatable_sgid: @allocatable.to_sgid.to_s), class: "space-y-6" do |f| %>
+  <% form_url = @grant ? scholarships_path(grant_id: @grant.id, return_to: params[:return_to]) : scholarships_path(allocatable_sgid: @allocatable.to_sgid.to_s) %>
+  <%= form_with model: @scholarship, url: form_url, class: "space-y-6" do |f| %>
     <%= render "form", f: f %>
   <% end %>
 </div>

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -18,6 +18,12 @@
       <dt class="text-sm font-medium text-gray-500">Tasks Completed</dt>
       <dd class="mt-1 text-sm text-gray-900"><%= @scholarship.tasks_completed? ? "Yes" : "No" %></dd>
     </div>
+    <% if @scholarship.grant.present? %>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Grant</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= link_to @scholarship.grant.name, grant_path(@scholarship.grant), class: "text-blue-700 hover:underline" %></dd>
+      </div>
+    <% end %>
     <% if @allocatable&.respond_to?(:event) %>
       <div>
         <dt class="text-sm font-medium text-gray-500">Event</dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
       patch :update_sections
     end
   end
+  resources :grants
   resources :scholarships, only: [ :new, :create, :show, :edit, :update, :destroy ]
   resources :discounts, only: [ :create, :show, :destroy ] do
     collection do

--- a/db/migrate/20260608120000_create_grants.rb
+++ b/db/migrate/20260608120000_create_grants.rb
@@ -1,0 +1,25 @@
+class CreateGrants < ActiveRecord::Migration[8.1]
+  def up
+    create_table :grants do |t|
+      t.string :name, null: false
+      t.text :description
+      t.integer :amount_cents, null: false, default: 0
+      t.references :donor, polymorphic: true, null: false
+      t.date :application_deadline
+      t.date :funds_received_on
+      t.text :eligibility_criteria
+      t.text :tasks
+      t.bigint :created_by_id
+      t.bigint :updated_by_id
+
+      t.timestamps
+    end
+
+    add_index :grants, :created_by_id
+    add_index :grants, :updated_by_id
+  end
+
+  def down
+    drop_table :grants, if_exists: true
+  end
+end

--- a/db/migrate/20260608120100_add_grant_to_scholarships.rb
+++ b/db/migrate/20260608120100_add_grant_to_scholarships.rb
@@ -1,0 +1,10 @@
+class AddGrantToScholarships < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :scholarships, :grant, null: true, foreign_key: true unless column_exists?(:scholarships, :grant_id)
+  end
+
+  def down
+    remove_foreign_key :scholarships, :grants if foreign_key_exists?(:scholarships, :grants)
+    remove_reference :scholarships, :grant if column_exists?(:scholarships, :grant_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_120100) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -593,6 +593,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_210000) do
     t.index ["form_builder_id"], name: "index_forms_on_form_builder_id"
   end
 
+  create_table "grants", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "amount_cents", default: 0, null: false
+    t.date "application_deadline"
+    t.datetime "created_at", null: false
+    t.bigint "created_by_id"
+    t.text "description"
+    t.bigint "donor_id", null: false
+    t.string "donor_type", null: false
+    t.text "eligibility_criteria"
+    t.date "funds_received_on"
+    t.string "name", null: false
+    t.text "tasks"
+    t.datetime "updated_at", null: false
+    t.bigint "updated_by_id"
+    t.index ["created_by_id"], name: "index_grants_on_created_by_id"
+    t.index ["donor_type", "donor_id"], name: "index_grants_on_donor"
+    t.index ["updated_by_id"], name: "index_grants_on_updated_by_id"
+  end
+
   create_table "images", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "file_content_type"
@@ -1016,9 +1035,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_210000) do
   create_table "scholarships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false
+    t.bigint "grant_id"
     t.bigint "recipient_id", null: false
     t.boolean "tasks_completed", default: false, null: false
     t.datetime "updated_at", null: false
+    t.index ["grant_id"], name: "index_scholarships_on_grant_id"
     t.index ["recipient_id"], name: "index_scholarships_on_recipient_id"
   end
 
@@ -1552,6 +1573,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_210000) do
   add_foreign_key "resources", "users", column: "created_by_id"
   add_foreign_key "resources", "windows_types"
   add_foreign_key "resources", "workshops"
+  add_foreign_key "scholarships", "grants"
   add_foreign_key "scholarships", "people", column: "recipient_id"
   add_foreign_key "sectorable_items", "sectors"
   add_foreign_key "stories", "organizations"

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -12,6 +12,7 @@ module DomainTheme
     people:                   :sky,
     organizations:            :emerald,
     quotes:                   :slate,
+    grants:                   :green,
 
     tags:                     :lime,
     sectors:                  :lime,

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe GrantDecorator, type: :decorator do
+  describe "money formatting" do
+    let(:grant) { create(:grant, amount_cents: 100_000).decorate }
+
+    it "formats the donation amount" do
+      expect(grant.amount).to eq("$1,000.00")
+    end
+
+    it "formats the remaining balance" do
+      create(:scholarship, grant: grant.object, amount_cents: 40_000)
+      expect(grant.remaining).to eq("$600.00")
+    end
+  end
+
+  describe "#fully_allocated?" do
+    let(:grant) { create(:grant, amount_cents: 50_000) }
+
+    it "is true once scholarships consume the full amount" do
+      create(:scholarship, grant:, amount_cents: 50_000)
+      expect(grant.decorate).to be_fully_allocated
+    end
+
+    it "is false while funds remain" do
+      expect(grant.decorate).not_to be_fully_allocated
+    end
+  end
+end

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :grant do
+    name { "Healing Arts Scholarship Fund" }
+    amount_cents { 500_000 }
+    association :donor, factory: :organization
+    application_deadline { Date.current + 30 }
+    funds_received_on { Date.current - 7 }
+    eligibility_criteria { "Must be a current facilitator\nMust serve a partner organization" }
+    tasks { "Submit application form\nComplete intake interview" }
+
+    trait :donated_by_person do
+      association :donor, factory: :person
+    end
+  end
+end

--- a/spec/helpers/grant_helper_spec.rb
+++ b/spec/helpers/grant_helper_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe GrantHelper, type: :helper do
+  describe "#grant_donor_badge" do
+    it "renders a person donor with the people-colored person icon and name" do
+      person = create(:person, first_name: "Bob", last_name: "Barker")
+      grant = create(:grant, donor: person)
+
+      badge = helper.grant_donor_badge(grant)
+
+      expect(badge).to include("fa-user")
+      expect(badge).to include(DomainTheme.text_class_for(:people))
+      expect(badge).to include("Bob Barker")
+      expect(badge).not_to include("Person:")
+    end
+
+    it "renders an organization donor with the organizations-colored building icon and name" do
+      organization = create(:organization, name: "Helping Hands")
+      grant = create(:grant, donor: organization)
+
+      badge = helper.grant_donor_badge(grant)
+
+      expect(badge).to include("fa-building")
+      expect(badge).to include(DomainTheme.text_class_for(:organizations))
+      expect(badge).to include("Helping Hands")
+      expect(badge).not_to include("Organization:")
+    end
+  end
+end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Grant, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:donor) }
+    it { is_expected.to belong_to(:created_by).class_name("User").optional }
+    it { is_expected.to belong_to(:updated_by).class_name("User").optional }
+    it { is_expected.to have_many(:scholarships).dependent(:restrict_with_error) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
+
+    it "is valid with an organization donor" do
+      expect(build(:grant)).to be_valid
+    end
+
+    it "is valid with a person donor" do
+      expect(build(:grant, :donated_by_person)).to be_valid
+    end
+  end
+
+  describe "money accessors" do
+    it "exposes the amount in dollars" do
+      expect(build(:grant, amount_cents: 250_000).amount_dollars).to eq(2_500)
+    end
+
+    it "stores dollars as cents" do
+      grant = build(:grant)
+      grant.amount_dollars = "1234.56"
+      expect(grant.amount_cents).to eq(123_456)
+    end
+  end
+
+  describe "#donor_sgid" do
+    it "round-trips a donor through a signed global id" do
+      organization = create(:organization)
+      grant = build(:grant)
+      grant.donor_sgid = organization.to_signed_global_id.to_s
+      expect(grant.donor).to eq(organization)
+      expect(GlobalID::Locator.locate_signed(grant.donor_sgid)).to eq(organization)
+    end
+  end
+
+  describe "list accessors" do
+    let(:grant) { build(:grant, eligibility_criteria: "One\n\n  Two  \n", tasks: "A\nB") }
+
+    it "splits eligibility criteria into a trimmed list" do
+      expect(grant.eligibility_criteria_list).to eq([ "One", "Two" ])
+    end
+
+    it "splits tasks into a list" do
+      expect(grant.task_list).to eq([ "A", "B" ])
+    end
+  end
+
+  describe "budget helpers" do
+    let(:grant) { create(:grant, amount_cents: 100_000) }
+
+    it "sums awarded scholarships" do
+      create(:scholarship, grant:, amount_cents: 30_000)
+      create(:scholarship, grant:, amount_cents: 20_000)
+      expect(grant.scholarships_total_cents).to eq(50_000)
+    end
+
+    it "reports remaining funds" do
+      create(:scholarship, grant:, amount_cents: 40_000)
+      expect(grant.remaining_cents).to eq(60_000)
+      expect(grant.remaining_dollars).to eq(600)
+    end
+  end
+end

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Scholarship, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:recipient).class_name("Person") }
+    it { is_expected.to belong_to(:grant).optional }
     it { is_expected.to have_one(:allocation).dependent(:destroy) }
   end
 
@@ -26,6 +27,30 @@ RSpec.describe Scholarship, type: :model do
         scholarship.build_allocation(allocatable: registration, amount: 0)
         expect(scholarship).not_to be_valid
         expect(scholarship.errors[:recipient]).to include("must be the same person as the event registration's registrant")
+      end
+    end
+
+    describe "within_grant_budget" do
+      let(:grant) { create(:grant, amount_cents: 100_000) }
+
+      it "is valid when the amount stays within the grant's funds" do
+        expect(build(:scholarship, grant:, amount_cents: 60_000)).to be_valid
+      end
+
+      it "is invalid when the amount exceeds the grant's funds" do
+        scholarship = build(:scholarship, grant:, amount_cents: 150_000)
+        expect(scholarship).not_to be_valid
+        expect(scholarship.errors[:amount_cents]).to include("would exceed the grant's available funds")
+      end
+
+      it "accounts for other scholarships already drawn from the grant" do
+        create(:scholarship, grant:, amount_cents: 70_000)
+        scholarship = build(:scholarship, grant:, amount_cents: 40_000)
+        expect(scholarship).not_to be_valid
+      end
+
+      it "is not constrained when no grant is set" do
+        expect(build(:scholarship, grant: nil, amount_cents: 9_999_999)).to be_valid
       end
     end
   end

--- a/spec/policies/grant_policy_spec.rb
+++ b/spec/policies/grant_policy_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe GrantPolicy, type: :policy do
+  let(:admin_user) { build_stubbed :user, :admin }
+  let(:regular_user) { build_stubbed :user }
+  let(:grant) { build_stubbed :grant }
+
+  def policy_for(record: grant, user:)
+    described_class.new(record, user: user)
+  end
+
+  %i[index? show? new? create? edit? update? destroy?].each do |rule|
+    describe "##{rule}" do
+      context "with admin user" do
+        subject { policy_for(user: admin_user) }
+
+        it { is_expected.to be_allowed_to(rule) }
+      end
+
+      context "with regular user" do
+        subject { policy_for(user: regular_user) }
+
+        it { is_expected.not_to be_allowed_to(rule) }
+      end
+    end
+  end
+
+  describe "relation_scope" do
+    let!(:existing_grant) { create(:grant) }
+
+    it "returns all grants for admins" do
+      policy = policy_for(user: create(:user, :admin))
+      scope = policy.apply_scope(Grant.all, type: :active_record_relation)
+      expect(scope).to contain_exactly(existing_grant)
+    end
+
+    it "returns no grants for regular users" do
+      policy = policy_for(user: create(:user))
+      scope = policy.apply_scope(Grant.all, type: :active_record_relation)
+      expect(scope).to be_empty
+    end
+  end
+end

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "/grants", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:organization) { create(:organization) }
+
+  let(:valid_attributes) do
+    {
+      name: "Healing Arts Grant",
+      amount_dollars: "5000",
+      donor_sgid: organization.to_signed_global_id.to_s,
+      application_deadline: "2026-12-31",
+      eligibility_criteria: "Must be a facilitator",
+      tasks: "Submit application"
+    }
+  end
+
+  let(:invalid_attributes) do
+    { name: "", amount_dollars: "1000", donor_sgid: "" }
+  end
+
+  describe "authorization" do
+    it "redirects non-admins away from the index" do
+      sign_in create(:user)
+      get grants_url
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "as an admin" do
+    before { sign_in admin }
+
+    describe "GET /index" do
+      it "renders a successful response" do
+        create(:grant)
+        get grants_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /show" do
+      it "renders a successful response" do
+        get grant_url(create(:grant))
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_grant_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /edit" do
+      it "renders a successful response" do
+        get edit_grant_url(create(:grant))
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new Grant attributed to the current user" do
+          expect {
+            post grants_url, params: { grant: valid_attributes }
+          }.to change(Grant, :count).by(1)
+
+          grant = Grant.last
+          expect(grant.donor).to eq(organization)
+          expect(grant.amount_cents).to eq(500_000)
+          expect(grant.created_by).to eq(admin)
+        end
+
+        it "redirects to the created grant" do
+          post grants_url, params: { grant: valid_attributes }
+          expect(response).to redirect_to(grant_url(Grant.last))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "does not create a new Grant" do
+          expect {
+            post grants_url, params: { grant: invalid_attributes }
+          }.not_to change(Grant, :count)
+        end
+
+        it "renders a 422 response" do
+          post grants_url, params: { grant: invalid_attributes }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+    end
+
+    describe "PATCH /update" do
+      it "updates the requested grant" do
+        grant = create(:grant)
+        patch grant_url(grant), params: { grant: valid_attributes.merge(name: "Renamed Grant") }
+        expect(grant.reload.name).to eq("Renamed Grant")
+        expect(response).to redirect_to(grant_url(grant))
+      end
+
+      it "renders a 422 response with invalid parameters" do
+        grant = create(:grant)
+        patch grant_url(grant), params: { grant: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "DELETE /destroy" do
+      it "destroys the requested grant" do
+        grant = create(:grant)
+        expect {
+          delete grant_url(grant)
+        }.to change(Grant, :count).by(-1)
+        expect(response).to redirect_to(grants_url)
+      end
+
+      it "refuses to destroy a grant that has associated scholarships" do
+        grant = create(:grant)
+        create(:scholarship, grant:, amount_cents: 1_000)
+
+        expect {
+          delete grant_url(grant)
+        }.not_to change(Grant, :count)
+        expect(response).to redirect_to(grant_url(grant))
+        expect(flash[:alert]).to include("associated scholarships")
+      end
+    end
+  end
+end

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -70,3 +70,72 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 end
+
+RSpec.describe "/scholarships (grant-funded flow)", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:donor) { create(:organization, name: "Helping Hands") }
+  let(:grant) { create(:grant, donor:, amount_cents: 100_000) }
+  let(:recipient) { create(:person, first_name: "Bob", last_name: "Barker") }
+
+  before { sign_in admin }
+
+  describe "GET /scholarships/new?grant_id=" do
+    it "renders the grant-funded form showing the funder" do
+      get new_scholarship_path(grant_id: grant.id, return_to: "grant_show")
+      expect(response).to be_successful
+      expect(response.body).to include("Funder")
+      expect(response.body).to include("Helping Hands")
+    end
+  end
+
+  describe "POST /scholarships?grant_id=" do
+    let(:valid_params) do
+      { scholarship: { recipient_id: recipient.id, amount_dollars: "250" } }
+    end
+
+    it "creates a grant-funded scholarship and returns to the grant show page" do
+      expect {
+        post scholarships_path(grant_id: grant.id, return_to: "grant_show"), params: valid_params
+      }.to change(Scholarship, :count).by(1)
+
+      scholarship = Scholarship.last
+      expect(scholarship.grant).to eq(grant)
+      expect(scholarship.recipient).to eq(recipient)
+      expect(scholarship.amount_cents).to eq(25_000)
+      expect(response).to redirect_to(grant_path(grant))
+    end
+
+    it "returns to the grant edit page when launched from there" do
+      post scholarships_path(grant_id: grant.id, return_to: "grant_edit"), params: valid_params
+      expect(response).to redirect_to(edit_grant_path(grant))
+    end
+
+    it "rejects an amount that exceeds the grant's available funds" do
+      expect {
+        post scholarships_path(grant_id: grant.id, return_to: "grant_show"),
+             params: { scholarship: { recipient_id: recipient.id, amount_dollars: "1500" } }
+      }.not_to change(Scholarship, :count)
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PATCH /scholarships/:id with grant return context" do
+    let(:scholarship) { create(:scholarship, grant:, recipient:, amount_cents: 10_000) }
+
+    it "updates and returns to the grant show page" do
+      patch scholarship_path(scholarship, return_to: "grant_show"),
+            params: { scholarship: { amount_dollars: "300" } }
+      expect(scholarship.reload.amount_cents).to eq(30_000)
+      expect(response).to redirect_to(grant_path(grant))
+    end
+  end
+
+  describe "grant pages list associated scholarships" do
+    it "shows the scholarship on the grant show page" do
+      create(:scholarship, grant:, recipient:, amount_cents: 10_000)
+      get grant_path(grant)
+      expect(response.body).to include("Bob Barker")
+      expect(response.body).to include("Add scholarship")
+    end
+  end
+end

--- a/spec/routing/grants_routing_spec.rb
+++ b/spec/routing/grants_routing_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe GrantsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/grants").to route_to("grants#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/grants/new").to route_to("grants#new")
+    end
+
+    it "routes to #show" do
+      expect(get: "/grants/1").to route_to("grants#show", id: "1")
+    end
+
+    it "routes to #edit" do
+      expect(get: "/grants/1/edit").to route_to("grants#edit", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/grants").to route_to("grants#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(put: "/grants/1").to route_to("grants#update", id: "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/grants/1").to route_to("grants#update", id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/grants/1").to route_to("grants#destroy", id: "1")
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/windows_types/index.html.erb"           => "admin-only bg-blue-100",
     "app/views/workshop_ideas/index.html.erb"          => "admin-only bg-blue-100",
     "app/views/workshop_variation_ideas/index.html.erb" => "admin-only bg-blue-100",
+    "app/views/grants/index.html.erb"                  => "admin-only bg-blue-100",
     # show
     "app/views/banners/show.html.erb"                  => "admin-only bg-blue-100",
     "app/views/categories/show.html.erb"               => "admin-only bg-blue-100",
@@ -128,6 +129,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/users/show.html.erb"                    => "admin-only bg-blue-100",
     "app/views/windows_types/show.html.erb"            => "admin-only bg-blue-100",
     "app/views/bookmarks/show.html.erb"               => "admin-only bg-blue-100",
+    "app/views/grants/show.html.erb"                   => "admin-only bg-blue-100",
     # new
     "app/views/banners/new.html.erb"                   => "admin-only bg-blue-100",
     "app/views/categories/new.html.erb"                => "admin-only bg-blue-100",
@@ -148,6 +150,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/windows_types/new.html.erb"             => "admin-only bg-blue-100",
     "app/views/scholarships/new.html.erb"              => "admin-only bg-blue-100",
     "app/views/scholarships/show.html.erb"             => "admin-only bg-blue-100",
+    "app/views/grants/new.html.erb"                    => "admin-only bg-blue-100",
     "app/views/refunds/show.html.erb"                  => "admin-only bg-blue-100",
     "app/views/discounts/show.html.erb"                => "admin-only bg-blue-100",
     "app/views/workshop_variations/new.html.erb"       => "admin-only bg-blue-100",
@@ -172,6 +175,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/workshop_ideas/edit.html.erb"           => "admin-only bg-blue-100",
     "app/views/workshop_variation_ideas/edit.html.erb" => "admin-only bg-blue-100",
     "app/views/scholarships/edit.html.erb"             => "admin-only bg-blue-100",
+    "app/views/grants/edit.html.erb"                   => "admin-only bg-blue-100",
     "app/views/workshop_variations/edit.html.erb"      => "admin-only bg-blue-100",
     "app/views/workshops/edit.html.erb"                => "admin-only bg-blue-100",
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

Introduces a **Grant** model — money donated by an Organization or Person — as the parent of **Scholarships**, so program staff can track a funding source's eligibility criteria, required tasks, deadlines, and remaining budget, and award scholarships against it without overspending.

### How did you approach the change?

**Grant model & CRUD**
- New `Grant` with a polymorphic `donor` (Organization or Person), `amount_cents`, `application_deadline`, `funds_received_on`, and newline-separated `eligibility_criteria` / `tasks` lists.
- Full admin-only CRUD (`GrantsController`, `GrantPolicy`, `GrantDecorator`), its own `grants` domain theme color, and an index/show/new/edit set of views.

**Grant → Scholarship relationship**
- `Scholarship` gains an optional `grant`; a validation rejects any scholarship whose amount would push the grant's awarded total past its donation amount.
- Grant **show and edit** pages list their scholarships (server-paginated, mirroring the allocations list) with an **"Add scholarship"** jump-link.
- Scholarships can now be created **directly from a grant** (no event registration): the recipient is chosen via person search, and on save you're returned to the grant page you came from (show or edit).

**Funder display**
- When a scholarship is grant-funded, the form shows the funder as a themed icon + name — a person icon in the people color, or a building icon in the organizations color (no `Person:`/`Organization:` label).

**Safety**
- A grant with associated scholarships **cannot be deleted** (`restrict_with_error`); the Delete button is disabled with a tooltip and the controller handles the blocked deletion gracefully.

### UI Testing Checklist
- [ ] Grants index / show / new / edit render and CRUD works
- [ ] Add a scholarship from a grant's show and edit pages; confirm it returns to the right page after save
- [ ] Funder shows the correct themed icon + name for person vs organization donors
- [ ] Awarding more than the grant's remaining funds is rejected
- [ ] A grant with scholarships cannot be deleted
- [ ] _Screenshots to be added_ (UI changes; not capturable in this headless run)

### Anything else to add?
- Grant-funded scholarships are standalone (recipient chosen directly), while the existing event-registration scholarship flow is unchanged.
- Eligibility criteria and tasks are modeled as newline-separated text rather than child records — happy to promote them to first-class records if preferred.
- Rebased on top of the registration-suite (#1591); ~235 specs pass and RuboCop is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)