### PR TITLE
Surface bulk payment form and improve form-editor navigation

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,5 +1,6 @@
 class FormsController < ApplicationController
   before_action :set_form, only: %i[show edit update destroy reorder_field reorder_fields edit_sections update_sections]
+  before_action :set_dashboard_event, only: %i[edit edit_sections update update_sections]
 
   def index
     authorize!
@@ -46,7 +47,7 @@ class FormsController < ApplicationController
     authorize! @form
 
     if @form.update(form_params)
-      redirect_to edit_form_path(@form), notice: "Form updated."
+      redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "Form updated."
     else
       @form_fields = @form.form_fields.reorder(position: :asc)
       render :edit, status: :unprocessable_content
@@ -84,12 +85,12 @@ class FormsController < ApplicationController
     removed_custom_ids = removed_custom_section_ids
     current_sections = (@form.sections || []).map(&:to_sym)
     if sections.to_set == current_sections.to_set && removed_custom_ids.empty?
-      redirect_to edit_form_path(@form), notice: "No section changes."
+      redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "No section changes."
       return
     end
 
     FormBuilderService.update_sections!(@form, sections, remove_custom_section_ids: removed_custom_ids)
-    redirect_to edit_form_path(@form), notice: "Sections updated."
+    redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "Sections updated."
   end
 
   def reorder_field
@@ -120,6 +121,16 @@ class FormsController < ApplicationController
 
   def set_form
     @form = Form.find(params[:id])
+  end
+
+  # Forms are shared across events, so the "go back to the dashboard" target
+  # can't be derived from the form alone — it comes from the event the admin
+  # navigated from (passed as event_id). Scope the lookup to this form's events
+  # so the link only ever points at a genuinely connected event. Fall back to
+  # the sole connected event when there's exactly one.
+  def set_dashboard_event
+    @dashboard_event = @form.events.find_by(id: params[:event_id]) if params[:event_id].present?
+    @dashboard_event ||= @form.events.one? ? @form.events.first : nil
   end
 
   def form_params

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -20,18 +20,12 @@
         <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <% if @event.bulk_payment_form %>
-        <%= link_to "Bulk payment", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+        <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>
       <%= link_to "Change form settings", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% else %>
       <%= link_to "Enable forms", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
-    <div class="my-1 border-t border-gray-100"></div>
-    <%# Bulk payment is a placeholder until that feature is built. %>
-    <span class="flex items-center justify-between gap-2 px-4 py-2 text-sm text-gray-400 cursor-not-allowed" title="Bulk payment link — coming soon">
-      <span>Bulk payment link</span>
-      <span class="rounded-full bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-500">Soon</span>
-    </span>
   </div>
 </div>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -8,7 +8,7 @@
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @form) %>
-          <%= link_to "Edit form", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_sections_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
         <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
       </div>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -5,6 +5,14 @@
     <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
     <% end %>
+    <% if allowed_to?(:dashboard?, @event) %>
+      <div class="ml-auto flex flex-wrap items-center gap-1">
+        <% if allowed_to?(:edit?, @form) %>
+          <%= link_to "Edit form", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <% end %>
+        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -25,7 +25,8 @@
       on that form plus the "Enable scholarship application" checkbox (which is what
       creates the scholarship event_form). The scholarship link points at the public
       registration page, so it also needs the registration form or it dead-ends there.
-      Links open in a new tab. Bulk payment is a placeholder until that feature is built. %>
+      Bulk payment is gated on the event having a bulk payment form.
+      Links open in a new tab. %>
   <% link_base = "inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors" %>
   <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-8">
     <% if @event.event_forms.registration.exists? %>
@@ -46,11 +47,14 @@
       <% end %>
     <% end %>
 
-    <span class="<%= link_base %> border-gray-200 text-gray-400 cursor-not-allowed" title="Bulk payment link — coming soon">
-      <i class="fa-solid fa-money-check-dollar text-gray-300"></i>
-      Bulk payment link
-      <span class="rounded-full bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-500">Soon</span>
-    </span>
+    <% if @event.bulk_payment_form %>
+      <%= link_to new_event_bulk_payment_path(@event), target: "_blank", rel: "noopener noreferrer",
+            class: "#{link_base} #{DomainTheme.border_class_for(:payments, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:payments, intensity: 300)} hover:bg-gray-50" do %>
+        <i class="fa-solid fa-money-check-dollar <%= DomainTheme.text_class_for(:payments, intensity: 600) %>"></i>
+        Bulk payment form
+        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
+      <% end %>
+    <% end %>
   </div>
 
   <%# Money cards (paid events only) — shown first %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -8,7 +8,7 @@
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @form) %>
-          <%= link_to "Edit form", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_sections_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
         <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
       </div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,6 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <% dashboard_event = @form.events.one? ? @form.events.first : nil %>
