### PR TITLE
Show and toggle scholarship status on event recipients roster

### DIFF
--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -1,5 +1,5 @@
 class ScholarshipsController < ApplicationController
-  before_action :set_scholarship, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_scholarship, only: [ :show, :edit, :update, :destroy, :toggle_tasks ]
   before_action :set_grant, only: [ :new, :create ]
 
   def show
@@ -86,10 +86,30 @@ class ScholarshipsController < ApplicationController
     redirect_to scholarship_return_path(grant), notice: "Scholarship removed."
   end
 
+  # Flip a recipient's tasks-completed state from the event recipients roster.
+  # The model's after_update allocates the award when complete and de-allocates
+  # it when outstanding, so this single toggle finalizes or unwinds the award.
+  def toggle_tasks
+    authorize! @scholarship, to: :update?
+    @scholarship.update!(tasks_completed: !@scholarship.tasks_completed?)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: recipients_fallback_path, notice: "Scholarship updated." }
+    end
+  end
+
   private
 
   def set_scholarship
     @scholarship = Scholarship.find(params[:id])
+  end
+
+  # The recipients roster the tasks toggle is operated from — used as the
+  # fallback when there's no referer to return to.
+  def recipients_fallback_path
+    event = @scholarship.allocation&.allocatable.try(:event)
+    event ? recipients_event_path(event) : root_path
   end
 
   def set_grant

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -120,6 +120,9 @@ application.register("scholarship-preview", ScholarshipPreviewController)
 import ScholarshipRequestedController from "./scholarship_requested_controller"
 application.register("scholarship-requested", ScholarshipRequestedController)
 
+import ScholarshipStatusToggleController from "./scholarship_status_toggle_controller"
+application.register("scholarship-status-toggle", ScholarshipStatusToggleController)
+
 import CeCreditRequestedController from "./ce_credit_requested_controller"
 application.register("ce-credit-requested", CeCreditRequestedController)
 

--- a/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="scholarship-status-toggle"
+// Shows or hides every recipient's scholarship status (awarded amount + whether
+// the tasks are completed) across all recipient cards at once, keeping the
+// switch's label, track, knob, and aria-checked state in sync.
+export default class extends Controller {
+  static targets = ["status", "label", "switch", "track", "knob"]
+  static values = { shown: { type: Boolean, default: false } }
+
+  toggle() {
+    this.shownValue = !this.shownValue
+  }
+
+  shownValueChanged() {
+    this.statusTargets.forEach((el) => el.classList.toggle("hidden", !this.shownValue))
+    if (this.hasLabelTarget) {
+      this.labelTarget.textContent = this.shownValue ? "Hide scholarship status" : "Show scholarship status"
+    }
+    if (this.hasSwitchTarget) {
+      this.switchTarget.setAttribute("aria-checked", this.shownValue)
+    }
+    if (this.hasTrackTarget) {
+      this.trackTarget.classList.toggle("bg-gray-300", !this.shownValue)
+      this.trackTarget.classList.toggle("bg-fuchsia-600", this.shownValue)
+    }
+    if (this.hasKnobTarget) {
+      this.knobTarget.classList.toggle("translate-x-5", this.shownValue)
+    }
+  }
+}

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -100,7 +100,7 @@ class EventDashboard
   # decide whether to flag a registrant as a scholarship recipient. First
   # scholarship wins if a person has several.
   def scholarship_by_recipient
-    @scholarship_by_recipient ||= scholarships.group_by(&:recipient_id).transform_values(&:first)
+    @scholarship_by_recipient ||= scholarships.includes(grant: :donor).group_by(&:recipient_id).transform_values(&:first)
   end
 
   # Active registration slug per registrant (Person id) — a stable, non-db

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -27,9 +27,22 @@
   </div>
 
   <% if @dashboard.scholarship_applicants.any? %>
