### PR TITLE
Add event-aware headers to public registration forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,7 @@ module ApplicationHelper
     "{{event_times}}" => [ "Event start-end time", "9 am - 4:30 pm PST" ],
     "{{event_fee}}" => [ "Registration fee", "$1,500" ],
     "{{event_platform}}" => [ "Virtual platform", "Zoom" ],
+    "{{event_location}}" => [ "In-person location", "Los Angeles, CA" ],
     "{{event_month_year}}" => [ "Event month and year", "July 2026" ],
     "{{registration_close}}" => [ "Registration close date", "June 20, 2026 9:00 am PST" ]
   }.freeze
@@ -40,9 +41,17 @@ module ApplicationHelper
       .gsub("{{event_times}}", event_times_label(event) || "the scheduled time")
       .gsub("{{event_fee}}", event_fee_label(event) || "the registration fee")
       .gsub("{{event_platform}}", event_platform_label(event) || "online")
+      .gsub("{{event_location}}", event_location_label(event) || "the event location")
       .gsub("{{event_month_year}}", event&.start_date&.strftime("%B %Y") || "upcoming")
       .gsub("{{registration_close}}", event_registration_close_label(event) || "soon")
     form_label_html(text)
+  end
+
+  # True when the header contains any {{token}} placeholder, so previews (which
+  # have no event in scope) can flag that the live values come from the event.
+  def form_header_uses_tokens?(form)
+    header = form&.header.to_s
+    FORM_HEADER_TOKENS.keys.any? { |token| header.include?(token) }
   end
 
   # Event date or date range as plain text (e.g. "July 23-24, 2026"), mirroring the
@@ -88,6 +97,12 @@ module ApplicationHelper
   def event_platform_label(event)
     return unless event&.videoconference_url.present?
     event.videoconference_label.presence
+  end
+
+  # In-person location name (e.g. "Los Angeles, CA"), or nil when the event has no
+  # physical location set.
+  def event_location_label(event)
+    event&.location&.name.presence
   end
 
   # Registration close date formatted like the event show page (e.g.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,91 @@ module ApplicationHelper
     sanitize(text.to_s, tags: FORM_LABEL_TAGS, attributes: FORM_LABEL_ATTRIBUTES)
   end
 
