### PR TITLE
HOLD: Allocate bulk payments to attendee registrations

### DIFF
--- a/app/frontend/javascript/controllers/bulk_payment_attendees_controller.js
+++ b/app/frontend/javascript/controllers/bulk_payment_attendees_controller.js
@@ -44,8 +44,9 @@ export default class extends Controller {
       const first_name = row.querySelector("[data-attendee-field=\"first_name\"]")?.value || ""
       const last_name = row.querySelector("[data-attendee-field=\"last_name\"]")?.value || ""
       const email = row.querySelector("[data-attendee-field=\"email\"]")?.value || ""
-      if (first_name || last_name || email) {
-        attendees.push({ first_name, last_name, email })
+      const amount = row.querySelector("[data-attendee-field=\"amount\"]")?.value || ""
+      if (first_name || last_name || email || amount) {
+        attendees.push({ first_name, last_name, email, amount })
       }
     })
     this.hiddenInputTarget.value = JSON.stringify(attendees)

--- a/app/models/concerns/pay_charge_extensions.rb
+++ b/app/models/concerns/pay_charge_extensions.rb
@@ -61,9 +61,10 @@ module PayChargeExtensions
       .joins(:form_field)
       .where(form_fields: { field_identifier: "bulk_payment_attendees" })
       .first
+    attendees = []
     if attendee_answer&.submitted_answer.present?
-      parsed = JSON.parse(attendee_answer.submitted_answer) rescue []
-      payment_metadata[:attendees] = parsed
+      attendees = JSON.parse(attendee_answer.submitted_answer) rescue []
+      payment_metadata[:attendees] = attendees
     end
     count_answer = submission.form_answers
       .joins(:form_field)
@@ -80,6 +81,58 @@ module PayChargeExtensions
       pay_charge_id: id,
       metadata: payment_metadata
     )
+
+    allocate_bulk_payment(payment, attendees, metadata["event_id"])
+  end
+
+  # Match each attendee to an existing registration by name + email and
+  # allocate the amount the payer entered for them, capped at the registration's
+  # remaining cost and the payment's unallocated balance. Ambiguous or unmatched
+  # attendees are left for manual allocation.
+  def allocate_bulk_payment(payment, attendees, event_id)
+    return if event_id.blank?
+
+    attendees.each do |attendee|
+      registration = matching_registration(attendee, event_id)
+      next unless registration
+
+      allocation_amount = [
+        bulk_attendee_amount_cents(attendee),
+        registration.remaining_cost,
+        payment.amount_cents_remaining
+      ].min
+      next unless allocation_amount > 0
+
+      Allocation.create!(
+        source: payment,
+        allocatable: registration,
+        amount: allocation_amount
+      )
+    end
+  end
+
+  def matching_registration(attendee, event_id)
+    first_name = attendee["first_name"].to_s.strip
+    last_name = attendee["last_name"].to_s.strip
+    email = attendee["email"].to_s.strip
+    return if first_name.blank? || last_name.blank? || email.blank?
+
+    people = Person.where(
+      "LOWER(first_name) = ? AND LOWER(last_name) = ? AND LOWER(email) = ?",
+      first_name.downcase, last_name.downcase, email.downcase
+    )
+    return unless people.count == 1
+
+    EventRegistration.find_by(event_id: event_id, registrant_id: people.first.id)
+  end
+
+  def bulk_attendee_amount_cents(attendee)
+    amount = attendee["amount"].to_s.strip
+    return 0 if amount.blank?
+
+    (BigDecimal(amount) * 100).round
+  rescue ArgumentError
+    0
   end
 
   def create_donation_payment(person_id)

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -161,56 +161,58 @@
           <div>
 
             <template data-bulk-payment-attendees-target="template">