-    <div data-controller="expandable-cards">
-      <%# Expand / collapse all — top right of the cards %>
-      <div class="flex justify-end mb-4 print:hidden">
+    <div data-controller="expandable-cards scholarship-status-toggle">
+      <%# Controls — show/hide scholarship status for all recipients, and expand/collapse all %>
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4 print:hidden">
+        <%# Show / hide each recipient's awarded amount + tasks-completed status %>
+        <button type="button" role="switch" aria-checked="false"
+                data-action="scholarship-status-toggle#toggle"
+                data-scholarship-status-toggle-target="switch"
+                class="group inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800">
+          <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-gray-300 transition-colors"
+                data-scholarship-status-toggle-target="track">
+            <span class="inline-block h-4 w-4 translate-x-0.5 transform rounded-full bg-white shadow transition-transform"
+                  data-scholarship-status-toggle-target="knob"></span>
+          </span>
+          <span data-scholarship-status-toggle-target="label">Show scholarship status</span>
+        </button>
+        <%# Expand / collapse all %>
         <button type="button" data-action="expandable-cards#toggleAll"
                 class="inline-flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> hover:<%= DomainTheme.text_class_for(:scholarships) %>">
           <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-cards-target="icon"></i>
@@ -127,6 +140,30 @@
               </div>
             </div>
           </div>
+
+          <%# Scholarship status — awarded amount + tasks-completed state. Hidden
+              until toggled on (page-wide) so it doesn't crowd the application;
+              stays visible regardless of the card's expand/collapse state. %>
+          <% scholarship = @dashboard.scholarship_by_recipient[person.id] %>
+          <% if scholarship %>
+            <div class="hidden px-5 py-3 border-b <%= DomainTheme.border_class_for(:scholarships) %> bg-gray-50"
+                 data-scholarship-status-toggle-target="status">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Scholarship</span>
+                <span class="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-900">
+                  <i class="fa-solid fa-sack-dollar text-gray-400"></i>
+                  <%= number_to_currency(scholarship.amount_dollars) %>
+                </span>
+                <% if scholarship.grant&.funder_name.present? %>
+                  <span class="inline-flex items-center gap-1.5 text-sm text-gray-600">
+                    <i class="fa-solid fa-hand-holding-heart text-gray-400"></i>
+                    Funded by <%= scholarship.grant.funder_name %>
+                  </span>
+                <% end %>
+                <%= render "scholarships/tasks_status", scholarship: scholarship %>
+              </div>
+            </div>
+          <% end %>
 
           <%# Scholarship application answers %>
           <div class="px-5 py-4 print:block" data-expandable-card-target="body">

--- a/app/views/scholarships/_tasks_status.html.erb
+++ b/app/views/scholarships/_tasks_status.html.erb
@@ -1,0 +1,28 @@
+<%# Tasks-completed state for one scholarship, shown on the event recipients
+    roster. For admins it's an inline toggle: clicking flips the state, which
+    allocates the award when complete and de-allocates it when outstanding. For
+    everyone else it's a static badge. Wrapped in a stable id so the toggle can
+    swap just this pill in place over Turbo. %>
+<% completed = scholarship.tasks_completed? %>
+<% pill_classes = class_names(
+     "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium",
+     "bg-green-50 text-green-700" => completed,
+     "bg-amber-50 text-amber-700" => !completed
+   ) %>
+<span id="<%= dom_id(scholarship, :tasks_status) %>" class="inline-block">
+  <% if allowed_to?(:update?, scholarship) %>
+    <% action_label = completed ? "Mark tasks outstanding" : "Mark tasks complete" %>
+    <%= button_to toggle_tasks_scholarship_path(scholarship), method: :patch,
+                  form_class: "inline-block",
+                  title: action_label, aria: { label: action_label },
+                  class: "#{pill_classes} cursor-pointer transition-colors #{completed ? "hover:bg-green-100" : "hover:bg-amber-100"}" do %>
+      <i class="fa-solid <%= completed ? "fa-circle-check" : "fa-clock" %>"></i>
+      <%= completed ? "Tasks completed" : "Tasks outstanding" %>
+    <% end %>
+  <% else %>
+    <span class="<%= pill_classes %>">
+      <i class="fa-solid <%= completed ? "fa-circle-check" : "fa-clock" %>"></i>
+      <%= completed ? "Tasks completed" : "Tasks outstanding" %>
+    </span>
+  <% end %>
+</span>

