### PR TITLE
Add form/payment quick links and form usage navigation to event dashboard

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -49,6 +49,7 @@ class Event < ApplicationRecord
   scope :featured, -> { registerable.where(published: true, featured: true) } # overrides Publishable
   scope :publicly_featured, -> { where(published: true, publicly_visible: true, publicly_featured: true) } # overrides Featureable
   scope :registerable, -> { where("registration_close_date IS NULL OR registration_close_date >= ?", Time.current) }
+  scope :using_form, ->(form_id) { joins(:event_forms).where(event_forms: { form_id: form_id }).distinct }
 
   def self.search_by_params(params)
     stories = is_a?(ActiveRecord::Relation) ? self : all
@@ -56,6 +57,7 @@ class Event < ApplicationRecord
     stories = stories.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     stories = stories.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
     stories = stories.windows_type_name(params[:windows_type_name]) if params[:windows_type_name].present?
+    stories = stories.using_form(params[:form_id]) if params[:form_id].present?
     stories
   end
 

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -20,9 +20,15 @@
         <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>
-      <%= link_to "Change base form", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
+      <%= link_to "Change form settings", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% else %>
       <%= link_to "Enable forms", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
+    <div class="my-1 border-t border-gray-100"></div>
+    <%# Bulk payment is a placeholder until that feature is built. %>
+    <span class="flex items-center justify-between gap-2 px-4 py-2 text-sm text-gray-400 cursor-not-allowed" title="Bulk payment link — coming soon">
+      <span>Bulk payment link</span>
+      <span class="rounded-full bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-500">Soon</span>
+    </span>
   </div>
 </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -20,6 +20,39 @@
     <% end %>
   </div>
 
