### PR TITLE
Add follow-up flag to comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -31,6 +31,18 @@ class CommentsController < ApplicationController
     end
   end
 
+  def update
+    @comment = @commentable.comments.find(params[:id])
+    authorize! @comment
+    @comment.updated_by = current_user
+    @comment.update(comment_params)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path }
+    end
+  end
+
   private
 
   def set_commentable
@@ -50,6 +62,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:topic, :body)
+    params.require(:comment).permit(:topic, :body, :flagged)
   end
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -222,7 +222,7 @@ class EventRegistrationsController < ApplicationController
       :scholarship_requested,
       :ce_credit_requested,
       organization_ids: [],
-      comments_attributes: [ :id, :topic, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]
     )
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -227,7 +227,7 @@ class OrganizationsController < ApplicationController
         :end_date,
         :_destroy
       ],
-      comments_attributes: [ :id, :topic, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       addresses_attributes: [
         :id,
         :address_type,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -456,7 +456,7 @@ class PeopleController < ApplicationController
         :end_date,
         :_destroy
       ],
-      comments_attributes: [ :id, :topic, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
     )
   end
 end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -157,7 +157,7 @@ class ScholarshipsController < ApplicationController
   def scholarship_params
     params.require(:scholarship).permit(
       :amount_dollars, :amount_cents, :tasks_completed, :grant_id, :recipient_id,
-      comments_attributes: [ :id, :topic, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]
     )
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -422,7 +422,7 @@ class UsersController < ApplicationController
       :phone, :phone2, :phone3, :birthday, :best_time_to_call, :notes, # legacy to remove later
       #####
 
-      comments_attributes: [ :id, :topic, :body, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       affiliations_attributes: [ :id, :organization_id, :position, :title, :inactive, :primary_contact, :start_date, :end_date, :_destroy ],
     )
   end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -292,7 +292,7 @@ class WorkshopsController < ApplicationController
       workshop_series_children_attributes: [ :id, :workshop_child_id, :workshop_parent_id, :theme_name,
                                             :series_description, :series_description_spanish,
                                             :position, :_destroy ],
-      comments_attributes: [ :id, :topic, :body, :_destroy ]
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
     )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,4 +9,5 @@ class Comment < ApplicationRecord
   validates :body, presence: true, unless: :persisted?
 
   scope :newest_first, -> { order(created_at: :desc) }
+  scope :flagged, -> { where(flagged: true) }
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,5 +1,5 @@
 class CommentPolicy < ApplicationPolicy
-  alias_rule :index?, :create?, to: :manage?
+  alias_rule :index?, :create?, :update?, to: :manage?
 
   def manage?
     admin?

--- a/app/views/comments/_comment_fields.html.erb
+++ b/app/views/comments/_comment_fields.html.erb
@@ -30,10 +30,15 @@
 <% updated_color = show_updated ? label_colors[(updated_user.id || 0) % label_colors.length] : nil %>
 <% current_color = label_colors[(current_user&.id || 0) % label_colors.length] %>
 <% is_age_range_data = f.object.persisted? && f.object.body&.include?("[AGE_RANGE_DATA]") %>
-<div class="nested-fields" data-paginated-fields-target="item">
+<div class="nested-fields flex items-start gap-x-1" data-paginated-fields-target="item">
   <%= f.hidden_field :id if f.object.persisted? %>
+  <label class="cursor-pointer shrink-0 mt-1 leading-none" title="Flag for follow-up">
+    <%= f.check_box :flagged, class: "peer sr-only" %>
+    <i class="fa-regular fa-flag text-gray-500 hover:text-orange-400 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+  </label>
+  <div class="grow">
   <% if f.object.persisted? %>
-    <div class="comment-view flex items-center mb-3 pl-4 gap-x-1 <%= "bg-amber-50 border border-amber-200 rounded-md py-1" if is_age_range_data %>">
+    <div class="comment-view flex items-center mb-3 gap-x-1 <%= "bg-amber-50 border border-amber-200 rounded-md py-1" if is_age_range_data %>">
       <span class="text-xs text-gray-400 whitespace-nowrap shrink-0">
         <%= f.object.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
       </span>
