### PR TITLE
HOLD: Add a section tier above form subsections (rename section→subsection)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ end
 - `TaggingSearchService` — Search and filter tagging data
 - `PersonFromUserService` — Create Person from User account
 - `BulkInviteService` — Bulk send welcome instructions and reset created_at for users
-- `FormBuilderService` — Builds configurable forms from composable sections with per-field visibility
+- `FormBuilderService` — Builds configurable forms from composable subsections (grouped into sections) with per-field visibility
 - `ModelDeduper` — Deduplication logic
 - `RichTextMigrator` — Rich text migration utility
 - `DisplayImagePresenter` — Image display logic

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -220,16 +220,16 @@ module Events
         end
 
         # Hide logged_out_only headers when all their non-header fields are hidden
-        logged_out_sections = @form.form_fields.where(visibility: :logged_out_only)
+        logged_out_subsections = @form.form_fields.where(visibility: :logged_out_only)
                                   .where.not(answer_type: :group_header)
-                                  .pluck(:section).uniq.compact
-        logged_out_sections.each do |sect|
-          section_field_ids = @form.form_fields.where(section: sect, visibility: :logged_out_only)
+                                  .pluck(:subsection).uniq.compact
+        logged_out_subsections.each do |subsect|
+          subsection_field_ids = @form.form_fields.where(subsection: subsect, visibility: :logged_out_only)
                                   .where.not(answer_type: :group_header).ids
-          if section_field_ids.any? && known_identifiers.any? && (section_field_ids - scope.where(id: section_field_ids).ids).any?
-            remaining = scope.where(id: section_field_ids).ids
+          if subsection_field_ids.any? && known_identifiers.any? && (subsection_field_ids - scope.where(id: subsection_field_ids).ids).any?
+            remaining = scope.where(id: subsection_field_ids).ids
             if remaining.empty?
-              scope = scope.where.not(section: sect, answer_type: :group_header, visibility: :logged_out_only)
+              scope = scope.where.not(subsection: subsect, answer_type: :group_header, visibility: :logged_out_only)
             end
           end
         end
@@ -267,14 +267,14 @@ module Events
           if answered_field_ids.any?
             scope = scope.where.not(id: answered_field_ids)
 
-            # Hide section headers when all their non-header fields are answered
-            answered_sections = @form.form_fields.where(id: answered_field_ids)
-                                    .pluck(:section).uniq.compact
-            answered_sections.each do |sect|
-              section_field_ids = @form.form_fields.where(section: sect, visibility: :answers_on_file)
+            # Hide subsection headers when all their non-header fields are answered
+            answered_subsections = @form.form_fields.where(id: answered_field_ids)
+                                    .pluck(:subsection).uniq.compact
+            answered_subsections.each do |subsect|
+              subsection_field_ids = @form.form_fields.where(subsection: subsect, visibility: :answers_on_file)
                                       .where.not(answer_type: :group_header).ids
-              if section_field_ids.any? && (section_field_ids - answered_field_ids).empty?
-                scope = scope.where.not(section: sect, answer_type: :group_header, visibility: :answers_on_file)
+              if subsection_field_ids.any? && (subsection_field_ids - answered_field_ids).empty?
+                scope = scope.where.not(subsection: subsect, answer_type: :group_header, visibility: :answers_on_file)
               end
             end
           end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,6 +1,6 @@
 class FormsController < ApplicationController
-  before_action :set_form, only: %i[show edit update destroy reorder_field reorder_fields edit_sections update_sections]
-  before_action :set_dashboard_event, only: %i[show edit edit_sections update update_sections]
+  before_action :set_form, only: %i[show edit update destroy reorder_field reorder_fields edit_subsections update_subsections edit_sections update_sections]
+  before_action :set_dashboard_event, only: %i[show edit edit_subsections update update_subsections edit_sections update_sections]
 
   def index
     authorize!
@@ -22,20 +22,20 @@ class FormsController < ApplicationController
   def create
     authorize!
 
-    sections = (params[:sections] || []).reject(&:blank?).map(&:to_sym)
-    if sections.empty?
-      flash.now[:alert] = "Please select at least one section."
+    subsections = (params[:subsections] || []).reject(&:blank?).map(&:to_sym)
+    if subsections.empty?
+      flash.now[:alert] = "Please select at least one subsection."
       render :new, status: :unprocessable_content
       return
     end
 
     form = FormBuilderService.new(
       name: params[:name].presence || "New Form",
-      sections: sections,
+      subsections: subsections,
       role: params[:role].presence
     ).call
 
-    redirect_to edit_sections_form_path(form), notice: "Form created with #{form.form_fields.size} fields."
+    redirect_to edit_subsections_form_path(form), notice: "Form created with #{form.form_fields.size} fields."
   end
 
   def edit
@@ -66,30 +66,43 @@ class FormsController < ApplicationController
     redirect_to forms_path, notice: "Form deleted."
   end
 
+  def edit_subsections
+    authorize! @form
+    @editable_subsections = FormBuilderService.editable_subsections(@form)
+  end
+
+  def update_subsections
+    authorize! @form
+
+    subsections = (params[:subsections] || []).reject(&:blank?).map(&:to_sym)
+    if subsections.empty?
+      flash.now[:alert] = "Please select at least one subsection."
+      @editable_subsections = FormBuilderService.editable_subsections(@form)
+      render :edit_subsections, status: :unprocessable_content
+      return
+    end
+
+    removed_custom_ids = removed_custom_subsection_ids
+    current_subsections = FormBuilderService.present_subsection_keys(@form)
+    if subsections.to_set == current_subsections.to_set && removed_custom_ids.empty?
+      redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "No subsection changes."
+      return
+    end
+
+    FormBuilderService.update_subsections!(@form, subsections, remove_custom_subsection_ids: removed_custom_ids)
+    redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "Subsections updated."
+  end
+
+  # Sections are the top-level grouping of subsections — a single screen where
+  # several subsections sit under one named heading.
   def edit_sections
     authorize! @form
-    @editable_sections = FormBuilderService.editable_sections(@form)
   end
 
   def update_sections
     authorize! @form
 
-    sections = (params[:sections] || []).reject(&:blank?).map(&:to_sym)
-    if sections.empty?
-      flash.now[:alert] = "Please select at least one section."
-      @editable_sections = FormBuilderService.editable_sections(@form)
-      render :edit_sections, status: :unprocessable_content
-      return
-    end
-
-    removed_custom_ids = removed_custom_section_ids
-    current_sections = FormBuilderService.present_section_keys(@form)
-    if sections.to_set == current_sections.to_set && removed_custom_ids.empty?
-      redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "No section changes."
-      return
-    end
-
-    FormBuilderService.update_sections!(@form, sections, remove_custom_section_ids: removed_custom_ids)
+    @form.assign_section_groups!(params[:section_labels] || {})
     redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "Sections updated."
   end
 
@@ -111,11 +124,11 @@ class FormsController < ApplicationController
 
   private
 
-  # Custom section header ids that were present on the page but left unchecked,
-  # i.e. the custom sections the user chose to remove.
-  def removed_custom_section_ids
-    present = Array(params[:custom_sections]).map(&:to_i)
-    kept = Array(params[:kept_custom_sections]).map(&:to_i)
+  # Custom subsection header ids that were present on the page but left unchecked,
+  # i.e. the custom subsections the user chose to remove.
+  def removed_custom_subsection_ids
+    present = Array(params[:custom_subsections]).map(&:to_i)
+    kept = Array(params[:kept_custom_subsections]).map(&:to_i)
     present - kept
   end
 
@@ -138,7 +151,7 @@ class FormsController < ApplicationController
       :name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
         :id, :name, :answer_type, :required, :subtitle, :hint_text,
-        :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy,
+        :field_identifier, :subsection, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy,
         form_field_answer_options_attributes: [ :id, :option_name, :_destroy ]
       ]
     )

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -194,7 +194,7 @@ class ScholarshipsController < ApplicationController
     answers = @form_submission ? @form_submission.form_answers.index_by(&:form_field_id) : {}
 
     @scholarship_answers = form.form_fields
-      .select { |field| field.section == "scholarship" || field.scholarship_only? }
+      .select { |field| field.subsection == "scholarship" || field.scholarship_only? }
       .reject { |field| field.group_header? || field.no_user_input? }
       .sort_by { |field| field.position.to_i }
       .map { |field| [ field, answers[field.id] ] }

