### PR TITLE
Edit multiple-choice answer options in the form builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (59) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (60) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -67,6 +67,7 @@ class FormsController < ApplicationController
 
   def edit_sections
     authorize! @form
+    @editable_sections = FormBuilderService.editable_sections(@form)
   end
 
   def update_sections
@@ -75,17 +76,19 @@ class FormsController < ApplicationController
     sections = (params[:sections] || []).reject(&:blank?).map(&:to_sym)
     if sections.empty?
       flash.now[:alert] = "Please select at least one section."
+      @editable_sections = FormBuilderService.editable_sections(@form)
       render :edit_sections, status: :unprocessable_content
       return
     end
 
+    removed_custom_ids = removed_custom_section_ids
     current_sections = (@form.sections || []).map(&:to_sym)
-    if sections.to_set == current_sections.to_set
+    if sections.to_set == current_sections.to_set && removed_custom_ids.empty?
       redirect_to edit_form_path(@form), notice: "No section changes."
       return
     end
 
-    FormBuilderService.update_sections!(@form, sections)
+    FormBuilderService.update_sections!(@form, sections, remove_custom_section_ids: removed_custom_ids)
     redirect_to edit_form_path(@form), notice: "Sections updated."
   end
 
@@ -106,6 +109,14 @@ class FormsController < ApplicationController
   end
 
   private
+
+  # Custom section header ids that were present on the page but left unchecked,
+  # i.e. the custom sections the user chose to remove.
+  def removed_custom_section_ids
+    present = Array(params[:custom_sections]).map(&:to_i)
+    kept = Array(params[:kept_custom_sections]).map(&:to_i)
+    present - kept
+  end
 
   def set_form
     @form = Form.find(params[:id])

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -116,7 +116,8 @@ class FormsController < ApplicationController
       :name, :role, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
         :id, :name, :answer_type, :required, :hint_text,
-        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy
+        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy,
+        form_field_answer_options_attributes: [ :id, :option_name, :_destroy ]
       ]
     )
   end

--- a/app/frontend/javascript/controllers/answer_options_controller.js
+++ b/app/frontend/javascript/controllers/answer_options_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Toggles the editable list of a multiple-choice field's answer options,
+// nested inside the expanded field-options panel.
+export default class extends Controller {
+  static targets = ["panel", "icon"]
+  static values = { expanded: Boolean }
+
+  toggle() {
+    this.expandedValue = !this.expandedValue
+  }
+
+  expandedValueChanged() {
+    this.panelTarget.classList.toggle("hidden", !this.expandedValue)
+    this.iconTarget.classList.toggle("rotate-90", this.expandedValue)
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -9,6 +9,9 @@ application.register("allocation-ref", AllocationRefController)
 import AnchorHighlightController from "./anchor_highlight_controller"
 application.register("anchor-highlight", AnchorHighlightController)
 
+import AnswerOptionsController from "./answer_options_controller"
+application.register("answer-options", AnswerOptionsController)
+
 import AttendanceStatusController from "./attendance_status_controller"
 application.register("attendance-status", AttendanceStatusController)
 

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -69,7 +69,8 @@ class FormField < ApplicationRecord
   }.freeze
 
   # Nested attributes
-  accepts_nested_attributes_for :form_field_answer_options
+  accepts_nested_attributes_for :form_field_answer_options, allow_destroy: true,
+    reject_if: ->(attrs) { attrs[:option_name].blank? }
 
   default_scope { order(position: :desc) }
   scope :published, -> { where(status: "active") }

--- a/app/models/form_field_answer_option.rb
+++ b/app/models/form_field_answer_option.rb
@@ -5,4 +5,20 @@ class FormFieldAnswerOption < ApplicationRecord
   def name
     answer_option.name if answer_option
   end
+
+  # Virtual attribute used by the form builder to edit an option's text.
+  alias_method :option_name, :name
+
+  # Editing the text re-points this join at a matching AnswerOption (creating
+  # one if needed) rather than renaming the existing record, which is shared
+  # across fields (built via AnswerOption.find_or_create_by!) — renaming it
+  # would change every other field that uses the same option.
+  def option_name=(value)
+    value = value.to_s.strip
+    self.answer_option = if value.present?
+      AnswerOption.find_or_create_by!(name: value) do |option|
+        option.position = (AnswerOption.maximum(:position) || 0) + 1
+      end
+    end
+  end
 end

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -82,10 +82,83 @@ class FormBuilderService
     bulk_payment: %w[bulk_payment]
   }.freeze
 
