### PR TITLE
Restore one-click registration for signed-in members on public events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,6 +71,14 @@ class Event < ApplicationRecord
     forms.find_by(event_forms: { role: "registration" })
   end
 
+  # Whether a signed-in user should register in one click rather than being
+  # routed to the registration form. True when no registration form is linked,
+  # or when an admin has explicitly opted members out of the form. A linked form
+  # (even one without fields yet) routes signed-in users to the form.
+  def one_click_for_signed_in?
+    signed_in_one_click_enabled? || registration_form.nil?
+  end
+
   def scholarship_form
     forms.find_by(event_forms: { role: "scholarship" })
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -111,6 +111,7 @@ class EventPolicy < ApplicationPolicy
                   :autoshow_pre_date_text,
                   :autoshow_registration_close,
                   :public_registration_enabled,
+                  :signed_in_one_click_enabled,
                   :pre_title,
                   :pre_date_text,
                   :featured,

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -69,15 +69,15 @@
       <span class="admin-only bg-blue-100 p-1 text-sm text-gray-500 italic">Not published</span>
     <% elsif event.registerable? %>
       <% if user_signed_in? %>
-        <% if event.object.registration_form&.form_fields&.any? %>
-          <%= link_to "Register",
-                      new_event_public_registration_path(event),
-                      data: { turbo_frame: "_top" },
-                      class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
-        <% else %>
+        <% if event.object.one_click_for_signed_in? %>
           <%= button_to "Register",
                       event_registrant_registration_path(event_id: event),
                       data: { turbo: !event.object.cost_cents.to_i.positive? },
+                      class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
+        <% else %>
+          <%= link_to "Register",
+                      new_event_public_registration_path(event),
+                      data: { turbo_frame: "_top" },
                       class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
         <% end %>
       <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -335,31 +335,6 @@
         <div id="registration_form_section" class="border border-gray-300 p-4 rounded-b-md" data-reveal-section-target="content">
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <p class="text-sm mb-2">
-                Public registration:
-                <% if @event.public_registration_enabled? %>
-                  <a href="#public_registration_setting"
-                     class="text-green-700 font-medium hover:underline"
-                     data-controller="anchor-highlight"
-                     data-action="click->anchor-highlight#flash"
-                     data-anchor-highlight-target-param="public_registration_setting">Enabled</a>
-                <% else %>
-                  <a href="#public_registration_setting"
-                     class="text-gray-500 font-medium hover:underline"
-                     data-controller="anchor-highlight"
-                     data-action="click->anchor-highlight#flash"
-                     data-anchor-highlight-target-param="public_registration_setting">Disabled</a>
-                <% end %>
-              </p>
-              <% if @event.event_forms.registration.exists? %>
-                <%= link_to "View public registration page",
-                            new_event_public_registration_path(@event),
-                            class: "text-sm text-blue-700 hover:text-blue-900 underline",
-                            target: "_blank" %>
-              <% end %>
-            </div>
-
-            <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Registration form</label>
               <% current_reg_form = @event.registration_form %>
               <% default_form_id = if current_reg_form
@@ -384,19 +359,74 @@
                 <%= link_to "View / Edit forms", forms_path, class: "text-blue-600 hover:text-blue-800 underline", target: "_blank" %>
               </p>
             </div>
+
+            <div>
+              <span class="block text-sm font-medium text-gray-700 mb-1">Public registration</span>
+              <div class="flex items-center gap-2 text-sm">
+                <% if @event.public_registration_enabled? %>
+                  <span class="inline-flex items-center gap-1 font-medium text-green-700">
+                    <i class="fa-solid fa-circle-check"></i> Enabled
+                  </span>
+                <% else %>
+                  <span class="inline-flex items-center gap-1 font-medium text-gray-500">
+                    <i class="fa-solid fa-circle-xmark"></i> Disabled
+                  </span>
+                <% end %>
+                <a href="#public_registration_setting"
+                   class="text-blue-600 hover:text-blue-800 underline"
+                   data-controller="anchor-highlight"
+                   data-action="click->anchor-highlight#flash"
+                   data-anchor-highlight-target-param="public_registration_setting">Change</a>
+              </div>
+              <% if @event.event_forms.registration.exists? %>
+                <%= link_to new_event_public_registration_path(@event),
+                            class: "inline-flex items-center gap-1 text-sm text-blue-700 hover:text-blue-900 underline mt-2",
+                            target: "_blank" do %>
+                  <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i> View public registration page
+                <% end %>
+              <% end %>
+            </div>
           </div>
 