-              <div class="flex items-start gap-3 mb-3" data-bulk-payment-attendees-target="row">
-                <div class="flex-1 grid grid-cols-1 md:grid-cols-4 gap-3">
-                  <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_first_name">Attendee first name</label>
-                    <input type="text"
-                           name="bulk_payment[attendees][INDEX][first_name]"
-                           id="attendee_INDEX_first_name"
-                           data-attendee-field="first_name"
-                           class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
-                  </div>
-                  <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_last_name">Attendee last name</label>
-                    <input type="text"
-                           name="bulk_payment[attendees][INDEX][last_name]"
-                           id="attendee_INDEX_last_name"
-                           data-attendee-field="last_name"
-                           class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
-                  </div>
-                  <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_email">Attendee email</label>
-                    <input type="email"
-                           name="bulk_payment[attendees][INDEX][email]"
-                           id="attendee_INDEX_email"
-                           data-attendee-field="email"
-                           class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
-                  </div>
-                  <div>
-                    <label class="block text-xs font-semibold text-gray-700 mb-1" for="attendee_INDEX_amount">Amount</label>
-                    <div class="relative">
-                      <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-gray-400">$</span>
-                      <input type="number"
-                             min="0"
-                             step="0.01"
-                             inputmode="decimal"
-                             name="bulk_payment[attendees][INDEX][amount]"
-                             id="attendee_INDEX_amount"
-                             data-attendee-field="amount"
-                             class="w-full rounded-lg border border-gray-300 bg-white pl-7 pr-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+              <li class="mb-3" data-bulk-payment-attendees-target="row">
+                <div class="flex items-start gap-3">
+                  <div class="flex-1 grid grid-cols-1 md:grid-cols-4 gap-3">
+                    <div>
+                      <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_first_name">Attendee first name</label>
+                      <input type="text"
+                             name="bulk_payment[attendees][INDEX][first_name]"
+                             id="attendee_INDEX_first_name"
+                             data-attendee-field="first_name"
+                             class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                    </div>
+                    <div>
+                      <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_last_name">Attendee last name</label>
+                      <input type="text"
+                             name="bulk_payment[attendees][INDEX][last_name]"
+                             id="attendee_INDEX_last_name"
+                             data-attendee-field="last_name"
+                             class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                    </div>
+                    <div>
+                      <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_email">Attendee email</label>
+                      <input type="email"
+                             name="bulk_payment[attendees][INDEX][email]"
+                             id="attendee_INDEX_email"
+                             data-attendee-field="email"
+                             class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                    </div>
+                    <div>
+                      <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_amount">Attendee amount</label>
+                      <div class="relative">
+                        <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-gray-400">$</span>
+                        <input type="number"
+                               min="0"
+                               step="0.01"
+                               inputmode="decimal"
+                               name="bulk_payment[attendees][INDEX][amount]"
+                               id="attendee_INDEX_amount"
+                               data-attendee-field="amount"
+                               class="w-full rounded-lg border border-gray-300 bg-white pl-7 pr-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                      </div>
                     </div>
                   </div>
+                  <button type="button"
+                          data-action="bulk-payment-attendees#removeRow"
+                          class="mt-7 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-400 hover:text-red-600 hover:bg-red-50 transition cursor-pointer">
+                    <i class="fa-solid fa-xmark"></i>
+                  </button>
                 </div>
-                <button type="button"
-                        data-action="bulk-payment-attendees#removeRow"
-                        class="mt-7 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-400 hover:text-red-600 hover:bg-red-50 transition cursor-pointer">
-                  <i class="fa-solid fa-xmark"></i>
-                </button>
-              </div>
+              </li>
             </template>
 
-            <div data-bulk-payment-attendees-target="rows"></div>
+            <ol class="list-decimal ps-8 marker:font-semibold marker:text-gray-500" data-bulk-payment-attendees-target="rows"></ol>
 
             <input type="hidden"
                    name="bulk_payment[form_fields][<%= @attendee_field.id %>]"

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -162,7 +162,7 @@
 
             <template data-bulk-payment-attendees-target="template">
               <div class="flex items-start gap-3 mb-3" data-bulk-payment-attendees-target="row">
-                <div class="flex-1 grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div class="flex-1 grid grid-cols-1 md:grid-cols-4 gap-3">
                   <div>
                     <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_first_name">Attendee first name</label>
                     <input type="text"
@@ -186,6 +186,20 @@
                            id="attendee_INDEX_email"
                            data-attendee-field="email"
                            class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                  </div>
+                  <div>
+                    <label class="block text-xs font-semibold text-gray-700 mb-1" for="attendee_INDEX_amount">Amount</label>
+                    <div class="relative">
+                      <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-gray-400">$</span>
+                      <input type="number"
+                             min="0"
+                             step="0.01"
+                             inputmode="decimal"
+                             name="bulk_payment[attendees][INDEX][amount]"
+                             id="attendee_INDEX_amount"
+                             data-attendee-field="amount"
+                             class="w-full rounded-lg border border-gray-300 bg-white pl-7 pr-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
+                    </div>
                   </div>
                 </div>
                 <button type="button"

--- a/spec/models/concerns/pay_charge_extensions_spec.rb
+++ b/spec/models/concerns/pay_charge_extensions_spec.rb
@@ -58,6 +58,81 @@ RSpec.describe PayChargeExtensions do
     end
   end
 
