### PR TITLE
Add curated staff roster to events via EventStaff join model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ This codebase (Rails 8.1)
 
 | Directory | Purpose | Count |
 |---|---|---|
-| `app/models/` | ActiveRecord models | ~74 files |
+| `app/models/` | ActiveRecord models | ~75 files |
 | `app/services/` | Service objects for complex logic | ~23 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 13 concerns |
@@ -95,6 +95,7 @@ This codebase (Rails 8.1)
 | `User` | Devise authentication, SearchCop search, super_user admin flag |
 | `Workshop` | Core content: rich text fields, categories, sectors, bookmarks, variations |
 | `Event` | Events with registrations, featured/published states |
+| `EventStaff` | Join model connecting `Person` to `Event` as staff (title, `expected_to_attend`); drives the "Meet the staff" roster and "My events" |
 | `Story` | Editorial content with facilitators, primary/gallery assets |
 | `Resource` | Handouts, toolkits, templates with downloadable assets |
 | `Person` | Organization affiliates with contacts, addresses, sectors |

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,7 @@ class ApplicationController < ActionController::Base
                                                   .active
                                                   .includes(:organization)
                                                   .load
+    @current_user_staffs_events = current_user.person.event_staffs.exists?
   end
 
   def set_current_user

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,11 +2,12 @@ class EventsController < ApplicationController
   include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show, :staff ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants staff recipients bulk_payments preview_reminder send_reminder copy_registration_form ]
+  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants staff edit_staff update_staff recipients bulk_payments preview_reminder send_reminder copy_registration_form ]
 
   def index
     authorize!
     base_scope = authorized_scope(Event.all)
+    base_scope = base_scope.staffed_by(current_user.person) if params[:staffed_by_me].present? && current_user&.person
     @events  = base_scope.search_by_params(params).order(start_date: :desc)
   end
 
@@ -92,12 +93,24 @@ class EventsController < ApplicationController
   def staff
     authorize! @event, to: :staff?
     @event = @event.decorate
-    @staff = @event.event_registrations
-      .active
-      .includes(registrant: [ :sectors, { avatar_attachment: :blob }, { affiliations: :organization } ])
-      .joins(:registrant)
-      .order(Arel.sql("people.first_name, people.last_name"))
-      .map(&:registrant)
+    @event_staffs = @event.event_staffs
+      .includes(person: [ :sectors, { avatar_attachment: :blob }, { affiliations: :organization } ])
+      .ordered_by_name
+  end
+
+  def edit_staff
+    authorize! @event, to: :edit_staff?
+    @event.event_staffs.build if @event.event_staffs.empty?
+  end
+
+  def update_staff
+    authorize! @event, to: :update_staff?
+
+    if @event.update(event_staff_params)
+      redirect_to staff_event_path(@event), notice: "Event staff updated."
+    else
+      render :edit_staff, status: :unprocessable_content
+    end
   end
 
   def recipients
@@ -333,5 +346,11 @@ class EventsController < ApplicationController
 
   def event_params
     authorized(params.require(:event))
+  end
+
+  def event_staff_params
+    params.require(:event).permit(
+      event_staffs_attributes: [ :id, :person_id, :title, :expected_to_attend, :_destroy ]
+    )
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ApplicationRecord
   belongs_to :location, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :event_registrations, dependent: :destroy
+  has_many :event_staffs, dependent: :destroy
   has_many :event_forms, dependent: :destroy
 
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
@@ -22,8 +23,12 @@ class Event < ApplicationRecord
   # has_many through
   has_many :forms, through: :event_forms
   has_many :registrants, through: :event_registrations, class_name: "Person"
+  has_many :staff_members, through: :event_staffs, source: :person
   has_many :categories, through: :categorizable_items
   has_many :sectors, through: :sectorable_items
+
+  accepts_nested_attributes_for :event_staffs, allow_destroy: true,
+    reject_if: proc { |attrs| attrs["person_id"].blank? }
 
   # Callbacks
   after_commit :build_public_registration_form, if: :public_registration_just_enabled?