--- a/app/views/scholarships/toggle_tasks.turbo_stream.erb
+++ b/app/views/scholarships/toggle_tasks.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@scholarship, :tasks_status) do %>
+  <%= render "scholarships/tasks_status", scholarship: @scholarship %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,7 +111,9 @@ Rails.application.routes.draw do
     end
   end
   resources :grants
-  resources :scholarships, only: [ :new, :create, :show, :edit, :update, :destroy ]
+  resources :scholarships, only: [ :new, :create, :show, :edit, :update, :destroy ] do
+    member { patch :toggle_tasks }
+  end
   resources :discounts, only: [ :create, :show, :destroy ] do
     collection do
       post :allocation_form

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -10,6 +10,11 @@
 #   * pending (tasks_completed: false) — the allocation stays $0, so the award is
 #     visible as "potentially awarded" but the registrant still owes the cost.
 #
+# Most of these event-allocated scholarships are drawn from a parent grant, so the
+# recipients page (events/recipients) shows the funding donor's name — a mix of
+# organization and individual (Person) funders, since a grant's donor is
+# polymorphic. A few are left grant-free so the no-donor case is covered too.
+#
 # A couple of scholarship + payment combos are seeded alongside the payments in
 # db/seeds/dev/payments.rb (Amy, Jessica); this file fills out the flagship
 # training with a full set of recipients. Looks up (rather than requires) the
@@ -24,14 +29,98 @@ facilitator_training = Event.find_by(title: "AWBW Facilitator Training")
 # Reused below to surface non-flagship applicants and print the per-event summary.
 scholarship_events = Event.joins(:event_forms).where(event_forms: { role: "scholarship" }).distinct.to_a
 
+# --- Grants (funding sources) ----------------------------------------------
+# Create the grants up front so the event-allocated scholarships below can be
+# drawn from them (recipients page → donor name). Grants cap the total
+# scholarship dollars from a single source, so amounts are sized to comfortably
+# cover both the event-allocated draws here and the standalone grant awards
+# further down.
+#   * a mix of donor types — three organization funders and two individual
+#     (Person) funders, since donor is polymorphic;
+#   * distinct donation totals, eligibility criteria, and tasks per grant.
+puts "Seeding Grants…"
+
+# Resolve a grant's donor by type: organizations by name, individuals by their
+# first/last name (so a Person can fund a grant, mirroring the polymorphic donor).
+resolve_donor = ->(donor_type, donor_name) do
+  if donor_type == "Person"
+    first, last = donor_name.split(" ", 2)
+    Person.find_by(first_name: first, last_name: last)
+  else
+    Organization.find_by(name: donor_name)
+  end
+end
+
+# [ name, donor_type, donor name, amount_cents, [ standalone award amounts… ], eligibility, tasks ]
+grant_plans = [
+  [ "Healing Arts Scholarship Fund", "Organization", "Joyful Heart Foundation", 2_000_000, [ 250_000, 150_000, 100_000 ],
+    "Lead expressive-arts groups for trauma survivors\nServe a community-based partner organization",
+    "Submit a portfolio of past workshops\nComplete the trauma-informed facilitation training\nFile a post-program impact report" ],
+  [ "Community Resilience Grant", "Organization", "Angel Step Inn", 1_500_000, [ 250_000, 150_000 ],
+    "Serve youth or families affected by community violence\nOperate in an underserved neighborhood",
+    "Outline a six-week workshop plan\nPartner with a local school or shelter\nShare participant feedback after the series" ],
+  [ "Trauma-Informed Practice Grant", "Organization", "Good Shepherd Shelter", 1_200_000, [ 300_000 ],
+    "Be a licensed clinician or peer-support specialist\nIntegrate art into ongoing therapeutic work",
+    "Describe your current caseload\nComplete the required continuing-education hours" ],
+  [ "Survivor Empowerment Grant", "Person", "Maria Johnson", 800_000, [ 200_000, 100_000 ],
+    "Work directly with domestic-violence survivors\nHold a current advocate or counselor role",
+    "Provide two professional references\nAttend the grantee orientation call" ],
+  [ "Creative Recovery Fund", "Person", "Lisa Williams", 1_000_000, [ 200_000, 150_000 ],
+    "Facilitate art groups for adults in substance-use recovery\nHold at least a year of group facilitation experience",
+    "Submit a one-page program proposal\nComplete a background check\nPresent outcomes at the year-end grantee showcase" ]
+]
+
+# Build the grants, re-syncing funder + descriptive fields for grants left over
+# from an earlier run. Indexed by plan so the standalone-award amounts stay paired
+# with their grant.
+grants = grant_plans.filter_map do |(name, donor_type, donor_name, amount_cents, _awards, eligibility, tasks)|
+  donor = resolve_donor.(donor_type, donor_name)
+  next unless donor
+
+  grant = Grant.find_or_create_by!(name: name) do |g|
+    g.donor = donor
+    g.amount_cents = amount_cents
+    g.application_deadline = Date.current + 30
+    g.funds_received_on = Date.current - 30
+    g.eligibility_criteria = eligibility
+    g.tasks = tasks
+  end
+
+  if grant.donor != donor || grant.amount_cents != amount_cents ||
+     grant.eligibility_criteria != eligibility || grant.tasks != tasks
+    grant.update!(donor: donor, amount_cents: amount_cents, eligibility_criteria: eligibility, tasks: tasks)
+  end
+
+  grant
+end
+
+# Round-robin across grants for donor variety, but only hand back one that can
+# still absorb this award within its donation cap; returns nil when none has room
+# (the scholarship is then created grant-free).
+grant_cursor = 0
+pick_grant_for = ->(amount_cents) do
+  return nil if grants.empty?
+
+  grants.length.times do
+    grant = grants[grant_cursor % grants.length]
+    grant_cursor += 1
+    drawn = Scholarship.where(grant: grant).sum(:amount_cents)
+    return grant if drawn + amount_cents <= grant.amount_cents
+  end
+  nil
+end
+
 # Mirrors ScholarshipsController: build the scholarship with a $0 allocation, then
 # set amount + tasks_completed so sync_allocation_amount funds the allocation only
 # when the recipient's tasks are complete (completed → allocated; pending → $0).
