### PR TITLE
Show all fields in forms preview; apply conditional logic only on registration

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -8,7 +8,10 @@ class FormsController < ApplicationController
 
   def show
     authorize! @form
-    @form_fields = preview_form_fields
+    # The forms preview shows every field, highlighting any with conditional
+    # visibility. The conditional logic itself only runs on the live
+    # registration and public registration forms.
+    @form_fields = @form.form_fields.reorder(position: :asc)
   end
 
   def new
@@ -100,20 +103,6 @@ class FormsController < ApplicationController
 
   def set_form
     @form = Form.find(params[:id])
-  end
-
-  def preview_form_fields
-    scope = @form.form_fields
-
-    if params[:preview_logged_in].present?
-      scope = scope.where.not(visibility: :logged_out_only)
-    end
-
-    if params[:preview_answered].present?
-      scope = scope.where.not(visibility: :answers_on_file)
-    end
-
-    scope.reorder(position: :asc)
   end
 
   def form_params

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -42,6 +42,14 @@ class FormField < ApplicationRecord
   # Prefixed because :third/:first/etc. collide with Active Record finder methods
   enum :width, [ :full, :half, :third, :quarter ], prefix: true
 
+  # Human-friendly labels for visibility, mirroring the form editor's options
+  VISIBILITY_LABELS = {
+    "always_ask" => "Always ask",
+    "scholarship_only" => "Scholarship only",
+    "logged_out_only" => "Logged out only",
+    "answers_on_file" => "Answers on file"
+  }.freeze
+
   # Human-friendly labels for answer types (radio is "single choice" because only one option can be picked)
   ANSWER_TYPE_LABELS = {
     "group_header" => "Section header",
@@ -81,6 +89,16 @@ class FormField < ApplicationRecord
 
   def answer_type_label
     ANSWER_TYPE_LABELS.fetch(answer_type, answer_type&.titleize)
+  end
+
+  def visibility_label
+    VISIBILITY_LABELS.fetch(visibility, visibility&.humanize)
+  end
+
+  # True when the field is only asked under certain conditions, i.e. anything
+  # other than "always ask". The forms preview highlights these.
+  def conditional_visibility?
+    !always_ask?
   end
 
   def free_form_text?

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
@@ -21,58 +22,6 @@
 
     <div class="px-6 py-6">
       <%
-        has_logged_out = @form.form_fields.where(visibility: :logged_out_only).exists?
-        has_answers_on_file = @form.form_fields.where(visibility: :answers_on_file).exists?
-        has_conditions = (has_logged_out && @form.hide_answered_person_questions?) || (has_answers_on_file && @form.hide_answered_form_questions?)
-
-        preview_logged_in = params[:preview_logged_in].present?
-        preview_answered = params[:preview_answered].present?
-      %>
-
-      <div class="mb-4 rounded-lg bg-blue-50 border border-blue-200 p-3 space-y-2">
-        <p class="text-xs font-medium text-blue-800">Preview mode</p>
-        <% if has_conditions %>
-          <p class="text-xs text-blue-600 mb-1">Toggle to simulate how the form appears under different conditions:</p>
-          <div class="flex flex-wrap gap-4">
-            <% if has_logged_out && @form.hide_answered_person_questions? %>
-              <%
-                logged_in_params = request.query_parameters.dup
-                if preview_logged_in
-                  logged_in_params.delete("preview_logged_in")
-                else
-                  logged_in_params["preview_logged_in"] = "1"
-                end
-              %>
-              <%= link_to form_path(@form, logged_in_params), class: "flex items-center gap-2 no-underline" do %>
-                <span class="text-xs text-blue-700">User logged in</span>
-                <span class="relative inline-block w-7 h-4 rounded-full <%= preview_logged_in ? 'bg-blue-600' : 'bg-gray-300' %>">
-                  <span class="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform duration-200 <%= preview_logged_in ? 'translate-x-3' : 'translate-x-0' %>"></span>
-                </span>
-              <% end %>
-            <% end %>
-            <% if has_answers_on_file && @form.hide_answered_form_questions? %>
-              <%
-                answered_params = request.query_parameters.dup
-                if preview_answered
-                  answered_params.delete("preview_answered")
-                else
-                  answered_params["preview_answered"] = "1"
-                end
-              %>
-              <%= link_to form_path(@form, answered_params), class: "flex items-center gap-2 no-underline" do %>
-                <span class="text-xs text-blue-700">Answers on file</span>
-                <span class="relative inline-block w-7 h-4 rounded-full <%= preview_answered ? 'bg-blue-600' : 'bg-gray-300' %>">
-                  <span class="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform duration-200 <%= preview_answered ? 'translate-x-3' : 'translate-x-0' %>"></span>
-                </span>
-              <% end %>
-            <% end %>
-          </div>
-        <% else %>
-          <p class="text-xs text-blue-600">No conditional visibility configured. All fields always shown.</p>
-        <% end %>
-      </div>
-
-      <%
         fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
         has_secondary_email = fields_by_identifier["secondary_email"].present?
         email_label_overrides = if has_secondary_email
@@ -80,18 +29,54 @@
         else
           {}
         end
+
+        # Mirror the editor's visibility chip colors so the same field reads
+        # the same in both places.
+        visibility_badge_styles = {
+          "scholarship_only" => "bg-blue-100 text-blue-700 border-blue-200",
+          "logged_out_only" => "bg-emerald-100 text-emerald-700 border-emerald-200",
+          "answers_on_file" => "bg-amber-100 text-amber-700 border-amber-200"
+        }
+        visibility_marker_styles = {
+          "scholarship_only" => "border-blue-300",
+          "logged_out_only" => "border-emerald-300",
+          "answers_on_file" => "border-amber-300"
+        }
+
+        has_conditional = @form_fields.any?(&:conditional_visibility?)
       %>
+
+      <div class="mb-6 rounded-lg bg-gray-50 border border-gray-200 p-3">
+        <% if has_conditional %>
+          <p class="text-xs text-gray-600">This preview shows every field. Highlighted fields are only asked under certain conditions — the conditional logic runs on the live registration form.</p>
+        <% else %>
+          <p class="text-xs text-gray-600">This preview shows every field. All fields are always asked.</p>
+        <% end %>
+      </div>
 
       <fieldset disabled>
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
           <% @form_fields.each do |field| %>
+            <% conditional = field.conditional_visibility? %>
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
-                <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
+                <div class="flex flex-wrap items-center gap-2">
+                  <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
+                  <% if conditional %>
+                    <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
+                  <% end %>
+                </div>
               </div>
             <% else %>
               <div class="<%= field.grid_span_class %>">
-                <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+                <% if conditional %>
+                  <div class="border-l-4 <%= visibility_marker_styles[field.visibility] %> pl-3">
+                    <span class="inline-block mb-1.5 text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
+                    <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+                  </div>
+                <% else %>
+                  <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+                <% end %>
               </div>
             <% end %>
           <% end %>

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -72,6 +72,31 @@ RSpec.describe FormField do
     end
   end
 
+  describe "#visibility_label" do
+    let(:form) { create(:form) }
+
+    it "returns the human-friendly label for each visibility" do
+      expect(build(:form_field, form: form, visibility: :always_ask).visibility_label).to eq("Always ask")
+      expect(build(:form_field, form: form, visibility: :scholarship_only).visibility_label).to eq("Scholarship only")
+      expect(build(:form_field, form: form, visibility: :logged_out_only).visibility_label).to eq("Logged out only")
+      expect(build(:form_field, form: form, visibility: :answers_on_file).visibility_label).to eq("Answers on file")
+    end
+  end
+
+  describe "#conditional_visibility?" do
+    let(:form) { create(:form) }
+
+    it "is false for always-ask fields" do
+      expect(build(:form_field, form: form, visibility: :always_ask).conditional_visibility?).to be false
+    end
+
+    it "is true for any non-always-ask visibility" do
+      expect(build(:form_field, form: form, visibility: :logged_out_only).conditional_visibility?).to be true
+      expect(build(:form_field, form: form, visibility: :answers_on_file).conditional_visibility?).to be true
+      expect(build(:form_field, form: form, visibility: :scholarship_only).conditional_visibility?).to be true
+    end
+  end
+
   describe "#min_words_error" do
     let(:form) { create(:form) }
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -141,6 +141,27 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Name")
     end
+
+    it "shows every field including conditional ones, without applying the conditional logic" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, name: "Always Field", visibility: :always_ask)
+      create(:form_field, form: form, name: "Hidden When Logged In", visibility: :logged_out_only)
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Always Field")
+      expect(response.body).to include("Hidden When Logged In")
+    end
+
+    it "highlights fields that are not always asked" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, name: "On File Field", visibility: :answers_on_file)
+
+      get form_path(form)
+
+      expect(response.body).to include("Answers on file")
+    end
   end
 
   describe "GET /forms/:id/edit_sections" do

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/registrants.html.erb"         => "admin-only bg-blue-100",
     "app/views/events/preview_reminder.html.erb"       => "admin-only bg-blue-100",
     "app/views/event_registrations/index.html.erb"     => "admin-only bg-blue-100",