--- a/app/frontend/javascript/controllers/form_fields_sortable_controller.js
+++ b/app/frontend/javascript/controllers/form_fields_sortable_controller.js
@@ -5,8 +5,8 @@ import Sortable from "sortablejs"
 /**
  * Sortable controller for form field editing.
  *
- * Section-aware: dragging a group header also moves all fields
- * that share the same section.
+ * Subsection-aware: dragging a group header also moves all fields
+ * that share the same subsection.
  *
  * Usage:
  *   data-controller="form-fields-sortable"
@@ -15,7 +15,7 @@ import Sortable from "sortablejs"
  * Each item needs:
  *   data-sortable-id="<field_id>"
  *   data-sortable-handle  (on the drag handle element)
- *   data-section="<section_name>"  (optional)
+ *   data-subsection="<subsection_name>"  (optional)
  *   data-group-header       (on header rows)
  */
 export default class extends Controller {
@@ -37,11 +37,11 @@ export default class extends Controller {
 
     // If a group header was moved, relocate its section members to follow it
     if (item.dataset.groupHeader !== undefined) {
-      const section = item.dataset.section
+      const subsection = item.dataset.subsection
       const members = []
 
       for (const el of this.element.children) {
-        if (el !== item && el.dataset.section === section && el.dataset.groupHeader === undefined) {
+        if (el !== item && el.dataset.subsection === subsection && el.dataset.groupHeader === undefined) {
           members.push(el)
         }
       }

--- a/app/frontend/javascript/controllers/form_subsection_toggle_controller.js
+++ b/app/frontend/javascript/controllers/form_subsection_toggle_controller.js
@@ -1,9 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Shows inline feedback as a section checkbox is toggled on the edit-sections
-// form: a destructive warning when an existing section is unchecked, and an
-// additive note when a new section is checked. Stays silent when the checkbox
-// matches the section's saved state.
+// Shows inline feedback as a subsection checkbox is toggled on the
+// edit-subsections form: a destructive warning when an existing subsection is
+// unchecked, and an additive note when a new subsection is checked. Stays
+// silent when the checkbox matches the subsection's saved state.
 export default class extends Controller {
   static targets = ["checkbox", "message"]
   static values = { included: Boolean }
@@ -17,9 +17,9 @@ export default class extends Controller {
     }
 
     if (checked) {
-      this.show("This section and default questions will be added in order.", false)
+      this.show("This subsection and default questions will be added in order.", false)
     } else {
-      this.show("Unchecking a section permanently removes it and all of its questions.", true)
+      this.show("Unchecking a subsection permanently removes it and all of its questions.", true)
     }
   }
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -162,8 +162,8 @@ application.register("section-filter", SectionFilterController)
 import PrimarySectorController from "./primary_sector_controller"
 application.register("primary-sector", PrimarySectorController)
 
-import FormSectionToggleController from "./form_section_toggle_controller"
-application.register("form-section-toggle", FormSectionToggleController)
+import FormSubsectionToggleController from "./form_subsection_toggle_controller"
+application.register("form-subsection-toggle", FormSubsectionToggleController)
 
 import ShareUrlController from "./share_url_controller"
 application.register("share-url", ShareUrlController)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -17,4 +17,39 @@ class Form < ApplicationRecord
   def display_name
     name.presence || (owner ? "#{owner.try(:name)} Form" : "New Form")
   end
+
+  # The top-level Section grouping of subsections. Each entry looks like
+  #   { "label" => "About you", "subsections" => ["person_identifier", ...] }
+  # An empty/absent value means the form has no Sections and renders flat.
+  def section_groups
+    Array(sections).map { |group| group.to_h.with_indifferent_access }
+  end
+
+  def sections?
+    section_groups.any?
+  end
+
+  # The Section label a given subsection belongs to, or nil when it is not
+  # grouped under any Section.
+  def section_label_for_subsection(subsection_key)
+    return if subsection_key.blank?
+
+    group = section_groups.find { |g| Array(g[:subsections]).include?(subsection_key.to_s) }
+    group && group[:label].presence
+  end
+
+  # Rebuilds the Section grouping from a { subsection_key => label } map,
+  # preserving subsection order and merging subsections that share a label.
+  # Blank labels leave a subsection ungrouped.
+  def assign_section_groups!(labels)
+    grouped = {}
+    Array(subsections).each do |key|
+      label = labels[key.to_s].to_s.strip
+      next if label.blank?
+
+      (grouped[label] ||= []) << key.to_s
+    end
+
+    update!(sections: grouped.map { |label, subs| { "label" => label, "subsections" => subs } })
+  end
 end

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -146,7 +146,7 @@ class FormField < ApplicationRecord
   # Human-friendly labels for answer types (radio/dropdown are "single select"
   # because only one option can be picked; checkbox allows several)
   ANSWER_TYPE_LABELS = {
-    "group_header" => "Section header",
+    "group_header" => "Subsection header",
     "free_form_input_one_line" => "One line",
     "free_form_input_paragraph" => "Paragraph",
     "single_select_radio" => "Single select radio",

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -39,7 +39,7 @@ class EventDashboard
   # Field identifiers for the scholarship-application questions, wherever they
   # are asked (the scholarship section can live on the registration form, the
   # standalone scholarship form, or both).
-  SCHOLARSHIP_ANSWER_IDENTIFIERS = FormBuilderService::SECTION_FIELD_IDENTIFIERS[:scholarship].freeze
+  SCHOLARSHIP_ANSWER_IDENTIFIERS = FormBuilderService::SUBSECTION_FIELD_IDENTIFIERS[:scholarship].freeze
 
   # Professional-info answers shown in each recipient's header. The view falls
   # back to the person's profile (sectors / age-range tags) when these aren't on

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -5,7 +5,7 @@ class FormBuilderService
   PAYMENT_METHOD_PAY_NOW = "Credit card (now)".freeze
   PAYMENT_METHOD_OPTIONS = [ PAYMENT_METHOD_PAY_NOW, "Credit card (later)", "Check" ].freeze
 
-  SECTIONS = {
+  SUBSECTIONS = {
     person_identifier: { label: "Person identifier", method: :build_person_identifier_fields },
     person_contact_info: { label: "Person contact info", method: :build_person_contact_info_fields },
     person_background: { label: "Person background", method: :build_person_background_fields },
@@ -18,29 +18,29 @@ class FormBuilderService
     bulk_payment: { label: "Bulk payment", method: :build_bulk_payment_fields }
   }.freeze
 
-  def initialize(name:, sections:, role: nil)
+  def initialize(name:, subsections:, role: nil)
     @name = name
-    @sections = sections.map(&:to_sym)
+    @subsections = subsections.map(&:to_sym)
     @role = role
   end
 
   def call
     form = Form.create!(
       name: @name,
-      sections: @sections.map(&:to_s),
+      subsections: @subsections.map(&:to_s),
       role: @role
     )
 
     position = 0
-    @sections.each do |key|
-      section = SECTIONS.fetch(key)
-      position = send(section[:method], form, position)
+    @subsections.each do |key|
+      subsection = SUBSECTIONS.fetch(key)
+      position = send(subsection[:method], form, position)
     end
 
     form
   end
 
-  SECTION_FIELD_IDENTIFIERS = {
+  SUBSECTION_FIELD_IDENTIFIERS = {
     person_identifier: %w[first_name last_name primary_email confirm_email],
     person_contact_info: %w[
       primary_email_type nickname pronouns secondary_email secondary_email_type
@@ -58,8 +58,8 @@ class FormBuilderService
     bulk_payment: %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees payment_method bulk_payment_attendees]
   }.freeze
 
-  # Header questions created by each section's builder method
-  SECTION_HEADERS = {
+  # Header questions created by each subsection's builder method
+  SUBSECTION_HEADERS = {
     person_identifier: [],
     person_contact_info: [ "Contact Information", "Mailing Address", "Organization Information" ],
     person_background: [ "Background Information" ],
@@ -72,11 +72,11 @@ class FormBuilderService
     bulk_payment: [ "Payer Information", "Payment Information", "Attendees" ]
   }.freeze
 
-  # User-facing field labels each section's builder creates (questions only,
+  # User-facing field labels each subsection's builder creates (questions only,
   # excluding group headers), in build order. Mirrors the build_* methods so the
-  # new-form page can list a section's fields before the form exists. A spec
+  # new-form page can list a subsection's fields before the form exists. A spec
   # asserts this stays in sync with what the builders actually create.
-  SECTION_FIELD_NAMES = {
+  SUBSECTION_FIELD_NAMES = {
     person_identifier: [ "First Name", "Last Name", "Email", "Confirm Email" ],
     person_contact_info: [
       "Primary Email Type", "Preferred Nickname", "Pronouns", "Secondary Email", "Secondary Email Type",
@@ -108,16 +108,16 @@ class FormBuilderService
     ]
   }.freeze
 
-  # Field labels a section's builder creates, for previewing a section's
+  # Field labels a subsection's builder creates, for previewing a subsection's
   # contents before the form exists (used on the new-form page).
-  def self.section_field_names(key)
-    SECTION_FIELD_NAMES.fetch(key.to_sym, [])
+  def self.subsection_field_names(key)
+    SUBSECTION_FIELD_NAMES.fetch(key.to_sym, [])
   end
 
-  # Maps each section to the `section` column value(s) its builder assigns to
-  # fields, so fields can be grouped back to their section when reordering.
-  # Several builders use a `group:` string that differs from the section key.
-  SECTION_GROUPS = {
+  # Maps each subsection to the `subsection` column value(s) its builder assigns to
+  # fields, so fields can be grouped back to their subsection when reordering.
+  # Several builders use a `group:` string that differs from the subsection key.
+  SUBSECTION_GROUPS = {
     person_identifier: %w[person_identifier],
     person_contact_info: %w[person_contact_info],
     person_background: %w[background],
@@ -130,11 +130,11 @@ class FormBuilderService
     bulk_payment: %w[bulk_payment]
   }.freeze
 
-  # Built-in section keys that apply to a form with the given role. Scholarship
-  # and bulk-payment forms show only their own section; every other role shows
-  # all sections except those two.
-  def self.applicable_section_keys(role)
-    SECTIONS.keys.select do |key|
+  # Built-in subsection keys that apply to a form with the given role. Scholarship
+  # and bulk-payment forms show only their own subsection; every other role shows
+  # all subsections except those two.
+  def self.applicable_subsection_keys(role)
+    SUBSECTIONS.keys.select do |key|
       case role
       when "scholarship" then key == :scholarship
       when "bulk_payment" then key == :bulk_payment
@@ -143,27 +143,27 @@ class FormBuilderService
     end
   end
 
-  # Built-in section keys that currently have fields on the form. This — not the
-  # stored `sections` column — is the source of truth for which sections are
-  # present, so add/remove stays consistent with the edit-sections checkboxes
+  # Built-in subsection keys that currently have fields on the form. This — not the
+  # stored `subsections` column — is the source of truth for which subsections are
+  # present, so add/remove stays consistent with the edit-subsections checkboxes
   # (which are rendered from the fields) even if the column drifts.
-  def self.present_section_keys(form)
-    group_to_key = SECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
+  def self.present_subsection_keys(form)
+    group_to_key = SUBSECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
     # pluck runs a fresh query rather than reading (and caching) the association,
     # so repeated calls within a single update see deletions made between them.
-    form.form_fields.pluck(:section).filter_map { |section| group_to_key[section] }.uniq
+    form.form_fields.pluck(:subsection).filter_map { |subsection| group_to_key[subsection] }.uniq
   end
 
-  # Ordered list of sections for the edit-sections page. Each entry is a hash
-  # with a :kind of :builtin or :custom. Built-in sections carry their :label,
-  # section :key, and :included state; custom (user-added) sections carry the
+  # Ordered list of subsections for the edit-subsections page. Each entry is a hash
+  # with a :kind of :builtin or :custom. Built-in subsections carry their :label,
+  # subsection :key, and :included state; custom (user-added) subsections carry the
   # group_header :label and the :questions that follow it on the form.
   #
-  # Sections present on the form are ordered by their position there, so a
-  # custom section slots into the list wherever it sits on the form. Built-in
-  # sections not currently on the form follow their canonical predecessor.
-  def self.editable_sections(form)
-    group_to_key = SECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
+  # Subsections present on the form are ordered by their position there, so a
+  # custom subsection slots into the list wherever it sits on the form. Built-in
+  # subsections not currently on the form follow their canonical predecessor.
+  def self.editable_subsections(form)
+    group_to_key = SUBSECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
 
     positions = {}
     header_names = {}
@@ -174,7 +174,7 @@ class FormBuilderService
     # Rank by iteration order rather than the stored position, which is nullable
     # and can collide, so the sort keys below are always comparable integers.
     form.form_fields.reorder(position: :asc).each_with_index do |field, order|
-      key = group_to_key[field.section]
+      key = group_to_key[field.subsection]
       if key
         current = nil
         positions[key] ||= order
@@ -193,16 +193,16 @@ class FormBuilderService
 
     entries = []
     last_position = 0
-    applicable_section_keys(form.role).each_with_index do |key, rank|
+    applicable_subsection_keys(form.role).each_with_index do |key, rank|
       position = positions[key]
       last_position = position if position
-      default_header = SECTION_HEADERS.fetch(key).first
+      default_header = SUBSECTION_HEADERS.fetch(key).first
       header_name = header_names[key]
       entries << {
         sort: [ position || last_position, position ? 0 : 1, rank ],
         kind: :builtin,
         key: key,
-        label: SECTIONS.fetch(key)[:label],
+        label: SUBSECTIONS.fetch(key)[:label],
         included: !position.nil?,
         questions: questions[key],
         renamed_header: (header_name if header_name.present? && header_name != default_header)
@@ -216,65 +216,65 @@ class FormBuilderService
     entries.sort_by { |entry| entry[:sort] }
   end
 
-  # Update sections on an existing form: add new sections, remove unchecked ones.
-  # remove_custom_section_ids are group_header field ids of custom sections the
+  # Update subsections on an existing form: add new subsections, remove unchecked ones.
+  # remove_custom_subsection_ids are group_header field ids of custom subsections the
   # user unchecked; each such header and the questions under it are deleted.
-  def self.update_sections!(form, new_sections, remove_custom_section_ids: [])
-    new_sections = new_sections.map(&:to_sym)
-    old_sections = present_section_keys(form)
+  def self.update_subsections!(form, new_subsections, remove_custom_subsection_ids: [])
+    new_subsections = new_subsections.map(&:to_sym)
+    old_subsections = present_subsection_keys(form)
 
-    remove_custom_sections!(form, remove_custom_section_ids)
+    remove_custom_subsections!(form, remove_custom_subsection_ids)
 
-    added = new_sections - old_sections
-    removed = old_sections - new_sections
+    added = new_subsections - old_subsections
+    removed = old_subsections - new_subsections
 
-    # Remove every field belonging to a removed section by its section group.
+    # Remove every field belonging to a removed subsection by its subsection group.
     # Keying off the group (not the canonical field_identifier or default header
     # name) deletes renamed headers too, so nothing is left orphaned to resurface
-    # as a duplicate when the section is added back.
+    # as a duplicate when the subsection is added back.
     removed.each do |key|
-      form.form_fields.where(section: SECTION_GROUPS.fetch(key)).destroy_all
+      form.form_fields.where(subsection: SUBSECTION_GROUPS.fetch(key)).destroy_all
     end
 
-    # Build fields for newly checked sections (created at the end for now), then
-    # renumber everything so sections follow the edit-sections page order.
+    # Build fields for newly checked subsections (created at the end for now), then
+    # renumber everything so subsections follow the edit-subsections page order.
     if added.any?
       max_position = form.form_fields.maximum(:position) || 0
-      builder = new(name: form.name, sections: added)
+      builder = new(name: form.name, subsections: added)
       added.each do |key|
-        section = SECTIONS.fetch(key)
-        max_position = builder.send(section[:method], form, max_position)
+        subsection = SUBSECTIONS.fetch(key)
+        max_position = builder.send(subsection[:method], form, max_position)
       end
-      reorder_to_page_order!(form, new_sections)
+      reorder_to_page_order!(form, new_subsections)
     end
 
-    form.update!(sections: new_sections.map(&:to_s))
+    form.update!(subsections: new_subsections.map(&:to_s))
     form
   end
 
-  # Delete the given custom sections — each group_header field plus the questions
+  # Delete the given custom subsections — each group_header field plus the questions
   # that follow it on the form — identified by their header field ids.
-  def self.remove_custom_sections!(form, header_ids)
+  def self.remove_custom_subsections!(form, header_ids)
     header_ids = Array(header_ids).map(&:to_i)
     return if header_ids.empty?
 
-    targets = editable_sections(form).select do |entry|
+    targets = editable_subsections(form).select do |entry|
       entry[:kind] == :custom && header_ids.include?(entry[:header].id)
     end
     field_ids = targets.flat_map { |entry| [ entry[:header].id, *entry[:questions].map(&:id) ] }
     form.form_fields.where(id: field_ids).destroy_all if field_ids.any?
   end
 
-  # Renumber a form's fields so sections appear in the canonical page order
-  # (the order of SECTIONS / the edit-sections checkboxes), preserving each
-  # field's existing order within its own section.
-  def self.reorder_to_page_order!(form, section_order)
-    section_for_group = SECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
-    rank = SECTIONS.keys.select { |key| section_order.include?(key) }.each_with_index.to_h
+  # Renumber a form's fields so subsections appear in the canonical page order
+  # (the order of SUBSECTIONS / the edit-subsections checkboxes), preserving each
+  # field's existing order within its own subsection.
+  def self.reorder_to_page_order!(form, subsection_order)
+    subsection_for_group = SUBSECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
+    rank = SUBSECTIONS.keys.select { |key| subsection_order.include?(key) }.each_with_index.to_h
 
     ordered = form.form_fields.reorder(:position).to_a.each_with_index.sort_by do |field, index|
-      section_key = section_for_group[field.section]
-      [ rank.fetch(section_key, rank.size), index ]
+      subsection_key = subsection_for_group[field.subsection]
+      [ rank.fetch(subsection_key, rank.size), index ]
     end
 
     ordered.each_with_index do |(field, _index), position|
@@ -285,7 +285,7 @@ class FormBuilderService
 
   private
 
-  SECTION_VISIBILITY = {
+  SUBSECTION_VISIBILITY = {
     "person_identifier" => :logged_out_only,
     "person_contact_info" => :logged_out_only,
     "background" => :logged_out_only,
@@ -298,8 +298,8 @@ class FormBuilderService
     "bulk_payment" => :always_ask
   }.freeze
 
-  # Sections where answers carry across all events (ask once ever)
-  ONE_TIME_SECTIONS = %w[professional background].freeze
+  # Subsections where answers carry across all events (ask once ever)
+  ONE_TIME_SUBSECTIONS = %w[professional background].freeze
 
   def add_header(form, position, title, group:, visibility: nil)
     position += 1
@@ -310,9 +310,9 @@ class FormBuilderService
       position: position,
       required: false,
       field_identifier: nil,
-      section: group,
-      visibility: visibility || SECTION_VISIBILITY.fetch(group, :always_ask),
-      one_time: ONE_TIME_SECTIONS.include?(group)
+      subsection: group,
+      visibility: visibility || SUBSECTION_VISIBILITY.fetch(group, :always_ask),
+      one_time: ONE_TIME_SUBSECTIONS.include?(group)
     )
     position
   end
@@ -328,9 +328,9 @@ class FormBuilderService
       required: required,
       subtitle: subtitle,
       field_identifier: key,
-      section: group,
-      visibility: visibility || SECTION_VISIBILITY.fetch(group, :always_ask),
-      one_time: ONE_TIME_SECTIONS.include?(group),
+      subsection: group,
+      visibility: visibility || SUBSECTION_VISIBILITY.fetch(group, :always_ask),
+      one_time: ONE_TIME_SUBSECTIONS.include?(group),
       width: width
     )
 
@@ -346,7 +346,7 @@ class FormBuilderService
     position
   end
 
-  # ---- Section builders ----
+  # ---- Subsection builders ----
 
   def build_person_identifier_fields(form, position)
     position = add_field(form, position, "First Name", :free_form_input_one_line,
@@ -471,7 +471,7 @@ class FormBuilderService
   # training form. Multi-select; the trailing "Other" reveals a free-text box.
   TRAINING_MOTIVATION_OPTIONS = [
     "Use art to offer accessible and effective client programming (strength-based, low-barrier, research-informed)",
-    "Deepen understanding of trauma-informed and intersectional practices",
+    "Deepen understanding of trauma-informed and intersubsectional practices",
     "Address staff burnout through art",
     "Support staff wellness through art",
     "Connect with and learn from a community of art facilitators",

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -15,7 +15,7 @@
 %>
 <div class="nested-fields flex items-center gap-3 <%= field.group_header? ? 'pl-3 pr-6' : 'px-6' %> py-3 border-b border-gray-100 hover:bg-gray-50"
      data-sortable-id="<%= field.id %>"
-     <% if field.section.present? %>data-section="<%= field.section %>"<% end %>
+     <% if field.subsection.present? %>data-subsection="<%= field.subsection %>"<% end %>
      <% if field.group_header? %>data-group-header<% end %>>
   <% if field.group_header? %>
     <div class="cursor-grab rounded bg-purple-50 text-purple-500 hover:bg-purple-100 hover:text-purple-700 px-1.5 py-1"

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -8,6 +8,7 @@
     <% if @dashboard_event %>
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
+    <%= link_to "Edit subsections", edit_subsections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,126 +1,49 @@
-<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="py-8 px-4">
+<div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
-    <% if @dashboard_event %>
-      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= form_editor_view_links(@form, @dashboard_event) %>
+    <%= link_to "Edit subsections", edit_subsections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit fields", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
+  <h1 class="text-2xl font-semibold mb-2">Edit sections: <%= @form.display_name %></h1>
 
-  <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <div class="flex items-center gap-4">
-          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
-            <i class="fa-solid fa-layer-group text-xl"></i>
-          </div>
-          <div>
-            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit sections</p>
-            <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
-          </div>
-        </div>
+  <% subsections = (@form.subsections || []).map(&:to_s) %>
 
-        <%# Quick stats pulled up into the header so the page reads at a glance %>
-        <div class="flex flex-wrap items-center gap-2">
-          <% events_count = @form.events.size %>
-          <% if events_count.positive? %>
-            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
-              <i class="fa-solid fa-calendar-day text-purple-600"></i>
-              <%= pluralize(events_count, "event") %> connected
-            <% end %>
-          <% else %>
-            <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600 shadow-sm">
-              <i class="fa-solid fa-calendar-day text-gray-400"></i>
-              No events connected
-            </span>
-          <% end %>
-          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
-            <i class="fa-solid fa-inbox text-purple-600"></i>
-            <%= pluralize(@form.form_submissions.size, "submission") %>
-          </span>
-        </div>
-      </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+  <% if subsections.empty? %>
+    <div class="rounded-lg bg-gray-50 border border-gray-200 p-4 text-sm text-gray-600">
+      This form has no subsections yet. <%= link_to "Add subsections", edit_subsections_form_path(@form), class: "text-blue-600 hover:text-blue-800 underline" %> first, then group them into sections here.
     </div>
+  <% else %>
+    <%= form_with url: update_sections_form_path(@form), method: :patch, class: "space-y-6" do |f| %>
+      <fieldset>
+        <legend class="text-sm font-medium text-gray-700 mb-1">Group subsections into sections:</legend>
+        <p class="text-xs text-gray-500 mb-3">A section is a single-screen heading that spans several subsections. Give two or more subsections the same section name to group them. Leave a name blank to keep that subsection ungrouped.</p>
 
-    <div class="px-4 sm:px-6 py-6">
-  <%= form_with url: update_sections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
-        <i class="fa-solid fa-list-check text-purple-700"></i>
-        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
-      </div>
-      <div class="p-6">
-        <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
+        <datalist id="section-name-suggestions">
+          <% @form.section_groups.each do |group| %>
+            <option value="<%= group[:label] %>"></option>
+          <% end %>
+        </datalist>
+
         <ol class="space-y-2">
-          <% @editable_sections.each_with_index do |section, index| %>
-            <% if section[:kind] == :custom %>
-              <% names = section[:questions].map(&:name) %>
-              <li data-controller="form-section-toggle expandable-card" data-expandable-card-expanded-value="false"
-                  data-form-section-toggle-included-value="true">
-                <div class="flex items-center gap-2">
-                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
-                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
-                    <%= hidden_field_tag "custom_sections[]", section[:header].id %>
-                    <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
-                          class: "rounded border-gray-300 text-purple-600",
-                          data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
-                    <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
-                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
-                  </label>
-                  <% if names.any? %>
-                    <%= render "forms/field_list_toggle", count: names.size %>
-                  <% end %>
-                </div>
-                <% if names.any? %>
-                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
-                <% end %>
-                <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
-              </li>
-            <% else %>
-              <%# Included sections list their real fields; not-yet-added ones fall back to the builder's defaults. %>
-              <% names = section[:questions].map(&:name).presence || FormBuilderService.section_field_names(section[:key]) %>
-              <li data-controller="form-section-toggle expandable-card" data-expandable-card-expanded-value="false"
-                  data-form-section-toggle-included-value="<%= section[:included] %>">
-                <div class="flex items-center gap-2">
-                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
-                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
-                    <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
-                           class="rounded border-gray-300 text-purple-600"
-                           data-form-section-toggle-target="checkbox"
-                           data-action="form-section-toggle#update"
-                           <%= "checked" if section[:included] %>>
-                    <span class="text-sm text-gray-800"><%= section[:label] %></span>
-                    <% if section[:renamed_header].present? %>
-                      <span class="text-xs text-gray-400 italic">titled &ldquo;<%= section[:renamed_header] %>&rdquo; on the form</span>
-                    <% end %>
-                  </label>
-                  <% if names.any? %>
-                    <%= render "forms/field_list_toggle", count: names.size %>
-                  <% end %>
-                </div>
-                <% if names.any? %>
-                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
-                <% end %>
-                <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
-              </li>
-            <% end %>
+          <% subsections.each do |key| %>
+            <% subsection = FormBuilderService::SUBSECTIONS[key.to_sym] %>
+            <li class="flex flex-col sm:flex-row sm:items-center gap-2">
+              <span class="text-sm text-gray-800 sm:w-48 shrink-0"><%= subsection ? subsection[:label] : key.humanize %></span>
+              <input type="text" name="section_labels[<%= key %>]"
+                     value="<%= @form.section_label_for_subsection(key) %>"
+                     list="section-name-suggestions"
+                     placeholder="Section name (optional)"
+                     class="flex-1 rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
+            </li>
           <% end %>
         </ol>
-      </div>
-    </div>
+      </fieldset>
 
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-      <div class="flex items-center gap-3">
-        <%= f.submit "Save changes", class: "btn btn-primary cursor-pointer" %>
-        <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "btn btn-secondary" %>
-        <%= link_to "Cancel", form_path(@form), class: "btn btn-secondary-outline" %>
+      <div class="flex gap-3">
+        <%= f.submit "Update sections", class: "btn btn-primary cursor-pointer" %>
+        <%= link_to "Cancel", edit_form_path(@form), class: "btn btn-secondary-outline" %>
       </div>
-    </div>
+    <% end %>
   <% end %>
-    </div>
-  </div>
 </div>

--- a/app/views/forms/edit_subsections.html.erb
+++ b/app/views/forms/edit_subsections.html.erb
@@ -1,0 +1,126 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="py-8 px-4">
+  <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <% if @dashboard_event %>
+      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% end %>
+    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= form_editor_view_links(@form, @dashboard_event) %>
+  </div>
+
+  <%# Colored hero banner so the page reads at a glance instead of all-white %>
+  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <div class="flex items-center gap-4">
+          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
+            <i class="fa-solid fa-layer-group text-xl"></i>
+          </div>
+          <div>
+            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit subsections</p>
+            <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
+          </div>
+        </div>
+
+        <%# Quick stats pulled up into the header so the page reads at a glance %>
+        <div class="flex flex-wrap items-center gap-2">
+          <% events_count = @form.events.size %>
+          <% if events_count.positive? %>
+            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
+              <i class="fa-solid fa-calendar-day text-purple-600"></i>
+              <%= pluralize(events_count, "event") %> connected
+            <% end %>
+          <% else %>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600 shadow-sm">
+              <i class="fa-solid fa-calendar-day text-gray-400"></i>
+              No events connected
+            </span>
+          <% end %>
+          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
+            <i class="fa-solid fa-inbox text-purple-600"></i>
+            <%= pluralize(@form.form_submissions.size, "submission") %>
+          </span>
+        </div>
+      </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+    </div>
+
+    <div class="px-4 sm:px-6 py-6">
+  <%= form_with url: update_subsections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
+    <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+        <i class="fa-solid fa-list-check text-purple-700"></i>
+        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Subsections to include</h2>
+      </div>
+      <div class="p-6">
+        <p class="text-xs text-gray-500 mb-3">Numbered in the order these subsections appear on this form. Custom subsections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
+        <ol class="space-y-2">
+          <% @editable_subsections.each_with_index do |subsection, index| %>
+            <% if subsection[:kind] == :custom %>
+              <% names = subsection[:questions].map(&:name) %>
+              <li data-controller="form-subsection-toggle expandable-card" data-expandable-card-expanded-value="false"
+                  data-form-subsection-toggle-included-value="true">
+                <div class="flex items-center gap-2">
+                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
+                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                    <%= hidden_field_tag "custom_subsections[]", subsection[:header].id %>
+                    <%= check_box_tag "kept_custom_subsections[]", subsection[:header].id, true,
+                          class: "rounded border-gray-300 text-purple-600",
+                          data: { form_subsection_toggle_target: "checkbox", action: "form-subsection-toggle#update" } %>
+                    <span class="text-sm font-semibold text-gray-800"><%= subsection[:label] %></span>
+                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
+                  </label>
+                  <% if names.any? %>
+                    <%= render "forms/field_list_toggle", count: names.size %>
+                  <% end %>
+                </div>
+                <% if names.any? %>
+                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
+                <% end %>
+                <p class="hidden mt-1 ml-12 text-xs" data-form-subsection-toggle-target="message"></p>
+              </li>
+            <% else %>
+              <%# Included subsections list their real fields; not-yet-added ones fall back to the builder's defaults. %>
+              <% names = subsection[:questions].map(&:name).presence || FormBuilderService.subsection_field_names(subsection[:key]) %>
+              <li data-controller="form-subsection-toggle expandable-card" data-expandable-card-expanded-value="false"
+                  data-form-subsection-toggle-included-value="<%= subsection[:included] %>">
+                <div class="flex items-center gap-2">
+                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
+                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                    <input type="checkbox" name="subsections[]" value="<%= subsection[:key] %>"
+                           class="rounded border-gray-300 text-purple-600"
+                           data-form-subsection-toggle-target="checkbox"
+                           data-action="form-subsection-toggle#update"
+                           <%= "checked" if subsection[:included] %>>
+                    <span class="text-sm text-gray-800"><%= subsection[:label] %></span>
+                    <% if subsection[:renamed_header].present? %>
+                      <span class="text-xs text-gray-400 italic">titled &ldquo;<%= subsection[:renamed_header] %>&rdquo; on the form</span>
+                    <% end %>
+                  </label>
+                  <% if names.any? %>
+                    <%= render "forms/field_list_toggle", count: names.size %>
+                  <% end %>
+                </div>
+                <% if names.any? %>
+                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
+                <% end %>
+                <p class="hidden mt-1 ml-12 text-xs" data-form-subsection-toggle-target="message"></p>
+              </li>
+            <% end %>
+          <% end %>
+        </ol>
+      </div>
+    </div>
+
+    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+      <div class="flex items-center gap-3">
+        <%= f.submit "Save changes", class: "btn btn-primary cursor-pointer" %>
+        <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "btn btn-secondary" %>
+        <%= link_to "Cancel", form_path(@form), class: "btn btn-secondary-outline" %>
+      </div>
+    </div>
+  <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -52,21 +52,21 @@
         <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
           <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
             <i class="fa-solid fa-list-check text-purple-700"></i>
-            <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
+            <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Subsections to include</h2>
           </div>
           <div class="p-6">
             <div class="space-y-1.5">
-              <% FormBuilderService::SECTIONS.each do |key, section| %>
+              <% FormBuilderService::SUBSECTIONS.each do |key, subsection| %>
                 <% section_role = key == :scholarship ? "scholarship" : key == :bulk_payment ? "bulk_payment" : "other" %>
-                <% field_names = FormBuilderService.section_field_names(key) %>
+                <% field_names = FormBuilderService.subsection_field_names(key) %>
                 <div class="rounded-lg border border-gray-200 px-3 py-2" data-section-role="<%= section_role %>"
                      data-controller="expandable-card" data-expandable-card-expanded-value="false">
                   <div class="flex items-center gap-2">
                     <label class="flex flex-1 items-center gap-2 cursor-pointer">
-                      <input type="checkbox" name="sections[]" value="<%= key %>"
+                      <input type="checkbox" name="subsections[]" value="<%= key %>"
                              class="rounded border-gray-300 text-purple-600"
-                             <%= "checked" if params.dig(:sections)&.include?(key.to_s) %>>
-                      <span class="text-sm font-medium text-gray-800"><%= section[:label] %></span>
+                             <%= "checked" if params.dig(:subsections)&.include?(key.to_s) %>>
+                      <span class="text-sm font-medium text-gray-800"><%= subsection[:label] %></span>
                     </label>
                     <% if field_names.any? %>
                       <%= render "forms/field_list_toggle", count: field_names.size %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -76,8 +76,18 @@
 
       <fieldset disabled>
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+          <% current_section_label = nil %>
           <% @form_fields.each do |field| %>
             <% conditional = field.conditional_visibility? %>
+            <% section_label = @form.section_label_for_subsection(field.subsection) %>
+            <% if section_label.present? && section_label != current_section_label %>
+              <div class="md:col-span-12 pt-8 mt-2 mb-2 border-t-2 border-purple-200">
+                <h2 class="rich-label text-xl font-bold text-purple-900"><%= form_label_html(section_label) %></h2>
+              </div>
+              <% current_section_label = section_label %>
+            <% elsif section_label.blank? %>
+              <% current_section_label = nil %>
+            <% end %>
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
                 <div class="flex flex-wrap items-center gap-2">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "a750b09d4d42ef567df595f7a9035933dc1178c533bf8ae8f8986ae8e837c6b8",
+      "fingerprint": "294fcc1f8d8065e292fae8d057984cd9b0d4cc0705d95807947d57ef13dae881",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
-      "line": 138,
+      "line": 151,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :subtitle, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
+      "code": "params.require(:form).permit(:name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :subtitle, :hint_text, :field_identifier, :subsection, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,8 @@ Rails.application.routes.draw do
     member do
       patch :reorder_field
       put :reorder_fields
+      get :edit_subsections
+      patch :update_subsections
       get :edit_sections
       patch :update_sections
     end

--- a/db/migrate/20260609120000_rename_form_fields_section_to_subsection.rb
+++ b/db/migrate/20260609120000_rename_form_fields_section_to_subsection.rb
@@ -1,0 +1,15 @@
+class RenameFormFieldsSectionToSubsection < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :form_fields, :section, :subsection if column_exists?(:form_fields, :section)
+    if index_exists?(:form_fields, :subsection, name: "index_form_fields_on_section")
+      rename_index :form_fields, "index_form_fields_on_section", "index_form_fields_on_subsection"
+    end
+  end
+
+  def down
+    if index_exists?(:form_fields, :subsection, name: "index_form_fields_on_subsection")
+      rename_index :form_fields, "index_form_fields_on_subsection", "index_form_fields_on_section"
+    end
+    rename_column :form_fields, :subsection, :section if column_exists?(:form_fields, :subsection)
+  end
+end

--- a/db/migrate/20260609120100_rename_forms_sections_to_subsections.rb
+++ b/db/migrate/20260609120100_rename_forms_sections_to_subsections.rb
@@ -1,0 +1,9 @@
+class RenameFormsSectionsToSubsections < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :forms, :sections, :subsections if column_exists?(:forms, :sections)
+  end
+
+  def down
+    rename_column :forms, :subsections, :sections if column_exists?(:forms, :subsections)
+  end
+end

--- a/db/migrate/20260609120200_add_sections_to_forms.rb
+++ b/db/migrate/20260609120200_add_sections_to_forms.rb
@@ -1,0 +1,12 @@
+class AddSectionsToForms < ActiveRecord::Migration[8.1]
+  # Reintroduces `forms.sections`, now meaning the top-level grouping of
+  # subsections (the new tier above subsections). Stored as JSON:
+  # [{ "label" => "About you", "subsections" => ["person_identifier", ...] }, ...]
+  def up
+    add_column :forms, :sections, :json unless column_exists?(:forms, :sections)
+  end
+
+  def down
+    remove_column :forms, :sections if column_exists?(:forms, :sections)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -621,15 +621,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.integer "parent_id"
     t.integer "position"
     t.boolean "required", default: true
-    t.string "section"
     t.integer "status", default: 1
+    t.string "subsection"
     t.text "subtitle"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "visibility", default: 0, null: false
     t.integer "width", default: 0, null: false
     t.index ["field_identifier"], name: "index_form_fields_on_field_identifier"
     t.index ["form_id"], name: "index_form_fields_on_form_id"
-    t.index ["section"], name: "index_form_fields_on_section"
+    t.index ["subsection"], name: "index_form_fields_on_subsection"
   end
 
   create_table "form_submissions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -657,6 +657,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.string "owner_type"
     t.string "role"
     t.json "sections"
+    t.json "subsections"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["form_builder_id"], name: "index_forms_on_form_builder_id"
   end

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -16,7 +16,7 @@ unless Form.standalone.exists?(name: "Training Registration Form")
   # magic questions are appended below and slotted into place by reorder.
   FormBuilderService.new(
     name: "Training Registration Form",
-    sections: %i[person_identifier person_contact_info professional_info person_background marketing payment consent],
+    subsections: %i[person_identifier person_contact_info professional_info person_background marketing payment consent],
     role: "registration"
   ).call
 end
@@ -24,7 +24,7 @@ end
 unless Form.standalone.find_by(role: "scholarship")
   FormBuilderService.new(
     name: "Scholarship Application",
-    sections: %i[scholarship],
+    subsections: %i[scholarship],
     role: "scholarship"
   ).call
 end
@@ -32,7 +32,7 @@ end
 unless Form.standalone.find_by(role: "bulk_payment")
   FormBuilderService.new(
     name: "Bulk Payment",
-    sections: %i[bulk_payment],
+    subsections: %i[bulk_payment],
     role: "bulk_payment"
   ).call
 end
@@ -1331,9 +1331,9 @@ if facilitator_training && registration_form
   # "Pending" only exists when the form has the Organization Name field,
   # which lives in the person_contact_info section the dev form otherwise omits.
   unless registration_form.form_fields.exists?(field_identifier: "agency_name")
-    FormBuilderService.update_sections!(
+    FormBuilderService.update_subsections!(
       registration_form,
-      (registration_form.sections || []).map(&:to_sym) | [ :person_contact_info ]
+      (registration_form.subsections || []).map(&:to_sym) | [ :person_contact_info ]
     )
   end
   agency_field = registration_form.form_fields.find_by(field_identifier: "agency_name")

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -235,7 +235,7 @@ scholarship_fields = scholarship_form ? scholarship_form.form_fields.where.not(a
 # person's profile (sectors / age-range tags).
 registration_form = Form.standalone.find_by(role: "registration")
 if registration_form && registration_form.form_fields.where(field_identifier: "additional_sectors").none?
-  FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
+  FormBuilderService.update_subsections!(registration_form, (registration_form.subsections || []).map(&:to_sym) | [ :professional_info ])
 end
 sector_field = registration_form&.form_fields&.find_by(field_identifier: "additional_sectors")
 age_group_field = registration_form&.form_fields&.find_by(field_identifier: "primary_age_group")

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe EventMailer, type: :mailer do
   describe "#bulk_payment_confirmation" do
     let(:event) { create(:event) }
     let(:form) do
-      f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+      f = FormBuilderService.new(name: "Bulk Payment", subsections: %i[bulk_payment], role: "bulk_payment").call
       event.event_forms.create!(form: f, role: "bulk_payment")
       f
     end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   describe "#bulk_payment_confirmation_fyi" do
     let(:event) { create(:event) }
     let(:form) do
-      f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+      f = FormBuilderService.new(name: "Bulk Payment", subsections: %i[bulk_payment], role: "bulk_payment").call
       event.event_forms.create!(form: f, role: "bulk_payment")
       f
     end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -67,4 +67,69 @@ RSpec.describe Form do
       end
     end
   end
+
+  describe 'section groups' do
+    let(:form) do
+      create(:form, :standalone, subsections: %w[person_identifier person_contact_info scholarship])
+    end
+
+    describe '#assign_section_groups!' do
+      it 'groups subsections that share a label, preserving subsection order' do
+        form.assign_section_groups!(
+          "person_identifier" => "About you",
+          "person_contact_info" => "About you",
+          "scholarship" => "Funding"
+        )
+
+        expect(form.reload.sections).to eq([
+          { "label" => "About you", "subsections" => %w[person_identifier person_contact_info] },
+          { "label" => "Funding", "subsections" => %w[scholarship] }
+        ])
+      end
+
+      it 'leaves subsections with a blank label ungrouped' do
+        form.assign_section_groups!(
+          "person_identifier" => "About you",
+          "person_contact_info" => "  ",
+          "scholarship" => ""
+        )
+
+        expect(form.reload.sections).to eq([
+          { "label" => "About you", "subsections" => %w[person_identifier] }
+        ])
+      end
+    end
+
+    describe '#section_label_for_subsection' do
+      before do
+        form.assign_section_groups!(
+          "person_identifier" => "About you",
+          "person_contact_info" => "About you"
+        )
+      end
+
+      it 'returns the section label for a grouped subsection' do
+        expect(form.section_label_for_subsection("person_contact_info")).to eq("About you")
+      end
+
+      it 'returns nil for an ungrouped subsection' do
+        expect(form.section_label_for_subsection("scholarship")).to be_nil
+      end
+
+      it 'returns nil for a blank subsection' do
+        expect(form.section_label_for_subsection(nil)).to be_nil
+      end
+    end
+
+    describe '#sections?' do
+      it 'is false when no sections are defined' do
+        expect(form.sections?).to be false
+      end
+
+      it 'is true once subsections are grouped' do
+        form.assign_section_groups!("person_identifier" => "About you")
+        expect(form.sections?).to be true
+      end
+    end
+  end
 end

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Events::BulkPayments", type: :request do
 
   describe "GET new with the seeded bulk payment form" do
     let(:seeded_form) do
-      FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+      FormBuilderService.new(name: "Bulk Payment", subsections: %i[bulk_payment], role: "bulk_payment").call
     end
 
     before do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe "Events::Registrations", type: :request do
     before do
       form = FormBuilderService.new(
         name: "Extended Event Registration",
-        sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
+        subsections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
       ).call
       EventForm.create!(event: event, form: form, role: "registration")
       form = event.registration_form

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe "Forms", type: :request do
   describe "GET /forms/new" do
     before { sign_in admin }
 
-    it "shows section checkboxes" do
+    it "shows subsection checkboxes" do
       get new_form_path
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Person identifier")
       expect(response.body).to include("Scholarship")
     end
 
-    it "lists each section's fields behind an expandable toggle" do
+    it "lists each subsection's fields behind an expandable toggle" do
       get new_form_path
       expect(response.body).to include("First Name")
       expect(response.body).to include("Confirm Email")
@@ -47,19 +47,19 @@ RSpec.describe "Forms", type: :request do
   describe "POST /forms" do
     before { sign_in admin }
 
-    it "creates a form with selected sections" do
+    it "creates a form with selected subsections" do
       post forms_path, params: {
         name: "Custom Form",
-        sections: %w[person_identifier consent]
+        subsections: %w[person_identifier consent]
       }
       form = Form.last
       expect(form.name).to eq("Custom Form")
-      expect(form.sections).to eq(%w[person_identifier consent])
-      expect(response).to redirect_to(edit_sections_form_path(form))
+      expect(form.subsections).to eq(%w[person_identifier consent])
+      expect(response).to redirect_to(edit_subsections_form_path(form))
     end
 
-    it "rejects when no sections selected" do
-      post forms_path, params: { name: "Empty", sections: [] }
+    it "rejects when no subsections selected" do
+      post forms_path, params: { name: "Empty", subsections: [] }
       expect(response).to have_http_status(:unprocessable_content)
     end
   end
@@ -80,8 +80,8 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include(dashboard_event_path(event))
       end
 
-      it "links the dashboard button to that event on the sections editor" do
-        get edit_sections_form_path(form, event_id: event.id)
+      it "links the dashboard button to that event on the subsections editor" do
+        get edit_subsections_form_path(form, event_id: event.id)
         expect(response.body).to include(dashboard_event_path(event))
       end
 
@@ -122,14 +122,14 @@ RSpec.describe "Forms", type: :request do
     before { sign_in admin }
 
     it "shows form field editor" do
-      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_identifier]).call
       get edit_form_path(form)
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Name")
     end
 
     it "renders the collapsible per-field options controls" do
-      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_identifier]).call
       get edit_form_path(form)
 
       expect(response.body).to include('data-controller="field-options answer-options"')
@@ -139,7 +139,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "renders the editable answer options for a multiple-choice field" do
-      form = FormBuilderService.new(name: "Test", sections: %i[person_contact_info]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_contact_info]).call
       get edit_form_path(form)
 
       expect(response.body).to include('data-controller="field-options answer-options"')
@@ -155,7 +155,7 @@ RSpec.describe "Forms", type: :request do
       # dropdown can reveal it client-side — otherwise a field changed to
       # "Single select radio" saves with no options and shows nothing on the
       # public form.
-      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_identifier]).call
       expect(form.form_fields.none?(&:selectable?)).to be(true)
 
       get edit_form_path(form)
@@ -166,7 +166,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "shows payment-method options read-only (no editable inputs) without the admin override" do
-      form = FormBuilderService.new(name: "Test", sections: %i[payment]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[payment]).call
       payment_field = form.form_fields.find_by(field_identifier: "payment_method")
       expect(payment_field).to be_present
 
@@ -184,7 +184,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "renders payment-method options as editable inputs with ?admin=true" do
-      form = FormBuilderService.new(name: "Test", sections: %i[payment]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[payment]).call
 
       get edit_form_path(form, admin: "true")
 
@@ -208,14 +208,14 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "renders the expand/collapse all toggle" do
-      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_identifier]).call
       get edit_form_path(form)
 
       expect(response.body).to include('data-controller="expand-all"')
       expect(response.body).to include("Expand all")
     end
 
-    it "renders the form header section with a textarea for HTML" do
+    it "renders the form header subsection with a textarea for HTML" do
       form = create(:form, :standalone, header: "<strong>Welcome</strong>")
       get edit_form_path(form)
 
@@ -226,13 +226,13 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "edits field and header names in textareas" do
-      form = FormBuilderService.new(name: "Test", sections: %i[person_contact_info]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[person_contact_info]).call
       get edit_form_path(form)
 
       expect(response.body).to include("<textarea")
     end
 
-    it "renders an editable subtext field for a section header" do
+    it "renders an editable subtext field for a subsection header" do
       form = create(:form, :standalone)
       create(:form_field, form: form, answer_type: :group_header, name: "Contact info")
 
@@ -317,13 +317,13 @@ RSpec.describe "Forms", type: :request do
 
     it "renders header and field-label HTML unescaped" do
       form = create(:form, :standalone)
-      create(:form_field, form: form, answer_type: :group_header, name: "<strong>Section</strong>")
+      create(:form_field, form: form, answer_type: :group_header, name: "<strong>Subsection</strong>")
       create(:form_field, form: form, answer_type: :free_form_input_one_line, name: "<em>Your name</em>", required: false)
 
       get form_path(form)
 
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("<strong>Section</strong>")
+      expect(response.body).to include("<strong>Subsection</strong>")
       expect(response.body).to include("<em>Your name</em>")
     end
 
@@ -340,7 +340,7 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("The \"Other\" option is hidden on dropdown fields")
     end
 
-    it "renders a section header's subtext under the heading" do
+    it "renders a subsection header's subtext under the heading" do
       form = create(:form, :standalone)
       create(:form_field, form: form, answer_type: :group_header, name: "Contact info", subtitle: "Tell us how to reach you")
 
@@ -423,7 +423,7 @@ RSpec.describe "Forms", type: :request do
       expect(response).to redirect_to(edit_form_path(form))
     end
 
-    it "saves the subtext for a section header" do
+    it "saves the subtext for a subsection header" do
       form = create(:form, :standalone)
       header = create(:form_field, form: form, answer_type: :group_header, name: "Contact info")
       patch form_path(form), params: {
@@ -489,7 +489,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "renames a multiple-choice field's answer option without renaming the shared option" do
-      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[marketing]).call
       field = form.form_fields.find_by(field_identifier: "interested_in_more")
       join = field.form_field_answer_options.joins(:answer_option).find_by(answer_options: { name: "Yes" })
 
@@ -506,7 +506,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "adds a new answer option to a multiple-choice field" do
-      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[marketing]).call
       field = form.form_fields.find_by(field_identifier: "interested_in_more")
 
       expect {
@@ -522,7 +522,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "ignores a blank new answer option" do
-      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[marketing]).call
       field = form.form_fields.find_by(field_identifier: "interested_in_more")
 
       expect {
@@ -536,7 +536,7 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "removes an answer option from a multiple-choice field" do
-      form = FormBuilderService.new(name: "Test", sections: %i[marketing]).call
+      form = FormBuilderService.new(name: "Test", subsections: %i[marketing]).call
       field = form.form_fields.find_by(field_identifier: "interested_in_more")
       join = field.form_field_answer_options.joins(:answer_option).find_by(answer_options: { name: "No" })
 
@@ -581,7 +581,7 @@ RSpec.describe "Forms", type: :request do
     before { sign_in admin }
 
     it "shows form preview" do
-      form = FormBuilderService.new(name: "Preview", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Preview", subsections: %i[person_identifier]).call
       get form_path(form)
       expect(response).to have_http_status(:success)
       expect(response.body).to include("First Name")
@@ -609,76 +609,76 @@ RSpec.describe "Forms", type: :request do
     end
   end
 
-  describe "GET /forms/:id/edit_sections" do
+  describe "GET /forms/:id/edit_subsections" do
     before { sign_in admin }
 
-    it "shows section checkboxes for existing form" do
-      form = FormBuilderService.new(name: "Editable", sections: %i[person_identifier]).call
-      get edit_sections_form_path(form)
+    it "shows subsection checkboxes for existing form" do
+      form = FormBuilderService.new(name: "Editable", subsections: %i[person_identifier]).call
+      get edit_subsections_form_path(form)
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Person identifier")
     end
 
-    it "lists an included section's actual fields behind an expandable toggle" do
-      form = FormBuilderService.new(name: "Editable", sections: %i[person_identifier]).call
-      get edit_sections_form_path(form)
+    it "lists an included subsection's actual fields behind an expandable toggle" do
+      form = FormBuilderService.new(name: "Editable", subsections: %i[person_identifier]).call
+      get edit_subsections_form_path(form)
       expect(response.body).to include("First Name")
-      expect(response.body).to include('data-controller="form-section-toggle expandable-card"')
+      expect(response.body).to include('data-controller="form-subsection-toggle expandable-card"')
     end
 
-    it "shows custom sections with a custom indicator" do
-      form = FormBuilderService.new(name: "Editable", sections: %i[person_identifier]).call
-      form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+    it "shows custom subsections with a custom indicator" do
+      form = FormBuilderService.new(name: "Editable", subsections: %i[person_identifier]).call
+      form.form_fields.create!(name: "My Special Subsection", answer_type: :group_header,
                                status: :active, position: 100, required: false)
 
-      get edit_sections_form_path(form)
+      get edit_subsections_form_path(form)
 
-      expect(response.body).to include("My Special Section")
-      expect(response.body).to include("Custom sections")
+      expect(response.body).to include("My Special Subsection")
+      expect(response.body).to include("Custom subsections")
     end
   end
 
-  describe "PATCH /forms/:id/update_sections" do
+  describe "PATCH /forms/:id/update_subsections" do
     before { sign_in admin }
 
-    it "adds new sections to existing form" do
-      form = FormBuilderService.new(name: "Growing", sections: %i[person_identifier]).call
+    it "adds new subsections to existing form" do
+      form = FormBuilderService.new(name: "Growing", subsections: %i[person_identifier]).call
       initial_count = form.form_fields.count
 
-      patch update_sections_form_path(form), params: {
-        sections: %w[person_identifier consent]
+      patch update_subsections_form_path(form), params: {
+        subsections: %w[person_identifier consent]
       }
 
       form.reload
-      expect(form.sections).to include("consent")
+      expect(form.subsections).to include("consent")
       expect(form.form_fields.count).to be > initial_count
       expect(response).to redirect_to(edit_form_path(form))
     end
 
-    it "removes sections from existing form" do
-      form = FormBuilderService.new(name: "Shrinking", sections: %i[person_identifier consent]).call
-      patch update_sections_form_path(form), params: {
-        sections: %w[person_identifier]
+    it "removes subsections from existing form" do
+      form = FormBuilderService.new(name: "Shrinking", subsections: %i[person_identifier consent]).call
+      patch update_subsections_form_path(form), params: {
+        subsections: %w[person_identifier]
       }
 
       form.reload
-      expect(form.sections).not_to include("consent")
-      expect(form.form_fields.where(section: "consent")).to be_empty
+      expect(form.subsections).not_to include("consent")
+      expect(form.form_fields.where(subsection: "consent")).to be_empty
     end
 
-    it "rejects empty sections" do
-      form = FormBuilderService.new(name: "Protected", sections: %i[person_identifier]).call
-      patch update_sections_form_path(form), params: { sections: [] }
+    it "rejects empty subsections" do
+      form = FormBuilderService.new(name: "Protected", subsections: %i[person_identifier]).call
+      patch update_subsections_form_path(form), params: { subsections: [] }
       expect(response).to have_http_status(:unprocessable_content)
     end
 
-    it "leaves the form untouched when the section set is unchanged" do
-      form = FormBuilderService.new(name: "Unchanged", sections: %i[person_identifier consent]).call
+    it "leaves the form untouched when the subsection set is unchanged" do
+      form = FormBuilderService.new(name: "Unchanged", subsections: %i[person_identifier consent]).call
       original_ids = form.form_fields.pluck(:id).sort
-      expect(FormBuilderService).not_to receive(:update_sections!)
+      expect(FormBuilderService).not_to receive(:update_subsections!)
 
-      patch update_sections_form_path(form), params: {
-        sections: %w[consent person_identifier]
+      patch update_subsections_form_path(form), params: {
+        subsections: %w[consent person_identifier]
       }
 
       form.reload
@@ -686,33 +686,77 @@ RSpec.describe "Forms", type: :request do
       expect(response).to redirect_to(edit_form_path(form))
     end
 
-    it "removes a custom section the user unchecked" do
-      form = FormBuilderService.new(name: "Custom", sections: %i[person_identifier]).call
-      header = form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+    it "removes a custom subsection the user unchecked" do
+      form = FormBuilderService.new(name: "Custom", subsections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "My Special Subsection", answer_type: :group_header,
                                         status: :active, position: 100, required: false)
 
-      patch update_sections_form_path(form), params: {
-        sections: %w[person_identifier],
-        custom_sections: [ header.id ],
-        kept_custom_sections: []
+      patch update_subsections_form_path(form), params: {
+        subsections: %w[person_identifier],
+        custom_subsections: [ header.id ],
+        kept_custom_subsections: []
       }
 
       expect(FormField.where(id: header.id)).to be_empty
       expect(response).to redirect_to(edit_form_path(form))
     end
 
-    it "keeps a custom section that stays checked" do
-      form = FormBuilderService.new(name: "Custom", sections: %i[person_identifier]).call
-      header = form.form_fields.create!(name: "My Special Section", answer_type: :group_header,
+    it "keeps a custom subsection that stays checked" do
+      form = FormBuilderService.new(name: "Custom", subsections: %i[person_identifier]).call
+      header = form.form_fields.create!(name: "My Special Subsection", answer_type: :group_header,
                                         status: :active, position: 100, required: false)
 
-      patch update_sections_form_path(form), params: {
-        sections: %w[person_identifier],
-        custom_sections: [ header.id ],
-        kept_custom_sections: [ header.id ]
+      patch update_subsections_form_path(form), params: {
+        subsections: %w[person_identifier],
+        custom_subsections: [ header.id ],
+        kept_custom_subsections: [ header.id ]
       }
 
       expect(FormField.where(id: header.id)).to exist
+    end
+  end
+
+  describe "GET /forms/:id/edit_sections" do
+    before { sign_in admin }
+
+    it "lists the form's subsections to group" do
+      form = FormBuilderService.new(name: "Groupable", subsections: %i[person_identifier consent]).call
+      get edit_sections_form_path(form)
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Person identifier")
+      expect(response.body).to include("Consent")
+    end
+  end
+
+  describe "PATCH /forms/:id/update_sections" do
+    before { sign_in admin }
+
+    it "groups subsections that share a section label" do
+      form = FormBuilderService.new(name: "Grouping", subsections: %i[person_identifier consent]).call
+
+      patch update_sections_form_path(form), params: {
+        section_labels: { person_identifier: "About you", consent: "About you" }
+      }
+
+      form.reload
+      expect(form.sections).to eq([
+        { "label" => "About you", "subsections" => %w[person_identifier consent] }
+      ])
+      expect(response).to redirect_to(edit_form_path(form))
+    end
+  end
+
+  describe "GET /forms/:id (preview) with sections" do
+    before { sign_in admin }
+
+    it "renders a section heading above the grouped subsections" do
+      form = FormBuilderService.new(name: "Sectioned", subsections: %i[person_identifier consent]).call
+      form.assign_section_groups!("person_identifier" => "About you", "consent" => "About you")
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("About you")
     end
   end
 
@@ -720,7 +764,7 @@ RSpec.describe "Forms", type: :request do
     before { sign_in admin }
 
     it "reorders fields" do
-      form = FormBuilderService.new(name: "Reorder", sections: %i[person_identifier]).call
+      form = FormBuilderService.new(name: "Reorder", subsections: %i[person_identifier]).call
       fields = form.form_fields.reorder(position: :asc)
       new_positions = fields.map.with_index { |f, i| { id: f.id, position: fields.size - i } }
 

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Scholarships", type: :request do
     it "shows the registrant's scholarship form answers with a link to the full submission" do
       form = create(:form, name: "Registration Form")
       create(:event_form, event: event, form: form, role: "registration")
-      field = create(:form_field, form: form, section: "scholarship",
+      field = create(:form_field, form: form, subsection: "scholarship",
                      name: "Why do you need a scholarship?", answer_type: :free_form_input_paragraph)
       submission = create(:form_submission, person: registration.registrant, form: form)
       create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Limited budget")

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe EventRegistrationServices::BulkPayment do
   let(:event) { create(:event, :published, :publicly_visible) }
   let(:form) do
-    f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+    f = FormBuilderService.new(name: "Bulk Payment", subsections: %i[bulk_payment], role: "bulk_payment").call
     event.event_forms.create!(form: f, role: "bulk_payment")
     f
   end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
   let(:form) do
     f = FormBuilderService.new(
       name: "Extended Event Registration",
-      sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
+      subsections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
     ).call
     event.event_forms.create!(form: f, role: "registration")
     f
@@ -205,7 +205,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         position: (form.form_fields.maximum(:position) || 0) + 1,
         required: false,
         field_identifier: described_class::CE_CREDIT_INTEREST_IDENTIFIER,
-        section: "continuing_education",
+        subsection: "continuing_education",
         visibility: :always_ask
       )
       %w[Yes No].each_with_index do |opt, idx|
@@ -288,7 +288,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         position: (form.form_fields.maximum(:position) || 0) + 1,
         required: false,
         field_identifier: described_class::ADDITIONAL_FORMS_IDENTIFIER,
-        section: "additional_forms",
+        subsection: "additional_forms",
         visibility: :always_ask
       )
       [ described_class::ADDITIONAL_FORMS_INVOICE, described_class::ADDITIONAL_FORMS_W9 ].each_with_index do |opt, idx|

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -3,28 +3,28 @@ require "rails_helper"
 RSpec.describe FormBuilderService do
   describe "#call" do
     it "creates a form with the given name" do
-      form = described_class.new(name: "Test Form", sections: %i[person_identifier]).call
+      form = described_class.new(name: "Test Form", subsections: %i[person_identifier]).call
       expect(form.name).to eq("Test Form")
     end
 
-    it "stores selected sections on the form" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
-      expect(form.sections).to eq(%w[person_identifier consent])
+    it "stores selected subsections on the form" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
+      expect(form.subsections).to eq(%w[person_identifier consent])
     end
 
     it "sets role flag" do
-      form = described_class.new(name: "Scholarship", sections: %i[scholarship], role: "scholarship").call
+      form = described_class.new(name: "Scholarship", subsections: %i[scholarship], role: "scholarship").call
       expect(form.role).to eq "scholarship"
     end
 
     it "creates fields with sequential positions" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
       positions = form.form_fields.order(:position).pluck(:position)
       expect(positions).to eq((1..positions.size).to_a)
     end
 
-    context "person_identifier section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[person_identifier]).call }
+    context "person_identifier subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[person_identifier]).call }
 
       it "creates first_name, last_name, primary_email, and confirm_email fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -38,7 +38,7 @@ RSpec.describe FormBuilderService do
     end
 
     context "default field widths" do
-      let(:form) { described_class.new(name: "Test", sections: %i[person_contact_info]).call }
+      let(:form) { described_class.new(name: "Test", subsections: %i[person_contact_info]).call }
 
       it "lays city/state/zip out as thirds" do
         widths = form.form_fields.where(field_identifier: %w[mailing_city mailing_state mailing_zip]).pluck(:width)
@@ -51,8 +51,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "person_contact_info section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[person_contact_info]).call }
+    context "person_contact_info subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[person_contact_info]).call }
 
       it "creates contact info fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -80,8 +80,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "scholarship section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[scholarship]).call }
+    context "scholarship subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[scholarship]).call }
 
       it "creates scholarship fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -96,8 +96,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "consent section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[consent]).call }
+    context "consent subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[consent]).call }
 
       it "creates communication_consent field" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -105,8 +105,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "payment section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[payment]).call }
+    context "payment subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[payment]).call }
 
       it "creates payment fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -114,8 +114,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "bulk_payment section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[bulk_payment], role: "bulk_payment").call }
+    context "bulk_payment subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[bulk_payment], role: "bulk_payment").call }
 
       it "creates payer fields including an optional phone field" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -139,8 +139,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "professional_info section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[professional_info]).call }
+    context "professional_info subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[professional_info]).call }
 
       it "asks for a single primary sector via a dropdown before the additional sectors checkboxes" do
         primary = form.form_fields.find_by(field_identifier: "primary_sector_single")
@@ -160,8 +160,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "person_background section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[person_background]).call }
+    context "person_background subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[person_background]).call }
 
       it "asks how respondents describe themselves as a single-select with options" do
         field = form.form_fields.find_by(field_identifier: "racial_ethnic_identity")
@@ -170,8 +170,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "marketing section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[marketing]).call }
+    context "marketing subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[marketing]).call }
 
       it "creates marketing fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -189,8 +189,8 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "post_event_feedback section" do
-      let(:form) { described_class.new(name: "Test", sections: %i[post_event_feedback]).call }
+    context "post_event_feedback subsection" do
+      let(:form) { described_class.new(name: "Test", subsections: %i[post_event_feedback]).call }
 
       it "creates post-event feedback fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
@@ -198,34 +198,34 @@ RSpec.describe FormBuilderService do
       end
     end
 
-    context "with multiple sections (short event registration)" do
+    context "with multiple subsections (short event registration)" do
       let(:form) do
         described_class.new(
           name: "Short Event Registration",
-          sections: %i[person_identifier consent marketing scholarship]
+          subsections: %i[person_identifier consent marketing scholarship]
         ).call
       end
 
-      it "creates fields from all selected sections" do
+      it "creates fields from all selected subsections" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include("first_name", "communication_consent", "referral_source", "scholarship_eligibility")
       end
 
-      it "does not include fields from unselected sections" do
+      it "does not include fields from unselected subsections" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).not_to include("nickname", "phone", "payment_method")
       end
     end
 
-    context "with multiple sections (extended event registration)" do
+    context "with multiple subsections (extended event registration)" do
       let(:form) do
         described_class.new(
           name: "Extended Event Registration",
-          sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
+          subsections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
         ).call
       end
 
-      it "creates fields from all sections" do
+      it "creates fields from all subsections" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include(
           "first_name", "nickname", "racial_ethnic_identity",
@@ -236,174 +236,174 @@ RSpec.describe FormBuilderService do
     end
   end
 
-  describe ".update_sections!" do
-    it "adds new sections and their fields" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+  describe ".update_subsections!" do
+    it "adds new subsections and their fields" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier]).call
       initial_count = form.form_fields.count
 
-      described_class.update_sections!(form, %i[person_identifier consent])
+      described_class.update_subsections!(form, %i[person_identifier consent])
 
       form.reload
-      expect(form.sections).to eq(%w[person_identifier consent])
+      expect(form.subsections).to eq(%w[person_identifier consent])
       expect(form.form_fields.count).to be > initial_count
       expect(form.form_fields.pluck(:field_identifier).compact).to include("communication_consent")
     end
 
-    it "removes unchecked sections and their fields" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
-      expect(form.form_fields.where(section: "consent").count).to be > 0
+    it "removes unchecked subsections and their fields" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
+      expect(form.form_fields.where(subsection: "consent").count).to be > 0
 
-      described_class.update_sections!(form, %i[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier])
 
       form.reload
-      expect(form.sections).to eq(%w[person_identifier])
-      expect(form.form_fields.where(section: "consent")).to be_empty
+      expect(form.subsections).to eq(%w[person_identifier])
+      expect(form.form_fields.where(subsection: "consent")).to be_empty
     end
 
-    it "removes section headers when a section is removed" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier scholarship]).call
+    it "removes subsection headers when a subsection is removed" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier scholarship]).call
       expect(form.form_fields.where(answer_type: :group_header, name: "Scholarship Application")).to exist
 