@@ -50,6 +55,7 @@ class Event < ApplicationRecord
   scope :publicly_featured, -> { where(published: true, publicly_visible: true, publicly_featured: true) } # overrides Featureable
   scope :registerable, -> { where("registration_close_date IS NULL OR registration_close_date >= ?", Time.current) }
   scope :using_form, ->(form_id) { joins(:event_forms).where(event_forms: { form_id: form_id }).distinct }
+  scope :staffed_by, ->(person) { joins(:event_staffs).where(event_staffs: { person_id: person }).distinct }
 
   def self.search_by_params(params)
     stories = is_a?(ActiveRecord::Relation) ? self : all

--- a/app/models/event_staff.rb
+++ b/app/models/event_staff.rb
@@ -1,0 +1,10 @@
+class EventStaff < ApplicationRecord
+  belongs_to :event
+  belongs_to :person
+
+  validates :person_id, uniqueness: { scope: :event_id }
+
+  scope :ordered_by_name, -> {
+    joins(:person).order(Arel.sql("people.first_name, people.last_name"))
+  }
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -22,9 +22,11 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
+  has_many :event_staffs, dependent: :destroy
   has_many :scholarships, foreign_key: :recipient_id, dependent: :destroy
   has_many :grants, as: :donor, dependent: :destroy
   has_many :events, through: :event_registrations
+  has_many :staffed_events, through: :event_staffs, source: :event
   has_many :categories, through: :categorizable_items
   has_many :sectors, through: :sectorable_items
   has_many :form_submissions, dependent: :destroy

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -61,6 +61,14 @@ class EventPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def edit_staff?
+    manage?
+  end
+
+  def update_staff?
+    manage?
+  end
+
   def recipients?
     manage?
   end

--- a/app/views/events/_event_staff_fields.html.erb
+++ b/app/views/events/_event_staff_fields.html.erb
@@ -1,0 +1,45 @@
+<div class="nested-fields flex flex-wrap items-end gap-x-4 gap-y-2 mb-3 rounded-lg border border-gray-200 bg-white p-3"
+     <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>>
+  <div style="width: 320px; min-width: 320px; flex-shrink: 0;">
+    <% if f.object.persisted? && f.object.person.present? %>
+      <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
+      <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
+      <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
+      <%= f.hidden_field :person_id %>
+    <% else %>
+      <%= f.input :person_id,
+        include_blank: true,
+        required: true,
+        input_html: {
+          data: {
+            controller: "remote-select",
+            remote_select_model_value: "person"
+          }
+        },
+        label: "Person" %>
+    <% end %>
+  </div>
+
+  <div class="w-full sm:w-auto" style="min-width: 200px;">
+    <%= f.input :title,
+                label: "Title",
+                input_html: {
+                  value: f.object.title.presence || "Staff",
+                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
+                } %>
+  </div>
+
+  <div class="w-full sm:w-auto pb-2">
+    <label class="block text-sm font-medium text-gray-700 mb-1">Expected to attend</label>
+    <label class="relative inline-flex items-center cursor-pointer">
+      <%= f.check_box :expected_to_attend, class: "sr-only peer" %>
+      <div class="w-11 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+    </label>
+  </div>
+
+  <div class="w-full sm:w-auto sm:ml-auto text-right pb-2">
+    <%= link_to_remove_association "Remove",
+                                   f,
+                                   class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap rounded px-2 py-1" %>
+  </div>
+</div>

