### PR TITLE
Add per-field width, min-word, and field-option controls to form builder

### DIFF
--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -118,6 +118,8 @@ module Events
           errors[field.id] = "must be a valid email address"
         elsif (word_error = field.min_words_error(value))
           errors[field.id] = word_error
+        elsif (char_error = field.max_characters_error(value))
+          errors[field.id] = char_error
         end
       end
 

--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -116,6 +116,8 @@ module Events
           errors[field.id] = "must be a whole number"
         elsif field.field_identifier == "payer_email" && value.to_s !~ /\A[^@\s]+@[^@\s]+\z/
           errors[field.id] = "must be a valid email address"
+        elsif (word_error = field.min_words_error(value))
+          errors[field.id] = word_error
         end
       end
 

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -332,6 +332,8 @@ module Events
           errors[field.id] = "must be a valid email address"
         elsif (word_error = field.min_words_error(value))
           errors[field.id] = word_error
+        elsif (char_error = field.max_characters_error(value))
+          errors[field.id] = char_error
         end
       end
 

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -330,6 +330,8 @@ module Events
           errors[field.id] = "must be a whole number"
         elsif field.field_identifier&.match?(/email(?!_type|_confirmation)/) && value.to_s !~ /\A[^@\s]+@[^@\s]+\z/
           errors[field.id] = "must be a valid email address"
+        elsif (word_error = field.min_words_error(value))
+          errors[field.id] = word_error
         end
       end
 

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -40,6 +40,10 @@ module Events
       registration_params, scholarship_params = split_form_params(all_params)
 
       @field_errors = validate_required_fields(registration_params)
+      if @scholarship_form
+        scholarship_fields = @scholarship_form.form_fields.where.not(answer_type: :group_header).to_a
+        @field_errors = @field_errors.merge(collect_field_errors(scholarship_fields, scholarship_params))
+      end
       if @field_errors.any?
         @form_fields = visible_form_fields
         @event = @event.decorate
@@ -310,11 +314,30 @@ module Events
     end
 
     def validate_required_fields(form_params)
-      errors = {}
-      fields = visible_form_fields
-      fields_by_identifier = fields.select { |f| f.field_identifier.present? }.index_by(&:field_identifier)
+      fields = visible_form_fields.to_a
+      errors = collect_field_errors(fields, form_params)
 
-      fields.find_each do |field|
+      fields_by_identifier = fields.select { |f| f.field_identifier.present? }.index_by(&:field_identifier)
+      confirm_field = fields_by_identifier["confirm_email"]
+      email_field = fields_by_identifier["primary_email"]
+      if confirm_field && email_field && errors[confirm_field.id].nil?
+        confirm_value = form_params[confirm_field.id.to_s].to_s.strip
+        email_value = form_params[email_field.id.to_s].to_s.strip
+        if confirm_value.present? && confirm_value != email_value
+          errors[confirm_field.id] = "must match email"
+        end
+      end
+
+      errors
+    end
+
+    # Per-field validation shared by every form role (registration, scholarship):
+    # presence, number/email format, and the per-field min-words / max-characters
+    # settings. Keyed by field id so results from multiple forms can be merged.
+    def collect_field_errors(fields, form_params)
+      errors = {}
+
+      fields.each do |field|
         next if field.group_header?
 
         value = form_params[field.id.to_s]
@@ -334,16 +357,6 @@ module Events
           errors[field.id] = word_error
         elsif (char_error = field.max_characters_error(value))
           errors[field.id] = char_error
-        end
-      end
-
-      confirm_field = fields_by_identifier["confirm_email"]
-      email_field = fields_by_identifier["primary_email"]
-      if confirm_field && email_field && errors[confirm_field.id].nil?
-        confirm_value = form_params[confirm_field.id.to_s].to_s.strip
-        email_value = form_params[email_field.id.to_s].to_s.strip
-        if confirm_value.present? && confirm_value != email_value
-          errors[confirm_field.id] = "must match email"
         end
       end
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -121,7 +121,7 @@ class FormsController < ApplicationController
       :name, :role, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
         :id, :name, :answer_type, :required, :hint_text,
-        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :_destroy
+        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy
       ]
     )
   end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -121,7 +121,7 @@ class FormsController < ApplicationController
       :name, :role, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
         :id, :name, :answer_type, :required, :hint_text,
-        :field_identifier, :section, :position, :visibility, :one_time, :_destroy
+        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :_destroy
       ]
     )
   end

--- a/app/frontend/javascript/controllers/expand_all_controller.js
+++ b/app/frontend/javascript/controllers/expand_all_controller.js
@@ -3,6 +3,12 @@ import { Controller } from "@hotwired/stimulus"
 // Expands or collapses every field's options panel at once. Connected to each
 // row's field-options controller via outlets, so dynamically added rows are
 // included automatically.
