### PR TITLE
Add optional topic field to comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (50) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (51) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -263,6 +263,7 @@ end
 - `collection` — Filter form auto-submit with debounce
 - `column_toggle` — Toggle table column visibility
 - `comment_edit_toggle` — Inline comment editing mode
+- `comment_required` — Require a comment body once a topic or body is filled in
 - `confirm_email` — Email confirmation UI
 - `dirty_form` — Unsaved changes detection
 - `dismiss` — Dismissable elements

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -50,6 +50,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:body)
+    params.require(:comment).permit(:topic, :body)
   end
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -222,7 +222,7 @@ class EventRegistrationsController < ApplicationController
       :scholarship_requested,
       :ce_credit_requested,
       organization_ids: [],
-      comments_attributes: [ :id, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :_destroy ],
       notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]
     )
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -227,7 +227,7 @@ class OrganizationsController < ApplicationController
         :end_date,
         :_destroy
       ],
-      comments_attributes: [ :id, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :_destroy ],
       addresses_attributes: [
         :id,
         :address_type,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -454,7 +454,7 @@ class PeopleController < ApplicationController
         :end_date,
         :_destroy
       ],
-      comments_attributes: [ :id, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :_destroy ],
     )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -422,7 +422,7 @@ class UsersController < ApplicationController
       :phone, :phone2, :phone3, :birthday, :best_time_to_call, :notes, # legacy to remove later
       #####
 
-      comments_attributes: [ :id, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :_destroy ],
       affiliations_attributes: [ :id, :organization_id, :position, :title, :inactive, :primary_contact, :start_date, :end_date, :_destroy ],
     )
   end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -292,7 +292,7 @@ class WorkshopsController < ApplicationController
       workshop_series_children_attributes: [ :id, :workshop_child_id, :workshop_parent_id, :theme_name,
                                             :series_description, :series_description_spanish,
                                             :position, :_destroy ],
-      comments_attributes: [ :id, :body, :_destroy ]
+      comments_attributes: [ :id, :topic, :body, :_destroy ]
     )
   end
 end