+  # Tokens an admin can drop into a form header; each is filled from the event the
+  # form is rendered for (see form_header_html). A standalone registration form is
+  # shared across events, so the header can't hard-code event specifics. Each entry:
+  # [label, example] — surfaced as a reference on the form editor. Keep the keys in
+  # sync with the substitutions in form_header_html.
+  FORM_HEADER_TOKENS = {
+    "{{event_title}}" => [ "Event title", "AWBW Facilitator Training" ],
+    "{{event_dates}}" => [ "Event date(s)", "July 23-24, 2026" ],
+    "{{event_times}}" => [ "Event start-end time", "9 am - 4:30 pm PST" ],
+    "{{event_fee}}" => [ "Registration fee", "$1,500" ],
+    "{{event_platform}}" => [ "Virtual platform", "Zoom" ],
+    "{{event_month_year}}" => [ "Event month and year", "July 2026" ],
+    "{{registration_close}}" => [ "Registration close date", "June 20, 2026 9:00 am PST" ]
+  }.freeze
+
+  # Render a form header, filling event-driven tokens (see FORM_HEADER_TOKENS) from
+  # the event the form is being shown for. The public registration pages pass
+  # `event:`; the standalone form preview has none, so tokens fall back to a neutral
+  # phrase. HTML is sanitized via form_label_html.
+  def form_header_html(form, event: nil)
+    text = form.header.to_s
+      .gsub("{{event_title}}", event&.title.presence || "this event")
+      .gsub("{{event_dates}}", event_dates_label(event) || "the event dates")
+      .gsub("{{event_times}}", event_times_label(event) || "the scheduled time")
+      .gsub("{{event_fee}}", event_fee_label(event) || "the registration fee")
+      .gsub("{{event_platform}}", event_platform_label(event) || "online")
+      .gsub("{{event_month_year}}", event&.start_date&.strftime("%B %Y") || "upcoming")
+      .gsub("{{registration_close}}", event_registration_close_label(event) || "soon")
+    form_label_html(text)
+  end
+
+  # Event date or date range as plain text (e.g. "July 23-24, 2026"), mirroring the
+  # event show page's date line, or nil when the event has no start date.
+  def event_dates_label(event)
+    return unless event&.start_date
+    s = event.start_date.in_time_zone(Time.zone)
+    e = (event.end_date || event.start_date).in_time_zone(Time.zone)
+    return s.strftime("%B %-d, %Y") if s.to_date == e.to_date
+    if s.year == e.year && s.month == e.month
+      "#{s.strftime("%B %-d")}-#{e.strftime("%-d")}, #{s.year}"
+    elsif s.year == e.year
+      "#{s.strftime("%B %-d")} - #{e.strftime("%B %-d")}, #{s.year}"
+    else
+      "#{s.strftime("%B %-d, %Y")} - #{e.strftime("%B %-d, %Y")}"
+    end
+  end
+
+  # Event start-end time as plain text (e.g. "9 am - 4:30 pm PST"), mirroring the
+  # event show page's time formatting (minutes hidden when :00), or nil with no start.
+  def event_times_label(event)
+    return unless event&.start_date
+    s = event.start_date.in_time_zone(Time.zone)
+    e = (event.end_date || event.start_date).in_time_zone(Time.zone)
+    format = ->(d) do
+      t = d.strftime("%-l")
+      t += ":#{d.strftime("%M")}" unless d.strftime("%M") == "00"
+      "#{t} #{d.strftime("%P")}"
+    end
+    zone = s.strftime("%Z")
+    return "#{format.call(s)} #{zone}" if s.hour == e.hour && s.min == e.min
+    "#{format.call(s)} - #{format.call(e)} #{zone}"
+  end
+
+  # Registration fee as plain text ("$1,500" or "Free"), or nil when no cost is set.
+  def event_fee_label(event)
+    return unless event && event.cost_cents.present?
+    event.cost_cents.zero? ? "Free" : dollars_from_cents(event.cost_cents)
+  end
+
+  # Virtual platform label (e.g. "Zoom"), only for events with a videoconference
+  # link configured; nil otherwise (in-person or unset).
+  def event_platform_label(event)
+    return unless event&.videoconference_url.present?
+    event.videoconference_label.presence
+  end
+
+  # Registration close date formatted like the event show page (e.g.
+  # "June 20, 2026 9:00 am PST"), or nil when there's no close date.
+  def event_registration_close_label(event)
+    close = event&.registration_close_date
+    return unless close
+    local = close.in_time_zone(Time.zone)
+    "#{local.strftime("%B %-d, %Y %-l:%M %P")} #{local.strftime("%Z")}"
+  end
+
   INDEX_BUTTON_ICONS = {
     community_news:      "fa-newspaper",
     stories:             "fa-book-open",

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -42,6 +42,11 @@
           <i class="fa-solid fa-location-dot text-blue-500"></i><%= @event.location.name %>
         </span>
       <% end %>
+      <% if @event.videoconference_url.present? && @event.autoshow_videoconference_label && @event.videoconference_label.present? %>
+        <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 px-4 py-1.5 text-sm font-semibold text-blue-900 ring-1 ring-blue-100">
+          <i class="fa-solid fa-video text-blue-500"></i><%= @event.videoconference_label %>
+        </span>
+      <% end %>
     </div>
   </div>
 
@@ -64,7 +69,7 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
-      <%= render "forms/header", form: @form %>
+      <%= render "forms/header", form: @form, event: @event %>
 
       <% if flash[:alert] %>
         <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -126,6 +126,7 @@
             <h3 class="flex items-center gap-2.5 text-lg font-bold text-blue-900 mb-5">
               <i class="fa-solid fa-hand-holding-heart text-accent"></i>Scholarship application
             </h3>
+            <%= render "forms/header", form: @scholarship_form, event: @event %>
             <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
               <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% next if field.group_header? %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -35,7 +35,7 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
-      <%= render "forms/header", form: @form %>
+      <%= render "forms/header", form: @form, event: @event %>
 
       <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
         <% @form_fields.each do |field| %>

--- a/app/views/forms/_header.html.erb
+++ b/app/views/forms/_header.html.erb
@@ -1,7 +1,10 @@
 <%# Optional admin-authored HTML intro, shown directly under a form's title on
-    the internal preview and the public registration pages. Locals: form. %>
+    the internal preview and the public registration pages. Tokens like
+    {{event_month_year}} are filled from `event` when one is passed (the public
+    registration pages); the standalone preview renders without it.
+    Locals: form. Optional: event. %>
 <% if form.header.present? %>
   <div class="rich-label mb-6 text-sm text-gray-700 leading-relaxed space-y-2">
-    <%= form_label_html(form.header) %>
+    <%= form_header_html(form, event: local_assigns[:event]) %>
   </div>
 <% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -101,14 +101,28 @@
         <i class="fa-solid fa-heading text-blue-700"></i>
         <h2 class="text-sm font-semibold text-blue-900 uppercase tracking-wide">Form header</h2>
       </div>
-      <div class="p-6 space-y-2">
-        <label class="block text-sm font-medium text-gray-700">Intro shown under the form title</label>
-        <p class="text-xs text-gray-500">
-          Optional. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Appears at the top of the form on the preview and public pages.
-        </p>
-        <%= f.text_area :header, rows: 4,
-              placeholder: "e.g. <strong>Welcome!</strong> Please complete all fields below.",
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
+      <div class="p-6 flex flex-col lg:flex-row gap-4">
+        <div class="flex-1 flex flex-col space-y-2">
+          <label class="block text-sm font-medium text-gray-700">Intro shown under the form title</label>
+          <p class="text-xs text-gray-500">
+            Optional. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.
+          </p>
+          <%= f.text_area :header, rows: 4,
+                placeholder: "e.g. <strong>Welcome!</strong> Please complete all fields below.",
+                class: "w-full flex-1 rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
+        </div>
+        <div class="lg:w-72 shrink-0 rounded-lg bg-gray-50 border border-gray-200 p-4 text-xs">
+          <p class="font-semibold text-gray-700 mb-1">Available placeholders</p>
+          <p class="text-gray-500 mb-3">Filled from the event when the form is shown.</p>
+          <dl class="space-y-3">
+            <% ApplicationHelper::FORM_HEADER_TOKENS.each do |token, (label, example)| %>
+              <div>
+                <dt><code class="rounded bg-blue-100 text-blue-900 px-1.5 py-0.5 font-mono"><%= token %></code></dt>
+                <dd class="mt-1 text-gray-600"><%= label %> — e.g. <span class="text-gray-800"><%= example %></span></dd>
+              </div>
+            <% end %>
+          </dl>
+        </div>
       </div>
     </div>
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -21,6 +21,12 @@
     </div>
 
     <div class="px-6 py-6">
+      <% if form_header_uses_tokens?(@form) %>
+        <p class="flex items-start gap-2 mb-4 rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-800">
+          <i class="fa-solid fa-circle-info mt-0.5 text-amber-500"></i>
+          <span>This is a preview — header placeholders show example text. On the live registration page they fill from the event (date, time, fee, location, etc.).</span>
+        </p>
+      <% end %>
       <%= render "forms/header", form: @form %>
 
       <%

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -34,6 +34,27 @@ registration_form = Form.standalone.find_by!(role: "registration")
 scholarship_form = Form.standalone.find_by!(role: "scholarship")
 bulk_payment_form = Form.standalone.find_by!(role: "bulk_payment")
 
+# Seed an example header (admin-authored HTML intro shown under the form title on
+# the public registration page) onto the base registration form, mirroring the
+# real AWBW Facilitator Training copy. Training dates, time, fee, and platform are
+# intentionally omitted — the public page already renders those from the event
+# (the date/time block, the "Cost:" badge, and the videoconference/platform badge),
+# and the form itself already notes that fields marked * are required. The form is
+# shared across events, so event-specific dates use tokens filled at render time
+# (see form_header_html): {{event_month_year}} from the event's start date and
+# {{registration_close}} from its registration close date, rather than hard-coded
+# values. Only set when blank so admin edits survive a re-seed.
+if registration_form.header.blank?
+  registration_form.update!(header: <<~HTML.strip)
+    <p style="font-size:17px;color:#166534;"><strong>We're so glad you're here.</strong></p>
+    <p>This training certifies you to lead trauma-informed creative art workshops, guiding adults, youth, and children through the AWBW model and the quiet, transformative work of making art together. Attending this training is required to facilitate Windows workshops.</p>
+    <p>Along the way, you'll experience the process hands-on as a maker yourself. Once you're certified, you'll join our Community of Practice with full access to the AWBW curriculum, ongoing training, and support services. Your training fee includes <a href="https://awbw.org/programs/what-awbw-offers-windows-facilitators/" target="_blank" rel="noopener" style="font-weight:600;">these ongoing benefits</a>, and <a href="https://awbw.org/programs/ce-hours-for-facilitator-trainings/" target="_blank" rel="noopener" style="font-weight:600;">Continuing Education (CE) hours</a> are available.</p>
+    <p><strong style="color:#b45309;">Registration closes {{registration_close}}.</strong> Payment is due within three weeks of registering, and we'll send everything you need as the dates approach.</p>
+    <p style="font-size:13px;color:#6b7280;"><em>There are no refunds for Windows Facilitator Trainings, though you're welcome to transfer your spot to a later training or a co-worker with AWBW's approval.</em></p>
+    <p style="background-color:#faf5ff;border:1px solid #e9d5ff;border-radius:12px;padding:16px 18px;color:#6b21a8;"><strong style="font-size:16px;">Ready when you are.</strong> Fill out the form below to claim your spot.<br><span style="color:#7e22ce;">You'll get a confirmation email shortly. If not, email us at <a href="mailto:trainings@awbw.org" style="color:#7e22ce;">trainings@awbw.org</a>.</span></p>
+  HTML
+end
+
 # Ensure the professional section (Primary Age Group(s) Served, Primary Service
 # Area, etc.) exists even on a registration form seeded before it was added — the
 # event Background charts aggregate answers to those questions.
@@ -116,6 +137,14 @@ dev_events.each_with_index do |(title, form_type, cost_cents, scholarship, visib
     end
   end
 end
+
+# The flagship training runs on Zoom — drive the platform from event settings so
+# it shows as a badge in the public registration header (rather than living in the
+# shared form header). force-set on re-seed, mirroring the date/cost refresh above.
+Event.find_by(title: "AWBW Facilitator Training")&.update!(
+  videoconference_url: "https://awbw-org.zoom.us/j/0000000000",
+  videoconference_label: "Zoom"
+)
 
 puts "Creating Event Registrations…"
 

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -55,6 +55,38 @@ if registration_form.header.blank?
   HTML
 end
 
+# Seed a scholarship-specific header, shown under the "Scholarship application"
+# heading when this form is appended to an event registration (see
+# events/public_registrations/new). Scoped strictly to scholarship concerns —
+# eligibility and what's asked of recipients — and deliberately does NOT repeat
+# anything already in the registration header above (dates/time/platform, fee, CE
+# hours, refund/transfer policy, confirmation email, registration close), since
+# both headers render on the same page. Styled to match the registration header so
+# the section reads as inviting rather than a wall of requirements. Only set when
+# blank so admin edits survive a re-seed.
+if scholarship_form.header.blank?
+  scholarship_form.update!(header: <<~HTML.strip)
+    <p style="font-size:17px;color:#166534;"><strong>Cost shouldn't stand between you and this work.</strong></p>
+    <p>If the training fee is a barrier, apply for a scholarship right here — there's no separate form, just the questions below.</p>
+    <p><strong>Scholarships are currently available for:</strong></p>
+    <ul>
+      <li>Those located in <strong>Los Angeles County</strong>, California (limit 1 per agency)</li>
+      <li>Those located in <strong>Orange County</strong>, California (limit 1 per agency)</li>
+      <li>Those located in the <strong>Coachella Valley</strong>, California</li>
+      <li>Those within a 30-mile radius of <strong>Victorville</strong>, CA</li>
+      <li>Individuals working in <strong>movement building, community organizing</strong>, and/or <strong>systems change work</strong></li>
+      <li>Individuals serving <strong>fire-impacted communities</strong></li>
+    </ul>
+    <p>If we're able to offer you a scholarship, we'll ask you to give a little back to the community in return:</p>
+    <ul>
+      <li>Respond to 3 short questions after the training</li>
+      <li>Share quarterly highlight stories with images of participant artwork</li>
+    </ul>
+    <p style="font-size:13px;color:#6b7280;"><em>More details come with your notification. Scholarship recipients still attend both full days of the training.</em></p>
+    <p style="background-color:#faf5ff;border:1px solid #e9d5ff;border-radius:12px;padding:16px 18px;color:#6b21a8;"><strong style="font-size:16px;">No need to choose between cost and care.</strong> Answer the questions below to apply — we review every request personally.</p>
+  HTML
+end
+
 # Ensure the professional section (Primary Age Group(s) Served, Primary Service
 # Area, etc.) exists even on a registration form seeded before it was added — the
 # event Background charts aggregate answers to those questions.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -217,9 +217,31 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.form_header_html(form, event: in_person)).to eq("Platform: online.")
     end
 
+    it "fills the {{event_location}} token from the event's location" do
+      form = build(:form, header: "Location: {{event_location}}.")
+      event = build(:event, location: build(:location, city: "Los Angeles", state: "CA"))
+      expect(helper.form_header_html(form, event: event)).to eq("Location: Los Angeles, CA.")
+    end
+
+    it "falls back when the event has no location" do
+      form = build(:form, header: "Location: {{event_location}}.")
+      expect(helper.form_header_html(form, event: build(:event, location: nil))).to eq("Location: the event location.")
+    end
+
     it "sanitizes the header markup" do
       form = build(:form, header: "<strong>Hi</strong><script>alert(1)</script>")
       expect(helper.form_header_html(form)).to eq("<strong>Hi</strong>alert(1)")
+    end
+  end
+
+  describe "#form_header_uses_tokens?" do
+    it "is true when the header contains a known placeholder" do
+      expect(helper.form_header_uses_tokens?(build(:form, header: "Closes {{registration_close}}."))).to be true
+    end
+
+    it "is false for plain headers or none" do
+      expect(helper.form_header_uses_tokens?(build(:form, header: "Welcome!"))).to be false
+      expect(helper.form_header_uses_tokens?(build(:form, header: nil))).to be false
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -158,4 +158,68 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.form_label_html("<br>")).to be_html_safe
     end
   end
+
+  describe "#form_header_html" do
+    it "fills the {{event_month_year}} token from the event's start date" do
+      form = build(:form, header: "Register for our {{event_month_year}} training.")
+      event = build(:event, start_date: Time.zone.local(2026, 7, 23))
+      expect(helper.form_header_html(form, event: event)).to eq("Register for our July 2026 training.")
+    end
+
+    it "falls back to a neutral phrase when no event is given" do
+      form = build(:form, header: "Register for our {{event_month_year}} training.")
+      expect(helper.form_header_html(form)).to eq("Register for our upcoming training.")
+    end
+
+    it "fills the {{registration_close}} token from the event's close date" do
+      form = build(:form, header: "Registration closes {{registration_close}}.")
+      event = build(:event, registration_close_date: Time.zone.local(2026, 6, 20, 9, 0))
+      expect(helper.form_header_html(form, event: event))
+        .to eq("Registration closes #{event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %-l:%M %P %Z")}.")
+    end
+
+    it "falls back when the event has no registration close date" do
+      form = build(:form, header: "Registration closes {{registration_close}}.")
+      event = build(:event, registration_close_date: nil)
+      expect(helper.form_header_html(form, event: event)).to eq("Registration closes soon.")
+    end
+
+    it "fills the {{event_title}} token" do
+      form = build(:form, header: "Welcome to {{event_title}}.")
+      event = build(:event, title: "AWBW Facilitator Training")
+      expect(helper.form_header_html(form, event: event)).to eq("Welcome to AWBW Facilitator Training.")
+    end
+
+    it "fills the {{event_dates}} token, collapsing a same-month multi-day range" do
+      form = build(:form, header: "Dates: {{event_dates}}.")
+      event = build(:event, start_date: Time.zone.local(2026, 7, 23, 9), end_date: Time.zone.local(2026, 7, 24, 16, 30))
+      expect(helper.form_header_html(form, event: event)).to eq("Dates: July 23-24, 2026.")
+    end
+
+    it "fills the {{event_times}} token, hiding :00 minutes and showing the range" do
+      form = build(:form, header: "Time: {{event_times}}.")
+      event = build(:event, start_date: Time.zone.local(2026, 7, 23, 9), end_date: Time.zone.local(2026, 7, 23, 16, 30))
+      zone = event.start_date.in_time_zone(Time.zone).strftime("%Z")
+      expect(helper.form_header_html(form, event: event)).to eq("Time: 9 am - 4:30 pm #{zone}.")
+    end
+
+    it "fills the {{event_fee}} token with a formatted amount, and Free when zero" do
+      form = build(:form, header: "Fee: {{event_fee}}.")
+      expect(helper.form_header_html(form, event: build(:event, cost_cents: 150_000))).to eq("Fee: $1,500.")
+      expect(helper.form_header_html(form, event: build(:event, cost_cents: 0))).to eq("Fee: Free.")
+    end
+
+    it "fills the {{event_platform}} token only when a videoconference link is set" do
+      form = build(:form, header: "Platform: {{event_platform}}.")
+      online = build(:event, videoconference_url: "https://zoom.us/j/1", videoconference_label: "Zoom")
+      in_person = build(:event, videoconference_url: nil)
+      expect(helper.form_header_html(form, event: online)).to eq("Platform: Zoom.")
+      expect(helper.form_header_html(form, event: in_person)).to eq("Platform: online.")
+    end
+
+    it "sanitizes the header markup" do
+      form = build(:form, header: "<strong>Hi</strong><script>alert(1)</script>")
+      expect(helper.form_header_html(form)).to eq("<strong>Hi</strong>alert(1)")
+    end
+  end
 end

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe "Public registration new page", type: :system do
       end
     end
   end
