### PR TITLE
Bulk payment form: payer phone/organization, sentence-case labels, and pay-now decoupling

### DIFF
--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -130,7 +130,7 @@ module Events
       payment_method_field = @form.form_fields.find_by(field_identifier: "payment_method")
       return false unless payment_method_field
 
-      form_params[payment_method_field.id.to_s] == "Credit Card Now"
+      form_params[payment_method_field.id.to_s] == FormBuilderService::PAYMENT_METHOD_PAY_NOW
     end
 
     def create_stripe_checkout_session(submission)

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -116,7 +116,7 @@ module Events
       payment_method_field = @form.form_fields.find_by(field_identifier: "payment_method")
       return false unless payment_method_field
 
-      form_params[payment_method_field.id.to_s] == "Credit Card Now"
+      form_params[payment_method_field.id.to_s] == FormBuilderService::PAYMENT_METHOD_PAY_NOW
     end
 
     def create_stripe_checkout_session(registration, submission = nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,6 +114,11 @@ module ApplicationHelper
     "#{local.strftime("%B %-d, %Y %-l:%M %P")} #{local.strftime("%Z")}"
   end
 
+  # Rainbow gradient accent bar shown beside form section headers.
+  def form_section_bar_class
+    "h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"
+  end
+
   INDEX_BUTTON_ICONS = {
     community_news:      "fa-newspaper",
     stories:             "fa-book-open",

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -17,6 +17,7 @@ module EventRegistrationServices
     def call
       ActiveRecord::Base.transaction do
         person = find_or_create_person
+        create_phone_contact(person) if field_value("payer_phone").present?
         submission = create_form_submission(person)
         Result.new(success?: true, form_submission: submission, errors: [])
       end
@@ -49,6 +50,28 @@ module EventRegistrationServices
         first_name: first_name,
         last_name: last_name,
         email: email
+      )
+    end
+
+    # Mirrors PublicRegistration#create_phone_contact. The bulk payment form has
+    # no phone-type field, so the payer phone is always stored as personal.
+    def create_phone_contact(person)
+      phone_value = field_value("payer_phone")&.strip
+      return if phone_value.blank?
+
+      existing = person.contact_methods.find_by(kind: :phone, value: phone_value)
+      if existing
+        existing.update!(contact_type: "personal", primary: true, inactive: false)
+        return existing
+      end
+
+      person.contact_methods.where(kind: :phone, primary: true).update_all(primary: false, inactive: true)
+
+      person.contact_methods.create!(
+        kind: :phone,
+        value: phone_value,
+        contact_type: "personal",
+        primary: true
       )
     end
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -49,7 +49,7 @@ class FormBuilderService
     payment: %w[payment_method],
     consent: %w[communication_consent],
     post_event_feedback: %w[event_rating most_valuable improvement_suggestions],
-    bulk_payment: %w[payer_first_name payer_last_name payer_email organization_name number_of_attendees payment_method bulk_payment_attendees]
+    bulk_payment: %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees payment_method bulk_payment_attendees]
   }.freeze
 
   # Header questions created by each section's builder method
@@ -466,17 +466,20 @@ class FormBuilderService
   def build_bulk_payment_fields(form, position)
     position = add_header(form, position, "Payer Information", group: "bulk_payment", visibility: :logged_out_only)
 