@@ -50,7 +55,7 @@
         <% if f.object.topic.present? %><span class="font-bold uppercase tracking-wide"><%= f.object.topic %></span> <% end %><%= truncate(f.object.body, length: 135) %>
       </span>
     </div>
-    <div class="comment-edit flex items-start mb-1 pl-4 gap-x-1 <%= "bg-amber-50 border border-amber-200 rounded-md py-1" if is_age_range_data %>" style="display:none">
+    <div class="comment-edit flex items-start mb-1 gap-x-1 <%= "bg-amber-50 border border-amber-200 rounded-md py-1" if is_age_range_data %>" style="display:none">
       <span class="text-xs text-gray-400 whitespace-nowrap shrink-0 mt-2">
         <%= f.object.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
       </span>
@@ -112,4 +117,5 @@
       </div>
     </div>
   <% end %>
+  </div>
 </div>

--- a/app/views/comments/_flag_toggle.html.erb
+++ b/app/views/comments/_flag_toggle.html.erb
@@ -1,0 +1,8 @@
+<%= button_to polymorphic_path([ commentable, comment ]),
+              method: :patch,
+              params: { comment: { flagged: !comment.flagged } },
+              form: { id: dom_id(comment, :flag) },
+              class: "leading-none",
+              title: comment.flagged? ? "Flagged for follow-up — click to clear" : "Flag for follow-up" do %>
+  <i class="fa-flag <%= comment.flagged? ? "fa-solid text-orange-500" : "fa-regular text-gray-500 hover:text-orange-400" %>"></i>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -14,5 +14,12 @@
                       class: "grow bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
   </div>
 
-  <%= f.submit "Add Comment", class: "btn btn-secondary-outline" %>
+  <div class="flex items-center gap-x-3">
+    <%= f.submit "Add Comment", class: "btn btn-secondary-outline" %>
+    <label class="inline-flex items-center cursor-pointer select-none" title="Flag this note for follow-up">
+      <%= f.check_box :flagged, class: "peer sr-only" %>
+      <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+      <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flag</span>
+    </label>
+  </div>
 <% end %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -2,7 +2,7 @@
   <div class="space-y-3">
     <% if comments.any? %>
       <% comments.each do |comment| %>
-        <div class="grid grid-cols-[auto_1fr] gap-x-3 items-start">
+        <div class="grid grid-cols-[auto_1fr_auto] gap-x-3 items-start">
           <span class="text-xs text-gray-400 mt-1 whitespace-nowrap">
             <%= comment.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
           </span>
@@ -12,6 +12,9 @@
             <% end %>
             <%= simple_format(comment.body) %>
           </div>
+          <span class="mt-0.5">
+            <%= render "comments/flag_toggle", commentable: commentable, comment: comment %>
+          </span>
         </div>
       <% end %>
 

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@comment, :flag) do %>
+  <%= render "comments/flag_toggle", commentable: @commentable, comment: @comment %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
       get :confirm_email_manual
       post :process_email_manual
     end
-    resources :comments, only: [ :index, :create ]
+    resources :comments, only: [ :index, :create, :update ]
   end
 
   get "contact_us", to: "contact_us#index"
@@ -100,7 +100,7 @@ Rails.application.routes.draw do
       get :link_organization
       post :select_organization
     end
-    resources :comments, only: [ :index, :create ]
+    resources :comments, only: [ :index, :create, :update ]
   end
   resources :forms do
     member do
@@ -144,7 +144,7 @@ Rails.application.routes.draw do
       get :workshop_logs
       get :checkout
     end
-    resources :comments, only: [ :index, :create ]
+    resources :comments, only: [ :index, :create, :update ]
   end
   resources :faqs
   resources :notifications, only: [ :index, :show, :update ] do
@@ -159,7 +159,7 @@ Rails.application.routes.draw do
     member do
       get :populations_served
     end
-    resources :comments, only: [ :index, :create ]
+    resources :comments, only: [ :index, :create, :update ]
     resources :monthly_reports, only: :index
   end
   resources :payments, only: [ :new, :create, :show, :index ] do
@@ -209,7 +209,7 @@ Rails.application.routes.draw do
   resources :workshop_variation_ideas
   resources :workshop_variations
   resources :workshops do
