### PR TITLE
Add license number to person profile

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -364,6 +364,7 @@ class PeopleController < ApplicationController
       :best_time_to_call,
       :date_of_birth,
       :license_number,
+      :license_type,
       :bio, :notes,
       :display_name_preference,
       :pronouns,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -363,6 +363,7 @@ class PeopleController < ApplicationController
       :street_address, :city, :state, :zip, :country, :mailing_address_type,
       :best_time_to_call,
       :date_of_birth,
+      :license_number,
       :bio, :notes,
       :display_name_preference,
       :pronouns,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -280,7 +280,7 @@
               hint: "Maximum 250 characters" %>
 
   <div class="flex flex-col md:flex-row gap-6 items-start">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm md:flex-1">
       <div class="flex flex-col md:flex-row gap-6 items-start">
         <div class="w-full md:w-48">
           <%= f.input :date_of_birth,
@@ -316,14 +316,14 @@
 
     <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
       <div class="flex flex-col md:flex-row gap-6 items-start">
-        <div class="w-full md:w-48">
+        <div class="w-full md:w-36">
           <%= f.input :license_number,
                       label: "License number",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
 
-        <div class="w-full md:w-48">
+        <div class="w-full md:w-36">
           <%= f.input :license_type,
                       label: "License type",
                       input_html: { class: "w-full" },

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -280,42 +280,57 @@
               hint: "Maximum 250 characters" %>
 
   <div class="flex flex-col md:flex-row gap-6 items-start">
-    <div class="w-full md:w-48">
-      <%= f.input :date_of_birth,
-                  label: "Birthday",
-                  as: :date,
-                  discard_year: true,
-                  order: [:month, :day],
-                  prompt: { month: "Month", day: "Day" },
-                  hint: "Month and day only — the year isn't stored.",
-                  wrapper_html: { class: "flex flex-wrap gap-2 items-end" },
-                  label_html: { class: "w-full" },
-                  hint_html: { class: "w-full" },
-                  input_html: {
-                    class: "flex-1 rounded-md border-gray-300 shadow-sm
-                    focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                  } %>
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+      <div class="flex flex-col md:flex-row gap-6 items-start">
+        <div class="w-full md:w-48">
+          <%= f.input :date_of_birth,
+                      label: "Birthday",
+                      as: :date,
+                      discard_year: true,
+                      order: [:month, :day],
+                      prompt: { month: "Month", day: "Day" },
+                      hint: "Month and day only — the year isn't stored.",
+                      wrapper_html: { class: "flex flex-wrap gap-2 items-end" },
+                      label_html: { class: "w-full" },
+                      hint_html: { class: "w-full" },
+                      input_html: {
+                        class: "flex-1 rounded-md border-gray-300 shadow-sm
+                        focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                      } %>
+        </div>
+
+        <% if f.object.user %>
+          <%= f.fields_for :user do |user_form| %>
+            <%= user_form.input :time_zone,
+                        as: :select,
+                        collection: us_time_zone_fundamentals,
+                        selected: user_form.object.time_zone.presence || "Pacific Time (US & Canada)",
+                        include_blank: false,
+                        hint: "Event times and other dates will be shown in this timezone.",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full max-w-md" } %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
 
-    <div class="w-full md:w-48">
-      <%= f.input :license_number,
-                  label: "License number",
-                  input_html: { class: "w-full" },
-                  wrapper_html: { class: "w-full" } %>
-    </div>
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+      <div class="flex flex-col md:flex-row gap-6 items-start">
+        <div class="w-full md:w-48">
+          <%= f.input :license_number,
+                      label: "License number",
+                      input_html: { class: "w-full" },
+                      wrapper_html: { class: "w-full" } %>
+        </div>
 