-      described_class.update_sections!(form, %i[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier])
 
       form.reload
       expect(form.form_fields.where(answer_type: :group_header, name: "Scholarship Application")).not_to exist
     end
 
-    it "preserves existing fields when sections are unchanged" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+    it "preserves existing fields when subsections are unchanged" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
       original_ids = form.form_fields.pluck(:id).sort
 
-      described_class.update_sections!(form, %i[person_identifier consent])
+      described_class.update_subsections!(form, %i[person_identifier consent])
 
       form.reload
       expect(form.form_fields.pluck(:id).sort).to eq(original_ids)
     end
 
     it "appends new fields after existing ones" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+      form = described_class.new(name: "Test", subsections: %i[person_identifier]).call
       max_before = form.form_fields.maximum(:position)
 
-      described_class.update_sections!(form, %i[person_identifier consent])
+      described_class.update_subsections!(form, %i[person_identifier consent])
 
-      new_fields = form.form_fields.where(section: "consent")
+      new_fields = form.form_fields.where(subsection: "consent")
       expect(new_fields.minimum(:position)).to be > max_before
     end
 
-    it "inserts a newly added section in page order rather than at the end" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier payment]).call
+    it "inserts a newly added subsection in page order rather than at the end" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier payment]).call
 
-      described_class.update_sections!(form, %i[person_identifier person_contact_info payment])
+      described_class.update_subsections!(form, %i[person_identifier person_contact_info payment])
 
       form.reload