+//
+// TODO(dedupe): duplicates the expandable-cards/expandable-card pattern (with
+// field-options mirroring expandable-card). Kept separate for now because this
+// uses the Outlets API (preferred per our Stimulus conventions) vs.
+// expandable-cards' @window event broadcasting. Consolidate to one pattern —
+// see PR #1606.
 export default class extends Controller {
   static outlets = ["field-options"]
   static targets = ["btn"]

--- a/app/frontend/javascript/controllers/expand_all_controller.js
+++ b/app/frontend/javascript/controllers/expand_all_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Expands or collapses every field's options panel at once. Connected to each
+// row's field-options controller via outlets, so dynamically added rows are
+// included automatically.
+export default class extends Controller {
+  static outlets = ["field-options"]
+  static targets = ["btn"]
+
+  toggleAll() {
+    const allExpanded = this.fieldOptionsOutlets.length > 0 &&
+      this.fieldOptionsOutlets.every(c => c.expandedValue)
+
+    this.fieldOptionsOutlets.forEach(c => { c.expandedValue = !allExpanded })
+
+    if (this.hasBtnTarget) {
+      this.btnTarget.textContent = allExpanded ? "Expand all" : "Collapse all"
+    }
+  }
+}

--- a/app/frontend/javascript/controllers/expandable_cards_controller.js
+++ b/app/frontend/javascript/controllers/expandable_cards_controller.js
@@ -4,6 +4,10 @@ import { Controller } from "@hotwired/stimulus"
 // Expand/collapse-all control for a group of expandable-card controllers.
 // Broadcasts expandAll/collapseAll (caught via @window) so each card toggles
 // itself, and keeps the button's label and chevron in sync.
+//
+// TODO(dedupe): the form builder added a parallel expand-all/field-options pair
+// (Outlets-based) that does the same job. Consolidate to one pattern — see
+// PR #1606.
 export default class extends Controller {
   static targets = ["label", "icon"]
   static values = { expanded: { type: Boolean, default: true } }

--- a/app/frontend/javascript/controllers/field_options_controller.js
+++ b/app/frontend/javascript/controllers/field_options_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Collapses a form field's secondary settings (width, min words, one-time)
+// behind a chevron. The main row stays visible; the panel toggles open.
+export default class extends Controller {
+  static targets = ["panel", "icon"]
+  static values = { expanded: Boolean }
+
+  toggle() {
+    this.expandedValue = !this.expandedValue
+  }
+
+  expandedValueChanged() {
+    this.panelTarget.classList.toggle("hidden", !this.expandedValue)
+    this.iconTarget.classList.toggle("rotate-180", this.expandedValue)
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -60,8 +60,14 @@ application.register("expandable-cards", ExpandableCardsController)
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
 
+import ExpandAllController from "./expand_all_controller"
+application.register("expand-all", ExpandAllController)
+
 import FilePreviewController from "./file_preview_controller"
 application.register("file-preview", FilePreviewController)
+
+import FieldOptionsController from "./field_options_controller"
+application.register("field-options", FieldOptionsController)
 
 import FormFieldsSortableController from "./form_fields_sortable_controller"
 application.register("form-fields-sortable", FormFieldsSortableController)

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -35,6 +35,10 @@
 @source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
 @source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
 
+/* Per-field form layout widths (generated from FormField::WIDTH_GRID_SPANS, which
+   lives in a model file Tailwind does not scan) */
+@source inline("md:col-span-{3,4,6,12}");
+
 /* ✅ Safelist dynamically generated colors */
 @layer utilities {
   .text-transparent { color: transparent; }
@@ -306,3 +310,12 @@ textarea.comment-truncated:focus {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   border-radius: 0 2px 2px 0;
 }
+
+/* Restore heading sizes inside admin-authored form labels/headers, since
+   Tailwind's preflight resets h1–h6. Scoped so it only affects rich labels. */
+.rich-label h1 { font-size: 1.875rem; line-height: 2.25rem; font-weight: 700; }
+.rich-label h2 { font-size: 1.5rem; line-height: 2rem; font-weight: 700; }
+.rich-label h3 { font-size: 1.25rem; line-height: 1.75rem; font-weight: 600; }
+.rich-label h4 { font-size: 1.125rem; line-height: 1.75rem; font-weight: 600; }
+.rich-label h5 { font-size: 1rem; line-height: 1.5rem; font-weight: 600; }
+.rich-label h6 { font-size: 0.875rem; line-height: 1.25rem; font-weight: 600; }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,19 @@
 module ApplicationHelper
+  # Tags an admin may use in a form field name / group header that should
+  # render (rather than escape) on the public form. Block + inline formatting,
+  # links, line breaks, and font sizing/coloring (via <font> or inline style).
+  # Anything outside this allowlist is stripped by `sanitize`.
+  FORM_LABEL_TAGS = %w[br a p span strong b em i u h1 h2 h3 h4 h5 h6 ul ol li font].freeze
+  FORM_LABEL_ATTRIBUTES = %w[href target rel style size color face].freeze
+
+  # Render a form field name / header with a safe subset of HTML allowed.
+  # Uses Rails' SafeListSanitizer, which strips dangerous URL schemes
+  # (e.g. javascript:) from href and CSS-scrubs the style attribute (dropping
+  # unsafe properties/values), so admin-authored markup can't inject XSS.
+  def form_label_html(text)
+    sanitize(text.to_s, tags: FORM_LABEL_TAGS, attributes: FORM_LABEL_ATTRIBUTES)
+  end
+
   INDEX_BUTTON_ICONS = {
     community_news:      "fa-newspaper",
     stories:             "fa-book-open",

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -17,6 +17,7 @@ class FormField < ApplicationRecord
   # database ValueTooLong exception (the column is text, this is the UX cap).
   validates :name, length: { maximum: 1000 }
   validates :min_words, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :max_characters, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 
   # Enum
   enum :status, [ :inactive, :active ]
@@ -100,6 +101,17 @@ class FormField < ApplicationRecord
     return if word_count(value) >= min_words
 
     "must be at least #{min_words} #{"word".pluralize(min_words)}"
+  end
+
+  # Returns a validation error string when a submitted value exceeds the
+  # configured maximum character count, or nil when it passes / does not apply.
+  def max_characters_error(value)
+    return unless free_form_text?
+    return unless max_characters.to_i.positive?
+    return if value.blank?
+    return if value.to_s.length <= max_characters
+
+    "must be #{max_characters} #{"character".pluralize(max_characters)} or fewer"
   end
 
   def html_input_type

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -8,8 +8,15 @@ class FormField < ApplicationRecord
   # has_many through
   has_many :answer_options, through: :form_field_answer_options
 
+  # Answer types that collect free-form text, where a minimum word count applies
+  FREE_FORM_TEXT_TYPES = %w[free_form_input_one_line free_form_input_paragraph].freeze
+
   # Validations
   validates_presence_of :name
+  # Keeps an over-long name as a friendly validation error instead of a
+  # database ValueTooLong exception (the column is text, this is the UX cap).
+  validates :name, length: { maximum: 1000 }
+  validates :min_words, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
   # Enum
   enum :status, [ :inactive, :active ]
@@ -31,6 +38,27 @@ class FormField < ApplicationRecord
     :date
   ]
 
+  # Prefixed because :third/:first/etc. collide with Active Record finder methods
+  enum :width, [ :full, :half, :third, :quarter ], prefix: true
+
+  # Human-friendly labels for answer types (radio is "single choice" because only one option can be picked)
+  ANSWER_TYPE_LABELS = {
+    "group_header" => "Section header",
+    "free_form_input_one_line" => "One line",
+    "free_form_input_paragraph" => "Paragraph",
+    "multiple_choice_radio" => "Single choice radio",
+    "multiple_choice_checkbox" => "Multiple choice checkbox",
+    "no_user_input" => "Informational-only"
+  }.freeze
+
+  # Tailwind column spans within the 12-column form layout grid
+  WIDTH_GRID_SPANS = {
+    "full" => "md:col-span-12",
+    "half" => "md:col-span-6",
+    "third" => "md:col-span-4",
+    "quarter" => "md:col-span-3"
+  }.freeze
+
   # Nested attributes
   accepts_nested_attributes_for :form_field_answer_options
 
@@ -44,6 +72,34 @@ class FormField < ApplicationRecord
 
   def html_id
     self.name.tr(" /#,')(.", "_").downcase
+  end
+
+  def grid_span_class
+    WIDTH_GRID_SPANS.fetch(width, "md:col-span-12")
+  end
+
+  def answer_type_label
+    ANSWER_TYPE_LABELS.fetch(answer_type, answer_type&.titleize)
+  end
+
+  def free_form_text?
+    FREE_FORM_TEXT_TYPES.include?(answer_type)
+  end
+
+  def word_count(value)
+    value.to_s.scan(/\S+/).size
+  end
+
+  # Returns a validation error string when a submitted value falls short of the
+  # configured minimum word count, or nil when it passes / does not apply.
+  # Blank values are left to the presence (required) check.
+  def min_words_error(value)
+    return unless free_form_text?
+    return unless min_words.to_i.positive?
+    return if value.blank?
+    return if word_count(value) >= min_words
+
+    "must be at least #{min_words} #{"word".pluralize(min_words)}"
   end
 
   def html_input_type

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -346,10 +346,10 @@ class FormBuilderService
 
     position = add_field(form, position, "Payer First Name", :free_form_input_one_line,
                          key: "payer_first_name", group: "bulk_payment", required: true,
-                         visibility: :logged_out_only)
+                         width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Payer Last Name", :free_form_input_one_line,
                          key: "payer_last_name", group: "bulk_payment", required: true,
-                         visibility: :logged_out_only)
+                         width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Payer Email", :free_form_input_one_line,
                          key: "payer_email", group: "bulk_payment", required: true,
                          visibility: :logged_out_only)

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -133,7 +133,7 @@ class FormBuilderService
     position
   end
 
-  def add_field(form, position, field_name, answer_type, key:, group:, required: true, hint: nil, options: nil, datatype: nil, visibility: nil)
+  def add_field(form, position, field_name, answer_type, key:, group:, required: true, hint: nil, options: nil, datatype: nil, visibility: nil, width: :full)
     position += 1
     field = form.form_fields.create!(
       name: field_name,
@@ -146,7 +146,8 @@ class FormBuilderService
       field_identifier: key,
       section: group,
       visibility: visibility || SECTION_VISIBILITY.fetch(group, :always_ask),
-      one_time: ONE_TIME_SECTIONS.include?(group)
+      one_time: ONE_TIME_SECTIONS.include?(group),
+      width: width
     )
 
     if options.present?
@@ -165,13 +166,13 @@ class FormBuilderService
 
   def build_person_identifier_fields(form, position)
     position = add_field(form, position, "First Name", :free_form_input_one_line,
-                         key: "first_name", group: "person_identifier", required: true)
+                         key: "first_name", group: "person_identifier", required: true, width: :half)
     position = add_field(form, position, "Last Name", :free_form_input_one_line,
-                         key: "last_name", group: "person_identifier", required: true)
+                         key: "last_name", group: "person_identifier", required: true, width: :half)
     position = add_field(form, position, "Email", :free_form_input_one_line,
-                         key: "primary_email", group: "person_identifier", required: true)
+                         key: "primary_email", group: "person_identifier", required: true, width: :half)
     position = add_field(form, position, "Confirm Email", :free_form_input_one_line,
-                         key: "confirm_email", group: "person_identifier", required: true)
+                         key: "confirm_email", group: "person_identifier", required: true, width: :half)
     position
   end
 
@@ -182,53 +183,52 @@ class FormBuilderService
                          key: "primary_email_type", group: "person_contact_info", required: true,
                          options: %w[Personal Work])
     position = add_field(form, position, "Preferred Nickname", :free_form_input_one_line,
-                         key: "nickname", group: "person_contact_info", required: false)
+                         key: "nickname", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Pronouns", :free_form_input_one_line,
-                         key: "pronouns", group: "person_contact_info", required: false)
+                         key: "pronouns", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Secondary Email", :free_form_input_one_line,
-                         key: "secondary_email", group: "person_contact_info", required: false)
+                         key: "secondary_email", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Secondary Email Type", :multiple_choice_radio,
                          key: "secondary_email_type", group: "person_contact_info", required: false,