+    <% if dashboard_event %>
+      <%= link_to "Dashboard", dashboard_event_path(dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit sections", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
@@ -114,10 +118,10 @@
          data-expand-all-field-options-outlet="[data-controller~='field-options']">
       <div class="px-6 py-3 bg-indigo-50 border-b border-indigo-200 flex items-center justify-between">
         <h2 class="flex items-center gap-2.5 text-sm font-semibold text-indigo-900 uppercase tracking-wide">
-          <i class="fa-solid fa-list-ul text-indigo-500"></i>Fields
+          <i class="fa-solid fa-list-ul text-indigo-500"></i>Questions
         </h2>
         <div class="flex items-center gap-3">
-          <span class="text-sm text-gray-500"><%= @form_fields.size %> fields</span>
+          <span class="text-sm text-gray-500"><%= pluralize(@form_fields.size, "question") %></span>
           <button type="button"
                   class="text-sm text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
                   data-action="expand-all#toggleAll"

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,13 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
-    <% dashboard_event = @form.events.one? ? @form.events.first : nil %>
-    <% if dashboard_event %>
-      <%= link_to "Dashboard", dashboard_event_path(dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% if @dashboard_event %>
+      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit sections", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
@@ -48,7 +47,7 @@
     </div>
 
     <div class="px-4 sm:px-6 py-6">
-  <%= form_with model: @form, class: "space-y-6" do |f| %>
+  <%= form_with model: @form, url: form_path(@form, event_id: @dashboard_event&.id), class: "space-y-6" do |f| %>
     <% if @form.errors.any? %>
       <div class="rounded-lg bg-red-50 border border-red-200 p-4">
         <p class="text-sm font-medium text-red-800">

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,12 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
-    <% dashboard_event = @form.events.one? ? @form.events.first : nil %>
-    <% if dashboard_event %>
-      <%= link_to "Dashboard", dashboard_event_path(dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% if @dashboard_event %>
+      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit questions", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
 
@@ -48,14 +47,14 @@
     </div>
 
     <div class="px-4 sm:px-6 py-6">
-  <%= form_with url: update_sections_form_path(@form), method: :patch, class: "space-y-6" do |f| %>
+  <%= form_with url: update_sections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
       <div class="flex items-center gap-2.5 px-6 py-3 bg-blue-100 border-b border-blue-300">
         <i class="fa-solid fa-list-check text-blue-700"></i>
         <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Sections to include</h2>
       </div>
       <div class="p-6">
-        <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
+        <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
         <ol class="space-y-2">
           <% @editable_sections.each_with_index do |section, index| %>
             <% if section[:kind] == :custom %>
@@ -98,7 +97,7 @@
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
       <div class="flex items-center gap-3">
         <%= f.submit "Save changes", class: "btn btn-primary cursor-pointer" %>
-        <%= link_to "Edit questions", edit_form_path(@form), class: "btn btn-secondary" %>
+        <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "btn btn-secondary" %>
         <%= link_to "Cancel", form_path(@form), class: "btn btn-secondary-outline" %>
       </div>
     </div>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,8 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <% dashboard_event = @form.events.one? ? @form.events.first : nil %>
+    <% if dashboard_event %>
+      <%= link_to "Dashboard", dashboard_event_path(dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit fields", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit questions", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
   </div>
 
@@ -51,7 +55,7 @@
         <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Sections to include</h2>
       </div>
       <div class="p-6">
-        <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit fields", edit_form_path(@form), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
+        <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
         <ol class="space-y-2">
           <% @editable_sections.each_with_index do |section, index| %>
             <% if section[:kind] == :custom %>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -57,6 +57,41 @@ RSpec.describe "Forms", type: :request do
     end
   end
 
+  describe "dashboard link on the form editor" do
+    before { sign_in admin }
+
+    let(:form) { create(:form, :standalone) }
+    let(:event) { create(:event) }
+
+    # Forms are shared across events, so the editor links back to the dashboard
+    # of the event the admin came from, passed as event_id.
+    context "when an event_id for a connected event is given" do
+      before { create(:event_form, form: form, event: event) }
+
+      it "links the dashboard button to that event on the questions editor" do
+        get edit_form_path(form, event_id: event.id)
+        expect(response.body).to include(dashboard_event_path(event))
+      end
+
+      it "links the dashboard button to that event on the sections editor" do
+        get edit_sections_form_path(form, event_id: event.id)
+        expect(response.body).to include(dashboard_event_path(event))
+      end
+    end
+
+    it "ignores an event_id that is not connected to the form" do
+      get edit_form_path(form, event_id: event.id)
+      expect(response.body).not_to include(dashboard_event_path(event))
+    end
+
+    it "shows no dashboard link when the form spans multiple events and none is given" do
+      create(:event_form, form: form, event: event)
+      create(:event_form, form: form, event: create(:event))
+      get edit_form_path(form)
+      expect(response.body).not_to include("Dashboard")
+    end
+  end
+
   describe "GET /forms/:id/edit" do
     before { sign_in admin }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Surface the now-built public bulk payment form where admins manage an event, and smooth out form-editor navigation. Previously the dashboard and registrants "Form actions" menu showed a disabled "coming soon" placeholder for bulk payment, and the form editor had no quick way back to an event.

### How did you approach the change?
- Dashboard and "Form actions" menu now link to the public bulk payment form (gated on the event having one), labelled "Bulk payment form" to distinguish it from the admin "Bulk payments" submissions list (unchanged).
- Added an admin-only "Edit form" / "Dashboard" header block to the bulk payment form page, mirroring the public registration page.
- Form editor (edit questions + edit sections) gains a "Dashboard" link when the form is tied to a single event, and aligns wording on "questions" (nav link, section header, and count) to match the existing "Edit questions" title.

### UI Testing Checklist
- [ ] On an event with a bulk payment form, the dashboard quick-link and "Form actions" → "Bulk payment form" open the public form; neither appears without one.
- [ ] As an admin, the bulk payment form page shows working "Edit form" and "Dashboard" links.
- [ ] The form editor shows a "Dashboard" link only when the form has exactly one connected event, and the section header/count/nav read "questions".

### Anything else to add?
View-only changes; `spec/requests/forms_spec.rb` passes and no specs reference the renamed labels.
