### PR TITLE
Distinguish partial payments in manage registrants status column

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -208,6 +208,10 @@ class EventRegistration < ApplicationRecord
     allocations_sum >= event.cost_cents.to_i
   end
 
+  def partially_paid?
+    !paid_in_full? && allocations_sum.to_i.positive?
+  end
+
   def joinable?
     active? && paid?
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -208,8 +208,12 @@ class EventRegistration < ApplicationRecord
     allocations_sum >= event.cost_cents.to_i
   end
 
+  def payments_sum
+    allocations.where(source_type: Payment.polymorphic_name).sum(:amount)
+  end
+
   def partially_paid?
-    !paid_in_full? && allocations_sum.to_i.positive?
+    !paid_in_full? && payments_sum.to_i.positive?
   end
 
   def joinable?

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -174,10 +174,31 @@
                   <% due_cents = @event.cost_cents - paid_cents %>
                   <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= due_cents %>">
                     <% is_paid = registration.paid_in_full? %>
+                    <% is_partial = registration.partially_paid? %>
+                    <% badge_classes = if is_paid
+                         "bg-green-50 text-green-700 border-green-200"
+                       elsif is_partial
+                         "bg-blue-50 text-blue-700 border-blue-200"
+                       else
+                         "bg-amber-50 text-amber-700 border-amber-200"
+                       end %>
+                    <% badge_icon = if is_paid
+                         "fa-circle-check"
+                       elsif is_partial
+                         "fa-circle-half-stroke"
+                       else
+                         "fa-circle-exclamation"
+                       end %>
 
-                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{is_paid ? 'bg-green-50 text-green-700 border-green-200' : 'bg-amber-50 text-amber-700 border-amber-200'} hover:opacity-80", title: (!is_paid && paid_cents > 0 ? "$%.2f paid" % (paid_cents / 100.0) : nil), data: { turbo_frame: "_top" } do %>
-                      <i class="fas <%= is_paid ? 'fa-circle-check' : 'fa-circle-exclamation' %>"></i>
-                      <span><%= is_paid ? 'Paid' : "$%.2f due" % (due_cents / 100.0) %></span>
+                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
+                      <i class="fas <%= badge_icon %>"></i>
+                      <% if is_paid %>
+                        <span>Paid</span>
+                      <% elsif is_partial %>
+                        <span>Partial · <%= "$%.2f due" % (due_cents / 100.0) %></span>
+                      <% else %>
+                        <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                      <% end %>
                     <% end %>
                   </td>
                 <% end %>

--- a/db/seeds/dev/payments.rb
+++ b/db/seeds/dev/payments.rb
@@ -268,6 +268,58 @@ fund_registration.(trauma_training, angel_g,
 fund_registration.(mindful_art, amy_person,
   payments: [ { payer: amy_person, amount_cents: 5_000, kind: :cash } ])
 
+# --- AWBW Facilitator Training ($1,500): registrants with MORE THAN ONE payment ---
+# The scenarios above all fund a registration with a single payment. These four
+# brand-new people each have two or more payment records (some also carrying a
+# completed scholarship), split across paid-in-full and still-owing, so the
+# registrants payment-status column ("Paid" vs "Partial · $X due") can be
+# exercised against multi-payment registrations. Amounts target the event's real
+# $1,500 cost so the paid-in-full / partial split is genuine.
+register_with_payments = ->(event, first_name:, last_name:, email:, scholarship: nil, payments: []) do
+  return unless event
+  person = Person.find_or_create_by!(email: email) do |p|
+    p.first_name = first_name
+    p.last_name = last_name
+  end
+  registration = EventRegistration.find_or_create_by!(registrant: person, event: event)
+  return registration if registration.allocations.exists?
+
+  award_scholarship.(registration, **scholarship) if scholarship
+  payments.each { |payment| record_payment.(registration, **{ payer: person }.merge(payment)) }
+  registration
+end
+
+# Nina: paid in full via two payments (cash $1,000 + check $500)
+register_with_payments.(facilitator_training,
+  first_name: "Nina", last_name: "Multipay", email: "nina.multipay@seed.example.com",
+  payments: [
+    { amount_cents: 100_000, kind: :cash },
+    { amount_cents: 50_000, kind: :check }
+  ])
+# Omar: paid in full via completed scholarship ($500) + two cash payments ($600 + $400)
+register_with_payments.(facilitator_training,
+  first_name: "Omar", last_name: "Multipay", email: "omar.multipay@seed.example.com",
+  scholarship: { amount_cents: 50_000, tasks_completed: true },
+  payments: [
+    { amount_cents: 60_000, kind: :cash },
+    { amount_cents: 40_000, kind: :cash }
+  ])
+# Priya: still owes — two cash payments ($500 + $400) of the $1,500 cost
+register_with_payments.(facilitator_training,
+  first_name: "Priya", last_name: "Multipay", email: "priya.multipay@seed.example.com",
+  payments: [
+    { amount_cents: 50_000, kind: :cash },
+    { amount_cents: 40_000, kind: :cash }
+  ])
+# Quincy: still owes — completed scholarship ($300) + cash $400 + check $200 of the $1,500 cost
+register_with_payments.(facilitator_training,
+  first_name: "Quincy", last_name: "Multipay", email: "quincy.multipay@seed.example.com",
+  scholarship: { amount_cents: 30_000, tasks_completed: true },
+  payments: [
+    { amount_cents: 40_000, kind: :cash },
+    { amount_cents: 20_000, kind: :check }
+  ])
+
 [ facilitator_training, trauma_training, mindful_art ].compact.each do |event|
   dashboard = EventDashboard.new(event)
   puts "  #{event.title}: #{dashboard.registrant_count} registrants, " \

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -321,11 +321,18 @@ RSpec.describe EventRegistration, type: :model do
       expect(reg).not_to be_partially_paid
     end
 
-    it "returns true when some but not all of the cost is covered" do
+    it "returns true when a payment covers some but not all of the cost" do
       reg = create(:event_registration, event: event, registrant: user.person)
       payment = create(:payment, person: user.person, amount_cents: 500, amount_cents_remaining: nil)
       create(:allocation, source: payment, allocatable: reg, amount: 500)
       expect(reg).to be_partially_paid
+    end
+
+    it "returns false when only a scholarship covers part of the cost" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      scholarship = create(:scholarship, tasks_completed: true, amount_cents: 500)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 500)
+      expect(reg).not_to be_partially_paid
     end
 
     it "returns false when paid in full" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -312,6 +312,36 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#partially_paid?" do
