### PR TITLE
Add sortable column headers to the registrants table

### DIFF
--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -36,29 +36,49 @@
     <% form_submissions = event_form_ids.any? ? FormSubmission.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
     <% if @event_registrations.any? %>
       <div class="overflow-x-auto">
-        <table class="w-full border-collapse border border-gray-200">
+        <% payment_col = @event.cost_cents.to_i > 0 %>
+        <% date_index = payment_col ? 5 : 4 %>
+        <% attendance_index = payment_col ? 6 : 5 %>
+        <table class="w-full border-collapse border border-gray-200" data-controller="table-sort">
           <thead class="bg-gray-100">
             <tr>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full">Organization</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Scholarship</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700" aria-sort="none">
+                <span class="inline-flex items-center gap-1.5">
+                  <%= render "shared/sortable_header", label: "First", index: 0, key: "first" %>
+                  <span class="text-gray-300" aria-hidden="true">/</span>
+                  <%= render "shared/sortable_header", label: "Last", index: 0, key: "last" %>
+                </span>
+              </th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none">
+                <%= render "shared/sortable_header", label: "Organization", index: 1 %>
+              </th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                <%= render "shared/sortable_header", label: "Scholarship", index: 2 %>
+              </th>
 
-              <% if @event.cost_cents.to_i > 0 %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Payment</th>
+              <% if payment_col %>
+                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                  <%= render "shared/sortable_header", label: "Payment", index: 3 %>
+                </th>
               <% end %>
 
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col>Confirmed</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Attendance</th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                <%= render "shared/sortable_header", label: "Date registered", index: date_index %>
+              </th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                <%= render "shared/sortable_header", label: "Attendance", index: attendance_index %>
+              </th>
               <th class="px-4 py-2"></th>
             </tr>
           </thead>
 
-          <tbody class="divide-y divide-gray-200">
+          <tbody class="divide-y divide-gray-200" data-table-sort-target="body">
             <% @event_registrations.each do |registration| %>
               <% person = registration.registrant %>
 
               <tr class="hover:bg-gray-50 transition-colors duration-150">
-                <td class="px-4 py-2">
+                <td class="px-4 py-2" data-sort-first="<%= person.first_name.to_s.downcase %>" data-sort-last="<%= person.last_name.to_s.downcase %>">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
@@ -150,9 +170,9 @@
                 </td>
 
                 <% if @event.cost_cents.to_i > 0 %>
-                  <td class="px-4 py-2 text-sm text-center">
-                    <% paid_cents = registration.allocations_sum %>
-                    <% due_cents = @event.cost_cents - paid_cents %>
+                  <% paid_cents = registration.allocations_sum %>
+                  <% due_cents = @event.cost_cents - paid_cents %>
+                  <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= due_cents %>">
                     <% is_paid = registration.paid_in_full? %>
 
                     <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{is_paid ? 'bg-green-50 text-green-700 border-green-200' : 'bg-amber-50 text-amber-700 border-amber-200'} hover:opacity-80", title: (!is_paid && paid_cents > 0 ? "$%.2f paid" % (paid_cents / 100.0) : nil), data: { turbo_frame: "_top" } do %>
@@ -173,7 +193,8 @@
                   <% end %>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-nowrap text-center"><%= render "event_registrations/attendance_status_badge", registration: registration %></td>
+                <td class="px-4 py-2 text-sm text-nowrap text-center text-gray-600" data-sort-value="<%= registration.created_at.to_i %>" title="<%= registration.created_at.strftime("%B %-d, %Y at %l:%M %P") %>"><%= registration.created_at.strftime("%b %-d, %Y") %></td>
+                <td class="px-4 py-2 text-sm text-nowrap text-center" data-sort-value="<%= registration.status %>"><%= render "event_registrations/attendance_status_badge", registration: registration %></td>
                 <td class="px-4 py-2 text-right text-sm"><%= link_to "Edit", edit_event_registration_path(registration, return_to: "registrants"), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
               </tr>
             <% end %>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -123,15 +123,7 @@
                   <span class="inline-flex items-center gap-1.5">
                     <% (col[:parts] || [ { label: col[:label] } ]).each_with_index do |part, i| %>
                       <% if i.positive? %><span class="text-gray-300" aria-hidden="true">/</span><% end %>