-      ordered_sections = form.form_fields.reorder(:position).pluck(:section).uniq
-      expect(ordered_sections.index("person_contact_info")).to be < ordered_sections.index("payment")
+      ordered_subsections = form.form_fields.reorder(:position).pluck(:subsection).uniq
+      expect(ordered_subsections.index("person_contact_info")).to be < ordered_subsections.index("payment")
     end
 
-    it "leaves positions sequential after inserting a section in the middle" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier payment]).call
+    it "leaves positions sequential after inserting a subsection in the middle" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier payment]).call
 
-      described_class.update_sections!(form, %i[person_identifier person_contact_info payment])
+      described_class.update_subsections!(form, %i[person_identifier person_contact_info payment])
 
       form.reload
       positions = form.form_fields.reorder(:position).pluck(:position)
       expect(positions).to eq((1..positions.size).to_a)
     end
 
-    it "removes a custom section and its questions by header id" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+    it "removes a custom subsection and its questions by header id" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier]).call
       header = form.form_fields.create!(name: "Custom", answer_type: :group_header,
                                         status: :active, position: 100, required: false)
       question = form.form_fields.create!(name: "Q1", answer_type: :free_form_input_one_line,
                                           status: :active, position: 101, required: false)
-      next_section = form.form_fields.create!(name: "Background Information", answer_type: :group_header,
-                                              status: :active, position: 102, section: "background", required: false)
+      next_subsection = form.form_fields.create!(name: "Background Information", answer_type: :group_header,
+                                              status: :active, position: 102, subsection: "background", required: false)
 