-          <div class="mt-4 pt-4 border-t border-gray-200">
-            <label class="flex items-center gap-2 cursor-pointer">
-              <%= check_box_tag "event[scholarship_enabled]", "1", @event.scholarship_form.present? %>
-              <span class="text-sm font-medium text-gray-700">Enable scholarship application</span>
-            </label>
-          </div>
-          <div class="pb-4">
-            <label class="flex items-center gap-2 cursor-pointer">
-              <%= check_box_tag "event[bulk_payment_enabled]", "1", @event.bulk_payment_form.present? %>
-              <span class="text-sm font-medium text-gray-700">Enable bulk payment</span>
-            </label>
+          <div class="mt-5 pt-4 border-t border-gray-200">
+            <span class="block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3">Registration options</span>
+            <div class="space-y-4">
+              <div>
+                <label class="flex items-center gap-2 cursor-pointer">
+                  <%= f.check_box :signed_in_one_click_enabled %>
+                  <span class="text-sm font-medium text-gray-700">Signed-in users register in one click</span>
+                </label>
+                <p class="text-xs text-gray-500 mt-1">Skip the registration form for logged-in users. Logged-out visitors still use the form.</p>
+              </div>
+              <div>
+                <label class="flex items-center gap-2 cursor-pointer">
+                  <%= check_box_tag "event[scholarship_enabled]", "1", @event.scholarship_form.present? %>
+                  <span class="text-sm font-medium text-gray-700">Enable scholarship application</span>
+                </label>
+                <p class="text-xs text-gray-500 mt-1">Add a scholarship form so registrants can request financial assistance.</p>
+                <% if @event.scholarship_form.present? %>
+                  <%= link_to new_event_public_registration_path(@event, scholarship_requested: true),
+                              class: "inline-flex items-center gap-1 text-xs text-blue-700 hover:text-blue-900 underline mt-1",
+                              target: "_blank" do %>
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i> Preview scholarship form
+                  <% end %>
+                <% end %>
+              </div>
+              <div class="pb-4">
+                <label class="flex items-center gap-2 cursor-pointer">
+                  <%= check_box_tag "event[bulk_payment_enabled]", "1", @event.bulk_payment_form.present? %>
+                  <span class="text-sm font-medium text-gray-700">Enable bulk payment</span>
+                </label>
+                <p class="text-xs text-gray-500 mt-1">Let one person register and pay for a group of attendees at once.</p>
+                <% if @event.bulk_payment_form.present? %>
+                  <%= link_to new_event_bulk_payment_path(@event),
+                              class: "inline-flex items-center gap-1 text-xs text-blue-700 hover:text-blue-900 underline mt-1",
+                              target: "_blank" do %>
+                    <i class="fa-solid fa-arrow-up-right-from-square"></i> Preview bulk payment page
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -21,17 +21,17 @@
         <span class="admin-only bg-blue-100 p-1 text-sm text-gray-500 italic">Not published</span>
       <% elsif event.registerable? %>
         <% if user_signed_in? %>
-          <% if event.object.registration_form&.form_fields&.any? %>
-            <%= link_to button_text,
-                        new_event_public_registration_path(event),
-                        class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
-                        style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
-          <% else %>
+          <% if event.object.one_click_for_signed_in? %>
             <%= button_to button_text,
                           event_registrant_registration_path(event_id: event),
                           data: { turbo: !event.object.cost_cents.to_i.positive? },
                           class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
                           style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+          <% else %>
+            <%= link_to button_text,
+                        new_event_public_registration_path(event),
+                        class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
+                        style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
           <% end %>
         <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
           <%= link_to button_text,

--- a/db/migrate/20260611160000_add_signed_in_one_click_enabled_to_events.rb
+++ b/db/migrate/20260611160000_add_signed_in_one_click_enabled_to_events.rb
@@ -1,0 +1,14 @@
+class AddSignedInOneClickEnabledToEvents < ActiveRecord::Migration[8.1]
+  # Lets signed-in users register in one click even when a registration form
+  # exists. The form is still required for logged-out visitors (we have none of
+  # their details), but admins can let members skip it. Default false preserves
+  # the existing behavior of routing signed-in users to a populated form.
+  def up
+    return if column_exists?(:events, :signed_in_one_click_enabled)
+    add_column :events, :signed_in_one_click_enabled, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :events, :signed_in_one_click_enabled, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_160000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -501,6 +501,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
     t.boolean "publicly_visible", default: false, null: false
     t.boolean "published", default: false, null: false
     t.datetime "registration_close_date", precision: nil