+  <%# Quick links: registration forms and bulk payment. Each form link is gated by
+      its event setting — registration on an associated registration form, scholarship
+      on that form plus the "Enable scholarship application" checkbox (which is what
+      creates the scholarship event_form). The scholarship link points at the public
+      registration page, so it also needs the registration form or it dead-ends there.
+      Links open in a new tab. Bulk payment is a placeholder until that feature is built. %>
+  <% link_base = "inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors" %>
+  <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-8">
+    <% if @event.event_forms.registration.exists? %>
+      <%= link_to new_event_public_registration_path(@event, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+            class: "#{link_base} #{DomainTheme.border_class_for(:events, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:events, intensity: 300)} hover:bg-gray-50" do %>
+        <i class="fa-solid fa-clipboard-list <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
+        Public registration form
+        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
+      <% end %>
+    <% end %>
+
+    <% if @event.event_forms.registration.exists? && @event.scholarship_form %>
+      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+            class: "#{link_base} #{DomainTheme.border_class_for(:scholarships, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:scholarships, intensity: 300)} hover:bg-gray-50" do %>
+        <i class="fa-solid fa-graduation-cap <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>"></i>
+        Scholarship form
+        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
+      <% end %>
+    <% end %>
+
+    <span class="<%= link_base %> border-gray-200 text-gray-400 cursor-not-allowed" title="Bulk payment link — coming soon">
+      <i class="fa-solid fa-money-check-dollar text-gray-300"></i>
+      Bulk payment link
+      <span class="rounded-full bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-500">Soon</span>
+    </span>
+  </div>
+
   <%# Money cards (paid events only) — shown first %>
   <% if @dashboard.free? %>
     <div class="bg-white rounded-xl border border-gray-200 p-4 text-center text-sm text-gray-500 mb-4">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -27,6 +27,16 @@
       <hr class="border-gray-300 mb-6">
     </div>
 
+    <% if params[:form_id].present? && (filtered_form = Form.find_by(id: params[:form_id])) %>
+      <div class="flex items-center justify-between gap-3 mb-6 rounded-lg bg-blue-50 border border-blue-200 px-4 py-2.5 text-sm text-blue-800">
+        <span class="inline-flex items-center gap-2">
+          <i class="fa-solid fa-filter text-blue-500"></i>
+          Showing events using form: <span class="font-semibold"><%= filtered_form.display_name %></span>
+        </span>
+        <%= link_to "Clear filter", events_path, class: "inline-flex items-center gap-1.5 font-medium text-blue-700 hover:text-blue-900" %>
+      </div>
+    <% end %>
+
     <% if @events.any? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <% @events.each do |event| %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -7,8 +7,10 @@
     <% end %>
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
+        <% if allowed_to?(:edit?, @form) %>
+          <%= link_to "Edit form", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <% end %>
         <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-        <%= link_to "Registrants", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
       </div>
     <% end %>
   </div>

--- a/app/views/forms/_stats.html.erb
+++ b/app/views/forms/_stats.html.erb
@@ -1,0 +1,23 @@
+<%# Quick stats shown below a form's title on the edit/edit-sections pages:
+    how many events use this form (links to the filtered events index) and how
+    many submissions it has. There is no submissions index yet, so that badge is
+    not yet a link. %>
+<div class="flex flex-wrap items-center gap-2 mb-6">
+  <% events_count = form.events.size %>
+  <% if events_count.positive? %>
+    <%= link_to events_path(form_id: form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
+      <i class="fa-solid fa-calendar-day text-blue-500"></i>
+      <%= pluralize(events_count, "event") %> connected
+    <% end %>
+  <% else %>
+    <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-500">
+      <i class="fa-solid fa-calendar-day text-gray-400"></i>
+      No events connected
+    </span>
+  <% end %>
+
+  <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600">
+    <i class="fa-solid fa-inbox text-gray-400"></i>
+    <%= pluralize(form.form_submissions.size, "submission") %>
+  </span>
+</div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -8,7 +8,8 @@
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>
     <% end %>
   </div>
-  <h1 class="text-2xl font-semibold mb-6">Edit: <%= @form.display_name %></h1>
+  <h1 class="text-2xl font-semibold mb-2">Edit questions: <%= @form.display_name %></h1>
+  <%= render "stats", form: @form %>
 
   <%= form_with model: @form, class: "space-y-6" do |f| %>
     <% if @form.errors.any? %>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -4,7 +4,8 @@
     <%= link_to "Edit fields", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold mb-6">Edit Sections: <%= @form.display_name %></h1>
+  <h1 class="text-2xl font-semibold mb-2">Edit Sections: <%= @form.display_name %></h1>
+  <%= render "stats", form: @form %>
 
   <% current_sections = (@form.sections || []).map(&:to_s) %>
 

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -20,11 +20,17 @@
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 text-sm font-medium text-gray-900"><%= form.display_name %></td>
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_fields.size %></td>
-            <td class="px-4 py-2 text-sm text-gray-600"><%= form.events.size %></td>
+            <td class="px-4 py-2 text-sm text-gray-600">
+              <% if form.events.size.positive? %>
+                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md bg-blue-50 px-2 py-0.5 text-blue-700 font-medium hover:bg-blue-100" %>
+              <% else %>
+                0
+              <% end %>
+            </td>
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_submissions.size %></td>
             <td class="px-4 py-2 text-right text-sm space-x-3">
               <%= link_to "View", form_path(form), class: "text-blue-600 hover:text-blue-800 underline" %>
-              <%= link_to "Edit", edit_form_path(form), class: "text-blue-600 hover:text-blue-800 underline" %>
+              <%= link_to "Edit", edit_sections_form_path(form), class: "text-blue-600 hover:text-blue-800 underline" %>
               <% if allowed_to?(:destroy?, form) && form.event_forms.none? %>
                 <%= link_to "Delete", form_path(form), class: "text-red-600 hover:text-red-800 underline",
                             data: { turbo_method: :delete, turbo_confirm: "Delete \"#{form.display_name}\"?" } %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>
       <%= link_to "Delete", form_path(@form), class: "text-sm text-red-600 hover:text-red-800 px-2 py-1",
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins managing an event had no fast path from the dashboard to the live registration/scholarship forms — they had to dig through the registrants page menu.
- There was also no way to navigate between a form and the events that use it.
- This stitches those journeys together and tidies up the form-editing entry points so the labels and destinations are consistent.

### How did you approach the change?

**Event dashboard**
- Added a quick-links row under the title: **Public registration form**, **Scholarship form**, and a **Bulk payment** placeholder ("Soon" — feature not built yet).
- Each form link is gated by its event setting: registration link needs an associated registration form; scholarship link needs that form **and** the "Enable scholarship application" checkbox (the scholarship link targets the public registration page, which dead-ends without a registration form).

**Registrants "Form actions" menu**
- Renamed **"Change base form" → "Change form settings"**.
- Added the same **Bulk payment** placeholder ("Soon").

**Public registration page (admin bar)**
- Simplified to **Edit form** + **Dashboard** (removed "Registrants"); "Edit form" is gated on `edit?` since form editing is admin-only.

**Form editing entry points**
- Pointed the "edit" links on the forms index, form show page, and the public-registration "Edit form" button at the **sections editor** (`edit_sections`).
- Renamed the field-editor heading from "Edit:" to **"Edit questions:"**.

**Form ↔ events navigation**
- The forms index **Events** count is now a button linking to a **form-filtered events index** (new `Event.using_form` scope + `form_id` param in `search_by_params`), with a "Showing events using form … / Clear filter" banner on the events index.
- Added an **events-connected** count (links to the filtered index) and a **submissions** count (display-only — no submissions index exists) under the form edit / edit-sections titles.

### UI Testing Checklist
- [ ] Dashboard quick links appear/hide per the event's form settings and open the correct forms in a new tab
- [ ] Bulk payment placeholder shows as a disabled "Soon" item on both the dashboard and the Form actions menu
- [ ] Public registration admin bar shows "Edit form" + "Dashboard" only; "Edit form" goes to the sections editor
- [ ] Forms index event count links to the filtered events index; banner shows and clears correctly
- [ ] Events-connected / submissions counts render under the form edit titles

### Anything else to add?
- **Bulk payment** is a placeholder in two spots — it needs a real destination once that feature exists.
- **Submissions** count is intentionally not a link: there is no submissions controller/route/index in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)