+  describe "bulk payment allocation" do
+    let(:event) { create(:event, cost_cents: 15_00) }
+
+    let(:alice) { create(:person, first_name: "Alice", last_name: "Anderson", email: "alice@example.com") }
+    let(:bob) { create(:person, first_name: "Bob", last_name: "Brown", email: "bob@example.com") }
+    let!(:alice_registration) { create(:event_registration, registrant: alice, event: event) }
+    let!(:bob_registration) { create(:event_registration, registrant: bob, event: event) }
+
+    let(:payer) { create(:person) }
+    let(:form) { create(:form) }
+    let(:submission) { FormSubmission.create!(person: payer, form: form, role: "bulk_payment") }
+
+    let(:attendees) do
+      [
+        { "first_name" => "Alice", "last_name" => "Anderson", "email" => "alice@example.com", "amount" => "15.00" },
+        { "first_name" => "Bob", "last_name" => "Brown", "email" => "bob@example.com", "amount" => "10.00" },
+        { "first_name" => "Carol", "last_name" => "Unknown", "email" => "carol@example.com", "amount" => "5.00" }
+      ]
+    end
+
+    before do
+      attendee_field = create(:form_field, form: form, field_identifier: "bulk_payment_attendees")
+      create(:form_answer,
+        form_submission: submission,
+        form_field: attendee_field,
+        submitted_answer: attendees.to_json)
+    end
+
+    let(:bulk_metadata) { { "form_submission_id" => submission.id, "event_id" => event.id } }
+
+    let(:bulk_charge_object) do
+      {
+        "id" => "ch_bulk",
+        "object" => "charge",
+        "amount" => 30_00,
+        "currency" => "usd",
+        "paid" => true,
+        "metadata" => bulk_metadata,
+        "refunds" => { "object" => "list", "data" => [], "has_more" => false }
+      }
+    end
+
+    let!(:bulk_charge) do
+      Pay::Charge.create!(
+        customer: pay_customer,
+        processor_id: "ch_bulk",
+        amount: 30_00,
+        amount_refunded: 0,
+        currency: "usd",
+        object: bulk_charge_object,
+        metadata: bulk_metadata
+      )
+    end
+
+    it "allocates each matched attendee's specified amount to their registration" do
+      payment = ExternalProcessorPayment.find_by(pay_charge_id: bulk_charge.id)
+
+      alice_allocation = Allocation.find_by(source: payment, allocatable: alice_registration)
+      bob_allocation = Allocation.find_by(source: payment, allocatable: bob_registration)
+
+      expect(alice_allocation.amount).to eq(15_00)
+      expect(bob_allocation.amount).to eq(10_00)
+    end
+
+    it "does not allocate to unmatched attendees" do
+      payment = ExternalProcessorPayment.find_by(pay_charge_id: bulk_charge.id)
+      expect(payment.allocations.count).to eq(2)
+    end
+
+    it "leaves the unallocated remainder on the payment" do
+      payment = ExternalProcessorPayment.find_by(pay_charge_id: bulk_charge.id)
+      expect(payment.amount_cents_remaining).to eq(5_00)
+    end
+  end
+
   describe "refund sync" do
     let(:refunded_object) do
       charge_object.deep_merge(


### PR DESCRIPTION
## Why

Bulk payments recorded a payer and an attendee list, but the money was never tied to anyone's event registration — allocating it was a manual admin step. This wires up auto-allocation so each attendee's share lands on their registration.

## What

- **Per-attendee amount** — each attendee row on the bulk payment form gains an `Attendee amount` field; the serialized JSON now carries `{ first_name, last_name, email, amount }`. Rows render as a numbered `<ol>`.
- **Allocation on payment** — when a bulk payment is confirmed, `create_bulk_payment` matches each attendee to a registration by name + email (the same identity rule `Person` uniqueness uses) and allocates the amount the payer entered, capped at the registration's `remaining_cost` and the payment's unallocated balance.
- **Ambiguous / unmatched attendees are skipped** — a no-match or a duplicate name+email is left unallocated so its share stays on the payment (`amount_cents_remaining`) for manual handling.

## Notes

- Matching on **name + email** (not email alone) resolves the shared-inbox case — e.g. two family members on one email are distinct people. Because `(registrant_id, event_id)` is unique, a matched person maps to exactly one registration per event.
- The amount arrives as a dollar string and is converted to cents (`BigDecimal`); non-numeric/blank amounts allocate nothing.

## Status

- [x] Form + serializer capture per-attendee amount
- [x] Spec for allocation behavior
- [x] Allocation logic implemented in `create_bulk_payment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)