### PR TITLE
HOLD UNTIL REQUESTED: Let admins register attendees without sending them a confirmation email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ end
 - `grant_details` — Swaps a grant's eligibility criteria + tasks when the grant picker changes
 - `grant_select` — Tom Select grant picker showing each grant's remaining-of-total funds
 - `inactive_toggle` — Gray out expired affiliations
+- `on_behalf` — Reveal hidden identity fields when an admin registers someone on their behalf
 - `optimistic_bookmark` — Instant bookmark UI feedback
 - `org_toggle` — Organization toggle UI
 - `paginated_fields` — Client-side pagination of nested fields

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -18,7 +18,7 @@ module Events
         return
       end
 
-      @form_fields = visible_form_fields
+      set_field_variables
       @scholarship = scholarship_mode?
       @scholarship_form = @event.scholarship_form if @scholarship
       @event = @event.decorate
@@ -45,7 +45,7 @@ module Events
         @field_errors = @field_errors.merge(FormAnswerValidator.call(scholarship_fields, scholarship_params))
       end
       if @field_errors.any?
-        @form_fields = visible_form_fields
+        set_field_variables
         @event = @event.decorate
         render :new, status: :unprocessable_content
         return
@@ -58,7 +58,10 @@ module Events
         form: @form,
         form_params: registration_params,
         scholarship_requested: @scholarship,
-        person: current_user&.person
+        # On-behalf mode finds/creates the registrant from the form rather than
+        # tying the registration to the admin filling it out.
+        person: registration_person,
+        send_confirmation: !on_behalf?
       )
 
       if result.success?
@@ -72,7 +75,7 @@ module Events
                       notice: "You have been successfully registered!"
         end
       else
-        @form_fields = visible_form_fields
+        set_field_variables
         @event = @event.decorate
         flash.now[:alert] = result.errors.join(", ")
         render :new, status: :unprocessable_content
@@ -111,6 +114,36 @@ module Events
     end
 
     private
+
+    # An admin (or event owner) registering someone else: only honored for users
+    # who can manage the event, so a guest can't suppress their own confirmation.
+    def on_behalf?
+      return false unless ActiveModel::Type::Boolean.new.cast(params[:on_behalf])
+      allowed_to?(:dashboard?, @event)
+    end
+    helper_method :on_behalf?
+
+    # The person the form is being filled out for. In on-behalf mode there's no
+    # logged-in registrant, so we treat it as a fresh (logged-out) submission.
+    def registration_person
+      on_behalf? ? nil : current_user&.person
+    end
+
+    # Builds @form_fields for the registration form. Admins always get the full
+    # logged-out form so they can register a not-logged-in person; the fields
+    # that are normally hidden for the logged-in admin are flagged as
+    # "behalf-only" and revealed client-side when "on behalf" is checked.
+    def set_field_variables
+      unless allowed_to?(:dashboard?, @event)
+        @form_fields = visible_form_fields
+        @behalf_only_field_ids = []
+        return
+      end
+
+      logged_in_ids = visible_form_fields(person: current_user&.person).ids
+      @form_fields = visible_form_fields(person: nil)
+      @behalf_only_field_ids = @form_fields.ids - logged_in_ids
+    end
 
     def credit_card_payment?(form_params)
       payment_method_field = @form.form_fields.find_by(field_identifier: "payment_method")
@@ -190,10 +223,9 @@ module Events
       end
     end
 
-    def visible_form_fields
+    def visible_form_fields(person: registration_person)
       scope = @form.form_fields
 
-      person = current_user&.person
       if person
         # Always hide logged_out_only fields for logged-in users with known data
         known_identifiers = person_known_identifiers(person)

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -84,6 +84,9 @@ application.register("grant-select", GrantSelectController)
 import InactiveToggleController from "./inactive_toggle_controller"
 application.register("inactive-toggle", InactiveToggleController)
 
+import OnBehalfController from "./on_behalf_controller"
+application.register("on-behalf", OnBehalfController)
+
 import OptimisticBookmarkController from "./optimistic_bookmark_controller"
 application.register("optimistic-bookmark", OptimisticBookmarkController)
 

