### PR TITLE
Form builder UI: new-form restyle, section field lists, editor polish

### DIFF
--- a/app/frontend/javascript/controllers/field_options_controller.js
+++ b/app/frontend/javascript/controllers/field_options_controller.js
@@ -13,5 +13,7 @@ export default class extends Controller {
   expandedValueChanged() {
     this.panelTarget.classList.toggle("hidden", !this.expandedValue)
     this.iconTarget.classList.toggle("rotate-180", this.expandedValue)
+    // Tint the whole row while open so it's clear which field you're editing.
+    this.element.closest(".nested-fields")?.classList.toggle("bg-amber-50", this.expandedValue)
   }
 }

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -72,6 +72,47 @@ class FormBuilderService
     bulk_payment: [ "Payer Information", "Payment Information", "Attendees" ]
   }.freeze
 
+  # User-facing field labels each section's builder creates (questions only,
+  # excluding group headers), in build order. Mirrors the build_* methods so the
+  # new-form page can list a section's fields before the form exists. A spec
+  # asserts this stays in sync with what the builders actually create.
+  SECTION_FIELD_NAMES = {
+    person_identifier: [ "First Name", "Last Name", "Email", "Confirm Email" ],
+    person_contact_info: [
+      "Primary Email Type", "Preferred Nickname", "Pronouns", "Secondary Email", "Secondary Email Type",
+      "Street Address", "Address Type", "City", "State / Province", "Zip / Postal Code",
+      "Phone", "Phone Type", "Agency / Organization Name", "Position / Title",
+      "Agency Street Address", "Agency City", "Agency State / Province", "Agency Zip / Postal Code",
+      "Agency Type", "Agency Website"
+    ],
+    person_background: [ "Racial / Ethnic Identity" ],
+    professional_info: [ "Primary Service Area(s)", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served" ],
+    marketing: [
+      "How did you hear about this training?",
+      "What motivates you to attend this training?",
+      "Are you interested in learning more about upcoming trainings or resources?"
+    ],
+    scholarship: [
+      "I / my agency cannot afford the full training cost and need a scholarship to attend.",
+      "How will what you gain from this training directly impact the people you serve?",
+      "Please describe one way in which you plan to use art workshops and how you envision it will help.",
+      "Anything else you'd like to share with us?"
+    ],
+    payment: [ "Payment method" ],
+    consent: [ "I agree to receive email communications from A Window Between Worlds." ],
+    post_event_feedback: [ "How would you rate this event?", "What did you find most valuable?", "Any suggestions for improvement?" ],
+    bulk_payment: [
+      "Payer first name", "Payer last name", "Payer email", "Phone", "Organization",
+      "Payment method", "Number of attendees", "Attendees"
+    ]
+  }.freeze
+
+  # Field labels a section's builder creates, for previewing a section's
+  # contents before the form exists (used on the new-form page).
+  def self.section_field_names(key)
+    SECTION_FIELD_NAMES.fetch(key.to_sym, [])
+  end
+
   # Maps each section to the `section` column value(s) its builder assigns to
   # fields, so fields can be grouped back to their section when reordering.
   # Several builders use a `group:` string that differs from the section key.
@@ -125,6 +166,7 @@ class FormBuilderService
 
     positions = {}
     header_names = {}
+    questions = Hash.new { |hash, key| hash[key] = [] }
     customs = []
     current = nil
 
@@ -135,7 +177,11 @@ class FormBuilderService
       if key
         current = nil
         positions[key] ||= order
-        header_names[key] ||= field.name if field.group_header?
+        if field.group_header?
+          header_names[key] ||= field.name
+        else
+          questions[key] << field
+        end
       elsif field.group_header?
         current = { kind: :custom, header: field, questions: [] }
         customs << [ order, current ]
@@ -157,6 +203,7 @@ class FormBuilderService
         key: key,
         label: SECTIONS.fetch(key)[:label],
         included: !position.nil?,
+        questions: questions[key],
         renamed_header: (header_name if header_name.present? && header_name != default_header)
       }
     end

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -86,7 +86,7 @@ class FormBuilderService
       "Agency Type", "Agency Website"
     ],
     person_background: [ "Racial / Ethnic Identity" ],