-award_scholarship = ->(registration, amount_cents:, tasks_completed:) do
+# When grant_funded, draws the award from a parent grant so the recipients page
+# can name the funding donor.
+award_scholarship = ->(registration, amount_cents:, tasks_completed:, grant_funded: false) do
   return unless registration
   return if registration.scholarships.exists?
 
-  scholarship = Scholarship.new(recipient: registration.registrant)
+  grant = grant_funded ? pick_grant_for.(amount_cents) : nil
+  scholarship = Scholarship.new(recipient: registration.registrant, grant: grant)
   scholarship.build_allocation(allocatable: registration, amount: 0)
   scholarship.save!
   scholarship.update!(amount_cents: amount_cents, tasks_completed: tasks_completed)
@@ -250,12 +339,15 @@ if facilitator_training
 
   # Fund the newly chosen recipients (Amy already has hers from payments); varied
   # shares and completion states give the dashboard both allocated and pending awards.
-  award_plan = [ [ 1.0, true ], [ 0.5, true ], [ 0.75, false ], [ 0.5, true ], [ 0.25, false ] ]
+  # Most draw from a parent grant so the recipients page shows the funding donor;
+  # one is left grant-free to cover the no-donor case.
+  # [ share of the registration fee, tasks_completed, grant_funded ]
+  award_plan = [ [ 1.0, true, true ], [ 0.5, true, true ], [ 0.75, false, true ], [ 0.5, true, true ], [ 0.25, false, false ] ]
   plan_index = 0
   recipients.each do |registration|
     next if registration.scholarships.exists?
-    share, completed = award_plan[plan_index % award_plan.length]
-    award_scholarship.(registration, amount_cents: (cost * share).round, tasks_completed: completed)
+    share, completed, grant_funded = award_plan[plan_index % award_plan.length]
+    award_scholarship.(registration, amount_cents: (cost * share).round, tasks_completed: completed, grant_funded: grant_funded)
     plan_index += 1
   end
 
