### PR TITLE
HOLD: Add admin-only option to skip the payer confirmation email (bulk payments)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (74) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (75) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -286,6 +286,7 @@ end
 - `grant_details` — Swaps a grant's eligibility criteria + tasks when the grant picker changes
 - `grant_select` — Tom Select grant picker showing each grant's remaining-of-total funds
 - `inactive_toggle` — Gray out expired affiliations
+- `on_behalf` — Reveal hidden identity fields when an admin submits a form (registration, bulk payment) on someone's behalf
 - `optimistic_bookmark` — Instant bookmark UI feedback
 - `org_toggle` — Organization toggle UI
 - `paginated_fields` — Client-side pagination of nested fields

--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -12,10 +12,8 @@ module Events
     def new
       authorize! :bulk_payment, to: :new?
 
-      @form_fields = visible_form_fields
+      set_field_variables
       @event = @event.decorate
-
-      @attendee_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
     end
 
     def create
@@ -25,9 +23,8 @@ module Events
 
       @field_errors = validate_required_fields
       if @field_errors.any?
-        @form_fields = visible_form_fields
+        set_field_variables
         @event = @event.decorate
-        @attendee_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
         render :new, status: :unprocessable_content
         return
       end
@@ -36,7 +33,10 @@ module Events
         event: @event,
         form: @form,
         form_params: @form_params,
-        person: current_user&.person
+        # On-behalf mode finds/creates the payer from the form rather than tying
+        # the submission to the admin filling it out.
+        person: registration_person,
+        send_confirmation: !on_behalf?
       )
 
       if result.success?
@@ -48,9 +48,8 @@ module Events
                       notice: "Your bulk payment information has been submitted."
         end
       else
-        @form_fields = visible_form_fields
+        set_field_variables
         @event = @event.decorate
-        @attendee_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
         flash.now[:alert] = result.errors.join(", ")
         render :new, status: :unprocessable_content
       end
@@ -111,15 +110,46 @@ module Events
 
     private
 
-    def visible_form_fields
-      scope = @form.form_fields.reorder(position: :asc)
+    # An admin (or event manager) submitting a bulk payment for someone else:
+    # only honored for users who can manage the event, so a guest can't suppress
+    # the payer's confirmation email.
+    def on_behalf?
+      return false unless ActiveModel::Type::Boolean.new.cast(params[:on_behalf])
+      allowed_to?(:dashboard?, @event)
+    end
+    helper_method :on_behalf?
 
-      if current_user
-        logged_out_only_ids = scope.where(visibility: :logged_out_only).ids
-        scope = scope.where.not(id: logged_out_only_ids) if logged_out_only_ids.any?
+    # The person the form is being filled out for. In on-behalf mode there's no
+    # logged-in payer, so we treat it as a fresh (logged-out) submission and let
+    # the service find/create the payer from the form.
+    def registration_person
+      on_behalf? ? nil : current_user&.person
+    end
+
+    # Builds @form_fields for the form. Admins always get the full logged-out
+    # field set so they can pay on a not-logged-in person's behalf; the payer
+    # fields normally hidden for the logged-in admin are flagged "behalf-only"
+    # and revealed client-side when "on behalf" is checked.
+    def set_field_variables
+      @attendee_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
+
+      unless allowed_to?(:dashboard?, @event)
+        @form_fields = visible_form_fields
+        @behalf_only_field_ids = []
+        return
       end
 
-      scope
+      logged_in_ids = visible_form_fields(include_logged_out_only: false).ids
+      @form_fields = visible_form_fields(include_logged_out_only: true)
+      @behalf_only_field_ids = @form_fields.ids - logged_in_ids
+    end
+
+    def visible_form_fields(include_logged_out_only: current_user.nil?)
+      scope = @form.form_fields.reorder(position: :asc)
+      return scope if include_logged_out_only
+
+      logged_out_only_ids = scope.where(visibility: :logged_out_only).ids
+      logged_out_only_ids.any? ? scope.where.not(id: logged_out_only_ids) : scope
     end
 
     def set_event
@@ -134,8 +164,11 @@ module Events
     end
 
     def validate_required_fields