+    "app/views/forms/show.html.erb"                    => "admin-only bg-blue-100",
     "app/views/notifications/index.html.erb"           => "admin-only bg-blue-100",
     "app/views/organization_statuses/index.html.erb"   => "admin-only bg-blue-100",
     "app/views/quotes/index.html.erb"                  => "admin-only bg-blue-100",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The **forms preview** (`/forms/:id`) was simulating conditional visibility with toggle controls, duplicating logic that already runs on the registration and public registration routes.
- An admin viewing a form wants to see **every** field, with a clear signal for which ones are conditionally shown — not a simulation of one runtime scenario at a time.
- The conditional filtering itself stays where it belongs: the live registration / public registration flows.

### How did you approach the change?
- `forms#show` now loads **all** fields ordered by position; removed the `preview_form_fields` param-driven filtering.
- The preview renders every field and highlights any that aren't *always ask* with a colored left-border marker and a visibility badge (Logged out only / Answers on file / Scholarship only), matching the editor's chip colors. Group headers with conditional visibility get a badge too.
- Removed the old "Preview mode" toggle UI; replaced with a short note explaining the preview shows all fields and the conditional logic runs on the live form.
- Added `FormField#visibility_label` and `#conditional_visibility?` (anything other than `always_ask`).
- Styled the preview as an admin-only page via `content_for(:page_bg_class, "admin-only bg-blue-100")` and registered it in the `page_bg_class` alignment spec (the `FormPolicy` is admin-only).

### UI Testing Checklist
- [ ] View a form with only always-ask fields — all fields shown, no highlights, note reads "All fields are always asked."
- [ ] View a form with logged-out-only / answers-on-file fields — every field renders, conditional ones show a badge + marker.
- [ ] Confirm the registration and public registration forms still apply the conditional hiding as before.
- [ ] Confirm the admin background color applies on the forms preview page.

### Anything else to add?
- `scholarship_only` isn't selectable in the field editor (only `always_ask` / `logged_out_only` / `answers_on_file` are) but exists in the enum — the preview styles it (blue) so it degrades gracefully if any field carries that value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)