--- a/app/views/events/edit_staff.html.erb
+++ b/app/views/events/edit_staff.html.erb
@@ -1,0 +1,40 @@
+<% content_for(:page_bg_class, "public") %>
+
+<div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6 sm:p-8">
+  <div class="flex flex-wrap items-center gap-2 mb-6">
+    <%= link_to "← Back to staff", staff_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  </div>
+
+  <div class="mb-8">
+    <p class="text-sm font-semibold uppercase tracking-wide <%= DomainTheme.text_class_for(:events) %>">Manage staff</p>
+    <h1 class="text-2xl font-bold text-gray-900 mt-1"><%= @event.title %></h1>
+    <p class="text-gray-500 mt-1 text-sm">Connect people to this event and set their role. Use the toggle to mark who is expected to attend.</p>
+  </div>
+
+  <%= simple_form_for @event, url: staff_event_path(@event), method: :patch, html: { id: "event-staff-form" } do |f| %>
+    <% if @event.errors.any? %>
+      <%= render "shared/errors", resource: @event %>
+    <% end %>
+
+    <div class="bg-gray-50 border border-gray-200 rounded-md p-4 sm:p-6 mb-6">
+      <div id="event-staffs">
+        <%= f.fields_for :event_staffs do |staff_form| %>
+          <%= render "event_staff_fields", f: staff_form %>
+        <% end %>
+      </div>
+
+      <div class="mt-2">
+        <%= link_to_add_association "➕ Add staff",
+                                    f,
+                                    :event_staffs,
+                                    data: { association_insertion_node: "#event-staffs", association_insertion_method: "append" },
+                                    class: "btn btn-secondary-outline" %>
+      </div>
+    </div>
+
+    <div class="flex justify-center gap-3">
+      <%= link_to "Cancel", staff_event_path(@event), class: "btn btn-secondary-outline" %>
+      <%= f.button :submit, "Save staff", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/edit_staff.html.erb
+++ b/app/views/events/edit_staff.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_bg_class, "public") %>
+<% content_for(:page_bg_class, "admin-only bg-white") %>
 
 <div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6 sm:p-8">
   <div class="flex flex-wrap items-center gap-2 mb-6">

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -4,6 +4,9 @@
   <div class="flex flex-wrap items-center gap-2 mb-6 print:hidden">
     <%= link_to "← Back to event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <div class="ml-auto flex flex-wrap gap-2">
+      <% if allowed_to?(:edit_staff?, @event) %>
+        <%= link_to "Edit staff", edit_staff_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <% end %>
       <% if allowed_to?(:manage?, @event) %>
         <%= link_to "Registrants", registrants_event_path(@event), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
       <% end %>
@@ -16,16 +19,15 @@
   <div class="text-center mb-10">
     <p class="text-sm font-semibold uppercase tracking-wide <%= DomainTheme.text_class_for(:events) %>">Meet the staff</p>
     <h1 class="text-3xl font-bold text-gray-900 mt-1"><%= @event.title %></h1>
-    <p class="text-gray-500 mt-2"><%= pluralize(@staff.size, "staff member") %></p>
+    <p class="text-gray-500 mt-2"><%= pluralize(@event_staffs.size, "staff member") %></p>
   </div>
 
-  <% if @staff.any? %>
+  <% if @event_staffs.any? %>
     <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-      <% @staff.each do |person| %>
-        <% person = person.decorate %>
+      <% @event_staffs.each do |event_staff| %>
+        <% person = event_staff.person.decorate %>
         <% active_affiliation = person.affiliations.find { |a| !a.inactive? } %>
         <% org = active_affiliation&.organization %>
-        <% role = active_affiliation&.title.presence %>
         <% has_bio = person.profile_show_bio? && person.bio.present? %>
         <% sectors = person.profile_show_sectors? ? person.sectors.sort_by(&:name) : [] %>
         <%# Facilitator tenure → one experience badge, computed from already-loaded
@@ -62,8 +64,8 @@
                 <p class="text-xs text-gray-400"><%= person.pronouns_display %></p>
               <% end %>
 
-              <% if role.present? %>
-                <p class="text-xs font-medium text-gray-700 mt-1"><%= role %></p>
+              <% if event_staff.title.present? %>
+                <p class="text-sm font-bold text-gray-900 mt-1"><%= event_staff.title %></p>
               <% end %>
 
               <% if org.present? %>
@@ -89,6 +91,12 @@
                     <span class="px-2 py-0.5 rounded-md text-xs font-medium text-gray-400">+<%= sectors.size - 3 %></span>
                   <% end %>
                 </div>
+              <% end %>
+
+              <% if event_staff.expected_to_attend? %>
+                <span class="mt-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
+                  <i class="fa-solid fa-circle-check"></i> Attending
+                </span>
               <% end %>
 
               <span class="mt-auto pt-2 text-xs text-gray-400 print:hidden">

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <% if @event_staffs.any? %>
-    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+    <div class="flex flex-wrap justify-center gap-6">
       <% @event_staffs.each do |event_staff| %>
         <% person = event_staff.person.decorate %>
         <% active_affiliation = person.affiliations.find { |a| !a.inactive? } %>