@@ -289,18 +381,13 @@ scholarship_events.each do |event|
        "outstanding #{dashboard.outstanding_scholarship_cents / 100.0}"
 end
 
-# --- Grants & grant-funded scholarships ------------------------------------
-# Grants cap the total scholarship dollars drawn from a single funding source.
-# Seed five so the grant pages show the full range the UI must handle:
-#   * a mix of donor types — three organization funders and two individual
-#     (Person) funders, since donor is polymorphic;
-#   * distinct donation totals, eligibility criteria, and tasks per grant;
-#   * both funding states — some fully issued (remaining $0, scholarships sum to
-#     the donation) and some with room left (only part of the donation drawn).
-# Grant-funded scholarships are standalone awards (recipient + grant, no event
-# allocation), mirroring the grant CRUD flow. Idempotent: skips a grant that
-# already exists and only funds a grant that has no scholarships yet.
-puts "Seeding Grants and grant-funded scholarships…"
+# --- Standalone grant-funded scholarships ----------------------------------
+# Beyond the event-allocated awards above (which now draw from these grants too),
+# seed a few standalone grant awards — recipient + grant, no event allocation —
+# mirroring the grant CRUD flow, so the grant pages show draws and remaining
+# balances. Idempotent: only adds standalone awards to a grant that has none yet,
+# and skips any award that would exceed the grant's remaining funds.
+puts "Seeding standalone grant-funded scholarships…"
 
 # Reuse existing dev people as recipients, cycling so each award goes to a
 # distinct person where the pool allows.
@@ -312,63 +399,20 @@ next_recipient = -> do
   person
 end
 
-# [ name, donor_type, donor name, amount_cents, [ scholarship amount_cents… ], eligibility, tasks ]
-# Three organization donors and two individual (Person) donors, each with a
-# distinct donation total, eligibility criteria, and tasks (newline-separated) so
-# the grant pages show varied funders and requirements. Award sets that sum to the
-# donation are fully issued; the rest leave a remaining balance.
-grant_plans = [
-  [ "Healing Arts Scholarship Fund", "Organization", "Joyful Heart Foundation", 500_000, [ 250_000, 150_000, 100_000 ],
-    "Lead expressive-arts groups for trauma survivors\nServe a community-based partner organization",
-    "Submit a portfolio of past workshops\nComplete the trauma-informed facilitation training\nFile a post-program impact report" ],
-  [ "Community Resilience Grant", "Organization", "Angel Step Inn", 1_000_000, [ 250_000, 150_000 ],
-    "Serve youth or families affected by community violence\nOperate in an underserved neighborhood",
-    "Outline a six-week workshop plan\nPartner with a local school or shelter\nShare participant feedback after the series" ],
-  [ "Trauma-Informed Practice Grant", "Organization", "Good Shepherd Shelter", 800_000, [ 300_000 ],
-    "Be a licensed clinician or peer-support specialist\nIntegrate art into ongoing therapeutic work",
-    "Describe your current caseload\nComplete the required continuing-education hours" ],
-  [ "Survivor Empowerment Grant", "Person", "Maria Johnson", 300_000, [ 200_000, 100_000 ],
-    "Work directly with domestic-violence survivors\nHold a current advocate or counselor role",
-    "Provide two professional references\nAttend the grantee orientation call" ],
-  [ "Creative Recovery Fund", "Person", "Lisa Williams", 650_000, [ 200_000, 150_000 ],
-    "Facilitate art groups for adults in substance-use recovery\nHold at least a year of group facilitation experience",
-    "Submit a one-page program proposal\nComplete a background check\nPresent outcomes at the year-end grantee showcase" ]
-]
-
-# Resolve a grant's donor by type: organizations by name, individuals by their
-# first/last name (so a Person can fund a grant, mirroring the polymorphic donor).
-resolve_donor = ->(donor_type, donor_name) do
-  if donor_type == "Person"
-    first, last = donor_name.split(" ", 2)
-    Person.find_by(first_name: first, last_name: last)
-  else
-    Organization.find_by(name: donor_name)
-  end
+# A standalone grant scholarship has no allocation (event-allocated ones do).
+grant_has_standalone = ->(grant) do
+  Scholarship.where(grant: grant).left_outer_joins(:allocation).where(allocations: { id: nil }).exists?
 end
 