-    professional_info: [ "Primary Service Area(s)", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served" ],
+    professional_info: [ "Primary service area", "Additional service areas", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served" ],
     marketing: [
       "How did you hear about this training?",
       "What motivates you to attend this training?",

--- a/app/views/forms/_field_list.html.erb
+++ b/app/views/forms/_field_list.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (names:, indent: "ml-6") %>
+<ul class="hidden mt-2 <%= indent %> list-disc list-inside space-y-0.5 text-xs text-gray-600 marker:text-gray-300"
+    data-expandable-card-target="body">
+  <% names.each do |name| %>
+    <li><%= name %></li>
+  <% end %>
+</ul>

--- a/app/views/forms/_field_list_toggle.html.erb
+++ b/app/views/forms/_field_list_toggle.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (count:) %>
+<button type="button"
+        class="flex shrink-0 items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
+        data-action="expandable-card#toggle">
+  <%= pluralize(count, "field") %>
+  <i class="fa-solid fa-chevron-down transition-transform" data-expandable-card-target="icon"></i>
+</button>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -52,7 +52,7 @@
         </button>
       </div>
 
-      <div class="hidden mt-2 flex flex-col gap-2" data-field-options-target="panel">
+      <div class="hidden mt-2 pb-2 flex flex-col gap-2" data-field-options-target="panel">
         <%= f.text_area :hint_text, rows: 2,
               class: "w-full text-sm text-gray-600 rounded border-gray-300 shadow-sm px-2 py-1",
               placeholder: "Subtitle" %>
@@ -93,7 +93,7 @@
       </div>
 
       <% option_source = form_field_option_source(field) %>
-      <div class="hidden mt-2 flex flex-col gap-3" data-field-options-target="panel">
+      <div class="hidden mt-2 pb-2 flex flex-col gap-3" data-field-options-target="panel">
         <div class="flex flex-wrap items-center gap-2">
           <%# Fixed-width first column so the Subtitle box lines up under the answer-type dropdown above. %>
           <div class="min-w-0 flex-[3_1_10rem]">

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -21,7 +21,7 @@
             <i class="fa-solid fa-list-check text-xl"></i>
           </div>
           <div>
-            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit questions</p>
+            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit</p>
             <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
           </div>
         </div>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -58,34 +58,53 @@
         <ol class="space-y-2">
           <% @editable_sections.each_with_index do |section, index| %>
             <% if section[:kind] == :custom %>
-              <li data-controller="form-section-toggle"
+              <% names = section[:questions].map(&:name) %>
+              <li data-controller="form-section-toggle expandable-card" data-expandable-card-expanded-value="false"
                   data-form-section-toggle-included-value="true">
-                <label class="flex items-center gap-2 cursor-pointer">
-                  <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
-                  <%= hidden_field_tag "custom_sections[]", section[:header].id %>
-                  <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
-                        class: "rounded border-gray-300 text-purple-600",
-                        data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
-                  <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
-                  <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
-                </label>
+                <div class="flex items-center gap-2">
+                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
+                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                    <%= hidden_field_tag "custom_sections[]", section[:header].id %>
+                    <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
+                          class: "rounded border-gray-300 text-purple-600",
+                          data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
+                    <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
+                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
+                  </label>
+                  <% if names.any? %>
+                    <%= render "forms/field_list_toggle", count: names.size %>
+                  <% end %>
+                </div>
+                <% if names.any? %>
+                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
+                <% end %>
                 <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
               </li>
             <% else %>
-              <li data-controller="form-section-toggle"
+              <%# Included sections list their real fields; not-yet-added ones fall back to the builder's defaults. %>
+              <% names = section[:questions].map(&:name).presence || FormBuilderService.section_field_names(section[:key]) %>
+              <li data-controller="form-section-toggle expandable-card" data-expandable-card-expanded-value="false"
                   data-form-section-toggle-included-value="<%= section[:included] %>">
-                <label class="flex items-center gap-2 cursor-pointer">
-                  <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
-                  <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
-                         class="rounded border-gray-300 text-purple-600"
-                         data-form-section-toggle-target="checkbox"
-                         data-action="form-section-toggle#update"
-                         <%= "checked" if section[:included] %>>
-                  <span class="text-sm text-gray-800"><%= section[:label] %></span>
-                  <% if section[:renamed_header].present? %>
-                    <span class="text-xs text-gray-400 italic">titled &ldquo;<%= section[:renamed_header] %>&rdquo; on the form</span>
+                <div class="flex items-center gap-2">
+                  <label class="flex flex-1 items-center gap-2 cursor-pointer">
+                    <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
+                    <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
+                           class="rounded border-gray-300 text-purple-600"
+                           data-form-section-toggle-target="checkbox"
+                           data-action="form-section-toggle#update"
+                           <%= "checked" if section[:included] %>>
+                    <span class="text-sm text-gray-800"><%= section[:label] %></span>
+                    <% if section[:renamed_header].present? %>
+                      <span class="text-xs text-gray-400 italic">titled &ldquo;<%= section[:renamed_header] %>&rdquo; on the form</span>
+                    <% end %>
+                  </label>
+                  <% if names.any? %>
+                    <%= render "forms/field_list_toggle", count: names.size %>
                   <% end %>
-                </label>
+                </div>
+                <% if names.any? %>
+                  <%= render "forms/field_list", names: names, indent: "ml-12" %>
+                <% end %>
                 <p class="hidden mt-1 ml-12 text-xs" data-form-section-toggle-target="message"></p>
               </li>
             <% end %>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -1,43 +1,93 @@
-<div class="max-w-2xl mx-auto py-8 px-4">
-  <h1 class="text-2xl font-semibold mb-6">New Form</h1>
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="py-8 px-4">
+  <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  </div>
 
-  <%= form_with url: forms_path, method: :post, class: "space-y-6", data: { controller: "section-filter" } do |f| %>
-    <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Form Name</label>
-      <input type="text" name="name" value="<%= params[:name] %>"
-             class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm"
-             placeholder="e.g. Short Event Registration">
-    </div>
-
-    <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Form role</label>
-      <select name="role" data-section-filter-target="select" data-action="section-filter#filter"
-              class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
-        <option value="">General</option>
-        <option value="registration" <%= "selected" if params[:role] == "registration" %>>Registration</option>
-        <option value="scholarship" <%= "selected" if params[:role] == "scholarship" %>>Scholarship</option>
-        <option value="bulk_payment" <%= "selected" if params[:role] == "bulk_payment" %>>Bulk Payment</option>
-      </select>
-    </div>
-
-    <fieldset>
-      <legend class="text-sm font-medium text-gray-700 mb-3">Select sections to include:</legend>
-      <div class="space-y-2">
-        <% FormBuilderService::SECTIONS.each do |key, section| %>
-          <% section_role = key == :scholarship ? "scholarship" : key == :bulk_payment ? "bulk_payment" : "other" %>
-          <label class="flex items-center gap-2 cursor-pointer" data-section-role="<%= section_role %>">
-            <input type="checkbox" name="sections[]" value="<%= key %>"
-                   class="rounded border-gray-300 text-purple-600"
-                   <%= "checked" if params.dig(:sections)&.include?(key.to_s) %>>
-            <span class="text-sm text-gray-800"><%= section[:label] %></span>
-          </label>
-        <% end %>
+  <%# Colored hero banner so the page reads at a glance instead of all-white %>
+  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
+      <div class="flex items-center gap-4">
+        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
+          <i class="fa-solid fa-file-circle-plus text-xl"></i>
+        </div>
+        <div>
+          <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">New form</p>
+          <h1 class="text-2xl font-bold tracking-tight leading-tight">Create a form</h1>
+        </div>
       </div>
-    </fieldset>
-
-    <div class="flex gap-3">
-      <%= f.submit "Create Form", class: "btn btn-primary cursor-pointer" %>
-      <%= link_to "Cancel", forms_path, class: "btn btn-secondary-outline" %>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
-  <% end %>
+
+    <div class="px-4 sm:px-6 py-6">
+      <%= form_with url: forms_path, method: :post, class: "space-y-6", data: { controller: "section-filter" } do |f| %>
+        <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+          <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+            <i class="fa-solid fa-gear text-purple-700"></i>
+            <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Form details</h2>
+          </div>
+          <div class="p-6 space-y-4">
+            <div class="flex flex-col sm:flex-row gap-4">
+              <div class="flex-1">
+                <label class="block text-sm font-medium text-gray-700 mb-1">Form name</label>
+                <input type="text" name="name" value="<%= params[:name] %>"
+                       class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-2xl font-bold"
+                       placeholder="e.g. Short Event Registration">
+              </div>
+
+              <div class="sm:w-56">
+                <label class="block text-sm font-medium text-gray-700 mb-1">Form role</label>
+                <select name="role" data-section-filter-target="select" data-action="section-filter#filter"
+                        class="w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm">
+                  <option value="">General</option>
+                  <option value="registration" <%= "selected" if params[:role] == "registration" %>>Registration</option>
+                  <option value="scholarship" <%= "selected" if params[:role] == "scholarship" %>>Scholarship</option>
+                  <option value="bulk_payment" <%= "selected" if params[:role] == "bulk_payment" %>>Bulk Payment</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+          <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
+            <i class="fa-solid fa-list-check text-purple-700"></i>
+            <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
+          </div>
+          <div class="p-6">
+            <div class="space-y-1.5">
+              <% FormBuilderService::SECTIONS.each do |key, section| %>
+                <% section_role = key == :scholarship ? "scholarship" : key == :bulk_payment ? "bulk_payment" : "other" %>
+                <% field_names = FormBuilderService.section_field_names(key) %>
+                <div class="rounded-lg border border-gray-200 px-3 py-2" data-section-role="<%= section_role %>"
+                     data-controller="expandable-card" data-expandable-card-expanded-value="false">
+                  <div class="flex items-center gap-2">
+                    <label class="flex flex-1 items-center gap-2 cursor-pointer">
+                      <input type="checkbox" name="sections[]" value="<%= key %>"
+                             class="rounded border-gray-300 text-purple-600"
+                             <%= "checked" if params.dig(:sections)&.include?(key.to_s) %>>
+                      <span class="text-sm font-medium text-gray-800"><%= section[:label] %></span>
+                    </label>
+                    <% if field_names.any? %>
+                      <%= render "forms/field_list_toggle", count: field_names.size %>
+                    <% end %>
+                  </div>
+                  <% if field_names.any? %>
+                    <%= render "forms/field_list", names: field_names %>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+          <div class="flex items-center gap-3">
+            <%= f.submit "Create form", class: "btn btn-primary cursor-pointer" %>
+            <%= link_to "Cancel", forms_path, class: "btn btn-secondary-outline" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("Person identifier")
       expect(response.body).to include("Scholarship")
     end
+
+    it "lists each section's fields behind an expandable toggle" do
+      get new_form_path
+      expect(response.body).to include("First Name")
+      expect(response.body).to include("Confirm Email")
+      expect(response.body).to include('data-controller="expandable-card"')
+    end
   end
 
   describe "POST /forms" do
@@ -487,6 +494,13 @@ RSpec.describe "Forms", type: :request do
       get edit_sections_form_path(form)
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Person identifier")
+    end
+
+    it "lists an included section's actual fields behind an expandable toggle" do
+      form = FormBuilderService.new(name: "Editable", sections: %i[person_identifier]).call
+      get edit_sections_form_path(form)
+      expect(response.body).to include("First Name")
+      expect(response.body).to include('data-controller="form-section-toggle expandable-card"')
     end
 
     it "shows custom sections with a custom indicator" do

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -419,5 +419,23 @@ RSpec.describe FormBuilderService do
 
       expect { described_class.editable_sections(form) }.not_to raise_error
     end
+
+    it "exposes each built-in section's question fields in order" do
+      identifier = described_class.editable_sections(form).find { |e| e[:key] == :person_identifier }
+      expect(identifier[:questions].map(&:name)).to eq([ "First Name", "Last Name", "Email", "Confirm Email" ])
+    end
+  end
+
+  # The new-form page lists a section's fields before the form exists, from the
+  # hard-coded SECTION_FIELD_NAMES. This guards it against drifting from what the
+  # builder methods actually create.
+  describe "SECTION_FIELD_NAMES" do
+    FormBuilderService::SECTIONS.each_key do |key|
+      it "matches the fields #{key} actually builds" do
+        form = described_class.new(name: "Test", sections: [ key ]).call
+        built = form.form_fields.where.not(answer_type: :group_header).reorder(:position).pluck(:name)
+        expect(built).to eq(FormBuilderService::SECTION_FIELD_NAMES[key])
+      end
+    end
   end
 end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/event_registrations/new.html.erb"       => "admin-only bg-blue-100",
     "app/views/events/new.html.erb"                    => "admin-only bg-blue-100",
     "app/views/faqs/new.html.erb"                      => "admin-only bg-blue-100",
+    "app/views/forms/new.html.erb"                     => "admin-only bg-blue-100",
     "app/views/organizations/new.html.erb"             => "admin-only bg-blue-100",
     "app/views/organization_statuses/new.html.erb"     => "admin-only bg-blue-100",
     "app/views/people/new.html.erb"                    => "admin-only bg-blue-100",


### PR DESCRIPTION
> 🔗 **Stacked PR** — base branch is `maebeale/form-preview`. Merge #1635 and the preview PR first; GitHub will retarget this to `main`. Review only this PR's own diff.

### What is the goal of this PR and why is this important?
- Polishes the form-building admin UI: a consistent new-form page, per-section field previews, and clearer field-editor affordances.

### How did you approach the change?
- **New-form restyle**: adopts the shared purple hero layout used by the questions/sections editors; the editor eyebrow now reads "Edit".
- **Section field lists**: a per-section expand toggle lists that section's fields vertically. New forms use a hard-coded `SECTION_FIELD_NAMES` map in `FormBuilderService` — **guarded by a spec that builds every section and asserts the map matches**, so it can't silently drift. The sections editor lists the form's *actual* fields, falling back to the defaults for not-yet-added sections.
- **Field editor**: expanding a field's options tray tints the row and adds bottom padding. Reuses the existing `expandable-card` Stimulus controller (no new toggle controller).

### UI Testing Checklist
- [ ] New-form page uses the purple hero layout; eyebrow on the editors reads "Edit".
- [ ] On new + sections pages, each section expands to a vertical field list.
- [ ] Expanding a field's options tints the row and has bottom padding.

### Anything else to add?
- Third of three stacked PRs (subtitle → preview → **builder UI**).