-    resources :comments, only: [ :index, :create ]
+    resources :comments, only: [ :index, :create, :update ]
   end
 
   resources :workshop_mentions, only: [ :index ]

--- a/db/migrate/20260611120000_add_flagged_to_comments.rb
+++ b/db/migrate/20260611120000_add_flagged_to_comments.rb
@@ -1,0 +1,10 @@
+class AddFlaggedToComments < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:comments, :flagged)
+    add_column :comments, :flagged, :boolean, null: false, default: false
+  end
+
+  def down
+    remove_column :comments, :flagged, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -369,6 +369,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_040000) do
     t.string "commentable_type", null: false
     t.datetime "created_at", null: false
     t.integer "created_by_id"
+    t.boolean "flagged", default: false, null: false
     t.string "topic"
     t.datetime "updated_at", null: false
     t.integer "updated_by_id"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     # Polymorphic association: belongs_to :commentable
     association :commentable, factory: :user
 
+    trait :flagged do
+      flagged { true }
+    end
+
     trait :for_person do
       association :commentable, factory: :person
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -67,5 +67,12 @@ RSpec.describe Comment, type: :model do
       expect(user.comments.first).to eq(new_comment)
       expect(user.comments.last).to eq(old_comment)
     end
+
+    it 'returns only flagged comments with the flagged scope' do
+      flagged = create(:comment, :flagged, commentable: user, body: "Flagged comment")
+
+      expect(Comment.flagged).to include(flagged)
+      expect(Comment.flagged).not_to include(old_comment, new_comment)
+    end
   end
 end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe "Comments", type: :request do
       expect(comment.topic).to eq("Follow up")
       expect(comment.body).to eq("Called the family.")
     end
+
+    it "creates a comment flagged for follow-up" do
+      post person_comments_path(person), params: { comment: { body: "Check back later.", flagged: "1" } }
+
+      expect(person.comments.last).to be_flagged
+    end
+  end
+
+  describe "PATCH /people/:person_id/comments/:id" do
+    it "toggles the flagged state" do
+      comment = create(:comment, commentable: person, body: "Called the family.")
+
+      patch person_comment_path(person, comment), params: { comment: { flagged: "true" } }, as: :turbo_stream
+      expect(comment.reload).to be_flagged
+      expect(response.body).to include("text-orange-500")
+
+      patch person_comment_path(person, comment), params: { comment: { flagged: "false" } }, as: :turbo_stream
+      expect(comment.reload).not_to be_flagged
+    end
   end
 
   describe "GET /people/:person_id/comments" do

--- a/spec/requests/people_create_spec.rb
+++ b/spec/requests/people_create_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe "POST /people", type: :request do
     end
   end
 
+  describe "flagging a comment via nested attributes on update" do
+    it "persists the flagged state from the person form" do
+      person = create(:person)
+      comment = create(:comment, commentable: person, body: "Called the family.")
+
+      patch person_path(person), params: {
+        person: {
+          first_name: person.first_name,
+          category_ids: [ "" ],
+          comments_attributes: {
+            "0" => { id: comment.id, body: comment.body, flagged: "1" }
+          }
+        }
+      }
+
+      expect(comment.reload).to be_flagged
+    end
+  end
+
   describe "user_attributes are applied on create" do
     it "updates the user's time_zone from the person form" do
       user = create(:user, time_zone: "Hawaii")


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins need a lightweight way to mark a comment as needing follow-up so important notes don't get lost.
- A `flagged` boolean on comments makes those notes visually stand out and filterable (a `Comment.flagged` scope is added).

### How did you approach the change?
- Added a reversible migration plus the `flagged` column, model scope, and `:flagged` permit across all commentable controllers' nested attributes.
- Surfaced flagging in three places: a flag checkbox when adding a comment, an inline Turbo-powered toggle on comment lists (new `update` action + `flag_toggle` partial + turbo stream), and via nested attributes on parent forms — all gated behind the existing admin `manage?` policy.

### UI Testing Checklist
- [ ] Add a comment with the flag checked and confirm it persists as flagged.
- [ ] Toggle the inline flag on a comment list and confirm it updates without a full page reload.
- [ ] Edit a parent record's comments and confirm flag state saves via nested attributes.

### Anything else to add?
- Specs cover the model scope, create/update requests, and nested-attribute flagging.