-      described_class.update_sections!(form, %i[person_identifier person_background],
-                                       remove_custom_section_ids: [ header.id ])
+      described_class.update_subsections!(form, %i[person_identifier person_background],
+                                       remove_custom_subsection_ids: [ header.id ])
 
       expect(FormField.where(id: [ header.id, question.id ])).to be_empty
-      expect(FormField.where(id: next_section.id)).to exist
+      expect(FormField.where(id: next_subsection.id)).to exist
     end
 
-    it "leaves custom sections untouched when none are unchecked" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+    it "leaves custom subsections untouched when none are unchecked" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier]).call
       header = form.form_fields.create!(name: "Custom", answer_type: :group_header,
                                         status: :active, position: 100, required: false)
 
-      described_class.update_sections!(form, %i[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier])
 
       expect(FormField.where(id: header.id)).to exist
     end
 
-    it "removes a section's header even after it has been renamed" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier scholarship]).call
+    it "removes a subsection's header even after it has been renamed" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier scholarship]).call
       form.form_fields.find_by(answer_type: :group_header, name: "Scholarship Application")
           .update!(name: "Funding Help")
 
-      described_class.update_sections!(form, %i[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier])
 
       form.reload
-      expect(form.form_fields.where(answer_type: :group_header, section: "scholarship")).to be_empty
+      expect(form.form_fields.where(answer_type: :group_header, subsection: "scholarship")).to be_empty
     end
 
