### PR TITLE
Show sender on notifications index

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
 
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
-      base_scope = authorized_scope(Notification.includes(:noticeable))
+      base_scope = authorized_scope(Notification.includes(:noticeable, sender: :person))
       filtered = base_scope.search_by_params(params.to_unsafe_h)
       @notifications = filtered.order(created_at: :desc)
                                .paginate(page: params[:page], per_page: per_page)

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -3,7 +3,7 @@
   <tr>
     <th class="px-4 py-3 text-left font-medium text-gray-600">Sent</th>
     <!--        <th class="px-4 py-3 text-left font-medium text-gray-600">Kind</th>-->
-    <th class="px-4 py-3 text-left font-medium text-gray-600">Recipient</th>
+    <th class="px-4 py-3 text-left font-medium text-gray-600">People</th>
     <th class="px-4 py-3 text-left font-medium text-gray-600">Subject</th>
     <th class="px-4 py-3 text-left font-medium text-gray-600">Record</th>
     <th class="px-4 py-3 text-center font-medium text-gray-600">Responded</th>
@@ -30,9 +30,10 @@
       <%#= notification.kind.to_s.humanize %>
       <!--          </td>-->
 
-      <!-- Recipient -->
+      <!-- People -->
       <td class="px-4 py-3 text-gray-700">
-        <%= notification.recipient_email %>
+        <div><span class="text-xs uppercase text-gray-500">To:</span> <%= notification.recipient_email %></div>
+        <div class="text-[10px] text-gray-400"><span class="uppercase">From:</span> <%= notification.sender&.full_name.presence || "AWBW portal" %></div>
       </td>
 
       <!-- Subject -->


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Surfaces who sent each system notification on the index, so staff can tell portal-generated emails apart from staff-sent ones without opening each record.

### How did you approach the change?
- Renamed the **Recipient** column to **People** and split the cell into two lines: `To: [recipient email]` and a smaller, lighter `From: [sender name]`.
- `From` falls back to **AWBW portal** when a notification has no sender (the association is optional).
- Eager-loaded `sender: :person` in the controller so the new `From` line doesn't trigger N+1 queries.

### UI Testing Checklist
- [ ] System notifications index shows a **People** column with To/From lines
- [ ] Notifications with a sender show the sender's name; sender-less notifications show **AWBW portal**

### Anything else to add?
- The `From` line uses `sender.full_name`, which falls back to the sender's email when their person/name is blank.