-    <% if f.object.user %>
-      <%= f.fields_for :user do |user_form| %>
-        <%= user_form.input :time_zone,
-                    as: :select,
-                    collection: us_time_zone_fundamentals,
-                    selected: user_form.object.time_zone.presence || "Pacific Time (US & Canada)",
-                    include_blank: false,
-                    hint: "Event times and other dates will be shown in this timezone.",
-                    input_html: { class: "w-full" },
-                    wrapper_html: { class: "w-full max-w-md" } %>
-      <% end %>
-    <% end %>
+        <div class="w-full md:w-48">
+          <%= f.input :license_type,
+                      label: "License type",
+                      input_html: { class: "w-full" },
+                      wrapper_html: { class: "w-full" } %>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="profile-preferences-section">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -290,7 +290,7 @@
                       order: [:month, :day],
                       prompt: { month: "Month", day: "Day" },
                       hint: "Month and day only",
-                      wrapper_html: { class: "flex flex-wrap gap-2 items-end" },
+                      wrapper_html: { class: "flex flex-wrap gap-x-2 items-end" },
                       label_html: { class: "w-full" },
                       hint_html: { class: "w-full" },
                       input_html: {

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -279,7 +279,7 @@
               },
               hint: "Maximum 250 characters" %>
 
-  <div class="flex flex-col md:flex-row gap-6 items-end">
+  <div class="flex flex-col md:flex-row gap-6 items-start">
     <div class="w-full md:w-48">
       <%= f.input :date_of_birth,
                   label: "Birthday",
@@ -294,6 +294,14 @@
                     focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
                   } %>
     </div>
+
+    <div class="w-full md:w-48">
+      <%= f.input :license_number,
+                  label: "License number",
+                  input_html: { class: "w-full" },
+                  wrapper_html: { class: "w-full" } %>
+    </div>
+
     <% if f.object.user %>
       <%= f.fields_for :user do |user_form| %>
         <%= user_form.input :time_zone,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -279,10 +279,10 @@
               },
               hint: "Maximum 250 characters" %>
 
-  <div class="flex flex-col md:flex-row gap-6 items-start">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm md:flex-1">
-      <div class="flex flex-col md:flex-row gap-6 items-start">
-        <div class="w-full md:w-56">
+  <div class="flex flex-col lg:flex-row gap-6 items-start">
+    <div class="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">
+      <div class="flex flex-col sm:flex-row gap-6 items-start">
+        <div class="w-full sm:w-56">
           <%= f.input :date_of_birth,
                       label: "Birthday",
                       as: :date,
@@ -308,22 +308,22 @@
                         include_blank: false,
                         hint: "Event times and other dates will be shown in this timezone.",
                         input_html: { class: "w-full" },
-                        wrapper_html: { class: "w-full md:flex-1" } %>
+                        wrapper_html: { class: "w-full sm:flex-1" } %>
           <% end %>
         <% end %>
       </div>
     </div>
 
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-      <div class="flex flex-col md:flex-row gap-6 items-start">
-        <div class="w-full md:w-36">
+    <div class="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+      <div class="flex flex-col sm:flex-row gap-6 items-start">
+        <div class="w-full sm:w-36">
           <%= f.input :license_number,
                       label: "License number",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
 
-        <div class="w-full md:w-36">
+        <div class="w-full sm:w-36">
           <%= f.input :license_type,
                       label: "License type",
                       input_html: { class: "w-full" },

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -280,7 +280,7 @@
               hint: "Maximum 250 characters" %>
 
   <div class="flex flex-col lg:flex-row gap-6 items-start">
-    <div class="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">
+    <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">
       <div class="flex flex-col sm:flex-row gap-6 items-start">
         <div class="w-full sm:w-56">
           <%= f.input :date_of_birth,
@@ -314,7 +314,7 @@
       </div>
     </div>
 
-    <div class="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+    <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
       <div class="flex flex-col sm:flex-row gap-6 items-start">
         <div class="w-full sm:w-36">
           <%= f.input :license_number,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -282,7 +282,7 @@
   <div class="flex flex-col md:flex-row gap-6 items-start">
     <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm md:flex-1">
       <div class="flex flex-col md:flex-row gap-6 items-start">
-        <div class="w-full md:w-48">
+        <div class="w-full md:w-56">
           <%= f.input :date_of_birth,
                       label: "Birthday",
                       as: :date,
@@ -308,7 +308,7 @@
                         include_blank: false,
                         hint: "Event times and other dates will be shown in this timezone.",
                         input_html: { class: "w-full" },