@@ -39,33 +39,45 @@
              years >= 10 ? [ :legacy_facilitator, "Legacy facilitator" ] : (years >= 3 ? [ :seasoned_facilitator, "Seasoned facilitator" ] : [ :new_facilitator, "New facilitator" ])
            end %>
 
-        <div class="group h-96 [perspective:1000px] cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-xl"
+        <div class="group w-48 sm:w-56 h-96 [perspective:1000px] cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-xl"
              data-controller="flip-card"
              data-action="click->flip-card#toggle keydown.enter->flip-card#toggle keydown.space:prevent->flip-card#toggle"
              tabindex="0" role="button" aria-pressed="false"
-             aria-label="<%= person.name %> — flip card to read bio">
+             aria-label="<%= person.name %> — flip card for details">
           <div class="relative w-full h-full transition-transform duration-500 [transform-style:preserve-3d]"
                data-flip-card-target="inner">
 
             <%# Front %>
-            <div class="absolute inset-0 [backface-visibility:hidden] flex flex-col items-center text-center bg-white border border-gray-200 rounded-xl shadow-sm p-4 overflow-hidden">
+            <div class="absolute inset-0 [backface-visibility:hidden] flex flex-col items-center text-center bg-white border border-gray-200 rounded-xl shadow-sm transition-shadow group-hover:shadow-md px-4 pt-12 pb-8 overflow-hidden">
+              <% if event_staff.expected_to_attend? %>
+                <span class="absolute top-2 right-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700" title="Expected to attend">
+                  <i class="fa-solid fa-circle-check"></i> Attending
+                </span>
+              <% end %>
+
               <% if person.avatar&.attached? %>
                 <%= image_tag person.avatar.variant(:thumbnail),
-                              class: "w-20 h-20 rounded-full object-cover border-2 border-gray-200 shadow mb-2 mt-1" %>
+                              class: "w-20 h-20 rounded-full object-cover border-2 border-gray-200 shadow mb-2" %>
               <% else %>
-                <span class="w-20 h-20 rounded-full flex items-center justify-center bg-sky-200 text-sky-700 font-bold text-2xl border-2 border-sky-300 shadow mb-2 mt-1">
+                <span class="w-20 h-20 rounded-full flex items-center justify-center <%= DomainTheme.bg_class_for(:events, intensity: 200) %> <%= DomainTheme.text_class_for(:events, intensity: 700) %> font-bold text-2xl border-2 <%= DomainTheme.border_class_for(:events) %> shadow mb-2">
                   <%= person.name.to_s.first.to_s.upcase %>
                 </span>
               <% end %>
 
-              <p class="font-semibold text-gray-900 leading-tight"><%= person.name %></p>
+              <% privacy_limited = person.display_name_preference.in?(%w[ first_name_last_initial first_name_only last_name_only ]) %>
+              <% if !privacy_limited && person.last_name.present? %>
+                <p class="text-lg font-bold text-gray-900 leading-tight"><%= person.first_name %></p>
+                <p class="text-sm font-medium text-gray-600 leading-tight"><%= person.last_name %></p>
+              <% else %>
+                <p class="text-lg font-bold text-gray-900 leading-tight"><%= person.name %></p>
+              <% end %>
 
               <% if person.pronouns_display.present? %>
-                <p class="text-xs text-gray-400"><%= person.pronouns_display %></p>
+                <p class="text-xs text-gray-400 mt-0.5"><%= person.pronouns_display %></p>
               <% end %>
 
               <% if event_staff.title.present? %>
-                <p class="text-sm font-bold text-gray-900 mt-1"><%= event_staff.title %></p>
+                <p class="text-xs font-semibold uppercase tracking-wide text-gray-500 mt-1.5"><%= event_staff.title %></p>
               <% end %>
 
               <% if org.present? %>
@@ -93,14 +105,8 @@
                 </div>
               <% end %>
 