-                         options: %w[Personal Work])
+                         width: :half, options: %w[Personal Work])
 
     position = add_header(form, position, "Mailing Address", group: "person_contact_info")
     position = add_field(form, position, "Street Address", :free_form_input_one_line,
-                         key: "mailing_street", group: "person_contact_info", required: true)
+                         key: "mailing_street", group: "person_contact_info", required: true, width: :half)
     position = add_field(form, position, "Address Type", :multiple_choice_radio,
                          key: "mailing_address_type", group: "person_contact_info", required: true,
-                         options: %w[Work Personal])
+                         width: :half, options: %w[Work Personal])
     position = add_field(form, position, "City", :free_form_input_one_line,
-                         key: "mailing_city", group: "person_contact_info", required: true)
+                         key: "mailing_city", group: "person_contact_info", required: true, width: :third)
     position = add_field(form, position, "State / Province", :free_form_input_one_line,
-                         key: "mailing_state", group: "person_contact_info", required: true)
+                         key: "mailing_state", group: "person_contact_info", required: true, width: :third)
     position = add_field(form, position, "Zip / Postal Code", :free_form_input_one_line,
-                         key: "mailing_zip", group: "person_contact_info", required: true)
+                         key: "mailing_zip", group: "person_contact_info", required: true, width: :third)
 
     position = add_field(form, position, "Phone", :free_form_input_one_line,
-                         key: "phone", group: "person_contact_info", required: true)
+                         key: "phone", group: "person_contact_info", required: true, width: :half)
     position = add_field(form, position, "Phone Type", :multiple_choice_radio,
                         key: "phone_type", group: "person_contact_info", required: true,
-                        options: %w[Work Personal])
+                        width: :half, options: %w[Work Personal])
 
     position = add_header(form, position, "Agency / Organization Information", group: "person_contact_info")
     position = add_field(form, position, "Agency / Organization Name", :free_form_input_one_line,
-                         key: "agency_name", group: "person_contact_info", required: false)
+                         key: "agency_name", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Position / Title", :free_form_input_one_line,
-                         key: "agency_position", group: "person_contact_info", required: false)
+                         key: "agency_position", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Agency Street Address", :free_form_input_one_line,
                          key: "agency_street", group: "person_contact_info", required: false)
     position = add_field(form, position, "Agency City", :free_form_input_one_line,
-                         key: "agency_city", group: "person_contact_info", required: false)
+                         key: "agency_city", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Agency State / Province", :free_form_input_one_line,
-                         key: "agency_state", group: "person_contact_info", required: false)
+                         key: "agency_state", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Agency Zip / Postal Code", :free_form_input_one_line,
-                         key: "agency_zip", group: "person_contact_info", required: false)
+                         key: "agency_zip", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Agency Type", :multiple_choice_radio,
                          key: "agency_type", group: "person_contact_info", required: false,
                          options: [
-                           "Domestic Violence", "Homeless Shelter", "Hospital",
-                           "Mental Health", "School", "After-School Program",
-                           "Community Center", "Other"
+                           "501c3/nonprofit", "For-profit", "Government agency",
+                           "Other (please specify below)"
                          ])
     position = add_field(form, position, "Agency Website", :free_form_input_one_line,
                          key: "agency_website", group: "person_contact_info", required: false)

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -60,8 +60,8 @@
 
           <% if field.group_header? %>
             <div class="pt-7 pb-4">
-              <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900">
-                <span class="h-5 w-1 rounded-full bg-accent"></span><%= field.name %>
+              <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
+                <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
               </h3>
             </div>
           <% elsif payer_fields.include?(field.field_identifier) %>
@@ -78,8 +78,8 @@
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <% end %>
               <div class="mb-5">
-                <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
-                  <%= field.name %>
+                <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
+                  <%= form_label_html(field.name) %>
                   <% if field.required %><span class="text-red-500">*</span><% end %>
                 </label>
                 <% if field.hint_text.present? %>
@@ -100,9 +100,12 @@
                        class="<%= input_classes %>"
                        <%= "required" if field.required %>
                        <%= raw(extra_attrs.join(" ")) %>>
+                <% if field.free_form_text? && field.min_words.to_i.positive? %>
+                  <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+                <% end %>
                 <% if error %>
                   <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
-                    <i class="fa-solid fa-circle-exclamation"></i><%= field.name %> <%= error %>
+                    <i class="fa-solid fa-circle-exclamation"></i><%= strip_tags(field.name) %> <%= error %>
                   </p>
                 <% end %>
               </div>
@@ -117,8 +120,8 @@
               field_id = "bulk_payment_form_fields_#{field.id}"
             %>
             <div class="mb-5">
-              <label class="block text-sm font-semibold text-gray-700 mb-1.5">
-                <%= field.name %>
+              <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5">
+                <%= form_label_html(field.name) %>
                 <% if field.required %><span class="text-red-500">*</span><% end %>
               </label>
               <div class="flex flex-wrap gap-2.5 mt-1">

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -55,100 +55,98 @@
           payer_fields = %w[payer_first_name payer_last_name payer_email organization_name number_of_attendees]
         %>
 
-        <% @form_fields.each do |field| %>
-          <% next if field.field_identifier == "bulk_payment_attendees" %>
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+          <% @form_fields.each do |field| %>
+            <% next if field.field_identifier == "bulk_payment_attendees" %>
 
-          <% if field.group_header? %>
-            <div class="pt-7 pb-4">
-              <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
-                <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
-              </h3>
-            </div>
-          <% elsif payer_fields.include?(field.field_identifier) %>
-            <%
-              submitted_value = @form_params&.dig(field.id.to_s)
-              error = @field_errors&.dig(field.id)
-              error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30"
-              input_classes = "w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition focus:outline-none focus:ring-2 #{error_border}"
-              field_name = "bulk_payment[form_fields][#{field.id}]"
-              field_id = "bulk_payment_form_fields_#{field.id}"
-              two_col = %w[payer_first_name payer_last_name].include?(field.field_identifier)
-            %>
-            <% if two_col %>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <% end %>
-              <div class="mb-5">
-                <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
-                  <%= form_label_html(field.name) %>
-                  <% if field.required %><span class="text-red-500">*</span><% end %>
-                </label>
-                <% if field.hint_text.present? %>
-                  <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>
-                <% end %>
-                <%
-                  html_type = case field.field_identifier
-                              when "payer_email" then "email"
-                              else field.number_integer? ? "number" : "text"
-                              end
-                  extra_attrs = []
-                  extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
-                  extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
-                %>
-                <input type="<%= html_type %>"
-                       name="<%= field_name %>"
-                       id="<%= field_id %>"
-                       value="<%= submitted_value %>"
-                       class="<%= input_classes %>"
-                       <%= "required" if field.required %>
-                       <%= raw(extra_attrs.join(" ")) %>>
-                <% if field.free_form_text? && field.min_words.to_i.positive? %>
-                  <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
-                <% end %>
-                <% if field.free_form_text? && field.max_characters.to_i.positive? %>
-                  <p class="text-left text-xs text-gray-500 mt-1.5">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
-                <% end %>
-                <% if error %>
-                  <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
-                    <i class="fa-solid fa-circle-exclamation"></i><%= strip_tags(field.name) %> <%= error %>
-                  </p>
-                <% end %>
+            <% if field.group_header? %>
+              <div class="md:col-span-12 pt-7 pb-4">
+                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
+                  <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
+                </h3>
               </div>
-            <% if two_col %>
-              </div>
-            <% end %>
-          <% elsif field.field_identifier == "payment_method" %>
-            <%
-              submitted_value = @form_params&.dig(field.id.to_s)
-              error = @field_errors&.dig(field.id)
-              error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30"
-              field_id = "bulk_payment_form_fields_#{field.id}"
-            %>
-            <div class="mb-5">
-              <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5">
-                <%= form_label_html(field.name) %>
-                <% if field.required %><span class="text-red-500">*</span><% end %>
-              </label>
-              <div class="flex flex-wrap gap-2.5 mt-1">
-                <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
-                  <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> px-4 py-2.5 cursor-pointer hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50 transition">
-                    <input type="radio"
-                           name="bulk_payment[form_fields][<%= field.id %>]"
-                           value="<%= ffao.answer_option.name %>"
-                           class="text-blue-600 focus:ring-blue-500"
-                           <%= "checked" if submitted_value == ffao.answer_option.name || (submitted_value.blank? && ffao.answer_option.name == "Credit Card") %>
-                           <%= "required" if field.required %>>
-                    <%= ffao.answer_option.name %>
+            <% elsif payer_fields.include?(field.field_identifier) %>
+              <%
+                submitted_value = @form_params&.dig(field.id.to_s)
+                error = @field_errors&.dig(field.id)
+                error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30"
+                input_classes = "w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition focus:outline-none focus:ring-2 #{error_border}"
+                field_name = "bulk_payment[form_fields][#{field.id}]"
+                field_id = "bulk_payment_form_fields_#{field.id}"
+              %>
+              <div class="<%= field.grid_span_class %>">
+                <div class="mb-5">
+                  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
+                    <%= form_label_html(field.name) %>
+                    <% if field.required %><span class="text-red-500">*</span><% end %>
                   </label>
-                <% end %>
+                  <% if field.hint_text.present? %>
+                    <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>
+                  <% end %>
+                  <%
+                    html_type = case field.field_identifier
+                                when "payer_email" then "email"
+                                else field.number_integer? ? "number" : "text"
+                                end
+                    extra_attrs = []
+                    extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
+                    extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
+                  %>
+                  <input type="<%= html_type %>"
+                         name="<%= field_name %>"
+                         id="<%= field_id %>"
+                         value="<%= submitted_value %>"
+                         class="<%= input_classes %>"
+                         <%= "required" if field.required %>
+                         <%= raw(extra_attrs.join(" ")) %>>
+                  <% if field.free_form_text? && field.min_words.to_i.positive? %>
+                    <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+                  <% end %>
+                  <% if field.free_form_text? && field.max_characters.to_i.positive? %>
+                    <p class="text-left text-xs text-gray-500 mt-1.5">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
+                  <% end %>
+                  <% if error %>
+                    <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
+                      <i class="fa-solid fa-circle-exclamation"></i><%= strip_tags(field.name) %> <%= error %>
+                    </p>
+                  <% end %>
+                </div>
               </div>