--- a/app/frontend/javascript/controllers/on_behalf_controller.js
+++ b/app/frontend/javascript/controllers/on_behalf_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// On the public registration form, an admin can register a not-logged-in person
+// on their behalf. The form hides identity fields (name, email, ...) that are
+// already on file for the logged-in admin — but the person being registered
+// isn't logged in, so those fields must reappear. Reveals them when the
+// "on behalf" checkbox is checked, hides them again when it's unchecked.
+export default class extends Controller {
+  static targets = ["toggle", "field"]
+
+  connect() {
+    this.reveal()
+  }
+
+  reveal() {
+    const show = this.toggleTarget.checked
+    this.fieldTargets.forEach((field) => field.classList.toggle("hidden", !show))
+  }
+}

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,16 +2,17 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
-    def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil)
-      new(event:, form:, form_params:, scholarship_requested:, person:).call
+    def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil, send_confirmation: true)
+      new(event:, form:, form_params:, scholarship_requested:, person:, send_confirmation:).call
     end
 
-    def initialize(event:, form:, form_params:, scholarship_requested: false, person: nil)
+    def initialize(event:, form:, form_params:, scholarship_requested: false, person: nil, send_confirmation: true)
       @event = event
       @form = form
       @form_params = form_params
       @scholarship_requested = scholarship_requested
       @person = person
+      @send_confirmation = send_confirmation
       @errors = []
     end
 
@@ -282,15 +283,17 @@ module EventRegistrationServices
     end
 
     def send_notifications(event_registration)