-              <% if event_staff.expected_to_attend? %>
-                <span class="mt-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
-                  <i class="fa-solid fa-circle-check"></i> Attending
-                </span>
-              <% end %>
-
-              <span class="mt-auto pt-2 text-xs text-gray-400 print:hidden">
-                <i class="fa-solid fa-rotate"></i> Tap for bio
+              <span class="absolute bottom-3 inset-x-0 text-xs text-gray-400 print:hidden">
+                <i class="fa-solid fa-rotate"></i> Flip for details
               </span>
             </div>
 

--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -65,6 +65,14 @@
       <% end %>
     <% end %>
 
+    <% if @current_user_staffs_events %>
+      <%= link_to events_path(staffed_by_me: true),
+                  class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>
+        <i class="fas fa-calendar-check"></i>
+        <span>My events</span>
+      <% end %>
+    <% end %>
+
     <% if allowed_to?(:personal?, Bookmark) %>
       <%= link_to personal_bookmarks_path,
                   class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,8 @@ Rails.application.routes.draw do
       get :background
       get :registrants
       get :staff
+      get "staff/edit", action: :edit_staff, as: :edit_staff
+      patch "staff", action: :update_staff
       get :recipients
       get :bulk_payments
       get :preview_reminder

--- a/db/migrate/20260609180000_create_event_staffs.rb
+++ b/db/migrate/20260609180000_create_event_staffs.rb
@@ -1,0 +1,17 @@
+class CreateEventStaffs < ActiveRecord::Migration[8.1]
+  def up
+    create_table :event_staffs do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :person, null: false, foreign_key: true
+      t.string :title
+      t.boolean :expected_to_attend, null: false, default: false
+      t.timestamps
+    end
+
+    add_index :event_staffs, [ :event_id, :person_id ], unique: true
+  end
+
+  def down
+    drop_table :event_staffs, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_180000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -457,6 +457,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_170000) do
     t.index ["registrant_id", "event_id"], name: "index_event_registrations_on_registrant_id_and_event_id", unique: true
     t.index ["registrant_id"], name: "index_event_registrations_on_registrant_id"
     t.index ["slug"], name: "index_event_registrations_on_slug", unique: true
+  end
+
+  create_table "event_staffs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "event_id", null: false
+    t.boolean "expected_to_attend", default: false, null: false
+    t.bigint "person_id", null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "person_id"], name: "index_event_staffs_on_event_id_and_person_id", unique: true
+    t.index ["event_id"], name: "index_event_staffs_on_event_id"
+    t.index ["person_id"], name: "index_event_staffs_on_person_id"
   end
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1542,6 +1554,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_170000) do
   add_foreign_key "event_registration_organizations", "organizations"
   add_foreign_key "event_registrations", "events"
   add_foreign_key "event_registrations", "people", column: "registrant_id"
+  add_foreign_key "event_staffs", "events"
+  add_foreign_key "event_staffs", "people"
   add_foreign_key "events", "locations"
   add_foreign_key "events", "users", column: "created_by_id"
   add_foreign_key "form_answers", "form_fields"

--- a/spec/factories/event_staffs.rb
+++ b/spec/factories/event_staffs.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :event_staff do
+    association :event
+    association :person
+    title { "Lead facilitator" }
+  end
+end

--- a/spec/models/event_staff_spec.rb
+++ b/spec/models/event_staff_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe EventStaff, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:event) }
+    it { is_expected.to belong_to(:person) }
+  end
+
+  describe "validations" do
+    subject { build(:event_staff) }
+
+    it "is valid with an event, person, and title" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a person to be unique per event" do
+      existing = create(:event_staff)
+      duplicate = build(:event_staff, event: existing.event, person: existing.person)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:person_id]).to be_present
+    end
+
+    it "allows the same person on different events" do
+      person = create(:person)
+      create(:event_staff, person: person)
+      other = build(:event_staff, person: person)
+      expect(other).to be_valid
+    end
+  end
+
+  describe "defaults" do
+    it "defaults expected_to_attend to false" do
+      event_staff = EventStaff.create!(event: create(:event), person: create(:person), title: "Staff")
+      expect(event_staff.reload.expected_to_attend).to be(false)
+    end
+  end
+
+  describe ".ordered_by_name" do
+    it "orders staff by the person's first then last name" do
+      event = create(:event)
+      zoe = create(:event_staff, event: event, person: create(:person, first_name: "Zoe", last_name: "Adams"))
+      abe = create(:event_staff, event: event, person: create(:person, first_name: "Abe", last_name: "Young"))
+      expect(event.event_staffs.ordered_by_name.to_a).to eq([ abe, zoe ])
+    end
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -762,25 +762,34 @@ RSpec.describe "Events", type: :request do
     let(:public_event) { create(:event, :published, :publicly_visible) }
     let(:staff_member) { create(:person, first_name: "Ada", last_name: "Lovelace") }
 