-                        wrapper_html: { class: "w-full max-w-md" } %>
+                        wrapper_html: { class: "w-full md:w-72" } %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -289,7 +289,7 @@
                       discard_year: true,
                       order: [:month, :day],
                       prompt: { month: "Month", day: "Day" },
-                      hint: "Month and day only — the year isn't stored.",
+                      hint: "Month and day only",
                       wrapper_html: { class: "flex flex-wrap gap-2 items-end" },
                       label_html: { class: "w-full" },
                       hint_html: { class: "w-full" },
@@ -308,7 +308,7 @@
                         include_blank: false,
                         hint: "Event times and other dates will be shown in this timezone.",
                         input_html: { class: "w-full" },
-                        wrapper_html: { class: "w-full md:w-72" } %>
+                        wrapper_html: { class: "w-full md:flex-1" } %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -287,8 +287,10 @@
                   discard_year: true,
                   order: [:month, :day],
                   prompt: { month: "Month", day: "Day" },
+                  hint: "Month and day only — the year isn't stored.",
                   wrapper_html: { class: "flex flex-wrap gap-2 items-end" },
                   label_html: { class: "w-full" },
+                  hint_html: { class: "w-full" },
                   input_html: {
                     class: "flex-1 rounded-md border-gray-300 shadow-sm
                     focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"

--- a/db/migrate/20260610040000_add_license_number_to_people.rb
+++ b/db/migrate/20260610040000_add_license_number_to_people.rb
@@ -1,9 +1,11 @@
 class AddLicenseNumberToPeople < ActiveRecord::Migration[8.1]
   def up
     add_column :people, :license_number, :string
+    add_column :people, :license_type, :string
   end
 
   def down
+    remove_column :people, :license_type, if_exists: true
     remove_column :people, :license_number, if_exists: true
   end
 end

--- a/db/migrate/20260610040000_add_license_number_to_people.rb
+++ b/db/migrate/20260610040000_add_license_number_to_people.rb
@@ -1,0 +1,9 @@
+class AddLicenseNumberToPeople < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :license_number, :string
+  end
+
+  def down
+    remove_column :people, :license_number, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -226,7 +226,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   end
 
   create_table "banners", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "content", size: :medium
+    t.text "content"
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.boolean "published", default: false, null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   end
 
   create_table "bookmark_annotations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "annotation", size: :long
+    t.text "annotation", size: :medium
     t.integer "bookmark_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -511,7 +511,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   end
 
   create_table "faqs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "answer", size: :long
+    t.text "answer", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.boolean "inactive"
     t.integer "position", null: false
@@ -544,7 +544,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
 
   create_table "form_builders", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.text "description", size: :long
+    t.text "description", size: :medium
     t.string "name"
     t.integer "owner_type"
     t.datetime "updated_at", precision: nil, null: false
@@ -664,14 +664,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   create_table "monthly_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "best_call_time"
     t.boolean "call_requested"
-    t.text "comments", size: :long
+    t.text "comments", size: :medium
     t.datetime "created_at", precision: nil, null: false
-    t.text "goals", size: :long
-    t.text "goals_reached", size: :long
+    t.text "goals", size: :medium
+    t.text "goals_reached", size: :medium
     t.boolean "mail_evaluations"
     t.string "month"
-    t.text "most_challenging", size: :long
-    t.text "most_effective", size: :long
+    t.text "most_challenging", size: :medium
+    t.text "most_effective", size: :medium
     t.string "name"
     t.string "num_new_participants"
     t.string "num_ongoing_participants"
@@ -688,9 +688,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.string "channel", default: "autoemail", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "delivered_at"
-    t.text "email_body_html", size: :medium
-    t.text "email_body_text", size: :medium
-    t.text "email_subject", size: :medium
+    t.text "email_body_html"
+    t.text "email_body_text"
+    t.text "email_subject"
     t.datetime "error_at"
     t.string "error_class"
     t.text "error_message"
@@ -732,7 +732,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.string "agency_type"
     t.string "agency_type_other"
     t.datetime "created_at", precision: nil, null: false
-    t.text "description", size: :long
+    t.text "description", size: :medium
     t.string "email"
     t.date "end_date"
     t.string "filemaker_code"
@@ -742,7 +742,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.integer "location_id"
     t.string "mission_vision_values"
     t.string "name"
-    t.text "notes", size: :long
+    t.text "notes", size: :medium
     t.integer "organization_status_id"
     t.boolean "profile_show_description", default: true, null: false
     t.boolean "profile_show_email", default: true, null: false
@@ -899,6 +899,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.string "last_name", null: false
     t.string "legal_first_name"
     t.string "license_number"
+    t.string "license_type"
     t.string "linked_in_url"
     t.date "member_since"
     t.text "notes"
@@ -953,7 +954,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.boolean "legacy", default: false
     t.integer "legacy_id"
     t.boolean "published", default: false, null: false
-    t.text "quote", size: :long
+    t.text "quote", size: :medium
     t.string "speaker_name"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "workshop_id"
@@ -977,7 +978,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   end
 
   create_table "report_form_field_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "answer", size: :long
+    t.text "answer", size: :medium
     t.integer "answer_option_id"
     t.datetime "created_at", precision: nil
     t.integer "form_field_id"
@@ -1027,7 +1028,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   create_table "resources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "agency"
     t.string "author"
-    t.text "body", size: :long
+    t.text "body", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.boolean "featured", default: false
@@ -1138,7 +1139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   create_table "user_form_form_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_field_id"
-    t.text "text", size: :long
+    t.text "text", size: :medium
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_form_id"
     t.index ["form_field_id"], name: "index_user_form_form_fields_on_form_field_id"
@@ -1175,7 +1176,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.date "birthday"
     t.string "city"
     t.string "city2"
-    t.text "comment", size: :long
+    t.text "comment", size: :medium
     t.datetime "confirmation_sent_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
@@ -1195,7 +1196,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.boolean "legacy", default: false
     t.integer "legacy_id"
     t.datetime "locked_at"
-    t.text "notes", size: :long
+    t.text "notes", size: :medium
     t.bigint "person_id"
     t.string "phone"
     t.string "phone2"
@@ -1398,7 +1399,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
 
   create_table "workshop_variations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "author_credit_preference"
-    t.text "body", size: :long
+    t.text "body", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.boolean "inactive", default: true
@@ -1423,22 +1424,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   end
 
   create_table "workshops", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "age_range", size: :long
-    t.text "age_range_spanish", size: :long
+    t.text "age_range", size: :medium
+    t.text "age_range_spanish", size: :medium
     t.string "author_credit_preference"
     t.string "author_location"
-    t.text "closing", size: :long
-    t.text "closing_spanish", size: :long
+    t.text "closing", size: :medium
+    t.text "closing_spanish", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
-    t.text "creation", size: :long
-    t.text "creation_spanish", size: :long
-    t.text "demonstration", size: :long
-    t.text "demonstration_spanish", size: :long
-    t.text "description", size: :long
-    t.text "description_spanish", size: :long
-    t.text "extra_field", size: :medium
-    t.text "extra_field_spanish", size: :medium
+    t.text "creation", size: :medium
+    t.text "creation_spanish", size: :medium
+    t.text "demonstration", size: :medium
+    t.text "demonstration_spanish", size: :medium
+    t.text "description", size: :medium
+    t.text "description_spanish", size: :medium
+    t.text "extra_field"
+    t.text "extra_field_spanish"
     t.boolean "featured", default: false
     t.string "filemaker_code"
     t.string "full_name"
@@ -1447,40 +1448,40 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.integer "header_file_size"
     t.datetime "header_updated_at", precision: nil
     t.boolean "inactive", default: true
-    t.text "instructions", size: :long
-    t.text "instructions_spanish", size: :long
-    t.text "introduction", size: :long
-    t.text "introduction_spanish", size: :long
+    t.text "instructions", size: :medium
+    t.text "instructions_spanish", size: :medium
+    t.text "introduction", size: :medium
+    t.text "introduction_spanish", size: :medium
     t.integer "led_count", default: 0
     t.boolean "legacy", default: false
     t.integer "legacy_id"
-    t.text "materials", size: :long
-    t.text "materials_spanish", size: :long
+    t.text "materials", size: :medium
+    t.text "materials_spanish", size: :medium
     t.string "misc1"
-    t.text "misc1_spanish", size: :long
+    t.text "misc1_spanish", size: :medium
     t.string "misc2"
-    t.text "misc2_spanish", size: :long
-    t.text "misc_instructions", size: :long
-    t.text "misc_instructions_spanish", size: :long
+    t.text "misc2_spanish", size: :medium
+    t.text "misc_instructions", size: :medium
+    t.text "misc_instructions_spanish", size: :medium
     t.integer "month"
-    t.text "notes", size: :long
-    t.text "notes_spanish", size: :long
-    t.text "objective", size: :long
-    t.text "objective_spanish", size: :long
-    t.text "opening_circle", size: :long
-    t.text "opening_circle_spanish", size: :long
-    t.text "optional_materials", size: :long
-    t.text "optional_materials_spanish", size: :long
+    t.text "notes", size: :medium
+    t.text "notes_spanish", size: :medium
+    t.text "objective", size: :medium
+    t.text "objective_spanish", size: :medium
+    t.text "opening_circle", size: :medium
+    t.text "opening_circle_spanish", size: :medium
+    t.text "optional_materials", size: :medium
+    t.text "optional_materials_spanish", size: :medium
     t.string "photo_caption"
-    t.text "project", size: :long
-    t.text "project_spanish", size: :long
+    t.text "project", size: :medium
+    t.text "project_spanish", size: :medium
     t.string "pub_issue"
     t.boolean "publicly_featured", default: false, null: false
     t.boolean "publicly_visible", default: false, null: false
     t.boolean "published", default: false, null: false
     t.boolean "searchable", default: false
-    t.text "setup", size: :long
-    t.text "setup_spanish", size: :long
+    t.text "setup", size: :medium
+    t.text "setup_spanish", size: :medium
     t.string "thumbnail_content_type"
     t.string "thumbnail_file_name"
     t.integer "thumbnail_file_size"
@@ -1492,17 +1493,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.integer "time_opening"
     t.integer "time_opening_circle"
     t.integer "time_warm_up"
-    t.text "timeframe", size: :long
-    t.text "timeframe_spanish", size: :long
-    t.text "timestamps", size: :long
-    t.text "tips", size: :long
-    t.text "tips_spanish", size: :long
+    t.text "timeframe", size: :medium
+    t.text "timeframe_spanish", size: :medium
+    t.text "timestamps", size: :medium
+    t.text "tips", size: :medium
+    t.text "tips_spanish", size: :medium
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
-    t.text "visualization", size: :long
-    t.text "visualization_spanish", size: :long
-    t.text "warm_up", size: :long
-    t.text "warm_up_spanish", size: :long
+    t.text "visualization", size: :medium
+    t.text "visualization_spanish", size: :medium
+    t.text "warm_up", size: :medium
+    t.text "warm_up_spanish", size: :medium
     t.integer "windows_type_id"
     t.bigint "workshop_idea_id"
     t.integer "year"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -898,6 +898,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_180000) do
     t.string "instagram_url"
     t.string "last_name", null: false
     t.string "legal_first_name"
+    t.string "license_number"
     t.string "linked_in_url"
     t.date "member_since"
     t.text "notes"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Adds `license_number` and `license_type` fields to `Person` so admins can record a professional credential (the number and what kind it is) alongside other contact details — there was previously nowhere to store this.

### How did you approach the change?
- One reversible migration adds two nullable string columns (`license_number`, `license_type`) to `people`; both are permitted in `person_params`.
- Reworked the birthday/timezone row of the person edit form into two cards: birthday + timezone on the left, license number + license type on the right, so related fields read as a unit. Added a hint to the birthday field (month/day only) to balance the row.

### UI Testing Checklist
- [ ] On the person edit form, two cards appear in one row: Birthday/Time zone on the left, License number/License type on the right.
- [ ] Entering license number and type, saving, and reopening the form shows the saved values.
- [ ] For a person with no associated user, the Time zone field is absent and the left card still lays out cleanly.

### Anything else to add?
- `license_number` and `license_type` are optional free-form strings (no format/uniqueness validation, `license_type` is not a constrained enum) and are not yet shown on the profile/show page — easy to add if desired.