-    position = add_field(form, position, "Payer First Name", :free_form_input_one_line,
+    position = add_field(form, position, "Payer first name", :free_form_input_one_line,
                          key: "payer_first_name", group: "bulk_payment", required: true,
                          width: :half, visibility: :logged_out_only)
-    position = add_field(form, position, "Payer Last Name", :free_form_input_one_line,
+    position = add_field(form, position, "Payer last name", :free_form_input_one_line,
                          key: "payer_last_name", group: "bulk_payment", required: true,
                          width: :half, visibility: :logged_out_only)
-    position = add_field(form, position, "Payer Email", :free_form_input_one_line,
+    position = add_field(form, position, "Payer email", :free_form_input_one_line,
                          key: "payer_email", group: "bulk_payment", required: true,
-                         visibility: :logged_out_only)
-    position = add_field(form, position, "Organization Name", :free_form_input_one_line,
-                         key: "organization_name", group: "bulk_payment", required: false,
+                         width: :half, visibility: :logged_out_only)
+    position = add_field(form, position, "Phone", :free_form_input_one_line,
+                         key: "payer_phone", group: "bulk_payment", required: false,
+                         width: :half, visibility: :logged_out_only)
+    position = add_field(form, position, "Organization", :free_form_input_one_line,
+                         key: "payer_organization", group: "bulk_payment", required: false,
                          visibility: :logged_out_only)
 
     position = add_header(form, position, "Payment Information", group: "bulk_payment")
@@ -487,7 +490,7 @@ class FormBuilderService
     position = add_header(form, position, "Attendees", group: "bulk_payment")
     position = add_field(form, position, "Number of Attendees", :free_form_input_one_line,
                          key: "number_of_attendees", group: "bulk_payment", required: true,
-                         datatype: :number_integer)
+                         datatype: :number_integer, width: :half)
     position = add_field(form, position, "Attendees", :no_user_input,
                          key: "bulk_payment_attendees", group: "bulk_payment", required: false)
     position

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -1,4 +1,10 @@
 class FormBuilderService
+  # Payment method options. The "pay now" option triggers an immediate Stripe
+  # charge, so controllers match against PAYMENT_METHOD_PAY_NOW rather than
+  # repeating its label. Keep this the single source of truth for the label.
+  PAYMENT_METHOD_PAY_NOW = "Credit card (now)".freeze
+  PAYMENT_METHOD_OPTIONS = [ PAYMENT_METHOD_PAY_NOW, "Credit card (later)", "Check", "Other" ].freeze
+
   SECTIONS = {
     person_identifier: { label: "Person identifier", method: :build_person_identifier_fields },
     person_contact_info: { label: "Person contact info", method: :build_person_contact_info_fields },
@@ -431,9 +437,9 @@ class FormBuilderService
   def build_payment_fields(form, position)
     position = add_header(form, position, "Payment Information", group: "payment")
 
-    position = add_field(form, position, "Payment Method", :multiple_choice_radio,
+    position = add_field(form, position, "Payment method", :multiple_choice_radio,
                          key: "payment_method", group: "payment", required: true,
-                         options: [ "Credit Card Now", "Credit Card Later", "Check", "Other" ])
+                         options: PAYMENT_METHOD_OPTIONS)
     position
   end
 
@@ -483,12 +489,12 @@ class FormBuilderService
                          visibility: :logged_out_only)
 
     position = add_header(form, position, "Payment Information", group: "bulk_payment")
-    position = add_field(form, position, "Payment Method", :multiple_choice_radio,
+    position = add_field(form, position, "Payment method", :multiple_choice_radio,
                          key: "payment_method", group: "bulk_payment", required: true,
-                         options: [ "Credit Card Now", "Credit Card Later", "Check", "Other" ])
+                         options: PAYMENT_METHOD_OPTIONS)
 
     position = add_header(form, position, "Attendees", group: "bulk_payment")
-    position = add_field(form, position, "Number of Attendees", :free_form_input_one_line,
+    position = add_field(form, position, "Number of attendees", :free_form_input_one_line,
                          key: "number_of_attendees", group: "bulk_payment", required: true,
                          datatype: :number_integer, width: :half)
     position = add_field(form, position, "Attendees", :no_user_input,

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -58,7 +58,7 @@
           <%= event_registration.event.decorate.times(display_day: true, display_date: true, styled: true) %>
         </div>
         <% if event_registration.event.decorate.labelled_cost.present? %>
-          <div class="text-lg font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif">
+          <div class="text-lg font-bold text-purple-900 uppercase" style="font-family: Lato, sans-serif">
             <%= event_registration.event.decorate.labelled_cost %>
           </div>
         <% end %>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -3,7 +3,7 @@
   <!-- Ticket Container -->
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
     <!-- Ticket Header -->
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -70,7 +70,7 @@
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-7 pb-4">
                 <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
-                  <span class="h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"></span><%= form_label_html(field.name) %>
+                  <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
               </div>
             <% elsif payer_fields.include?(field.field_identifier) %>
@@ -140,7 +140,7 @@
                                name="bulk_payment[form_fields][<%= field.id %>]"
                                value="<%= ffao.answer_option.name %>"
                                class="text-blue-600 focus:ring-blue-500"
-                               <%= "checked" if submitted_value == ffao.answer_option.name || (submitted_value.blank? && ffao.answer_option.name == "Credit Card Now") %>
+                               <%= "checked" if submitted_value == ffao.answer_option.name || (submitted_value.blank? && ffao.answer_option.name == FormBuilderService::PAYMENT_METHOD_PAY_NOW) %>
                                <%= "required" if field.required %>>
                         <%= ffao.answer_option.name %>
                       </label>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -29,7 +29,7 @@
 
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
@@ -60,7 +60,7 @@
 
         <%
           fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-          payer_fields = %w[payer_first_name payer_last_name payer_email organization_name number_of_attendees]
+          payer_fields = %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees]
         %>
 
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
@@ -69,8 +69,8 @@
 
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-7 pb-4">
-                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
-                  <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
+                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
+                  <span class="h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"></span><%= form_label_html(field.name) %>
                 </h3>
               </div>
             <% elsif payer_fields.include?(field.field_identifier) %>
@@ -94,6 +94,7 @@
                   <%
                     html_type = case field.field_identifier
                                 when "payer_email" then "email"
+                                when "payer_phone" then "tel"
                                 else field.number_integer? ? "number" : "text"
                                 end
                     extra_attrs = []
@@ -132,9 +133,9 @@
                     <%= form_label_html(field.name) %>
                     <% if field.required %><span class="text-red-500">*</span><% end %>
                   </label>
-                  <div class="flex flex-wrap gap-2.5 mt-1">
+                  <div class="flex flex-wrap gap-2 mt-1">
                     <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
-                      <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> px-4 py-2.5 cursor-pointer hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50 transition">
+                      <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> px-3 py-2.5 cursor-pointer hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50 transition">
                         <input type="radio"
                                name="bulk_payment[form_fields][<%= field.id %>]"
                                value="<%= ffao.answer_option.name %>"
@@ -163,7 +164,7 @@
               <div class="flex items-start gap-3 mb-3" data-bulk-payment-attendees-target="row">
                 <div class="flex-1 grid grid-cols-1 md:grid-cols-3 gap-3">
                   <div>
-                    <label class="block text-xs font-semibold text-gray-700 mb-1" for="attendee_INDEX_first_name">First Name</label>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_first_name">Attendee first name</label>
                     <input type="text"
                            name="bulk_payment[attendees][INDEX][first_name]"
                            id="attendee_INDEX_first_name"
@@ -171,7 +172,7 @@
                            class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
                   </div>
                   <div>
-                    <label class="block text-xs font-semibold text-gray-700 mb-1" for="attendee_INDEX_last_name">Last Name</label>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_last_name">Attendee last name</label>
                     <input type="text"
                            name="bulk_payment[attendees][INDEX][last_name]"
                            id="attendee_INDEX_last_name"
@@ -179,7 +180,7 @@
                            class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
                   </div>
                   <div>
-                    <label class="block text-xs font-semibold text-gray-700 mb-1" for="attendee_INDEX_email">Email</label>
+                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_email">Attendee email</label>
                     <input type="email"
                            name="bulk_payment[attendees][INDEX][email]"
                            id="attendee_INDEX_email"
@@ -189,7 +190,7 @@
                 </div>
                 <button type="button"
                         data-action="bulk-payment-attendees#removeRow"
-                        class="mt-6 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-400 hover:text-red-600 hover:bg-red-50 transition cursor-pointer">
+                        class="mt-7 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-400 hover:text-red-600 hover:bg-red-50 transition cursor-pointer">
                   <i class="fa-solid fa-xmark"></i>
                 </button>
               </div>

--- a/app/views/events/bulk_payments/show.html.erb
+++ b/app/views/events/bulk_payments/show.html.erb
@@ -12,7 +12,7 @@
 
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>

--- a/app/views/events/bulk_payments/show.html.erb
+++ b/app/views/events/bulk_payments/show.html.erb
@@ -44,7 +44,9 @@
 
         <% if field.group_header? %>
           <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-            <h3 class="text-lg font-semibold text-gray-800"><%= field.name %></h3>
+            <h3 class="flex items-center gap-2.5 text-lg font-semibold text-gray-800">
+              <span class="<%= form_section_bar_class %>"></span><%= field.name %>
+            </h3>
           </div>
         <% else %>
           <div class="py-2">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -105,8 +105,8 @@
           <% @form_fields.each do |field| %>
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-7 pb-4">
-                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-blue-900">
-                  <span class="h-5 w-1 rounded-full bg-accent"></span><%= form_label_html(field.name) %>
+                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
+                  <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
               </div>
             <% else %>
@@ -123,7 +123,7 @@
 
         <% if @scholarship_form && @scholarship_form.form_fields.any? %>
           <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">
-            <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900 mb-5">
+            <h3 class="flex items-center gap-2.5 text-lg font-bold text-purple-900 mb-5">
               <i class="fa-solid fa-hand-holding-heart text-accent"></i>Scholarship application
             </h3>
             <%= render "forms/header", form: @scholarship_form, event: @event %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -54,7 +54,7 @@
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -20,7 +20,7 @@
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -43,7 +43,9 @@
 
           <% if field.group_header? %>
             <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
-              <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
+              <h3 class="rich-label flex items-center gap-2.5 text-lg font-semibold text-gray-800">
+                <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
+              </h3>
             </div>
           <% else %>
             <% response = @responses[field.id] %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -18,7 +18,7 @@
      <% if field.section.present? %>data-section="<%= field.section %>"<% end %>
      <% if field.group_header? %>data-group-header<% end %>>
   <% if field.group_header? %>
-    <div class="cursor-grab rounded bg-indigo-50 text-indigo-500 hover:bg-indigo-100 hover:text-indigo-700 px-1.5 py-1"
+    <div class="cursor-grab rounded bg-purple-50 text-purple-500 hover:bg-purple-100 hover:text-purple-700 px-1.5 py-1"
          data-sortable-handle
          title="Drag to move this entire section">
       <i class="fa-solid fa-up-down-left-right"></i>
@@ -69,7 +69,7 @@
               {},
               class: "flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0">
-          <%= f.check_box :required, class: "rounded border-gray-300 text-blue-600" %>
+          <%= f.check_box :required, class: "rounded border-gray-300 text-purple-600" %>
           Required
         </label>
         <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0 ml-auto" title="Ask only the first time — hide if the person already answered it on any form, not just this event">
@@ -127,7 +127,7 @@
               <%= render "form_field_answer_option_fields", f: opt %>
             <% end %>
             <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
-                  class: "text-sm text-blue-600 hover:text-blue-800 font-medium" %>
+                  class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
           </div>
         <% end %>
       </div>

--- a/app/views/forms/_question_library.html.erb
+++ b/app/views/forms/_question_library.html.erb
@@ -23,7 +23,7 @@
                            data-question-library-target="item"
                            data-question-text="<%= field.question.downcase %>">
                       <input type="checkbox" name="source_field_ids[]" value="<%= field.id %>"
-                             class="h-4 w-4 text-blue-600 rounded border-gray-300">
+                             class="h-4 w-4 text-purple-600 rounded border-gray-300">
                       <div class="flex-1">
                         <span class="text-sm text-gray-800"><%= field.question %></span>
                         <span class="text-xs text-gray-400 ml-2 font-mono"><%= field.field_key %></span>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-blue-900">
+  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
     <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="flex items-center gap-4">
@@ -18,7 +18,7 @@
             <i class="fa-solid fa-list-check text-xl"></i>
           </div>
           <div>
-            <p class="text-xs font-medium uppercase tracking-[0.2em] text-blue-200">Edit questions</p>
+            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit questions</p>
             <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
           </div>
         </div>
@@ -27,8 +27,8 @@
         <div class="flex flex-wrap items-center gap-2">
           <% events_count = @form.events.size %>
           <% if events_count.positive? %>
-            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-blue-900 shadow-sm hover:bg-blue-50" do %>
-              <i class="fa-solid fa-calendar-day text-blue-600"></i>
+            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
+              <i class="fa-solid fa-calendar-day text-purple-600"></i>
               <%= pluralize(events_count, "event") %> connected
             <% end %>
           <% else %>
@@ -37,8 +37,8 @@
               No events connected
             </span>
           <% end %>
-          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-blue-900 shadow-sm">
-            <i class="fa-solid fa-inbox text-blue-600"></i>
+          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
+            <i class="fa-solid fa-inbox text-purple-600"></i>
             <%= pluralize(@form.form_submissions.size, "submission") %>
           </span>
         </div>
@@ -62,9 +62,9 @@
     <% end %>
 
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <div class="flex items-center gap-2.5 px-6 py-3 bg-blue-100 border-b border-blue-300">
-        <i class="fa-solid fa-gear text-blue-700"></i>
-        <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Form settings</h2>
+      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+        <i class="fa-solid fa-gear text-purple-700"></i>
+        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Form settings</h2>
       </div>
       <div class="p-6 space-y-4">
         <div class="flex flex-col sm:flex-row gap-4">
@@ -84,11 +84,11 @@
 
         <div class="flex flex-wrap gap-x-6 gap-y-2">
           <label class="flex items-center gap-2 cursor-pointer">
-            <%= f.check_box :hide_answered_person_questions, class: "rounded border-gray-300 text-blue-600" %>
+            <%= f.check_box :hide_answered_person_questions, class: "rounded border-gray-300 text-purple-600" %>
             <span class="text-sm text-gray-800">Hide any answered person & organization questions</span>
           </label>
           <label class="flex items-center gap-2 cursor-pointer">
-            <%= f.check_box :hide_answered_form_questions, class: "rounded border-gray-300 text-blue-600" %>
+            <%= f.check_box :hide_answered_form_questions, class: "rounded border-gray-300 text-purple-600" %>
             <span class="text-sm text-gray-800">Hide any questions the user already answered</span>
           </label>
         </div>
@@ -97,9 +97,9 @@
 
     <%# Optional HTML intro rendered under the title on the form's public pages %>
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <div class="flex items-center gap-2.5 px-6 py-3 bg-blue-100 border-b border-blue-300">
-        <i class="fa-solid fa-heading text-blue-700"></i>
-        <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Form header</h2>
+      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+        <i class="fa-solid fa-heading text-purple-700"></i>
+        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Form header</h2>
       </div>
       <div class="p-6 flex flex-col lg:flex-row gap-4">
         <div class="flex-1 flex flex-col space-y-2">
@@ -117,7 +117,7 @@
           <dl class="space-y-3">
             <% ApplicationHelper::FORM_HEADER_TOKENS.each do |token, (label, example)| %>
               <div>
-                <dt><code class="rounded bg-blue-100 text-blue-900 px-1.5 py-0.5 font-mono"><%= token %></code></dt>
+                <dt><code class="rounded bg-purple-100 text-purple-900 px-1.5 py-0.5 font-mono"><%= token %></code></dt>
                 <dd class="mt-1 text-gray-600"><%= label %> — e.g. <span class="text-gray-800"><%= example %></span></dd>
               </div>
             <% end %>
@@ -129,14 +129,14 @@
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden"
          data-controller="expand-all"
          data-expand-all-field-options-outlet="[data-controller~='field-options']">
-      <div class="px-6 py-3 bg-indigo-50 border-b border-indigo-200 flex items-center justify-between">
-        <h2 class="flex items-center gap-2.5 text-sm font-semibold text-indigo-900 uppercase tracking-wide">
-          <i class="fa-solid fa-list-ul text-indigo-500"></i>Questions
+      <div class="px-6 py-3 bg-purple-50 border-b border-purple-200 flex items-center justify-between">
+        <h2 class="flex items-center gap-2.5 text-sm font-semibold text-purple-900 uppercase tracking-wide">
+          <i class="fa-solid fa-list-ul text-purple-500"></i>Questions
         </h2>
         <div class="flex items-center gap-3">
           <span class="text-sm text-gray-500"><%= pluralize(@form_fields.size, "question") %></span>
           <button type="button"
-                  class="text-sm text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
+                  class="text-sm text-purple-600 hover:text-purple-800 font-medium cursor-pointer"
                   data-action="expand-all#toggleAll"
                   data-expand-all-target="btn">Expand all</button>
         </div>
@@ -199,7 +199,7 @@
         <%= link_to_add_association "+ Add field", f, :form_fields,
               data: { association_insertion_node: "[data-controller='form-fields-sortable']",
                       association_insertion_method: "append" },
-              class: "text-sm text-blue-600 hover:text-blue-800 font-medium" %>
+              class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
       </div>
     </div>
 

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -11,7 +11,7 @@
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
   <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-blue-900">
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-6">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="flex items-center gap-4">
           <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-blue-900">
+  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
     <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="flex items-center gap-4">
@@ -18,7 +18,7 @@
             <i class="fa-solid fa-layer-group text-xl"></i>
           </div>
           <div>
-            <p class="text-xs font-medium uppercase tracking-[0.2em] text-blue-200">Edit sections</p>
+            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit sections</p>
             <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
           </div>
         </div>
@@ -27,8 +27,8 @@
         <div class="flex flex-wrap items-center gap-2">
           <% events_count = @form.events.size %>
           <% if events_count.positive? %>
-            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-blue-900 shadow-sm hover:bg-blue-50" do %>
-              <i class="fa-solid fa-calendar-day text-blue-600"></i>
+            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
+              <i class="fa-solid fa-calendar-day text-purple-600"></i>
               <%= pluralize(events_count, "event") %> connected
             <% end %>
           <% else %>
@@ -37,8 +37,8 @@
               No events connected
             </span>
           <% end %>
-          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-blue-900 shadow-sm">
-            <i class="fa-solid fa-inbox text-blue-600"></i>
+          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
+            <i class="fa-solid fa-inbox text-purple-600"></i>
             <%= pluralize(@form.form_submissions.size, "submission") %>
           </span>
         </div>
@@ -49,9 +49,9 @@
     <div class="px-4 sm:px-6 py-6">
   <%= form_with url: update_sections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <div class="flex items-center gap-2.5 px-6 py-3 bg-blue-100 border-b border-blue-300">
-        <i class="fa-solid fa-list-check text-blue-700"></i>
-        <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Sections to include</h2>
+      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+        <i class="fa-solid fa-list-check text-purple-700"></i>
+        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
       </div>
       <div class="p-6">
         <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
@@ -64,7 +64,7 @@
                   <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
                   <%= hidden_field_tag "custom_sections[]", section[:header].id %>
                   <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
-                        class: "rounded border-gray-300 text-blue-600",
+                        class: "rounded border-gray-300 text-purple-600",
                         data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
                   <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
                   <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
@@ -77,7 +77,7 @@
                 <label class="flex items-center gap-2 cursor-pointer">
                   <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
                   <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
-                         class="rounded border-gray-300 text-blue-600"
+                         class="rounded border-gray-300 text-purple-600"
                          data-form-section-toggle-target="checkbox"
                          data-action="form-section-toggle#update"
                          <%= "checked" if section[:included] %>>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -11,7 +11,7 @@
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
   <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-blue-900">
-    <div class="relative bg-gradient-to-r from-blue-900 to-blue-800 text-white px-6 sm:px-8 py-6">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="flex items-center gap-4">
           <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -34,15 +34,15 @@
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_fields.size %></td>
             <td class="px-4 py-2 text-sm text-gray-600">
               <% if form.events.size.positive? %>
-                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md bg-blue-50 px-2 py-0.5 text-blue-700 font-medium hover:bg-blue-100" %>
+                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md bg-purple-50 px-2 py-0.5 text-purple-700 font-medium hover:bg-purple-100" %>
               <% else %>
                 0
               <% end %>
             </td>
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_submissions.size %></td>
             <td class="px-4 py-2 text-right text-sm space-x-3">
-              <%= link_to "View", form_path(form), class: "text-blue-600 hover:text-blue-800 underline" %>
-              <%= link_to "Edit", edit_sections_form_path(form), class: "text-blue-600 hover:text-blue-800 underline" %>
+              <%= link_to "View", form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
+              <%= link_to "Edit", edit_sections_form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
               <% if allowed_to?(:destroy?, form) && form.event_forms.none? %>
                 <%= link_to "Delete", form_path(form), class: "text-red-600 hover:text-red-800 underline",
                             data: { turbo_method: :delete, turbo_confirm: "Delete \"#{form.display_name}\"?" } %>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -27,7 +27,7 @@
           <% section_role = key == :scholarship ? "scholarship" : key == :bulk_payment ? "bulk_payment" : "other" %>
           <label class="flex items-center gap-2 cursor-pointer" data-section-role="<%= section_role %>">
             <input type="checkbox" name="sections[]" value="<%= key %>"
-                   class="rounded border-gray-300 text-blue-600"
+                   class="rounded border-gray-300 text-purple-600"
                    <%= "checked" if params.dig(:sections)&.include?(key.to_s) %>>
             <span class="text-sm text-gray-800"><%= section[:label] %></span>
           </label>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
-    <div class="bg-blue-900 text-white px-6 py-4">
+    <div class="bg-purple-900 text-white px-6 py-4">
       <div class="flex items-center gap-8">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
@@ -41,12 +41,12 @@
         # Mirror the editor's visibility chip colors so the same field reads
         # the same in both places.
         visibility_badge_styles = {
-          "scholarship_only" => "bg-blue-100 text-blue-700 border-blue-200",
+          "scholarship_only" => "bg-purple-100 text-purple-700 border-purple-200",
           "logged_out_only" => "bg-emerald-100 text-emerald-700 border-emerald-200",
           "answers_on_file" => "bg-amber-100 text-amber-700 border-amber-200"
         }
         visibility_marker_styles = {
-          "scholarship_only" => "border-blue-300",
+          "scholarship_only" => "border-purple-300",
           "logged_out_only" => "border-emerald-300",
           "answers_on_file" => "border-amber-300"
         }

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -69,6 +69,7 @@
             <% if field.group_header? %>
               <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
                 <div class="flex flex-wrap items-center gap-2">
+                  <span class="<%= form_section_bar_class %>"></span>
                   <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>
                   <% if conditional %>
                     <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -19,7 +19,7 @@ module DomainTheme
     categories:               :lime,
     category_types:            :lime,
 
-    forms:                    :stone,
+    forms:                    :purple,
     faqs:                     :pink,
     video_recordings:         :cyan,
 

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "Events::BulkPayments", type: :request do
   let(:event) { create(:event, cost_cents: 0) }
   let(:form) { create(:form) }
   # The bulk payment view only renders a known set of "payer" fields, so the
-  # min-word rule is exercised through organization_name (a free-form text field).
+  # min-word rule is exercised through payer_organization (a free-form text field).
   let!(:org_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "organization_name", name: "Organization name",
+           field_identifier: "payer_organization", name: "Organization",
            required: true, min_words: 5)
   end
 
@@ -50,6 +50,31 @@ RSpec.describe "Events::BulkPayments", type: :request do
       get new_event_bulk_payment_path(event)
 
       expect(response.body).to include("md:col-span-6")
+    end
+  end
+
+  describe "GET new with the seeded bulk payment form" do
+    let(:seeded_form) do
+      FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+    end
+
+    before do
+      # Payer fields are logged_out_only, so test the public (signed-out) view.
+      sign_out admin
+      EventForm.where(event: event).destroy_all
+      EventForm.create!(event: event, form: seeded_form, role: "bulk_payment")
+    end
+
+    it "renders the optional payer phone field" do
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include("Phone")
+    end
+
+    it "labels the attendee fields with the 'Attendee' prefix" do
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include("Attendee first name", "Attendee last name", "Attendee email")
     end
   end
 end

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe EventRegistrationServices::BulkPayment do
+  let(:event) { create(:event, :published, :publicly_visible) }
+  let(:form) do
+    f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+    event.event_forms.create!(form: f, role: "bulk_payment")
+    f
+  end
+
+  def field_id(key)
+    form.form_fields.find_by!(field_identifier: key).id.to_s
+  end
+
+  def base_form_params(overrides = {})
+    {
+      field_id("payer_first_name") => "Pat",
+      field_id("payer_last_name") => "Payer",
+      field_id("payer_email") => "pat@example.com",
+      field_id("payment_method") => "Check",
+      field_id("number_of_attendees") => "3"
+    }.merge(overrides)
+  end
+
+  describe "payer phone" do
+    it "stores the payer phone as a primary phone contact method on the person" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(field_id("payer_phone") => "555-123-4567")
+      )
+
+      expect(result.success?).to be true
+      person = result.form_submission.person
+      contact = person.contact_methods.find_by(kind: :phone)
+      expect(contact).to have_attributes(value: "555-123-4567", primary: true)
+      expect(person.phone_number).to eq("555-123-4567")
+    end
+
+    it "does not create a phone contact when no payer phone is given" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params
+      )
+
+      expect(result.success?).to be true
+      expect(result.form_submission.person.contact_methods.where(kind: :phone)).to be_empty
+    end
+  end
+end

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -94,6 +94,31 @@ RSpec.describe FormBuilderService do
       end
     end
 
+    context "bulk_payment section" do
+      let(:form) { described_class.new(name: "Test", sections: %i[bulk_payment], role: "bulk_payment").call }
+
+      it "creates payer fields including an optional phone field" do
+        keys = form.form_fields.pluck(:field_identifier).compact
+        expect(keys).to include(
+          "payer_first_name", "payer_last_name", "payer_email", "payer_phone", "payer_organization"
+        )
+      end
+
+      it "makes the phone and organization fields optional" do
+        phone = form.form_fields.find_by(field_identifier: "payer_phone")
+        organization = form.form_fields.find_by(field_identifier: "payer_organization")
+        expect(phone.required).to be(false)
+        expect(organization.required).to be(false)
+      end
+
+      it "lays payer name, email, and phone fields out as halves" do
+        widths = form.form_fields.where(
+          field_identifier: %w[payer_first_name payer_last_name payer_email payer_phone]
+        ).pluck(:width)
+        expect(widths).to all(eq("half"))
+      end
+    end
+
     context "marketing section" do
       let(:form) { described_class.new(name: "Test", sections: %i[marketing]).call }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Rounds out the bulk-payment seed form: adds an optional **phone** field and renames the generic `organization_name` key to `payer_organization` so every payer field shares the `payer_*` convention.
- Improves the form's readability — sentence-case labels throughout and half-width layout for name/email/phone and number-of-attendees.
- Decouples the Stripe "pay now" branch from the option's display text, so relabeling a payment option can't silently break charging.
- Refreshes the public-facing look to match the AWBW brand.

### How did you approach the change?
- **Form builder** (`FormBuilderService`): replaced `organization_name` with `payer_organization`, added optional `payer_phone`, set name/email/phone/number-of-attendees to `width: :half`, and sentence-cased the labels ("Number of attendees", "Payment method", "Credit card (now)/(later)").
- **Pay-now decoupling**: extracted `PAYMENT_METHOD_PAY_NOW` (+ `PAYMENT_METHOD_OPTIONS`) as the single source of truth for the option list, and pointed both payment controllers and the bulk-payment view at the constant instead of repeating the literal string.
- **Bulk payment view**: renders the new `payer_phone`/`payer_organization` fields (phone uses `type="tel"`), prefixes attendee labels with "Attendee", and gives the section divider a logo-inspired rainbow gradient instead of the flat red bar.
- **Shared header bar**: extracted `form_section_bar_class` so the gradient section-header bar is defined once and shared across public registration, bulk payment, and form preview views.
- **Headers**: recolored the public card/hero headers from blue to purple across bulk payments, public registrations, and form edit pages.
- **Specs**: added request specs for the seeded form (phone field + attendee labels) and service specs covering the new fields, optionality, and half-width layout.

### UI Testing Checklist
- [ ] Bulk payment form (signed out) shows the optional Phone field and Organization field
- [ ] Attendee rows read "Attendee first name / last name / email"
- [ ] Payment options read "Credit card (now)", "Credit card (later)", "Check", "Other"
- [ ] Section divider shows the rainbow gradient (run `bin/vite build --mode development` if stale)
- [ ] Card/hero headers render purple on bulk payments, public registrations, and form edit pages

### Anything else to add?
- The "pay now" string still ultimately matches on the submitted label; an admin renaming the option in the form-builder UI would desync the charge branch. A stable per-option key would fully fix that — deferred as a larger change.
- All affected specs pass; rubocop clean.
- The section divider uses an arbitrary Tailwind gradient class, which can serve stale until a forced vite dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