-              <% if error %>
-                <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
-                  <i class="fa-solid fa-circle-exclamation"></i>Payment method is required
-                </p>
-              <% end %>
-            </div>
+            <% elsif field.field_identifier == "payment_method" %>
+              <%
+                submitted_value = @form_params&.dig(field.id.to_s)
+                error = @field_errors&.dig(field.id)
+                field_id = "bulk_payment_form_fields_#{field.id}"
+              %>
+              <div class="<%= field.grid_span_class %>">
+                <div class="mb-5">
+                  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5">
+                    <%= form_label_html(field.name) %>
+                    <% if field.required %><span class="text-red-500">*</span><% end %>
+                  </label>
+                  <div class="flex flex-wrap gap-2.5 mt-1">
+                    <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
+                      <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> px-4 py-2.5 cursor-pointer hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50 transition">
+                        <input type="radio"
+                               name="bulk_payment[form_fields][<%= field.id %>]"
+                               value="<%= ffao.answer_option.name %>"
+                               class="text-blue-600 focus:ring-blue-500"
+                               <%= "checked" if submitted_value == ffao.answer_option.name || (submitted_value.blank? && ffao.answer_option.name == "Credit Card") %>
+                               <%= "required" if field.required %>>
+                        <%= ffao.answer_option.name %>
+                      </label>
+                    <% end %>
+                  </div>
+                  <% if error %>
+                    <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
+                      <i class="fa-solid fa-circle-exclamation"></i>Payment method is required
+                    </p>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
 
         <% if @attendee_field %>
           <div>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -92,6 +92,7 @@
                               end
                   extra_attrs = []
                   extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
+                  extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
                 %>
                 <input type="<%= html_type %>"
                        name="<%= field_name %>"
@@ -102,6 +103,9 @@
                        <%= raw(extra_attrs.join(" ")) %>>
                 <% if field.free_form_text? && field.min_words.to_i.positive? %>
                   <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+                <% end %>
+                <% if field.free_form_text? && field.max_characters.to_i.positive? %>
+                  <p class="text-left text-xs text-gray-500 mt-1.5">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
                 <% end %>
                 <% if error %>
                   <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -43,6 +43,7 @@
                      end
         extra_attrs = []
         extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
+        extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
       %>
       <input type="<%= html_type %>"
              name="<%= field_name %>"
@@ -58,6 +59,7 @@
               id="<%= field_id %>"
               rows="4"
               class="<%= input_classes %>"
+              <%= "maxlength=\"#{field.max_characters}\"".html_safe if field.max_characters.to_i.positive? %>
               <%= "required" if field.required %>><%= value %></textarea>
 
   <% when "multiple_choice_radio" %>
@@ -137,6 +139,10 @@
 
   <% if field.free_form_text? && field.min_words.to_i.positive? %>
     <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+  <% end %>
+
+  <% if field.free_form_text? && field.max_characters.to_i.positive? %>
+    <p class="text-left text-xs text-gray-500 mt-1.5">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
   <% end %>
 
   <% if error %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -5,9 +5,9 @@
 <% error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30" %>
 <% input_classes = "w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition focus:outline-none focus:ring-2 #{error_border}" %>
 
-<div class="mb-5">
-  <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="public_registration_form_fields_<%= field.id %>">
-    <%= label || field.name %>
+<div class="mb-7">
+  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="public_registration_form_fields_<%= field.id %>">
+    <%= form_label_html(label || field.name) %>
     <% if field.required %>
       <span class="text-red-500">*</span>
     <% end %>
@@ -135,9 +135,13 @@
 
   <% end %>
 
+  <% if field.free_form_text? && field.min_words.to_i.positive? %>
+    <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+  <% end %>
+
   <% if error %>
     <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
-      <i class="fa-solid fa-circle-exclamation"></i><%= field.name %> <%= error %>
+      <i class="fa-solid fa-circle-exclamation"></i><%= strip_tags(field.name) %> <%= error %>
     </p>
   <% end %>
 </div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -83,36 +83,9 @@
           <input type="text" name="public_registration[website_url]" tabindex="-1" autocomplete="off">
         </div>
 
-        <%# Row groupings: related fields share a grid row on md+ screens %>
+        <%# Per-field widths flow into a 12-column grid; full-width fields and headers take a whole row %>
         <%