-    it "does not duplicate a header when a renamed section is removed then re-added" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+    it "does not duplicate a header when a renamed subsection is removed then re-added" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
       form.form_fields.find_by(answer_type: :group_header, name: "Consent").update!(name: "Agreement")
 
-      described_class.update_sections!(form, %i[person_identifier])
-      described_class.update_sections!(form, %i[person_identifier consent])
+      described_class.update_subsections!(form, %i[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier consent])
 
       form.reload
-      expect(form.form_fields.where(answer_type: :group_header, section: "consent").count).to eq(1)
+      expect(form.form_fields.where(answer_type: :group_header, subsection: "consent").count).to eq(1)
       expect(form.form_fields.where(field_identifier: "communication_consent").count).to eq(1)
     end
 
-    it "does not re-add fields when a section already present is submitted again" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
-      consent_count = form.form_fields.where(section: "consent").count
+    it "does not re-add fields when a subsection already present is submitted again" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
+      consent_count = form.form_fields.where(subsection: "consent").count
 
-      # Column drift: the stored sections list lost an entry that still has fields.
-      form.update_column(:sections, %w[person_identifier])
-      described_class.update_sections!(form, %i[person_identifier consent])
+      # Column drift: the stored subsections list lost an entry that still has fields.
+      form.update_column(:subsections, %w[person_identifier])
+      described_class.update_subsections!(form, %i[person_identifier consent])
 
       form.reload
