### PR TITLE
Use the rhino editor for the form header field

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -124,7 +124,7 @@ class FormsController < ApplicationController
 
   def form_params
     params.require(:form).permit(
-      :name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions,
+      :name, :role, :rhino_header, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
         :id, :name, :answer_type, :required, :hint_text,
         :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy,

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,8 @@
 class Form < ApplicationRecord
+  # Optional rich-text intro shown under the form title on the preview and
+  # public registration pages.
+  has_rich_text :rhino_header
+
   belongs_to :owner, polymorphic: true, optional: true
   has_many :form_fields, dependent: :destroy, inverse_of: :form
   has_many :event_forms, dependent: :destroy

--- a/app/views/forms/_header.html.erb
+++ b/app/views/forms/_header.html.erb
@@ -1,7 +1,7 @@
-<%# Optional admin-authored HTML intro, shown directly under a form's title on
-    the internal preview and the public registration pages. Locals: form. %>
-<% if form.header.present? %>
-  <div class="rich-label mb-6 text-sm text-gray-700 leading-relaxed space-y-2">
-    <%= form_label_html(form.header) %>
+<%# Optional admin-authored rich-text intro, shown directly under a form's title
+    on the internal preview and the public registration pages. Locals: form. %>
+<% if form.rhino_header.present? %>
+  <div class="rich-label prose max-w-none mb-6 text-sm text-gray-700 leading-relaxed space-y-2 prose-strong:text-inherit prose-em:text-inherit">
+    <%= form.rhino_header %>
   </div>
 <% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -92,7 +92,7 @@
       </div>
     </div>
 
-    <%# Optional HTML intro rendered under the title on the form's public pages %>
+    <%# Optional rich-text intro rendered under the title on the form's public pages %>
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
       <div class="flex items-center gap-2.5 px-6 py-3 bg-blue-100 border-b border-blue-300">
         <i class="fa-solid fa-heading text-blue-700"></i>
@@ -101,11 +101,9 @@
       <div class="p-6 space-y-2">
         <label class="block text-sm font-medium text-gray-700">Intro shown under the form title</label>
         <p class="text-xs text-gray-500">
-          Optional. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Appears at the top of the form on the preview and public pages.
+          Optional. Appears at the top of the form on the preview and public pages.
         </p>
-        <%= f.text_area :header, rows: 4,
-              placeholder: "e.g. <strong>Welcome!</strong> Please complete all fields below.",
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
+        <%= rhino_editor(f, :header) %>
       </div>
     </div>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "ed621305ecb26c24fe0cfb0b55955439f0d2a7d0e7ff19e5911657f47bcb3ff1",
+      "fingerprint": "0ad5e5e590fdaeea9c44b9733922828022e23817520e96117d4828ff29825768",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
       "line": 121,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
+      "code": "params.require(:form).permit(:name, :role, :rhino_header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/db/migrate/20260609180000_switch_form_header_to_rich_text.rb
+++ b/db/migrate/20260609180000_switch_form_header_to_rich_text.rb
@@ -1,0 +1,28 @@
+class SwitchFormHeaderToRichText < ActiveRecord::Migration[8.1]
+  # The optional form header moved from a plain-HTML `header` text column to an
+  # ActionText rich-text field (`rhino_header`), edited with the rhino editor.
+  def up
+    if column_exists?(:forms, :header)
+      execute(<<~SQL)
+        INSERT INTO action_text_rich_texts (name, body, record_type, record_id, created_at, updated_at)
+        SELECT 'rhino_header', header, 'Form', id, NOW(), NOW()
+        FROM forms
+        WHERE header IS NOT NULL AND header <> ''
+      SQL
+    end
+    remove_column :forms, :header, :text, if_exists: true
+  end
+
+  def down
+    add_column :forms, :header, :text unless column_exists?(:forms, :header)
+    execute(<<~SQL)
+      UPDATE forms
+      SET header = (
+        SELECT body FROM action_text_rich_texts
+        WHERE record_type = 'Form' AND name = 'rhino_header' AND record_id = forms.id
+        LIMIT 1
+      )
+    SQL
+    execute("DELETE FROM action_text_rich_texts WHERE record_type = 'Form' AND name = 'rhino_header'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_180000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -586,7 +586,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_170000) do
   create_table "forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "form_builder_id"
-    t.text "header"
     t.boolean "hide_answered_form_questions", default: false, null: false
     t.boolean "hide_answered_person_questions", default: false, null: false
     t.string "name"

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -96,14 +96,13 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("Expand all")
     end
 
-    it "renders the form header section with a textarea for HTML" do
-      form = create(:form, :standalone, header: "<strong>Welcome</strong>")
+    it "renders the form header section with a rich-text editor" do
+      form = create(:form, :standalone, rhino_header: "<strong>Welcome</strong>")
       get edit_form_path(form)
 
       expect(response.body).to include("Form header")
-      expect(response.body).to include('name="form[header]"')
-      # The raw HTML is escaped inside the textarea so admins edit the markup.
-      expect(response.body).to include("&lt;strong&gt;Welcome&lt;/strong&gt;")
+      expect(response.body).to include('name="form[rhino_header]"')
+      expect(response.body).to include("custom-rhino-editor")
     end
 
     it "edits field and header names in textareas" do
@@ -129,14 +128,15 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("<em>Your name</em>")
     end
 
-    it "renders the form header HTML under the title" do
-      form = create(:form, :standalone, header: %(<strong>Welcome</strong> — <a href="https://awbw.org">learn more</a>))
+    it "renders the form header rich text under the title" do
+      form = create(:form, :standalone, rhino_header: %(<strong>Welcome</strong> — <a href="https://awbw.org">learn more</a>))
 
       get form_path(form)
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("<strong>Welcome</strong>")
-      expect(response.body).to include(%(<a href="https://awbw.org">learn more</a>))
+      expect(response.body).to include("learn more")
+      expect(response.body).to include("https://awbw.org")
     end
   end
 
@@ -150,10 +150,10 @@ RSpec.describe "Forms", type: :request do
       expect(response).to redirect_to(edit_form_path(form))
     end
 
-    it "updates the form header HTML" do
+    it "updates the form header rich text" do
       form = create(:form, :standalone)
-      patch form_path(form), params: { form: { header: "<strong>Read carefully</strong>" } }
-      expect(form.reload.header).to eq("<strong>Read carefully</strong>")
+      patch form_path(form), params: { form: { rhino_header: "<strong>Read carefully</strong>" } }
+      expect(form.reload.rhino_header.to_plain_text).to eq("Read carefully")
       expect(response).to redirect_to(edit_form_path(form))
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The optional form header was a plain-HTML `<textarea>` (added in #1613), forcing admins to hand-write markup like `<strong>…</strong>`.
- This switches it to the **rhino rich-text editor** — the same one already used for Event headers — so editing the form intro matches the rest of the app and admins never touch raw HTML.

### How did you approach the change?

- Followed the existing Event convention exactly:
  - `Form` now declares `has_rich_text :rhino_header`.
  - The form builder edit view renders `rhino_editor(f, :header)` in place of the textarea.
  - `forms_controller` permits `:rhino_header` instead of `:header`.
  - The `forms/_header` partial (used on the preview, public registration `new`/`show`) renders `form.rhino_header` as `prose` rich text.
- Migration `SwitchFormHeaderToRichText` copies any existing `header` HTML into the `rhino_header` ActionText record, then drops the now-unused `forms.header` column. The column was one day old (added in #1613) with no seed/factory data, so it's removed rather than left orphaned; the migration is reversible.
- Refreshed the Brakeman ignore baseline: the pre-existing `PermitAttributes` warning on `form_params` is fingerprinted on the code string, so renaming the permitted attribute required re-pointing the existing ignore entry.

### UI Testing Checklist

- [ ] In the form builder, the **Form header** card shows the rich-text editor (not a textarea); bold/italic/links/lists work.
- [ ] Saving a header persists and the editor re-opens with the saved content.
- [ ] The header renders correctly under the title on the form **preview**, and the **public registration** new/show pages.
- [ ] A form with no header renders nothing in that slot.

### Anything else to add?

- Left the `form_label_html` helper in place — it's still used for form-field and section-header labels elsewhere.
- Specs in `spec/requests/forms_spec.rb` updated to exercise `rhino_header` / the rich-text editor (36 examples, 0 failures); `ai/lint` clean.