-      registrant_email = event_registration.registrant.preferred_email
-
-      NotificationServices::CreateNotification.call(
-        noticeable: event_registration,
-        kind: :event_registration_confirmation,
-        recipient_role: :person,
-        recipient_email: registrant_email,
-        notification_type: 0
-      )
+      # When an admin registers on someone's behalf we skip the registrant-facing
+      # confirmation (they didn't ask to be emailed) but still notify staff.
+      if @send_confirmation
+        NotificationServices::CreateNotification.call(
+          noticeable: event_registration,
+          kind: :event_registration_confirmation,
+          recipient_role: :person,
+          recipient_email: event_registration.registrant.preferred_email,
+          notification_type: 0
+        )
+      end
 
       NotificationServices::CreateNotification.call(
         noticeable: event_registration,

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -15,6 +15,7 @@
     <% if @event.event_forms.registration.exists? || @event.scholarship_form || @event.bulk_payment_form %>
       <% if @event.event_forms.registration.exists? %>
         <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+        <%= link_to "Register on behalf", new_event_public_registration_path(@event, on_behalf: true), class: item_class %>
       <% end %>
       <% if @event.scholarship_form %>
         <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -30,7 +30,7 @@
   <% link_base = "inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors" %>
   <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-8">
     <% if @event.event_forms.registration.exists? %>
-      <%= link_to new_event_public_registration_path(@event, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+      <%= link_to new_event_public_registration_path(@event), target: "_blank", rel: "noopener noreferrer",
             class: "#{link_base} #{DomainTheme.border_class_for(:events, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:events, intensity: 300)} hover:bg-gray-50" do %>
         <i class="fa-solid fa-clipboard-list <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
         Public registration form
@@ -39,7 +39,7 @@
     <% end %>
 
     <% if @event.event_forms.registration.exists? && @event.scholarship_form %>
-      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true), target: "_blank", rel: "noopener noreferrer",
             class: "#{link_base} #{DomainTheme.border_class_for(:scholarships, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:scholarships, intensity: 300)} hover:bg-gray-50" do %>
         <i class="fa-solid fa-graduation-cap <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>"></i>
         Scholarship form

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -69,8 +69,6 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
-      <%= render "forms/header", form: @form, event: @event %>
-
       <% if flash[:alert] %>
         <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
@@ -101,6 +99,8 @@
             </span>
           </label>
         <% end %>
+
+        <%= render "forms/header", form: @form, event: @event %>
 
         <%# Honeypot %>
         <div class="hidden" aria-hidden="true">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -78,12 +78,29 @@
         </div>
       <% end %>
 
-      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2", data: { turbo: !@event.cost_cents.to_i.positive? } do |f| %>
+      <% form_data = { turbo: !@event.cost_cents.to_i.positive? } %>
+      <% form_data[:controller] = "on-behalf" if allowed_to?(:dashboard?, @event) %>
+      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2", data: form_data do |f| %>
 
         <% if @scholarship %>
           <input type="hidden" name="scholarship_requested" value="true">
         <% end %>
 
+        <%# Admin-only: register on someone's behalf without emailing them a
+            confirmation. The submitter is still found/created from the form. %>
+        <% if allowed_to?(:dashboard?, @event) %>
+          <label class="admin-only flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 mb-4 cursor-pointer">
+            <%= check_box_tag :on_behalf, "1", on_behalf?, class: "mt-0.5", data: { on_behalf_target: "toggle", action: "on-behalf#reveal" } %>
+            <span>
+              <span class="block text-sm font-semibold text-blue-900">Registering on someone's behalf</span>
+              <span class="block text-xs text-blue-700">They won't receive a confirmation email — FYI will still be sent.</span>
+            </span>
+            <span class="ml-auto inline-flex items-center gap-1 rounded-full bg-blue-200 px-2 py-0.5 text-[0.65rem] font-semibold text-blue-800">
+              <i class="fa-solid fa-user-shield text-[0.6rem]"></i>
+              Admin only
+            </span>
+          </label>
+        <% end %>
 
         <%# Honeypot %>
         <div class="hidden" aria-hidden="true">
@@ -103,23 +120,25 @@
 
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
           <% @form_fields.each do |field| %>
+            <% behalf_only = @behalf_only_field_ids.include?(field.id) %>
+            <% behalf_data = { on_behalf_target: "field" } if behalf_only %>
             <% if field.group_header? %>
-              <div class="md:col-span-12 pt-7 pb-4">
+              <%= tag.div class: class_names("md:col-span-12 pt-7 pb-4", "hidden" => behalf_only && !on_behalf?), data: behalf_data do %>
                 <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
                   <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
                 <% if field.hint_text.present? %>
                   <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
                 <% end %>
-              </div>
+              <% end %>
             <% else %>
               <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
               <% if submitted_value.blank? && field.field_identifier == "payment_method" %>
                 <% submitted_value = @scholarship ? "Other" : FormBuilderService::PAYMENT_METHOD_PAY_NOW %>
               <% end %>
-              <div class="<%= field.grid_span_class %>">
+              <%= tag.div class: class_names(field.grid_span_class, "hidden" => behalf_only && !on_behalf?), data: behalf_data do %>
                 <%= render "events/public_registrations/form_field", field: field, value: submitted_value, label: email_label_overrides[field.field_identifier] %>
-              </div>
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -22,6 +22,9 @@
       <% end %>
       <%= render "bulk_actions_menu" %>
       <% if allowed_to?(:new?, EventRegistration) %>
+        <% if @event.event_forms.registration.exists? %>
+          <%= link_to "Register on behalf", new_event_public_registration_path(@event, on_behalf: true), class: "admin-only bg-blue-100 btn btn-secondary-outline", title: "Fill out the registration form for someone without emailing them a confirmation" %>
+        <% end %>
         <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "registrants"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
       <% end %>
     </div>

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -179,6 +179,56 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).to include("Community mental health, outpatient, etc")
     end
+
+    it "hides the on-behalf toggle from guests" do
+      get new_event_public_registration_path(event)
+
+      expect(response.body).not_to include("Registering on someone's behalf")
+    end
+
+    it "shows the on-behalf toggle to admins, pre-checked when requested" do
+      sign_in create(:user, :with_person, super_user: true)
+
+      get new_event_public_registration_path(event, on_behalf: true)
+
+      expect(response.body).to include("Registering on someone's behalf")
+      expect(response.body).to match(/name="on_behalf"[^>]*checked/)
+    end
+
+    context "with an identity field that is hidden for a logged-in user" do
+      let(:admin) { create(:user, :with_person, super_user: true) }
+      let!(:first_name_field) do
+        create(:form_field, form: form, field_identifier: "first_name",
+               visibility: :logged_out_only, required: true, name: "First name")
+      end
+
+      before { admin.person.update!(first_name: "Adminna") }
+
+      def first_name_wrapper
+        doc = Nokogiri::HTML(response.body)
+        input = doc.at_css("[name='public_registration[form_fields][#{first_name_field.id}]']")
+        input&.ancestors("[data-on-behalf-target='field']")&.first
+      end
+
+      it "renders the hidden field in the DOM but collapsed behind the toggle" do
+        sign_in admin
+        get new_event_public_registration_path(event)
+
+        expect(response.body).to include('data-controller="on-behalf"')
+        wrapper = first_name_wrapper
+        expect(wrapper).to be_present
+        expect(wrapper["class"]).to include("hidden")
+      end
+
+      it "reveals the field when the form is opened in on-behalf mode" do
+        sign_in admin
+        get new_event_public_registration_path(event, on_behalf: true)
+
+        wrapper = first_name_wrapper
+        expect(wrapper).to be_present
+        expect(wrapper["class"]).not_to include("hidden")
+      end
+    end
   end
 
   describe "GET show" do