+      # In on-behalf mode the payer fields are shown and must be validated even
+      # though they're hidden for a logged-in admin by default.
+      visible_fields = on_behalf? ? visible_form_fields(include_logged_out_only: true) : visible_form_fields
       # The nested attendees field is validated separately, so exclude it here.
-      fields = visible_form_fields.reject { |field| field.field_identifier == "bulk_payment_attendees" }
+      fields = visible_fields.reject { |field| field.field_identifier == "bulk_payment_attendees" }
       FormAnswerValidator.call(fields, @form_params)
     end
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -99,6 +99,9 @@ application.register("grant-select", GrantSelectController)
 import InactiveToggleController from "./inactive_toggle_controller"
 application.register("inactive-toggle", InactiveToggleController)
 
+import OnBehalfController from "./on_behalf_controller"
+application.register("on-behalf", OnBehalfController)
+
 import OptimisticBookmarkController from "./optimistic_bookmark_controller"
 application.register("optimistic-bookmark", OptimisticBookmarkController)
 

--- a/app/frontend/javascript/controllers/on_behalf_controller.js
+++ b/app/frontend/javascript/controllers/on_behalf_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// An admin can fill out a public form (registration, bulk payment) on a
+// not-logged-in person's behalf. The form hides identity fields (name, email,
+// ...) that are already on file for the logged-in admin — but the person being
+// served isn't logged in, so those fields must reappear. Reveals them when the
+// "on behalf" checkbox is checked, hides them again when it's unchecked.
+export default class extends Controller {
+  static targets = ["toggle", "field"]
+
+  connect() {
+    this.reveal()
+  }
+
+  reveal() {
+    const show = this.toggleTarget.checked
+    this.fieldTargets.forEach((field) => field.classList.toggle("hidden", !show))
+  }
+}

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -2,15 +2,16 @@ module EventRegistrationServices
   class BulkPayment
     Result = Struct.new(:success?, :form_submission, :errors, keyword_init: true)
 
-    def self.call(event:, form:, form_params:, person: nil)
-      new(event:, form:, form_params:, person:).call
+    def self.call(event:, form:, form_params:, person: nil, send_confirmation: true)
+      new(event:, form:, form_params:, person:, send_confirmation:).call
     end
 
-    def initialize(event:, form:, form_params:, person: nil)
+    def initialize(event:, form:, form_params:, person: nil, send_confirmation: true)
       @event = event
       @form = form
       @form_params = form_params
       @person = person
+      @send_confirmation = send_confirmation
       @errors = []
     end
 
@@ -28,17 +29,20 @@ module EventRegistrationServices
 
     private
 
-    # Emails the payer a confirmation and notifies staff with an FYI.
+    # Emails the payer a confirmation (unless an admin suppressed it via the
+    # on-behalf option) and always notifies staff with an FYI.
     def send_notifications(submission, person)