-  # Update sections on an existing form: add new sections, remove unchecked ones
-  def self.update_sections!(form, new_sections)
+  # Built-in section keys that apply to a form with the given role. Scholarship
+  # and bulk-payment forms show only their own section; every other role shows
+  # all sections except those two.
+  def self.applicable_section_keys(role)
+    SECTIONS.keys.select do |key|
+      case role
+      when "scholarship" then key == :scholarship
+      when "bulk_payment" then key == :bulk_payment
+      else key != :scholarship && key != :bulk_payment
+      end
+    end
+  end
+
+  # Ordered list of sections for the edit-sections page. Each entry is a hash
+  # with a :kind of :builtin or :custom. Built-in sections carry their :label,
+  # section :key, and :included state; custom (user-added) sections carry the
+  # group_header :label and the :questions that follow it on the form.
+  #
+  # Sections present on the form are ordered by their position there, so a
+  # custom section slots into the list wherever it sits on the form. Built-in
+  # sections not currently on the form follow their canonical predecessor.
+  def self.editable_sections(form)
+    group_to_key = SECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
+
+    positions = {}
+    header_names = {}
+    customs = []
+    current = nil
+
+    # Rank by iteration order rather than the stored position, which is nullable
+    # and can collide, so the sort keys below are always comparable integers.
+    form.form_fields.reorder(position: :asc).each_with_index do |field, order|
+      key = group_to_key[field.section]
+      if key
+        current = nil
+        positions[key] ||= order
+        header_names[key] ||= field.name if field.group_header?
+      elsif field.group_header?
+        current = { kind: :custom, header: field, questions: [] }
+        customs << [ order, current ]
+      elsif current
+        current[:questions] << field
+      end
+    end
+
+    entries = []
+    last_position = 0
+    applicable_section_keys(form.role).each_with_index do |key, rank|
+      position = positions[key]
+      last_position = position if position
+      default_header = SECTION_HEADERS.fetch(key).first
+      header_name = header_names[key]
+      entries << {
+        sort: [ position || last_position, position ? 0 : 1, rank ],
+        kind: :builtin,
+        key: key,
+        label: SECTIONS.fetch(key)[:label],
+        included: !position.nil?,
+        renamed_header: (header_name if header_name.present? && header_name != default_header)
+      }
+    end
+
+    customs.each do |position, custom|
+      entries << custom.merge(sort: [ position, 0, 0 ], label: custom[:header].name)
+    end
+
+    entries.sort_by { |entry| entry[:sort] }
+  end
+
+  # Update sections on an existing form: add new sections, remove unchecked ones.
+  # remove_custom_section_ids are group_header field ids of custom sections the
+  # user unchecked; each such header and the questions under it are deleted.
+  def self.update_sections!(form, new_sections, remove_custom_section_ids: [])
     new_sections = new_sections.map(&:to_sym)
     old_sections = (form.sections || []).map(&:to_sym)
+
+    remove_custom_sections!(form, remove_custom_section_ids)
 
     added = new_sections - old_sections
     removed = old_sections - new_sections
@@ -115,6 +188,19 @@ class FormBuilderService
 
     form.update!(sections: new_sections.map(&:to_s))
     form
+  end
+
+  # Delete the given custom sections — each group_header field plus the questions
+  # that follow it on the form — identified by their header field ids.
+  def self.remove_custom_sections!(form, header_ids)
+    header_ids = Array(header_ids).map(&:to_i)
+    return if header_ids.empty?
+
+    targets = editable_sections(form).select do |entry|
+      entry[:kind] == :custom && header_ids.include?(entry[:header].id)
+    end
+    field_ids = targets.flat_map { |entry| [ entry[:header].id, *entry[:questions].map(&:id) ] }
+    form.form_fields.where(id: field_ids).destroy_all if field_ids.any?
   end
 
   # Renumber a form's fields so sections appear in the canonical page order

--- a/app/views/forms/_form_field_answer_option_fields.html.erb
+++ b/app/views/forms/_form_field_answer_option_fields.html.erb
@@ -1,0 +1,10 @@
+<div class="nested-fields flex items-center gap-2">
+  <i class="fa-solid fa-circle text-gray-300 text-[5px] shrink-0"></i>
+  <%= f.text_field :option_name, placeholder: "Option text",
+        class: "flex-1 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+  <%= link_to_remove_association f,
+        class: "shrink-0 text-gray-400 hover:text-red-600 px-1 cursor-pointer",
+        title: "Remove option" do %>
+    <i class="fa-solid fa-xmark"></i>
+  <% end %>
+</div>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -17,27 +17,44 @@
      data-sortable-id="<%= field.id %>"
      <% if field.section.present? %>data-section="<%= field.section %>"<% end %>
      <% if field.group_header? %>data-group-header<% end %>>
-  <div class="cursor-grab text-gray-400 hover:text-gray-600" data-sortable-handle>
-    <i class="fa-solid fa-grip-vertical"></i>
-  </div>
+  <% if field.group_header? %>
+    <div class="cursor-grab rounded bg-indigo-50 text-indigo-500 hover:bg-indigo-100 hover:text-indigo-700 px-1.5 py-1"
+         data-sortable-handle
+         title="Drag to move this entire section">
+      <i class="fa-solid fa-up-down-left-right"></i>
+    </div>
+  <% else %>
+    <div class="cursor-grab text-gray-400 hover:text-gray-600" data-sortable-handle title="Drag to reorder this field">
+      <i class="fa-solid fa-grip-vertical"></i>
+    </div>
+  <% end %>
 
   <%= f.hidden_field :id if field.persisted? %>
   <%= f.hidden_field :position, value: field.position %>
 
   <% if field.group_header? %>
-    <div class="flex-1 flex items-start gap-3">
-      <div class="flex-1 min-w-0">
-        <%= f.text_area :name, required: true, rows: 1,
-              class: "w-full text-lg font-semibold text-gray-800 rounded border-gray-300 shadow-sm px-2 py-1",
-              placeholder: "Header text" %>
+    <div class="flex-1 min-w-0" data-controller="field-options">
+      <div class="flex items-start gap-3">
+        <div class="flex-1 min-w-0">
+          <%= f.text_area :name, required: true, rows: 1,
+                class: "w-full text-lg font-semibold text-gray-800 rounded border-gray-300 shadow-sm px-2 py-1",
+                placeholder: "Header text" %>
+        </div>
+        <%= f.select :visibility, visibility_options,
+              {},
+              class: "mt-1 w-36 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+              data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
+        <button type="button"
+                class="mt-1 shrink-0 text-gray-400 hover:text-gray-600 px-1 cursor-pointer"
+                title="More options"
+                data-action="field-options#toggle">
+          <i class="fa-solid fa-chevron-down transition-transform" data-field-options-target="icon"></i>
+        </button>
       </div>