-grant_plans.each_with_index do |(name, donor_type, donor_name, amount_cents, awards, eligibility, tasks), i|
-  donor = resolve_donor.(donor_type, donor_name)
-  next unless donor && grant_recipient_pool.any?
-
-  grant = Grant.find_or_create_by!(name: name) do |g|
-    g.donor = donor
-    g.amount_cents = amount_cents
-    g.application_deadline = Date.current + (15 + i * 20)
-    g.funds_received_on = Date.current - (30 + i * 10)
-    g.eligibility_criteria = eligibility
-    g.tasks = tasks
-  end
-
-  # Re-sync funder + descriptive fields so grants seeded by an earlier run pick up
-  # the now-distinct donor, donation total, criteria, and tasks.
-  if grant.donor != donor || grant.amount_cents != amount_cents ||
-     grant.eligibility_criteria != eligibility || grant.tasks != tasks
-    grant.update!(donor: donor, amount_cents: amount_cents, eligibility_criteria: eligibility, tasks: tasks)
-  end
-
-  next if grant.scholarships.exists?
+grant_plans.each do |(name, _donor_type, _donor_name, _amount_cents, awards, _eligibility, _tasks)|
+  grant = grants.find { |g| g.name == name }
+  next unless grant && grant_recipient_pool.any?
+  next if grant_has_standalone.(grant)
 
   awards.each_with_index do |award_cents, j|
+    drawn = Scholarship.where(grant: grant).sum(:amount_cents)
+    next if drawn + award_cents > grant.amount_cents
+
     Scholarship.create!(recipient: next_recipient.(), grant: grant,
                         amount_cents: award_cents, tasks_completed: j.even?)
   end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -918,11 +918,77 @@ RSpec.describe "Events", type: :request do
       it "renders the collapsible card controls and an expand/collapse-all button" do
         get recipients_event_path(event)
 
-        expect(response.body).to include('data-controller="expandable-cards"')
+        expect(response.body).to include('data-controller="expandable-cards scholarship-status-toggle"')
         expect(response.body).to include("Collapse all")
         expect(response.body).to include('data-controller="expandable-card"')
         expect(response.body).to include("expandable-card#toggle")
         expect(response.body).to include('data-expandable-card-target="body"')
+      end
+
+      it "renders a page-wide toggle to show/hide scholarship status" do
+        get recipients_event_path(event)
+
+        expect(response.body).to include('data-controller="expandable-cards scholarship-status-toggle"')
+        expect(response.body).to include('data-action="scholarship-status-toggle#toggle"')
+        expect(response.body).to include("Show scholarship status")
+      end
+
+      it "shows each recipient's awarded amount and completed tasks status" do
+        event.update!(cost_cents: 50_000)
+        registration = event.event_registrations.find_by(registrant: applicant)
+        scholarship = create(:scholarship, recipient: applicant, amount_cents: 50_000, tasks_completed: true)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 50_000)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include('data-scholarship-status-toggle-target="status"')
+        expect(response.body).to include("$500.00")
+        expect(response.body).to include("Tasks completed")
+      end
+
+      it "names the funding donor when the scholarship is drawn from a grant" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+        org = create(:organization, name: "Joyful Heart Foundation")
+        grant = create(:grant, name: "Healing Arts Fund", donor: org, amount_cents: 100_000)
+        scholarship = create(:scholarship, recipient: applicant, grant: grant, amount_cents: 1_000, tasks_completed: true)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include("Funded by")
+        expect(response.body).to include("Joyful Heart Foundation")
+      end
+
+      it "omits the donor line for a scholarship with no parent grant" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+        scholarship = create(:scholarship, recipient: applicant, amount_cents: 1_000, tasks_completed: true)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+        get recipients_event_path(event)
+
+        expect(response.body).not_to include("Funded by")
+      end
+
+      it "flags a recipient whose tasks are still outstanding" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+        scholarship = create(:scholarship, recipient: applicant, amount_cents: 25_000, tasks_completed: false)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 0)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include("$250.00")
+        expect(response.body).to include("Tasks outstanding")
+      end
+
+      it "renders the tasks status as an inline toggle that flips the completed state" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+        scholarship = create(:scholarship, recipient: applicant, amount_cents: 25_000, tasks_completed: false)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 0)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include(toggle_tasks_scholarship_path(scholarship))
+        expect(response.body).to include("Mark tasks complete")
       end
 
       it "shows the non-facilitator affiliation's title and linked organization, excluding facilitator roles" do

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -145,6 +145,54 @@ RSpec.describe "Scholarships", type: :request do
       expect(flash[:notice]).to eq("Scholarship removed.")
     end
   end