-    it "renders the staff for a publicly visible event without authentication" do
-      create(:event_registration, event: public_event, registrant: staff_member, status: "registered")
+    it "renders the curated staff roster for a publicly visible event without authentication" do
+      create(:event_staff, event: public_event, person: staff_member, title: "Lead facilitator")
 
       get staff_event_path(public_event)
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Meet the staff")
       expect(response.body).to include("Ada Lovelace")
+      expect(response.body).to include("Lead facilitator")
     end
 
-    it "excludes registrants with an inactive status" do
-      cancelled = create(:person, first_name: "Grace", last_name: "Hopper")
-      create(:event_registration, event: public_event, registrant: staff_member, status: "registered")
-      create(:event_registration, event: public_event, registrant: cancelled, status: "cancelled")
+    it "shows only people on the staff roster, not event registrants" do
+      registrant_only = create(:person, first_name: "Grace", last_name: "Hopper")
+      create(:event_staff, event: public_event, person: staff_member)
+      create(:event_registration, event: public_event, registrant: registrant_only, status: "registered")
 
       get staff_event_path(public_event)
 
       expect(response.body).to include("Ada Lovelace")
       expect(response.body).not_to include("Grace Hopper")
+    end
+
+    it "flags a staff member who is expected to attend" do
+      create(:event_staff, event: public_event, person: staff_member, expected_to_attend: true)
+
+      get staff_event_path(public_event)
+
+      expect(response.body).to include("Attending")
     end
 
     context "when the event has ended" do
@@ -948,6 +957,98 @@ RSpec.describe "Events", type: :request do
         expect(owned_event.ga4_snippet).to be_nil
         expect(owned_event.gtm_head_snippet).to be_nil
         expect(owned_event.gtm_body_snippet).to be_nil
+      end
+    end
+  end
+
+  describe "event staff" do
+    let(:published_event) { create(:event, :published) }
+    let(:staffer) { create(:person, first_name: "Dana", last_name: "Reed") }
+
+    describe "GET /staff" do
+      it "shows connected staff with their title in bold" do
+        create(:event_staff, event: published_event, person: staffer, title: "Lead facilitator")
+        sign_in admin
+        get staff_event_path(published_event)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Dana Reed")
+        expect(response.body).to include("Lead facilitator")
+      end
+
+      it "links admins to the edit staff page" do
+        sign_in admin
+        get staff_event_path(published_event)
+        expect(response.body).to include(edit_staff_event_path(published_event))
+      end
+    end
+
+    describe "GET /staff/edit" do
+      it "renders for an admin" do
+        sign_in admin
+        get edit_staff_event_path(published_event)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "redirects a non-admin" do
+        sign_in user
+        get edit_staff_event_path(published_event)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "PATCH /staff" do
+      it "adds a staff member to the event" do
+        sign_in admin
+        expect {
+          patch staff_event_path(published_event), params: {
+            event: {
+              event_staffs_attributes: {
+                "0" => { person_id: staffer.id, title: "Staff", expected_to_attend: "1" }
+              }
+            }
+          }
+        }.to change(EventStaff, :count).by(1)
+        staff = published_event.event_staffs.last
+        expect(staff.person).to eq(staffer)
+        expect(staff.title).to eq("Staff")
+        expect(staff.expected_to_attend).to be(true)
+        expect(response).to redirect_to(staff_event_path(published_event))
+      end
+
+      it "removes a staff member when _destroy is set" do
+        event_staff = create(:event_staff, event: published_event, person: staffer)
+        sign_in admin
+        expect {
+          patch staff_event_path(published_event), params: {
+            event: {
+              event_staffs_attributes: {
+                "0" => { id: event_staff.id, _destroy: "1" }
+              }
+            }
+          }
+        }.to change(EventStaff, :count).by(-1)
+      end
+
+      it "forbids a non-admin" do
+        sign_in user
+        patch staff_event_path(published_event), params: {
+          event: { event_staffs_attributes: { "0" => { person_id: staffer.id, title: "Staff" } } }
+        }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "GET /index?staffed_by_me" do
+      it "returns only events the current user's person staffs" do
+        admin_with_person = create(:user, :admin, :with_person)
+        staffed = create(:event, :published, title: "Staffed event")
+        create(:event, :published, title: "Other event")
+        create(:event_staff, event: staffed, person: admin_with_person.person)
+
+        sign_in admin_with_person
+        get events_path(staffed_by_me: true)
+        expect(response.body).to include("Staffed event")
+        expect(response.body).not_to include("Other event")
       end
     end
   end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -769,7 +769,8 @@ RSpec.describe "Events", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Meet the staff")