-                      <button type="button"
-                              class="inline-flex items-center gap-1 cursor-pointer select-none hover:text-gray-900"
-                              data-table-sort-target="header"
-                              data-sort-index="<%= col[:index] %>"
-                              <%= "data-sort-key=#{part[:key]}".html_safe if part[:key] %>
-                              data-action="table-sort#sort">
-                        <%= part[:label] %>
-                        <span data-sort-indicator><i class="fa-solid fa-sort text-gray-400"></i></span>
-                      </button>
+                      <%= render "shared/sortable_header", label: part[:label], index: col[:index], key: part[:key] %>
                     <% end %>
                   </span>
                 </th>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -51,14 +51,8 @@
                  ] %>
               <% columns.each do |col| %>
                 <th class="px-4 py-3 <%= col[:align] %>" aria-sort="none">
-                  <button type="button"
-                          class="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500 cursor-pointer select-none hover:text-gray-700"
-                          data-table-sort-target="header"
-                          data-sort-index="<%= col[:index] %>"
-                          data-action="table-sort#sort">
-                    <%= col[:label] %>
-                    <span data-sort-indicator><i class="fa-solid fa-sort text-gray-400"></i></span>
-                  </button>
+                  <%= render "shared/sortable_header", label: col[:label], index: col[:index],
+                        class: "text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-700" %>
                 </th>
               <% end %>
             </tr>

--- a/app/views/shared/_sortable_header.html.erb
+++ b/app/views/shared/_sortable_header.html.erb
@@ -1,0 +1,20 @@
+<%# Click-to-sort column header button for the table-sort Stimulus controller.
+    Pair with data-controller="table-sort" on the table and
+    data-table-sort-target="body" on the tbody.
+    Locals:
+      label  - header text
+      index  - column position, matching the cell index in the row
+      key    - optional named sort key (reads data-sort-<key> from the cell),
+               letting one cell offer several sub-sorts (e.g. first/last name)
+      class  - optional button styling; defaults to a neutral hover %>
+<% key = local_assigns.fetch(:key, nil) %>
+<% button_class = local_assigns.fetch(:class, "hover:text-gray-900") %>
+<button type="button"
+        class="inline-flex items-center gap-1.5 cursor-pointer select-none <%= button_class %>"
+        data-table-sort-target="header"
+        data-sort-index="<%= index %>"
+        <%= "data-sort-key=#{key}".html_safe if key %>
+        data-action="table-sort#sort">
+  <%= label %>
+  <span data-sort-indicator><i class="fa-solid fa-sort text-gray-400"></i></span>
+</button>


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
Staff reviewing an event's registrant list could not reorder it, making large rosters hard to scan. This makes every column header on the registrants table click-to-sort, and adds a new **Date registered** column so registrations can be ordered chronologically.

### How did you approach the change?
Wired the registrants table to the existing `table-sort` Stimulus controller and gave each cell the right `data-sort-value` so money sorts numerically and dates chronologically; the Name header offers separate **First** / **Last** sub-sorts. To avoid duplicating header-button markup, I extracted a shared `shared/_sortable_header` partial and refactored the existing Grants and event Background tables to render through it as well (their existing styling preserved via an optional `class:` local).

### UI Testing Checklist
- [ ] Registrants table headers (First/Last, Organization, Scholarship, Payment, Date registered, Attendance) sort ascending/descending on click
- [ ] Date registered column displays and sorts chronologically
- [ ] Grants index and event Background tables still sort and look unchanged

### Anything else to add?
Sorting is client-side (operates on the currently loaded/filtered rows), consistent with the Grants and Background tables. One minor cosmetic change: Background header buttons now use `gap-1.5` to match the other tables.