+
+  describe "PATCH /scholarships/:id/toggle_tasks" do
+    let(:tasks_status_id) { ActionView::RecordIdentifier.dom_id(scholarship, :tasks_status) }
+
+    it "flips a completed scholarship to outstanding and de-allocates the award" do
+      patch toggle_tasks_scholarship_path(scholarship)
+
+      expect(scholarship.reload.tasks_completed?).to be(false)
+      expect(allocation.reload.amount).to eq(0)
+    end
+
+    it "flips an outstanding scholarship to completed and allocates the award" do
+      scholarship.update!(tasks_completed: false)
+
+      patch toggle_tasks_scholarship_path(scholarship)
+
+      expect(scholarship.reload.tasks_completed?).to be(true)
+      expect(allocation.reload.amount).to eq(5000)
+    end
+
+    it "replaces just the status pill in response to a turbo-stream request" do
+      patch toggle_tasks_scholarship_path(scholarship),
+            headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include(%(<turbo-stream action="replace" target="#{tasks_status_id}">))
+      expect(response.body).to include("Tasks outstanding")
+    end
+
+    it "redirects back to the recipients page for a non-Turbo request" do
+      patch toggle_tasks_scholarship_path(scholarship)
+
+      expect(response).to redirect_to(recipients_event_path(event))
+    end
+
+    context "as a non-admin" do
+      let(:member) { create(:user, :with_person) }
+
+      before { sign_in member }
+
+      it "is not authorized and leaves the scholarship unchanged" do
+        patch toggle_tasks_scholarship_path(scholarship)
+
+        expect(response).to redirect_to(root_path)
+        expect(scholarship.reload.tasks_completed?).to be(true)
+      end
+    end
+  end
 end
 
 RSpec.describe "/scholarships (grant-funded flow)", type: :request do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Event organizers reviewing the recipients roster (`events/recipients`) had no visibility into scholarship status — who was awarded, for how much, who funded it, or whether their tasks were complete
- They also had no way to finalize or unwind an award without leaving the page to edit the scholarship record
- This surfaces that status inline and lets organizers flip a recipient's tasks-completed state directly from the roster

### How did you approach the change?

- **Page-wide show/hide switch** — a Stimulus controller (`scholarship-status-toggle`) toggles every recipient card's scholarship status panel at once, keeping the switch label, track, knob, and `aria-checked` in sync. Status stays visible regardless of a card's expand/collapse state
- **Status panel** — shows the awarded amount, the funding donor's name when the scholarship is drawn from a grant (omitted when grant-free), and a tasks-completed badge
- **Inline tasks toggle** — for admins the badge is a `button_to` hitting a new `PATCH /scholarships/:id/toggle_tasks`; the existing model `after_update` allocates the award when complete and de-allocates it when outstanding, so one toggle finalizes or unwinds the award. Responds with a Turbo Stream that swaps just the status pill in place; falls back to a redirect for non-Turbo requests. Non-admins see a static badge
- **N+1 fix** — `EventDashboard#scholarship_by_recipient` now eager-loads `grant: :donor` for the donor name
- **Seeds** — reworked dev scholarship seeds so most event-allocated awards draw from a parent grant (mix of org and individual polymorphic donors), exercising both the donor and no-donor cases on the recipients page

### Anything else to add?

- New request specs cover the status panel, donor line presence/absence, the outstanding flag, authorization, and both the Turbo-stream and redirect responses of `toggle_tasks`