-          fields_by_id_check = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-          email_row = if fields_by_id_check["confirm_email"] && fields_by_id_check["primary_email_type"]
-            { keys: %w[primary_email confirm_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" }
-          elsif fields_by_id_check["confirm_email"]
-            { keys: %w[primary_email confirm_email], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" }
-          else
-            { keys: %w[primary_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "primary_email" => "md:col-span-2" } }
-          end
-
-          row_groups = [
-            { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-            { keys: %w[nickname pronouns], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-            email_row,
-            { keys: %w[secondary_email secondary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "secondary_email" => "md:col-span-2" } },
-            { keys: %w[mailing_street mailing_address_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-            { keys: %w[mailing_city mailing_state mailing_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-            { keys: %w[phone phone_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-            { keys: %w[agency_name agency_position], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-            { keys: %w[agency_city agency_state agency_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-            { keys: %w[payment_method], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          ]
-
-          identifier_to_group = {}
-          row_groups.each { |g| g[:keys].each { |k| identifier_to_group[k] = g } }
-
           fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-          rendered_ids = {}
-
           has_secondary_email = fields_by_identifier["secondary_email"].present?
           email_label_overrides = if has_secondary_email
             { "primary_email" => "Primary Email", "confirm_email" => "Confirm Primary Email", "primary_email_type" => "Primary Email Type" }
@@ -121,41 +94,25 @@
           end
         %>
 
-        <% @form_fields.each do |field| %>
-          <% next if field.field_identifier.present? && rendered_ids[field.field_identifier] %>
-
-          <% if field.group_header? %>
-            <div class="pt-7 pb-4">
-              <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900">
-                <span class="h-5 w-1 rounded-full bg-accent"></span><%= field.name %>
-              </h3>
-            </div>
-          <% elsif (group = field.field_identifier.present? && identifier_to_group[field.field_identifier]) %>
-            <div class="<%= group[:grid] %>">
-              <% group[:keys].each do |key| %>
-                <% row_field = fields_by_identifier[key] %>
-                <% next unless row_field %>
-                <% rendered_ids[key] = true %>
-                <% span = group.dig(:spans, key) %>
-                <% submitted_value = params.dig(:public_registration, :form_fields, row_field.id.to_s) %>
-                <% if submitted_value.blank? && row_field.field_identifier == "payment_method" %>
-                  <% submitted_value = @scholarship ? "Other" : "Credit Card" %>
-                <% end %>
-                <% label_override = email_label_overrides[key] %>
-                <% if span %>
-                  <div class="<%= span %>">
-                    <%= render "events/public_registrations/form_field", field: row_field, value: submitted_value, label: label_override %>
-                  </div>
-                <% else %>
-                  <%= render "events/public_registrations/form_field", field: row_field, value: submitted_value, label: label_override %>
-                <% end %>
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+          <% @form_fields.each do |field| %>
+            <% if field.group_header? %>
+              <div class="md:col-span-12 pt-7 pb-4">
+                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
+                  <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
+                </h3>
+              </div>
+            <% else %>
+              <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
+              <% if submitted_value.blank? && field.field_identifier == "payment_method" %>
+                <% submitted_value = @scholarship ? "Other" : "Credit Card" %>
               <% end %>
-            </div>
-          <% else %>
-            <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
-            <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+              <div class="<%= field.grid_span_class %>">
+                <%= render "events/public_registrations/form_field", field: field, value: submitted_value, label: email_label_overrides[field.field_identifier] %>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
 
         <% if @scholarship_form && @scholarship_form.form_fields.any? %>
           <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -119,11 +119,13 @@
             <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900 mb-5">
               <i class="fa-solid fa-hand-holding-heart text-accent"></i>Scholarship application
             </h3>
-            <div class="space-y-4">
+            <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
               <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% next if field.group_header? %>
                 <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
-                <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+                <div class="<%= field.grid_span_class %>">
+                  <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+                </div>
               <% end %>
             </div>
           </div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -34,62 +34,26 @@
     </div>
 
     <%# Card Body %>
-    <div class="px-6 sm:px-8 py-7 space-y-1">
-      <%
-        row_groups = [
-          { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[nickname pronouns], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[primary_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "primary_email" => "md:col-span-2" } },
-          { keys: %w[secondary_email secondary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "secondary_email" => "md:col-span-2" } },
-          { keys: %w[mailing_street mailing_address_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[mailing_city mailing_state mailing_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-          { keys: %w[phone phone_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[agency_name agency_position], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[agency_city agency_state agency_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-          { keys: %w[payment_method], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-        ]
+    <div class="px-6 sm:px-8 py-7">
+      <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+        <% @form_fields.each do |field| %>
+          <% next if field.field_identifier == "confirm_email" %>
 
-        identifier_to_group = {}
-        row_groups.each { |g| g[:keys].each { |k| identifier_to_group[k] = g } }
-
-        fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-        rendered_ids = {}
-      %>
-
-      <% @form_fields.each do |field| %>
-        <% next if field.field_identifier == "confirm_email" %>
-        <% next if field.field_identifier.present? && rendered_ids[field.field_identifier] %>
-
-        <% if field.group_header? %>
-          <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-            <h3 class="text-lg font-semibold text-gray-800"><%= field.name %></h3>
-          </div>
-        <% elsif (group = field.field_identifier.present? && identifier_to_group[field.field_identifier]) %>
-          <div class="<%= group[:grid] %>">
-            <% group[:keys].each do |key| %>
-              <% row_field = fields_by_identifier[key] %>
-              <% next unless row_field %>
-              <% rendered_ids[key] = true %>
-              <% response = @responses[row_field.id] %>
-              <% span = group.dig(:spans, key) %>
-              <div class="<%= span %> py-2">
-                <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= row_field.name %></dt>
-                <dd class="mt-1 text-sm text-gray-900">
-                  <%= display_response_text(row_field, response) %>
-                </dd>
-              </div>
-            <% end %>
-          </div>
-        <% else %>
-          <% response = @responses[field.id] %>
-          <div class="py-2">
-            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= field.name %></dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              <%= display_response_text(field, response) %>
-            </dd>
-          </div>
+          <% if field.group_header? %>
+            <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
+              <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
+            </div>
+          <% else %>
+            <% response = @responses[field.id] %>
+            <div class="<%= field.grid_span_class %> py-2">
+              <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(field.name) %></dt>
+              <dd class="mt-1 text-sm text-gray-900">
+                <%= display_response_text(field, response) %>
+              </dd>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
 
       <div class="pt-4 border-t border-gray-200 mt-4">
         <p class="text-xs text-gray-500">

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -25,49 +25,71 @@
   <%= f.hidden_field :position, value: field.position %>
 
   <% if field.group_header? %>
-    <div class="flex-1 flex items-center gap-3">
+    <div class="flex-1 flex items-start gap-3">
       <%= f.select :visibility, visibility_options,
             {},
-            class: "text-xs rounded-full border px-2 py-0.5 cursor-pointer",
+            class: "mt-1 text-xs rounded-full border px-2 py-0.5 cursor-pointer",
             data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
-      <%= f.text_field :name, required: true, class: "flex-1 text-lg font-semibold text-gray-800 rounded border-gray-300 shadow-sm px-2 py-1" %>
-      <div class="ml-auto">
+      <div class="flex-1 min-w-0">
+        <%= f.text_area :name, required: true, rows: 1,
+              class: "w-full text-lg font-semibold text-gray-800 rounded border-gray-300 shadow-sm px-2 py-1",
+              placeholder: "Header text" %>
+      </div>
+      <div class="ml-auto mt-1">
         <%= link_to_remove_association "Remove", f,
               class: "text-sm text-gray-400 hover:text-red-600 underline" %>
       </div>
     </div>
   <% else %>
-    <div class="flex-1 flex flex-wrap items-center gap-2">
-      <%= f.select :visibility, visibility_options,
-            {},
-            class: "text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
-            data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
-      <%= f.text_field :name, required: true, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-      <%
-        type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_checkbox no_user_input group_header]
-        type_labels = {
-          "group_header" => "Section header",
-          "free_form_input_one_line" => "One line",
-          "free_form_input_paragraph" => "Paragraph",
-          "multiple_choice_radio" => "Multiple choice radio",
-          "multiple_choice_checkbox" => "Multiple choice checkbox",
-          "no_user_input" => "Informational-only"
-        }
-        type_options = type_order.map { |t| [ type_labels[t] || t.titleize.gsub("_", " "), t ] }
-      %>
-      <%= f.select :answer_type, type_options,
-            {},
-            class: "flex-[2_1_11rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-      <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0">
-        <%= f.check_box :required, class: "rounded border-gray-300 text-blue-600" %>
-        Required
-      </label>
-      <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0" title="Hide if already answered on any form (not just this event)">
-        <%= f.check_box :one_time, class: "rounded border-gray-300 text-amber-600" %>
-        One-time
-      </label>
-      <%= link_to_remove_association "Remove", f,
-            class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
+    <div class="flex-1" data-controller="field-options">
+      <div class="flex flex-wrap items-center gap-2">
+        <%= f.select :visibility, visibility_options,
+              {},
+              class: "text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+              data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
+        <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+        <%
+          type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_checkbox no_user_input group_header]
+          type_options = type_order.map { |t| [ FormField::ANSWER_TYPE_LABELS[t] || t.titleize, t ] }
+        %>
+        <%= f.select :answer_type, type_options,
+              {},
+              class: "flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+        <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0">
+          <%= f.check_box :required, class: "rounded border-gray-300 text-blue-600" %>
+          Required
+        </label>
+        <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0 ml-auto" title="Ask only the first time — hide if the person already answered it on any form, not just this event">
+          <%= f.check_box :one_time, class: "rounded border-gray-300 text-amber-600" %>
+          Only ask once
+        </label>
+        <button type="button"
+                class="shrink-0 text-gray-400 hover:text-gray-600 px-1 cursor-pointer"
+                title="More options"
+                data-action="field-options#toggle">
+          <i class="fa-solid fa-chevron-down transition-transform" data-field-options-target="icon"></i>
+        </button>
+      </div>
+
+      <div class="hidden mt-2 flex flex-wrap items-center gap-3" data-field-options-target="panel">
+        <%
+          width_options = [
+            [ "Full width", "full" ],
+            [ "Half width", "half" ],
+            [ "Third width", "third" ],
+            [ "Quarter width", "quarter" ]
+          ]
+        %>
+        <%= f.select :width, width_options,
+              {},
+              class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+              title: "How wide this field appears on the form" %>
+        <%= f.number_field :min_words, min: 0, placeholder: "Min words",
+              class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+              title: "Minimum number of words required (free-form text fields only)" %>
+        <%= link_to_remove_association "Remove", f,
+              class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -87,6 +87,9 @@
         <%= f.number_field :min_words, min: 0, placeholder: "Min words",
               class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               title: "Minimum number of words required (free-form text fields only)" %>
+        <%= f.number_field :max_characters, min: 1, placeholder: "Max chars",
+              class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+              title: "Maximum number of characters allowed (free-form text fields only)" %>
         <%= link_to_remove_association "Remove", f,
               class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
       </div>

--- a/app/views/forms/_question_library.html.erb
+++ b/app/views/forms/_question_library.html.erb
@@ -28,7 +28,7 @@
                         <span class="text-sm text-gray-800"><%= field.question %></span>
                         <span class="text-xs text-gray-400 ml-2 font-mono"><%= field.field_key %></span>
                       </div>
-                      <span class="text-xs text-gray-500"><%= field.answer_type.humanize %></span>
+                      <span class="text-xs text-gray-500"><%= field.answer_type_label %></span>
                     </label>
                   <% end %>
                 </div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -26,17 +26,19 @@
     <% end %>
 
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 space-y-4">
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Form Name</label>
-        <%= f.text_field :name, class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm" %>
-      </div>
+      <div class="flex flex-col sm:flex-row gap-4">
+        <div class="flex-1">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Form name</label>
+          <%= f.text_field :name, class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm" %>
+        </div>
 
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Form role</label>
-        <%= f.select :role,
-              [["General", ""], ["Registration", "registration"], ["Scholarship", "scholarship"], ["Bulk Payment", "bulk_payment"]],
-              { selected: @form.role || "" },
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm" %>
+        <div class="sm:w-56">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Form role</label>
+          <%= f.select :role,
+                [["General", ""], ["Registration", "registration"], ["Scholarship", "scholarship"], ["Bulk Payment", "bulk_payment"]],
+                { selected: @form.role || "" },
+                class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm" %>
+        </div>
       </div>
 
       <div class="flex flex-wrap gap-x-6 gap-y-2">
@@ -51,10 +53,18 @@
       </div>
     </div>
 
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+    <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden"
+         data-controller="expand-all"
+         data-expand-all-field-options-outlet="[data-controller~='field-options']">
       <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
         <h2 class="text-lg font-semibold">Fields</h2>
-        <span class="text-sm text-gray-500"><%= @form_fields.size %> fields</span>
+        <div class="flex items-center gap-3">
+          <span class="text-sm text-gray-500"><%= @form_fields.size %> fields</span>
+          <button type="button"
+                  class="text-sm text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
+                  data-action="expand-all#toggleAll"
+                  data-expand-all-target="btn">Expand all</button>
+        </div>
       </div>
 
       <div class="px-6 py-3 border-b border-gray-100">

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -73,34 +73,7 @@
       </div>
 
       <%
-        fields_by_id_check = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-        email_row = if fields_by_id_check["confirm_email"] && fields_by_id_check["primary_email_type"]
-          { keys: %w[primary_email confirm_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" }
-        elsif fields_by_id_check["confirm_email"]
-          { keys: %w[primary_email confirm_email], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" }
-        else
-          { keys: %w[primary_email primary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "primary_email" => "md:col-span-2" } }
-        end
-
-        row_groups = [
-          { keys: %w[first_name last_name], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[nickname pronouns], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          email_row,
-          { keys: %w[secondary_email secondary_email_type], grid: "grid grid-cols-1 md:grid-cols-3 gap-4", spans: { "secondary_email" => "md:col-span-2" } },
-          { keys: %w[mailing_street mailing_address_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[mailing_city mailing_state mailing_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-          { keys: %w[phone phone_type], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[agency_name agency_position], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" },
-          { keys: %w[agency_city agency_state agency_zip], grid: "grid grid-cols-1 md:grid-cols-3 gap-4" },
-          { keys: %w[payment_method], grid: "grid grid-cols-1 md:grid-cols-2 gap-4" }
-        ]
-
-        identifier_to_group = {}
-        row_groups.each { |g| g[:keys].each { |k| identifier_to_group[k] = g } }
-
         fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-        rendered_ids = {}
-
         has_secondary_email = fields_by_identifier["secondary_email"].present?
         email_label_overrides = if has_secondary_email
           { "primary_email" => "Primary Email", "confirm_email" => "Confirm Primary Email", "primary_email_type" => "Primary Email Type" }
@@ -110,34 +83,19 @@
       %>
 
       <fieldset disabled>
-        <% @form_fields.each do |field| %>
-          <% next if field.field_identifier.present? && rendered_ids[field.field_identifier] %>
-
-          <% if field.group_header? %>
-            <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-              <h3 class="text-lg font-semibold text-gray-800"><%= field.name %></h3>
-            </div>
-          <% elsif (group = field.field_identifier.present? && identifier_to_group[field.field_identifier]) %>
-            <div class="<%= group[:grid] %>">
-              <% group[:keys].each do |key| %>
-                <% row_field = fields_by_identifier[key] %>
-                <% next unless row_field %>
-                <% rendered_ids[key] = true %>
-                <% span = group.dig(:spans, key) %>
-                <% label_override = email_label_overrides[key] %>
-                <% if span %>
-                  <div class="<%= span %>">
-                    <%= render "events/public_registrations/form_field", field: row_field, value: nil, label: label_override %>
-                  </div>
-                <% else %>
-                  <%= render "events/public_registrations/form_field", field: row_field, value: nil, label: label_override %>
-                <% end %>
-              <% end %>
-            </div>
-          <% else %>
-            <%= render "events/public_registrations/form_field", field: field, value: nil %>
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+          <% @form_fields.each do |field| %>
+            <% if field.group_header? %>
+              <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
+                <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
+              </div>
+            <% else %>
+              <div class="<%= field.grid_span_class %>">
+                <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </fieldset>
     </div>
   </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "ba14f5d8dca1d3100eac5857e323dd0fa62631bec9ad13f7cfa0f8dbdf46fa16",
+      "fingerprint": "2ff57a7df86fdf510c6b5ad01e9eaf77e654a29fb5bbc945c4389593ddb6bda5",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
       "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :_destroy]))",
+      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :_destroy]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "2ff57a7df86fdf510c6b5ad01e9eaf77e654a29fb5bbc945c4389593ddb6bda5",
+      "fingerprint": "5473b25a3e7836314952560daf8b227d719838ca52c1fd7388a03b60415dd015",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
       "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :_destroy]))",
+      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/db/migrate/20260608190000_add_width_to_form_fields.rb
+++ b/db/migrate/20260608190000_add_width_to_form_fields.rb
@@ -1,0 +1,23 @@
+class AddWidthToFormFields < ActiveRecord::Migration[8.1]
+  # Layout widths previously hardcoded by field_identifier in the form views.
+  # Backfill them so existing forms keep their multi-column appearance now that
+  # width is configurable per field.
+  HALF = %w[
+    first_name last_name nickname pronouns primary_email confirm_email
+    mailing_street mailing_address_type phone phone_type agency_name
+    agency_position secondary_email secondary_email_type
+  ].freeze
+  THIRD = %w[mailing_city mailing_state mailing_zip agency_city agency_state agency_zip].freeze
+
+  def up
+    add_column :form_fields, :width, :integer, default: 0, null: false unless column_exists?(:form_fields, :width)
+
+    FormField.reset_column_information
+    FormField.where(field_identifier: HALF).update_all(width: 1)
+    FormField.where(field_identifier: THIRD).update_all(width: 2)
+  end
+
+  def down
+    remove_column :form_fields, :width, if_exists: true
+  end
+end

--- a/db/migrate/20260609040000_change_form_field_name_to_text.rb
+++ b/db/migrate/20260609040000_change_form_field_name_to_text.rb
@@ -1,0 +1,11 @@
+class ChangeFormFieldNameToText < ActiveRecord::Migration[8.1]
+  # Question names can be long, multi-sentence prompts that overflowed the
+  # varchar(255) limit and raised ActiveRecord::ValueTooLong. Widen to text.
+  def up
+    change_column :form_fields, :name, :text
+  end
+
+  def down
+    change_column :form_fields, :name, :string
+  end
+end

--- a/db/migrate/20260609050000_add_min_words_to_form_fields.rb
+++ b/db/migrate/20260609050000_add_min_words_to_form_fields.rb
@@ -1,0 +1,11 @@
+class AddMinWordsToFormFields < ActiveRecord::Migration[8.1]
+  # Optional per-field minimum word count for free-form text answers.
+  # NULL means no minimum is enforced.
+  def up
+    add_column :form_fields, :min_words, :integer unless column_exists?(:form_fields, :min_words)
+  end
+
+  def down
+    remove_column :form_fields, :min_words, if_exists: true
+  end
+end

--- a/db/migrate/20260609060000_add_max_characters_to_form_fields.rb
+++ b/db/migrate/20260609060000_add_max_characters_to_form_fields.rb
@@ -1,0 +1,11 @@
+class AddMaxCharactersToFormFields < ActiveRecord::Migration[8.1]
+  # Optional per-field maximum character count for free-form text answers.
+  # NULL means no maximum is enforced.
+  def up
+    add_column :form_fields, :max_characters, :integer unless column_exists?(:form_fields, :max_characters)
+  end
+
+  def down
+    remove_column :form_fields, :max_characters, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_050000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_060000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -556,6 +556,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_050000) do
     t.integer "form_id"
     t.text "hint_text"
     t.integer "input_type"
+    t.integer "max_characters"
     t.integer "min_words"
     t.text "name"
     t.boolean "one_time", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_184843) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_050000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -556,7 +556,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_184843) do
     t.integer "form_id"
     t.text "hint_text"
     t.integer "input_type"
-    t.string "name"
+    t.integer "min_words"
+    t.text "name"
     t.boolean "one_time", default: false, null: false
     t.integer "parent_id"
     t.integer "position"
@@ -565,6 +566,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_184843) do
     t.integer "status", default: 1
     t.datetime "updated_at", precision: nil, null: false
     t.integer "visibility", default: 0, null: false
+    t.integer "width", default: 0, null: false
     t.index ["field_identifier"], name: "index_form_fields_on_field_identifier"
     t.index ["form_id"], name: "index_form_fields_on_form_id"
     t.index ["section"], name: "index_form_fields_on_section"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -116,4 +116,46 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#form_label_html" do
+    it "preserves allowed formatting and link tags" do
+      input = %(Visit <a href="https://example.com">our site</a><br>line two <strong>bold</strong>)
+      expect(helper.form_label_html(input)).to eq(input)
+    end
+
+    it "keeps heading tags" do
+      expect(helper.form_label_html("<h2>Section</h2>")).to eq("<h2>Section</h2>")
+    end
+
+    it "keeps font size and color via inline style" do
+      input = %(<span style="font-size:24px;color:#ff0000">big red</span>)
+      result = helper.form_label_html(input)
+      expect(result).to include("font-size:24px")
+      expect(result).to include("color:#ff0000")
+    end
+
+    it "keeps font size and color via the font tag" do
+      input = %(<font size="5" color="blue">styled</font>)
+      expect(helper.form_label_html(input)).to eq(input)
+    end
+
+    it "scrubs dangerous css from the style attribute while keeping safe properties" do
+      result = helper.form_label_html(%(<span style="color:red;background:url(javascript:alert(1))">x</span>))
+      expect(result).to include("color:red")
+      expect(result).not_to include("javascript")
+    end
+
+    it "strips disallowed tags but keeps their text" do
+      expect(helper.form_label_html("<script>alert(1)</script>Hello")).to eq("alert(1)Hello")
+    end
+
+    it "removes dangerous link schemes" do
+      result = helper.form_label_html(%(<a href="javascript:alert(1)">x</a>))
+      expect(result).not_to include("javascript:")
+    end
+
+    it "returns an html_safe string" do
+      expect(helper.form_label_html("<br>")).to be_html_safe
+    end
+  end
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe FormField do
       build(:form_field, form: create(:form))
     end
     it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(1000) }
+
+    it "accepts a long, multi-sentence question name" do
+      field = build(:form_field, form: create(:form), name: "A. " * 100)
+      expect(field).to be_valid
+    end
   end
 
   describe 'enums' do
@@ -33,6 +39,92 @@ RSpec.describe FormField do
 
   describe "enums" do
     it { should define_enum_for(:visibility).with_values([ :always_ask, :scholarship_only, :logged_out_only, :answers_on_file ]) }
+    it { should define_enum_for(:width).with_values([ :full, :half, :third, :quarter ]).with_prefix(true) }
+  end
+
+  describe "#grid_span_class" do
+    let(:form) { create(:form) }
+
+    it "spans the full grid for full-width fields" do
+      field = build(:form_field, form: form, width: :full)
+      expect(field.grid_span_class).to eq("md:col-span-12")
+    end
+
+    it "spans half the grid for half-width fields" do
+      field = build(:form_field, form: form, width: :half)
+      expect(field.grid_span_class).to eq("md:col-span-6")
+    end
+
+    it "spans a third of the grid for third-width fields" do
+      field = build(:form_field, form: form, width: :third)
+      expect(field.grid_span_class).to eq("md:col-span-4")
+    end
+
+    it "spans a quarter of the grid for quarter-width fields" do
+      field = build(:form_field, form: form, width: :quarter)
+      expect(field.grid_span_class).to eq("md:col-span-3")
+    end
+
+    it "falls back to full width when width is blank" do
+      field = build(:form_field, form: form)
+      field.width = nil
+      expect(field.grid_span_class).to eq("md:col-span-12")
+    end
+  end
+
+  describe "#min_words_error" do
+    let(:form) { create(:form) }
+
+    it "returns nil when no minimum is configured" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: nil)
+      expect(field.min_words_error("just two")).to be_nil
+    end
+
+    it "returns nil when the value meets the minimum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 3)
+      expect(field.min_words_error("one two three")).to be_nil
+    end
+
+    it "ignores surrounding and repeated whitespace when counting" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 3)
+      expect(field.min_words_error("  one\ntwo   three  ")).to be_nil
+    end
+
+    it "returns an error when the value has too few words" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 5)
+      expect(field.min_words_error("only three words")).to eq("must be at least 5 words")
+    end
+
+    it "pluralizes the word count for a minimum of one" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 1)
+      expect(field.min_words_error("")).to be_nil
+      expect(field.min_words_error("   ")).to be_nil
+    end
+
+    it "leaves blank values to the required check" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 5)
+      expect(field.min_words_error("")).to be_nil
+      expect(field.min_words_error(nil)).to be_nil
+    end
+
+    it "does not apply to non-text answer types" do
+      field = build(:form_field, form: form, answer_type: :multiple_choice_radio, min_words: 5)
+      expect(field.min_words_error("Yes")).to be_nil
+    end
+  end
+
+  describe "min_words validation" do
+    let(:form) { create(:form) }
+
+    it "rejects a negative minimum" do
+      field = build(:form_field, form: form, min_words: -1)
+      expect(field).not_to be_valid
+    end
+
+    it "allows a nil minimum" do
+      field = build(:form_field, form: form, min_words: nil)
+      expect(field).to be_valid
+    end
   end
 
   describe "#multiple_choice?" do
@@ -109,6 +201,25 @@ RSpec.describe FormField do
     it "returns :radio_button for radio fields" do
       field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
       expect(field.form_helper_type).to eq(:radio_button)
+    end
+  end
+
+  describe "#answer_type_label" do
+    let(:form) { create(:form) }
+
+    it "calls radio fields single choice" do
+      field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
+      expect(field.answer_type_label).to eq("Single choice radio")
+    end
+
+    it "calls checkbox fields multiple choice" do
+      field = build(:form_field, form: form, answer_type: :multiple_choice_checkbox)
+      expect(field.answer_type_label).to eq("Multiple choice checkbox")
+    end
+
+    it "falls back to a humanized label for unmapped types" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_one_line)
+      expect(field.answer_type_label).to eq("One line")
     end
   end
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -127,6 +127,65 @@ RSpec.describe FormField do
     end
   end
 
+  describe "#max_characters_error" do
+    let(:form) { create(:form) }
+
+    it "returns nil when no maximum is configured" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: nil)
+      expect(field.max_characters_error("a" * 500)).to be_nil
+    end
+
+    it "returns nil when the value is within the maximum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 10)
+      expect(field.max_characters_error("short")).to be_nil
+    end
+
+    it "returns nil when the value is exactly at the maximum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 5)
+      expect(field.max_characters_error("12345")).to be_nil
+    end
+
+    it "returns an error when the value exceeds the maximum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 5)
+      expect(field.max_characters_error("123456")).to eq("must be 5 characters or fewer")
+    end
+
+    it "pluralizes correctly for a maximum of one" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_one_line, max_characters: 1)
+      expect(field.max_characters_error("ab")).to eq("must be 1 character or fewer")
+    end
+
+    it "leaves blank values to the required check" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 5)
+      expect(field.max_characters_error("")).to be_nil
+      expect(field.max_characters_error(nil)).to be_nil
+    end
+
+    it "does not apply to non-text answer types" do
+      field = build(:form_field, form: form, answer_type: :multiple_choice_radio, max_characters: 1)
+      expect(field.max_characters_error("Yes")).to be_nil
+    end
+  end
+
+  describe "max_characters validation" do
+    let(:form) { create(:form) }
+
+    it "rejects a zero maximum" do
+      field = build(:form_field, form: form, max_characters: 0)
+      expect(field).not_to be_valid
+    end
+
+    it "rejects a negative maximum" do
+      field = build(:form_field, form: form, max_characters: -1)
+      expect(field).not_to be_valid
+    end
+
+    it "allows a nil maximum" do
+      field = build(:form_field, form: form, max_characters: nil)
+      expect(field).to be_valid
+    end
+  end
+
   describe "#multiple_choice?" do
     let(:form) { create(:form) }
 

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -43,5 +43,13 @@ RSpec.describe "Events::BulkPayments", type: :request do
 
       expect(response.body).to include("Minimum of 5 words.")
     end
+
+    it "renders the field at its configured width" do
+      org_field.update!(width: :half)
+
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include("md:col-span-6")
+    end
   end
 end

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Events::BulkPayments", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, cost_cents: 0) }
+  let(:form) { create(:form) }
+  # The bulk payment view only renders a known set of "payer" fields, so the
+  # min-word rule is exercised through organization_name (a free-form text field).
+  let!(:org_field) do
+    create(:form_field, form: form, answer_type: :free_form_input_one_line,
+           field_identifier: "organization_name", name: "Organization name",
+           required: true, min_words: 5)
+  end
+
+  before do
+    EventForm.create!(event: event, form: form, role: "bulk_payment")
+    sign_in admin
+  end
+
+  def post_bulk_payment(answer)
+    post event_bulk_payment_path(event),
+         params: { bulk_payment: { form_fields: { org_field.id.to_s => answer } } }
+  end
+
+  describe "POST create with a minimum word count" do
+    it "rejects an answer with too few words" do
+      post_bulk_payment("not quite enough")
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be at least 5 words")
+    end
+
+    it "does not flag an answer that meets the minimum" do
+      post_bulk_payment("this answer easily has plenty of words")
+
+      expect(response.body).not_to include("must be at least 5 words")
+    end
+  end
+
+  describe "GET new" do
+    it "shows the minimum word hint below the field" do
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include("Minimum of 5 words.")
+    end
+  end
+end

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Events::PublicRegistrations", type: :request do
+  # A guest registering on a free event so we exercise the bare create path
+  # without payment or auth.
+  let(:event) { create(:event, cost_cents: 0) }
+  let(:form) { create(:form) }
+  let!(:essay_field) do
+    create(:form_field, form: form, answer_type: :free_form_input_paragraph,
+           name: "Tell us why you'd like to attend", required: true, min_words: 5)
+  end
+
+  before { EventForm.create!(event: event, form: form, role: "registration") }
+
+  def post_registration(answer)
+    post event_public_registration_path(event),
+         params: { public_registration: { form_fields: { essay_field.id.to_s => answer } } }
+  end
+
+  describe "POST create with a minimum word count" do
+    it "rejects an answer with too few words" do
+      expect {
+        post_registration("not quite enough")
+      }.not_to change(EventRegistration, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be at least 5 words")
+    end
+
+    it "does not flag an answer that meets the minimum" do
+      post_registration("this answer has plenty of words")
+
+      expect(response.body).not_to include("must be at least 5 words")
+    end
+  end
+
+  describe "GET new" do
+    it "shows the minimum word hint below the field" do
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("Minimum of 5 words.")
+    end
+  end
+end

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -64,6 +64,42 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "POST create enforces the same settings on the scholarship form" do
+    let(:scholarship_form) { create(:form, role: "scholarship") }
+    let!(:scholarship_essay) do
+      create(:form_field, form: scholarship_form, answer_type: :free_form_input_paragraph,
+             name: "Describe your need", required: true, min_words: 8)
+    end
+
+    before { EventForm.create!(event: event, form: scholarship_form, role: "scholarship") }
+
+    def post_with_scholarship(scholarship_answer)
+      post event_public_registration_path(event),
+           params: {
+             scholarship_requested: "true",
+             public_registration: { form_fields: {
+               essay_field.id.to_s => "this answer has plenty of words",
+               scholarship_essay.id.to_s => scholarship_answer
+             } }
+           }
+    end
+
+    it "rejects a scholarship answer with too few words" do
+      expect {
+        post_with_scholarship("too short here")
+      }.not_to change(EventRegistration, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be at least 8 words")
+    end
+
+    it "does not flag a scholarship answer that meets the minimum" do
+      post_with_scholarship("this scholarship answer clearly has more than eight words total")
+
+      expect(response.body).not_to include("must be at least 8 words")
+    end
+  end
+
   describe "GET new" do
     it "shows the minimum word hint below the field" do
       get new_event_public_registration_path(event)

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -34,11 +34,50 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "POST create with a maximum character count" do
+    let!(:bio_field) do
+      create(:form_field, form: form, answer_type: :free_form_input_one_line,
+             name: "Nickname", required: false, max_characters: 10)
+    end
+
+    def post_bio(answer)
+      post event_public_registration_path(event),
+           params: { public_registration: { form_fields: {
+             essay_field.id.to_s => "this answer has plenty of words",
+             bio_field.id.to_s => answer
+           } } }
+    end
+
+    it "rejects an answer that is too long" do
+      expect {
+        post_bio("a" * 11)
+      }.not_to change(EventRegistration, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be 10 characters or fewer")
+    end
+
+    it "does not flag an answer within the maximum" do
+      post_bio("short")
+
+      expect(response.body).not_to include("must be 10 characters or fewer")
+    end
+  end
+
   describe "GET new" do
     it "shows the minimum word hint below the field" do
       get new_event_public_registration_path(event)
 
       expect(response.body).to include("Minimum of 5 words.")
+    end
+
+    it "shows the maximum character hint below the field" do
+      create(:form_field, form: form, answer_type: :free_form_input_paragraph,
+             name: "Bio", required: false, max_characters: 250)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("Maximum of 250 characters.")
     end
   end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -87,6 +87,38 @@ RSpec.describe "Forms", type: :request do
       expect(form.hide_answered_person_questions).to be true
       expect(form.hide_answered_form_questions).to be true
     end
+
+    it "saves a long, multi-sentence question name" do
+      form = create(:form, :standalone)
+      long_name = "AWBW workshops are used in a variety of ways. " * 8
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { name: long_name, answer_type: "free_form_input_paragraph" } } }
+      }
+      expect(response).to redirect_to(edit_form_path(form))
+      expect(form.form_fields.where(name: long_name)).to exist
+    end
+
+    it "renders a validation error instead of 500 when a name is too long" do
+      form = create(:form, :standalone)
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { name: "x" * 1001, answer_type: "free_form_input_one_line" } } }
+      }
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("too long")
+    end
+
+    it "saves the per-field width and minimum word count" do
+      form = create(:form, :standalone)
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => {
+          name: "Essay", answer_type: "free_form_input_paragraph", width: "half", min_words: "25"
+        } } }
+      }
+      expect(response).to redirect_to(edit_form_path(form))
+      field = form.form_fields.find_by(name: "Essay")
+      expect(field.width).to eq("half")
+      expect(field.min_words).to eq(25)
+    end
   end
 
   describe "DELETE /forms/:id" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -107,17 +107,18 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("too long")
     end
 
-    it "saves the per-field width and minimum word count" do
+    it "saves the per-field width, minimum word count, and maximum character count" do
       form = create(:form, :standalone)
       patch form_path(form), params: {
         form: { form_fields_attributes: { "0" => {
-          name: "Essay", answer_type: "free_form_input_paragraph", width: "half", min_words: "25"
+          name: "Essay", answer_type: "free_form_input_paragraph", width: "half", min_words: "25", max_characters: "500"
         } } }
       }
       expect(response).to redirect_to(edit_form_path(form))
       field = form.form_fields.find_by(name: "Essay")
       expect(field.width).to eq("half")
       expect(field.min_words).to eq(25)
+      expect(field.max_characters).to eq(500)
     end
   end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe FormBuilderService do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include("first_name", "last_name", "primary_email", "confirm_email")
       end
+
+      it "defaults paired name fields to half width" do
+        field = form.form_fields.find_by(field_identifier: "first_name")
+        expect(field.width).to eq("half")
+      end
+    end
+
+    context "default field widths" do
+      let(:form) { described_class.new(name: "Test", sections: %i[person_contact_info]).call }
+
+      it "lays city/state/zip out as thirds" do
+        widths = form.form_fields.where(field_identifier: %w[mailing_city mailing_state mailing_zip]).pluck(:width)
+        expect(widths).to all(eq("third"))
+      end
+
+      it "leaves unlisted fields at full width" do
+        field = form.form_fields.find_by(field_identifier: "agency_website")
+        expect(field.width).to eq("full")
+      end
     end
 
     context "person_contact_info section" do
@@ -38,6 +57,13 @@ RSpec.describe FormBuilderService do
       it "creates contact info fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include("nickname", "pronouns", "phone", "mailing_city", "agency_name")
+      end
+
+      it "offers the agency type as the four organization classifications" do
+        field = form.form_fields.find_by(field_identifier: "agency_type")
+        expect(field.answer_options.pluck(:name)).to contain_exactly(
+          "501c3/nonprofit", "For-profit", "Government agency", "Other (please specify below)"
+        )
       end
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Give form admins real layout control over the form builder instead of relying on hardcoded, identifier-based field groupings
- Let questions sit at **full / half / third / quarter** width so multi-column forms can be composed for any field, not just the predefined name/email/address rows
- Support long, multi-sentence question prompts that were previously hitting the `varchar(255)` limit and raising `ActiveRecord::ValueTooLong`
- Add per-field **minimum word count** and **maximum character count** validation, plus an expandable options editor, to round out the field-configuration UI

### How did you approach the change?

- Added a `width` enum to `FormField` (`full/half/third/quarter`, prefixed to avoid colliding with AR finder methods like `.third`) plus a `grid_span_class` helper mapping each width to a Tailwind 12-column span
- Replaced the brittle `row_groups` machinery (duplicated across the preview, live, and read-only registration views) with a single `md:grid-cols-12` grid driven by each field's width; group headers and full-width fields take a whole row
- Backfilled `width` on existing fields in the migration (name pairs → half, city/state/zip → thirds, …) and set sensible defaults in `FormBuilderService` so existing forms keep their current appearance
- Widened `form_fields.name` to `text`; added nullable `min_words` and `max_characters` columns
- Min/max are enforced server-side in both the public-registration and bulk-payment flows via `min_words_error` / `max_characters_error`, surfaced as `maxlength` + hint text on the rendered fields, and edited in the form builder's collapsible "More options" panel (width / min words / max chars)
- Added `field_options` and `expand_all` Stimulus controllers for the editor UI
- Updated the Brakeman ignore fingerprint for the (admin-only, pre-existing) `forms_controller` permit warning, since the permit list changed

### Anything else to add?

- Min words / max chars apply only to free-form text answer types (one-line and paragraph); they're left to the presence check when blank
- One trade-off: the old layout had a couple of 2/3-width special cases (e.g. `secondary_email`); those now map to the nearest of the four supported widths (half), adjustable per-field via the new control
- New Tailwind classes (`md:grid-cols-12`, `md:col-span-{12,6,4,3}`) required a Vite dev rebuild
- Tests: model enum + `grid_span_class`, `min_words_error` / `max_characters_error` + their validations, service width defaults, controller enforcement in both flows, and the existing form/registration/bulk-payment suites — all green

- Known follow-up (deferred): the new `expand_all` / `field_options` Stimulus controllers duplicate the existing `expandable_cards` / `expandable_card` pattern. Kept as-is for now (the new pair uses the Outlets API, which our conventions prefer over `expandable_cards`' `@window` event broadcasting); cross-referencing `TODO(dedupe)` notes are in both controllers. To consolidate later.


- Scholarship fields now render in the same `md:grid-cols-12` grid (respecting per-field width) and have min-word / max-char rules enforced on submit; the shared per-field checks were extracted into `collect_field_errors` so registration and scholarship forms validate identically