-      <%= f.select :visibility, visibility_options,
-            {},
-            class: "mt-1 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
-            data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
-      <div class="mt-1">
+
+      <div class="hidden mt-2 flex items-center" data-field-options-target="panel">
         <%= link_to_remove_association "Remove", f,
-              class: "text-sm text-gray-400 hover:text-red-600 underline" %>
+              class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
       </div>
     </div>
   <% else %>
@@ -61,7 +78,7 @@
         </label>
         <%= f.select :visibility, visibility_options,
               {},
-              class: "text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+              class: "w-36 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
               data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
         <button type="button"
                 class="shrink-0 text-gray-400 hover:text-gray-600 px-1 cursor-pointer"
@@ -71,8 +88,17 @@
         </button>
       </div>
 
-      <div class="hidden mt-2 flex flex-col gap-3" data-field-options-target="panel">
+      <div class="hidden mt-2 flex flex-col gap-3" data-field-options-target="panel"<% if field.multiple_choice? %> data-controller="answer-options"<% end %>>
         <div class="flex flex-wrap items-center gap-3">
+          <% if field.multiple_choice? %>
+            <button type="button"
+                    class="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
+                    data-action="answer-options#toggle">
+              <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>
+              Answer options
+              <span class="text-xs text-gray-400">(<%= field.form_field_answer_options.size %>)</span>
+            </button>
+          <% end %>
           <%
             width_options = [
               [ "Full width", "full" ],
@@ -83,7 +109,7 @@
           %>
           <%= f.select :width, width_options,
                 {},
-                class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "How wide this field appears on the form" %>
           <%= f.number_field :min_words, min: 0, placeholder: "Min words",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
@@ -92,26 +118,16 @@
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Maximum number of characters allowed (free-form text fields only)" %>
           <%= link_to_remove_association "Remove", f,
-                class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
+                class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0" %>
         </div>
 
         <% if field.multiple_choice? %>
-          <div class="border-t border-gray-100 pt-3" data-controller="answer-options">
-            <button type="button"
-                    class="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
-                    data-action="answer-options#toggle">
-              <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>
-              Answer options
-              <span class="text-xs text-gray-400">(<%= field.form_field_answer_options.size %>)</span>
-            </button>
-
-            <div class="hidden mt-2 space-y-2 pl-1" data-answer-options-target="panel">
-              <%= f.fields_for :form_field_answer_options do |opt| %>
-                <%= render "form_field_answer_option_fields", f: opt %>
-              <% end %>
-              <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
-                    class: "text-sm text-blue-600 hover:text-blue-800 font-medium" %>
-            </div>
+          <div class="hidden space-y-2 pl-1 border-t border-gray-100 pt-3" data-answer-options-target="panel">
+            <%= f.fields_for :form_field_answer_options do |opt| %>
+              <%= render "form_field_answer_option_fields", f: opt %>
+            <% end %>
+            <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
+                  class: "text-sm text-blue-600 hover:text-blue-800 font-medium" %>
           </div>
         <% end %>
       </div>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -9,8 +9,8 @@
 
   visibility_styles = {
     always_ask: "bg-white text-gray-600 border-gray-300",
-    logged_out_only: "bg-emerald-100 text-emerald-700 border-emerald-200",
-    answers_on_file: "bg-amber-100 text-amber-700 border-amber-200"
+    logged_out_only: "bg-white text-emerald-600 border-emerald-300",
+    answers_on_file: "bg-white text-amber-600 border-amber-300"
   }
 %>
 <div class="nested-fields flex items-center gap-3 <%= field.group_header? ? 'pl-3 pr-6' : 'px-6' %> py-3 border-b border-gray-100 hover:bg-gray-50"
@@ -26,25 +26,21 @@
 
   <% if field.group_header? %>
     <div class="flex-1 flex items-start gap-3">
-      <%= f.select :visibility, visibility_options,
-            {},
-            class: "mt-1 text-xs rounded-full border px-2 py-0.5 cursor-pointer",
-            data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
       <div class="flex-1 min-w-0">
         <%= f.text_area :name, required: true, rows: 1,
               class: "w-full text-lg font-semibold text-gray-800 rounded border-gray-300 shadow-sm px-2 py-1",
               placeholder: "Header text" %>
       </div>
-      <div class="ml-auto mt-1">
+      <%= f.select :visibility, visibility_options,
+            {},
+            class: "mt-1 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+            data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
+      <div class="mt-1">
         <%= link_to_remove_association "Remove", f,
               class: "text-sm text-gray-400 hover:text-red-600 underline" %>
       </div>
     </div>
   <% else %>
-    <%= f.select :visibility, visibility_options,
-          {},
-          class: "self-start mt-1 text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
-          data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
     <div class="flex-1 min-w-0" data-controller="field-options">
       <div class="flex flex-wrap items-center gap-2">
         <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
@@ -63,6 +59,10 @@
           <%= f.check_box :one_time, class: "rounded border-gray-300 text-amber-600" %>
           Only ask once
         </label>
+        <%= f.select :visibility, visibility_options,
+              {},
+              class: "text-xs rounded-full border px-2 py-0.5 shrink-0 cursor-pointer",
+              data: { controller: "chip-select", chip_select_styles_value: visibility_styles, action: "chip-select#update" } %>
         <button type="button"
                 class="shrink-0 text-gray-400 hover:text-gray-600 px-1 cursor-pointer"
                 title="More options"
@@ -71,27 +71,49 @@
         </button>
       </div>
 
-      <div class="hidden mt-2 flex flex-wrap items-center gap-3" data-field-options-target="panel">
-        <%
-          width_options = [
-            [ "Full width", "full" ],
-            [ "Half width", "half" ],
-            [ "Third width", "third" ],
-            [ "Quarter width", "quarter" ]
-          ]
-        %>
-        <%= f.select :width, width_options,
-              {},
-              class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
-              title: "How wide this field appears on the form" %>
-        <%= f.number_field :min_words, min: 0, placeholder: "Min words",
-              class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
-              title: "Minimum number of words required (free-form text fields only)" %>
-        <%= f.number_field :max_characters, min: 1, placeholder: "Max chars",
-              class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
-              title: "Maximum number of characters allowed (free-form text fields only)" %>
-        <%= link_to_remove_association "Remove", f,
-              class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
+      <div class="hidden mt-2 flex flex-col gap-3" data-field-options-target="panel">
+        <div class="flex flex-wrap items-center gap-3">
+          <%
+            width_options = [
+              [ "Full width", "full" ],
+              [ "Half width", "half" ],
+              [ "Third width", "third" ],
+              [ "Quarter width", "quarter" ]
+            ]
+          %>
+          <%= f.select :width, width_options,
+                {},
+                class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                title: "How wide this field appears on the form" %>
+          <%= f.number_field :min_words, min: 0, placeholder: "Min words",
+                class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                title: "Minimum number of words required (free-form text fields only)" %>
+          <%= f.number_field :max_characters, min: 1, placeholder: "Max chars",
+                class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                title: "Maximum number of characters allowed (free-form text fields only)" %>
+          <%= link_to_remove_association "Remove", f,
+                class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
+        </div>
+
+        <% if field.multiple_choice? %>
+          <div class="border-t border-gray-100 pt-3" data-controller="answer-options">
+            <button type="button"
+                    class="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
+                    data-action="answer-options#toggle">
+              <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>
+              Answer options
+              <span class="text-xs text-gray-400">(<%= field.form_field_answer_options.size %>)</span>
+            </button>
+
+            <div class="hidden mt-2 space-y-2 pl-1" data-answer-options-target="panel">
+              <%= f.fields_for :form_field_answer_options do |opt| %>
+                <%= render "form_field_answer_option_fields", f: opt %>
+              <% end %>
+              <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
+                    class: "text-sm text-blue-600 hover:text-blue-800 font-medium" %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -68,18 +68,18 @@
       </div>
 
       <div class="px-6 py-3 border-b border-gray-100">
-        <p class="text-xs font-medium text-gray-500 mb-1.5">Conditional visibility</p>
-        <div class="flex flex-col gap-1">
+        <p class="text-xs font-medium text-gray-500 mb-1.5 text-right">Conditional visibility</p>
+        <div class="flex flex-col items-end gap-1">
           <div class="flex items-center gap-1.5">
             <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-gray-600 border border-gray-300">Always ask</span>
             <span class="text-xs text-gray-500">Always shown to all users</span>
           </div>
           <div class="flex items-center gap-1.5">
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700">Logged out only</span>
+            <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-emerald-600 border border-emerald-300">Logged out only</span>
             <span class="text-xs text-gray-500">Hidden for logged-in users</span>
           </div>
           <div class="flex items-center gap-1.5">
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700">Answers on file</span>
+            <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-amber-600 border border-amber-300">Answers on file</span>
             <span class="text-xs text-gray-500">Hidden when answered on this event's forms; if "One-time", hidden when answered on any form</span>
           </div>
         </div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -75,7 +75,15 @@
               <div class="flex items-center gap-2">
                 <span class="min-w-0 flex-[3_1_10rem]">Question</span>
                 <span class="flex-[2_1_9rem]">Type</span>
-                <span class="w-36 shrink-0 ml-auto inline-flex items-center gap-1">
+                <span class="flex items-center gap-1 text-sm shrink-0 invisible" aria-hidden="true">
+                  <input type="checkbox" class="rounded border-gray-300" disabled>
+                  Required
+                </span>
+                <span class="flex items-center gap-1 text-sm shrink-0 ml-auto invisible" aria-hidden="true">
+                  <input type="checkbox" class="rounded border-gray-300" disabled>
+                  Only ask once
+                </span>
+                <span class="w-36 shrink-0 inline-flex items-center gap-1">
                   Visibility
                   <i class="fa-solid fa-chevron-down text-gray-400 text-xs transition-transform [[open]_&]:rotate-180"></i>
                 </span>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -67,23 +67,44 @@
         </div>
       </div>
 
-      <div class="px-6 py-3 border-b border-gray-100">
-        <p class="text-xs font-medium text-gray-500 mb-1.5 text-right">Conditional visibility</p>
-        <div class="flex flex-col items-end gap-1">
-          <div class="flex items-center gap-1.5">
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-gray-600 border border-gray-300">Always ask</span>
-            <span class="text-xs text-gray-500">Always shown to all users</span>
+      <details class="border-b border-gray-100">
+        <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden hover:bg-gray-50">
+          <div class="flex items-center gap-3 px-6 py-2 text-xs font-medium text-gray-500">
+            <span class="w-3 shrink-0" aria-hidden="true"></span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="min-w-0 flex-[3_1_10rem]">Question</span>
+                <span class="flex-[2_1_9rem]">Type</span>
+                <span class="w-36 shrink-0 ml-auto inline-flex items-center gap-1">
+                  Visibility
+                  <i class="fa-solid fa-chevron-down text-gray-400 text-xs transition-transform [[open]_&]:rotate-180"></i>
+                </span>
+                <span class="w-6 shrink-0" aria-hidden="true"></span>
+              </div>
+            </div>
           </div>
-          <div class="flex items-center gap-1.5">
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-emerald-600 border border-emerald-300">Logged out only</span>
-            <span class="text-xs text-gray-500">Hidden for logged-in users</span>
+        </summary>
+        <dl class="px-6 pb-3 ml-auto max-w-xl space-y-1">
+          <div class="flex items-start gap-2">
+            <dt class="w-32 shrink-0">
+              <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-gray-600 border border-gray-300">Always ask</span>
+            </dt>
+            <dd class="text-xs text-gray-500">Always shown to all users</dd>
           </div>
-          <div class="flex items-center gap-1.5">
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-amber-600 border border-amber-300">Answers on file</span>
-            <span class="text-xs text-gray-500">Hidden when answered on this event's forms; if "One-time", hidden when answered on any form</span>
+          <div class="flex items-start gap-2">
+            <dt class="w-32 shrink-0">
+              <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-emerald-600 border border-emerald-300">Logged out only</span>
+            </dt>
+            <dd class="text-xs text-gray-500">Hidden for logged-in users</dd>
           </div>
-        </div>
-      </div>
+          <div class="flex items-start gap-2">
+            <dt class="w-32 shrink-0">
+              <span class="text-xs px-1.5 py-0.5 rounded-full bg-white text-amber-600 border border-amber-300">Answers on file</span>
+            </dt>
+            <dd class="text-xs text-gray-500">Hidden when answered on this event's forms; if "One-time", hidden when answered on any form</dd>
+          </div>
+        </dl>
+      </details>
 
       <div data-controller="form-fields-sortable" data-form-fields-sortable-url-value="<%= reorder_fields_form_path(@form) %>">
         <%= f.fields_for :form_fields, @form_fields do |ff| %>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -7,34 +7,54 @@
   <h1 class="text-2xl font-semibold mb-2">Edit Sections: <%= @form.display_name %></h1>
   <%= render "stats", form: @form %>
 
-  <% current_sections = (@form.sections || []).map(&:to_s) %>
-
   <%= form_with url: update_sections_form_path(@form), method: :patch, class: "space-y-6" do |f| %>
     <fieldset>
       <legend class="text-sm font-medium text-gray-700 mb-1">Select sections to include:</legend>
-      <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on default forms. Unless you make changes to these section selections, saving here does not change your form.</p>
+      <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit fields", edit_form_path(@form), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
       <ol class="space-y-2">
-        <% position = 0 %>
-        <% FormBuilderService::SECTIONS.each do |key, section| %>
-          <% next if key == :scholarship && @form.role != "scholarship" %>
-          <% next if key == :bulk_payment && @form.role != "bulk_payment" %>
-          <% next if key != :scholarship && key != :bulk_payment && @form.role == "scholarship" %>
-          <% next if key != :bulk_payment && key != :scholarship && @form.role == "bulk_payment" %>
-          <% position += 1 %>
-          <% included = current_sections.include?(key.to_s) %>
-          <li data-controller="form-section-toggle"
-              data-form-section-toggle-included-value="<%= included %>">
-            <label class="flex items-center gap-2 cursor-pointer">
-              <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= position %>.</span>
-              <input type="checkbox" name="sections[]" value="<%= key %>"
-                     class="rounded border-gray-300 text-blue-600"
-                     data-form-section-toggle-target="checkbox"
-                     data-action="form-section-toggle#update"
-                     <%= "checked" if included %>>
-              <span class="text-sm text-gray-800"><%= section[:label] %></span>
-            </label>
-            <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
-          </li>
+        <% @editable_sections.each_with_index do |section, index| %>
+          <% if section[:kind] == :custom %>
+            <li data-controller="form-section-toggle"
+                data-form-section-toggle-included-value="true">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                <%= hidden_field_tag "custom_sections[]", section[:header].id %>
+                <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
+                      class: "rounded border-gray-300 text-blue-600",
+                      data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
+                <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
+                <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
+              </label>
+              <% if section[:questions].any? %>
+                <ul class="mt-1 ml-12 space-y-0.5">
+                  <% section[:questions].each do |question| %>
+                    <li class="text-sm text-gray-600 flex items-start gap-2">
+                      <span class="text-gray-300">&bull;</span>
+                      <span><%= question.name %></span>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
+              <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
+            </li>
+          <% else %>
+            <li data-controller="form-section-toggle"
+                data-form-section-toggle-included-value="<%= section[:included] %>">
+              <label class="flex items-center gap-2 cursor-pointer">
+                <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
+                       class="rounded border-gray-300 text-blue-600"
+                       data-form-section-toggle-target="checkbox"
+                       data-action="form-section-toggle#update"
+                       <%= "checked" if section[:included] %>>
+                <span class="text-sm text-gray-800"><%= section[:label] %></span>
+                <% if section[:renamed_header].present? %>
+                  <span class="text-xs text-gray-400 italic">titled &ldquo;<%= section[:renamed_header] %>&rdquo; on the form</span>
+                <% end %>
+              </label>
+              <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
+            </li>
+          <% end %>
         <% end %>
       </ol>
     </fieldset>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -40,8 +40,9 @@
     </fieldset>
 
     <div class="flex gap-3">
-      <%= f.submit "Update Sections", class: "btn btn-primary cursor-pointer" %>
-      <%= link_to "Cancel", edit_form_path(@form), class: "btn btn-secondary-outline" %>
+      <%= f.submit "Save changes", class: "btn btn-primary cursor-pointer" %>
+      <%= link_to "Edit questions", edit_form_path(@form), class: "btn btn-secondary" %>
+      <%= link_to "Cancel", form_path(@form), class: "btn btn-secondary-outline" %>
     </div>
   <% end %>
 </div>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -25,16 +25,6 @@
                 <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
                 <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
               </label>
-              <% if section[:questions].any? %>
-                <ul class="mt-1 ml-12 space-y-0.5">
-                  <% section[:questions].each do |question| %>
-                    <li class="text-sm text-gray-600 flex items-start gap-2">
-                      <span class="text-gray-300">&bull;</span>
-                      <span><%= question.name %></span>
-                    </li>
-                  <% end %>
-                </ul>
-              <% end %>
               <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
             </li>
           <% else %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "5473b25a3e7836314952560daf8b227d719838ca52c1fd7388a03b60415dd015",
+      "fingerprint": "409787bd055764cbde1429558af080ceadef1d12b5a5b082746e6bec159f15b2",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
       "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy]))",
+      "code": "params.require(:form).permit(:name, :role, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/spec/models/form_field_answer_option_spec.rb
+++ b/spec/models/form_field_answer_option_spec.rb
@@ -1,23 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe FormFieldAnswerOption do
-  # pending "add some examples to (or delete) #{__FILE__}"
-
   describe 'associations' do
     it { should belong_to(:form_field) }
     it { should belong_to(:answer_option) }
   end
 
-  describe 'validations' do
-    # Add validation tests if any (e.g., presence)
-    # subject { build(:form_field_answer_option) } # Requires associations
-    # it { should validate_presence_of(:form_field_id) }
-    # it { should validate_presence_of(:answer_option_id) }
+  describe '#option_name' do
+    it 'returns the linked answer option name' do
+      join = build(:form_field_answer_option, answer_option: build(:answer_option, name: "Yes"))
+      expect(join.option_name).to eq("Yes")
+    end
+
+    it 'is nil when no answer option is linked' do
+      expect(FormFieldAnswerOption.new.option_name).to be_nil
+    end
   end
 
-  # it 'is valid with valid attributes' do
-  #   # Note: Factory needs associations uncommented for create
-  #   # expect(build(:form_field_answer_option)).to be_valid
-  #   pending("Requires functional form_field/answer_option factories and associations uncommented")
-  # end
+  describe '#option_name=' do
+    it 'links to an existing answer option with the same name instead of creating a duplicate' do
+      existing = create(:answer_option, name: "Personal")
+      join = build(:form_field_answer_option)
+
+      expect { join.option_name = "Personal" }.not_to change(AnswerOption, :count)
+      expect(join.answer_option).to eq(existing)
+    end
+
+    it 'creates a new answer option when none matches' do
+      join = build(:form_field_answer_option)
+
+      expect { join.option_name = "Brand New" }.to change(AnswerOption, :count).by(1)
+      expect(join.answer_option.name).to eq("Brand New")
+    end
+
+    it 're-points to a different answer option rather than renaming the shared one' do
+      shared = create(:answer_option, name: "Work")
+      join = create(:form_field_answer_option, answer_option: shared)
+
+      join.option_name = "Home"
+
+      expect(shared.reload.name).to eq("Work")
+      expect(join.answer_option.name).to eq("Home")
+    end
+
+    it 'strips surrounding whitespace' do
+      join = build(:form_field_answer_option)
+      join.option_name = "  Spaced  "
+      expect(join.answer_option.name).to eq("Spaced")
+    end
+  end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("Min words")
     end
 
+    it "renders the editable answer options for a multiple-choice field" do
+      form = FormBuilderService.new(name: "Test", sections: %i[person_contact_info]).call
+      get edit_form_path(form)
+
+      expect(response.body).to include('data-controller="answer-options"')
+      expect(response.body).to include("answer-options#toggle")
+      # The radio field's seeded options are rendered as editable inputs
+      expect(response.body).to include("[option_name]")
+      expect(response.body).to include("+ Add option")
+    end
+
     it "renders the expand/collapse all toggle" do
       form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
       get edit_form_path(form)
@@ -146,6 +157,70 @@ RSpec.describe "Forms", type: :request do
       }
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("too long")
+    end
+
+    it "renames a multiple-choice field's answer option without renaming the shared option" do
+      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      field = form.form_fields.find_by(field_identifier: "interested_in_more")
+      join = field.form_field_answer_options.joins(:answer_option).find_by(answer_options: { name: "Yes" })
+
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => {
+          id: field.id, name: field.name, answer_type: field.answer_type,
+          form_field_answer_options_attributes: { "0" => { id: join.id, option_name: "Absolutely" } }
+        } } }
+      }
+
+      expect(response).to redirect_to(edit_form_path(form))
+      expect(join.reload.answer_option.name).to eq("Absolutely")
+      expect(field.reload.answer_options.map(&:name)).to include("Absolutely")
+    end
+
+    it "adds a new answer option to a multiple-choice field" do
+      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      field = form.form_fields.find_by(field_identifier: "interested_in_more")
+
+      expect {
+        patch form_path(form), params: {
+          form: { form_fields_attributes: { "0" => {
+            id: field.id, name: field.name, answer_type: field.answer_type,
+            form_field_answer_options_attributes: { "0" => { option_name: "Maybe" } }
+          } } }
+        }
+      }.to change { field.reload.form_field_answer_options.count }.by(1)
+
+      expect(field.answer_options.map(&:name)).to include("Maybe")
+    end
+
+    it "ignores a blank new answer option" do
+      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      field = form.form_fields.find_by(field_identifier: "interested_in_more")
+
+      expect {
+        patch form_path(form), params: {
+          form: { form_fields_attributes: { "0" => {
+            id: field.id, name: field.name, answer_type: field.answer_type,
+            form_field_answer_options_attributes: { "0" => { option_name: "" } }
+          } } }
+        }
+      }.not_to change { field.reload.form_field_answer_options.count }
+    end
+
+    it "removes an answer option from a multiple-choice field" do
+      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      field = form.form_fields.find_by(field_identifier: "interested_in_more")
+      join = field.form_field_answer_options.joins(:answer_option).find_by(answer_options: { name: "No" })
+
+      expect {
+        patch form_path(form), params: {
+          form: { form_fields_attributes: { "0" => {
+            id: field.id, name: field.name, answer_type: field.answer_type,
+            form_field_answer_options_attributes: { "0" => { id: join.id, option_name: "No", _destroy: "1" } }
+          } } }
+        }
+      }.to change { field.reload.form_field_answer_options.count }.by(-1)
+
+      expect(field.answer_options.map(&:name)).not_to include("No")
     end
 
     it "saves the per-field width, minimum word count, and maximum character count" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -289,6 +289,17 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Person identifier")
     end
