### PR TITLE
Form preview: option-source links, header, and View/Preview links

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,0 +1,20 @@
+module FormsHelper
+  # The form editor's top-right links. The standalone "Preview form" is always
+  # available. When we also know which event the admin came from, we add a
+  # "View form" link to the real public-facing registration page — the preview
+  # can't fill header tokens or run conditional logic without an event.
+  def form_editor_view_links(form, event)
+    link_class = "text-sm text-gray-500 hover:text-gray-700 px-2 py-1"
+    preview = link_to "Preview", form_path(form), class: link_class
+    return preview unless event
+
+    view = link_to "View", new_event_public_registration_path(event), class: link_class
+    safe_join([ view, preview ])
+  end
+
+  # Human-readable role for a form: "Registration", "Bulk Payment", etc.,
+  # falling back to "General" when no role is set.
+  def form_role_label(form)
+    form.role.presence&.titleize || "General"
+  end
+end

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (field:, value: nil, label: nil) %>
+<%# locals: (field:, value: nil, label: nil, show_option_source: false) %>
 <% return if field.group_header? %>
 
 <% error = @field_errors&.dig(field.id) %>
@@ -6,12 +6,17 @@
 <% input_classes = "w-full rounded-lg border bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition focus:outline-none focus:ring-2 #{error_border}" %>
 
 <div class="mb-7">
-  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="public_registration_form_fields_<%= field.id %>">
-    <%= form_label_html(label || field.name) %>
-    <% if field.required %>
-      <span class="text-red-500">*</span>
+  <div class="flex flex-wrap items-center gap-2 mb-1.5">
+    <label class="rich-label text-sm font-semibold text-gray-700" for="public_registration_form_fields_<%= field.id %>">
+      <%= form_label_html(label || field.name) %>
+      <% if field.required %>
+        <span class="text-red-500">*</span>
+      <% end %>
+    </label>
+    <% if show_option_source %>
+      <%= render "forms/option_source_link", field: field %>
     <% end %>
-  </label>
+  </div>
 
   <% if field.hint_text.present? %>
     <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>

--- a/app/views/forms/_option_source_link.html.erb
+++ b/app/views/forms/_option_source_link.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (field:) %>
+<% source = form_field_option_source(field) %>
+<% if source %>
+  <%= link_to source[:path], target: "_blank", rel: "noopener",
+        class: "inline-flex items-center gap-1 text-xs font-medium text-purple-700 hover:text-purple-900" do %>
+    <span class="underline">Options from <%= source[:label] %></span>
+    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+  <% end %>
+<% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
     <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -6,7 +6,7 @@
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View form", form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -14,12 +14,21 @@
   </div>
 
   <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
-    <div class="bg-purple-900 text-white px-6 py-4">
-      <div class="flex items-center gap-8">
-        <div class="shrink-0">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto") %>
+    <%# Admin chrome wrapping the form preview below. The amber "Preview" badge
+        signals this is not the live page (echoing the amber token note inside). %>
+    <div class="bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 py-5">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <div class="flex items-center gap-4">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto shrink-0") %>
+          <div class="h-8 w-px bg-white/20"></div>
+          <div>
+            <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= @form.display_name %></h2>
+            <p class="mt-0.5 text-xs text-purple-200"><%= form_role_label(@form) %> form</p>
+          </div>
         </div>
-        <h2 class="text-xl font-semibold tracking-wide"><%= @form.display_name %></h2>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-amber-400 px-3 py-1 text-xs font-bold uppercase tracking-[0.15em] text-purple-950 shadow-sm">
+          <i class="fa-solid fa-eye"></i>Preview
+        </span>
       </div>
     </div>
 
@@ -86,11 +95,14 @@
               <div class="<%= field.grid_span_class %>">
                 <% if conditional %>
                   <div class="border-l-4 <%= visibility_marker_styles[field.visibility] %> pl-3">
-                    <span class="inline-block mb-1.5 text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
+                    <div class="mb-1.5 flex flex-wrap items-center gap-1.5">
+                      <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
+                      <%= render "forms/option_source_link", field: field %>
+                    </div>
                     <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
                   </div>
                 <% else %>
-                  <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+                  <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier], show_option_source: true %>
                 <% end %>
               </div>
             <% end %>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe "Forms", type: :request do
       get edit_form_path(form)
       expect(response.body).not_to include("Dashboard")
     end
+
+    it "offers only the standalone Preview link when no event is known" do
+      get edit_form_path(form)
+      expect(response.body).to include(">Preview<")
+      expect(response.body).not_to include(">View<")
+    end
+
+    it "adds a View link to the live registration form when the event is known" do
+      create(:event_form, form: form, event: event)
+      get edit_form_path(form, event_id: event.id)
+      expect(response.body).to include(">View<")
+      expect(response.body).to include(new_event_public_registration_path(event))
+      expect(response.body).to include(">Preview<")
+    end
   end
 
   describe "GET /forms/:id/edit" do
@@ -260,6 +274,31 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("<strong>Welcome</strong>")
       expect(response.body).to include(%(<a href="https://awbw.org">learn more</a>))
+    end
+
+    it "labels the preview header with the form role and a Preview badge" do
+      form = create(:form, :standalone, name: "Summer Camp", role: "registration")
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Summer Camp")
+      expect(response.body).to include("Registration form")
+      expect(response.body).to include("Preview")
+    end
+
+    it "links a dynamic field's options to the managed list" do
+      type = CategoryType.create!(name: "AgeRange", published: true)
+      form = create(:form, :standalone)
+      create(:form_field, form: form, answer_type: :single_select_radio,
+             field_identifier: "primary_age_group", name: "Primary age group", status: :active)
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Options from")
+      expect(response.body).to include("Age range categories")
+      expect(response.body).to include(categories_path(category_type_id: type.id))
     end
   end
 


### PR DESCRIPTION
> 🔗 **Stacked PR** — the base (`maebeale/subtitle-field`, #1635) is now merged into `main`; this PR has been rebased onto `main`. Third PR in the stack (builder UI) follows.

### What is the goal of this PR and why is this important?
- The form **preview** gave little context, and dynamic-option fields gave no hint about where their choices come from. This makes the preview read as clear admin chrome and links dynamic fields to the lists that manage them.

### How did you approach the change?
- **Option-source links**: dynamic-option fields (sourced from Sectors/Categories) show an "Options from …" link to their managed list — beside the visibility badge, or the field label when there's no badge.
- **Preview header**: now shows the form name, role, and an amber "Preview" badge signaling it's not the live page.
- **Editor links**: always offer a standalone "Preview"; add "View" to the live registration form when the originating event is known.

### UI Testing Checklist
- [ ] Preview header shows form name, role, and the amber "Preview" badge.
- [ ] A dynamic-option field shows an "Options from …" link to the managed list on the preview.
- [ ] Editor shows "Preview" with no event; "View" + "Preview" when an event is known (View → live registration page).

### Anything else to add?
- Second of three stacked PRs (subtitle → **preview** → builder UI).
- Rebased onto `main` after #1635 merged; updated the request spec for the renamed `single_select_radio` answer type (was `multiple_choice_radio`, renamed in #1634).