+    t.boolean "signed_in_one_click_enabled", default: false, null: false
     t.datetime "start_date", precision: nil
     t.string "title"
     t.datetime "updated_at", null: false

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -171,6 +171,34 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#one_click_for_signed_in?" do
+    it "is true when no registration form is linked" do
+      event = create(:event)
+      expect(event.one_click_for_signed_in?).to be true
+    end
+
+    it "is false when an empty registration form is linked" do
+      form = create(:form, name: "Empty Registration")
+      event = create(:event)
+      create(:event_form, event: event, form: form, role: "registration")
+      expect(event.one_click_for_signed_in?).to be false
+    end
+
+    it "is false when a registration form with fields is linked" do
+      form = create(:form, :with_fields, name: "Real Registration")
+      event = create(:event)
+      create(:event_form, event: event, form: form, role: "registration")
+      expect(event.one_click_for_signed_in?).to be false
+    end
+
+    it "is true when signed_in_one_click_enabled overrides a populated form" do
+      form = create(:form, :with_fields, name: "Real Registration")
+      event = create(:event, signed_in_one_click_enabled: true)
+      create(:event_form, event: event, form: form, role: "registration")
+      expect(event.one_click_for_signed_in?).to be true
+    end
+  end
+
   describe '.search_by_params' do
     let!(:art_event) { create(:event, title: 'Art Workshop Showcase', description: 'Annual art exhibition') }
     let!(:music_event) { create(:event, title: 'Music Therapy Session', description: 'Healing through music') }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -112,6 +112,28 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "GET /edit registration form section" do
+    let(:event) { create(:event) }
+
+    before { sign_in admin }
+
+    it "shows preview links for enabled add-ons" do
+      create(:event_form, event: event, form: create(:form, name: "Scholarship"), role: "scholarship")
+      create(:event_form, event: event, form: create(:form, name: "Bulk"), role: "bulk_payment")
+      get edit_event_path(event)
+      expect(response.body).to include("Preview scholarship form")
+      expect(response.body).to include("scholarship_requested=true")
+      expect(response.body).to include("Preview bulk payment page")
+      expect(response.body).to include("/events/#{event.id}/bulk_payment/new")
+    end
+
+    it "omits preview links when add-ons are disabled" do
+      get edit_event_path(event)
+      expect(response.body).not_to include("Preview scholarship form")
+      expect(response.body).not_to include("Preview bulk payment page")
+    end
+  end
+
   describe "POST /create" do
     context "as admin" do
       before { sign_in admin }
@@ -1051,6 +1073,36 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Staffed event")
         expect(response.body).not_to include("Other event")
       end
+    end
+  end
+
+  describe "GET /show register button for signed-in users" do
+    let(:registerable_event) { create(:event, :published) }
+    let(:one_click_action) { "/events/#{registerable_event.id}/registrations" }
+    let(:form_path) { new_event_public_registration_path(registerable_event) }
+
+    before { sign_in user }
+
+    it "renders a one-click register button when no registration form is linked" do
+      get event_url(registerable_event)
+      expect(response.body).to include(one_click_action)
+      expect(response.body).not_to include(form_path)
+    end
+
+    it "routes to the registration form when one is linked" do
+      form = create(:form, name: "Registration")
+      create(:event_form, event: registerable_event, form: form, role: "registration")
+      get event_url(registerable_event)
+      expect(response.body).to include(form_path)
+    end
+
+    it "renders a one-click button when a form is linked but signed_in_one_click is enabled" do
+      form = create(:form, name: "Registration")
+      create(:event_form, event: registerable_event, form: form, role: "registration")
+      registerable_event.update!(signed_in_one_click_enabled: true)
+      get event_url(registerable_event)
+      expect(response.body).to include(one_click_action)
+      expect(response.body).not_to include(form_path)
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Since the custom-forms refactor, every publicly-registerable event is required to carry a registration form (logged-out visitors need it), which forced signed-in members through the full form and silently removed their one-click "Register" — the reported regression. This restores one-click for members without taking the form away from guests.

### How did you approach the change?
Added a per-event `signed_in_one_click_enabled` flag and an `Event#one_click_for_signed_in?` decision (one-click when no registration form is linked, or when the flag opts members out); the event card and registration section now branch on it. While in the Registration Form settings card, I also clarified its layout (grouped "Registration options", an explicit "Change" affordance for the public-registration status) and added preview links for the scholarship and bulk-payment add-ons to match the registration form's existing preview link.

### UI Testing Checklist
- [ ] Signed-in user on a public event with a registration form: "Register" goes to the form
- [ ] Enable "Signed-in users register in one click": signed-in "Register" now one-clicks; logged-out visitors still get the form
- [ ] Event with no registration form: signed-in "Register" one-clicks
- [ ] Registration Form settings card: scholarship/bulk-payment preview links appear only when each add-on is enabled and open the right page

### Anything else to add?
Covered by new model specs (`Event#one_click_for_signed_in?`) and request specs (register button rendering + add-on preview links). The toggle lives in the Registration Form card next to the scholarship/bulk-payment options.