-      expect(response.body).to include("Ada Lovelace")
+      expect(response.body).to include("Ada")
+      expect(response.body).to include("Lovelace")
       expect(response.body).to include("Lead facilitator")
     end
 
@@ -780,8 +781,8 @@ RSpec.describe "Events", type: :request do
 
       get staff_event_path(public_event)
 
-      expect(response.body).to include("Ada Lovelace")
-      expect(response.body).not_to include("Grace Hopper")
+      expect(response.body).to include("Ada")
+      expect(response.body).not_to include("Grace")
     end
 
     it "flags a staff member who is expected to attend" do

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/category_types/index.html.erb"          => "admin-only bg-blue-100",
     "app/views/events/dashboard.html.erb"              => "admin-only bg-blue-100",
     "app/views/events/background.html.erb"             => "admin-only bg-blue-100",
+    "app/views/events/edit_staff.html.erb"             => "admin-only bg-white",
     "app/views/events/recipients.html.erb"             => "admin-only bg-white",
     "app/views/events/registrants.html.erb"         => "admin-only bg-blue-100",
     "app/views/events/preview_reminder.html.erb"       => "admin-only bg-blue-100",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Events had no real notion of "staff" — the public **Meet the staff** page just re-rendered active *registrants*, conflating people attending with people running the event, and admins couldn't curate who appeared.
- This adds a first-class **`EventStaff`** join (person + title + `expected_to_attend`) so an event's staff are managed independently of registrations, and gives the public roster a polished, purpose-built card layout.
- Also adds user menu item for "My events"

### How did you approach the change?

- New `EventStaff` model/migration/join, with `Event`/`Person` associations, a `staffed_by` scope, and `accepts_nested_attributes_for`.
- New **Edit staff** screen (cocoon nested fields: person picker, title, attending toggle) gated by `edit_staff?`/`update_staff?` policies; the **Meet the staff** flip-card roster renders the curated `EventStaff` list (staff title + "Attending" badge) instead of registrants.
- Refined the roster cards: top-aligned so avatars/names line up, centered short rosters, themed avatars with a hover lift, a corner "Attending" badge, and a large-first-name / muted-last-name treatment (privacy-aware — falls back to the display-name preference) with the title as a grey label.
- Added a **My events** navbar shortcut for anyone who staffs an event (`events?staffed_by_me=true`), plus model/request spec coverage.

### UI Testing Checklist

- [ ] As an admin, open an event → **Staff** → **Edit staff**, add a person, set a title, toggle "Expected to attend", save.
- [ ] Confirm the person appears on the public **Meet the staff** roster with the right title/attending badge, that the count reflects the roster, and the card flips to show bio + View profile.
- [ ] Confirm a person using a first-name-only display preference does not have their last name exposed on the card.
- [ ] As a staff member, confirm the **My events** nav link appears and filters to staffed events.

### Anything else to add?

Rebased onto latest `main`; the staff page coexists with main's renamed `registrants` action. `staff?` keeps the page publicly viewable for published, publicly-visible, non-ended events.