-      expect(form.form_fields.where(section: "consent").count).to eq(consent_count)
+      expect(form.form_fields.where(subsection: "consent").count).to eq(consent_count)
     end
   end
 
-  describe ".present_section_keys" do
-    it "returns the built-in section keys that have fields on the form" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
-      expect(described_class.present_section_keys(form)).to contain_exactly(:person_identifier, :consent)
+  describe ".present_subsection_keys" do
+    it "returns the built-in subsection keys that have fields on the form" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
+      expect(described_class.present_subsection_keys(form)).to contain_exactly(:person_identifier, :consent)
     end
 
     it "reflects fields present even when a header has been renamed" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      form = described_class.new(name: "Test", subsections: %i[person_identifier consent]).call
       form.form_fields.find_by(answer_type: :group_header, name: "Consent").update!(name: "Agreement")
 
-      expect(described_class.present_section_keys(form)).to include(:consent)
+      expect(described_class.present_subsection_keys(form)).to include(:consent)
     end
 
-    it "ignores custom sections that are not built-in groups" do
-      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+    it "ignores custom subsections that are not built-in groups" do
+      form = described_class.new(name: "Test", subsections: %i[person_identifier]).call
       form.form_fields.create!(name: "Custom", answer_type: :group_header,
                                status: :active, position: 100, required: false)
 