@@ -195,6 +245,42 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("<strong>Your details</strong>")
       expect(response.body).to include("<em>Name</em>")
+    end
+  end
+
+  describe "POST create on behalf of someone" do
+    let(:admin) { create(:user, :with_person, super_user: true) }
+    let(:registration) { create(:event_registration, event: event) }
+    let(:result) do
+      EventRegistrationServices::PublicRegistration::Result.new(
+        success?: true, event_registration: registration, form_submission: nil, errors: []
+      )
+    end
+
+    def post_on_behalf
+      post event_public_registration_path(event),
+           params: { on_behalf: "1", public_registration: { form_fields: {
+             essay_field.id.to_s => "this answer has plenty of words"
+           } } }
+    end
+
+    it "tells the service to skip the registrant confirmation when an admin opts in" do
+      sign_in admin
+      expect(EventRegistrationServices::PublicRegistration).to receive(:call)
+        .with(hash_including(send_confirmation: false, person: nil)).and_return(result)
+
+      post_on_behalf
+
+      expect(response).to redirect_to(registration_ticket_path(registration.slug))
+    end
+
+    it "ignores the flag for a guest so the confirmation still sends" do
+      expect(EventRegistrationServices::PublicRegistration).to receive(:call)
+        .with(hash_including(send_confirmation: true)).and_return(result)
+
+      post_on_behalf
+
+      expect(response).to redirect_to(registration_ticket_path(registration.slug))
     end
   end
 end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -104,4 +104,30 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       )
     end
   end
+
+  describe "send_confirmation option" do
+    let(:params) { base_form_params(first_name: "Mara", last_name: "New", email: "mara@example.com") }
+
+    it "sends both the registrant confirmation and the admin FYI by default" do
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation, recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation_fyi, recipient_role: :admin)
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+    end
+
+    it "skips the registrant confirmation but still sends the admin FYI when send_confirmation is false" do
+      expect(NotificationServices::CreateNotification).not_to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation, recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :event_registration_confirmation_fyi, recipient_role: :admin)
+      )
+
+      described_class.call(event: event, form: form, form_params: params, send_confirmation: false)
+    end
+  end
 end


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- Staff frequently register people *on their behalf*, where the automatic "you're registered" email to the attendee is unwanted noise (and sometimes goes to someone who never asked to be emailed).
- This adds an admin-only "on behalf" mode to the public registration form that captures the full registration but suppresses the registrant-facing confirmation — while still sending the staff FYI notification.

### How did you approach the change?
- `PublicRegistration` gained a `send_confirmation:` flag; the controller only honors `on_behalf` for users who can manage the event, finds/creates the registrant from the form (not the admin), and keeps the admin FYI.
- Because the on-behalf attendee isn't logged in, the form now renders the full logged-out field set for admins and reveals the identity fields it normally hides for a logged-in user via a small `on-behalf` Stimulus controller, with "Register on behalf" entry points on the registrants roster and the event Form actions menu.

### UI Testing Checklist
- [ ] As an admin, open an event's registrants page and click "Register on behalf" — the toggle is pre-checked and the name/email identity fields are visible.
- [ ] Submitting in on-behalf mode creates the registration but sends **no** confirmation email to the attendee (staff FYI still arrives).
- [ ] Unchecking "Registering on someone's behalf" re-hides the identity fields; re-checking reveals them.
- [ ] As a logged-out visitor, the on-behalf toggle is not present and registration still emails a confirmation.

### Anything else to add?
- The existing admin "New registration" → confirm-page flow (opt-in email) is unchanged; this complements it for the full-form case. Covered by new request and service specs.