### PR TITLE
Align event card register button left and dashboard right

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -46,13 +46,7 @@
     </div>
 
     <div class="flex items-center gap-3">
-    <% if allowed_to?(:dashboard?, event) %>
-      <%= link_to "Dashboard",
-                dashboard_event_path(event),
-                data: { turbo_frame: "_top" },
-                class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <% end %>
-
+    <div class="flex items-center gap-3">
     <% if registered %>
       <% if ended %>
         <span class="text-sm text-gray-500 italic">Event ended</span>
@@ -94,6 +88,14 @@
       <% end %>
     <% else %>
       <span class="text-sm text-gray-500 italic">Registration closed</span>
+    <% end %>
+    </div>
+
+    <% if allowed_to?(:dashboard?, event) %>
+      <%= link_to "Dashboard",
+                dashboard_event_path(event),
+                data: { turbo_frame: "_top" },
+                class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1 ml-auto" %>
     <% end %>
     </div>
   </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the events index, each card's action row now places the register/registration control on the far left and the Dashboard admin link on the far right, giving admins a consistent, scannable position for each action.

### How did you approach the change?
- Wrapped the register/status controls in their own flex group so they always sit at the left.
- Moved the Dashboard admin link to the end of the row and pinned it right with `ml-auto`, so it stays right-aligned even when no register button is shown for an event's state.

### UI Testing Checklist
- [ ] Event card shows register button on the left and Dashboard link on the right when both are present.
- [ ] Dashboard link stays right-aligned for events with no register button (ended, not published, registration closed).

### Anything else to add?
- Layout-only change to `app/views/events/_card.html.erb`; no behavior or routing changes.