+    let(:event) { create(:event, cost_cents: 1000) }
+    let(:user) { create(:user, :with_person) }
+
+    it "returns false when nothing has been paid" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      expect(reg).not_to be_partially_paid
+    end
+
+    it "returns true when some but not all of the cost is covered" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      payment = create(:payment, person: user.person, amount_cents: 500, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 500)
+      expect(reg).to be_partially_paid
+    end
+
+    it "returns false when paid in full" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      payment = create(:payment, person: user.person, amount_cents: 1000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 1000)
+      expect(reg).not_to be_partially_paid
+    end
+
+    it "returns false when the event is free" do
+      free_event = create(:event, cost_cents: 0)
+      reg = create(:event_registration, event: free_event, registrant: user.person)
+      expect(reg).not_to be_partially_paid
+    end
+  end
+
   describe '.search_by_params' do
     let(:person_alice) { create(:person, first_name: 'Alice', last_name: 'Smith') }
     let(:person_bob) { create(:person, first_name: 'Bob', last_name: 'Jones') }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Partial")
       end
 
-      it "shows both due and paid amounts for a partial payment" do
+      it "shows the partial badge when a payment covers part of the cost" do
         payment = create(:payment, person: person, amount_cents: 400, amount_cents_remaining: nil)
         create(:allocation, source: payment, allocatable: registration, amount: 400)
 
@@ -442,6 +442,17 @@ RSpec.describe "Events", type: :request do
 
         expect(response.body).to include("fa-circle-half-stroke")
         expect(response.body).to include("Partial · $6.00 due")
+      end
+
+      it "does not show the partial badge when only a scholarship covers part of the cost" do
+        scholarship = create(:scholarship, recipient: person, tasks_completed: true, amount_cents: 400)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 400)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include("fa-circle-exclamation")
+        expect(response.body).to include("$6.00 due")
+        expect(response.body).not_to include("Partial")
       end
 
       it "shows Paid when paid in full" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -423,6 +423,38 @@ RSpec.describe "Events", type: :request do
       end
     end
 
+    context "payment status column" do
+      let(:event) { create(:event, cost_cents: 1000) }
+
+      it "shows the due amount and no paid amount when nothing has been paid" do
+        get registrants_event_path(event)
+
+        expect(response.body).to include("fa-circle-exclamation")
+        expect(response.body).to include("$10.00 due")
+        expect(response.body).not_to include("Partial")
+      end
+
+      it "shows both due and paid amounts for a partial payment" do
+        payment = create(:payment, person: person, amount_cents: 400, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: registration, amount: 400)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include("fa-circle-half-stroke")
+        expect(response.body).to include("Partial · $6.00 due")
+      end
+
+      it "shows Paid when paid in full" do
+        payment = create(:payment, person: person, amount_cents: 1000, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: registration, amount: 1000)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include("fa-circle-check")
+        expect(response.body).to include(">Paid</span>")
+      end
+    end
+
     context "registration form icon" do
       let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the **manage registrants** page, a registrant who made a *partial* payment looked identical to one who had paid nothing — both showed only `$X due`.
- The amount already paid was hidden in a hover `title` tooltip, which is invisible on touch devices and easy to miss.
- Admins had no at-a-glance way to tell who had started paying versus who owed the full amount.

### How did you approach the change?
- Added an `EventRegistration#partially_paid?` predicate (non-zero allocations that don't yet cover the cost).
- Gave the status badge a distinct third state:
  - **Paid in full** — green, `fa-circle-check`, "Paid"
  - **Partial** — blue, `fa-circle-half-stroke`, "Partial · $X due"
  - **Nothing paid** — amber, `fa-circle-exclamation`, "$X due"

### UI Testing Checklist
- [ ] Registrant with no payment shows amber "$X due"
- [ ] Registrant with a partial payment shows blue "Partial · $X due"
- [ ] Fully-paid registrant shows green "Paid"
- [ ] Free events (cost 0) show no payment badge

### Anything else to add?
- Covered by request specs (all three badge states render through the real manage page) and model specs for `partially_paid?`.
- Considered showing both amounts inline ("$6 due ($4 paid)") but went with the more compact "Partial · $X due" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)