+
+  describe "scholarship form header" do
+    let(:scholarship_form) do
+      create(:form, :standalone, :scholarship, :with_fields,
+             header: "<p>Scholarship intro for {{event_month_year}}.</p>")
+    end
+
+    before do
+      EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+    end
+
+    it "renders the scholarship form's header above the scholarship questions" do
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      expect(page).to have_text("Scholarship application")
+      expect(page).to have_text("Scholarship intro for #{event.start_date.strftime("%B %Y")}.")
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- A standalone registration form is shared across many events, so its intro copy can't hard-code dates, fees, location, or platform — it goes stale the moment the form is reused for the next event.
- This lets an admin write the header once with placeholders that fill from whichever event the form is shown for.
- The scholarship form's header was also being dropped entirely when the form is appended to an event registration, so admin-authored scholarship copy never reached applicants.

### How did you approach the change?
- Added a token layer to `form_header_html`: `{{event_title}}`, `{{event_dates}}`, `{{event_times}}`, `{{event_fee}}`, `{{event_platform}}`, `{{event_location}}`, `{{event_month_year}}`, `{{registration_close}}` — each filled from the event, mirroring the event show page's date/time/fee formatting, with neutral fallbacks on the standalone preview (no event).
- Surfaced the available placeholders as a reference panel beside the header field in the form editor so they're discoverable. The header field now grows to fill available width/height while the placeholder panel stays a fixed width pinned right.
- On the standalone form preview (no event in scope), added a notice that any placeholders render as example text and fill from the event on the live page — so the fallbacks don't mislead.
- Passed the event into the `forms/_header` partial on both public registration pages, and drove the virtual-platform badge from event videoconference settings.
- Rendered the scholarship form's header inline above the scholarship questions when it's appended to an event registration (previously dropped).
- Seeded warm, scannable example headers (AWBW green + purple call-to-action panels): one on the registration form, and a scholarship-specific one scoped to eligibility and recipient obligations — deliberately not repeating registration-header content since both render on the same page. Set the flagship training to run on Zoom.

### UI Testing Checklist
- [ ] Public registration page renders the header with tokens filled from the event (dates, times, fee, platform, location, registration close).
- [ ] Scholarship application section renders the scholarship form's header above its questions.
- [ ] Standalone form preview (no event) renders neutral fallback phrasing and shows the "this is a preview" token notice.
- [ ] Form editor shows the placeholder reference panel next to the header field, sized to the right.
- [ ] Header HTML stays sanitized — admin styling renders, scripts/unsafe attrs stripped.

### Anything else to add?
- Header content is still sanitized through `form_label_html`; the seeds use only inline styles that survive the allowlist.
- 🤖 Generated with [Claude Code](https://claude.com/claude-code)
