### PR TITLE
Refine registration close date display and default

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
     "{{event_platform}}" => [ "Virtual platform", "Zoom" ],
     "{{event_location}}" => [ "In-person location", "Los Angeles, CA" ],
     "{{event_month_year}}" => [ "Event month and year", "July 2026" ],
-    "{{registration_close}}" => [ "Registration close date", "June 20, 2026 9:00 am PST" ]
+    "{{registration_close}}" => [ "Registration close date", "July 20th at 9am PST" ]
   }.freeze
 
   # Render a form header, filling event-driven tokens (see FORM_HEADER_TOKENS) from
@@ -105,13 +105,17 @@ module ApplicationHelper
     event&.location&.name.presence
   end
 
-  # Registration close date formatted like the event show page (e.g.
-  # "June 20, 2026 9:00 am PST"), or nil when there's no close date.
+  # Registration close date for form-header interpolation, e.g.
+  # "July 20th at 9am PST": ordinal day, no year, compact time (minutes only
+  # when not on the hour). Nil when there's no close date.
   def event_registration_close_label(event)
     close = event&.registration_close_date
     return unless close
     local = close.in_time_zone(Time.zone)
-    "#{local.strftime("%B %-d, %Y %-l:%M %P")} #{local.strftime("%Z")}"
+    time = local.strftime("%-l")
+    time += ":#{local.strftime("%M")}" unless local.strftime("%M") == "00"
+    time += local.strftime("%P")
+    "#{local.strftime("%B")} #{local.day.ordinalize} at #{time} #{local.strftime("%Z")}"
   end
 
   # Rainbow gradient accent bar shown beside form section headers.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,6 +118,15 @@ module ApplicationHelper
     "#{local.strftime("%B")} #{local.day.ordinalize} at #{time} #{local.strftime("%Z")}"
   end
 
+  # Default registration close datetime suggested on the event form: 9am on the
+  # Monday before the event's start date. New events without a start date yet
+  # fall back to two days out at 9am.
+  def event_registration_close_default(event)
+    start = event&.start_date
+    base = start ? (start.in_time_zone(Time.zone) - 1.day).beginning_of_week(:monday) : 2.days.from_now
+    base.change(hour: 9, min: 0)
+  end
+
   # Rainbow gradient accent bar shown beside form section headers.
   def form_section_bar_class
     "h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -117,7 +117,7 @@
                 "Registration close time",
                 class: "block font-medium mb-1" %>
 
-          <% registration_close_default = @event.registration_close_date || 2.days.from_now.change(hour: 9, min: 0) %>
+          <% registration_close_default = @event.registration_close_date || event_registration_close_default(@event) %>
           <%= f.text_field :registration_close_date,
                        type: "datetime-local",
                        class:

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -117,11 +117,12 @@
                 "Registration close time",
                 class: "block font-medium mb-1" %>
 
+          <% registration_close_default = @event.registration_close_date || 2.days.from_now.change(hour: 9, min: 0) %>
           <%= f.text_field :registration_close_date,
                        type: "datetime-local",
                        class:
                          "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                       value: @event.registration_close_date&.strftime("%Y-%m-%dT%H:%M") %>
+                       value: registration_close_default.strftime("%Y-%m-%dT%H:%M") %>
 
           <% if f.object.errors[:registration_close_date].any? %>
             <p class="text-red-500 text-sm mt-1">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -61,7 +61,7 @@
         </div>
         <div>
           <h2 class="text-xl font-semibold tracking-wide leading-tight">Registration</h2>
-          <p class="text-sm text-blue-200">Reserve your spot — it only takes a minute.</p>
+          <p class="text-sm text-blue-200">Reserve your spot.</p>
         </div>
       </div>
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -255,4 +255,24 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.form_header_uses_tokens?(build(:form, header: nil))).to be false
     end
   end
+
+  describe "#event_registration_close_default" do
+    it "is 9am on the Monday of the start date's week" do
+      event = build(:event, start_date: Time.zone.local(2026, 7, 22, 13, 0)) # Wednesday
+      expect(helper.event_registration_close_default(event)).to eq(Time.zone.local(2026, 7, 20, 9, 0))
+    end
+
+    it "is the prior Monday at 9am when the event starts on a Monday" do
+      event = build(:event, start_date: Time.zone.local(2026, 7, 20, 9, 0)) # Monday
+      expect(helper.event_registration_close_default(event)).to eq(Time.zone.local(2026, 7, 13, 9, 0))
+    end
+
+    it "falls back to two days out at 9am when there is no start date" do
+      event = build(:event, start_date: nil)
+      default = helper.event_registration_close_default(event)
+      expect(default.hour).to eq(9)
+      expect(default.min).to eq(0)
+      expect(default.to_date).to eq(2.days.from_now.to_date)
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -171,11 +171,22 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.form_header_html(form)).to eq("Register for our upcoming training.")
     end
 
-    it "fills the {{registration_close}} token from the event's close date" do
+    it "fills the {{registration_close}} token as 'Month Dayth at time' without the year" do
       form = build(:form, header: "Registration closes {{registration_close}}.")
-      event = build(:event, registration_close_date: Time.zone.local(2026, 6, 20, 9, 0))
+      close = Time.zone.local(2026, 7, 20, 9, 0)
+      event = build(:event, registration_close_date: close)
+      tz = close.strftime("%Z")
       expect(helper.form_header_html(form, event: event))
-        .to eq("Registration closes #{event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %-l:%M %P %Z")}.")
+        .to eq("Registration closes July 20th at 9am #{tz}.")
+    end
+
+    it "includes minutes in the {{registration_close}} token when not on the hour" do
+      form = build(:form, header: "Registration closes {{registration_close}}.")
+      close = Time.zone.local(2026, 7, 20, 14, 30)
+      event = build(:event, registration_close_date: close)
+      tz = close.strftime("%Z")
+      expect(helper.form_header_html(form, event: event))
+        .to eq("Registration closes July 20th at 2:30pm #{tz}.")
     end
 
     it "falls back when the event has no registration close date" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Make the registration deadline read naturally in form copy and faster for staff to set.

### How did you approach the change?
- Removed the filler "it only takes a minute." line from the public registration card header.
- Reformatted the `{{registration_close}}` form-header token to `July 20th at 9am PST` — ordinal day, no year, compact time (minutes shown only when not on the hour) — via `event_registration_close_label`.
- Defaulted the event-edit registration close datetime field to **9am on the Monday before the event's start date** (`event_registration_close_default`), falling back to two days out at 9am for new events that have no start date yet. The field is a `datetime-local`, so both date and time stay editable.
- Updated the token reference example shown on the form editor and added helper specs (compact-time, not-on-the-hour, and the Monday-before default including the Monday-start edge case).

### Anything else to add?
- The interpolated label shows the **actual** chosen close time (year omitted); it is not pinned to 9am — only the edit field *defaults* to 9am, so an admin's chosen time is always what registrants see.
- "Monday before" resolves to the prior Monday when the event itself starts on a Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)