### PR TITLE
Make field subtitles editable in the form editor

### DIFF
--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -108,6 +108,9 @@
                 <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
                   <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
+                <% if field.hint_text.present? %>
+                  <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
+                <% end %>
               </div>
             <% else %>
               <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -52,7 +52,10 @@
         </button>
       </div>
 
-      <div class="hidden mt-2 flex items-center" data-field-options-target="panel">
+      <div class="hidden mt-2 flex flex-col gap-2" data-field-options-target="panel">
+        <%= f.text_area :hint_text, rows: 2,
+              class: "w-full text-sm text-gray-600 rounded border-gray-300 shadow-sm px-2 py-1",
+              placeholder: "Subtitle" %>
         <%= link_to_remove_association "Remove", f,
               class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0 ml-auto" %>
       </div>
@@ -91,26 +94,29 @@
 
       <% option_source = form_field_option_source(field) %>
       <div class="hidden mt-2 flex flex-col gap-3" data-field-options-target="panel">
-        <div class="flex flex-wrap items-center gap-3">
-          <% if option_source %>
-            <%# These options are managed centrally, not per-field — link admins to that list. %>
-            <span class="inline-flex items-center gap-1.5 text-sm text-gray-500">
-              <i class="fa-solid fa-database text-xs text-gray-400"></i>
-              Options from
-              <%= link_to option_source[:label], option_source[:path],
-                    class: "font-medium text-purple-600 hover:text-purple-800 underline",
-                    target: "_blank", rel: "noopener" %>
-            </span>
-          <% else %>
-            <button type="button"
-                    class="<%= "hidden" unless field.multiple_choice? %> flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
-                    data-answer-options-target="section"
-                    data-action="answer-options#toggle">
-              <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>
-              Answer options
-              <span class="text-xs text-gray-400">(<%= field.form_field_answer_options.size %>)</span>
-            </button>
-          <% end %>
+        <div class="flex flex-wrap items-center gap-2">
+          <%# Fixed-width first column so the Subtitle box lines up under the answer-type dropdown above. %>
+          <div class="min-w-0 flex-[3_1_10rem]">
+            <% if option_source %>
+              <%# These options are managed centrally, not per-field — link admins to that list. %>
+              <span class="inline-flex items-center gap-1.5 text-sm text-gray-500">
+                <i class="fa-solid fa-database text-xs text-gray-400"></i>
+                Options from
+                <%= link_to option_source[:label], option_source[:path],
+                      class: "font-medium text-purple-600 hover:text-purple-800 underline",
+                      target: "_blank", rel: "noopener" %>
+              </span>
+            <% else %>
+              <button type="button"
+                      class="<%= "hidden" unless field.multiple_choice? %> flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
+                      data-answer-options-target="section"
+                      data-action="answer-options#toggle">
+                <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>
+                Answer options
+                <span class="text-xs text-gray-400">(<%= field.form_field_answer_options.size %>)</span>
+              </button>
+            <% end %>
+          </div>
           <%
             width_options = [
               [ "Full width", "full" ],
@@ -119,6 +125,9 @@
               [ "Quarter width", "quarter" ]
             ]
           %>
+          <%= f.text_area :hint_text, rows: 1, placeholder: "Subtitle",
+                class: "min-w-0 flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                title: "Optional subtitle shown under the field label" %>
           <%= f.select :width, width_options,
                 {},
                 class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -75,6 +75,9 @@
                     <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
                   <% end %>
                 </div>
+                <% if field.hint_text.present? %>
+                  <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
+                <% end %>
               </div>
             <% else %>
               <div class="<%= field.grid_span_class %>">

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -178,6 +178,15 @@ RSpec.describe "Forms", type: :request do
 
       expect(response.body).to include("<textarea")
     end
+
+    it "renders an editable subtext field for a section header" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, answer_type: :group_header, name: "Contact info")
+
+      get edit_form_path(form)
+
+      expect(response.body).to include("[hint_text]")
+    end
   end
 
   describe "GET /forms/:id (preview)" do
@@ -193,6 +202,16 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("<strong>Section</strong>")
       expect(response.body).to include("<em>Your name</em>")
+    end
+
+    it "renders a section header's subtext under the heading" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, answer_type: :group_header, name: "Contact info", hint_text: "Tell us how to reach you")
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Tell us how to reach you")
     end
 
     it "renders the form header HTML under the title" do
@@ -220,6 +239,16 @@ RSpec.describe "Forms", type: :request do
       form = create(:form, :standalone)
       patch form_path(form), params: { form: { header: "<strong>Read carefully</strong>" } }
       expect(form.reload.header).to eq("<strong>Read carefully</strong>")
+      expect(response).to redirect_to(edit_form_path(form))
+    end
+
+    it "saves the subtext for a section header" do
+      form = create(:form, :standalone)
+      header = create(:form_field, form: form, answer_type: :group_header, name: "Contact info")
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { id: header.id, hint_text: "Tell us how to reach you" } } }
+      }
+      expect(header.reload.hint_text).to eq("Tell us how to reach you")
       expect(response).to redirect_to(edit_form_path(form))
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins had no way to set a field/section **subtitle**. The `hint_text` column existed and already rendered on public forms, but it wasn't editable.

### How did you approach the change?
- Added a "Subtitle" input to the field editor — inline under the input-type dropdown for fields (aligned beneath it) and in the section-header options panel.
- Section-header subtitles now render under the heading on the public registration form and the preview; regular-field subtitles already rendered.
- No migration or controller change — `hint_text` was already permitted. Added request specs for the editor input, saving, and rendering.

### UI Testing Checklist
- [ ] Expand a field's options — the Subtitle box sits under the input-type dropdown.
- [ ] Section header — subtitle editable in its options panel; renders under the heading on the public form and preview.
- [ ] Set subtitles, save, confirm they persist and render.

### Anything else to add?
- This is the first of three stacked PRs split by topic. The next two build on it: **form preview** and **form builder UI**.
- Subtitles are plain text (not rich HTML like section names) — say the word if HTML/links should be supported.
