### PR TITLE
Align field-option controls under the name field in form builder

### DIFF
--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -41,12 +41,12 @@
       </div>
     </div>
   <% else %>
-    <div class="flex-1" data-controller="field-options">
+    <%= f.select :visibility, visibility_options,
+          {},
+          class: "self-start mt-1 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+          data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
+    <div class="flex-1 min-w-0" data-controller="field-options">
       <div class="flex flex-wrap items-center gap-2">
-        <%= f.select :visibility, visibility_options,
-              {},
-              class: "text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
-              data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
         <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         <%
           type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_checkbox no_user_input group_header]

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -115,5 +115,35 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).to include("Maximum of 250 characters.")
     end
+
+    it "renders header and field-label HTML unescaped" do
+      create(:form_field, form: form, answer_type: :group_header,
+             name: %(Visit <a href="https://awbw.org">our site</a>))
+      create(:form_field, form: form, answer_type: :free_form_input_one_line,
+             name: "<h2>About you</h2>", required: false)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include(%(<a href="https://awbw.org">our site</a>))
+      expect(response.body).to include("<h2>About you</h2>")
+      expect(response.body).to include("rich-label")
+    end
+  end
+
+  describe "GET show" do
+    let(:person) { create(:person) }
+
+    before { create(:form_submission, person: person, form: form) }
+
+    it "renders header and field-label HTML unescaped on the response page" do
+      create(:form_field, form: form, answer_type: :group_header, name: "<strong>Your details</strong>")
+      create(:form_field, form: form, answer_type: :free_form_input_one_line, name: "<em>Name</em>", required: false)
+
+      get event_public_registration_path(event, person_id: person.id)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("<strong>Your details</strong>")
+      expect(response.body).to include("<em>Name</em>")
+    end
   end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -66,6 +66,47 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Name")
     end
+
+    it "renders the collapsible per-field options controls" do
+      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      get edit_form_path(form)
+
+      expect(response.body).to include('data-controller="field-options"')
+      expect(response.body).to include("field-options#toggle")
+      expect(response.body).to include("Only ask once")
+      expect(response.body).to include("Min words")
+    end
+
+    it "renders the expand/collapse all toggle" do
+      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      get edit_form_path(form)
+
+      expect(response.body).to include('data-controller="expand-all"')
+      expect(response.body).to include("Expand all")
+    end
+
+    it "edits field and header names in textareas" do
+      form = FormBuilderService.new(name: "Test", sections: %i[person_contact_info]).call
+      get edit_form_path(form)
+
+      expect(response.body).to include("<textarea")
+    end
+  end
+
+  describe "GET /forms/:id (preview)" do
+    before { sign_in admin }
+
+    it "renders header and field-label HTML unescaped" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, answer_type: :group_header, name: "<strong>Section</strong>")
+      create(:form_field, form: form, answer_type: :free_form_input_one_line, name: "<em>Your name</em>", required: false)
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("<strong>Section</strong>")
+      expect(response.body).to include("<em>Your name</em>")
+    end
   end
 
   describe "PATCH /forms/:id" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- In the form builder, the collapsible per-field options row (width / min words / max chars) lined up under the **visibility chip** instead of under the **field name**, which read as a misaligned, ragged second row.
- This is a follow-up polish to #1606 (per-field width / min-word / field-option controls), which has merged.

### How did you approach the change?
- Pulled the visibility chip out of the `field-options` container and made it a sibling of it, so the container holding both rows now begins at the field name. The options row therefore starts at the name field's left edge.
- Gave the chip `self-start mt-1` so it stays parallel to the name field whether the options panel is collapsed or expanded.
- Added request specs covering rich (unescaped) HTML rendering of header/field labels and the per-field options controls.

### UI Testing Checklist
- [ ] Open a form in the builder; confirm the "Full width / Min words / Max chars" row starts under the field name, not the visibility chip
- [ ] Confirm the visibility chip stays aligned with the name field when the options panel is expanded and collapsed
- [ ] Confirm group-header rows are unaffected

### Anything else to add?
- View-only layout change plus tests; no model or controller changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)