### PR TITLE
Land new forms on the section editor; route Edit links to the field editor

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -35,7 +35,7 @@ class FormsController < ApplicationController
       role: params[:role].presence
     ).call
 
-    redirect_to edit_form_path(form), notice: "Form created with #{form.form_fields.size} fields."
+    redirect_to edit_sections_form_path(form), notice: "Form created with #{form.form_fields.size} fields."
   end
 
   def edit

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -8,7 +8,7 @@
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @form) %>
-          <%= link_to "Edit form", edit_sections_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
         <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
       </div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -8,7 +8,7 @@
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @form) %>
-          <%= link_to "Edit form", edit_sections_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
         <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
       </div>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -42,7 +42,7 @@
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_submissions.size %></td>
             <td class="px-4 py-2 text-right text-sm space-x-3">
               <%= link_to "View", form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
-              <%= link_to "Edit", edit_sections_form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
+              <%= link_to "Edit", edit_form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
               <% if allowed_to?(:destroy?, form) && form.event_forms.none? %>
                 <%= link_to "Delete", form_path(form), class: "text-red-600 hover:text-red-800 underline",
                             data: { turbo_method: :delete, turbo_confirm: "Delete \"#{form.display_name}\"?" } %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -3,7 +3,7 @@
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit", edit_sections_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>
       <%= link_to "Delete", form_path(@form), class: "text-sm text-red-600 hover:text-red-800 px-2 py-1",
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Forms", type: :request do
       form = Form.last
       expect(form.name).to eq("Custom Form")
       expect(form.sections).to eq(%w[person_identifier consent])
-      expect(response).to redirect_to(edit_form_path(form))
+      expect(response).to redirect_to(edit_sections_form_path(form))
     end
 
     it "rejects when no sections selected" do


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- A freshly created form has no fields to arrange yet — the first thing an admin needs is to confirm which sections it contains
- So `create` now lands on the section editor (`edit_sections`) instead of the field editor

### How did you approach the change?
- Redirect `FormsController#create` to `edit_sections_form_path`
- Repoint the general "Edit" / "Edit form" links (forms index, form show, public registration, bulk payment) at `edit_form_path`, the field editor where day-to-day field changes happen
- The explicit "Edit sections" link on the field editor is unchanged
- Updated the create-redirect request spec to match

### Anything else to add?
- The "Edit sections" link in `forms/edit.html.erb` still lets admins jump to the section editor from the field editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)