-      payer_email = person.preferred_email.presence || field_value("payer_email")&.strip
-      if payer_email.present?
-        NotificationServices::CreateNotification.call(
-          noticeable: submission,
-          kind: :bulk_payment_confirmation,
-          recipient_role: :person,
-          recipient_email: payer_email,
-          notification_type: 0
-        )
+      if @send_confirmation
+        payer_email = person.preferred_email.presence || field_value("payer_email")&.strip
+        if payer_email.present?
+          NotificationServices::CreateNotification.call(
+            noticeable: submission,
+            kind: :bulk_payment_confirmation,
+            recipient_role: :person,
+            recipient_email: payer_email,
+            notification_type: 0
+          )
+        end
       end
 
       NotificationServices::CreateNotification.call(

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -21,6 +21,7 @@
       <% end %>
       <% if @event.bulk_payment_form %>
         <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+        <%= link_to "Bulk payment on behalf", new_event_bulk_payment_path(@event, on_behalf: true), class: item_class %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>
       <%= link_to "Change form settings", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -50,13 +50,31 @@
         </div>
       <% end %>
 
+      <% form_controllers = "bulk-payment-attendees" %>
+      <% form_controllers += " on-behalf" if allowed_to?(:dashboard?, @event) %>
       <%= form_with url: event_bulk_payment_path(@event), method: :post,
-                     data: { controller: "bulk-payment-attendees", action: "submit->bulk-payment-attendees#serialize", turbo: false },
+                     data: { controller: form_controllers, action: "submit->bulk-payment-attendees#serialize", turbo: false },
                      class: "space-y-2" do |f| %>
 
         <div class="hidden" aria-hidden="true">
           <input type="text" name="bulk_payment[website_url]" tabindex="-1" autocomplete="off">
         </div>
+
+        <%# Admin-only: submit a bulk payment on someone's behalf without emailing
+            them a confirmation. The payer is still found/created from the form. %>
+        <% if allowed_to?(:dashboard?, @event) %>
+          <label class="admin-only flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 mb-4 cursor-pointer">
+            <%= check_box_tag :on_behalf, "1", on_behalf?, class: "mt-0.5", data: { on_behalf_target: "toggle", action: "on-behalf#reveal" } %>
+            <span>
+              <span class="block text-sm font-semibold text-blue-900">Submitting on someone's behalf</span>
+              <span class="block text-xs text-blue-700">They won't receive a confirmation email — staff FYI will still be sent.</span>
+            </span>
+            <span class="ml-auto inline-flex items-center gap-1 rounded-full bg-blue-200 px-2 py-0.5 text-[0.65rem] font-semibold text-blue-800">
+              <i class="fa-solid fa-user-shield text-[0.6rem]"></i>
+              Admin only
+            </span>
+          </label>
+        <% end %>
 
         <%
           fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
@@ -66,13 +84,15 @@
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
           <% @form_fields.each do |field| %>
             <% next if field.field_identifier == "bulk_payment_attendees" %>
+            <% behalf_only = @behalf_only_field_ids.include?(field.id) %>
+            <% behalf_data = { on_behalf_target: "field" } if behalf_only %>
 
             <% if field.group_header? %>
-              <div class="md:col-span-12 pt-7 pb-4">
+              <%= tag.div class: class_names("md:col-span-12 pt-7 pb-4", "hidden" => behalf_only && !on_behalf?), data: behalf_data do %>
                 <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
                   <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
-              </div>
+              <% end %>
             <% elsif payer_fields.include?(field.field_identifier) %>
               <%
                 submitted_value = @form_params&.dig(field.id.to_s)
@@ -82,7 +102,7 @@
                 field_name = "bulk_payment[form_fields][#{field.id}]"
                 field_id = "bulk_payment_form_fields_#{field.id}"
               %>
-              <div class="<%= field.grid_span_class %>">
+              <%= tag.div class: class_names(field.grid_span_class, "hidden" => behalf_only && !on_behalf?), data: behalf_data do %>
                 <div class="mb-5">
                   <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
                     <%= form_label_html(field.name) %>
@@ -123,14 +143,14 @@
                     </p>
                   <% end %>
                 </div>
-              </div>
+              <% end %>
             <% elsif field.field_identifier == "payment_method" %>
               <%
                 submitted_value = @form_params&.dig(field.id.to_s)
                 error = @field_errors&.dig(field.id)
                 field_id = "bulk_payment_form_fields_#{field.id}"
               %>
-              <div class="<%= field.grid_span_class %>">
+              <%= tag.div class: class_names(field.grid_span_class, "hidden" => behalf_only && !on_behalf?), data: behalf_data do %>
                 <div class="mb-5">
                   <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5">
                     <%= form_label_html(field.name) %>
@@ -155,7 +175,7 @@
                     </p>
                   <% end %>
                 </div>
-              </div>
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -330,4 +330,81 @@ RSpec.describe "Events::BulkPayments", type: :request do
       expect(flash[:notice]).to eq("Confirmation email sent.")
     end
   end
+
+  describe "admin on-behalf mode" do
+    let(:seeded_form) do
+      FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+    end
+
+    before do
+      EventForm.where(event: event).destroy_all
+      EventForm.create!(event: event, form: seeded_form, role: "bulk_payment")
+    end
+
+    def field_id(key)
+      seeded_form.form_fields.find_by!(field_identifier: key).id.to_s
+    end
+
+    describe "GET new" do
+      it "hides the on-behalf toggle from guests" do
+        sign_out admin
+
+        get new_event_bulk_payment_path(event)
+
+        expect(response.body).not_to include("Submitting on someone's behalf")
+      end
+
+      it "shows the on-behalf toggle to admins, pre-checked when requested" do
+        get new_event_bulk_payment_path(event, on_behalf: true)
+
+        expect(response.body).to include("Submitting on someone's behalf")
+        expect(response.body).to match(/name="on_behalf"[^>]*checked/)
+      end
+
+      it "wires the on-behalf Stimulus controller for admins" do
+        get new_event_bulk_payment_path(event)
+
+        expect(response.body).to include("bulk-payment-attendees on-behalf")
+      end
+    end
+
+    describe "POST create" do
+      let(:submission) { create(:form_submission, form: seeded_form, person: create(:person), role: "bulk_payment") }
+      let(:result) do
+        EventRegistrationServices::BulkPayment::Result.new(success?: true, form_submission: submission, errors: [])
+      end
+
+      def submit(on_behalf:)
+        post event_bulk_payment_path(event),
+             params: {
+               on_behalf: on_behalf ? "1" : "0",
+               bulk_payment: { form_fields: {
+                 field_id("payer_first_name") => "Pat",
+                 field_id("payer_last_name") => "Payer",
+                 field_id("payer_email") => "pat@example.com",
+                 field_id("payment_method") => "Check",
+                 field_id("number_of_attendees") => "3"
+               } }
+             }
+      end
+
+      it "tells the service to skip the payer confirmation when an admin opts in" do
+        expect(EventRegistrationServices::BulkPayment).to receive(:call)
+          .with(hash_including(send_confirmation: false, person: nil)).and_return(result)
+
+        submit(on_behalf: true)
+
+        expect(response).to redirect_to(bulk_payment_ticket_path(submission.slug))
+      end
+
+      it "still sends the confirmation when not in on-behalf mode" do
+        expect(EventRegistrationServices::BulkPayment).to receive(:call)
+          .with(hash_including(send_confirmation: true)).and_return(result)
+
+        submit(on_behalf: false)
+
+        expect(response).to redirect_to(bulk_payment_ticket_path(submission.slug))
+      end
+    end
+  end
 end

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -60,5 +60,16 @@ RSpec.describe EventRegistrationServices::BulkPayment do
 
       described_class.call(event: event, form: form, form_params: base_form_params)
     end
+
+    it "skips the payer confirmation but still sends the FYI when send_confirmation is false" do
+      expect(NotificationServices::CreateNotification).not_to receive(:call).with(
+        hash_including(kind: :bulk_payment_confirmation, recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :bulk_payment_confirmation_fyi, recipient_role: :admin)
+      )
+
+      described_class.call(event: event, form: form, form_params: base_form_params, send_confirmation: false)
+    end
   end
 end


### PR DESCRIPTION
Closes [link an issue or remove this line]

> **Stacked on #1647** (bulk payment confirmation + FYI emails). Review/merge that first; this PR's diff is only the admin skip-email layer. Once #1647 merges, this PR will be retargeted to `main`.

### What is the goal of this PR and why is this important?
- Staff frequently submit bulk payments **on someone's behalf**, where the automatic confirmation email to the payer is unwanted noise (and sometimes reaches someone who never asked to be emailed).
- This adds an admin-only option to suppress the payer confirmation for those submissions, while still sending the staff FYI.

### How did you approach the change?
- `BulkPayment` gained a `send_confirmation:` flag; the controller only honors `on_behalf` for users who can manage the event (so a guest can't suppress their own confirmation) and finds/creates the payer from the form rather than the admin.
- An admin-only checkbox on the bulk payment form toggles this, and a small `on-behalf` Stimulus controller reveals the payer identity fields that are normally hidden for a logged-in admin. Added a "Bulk payment on behalf" entry to the event Form actions menu.

### UI Testing Checklist
- [ ] As an admin, open a bulk payment form — the blue "Submitting on someone's behalf / Admin only" toggle appears (hidden from logged-out visitors).
- [ ] Checking the toggle reveals the payer name/email fields; unchecking re-hides them.
- [ ] Submitting on-behalf sends **no** payer confirmation (staff FYI still arrives); a normal submission emails both.
- [ ] "Bulk payment on behalf" entry in the Form actions menu pre-checks the toggle.

### Anything else to add?
- Overlaps with PR #1626, which introduces the same `on_behalf_controller.js`; this branch carries an identical copy.
- rubocop clean; on-behalf request + service specs pass.
