### PR TITLE
Clarify zero-due label and make allocations card clickable

### DIFF
--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -6,14 +6,14 @@
 <% due_cents = cost_cents - paid_cents %>
 <%# Free event with nothing allocated — nothing to manage, so hide the section. %>
 <% return if cost_cents <= 0 && event_registration.allocations.empty? %>
-<section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+<section class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:border-gray-300 hover:shadow-md">
   <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:payments, intensity: 100) %> <%= DomainTheme.text_class_for(:payments, intensity: 600) %>">
       <i class="fa-solid fa-dollar-sign"></i>
     </span>
     <h2 class="text-sm font-semibold text-gray-700">Registration allocations</h2>
     <%= link_to allocations_path(allocatable_sgid: event_registration.to_sgid.to_s),
-                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline after:absolute after:inset-0 after:content-['']",
                 target: "_blank", rel: "noopener" do %>
       View all
       <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
@@ -40,7 +40,7 @@
               $<%= "%.2f" % (due_cents / 100.0) %>
             <% else %>
               <i class="fa-solid fa-thumbs-up"></i>
-              Paid up
+              Nothing
             <% end %>
           </dd>
         </div>

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Event registration edit page", type: :system do
       end
     end
 
-    it "shows a paid-up state when the cost is fully allocated" do
+    it "shows a fully-allocated state when the cost is fully allocated" do
       payment = create(:payment, amount_cents: 1099, amount_cents_remaining: 1099)
       create(:allocation, source: payment, allocatable: registration, amount: 1099)
 
@@ -60,7 +60,7 @@ RSpec.describe "Event registration edit page", type: :system do
       visit edit_event_registration_path(registration)
 
       within("section", text: "Registration allocations") do
-        expect(page).to have_text("Paid up")
+        expect(page).to have_text("Nothing")
       end
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The zero-due state on the event registration allocations card read **"Paid up"**, which implies a payment was actually made.
- That card is framed around *allocations* (which can be scholarships or pending arrangements), so "Paid up" overclaimed — the registrant may owe nothing without having paid anything.
- Replaced it with the neutral **"Nothing"** in the "Amount due" cell.

### How did you approach the change?

- Swapped the label text in the `_payment_history` partial and updated the matching system spec.
- Made the **entire card a click target** for the allocations page using the stretched-link pattern (`relative` on the section + `after:absolute after:inset-0` on the existing "View all" link), instead of limiting the affordance to the small "View all" link.
- Added a subtle hover affordance (`hover:border-gray-300 hover:shadow-md`) so the card reads as interactive.

### Anything else to add?

- The stretched overlay means the dollar figures inside the card are no longer text-selectable. They weren't interactive before, so this is acceptable; can scope the click target to the header if selection matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)