--- a/app/frontend/javascript/controllers/comment_required_controller.js
+++ b/app/frontend/javascript/controllers/comment_required_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="comment-required"
+//
+// Makes the comment body required only once the row is in use (the topic or the
+// body has any content). An untouched, cocoon-added row stays optional so the
+// parent form can still submit — reject_if drops empty rows server-side — while
+// a filled-in topic can't be saved without an accompanying comment.
+//
+export default class extends Controller {
+  static targets = ["topic", "body"];
+
+  connect() {
+    this.update();
+  }
+
+  update() {
+    const inUse =
+      (this.hasTopicTarget && this.topicTarget.value.trim() !== "") ||
+      this.bodyTarget.value.trim() !== "";
+    this.bodyTarget.required = inUse;
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -39,6 +39,9 @@ application.register("column-toggle", ColumnToggleController)
 import CommentEditToggleController from "./comment_edit_toggle_controller"
 application.register("comment-edit-toggle", CommentEditToggleController)
 
+import CommentRequiredController from "./comment_required_controller"
+application.register("comment-required", CommentRequiredController)
+
 import DirtyFormController from "./dirty_form_controller"
 application.register("dirty-form", DirtyFormController)
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,10 @@ class Comment < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
 
-  validates :body, presence: true
+  # Required for new comments only — existing comments (some legacy ones may have
+  # blank bodies) must stay savable, so this is intentionally not a blanket
+  # validation. The UI enforces it client-side via the comment-required controller.
+  validates :body, presence: true, unless: :persisted?
 
   scope :newest_first, -> { order(created_at: :desc) }
 end

--- a/app/views/comments/_comment_fields.html.erb
+++ b/app/views/comments/_comment_fields.html.erb
@@ -45,9 +45,9 @@
           <span class="<%= created_color[0] %> <%= created_color[1] %> text-xs px-1.5 py-0.5 rounded cursor-default truncate w-full text-left" title="<%= created_name %>"><%= truncate(created_first_name.presence || "--", length: 10, omission: "..") %></span>
         <% end %>
       </span>
-      <span class="text-sm <%= is_age_range_data ? "text-amber-700" : "text-gray-900" %> comment-body truncate" title="<%= f.object.body %>">
+      <span class="text-sm <%= is_age_range_data ? "text-amber-700" : "text-gray-900" %> comment-body truncate" title="<%= [ f.object.topic, f.object.body ].compact_blank.join(" — ") %>">
         <% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i><% end %>
-        <%= truncate(f.object.body, length: 135) %>
+        <% if f.object.topic.present? %><span class="font-bold uppercase tracking-wide"><%= f.object.topic %></span> <% end %><%= truncate(f.object.body, length: 135) %>
       </span>
     </div>
     <div class="comment-edit flex items-start mb-1 pl-4 gap-x-1 <%= "bg-amber-50 border border-amber-200 rounded-md py-1" if is_age_range_data %>" style="display:none">
@@ -62,11 +62,22 @@
           <span class="<%= created_color[0] %> <%= created_color[1] %> text-xs px-1.5 py-0.5 rounded cursor-default truncate w-full text-left" title="<%= created_name %>"><%= truncate(created_first_name.presence || "--", length: 10, omission: "..") %></span>
         <% end %>
       </span>
-      <div class="grow">
-        <%= f.input :body,
-                    label: false,
-                    as: :text,
-                    input_html: { rows: 1, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 text-sm" } %>
+      <div class="grow flex items-start gap-x-2"
+           data-controller="comment-required"
+           data-action="input->comment-required#update">
+        <div class="w-1/3 shrink-0">
+          <%= f.input_field :topic,
+                            placeholder: "Topic",
+                            data: { comment_required_target: "topic" },
+                            class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+          <p class="text-gray-500 text-xs mt-1">Reason you're making a note</p>
+        </div>
+        <%= f.input_field :body,
+                          as: :text,
+                          rows: 1,
+                          required: false,
+                          data: { comment_required_target: "body" },
+                          class: "grow bg-white rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
       </div>
       <%= link_to_remove_association "Remove", f,
             class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap mt-2 shrink-0" %>
@@ -81,12 +92,23 @@
       <span class="inline-flex items-center w-20 shrink-0 mt-2">
         <span class="<%= current_color[0] %> <%= current_color[1] %> text-xs px-1.5 py-0.5 rounded cursor-default truncate w-full text-left" title="<%= current_user&.person&.name || current_user&.name %>"><%= truncate(current_first_name.to_s, length: 10, omission: "..") %></span>
       </span>
-      <div class="grow">
-        <%= f.input :body,
-                    label: false,
-                    as: :text,
-                    placeholder: "Add a comment...",
-                    input_html: { rows: 2, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200" } %>
+      <div class="grow flex items-start gap-x-2"
+           data-controller="comment-required"
+           data-action="input->comment-required#update">
+        <div class="w-1/3 shrink-0">
+          <%= f.input_field :topic,
+                            placeholder: "Topic",
+                            data: { comment_required_target: "topic" },
+                            class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+          <p class="text-gray-500 text-xs mt-1">Reason you're making a note</p>
+        </div>
+        <%= f.input_field :body,
+                          as: :text,
+                          rows: 2,
+                          required: false,
+                          placeholder: "Type your comment",
+                          data: { comment_required_target: "body" },
+                          class: "grow bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
       </div>
     </div>
   <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,18 @@
 <%= simple_form_for @comment || commentable.comments.build, url: polymorphic_path([commentable, :comments]), html: { class: "mb-4" } do |f| %>
-  <%= f.input :body,
-              label: false,
-              as: :text,
-              placeholder: "Add a comment...",
-              input_html: { rows: 2, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200" } %>
+  <div class="flex items-start gap-x-2 mb-4">
+    <div class="w-1/3 shrink-0">
+      <%= f.input_field :topic,
+                        placeholder: "Topic",
+                        class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      <p class="text-gray-500 text-xs mt-1">Reason you're making a note</p>
+    </div>
+    <%= f.input_field :body,
+                      as: :text,
+                      rows: 2,
+                      required: true,
+                      placeholder: "Type your comment",
+                      class: "grow bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+  </div>
 
   <%= f.submit "Add Comment", class: "btn btn-secondary-outline" %>
 <% end %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -7,6 +7,9 @@
             <%= comment.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
           </span>
           <div class="text-sm text-gray-900">
+            <% if comment.topic.present? %>
+              <div class="font-bold uppercase tracking-wide"><%= comment.topic %></div>
+            <% end %>
             <%= simple_format(comment.body) %>
           </div>
         </div>

--- a/db/migrate/20260608130000_add_topic_to_comments.rb
+++ b/db/migrate/20260608130000_add_topic_to_comments.rb
@@ -1,0 +1,5 @@
+class AddTopicToComments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :comments, :topic, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_130000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -369,6 +369,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_120100) do
     t.string "commentable_type", null: false
     t.datetime "created_at", null: false
     t.integer "created_by_id"
+    t.string "topic"
     t.datetime "updated_at", null: false
     t.integer "updated_by_id"
     t.index ["commentable_type", "commentable_id", "created_at"], name: "idx_on_commentable_type_commentable_id_created_at_89c6e27600"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :comment do
+    topic { "Test topic" }
     body { "This is a test comment" }
 
     # Polymorphic association: belongs_to :commentable

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe Comment, type: :model do
       comment = build(:comment, commentable: user, body: nil)
       expect(comment).not_to be_valid
     end
+
+    it 'allows an existing comment to be saved without a body (body is only required on new records)' do
+      user = create(:user)
+      comment = create(:comment, commentable: user, body: "Test comment")
+      comment.body = nil
+      expect(comment).to be_valid
+    end
   end
 
   describe 'polymorphic association' do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Comments", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+
+  before { sign_in admin }
+
+  describe "POST /people/:person_id/comments" do
+    it "creates a comment with a topic and body" do
+      expect {
+        post person_comments_path(person), params: { comment: { topic: "Follow up", body: "Called the family." } }
+      }.to change(person.comments, :count).by(1)
+
+      comment = person.comments.last
+      expect(comment.topic).to eq("Follow up")
+      expect(comment.body).to eq("Called the family.")
+    end
+  end
+
+  describe "GET /people/:person_id/comments" do
+    it "renders the topic in bold followed by the body" do
+      create(:comment, commentable: person, topic: "Follow up", body: "Called the family.")
+
+      get person_comments_path(person)
+
+      expect(response.body).to include('<div class="font-bold uppercase tracking-wide">Follow up</div>')
+      expect(response.body).to include("Called the family.")
+    end
+  end
+end

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Event registration edit page", type: :system do
         click_on "Add comment"
       end
 
-      expect(page).to have_field("Add a comment...")
+      expect(page).to have_field("Type your comment")
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Comments act as freeform notes across people, organizations, users, workshops, and event registrations — but a long list of bodies is hard to scan.
- Adds an optional **topic** to each comment so notes get a short, bold, scannable heading (e.g. "Follow up", "Scholarship") without forcing structure onto existing notes.

### How did you approach the change?

- Migration adds a nullable `topic:string` column to `comments`.
- Topic is **optional**; body presence is enforced only on new records (`unless: :persisted?`) so legacy/blank-body comments stay savable.
- New `comment-required` Stimulus controller makes the body `required` client-side once a nested comment row is in use (topic or body filled in), so empty cocoon rows still submit while a filled-in topic can't be saved without a comment.
- `topic` permitted in every controller that nests `comments_attributes` (people, organizations, users, workshops, event registrations) and in the standalone comments controller.
- Inline edit/add fields and the standalone form now show a topic input (with "Reason you're making a note" hint); the comment list and inline display render the topic in bold above the body.

### Anything else to add?

- Model spec covers the new "body required on create only" rule; request spec covers creating a comment with a topic and rendering the topic heading.
- AGENTS.md updated for the new Stimulus controller (count 36 → 37).