-      expect(described_class.present_section_keys(form)).to contain_exactly(:person_identifier)
+      expect(described_class.present_subsection_keys(form)).to contain_exactly(:person_identifier)
     end
   end
 
-  describe ".editable_sections" do
-    let(:form) { described_class.new(name: "Test", sections: %i[person_identifier consent]).call }
+  describe ".editable_subsections" do
+    let(:form) { described_class.new(name: "Test", subsections: %i[person_identifier consent]).call }
 
-    def add_field(name, answer_type, position, section: nil)
+    def add_field(name, answer_type, position, subsection: nil)
       form.form_fields.create!(name: name, answer_type: answer_type, status: :active,
-                               position: position, required: false, section: section)
+                               position: position, required: false, subsection: subsection)
     end
 
-    it "marks built-in sections on the form as included and others as not" do
-      entries = described_class.editable_sections(form)
+    it "marks built-in subsections on the form as included and others as not" do
+      entries = described_class.editable_subsections(form)
       included = entries.select { |e| e[:kind] == :builtin && e[:included] }.map { |e| e[:key] }
       excluded = entries.select { |e| e[:kind] == :builtin && !e[:included] }.map { |e| e[:key] }
 
@@ -411,34 +411,34 @@ RSpec.describe FormBuilderService do
       expect(excluded).to include(:marketing, :payment)
     end
 
-    it "includes a custom section with the questions that follow it" do
-      add_field("My Custom Section", :group_header, 100)
+    it "includes a custom subsection with the questions that follow it" do
+      add_field("My Custom Subsection", :group_header, 100)
       first = add_field("Favorite color", :free_form_input_one_line, 101)
       second = add_field("Why?", :free_form_input_paragraph, 102)
 
-      custom = described_class.editable_sections(form).find { |e| e[:kind] == :custom }
+      custom = described_class.editable_subsections(form).find { |e| e[:kind] == :custom }
 
-      expect(custom[:label]).to eq("My Custom Section")
+      expect(custom[:label]).to eq("My Custom Subsection")
       expect(custom[:questions]).to eq([ first, second ])
     end
 
-    it "stops a custom section's questions at the next header" do
-      add_field("My Custom Section", :group_header, 100)
+    it "stops a custom subsection's questions at the next header" do
+      add_field("My Custom Subsection", :group_header, 100)
       question = add_field("Favorite color", :free_form_input_one_line, 101)
-      add_field("Background Information", :group_header, 102, section: "background")
+      add_field("Background Information", :group_header, 102, subsection: "background")
 
-      custom = described_class.editable_sections(form).find { |e| e[:kind] == :custom }
+      custom = described_class.editable_subsections(form).find { |e| e[:kind] == :custom }
 
       expect(custom[:questions]).to eq([ question ])
     end
 
-    it "orders a custom section by where it sits on the form" do
+    it "orders a custom subsection by where it sits on the form" do
       # person_identifier (pos 1-4), consent header + field, then the custom
-      # section is dropped between them by giving it an in-between position.
-      consent_position = form.form_fields.find_by(section: "consent", answer_type: :group_header).position
-      add_field("My Custom Section", :group_header, consent_position - 1)
+      # subsection is dropped between them by giving it an in-between position.
+      consent_position = form.form_fields.find_by(subsection: "consent", answer_type: :group_header).position
+      add_field("My Custom Subsection", :group_header, consent_position - 1)
 
-      kinds = described_class.editable_sections(form)
+      kinds = described_class.editable_subsections(form)
         .select { |e| (e[:kind] == :builtin && e[:included]) || e[:kind] == :custom }
         .map { |e| e[:kind] == :custom ? :custom : e[:key] }
 
@@ -446,43 +446,43 @@ RSpec.describe FormBuilderService do
     end
 
     it "has no custom entries when the form has none" do
-      expect(described_class.editable_sections(form).map { |e| e[:kind] }).to all(eq(:builtin))
+      expect(described_class.editable_subsections(form).map { |e| e[:kind] }).to all(eq(:builtin))
     end
 
-    it "surfaces a renamed built-in section header" do
-      form.form_fields.find_by(section: "consent", answer_type: :group_header).update!(name: "Agreement")
+    it "surfaces a renamed built-in subsection header" do
+      form.form_fields.find_by(subsection: "consent", answer_type: :group_header).update!(name: "Agreement")
 
-      consent = described_class.editable_sections(form).find { |e| e[:key] == :consent }
+      consent = described_class.editable_subsections(form).find { |e| e[:key] == :consent }
       expect(consent[:renamed_header]).to eq("Agreement")
     end
 
-    it "does not flag a built-in section header left at its default name" do
-      consent = described_class.editable_sections(form).find { |e| e[:key] == :consent }
+    it "does not flag a built-in subsection header left at its default name" do
+      consent = described_class.editable_subsections(form).find { |e| e[:key] == :consent }
       expect(consent[:renamed_header]).to be_nil
     end
 
     it "tolerates fields with a nil position without raising" do
-      form.form_fields.create!(name: "My Custom Section", answer_type: :group_header,
+      form.form_fields.create!(name: "My Custom Subsection", answer_type: :group_header,
                                status: :active, position: nil, required: false)
 
-      expect { described_class.editable_sections(form) }.not_to raise_error
+      expect { described_class.editable_subsections(form) }.not_to raise_error
     end
 
-    it "exposes each built-in section's question fields in order" do
-      identifier = described_class.editable_sections(form).find { |e| e[:key] == :person_identifier }
+    it "exposes each built-in subsection's question fields in order" do
+      identifier = described_class.editable_subsections(form).find { |e| e[:key] == :person_identifier }
       expect(identifier[:questions].map(&:name)).to eq([ "First Name", "Last Name", "Email", "Confirm Email" ])
     end
   end
 
-  # The new-form page lists a section's fields before the form exists, from the
-  # hard-coded SECTION_FIELD_NAMES. This guards it against drifting from what the
+  # The new-form page lists a subsection's fields before the form exists, from the
+  # hard-coded SUBSECTION_FIELD_NAMES. This guards it against drifting from what the
   # builder methods actually create.
-  describe "SECTION_FIELD_NAMES" do
-    FormBuilderService::SECTIONS.each_key do |key|
+  describe "SUBSECTION_FIELD_NAMES" do
+    FormBuilderService::SUBSECTIONS.each_key do |key|
       it "matches the fields #{key} actually builds" do
-        form = described_class.new(name: "Test", sections: [ key ]).call
+        form = described_class.new(name: "Test", subsections: [ key ]).call
         built = form.form_fields.where.not(answer_type: :group_header).reorder(:position).pluck(:name)
-        expect(built).to eq(FormBuilderService::SECTION_FIELD_NAMES[key])
+        expect(built).to eq(FormBuilderService::SUBSECTION_FIELD_NAMES[key])
       end
     end
   end

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Event registration show page", type: :system do
     it "links to form show with slug param" do
       FormBuilderService.new(
         name: "Extended Event Registration",
-        sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
+        subsections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
       ).call.tap { |form| EventForm.create!(event: event, form: form, role: "registration") }
       form = event.registration_form
       form.form_submissions.create!(person: user.person)

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe "Public form submissions", type: :system do
 
   let(:registration_form) { build_registration_form }
   let(:scholarship_form) do
-    FormBuilderService.new(name: "Scholarship Application", sections: %i[scholarship], role: "scholarship").call
+    FormBuilderService.new(name: "Scholarship Application", subsections: %i[scholarship], role: "scholarship").call
   end
   let(:bulk_payment_form) do
-    FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+    FormBuilderService.new(name: "Bulk Payment", subsections: %i[bulk_payment], role: "bulk_payment").call
   end
 
   # Published Sectors + AgeRange categories so the dynamic sector / age fields
@@ -291,7 +291,7 @@ RSpec.describe "Public form submissions", type: :system do
       name: "Do you plan to use Continuing Education (CE) hours for this course?",
       answer_type: :single_select_radio, status: :active, position: position += 1, required: false,
       field_identifier: EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER,
-      section: "continuing_education", visibility: :always_ask
+      subsection: "continuing_education", visibility: :always_ask
     )
     %w[Yes No].each do |name|
       ce.form_field_answer_options.create!(answer_option: AnswerOption.find_or_create_by!(name: name))
@@ -301,7 +301,7 @@ RSpec.describe "Public form submissions", type: :system do
       name: "Do you need either of the following?",
       answer_type: :multi_select_checkbox, status: :active, position: position += 1, required: false,
       field_identifier: EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_IDENTIFIER,
-      section: "additional_forms", visibility: :always_ask
+      subsection: "additional_forms", visibility: :always_ask
     )
     [ EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_W9,
       EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_INVOICE,

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Public registration new page", type: :system do
     driven_by(:rack_test)
     form = FormBuilderService.new(
       name: "Extended Event Registration",
-      sections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
+      subsections: %i[person_identifier person_contact_info person_background professional_info marketing scholarship payment consent]
     ).call
     EventForm.create!(event: event, form: form, role: "registration")
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins needed to present several related subsections under **one heading on a single form screen** — a grouping level above the existing tier.
- The old "section" concept was one level too low for this, and reusing the word would have collided with the `group_header` field already labelled **"Section header"** in the UI.
- This introduces a true top-level **Section** tier without disturbing existing forms.

### How did you approach the change?

- **Renamed the existing tier to "subsection"** (behavior-preserving): `form_fields.section → subsection`, `forms.sections → subsections`, plus `FormBuilderService` constants/kwargs, the live-registration field-hiding logic, the scholarships view, the `group_header` label ("Subsection header"), routes/views/Stimulus (`form_subsection_toggle`), seeds, and specs.
- **Reintroduced `forms.sections`** with its new meaning: an ordered grouping of subsections under named headings, stored as `[{ "label", "subsections": [...] }]`.
- Added `Form#assign_section_groups!` / `#section_label_for_subsection` / `#section_groups`, a new **Edit sections** page to group subsections (same name = same section), and rendering of bold section headers in the form preview.
- Existing forms have an empty `sections` and render flat until an admin defines sections.

### UI Testing Checklist

- [ ] **Edit subsections** page lists/saves which subsections a form includes (unchanged behavior, relabelled).
- [ ] **Edit sections** page groups subsections by typing a shared section name; blanks stay ungrouped.
- [ ] Form preview shows a bold section heading above each grouped run of subsections.
- [ ] Live event registration still hides answered/logged-out subsection headers correctly.

### Anything else to add?

- Verified: full affected RSpec suite green, RuboCop clean, Brakeman 0 un-ignored warnings (ignore fingerprint refreshed), vite dev build OK.
- Left the pre-existing `SUBSECTION_GROUPS` indirection (`person_background → background`) as-is; reconciling that is a separate cleanup.
- Three reversible migrations (two renames + one additive column).