+
+    it "shows custom sections with a custom indicator" do
+      form = FormBuilderService.new(name: "Editable", sections: %i[person_identifier]).call
+      form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+                               status: :active, position: 100, required: false)
+
+      get edit_sections_form_path(form)
+
+      expect(response.body).to include("My Special Section")
+      expect(response.body).to include("Custom sections")
+    end
   end
 
   describe "PATCH /forms/:id/update_sections" do
@@ -337,6 +348,35 @@ RSpec.describe "Forms", type: :request do
       form.reload
       expect(form.form_fields.pluck(:id).sort).to eq(original_ids)
       expect(response).to redirect_to(edit_form_path(form))
+    end
+
+    it "removes a custom section the user unchecked" do
+      form = FormBuilderService.new(name: "Custom", sections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+                                        status: :active, position: 100, required: false)
+
+      patch update_sections_form_path(form), params: {
+        sections: %w[person_identifier],
+        custom_sections: [ header.id ],
+        kept_custom_sections: []
+      }
+
+      expect(FormField.where(id: header.id)).to be_empty
+      expect(response).to redirect_to(edit_form_path(form))
+    end
+
+    it "keeps a custom section that stays checked" do
+      form = FormBuilderService.new(name: "Custom", sections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+                                        status: :active, position: 100, required: false)
+
+      patch update_sections_form_path(form), params: {
+        sections: %w[person_identifier],
+        custom_sections: [ header.id ],
+        kept_custom_sections: [ header.id ]
+      }
+
+      expect(FormField.where(id: header.id)).to exist
     end
   end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -223,5 +223,105 @@ RSpec.describe FormBuilderService do
       positions = form.form_fields.reorder(:position).pluck(:position)
       expect(positions).to eq((1..positions.size).to_a)
     end
+
+    it "removes a custom section and its questions by header id" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "Custom", answer_type: :group_header,
+                                        status: :active, position: 100, required: false)
+      question = form.form_fields.create!(name: "Q1", answer_type: :free_form_input_one_line,
+                                          status: :active, position: 101, required: false)
+      next_section = form.form_fields.create!(name: "Background Information", answer_type: :group_header,
+                                              status: :active, position: 102, section: "background", required: false)
+
+      described_class.update_sections!(form, %i[person_identifier], remove_custom_section_ids: [ header.id ])
+
+      expect(FormField.where(id: [ header.id, question.id ])).to be_empty
+      expect(FormField.where(id: next_section.id)).to exist
+    end
+
+    it "leaves custom sections untouched when none are unchecked" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "Custom", answer_type: :group_header,
+                                        status: :active, position: 100, required: false)
+
+      described_class.update_sections!(form, %i[person_identifier])
+
+      expect(FormField.where(id: header.id)).to exist
+    end
+  end
+
+  describe ".editable_sections" do
+    let(:form) { described_class.new(name: "Test", sections: %i[person_identifier consent]).call }
+
+    def add_field(name, answer_type, position, section: nil)
+      form.form_fields.create!(name: name, answer_type: answer_type, status: :active,
+                               position: position, required: false, section: section)
+    end
+
+    it "marks built-in sections on the form as included and others as not" do
+      entries = described_class.editable_sections(form)
+      included = entries.select { |e| e[:kind] == :builtin && e[:included] }.map { |e| e[:key] }
+      excluded = entries.select { |e| e[:kind] == :builtin && !e[:included] }.map { |e| e[:key] }
+
+      expect(included).to include(:person_identifier, :consent)
+      expect(excluded).to include(:marketing, :payment)
+    end
+
+    it "includes a custom section with the questions that follow it" do
+      add_field("My Custom Section", :group_header, 100)
+      first = add_field("Favorite color", :free_form_input_one_line, 101)
+      second = add_field("Why?", :free_form_input_paragraph, 102)
+
+      custom = described_class.editable_sections(form).find { |e| e[:kind] == :custom }
+
+      expect(custom[:label]).to eq("My Custom Section")
+      expect(custom[:questions]).to eq([ first, second ])
+    end
+
+    it "stops a custom section's questions at the next header" do
+      add_field("My Custom Section", :group_header, 100)
+      question = add_field("Favorite color", :free_form_input_one_line, 101)
+      add_field("Background Information", :group_header, 102, section: "background")
+
+      custom = described_class.editable_sections(form).find { |e| e[:kind] == :custom }
+
+      expect(custom[:questions]).to eq([ question ])
+    end
+
+    it "orders a custom section by where it sits on the form" do
+      # person_identifier (pos 1-4), consent header + field, then the custom
+      # section is dropped between them by giving it an in-between position.
+      consent_position = form.form_fields.find_by(section: "consent", answer_type: :group_header).position
+      add_field("My Custom Section", :group_header, consent_position - 1)
+
+      kinds = described_class.editable_sections(form)
+        .select { |e| (e[:kind] == :builtin && e[:included]) || e[:kind] == :custom }
+        .map { |e| e[:kind] == :custom ? :custom : e[:key] }
+
+      expect(kinds).to eq([ :person_identifier, :custom, :consent ])
+    end
+
+    it "has no custom entries when the form has none" do
+      expect(described_class.editable_sections(form).map { |e| e[:kind] }).to all(eq(:builtin))
+    end
+
+    it "surfaces a renamed built-in section header" do
+      form.form_fields.find_by(section: "consent", answer_type: :group_header).update!(name: "Agreement")
+
+      consent = described_class.editable_sections(form).find { |e| e[:key] == :consent }
+      expect(consent[:renamed_header]).to eq("Agreement")
+    end
+
+    it "does not flag a built-in section header left at its default name" do
+      consent = described_class.editable_sections(form).find { |e| e[:key] == :consent }
+      expect(consent[:renamed_header]).to be_nil
+    end
+
+    it "tolerates fields with a nil position without raising" do
+      form.form_fields.create!(name: "My Custom Section", answer_type: :group_header,
+                               status: :active, position: nil, required: false)
+
+      expect { described_class.editable_sections(form) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Form admins can now **edit a multiple-choice field's answer options** directly in the form builder — previously there was no UI to add, rename, or remove choices.
- Makes the form-builder field rows readable at a glance and gives admins a **true picture of a form's sections** when deciding what to include.

### How did you approach the change?

**Answer options editing**

- Added an **"Answer options" toggle** inside the expanded field panel (only for radio/checkbox fields). It lists each option as an editable input with add/remove, persisted via nested attributes.
- **Avoided cross-field rename leakage:** options are stored as shared `AnswerOption` records (built with `find_or_create_by!`), so editing text **re-points the join at a matching `AnswerOption`** instead of renaming the shared record. Changing one field's "Work" → "Home" leaves every other field that reuses "Work" untouched.
- `FormField` nested attributes now `allow_destroy` and reject blank new rows; controller permits `form_field_answer_options_attributes: [:id, :option_name, :_destroy]`.
- New `answer-options` Stimulus controller mirrors the existing `field-options` show/hide pattern.
- Refreshed the existing Brakeman ignore fingerprint for the (pre-existing, intentional) `:role` mass-assignment entry, since the permit line changed.

**Field-row layout & section drag**

- **Right-aligned** each field's options (width / min words / max chars) next to **Remove**, and moved the **Answer options** toggle onto that same row, so the expanded panel mirrors the collapsed row's columns instead of drifting left.
- Moved the **section-header (informational) row's Remove link into the same "More options" dropdown** the other field types use, so every row follows one pattern.
- Dropped the **Required / Only-ask-once column headers** (the inline labels next to each checkbox already name them) and re-added those columns as **invisible spacers** so the header's flex-grow math matches the rows and Question / Type / Visibility sit directly above their inputs.
- Added a **distinct section drag handle** on group-header rows (4-way move icon on an indigo pill) to signal that dragging a header moves the **whole section** — behavior the `form-fields-sortable` controller already implements; this just makes it discoverable.
- Collapsed the conditional-visibility legend into a **details/summary column header** so it reads as a key for the right-aligned per-field visibility chips rather than as a standalone block.

**Editable sections overview**

- The edit-sections page now lists **custom (admin-added) sections alongside the built-in ones**, ordered by their real position on the form, via new `FormBuilderService.editable_sections`. Removal/reorder decisions are made against what the form actually contains.

### UI Testing Checklist

- [ ] Expand a multiple-choice field → "Answer options" toggle appears (on the controls row) with the current options below
- [ ] Edit an option's text and save → updates only this field, not other fields sharing the same option
- [ ] Add a new option and save → option persists and renders on the form
- [ ] Remove an option and save → option is gone
- [ ] Blank new option rows are ignored on save
- [ ] Field options row (width / min / max / Remove) is right-aligned and columns line up with the collapsed row
- [ ] Section-header row's Remove sits inside its "More options" dropdown like other rows
- [ ] Column headers (Question / Type / Visibility) line up with their inputs; no Required/Only-ask-once header text shows
- [ ] Group-header rows show the indigo move handle; dragging one reorders its whole section
- [ ] Edit-sections page shows custom sections interleaved in form order (no per-question bullet list)

### Anything else to add?

- Options are not drag-reorderable here; `AnswerOption.position` is global/shared today, so per-field ordering isn't cleanly modeled yet — left as a follow-up.
- Specs: model specs for `option_name` (get/set, dedup, re-point-not-rename, whitespace), request specs (render, rename, add, blank-ignore, remove), and service specs for `editable_sections`. Full suite green.
