### PR TITLE
Add editable descriptions for workshop setting options

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -99,7 +99,7 @@ class CategoriesController < ApplicationController
   def category_params
     if params[:category]
       params.require(:category).permit(
-        :name, :category_type_id, :published, :position
+        :name, :category_type_id, :published, :position, :description
       )
     else
       params.permit(:position)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -141,8 +141,9 @@ module ApplicationHelper
     "primary_age_group" => "AgeRange"
   }.freeze
 
-  # Returns the selectable options for a form field as [ label, value ] pairs,
-  # or nil when the field has no dynamic source (callers fall back to the
+  # Returns the selectable options for a form field as [ label, value, description ]
+  # tuples (description is nil for sectors and present only for categories that have
+  # one), or nil when the field has no dynamic source (callers fall back to the
   # field's own stored answer options). Shared by the public form's radio and
   # checkbox rendering so a dynamic field renders the same options regardless
   # of which single/multiple choice type it was set to.
@@ -152,7 +153,7 @@ module ApplicationHelper
       Sector.published.order(:name).map { |sector| [ sector.name, sector.id.to_s ] }
     when *DYNAMIC_FIELD_CATEGORY_TYPES.keys
       type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
-      (type&.categories&.published&.order(:position, :name) || []).map { |category| [ category.name, category.id.to_s ] }
+      (type&.categories&.published&.order(:position, :name) || []).map { |category| [ category.name, category.id.to_s, category.description ] }
     end
   end
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -382,10 +382,10 @@ class FormBuilderService
                          key: "workshop_environments", group: "professional", required: false,
                          hint: "Select all settings where you facilitate or plan to facilitate workshops.",
                          options: [
-                           "Clinical", "Educational", "Events / conferences",
-                           "Faith-based", "Home visits", "Hospitals",
-                           "Law enforcement / court / legal", "Outreach",
-                           "Prisons / jails", "Private practice", "Residential",
+                           "Clinical setting", "Educational setting", "Events and conferences",
+                           "Faith-based setting", "Home visits", "Hospitals",
+                           "Law enforcement/court/legal", "Outreach program",
+                           "Prisons/jails", "Private practice", "Residential program",
                            "Virtually", "With staff", "Other"
                          ])
     position = add_field(form, position, "Client Life Experiences", :multiple_choice_checkbox,

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -48,6 +48,15 @@
 
     </div>
 
+    <!-- Description -->
+    <div>
+      <%= f.input :description,
+                  as: :text,
+                  label: "Description",
+                  hint: "Optional. Shown under this option on the public registration form to clarify its meaning when the name alone isn't enough.",
+                  input_html: { class: "form-control", rows: 2 } %>
+    </div>
+
     <div class="action-buttons mt-8 flex justify-center gap-3">
       <% if allowed_to?(:destroy?, f.object) %>
         <%= link_to "Delete", @category, class: "btn btn-danger-outline",

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -64,6 +64,10 @@
                        data-sortable-handle=""></i>
                   </span>
                   <%= category.name %>
+                  <% if category.description.present? %>
+                    <i class="fa-solid fa-circle-info ml-1 text-sm font-normal text-gray-400 hover:text-blue-600 cursor-help"
+                       title="<%= category.description %>"></i>
+                  <% end %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800 truncate">

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -29,6 +29,12 @@
               </div>
 
           </div>
+          <% if @category.description.present? %>
+            <div class="mb-3">
+              <p class="font-bold text-gray-700">Description:</p>
+              <p class="text-gray-900"><%= @category.description %></p>
+            </div>
+          <% end %>
         </div>
       </div>
 </div>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -68,15 +68,20 @@
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
     <div class="flex flex-wrap gap-2.5 mt-1">
-      <% radio_options.each do |option_label, option_value| %>
-        <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+      <% radio_options.each do |option_label, option_value, option_description| %>
+        <label class="inline-flex items-start gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <input type="radio"
                  name="<%= field_name %>"
                  value="<%= option_value %>"
-                 class="text-blue-600 focus:ring-blue-500"
+                 class="mt-0.5 text-blue-600 focus:ring-blue-500"
                  <%= "checked" if value == option_value || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
                  <%= "required" if field.required %>>
-          <%= option_label %>
+          <span>
+            <%= option_label %>
+            <% if option_description.present? %>
+              <span class="block text-xs font-normal text-gray-500"><%= option_description %></span>
+            <% end %>
+          </span>
         </label>
       <% end %>
     </div>
@@ -85,18 +90,24 @@
     <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
     <% selected_values = Array(value) %>
     <%# Dynamic fields (e.g. primary_service_area) source options from Sector/Category
-        data; everything else uses the field's own stored answer options. %>
+        data; everything else uses the field's own stored answer options. Category
+        options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
-      <% checkbox_options.each do |option_label, option_value| %>
-        <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+      <% checkbox_options.each do |option_label, option_value, option_description| %>
+        <label class="inline-flex items-start gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <input type="checkbox"
                  name="<%= checkbox_name %>"
                  value="<%= option_value %>"
-                 class="rounded text-blue-600 focus:ring-blue-500"
+                 class="mt-0.5 rounded text-blue-600 focus:ring-blue-500"
                  <%= "checked" if selected_values.include?(option_value) %>>
-          <%= option_label %>
+          <span>
+            <%= option_label %>
+            <% if option_description.present? %>
+              <span class="block text-xs font-normal text-gray-500"><%= option_description %></span>
+            <% end %>
+          </span>
         </label>
       <% end %>
     </div>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -94,9 +94,11 @@
         options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
+    <%# Multi-column (not grid) so a sorted option list reads straight down each
+        column then onto the next, rather than zig-zagging across rows. %>
+    <div class="columns-1 sm:columns-2 gap-2.5 mt-1">
       <% checkbox_options.each do |option_label, option_value, option_description| %>
-        <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+        <label class="flex flex-col gap-1 mb-2.5 break-inside-avoid rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
             <input type="checkbox"
                    name="<%= checkbox_name %>"

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -69,19 +69,19 @@
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
     <div class="flex flex-wrap gap-2.5 mt-1">
       <% radio_options.each do |option_label, option_value, option_description| %>
-        <label class="inline-flex items-start gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
-          <input type="radio"
-                 name="<%= field_name %>"
-                 value="<%= option_value %>"
-                 class="mt-0.5 text-blue-600 focus:ring-blue-500"
-                 <%= "checked" if value == option_value || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
-                 <%= "required" if field.required %>>
-          <span>
+        <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+          <span class="flex items-center gap-2">
+            <input type="radio"
+                   name="<%= field_name %>"
+                   value="<%= option_value %>"
+                   class="text-blue-600 focus:ring-blue-500"
+                   <%= "checked" if value == option_value || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
+                   <%= "required" if field.required %>>
             <%= option_label %>
-            <% if option_description.present? %>
-              <span class="block text-xs font-normal text-gray-500"><%= option_description %></span>
-            <% end %>
           </span>
+          <% if option_description.present? %>
+            <span class="pl-6 text-xs font-normal text-gray-500"><%= option_description %></span>
+          <% end %>
         </label>
       <% end %>
     </div>
@@ -96,18 +96,18 @@
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-1">
       <% checkbox_options.each do |option_label, option_value, option_description| %>
-        <label class="inline-flex items-start gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
-          <input type="checkbox"
-                 name="<%= checkbox_name %>"
-                 value="<%= option_value %>"
-                 class="mt-0.5 rounded text-blue-600 focus:ring-blue-500"
-                 <%= "checked" if selected_values.include?(option_value) %>>
-          <span>
+        <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+          <span class="flex items-center gap-2">
+            <input type="checkbox"
+                   name="<%= checkbox_name %>"
+                   value="<%= option_value %>"
+                   class="rounded text-blue-600 focus:ring-blue-500"
+                   <%= "checked" if selected_values.include?(option_value) %>>
             <%= option_label %>
-            <% if option_description.present? %>
-              <span class="block text-xs font-normal text-gray-500"><%= option_description %></span>
-            <% end %>
           </span>
+          <% if option_description.present? %>
+            <span class="pl-6 text-xs font-normal text-gray-500"><%= option_description %></span>
+          <% end %>
         </label>
       <% end %>
     </div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "public") %>
 
-<div class="max-w-2xl mx-auto px-4">
+<div class="max-w-3xl mx-auto px-4">
   <div class="flex flex-wrap items-center gap-2 pt-4">
     <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
@@ -16,7 +16,7 @@
   </div>
 </div>
 
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
+<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
 
   <%# ---- EVENT HEADER ---- %>
   <div class="text-center mb-8">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -55,11 +55,11 @@
 
     <%# Card Header %>
     <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
-      <div class="flex items-center gap-5">
+      <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
-        <div>
+        <div class="min-w-0">
           <h2 class="text-xl font-semibold tracking-wide leading-tight">Registration</h2>
           <p class="text-sm text-blue-200">Reserve your spot.</p>
         </div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -3,7 +3,7 @@
 <% reg = @form_submission.person.event_registrations.find_by(event: @event) %>
 <% back_path = reg&.slug.present? ? registration_ticket_path(reg.slug) : event_path(@event) %>
 <% back_label = reg&.slug.present? ? "Back to ticket" : "Back to event" %>
-<div class="max-w-2xl mx-auto px-4 pt-4">
+<div class="max-w-3xl mx-auto px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
+<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
 
   <%# ---- FORM RESPONSES CARD ---- %>
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">

--- a/db/migrate/20260612130000_add_description_to_categories.rb
+++ b/db/migrate/20260612130000_add_description_to_categories.rb
@@ -1,0 +1,9 @@
+class AddDescriptionToCategories < ActiveRecord::Migration[8.1]
+  def up
+    add_column :categories, :description, :text unless column_exists?(:categories, :description)
+  end
+
+  def down
+    remove_column :categories, :description, :text, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_130000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -315,6 +315,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_160000) do
   create_table "categories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "category_type_id"
     t.datetime "created_at", precision: nil, null: false
+    t.text "description"
     t.integer "legacy_id"
     t.string "name"
     t.integer "position", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -333,7 +333,12 @@ workshop_settings_type.categories.order(:id).each_with_index do |cat, i|
 end
 
 workshop_settings.each_with_index do |(name, description), index|
-  cat = workshop_settings_type.categories.where("LOWER(name) = LOWER(?)", name).first
+  # Match the clean name, or the earlier "Name (examples)" form that baked the
+  # examples into the label, so a category seeded before descriptions moved into
+  # their own column is renamed in place — preserving its taggings — rather than
+  # duplicated and left orphaned.
+  cat = workshop_settings_type.categories.where("LOWER(name) = LOWER(?)", name).first ||
+        workshop_settings_type.categories.where("LOWER(name) LIKE LOWER(?)", "#{name} (%").first
   cat ||= workshop_settings_type.categories.create!(name: name)
   cat.update!(name: name, published: true, description: description)
   cat.update_columns(position: index + 1)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -304,27 +304,43 @@ workshop_settings_type = find_or_create_by_name!(CategoryType, "WorkshopEnvironm
 end
 workshop_settings_type.update!(display_text: "Workshop Settings", story_specific: false, profile_specific: true, published: true)
 
-[
-  "Clinical setting (community mental health, outpatient, etc.)",
-  "Educational setting (schools, universities, etc.)",
-  "Events and conferences",
-  "Faith-based setting",
-  "Home visits",
-  "Hospitals",
-  "Law enforcement/court/legal",
-  "Outreach program (drop-in services, support groups, etc.)",
-  "Prisons/jails",
-  "Private practice",
-  "Residential program (emergency shelters, inpatient, etc.)",
-  "Virtually",
-  "With staff",
-  "Other (please specify below)"
-].each do |name|
-  cat = Category.where("LOWER(name) = LOWER(?)", name).first
-  if cat
-    cat.update!(category_type: workshop_settings_type) unless cat.category_type_id == workshop_settings_type.id
-  else
-    cat = workshop_settings_type.categories.create!(name: name, published: true)
-  end
-  cat.update!(published: true) unless cat.published?
+# Canonical workshop settings, in display order. The parenthetical examples from
+# the registration form live in each option's description, shown as subtext under
+# the option so the label stays a clean, clickable phrase. Obvious settings have
+# no description. Admins can rename, re-describe, reorder, and publish/unpublish
+# each from the Categories admin once seeded.
+workshop_settings = [
+  [ "Clinical setting", "Community mental health, outpatient, etc." ],
+  [ "Educational setting", "Schools, universities, etc." ],
+  [ "Events and conferences", nil ],
+  [ "Faith-based setting", nil ],
+  [ "Home visits", nil ],
+  [ "Hospitals", nil ],
+  [ "Law enforcement/court/legal", nil ],
+  [ "Outreach program", "Drop-in services, support groups, etc." ],
+  [ "Prisons/jails", nil ],
+  [ "Private practice", nil ],
+  [ "Residential program", "Emergency shelters, inpatient, etc." ],
+  [ "Virtually", nil ],
+  [ "With staff", nil ],
+  [ "Other", "Please specify below." ]
+]
+
+# Park existing positions above the canonical range so we can renumber 1..N without
+# tripping the unique [category_type_id, position] index mid-reconcile.
+workshop_settings_type.categories.order(:id).each_with_index do |cat, i|
+  cat.update_columns(position: 10_000 + i)
 end
+
+workshop_settings.each_with_index do |(name, description), index|
+  cat = workshop_settings_type.categories.where("LOWER(name) = LOWER(?)", name).first
+  cat ||= workshop_settings_type.categories.create!(name: name)
+  cat.update!(name: name, published: true, description: description)
+  cat.update_columns(position: index + 1)
+end
+
+# Hide settings that are no longer offered without destroying historical taggings.
+canonical_names = workshop_settings.map { |name, _| name.downcase }
+workshop_settings_type.categories
+  .reject { |cat| canonical_names.include?(cat.name.downcase) }
+  .each { |cat| cat.update!(published: false) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -310,17 +310,17 @@ workshop_settings_type.update!(display_text: "Workshop Settings", story_specific
 # no description. Admins can rename, re-describe, reorder, and publish/unpublish
 # each from the Categories admin once seeded.
 workshop_settings = [
-  [ "Clinical setting", "Community mental health, outpatient, etc." ],
-  [ "Educational setting", "Schools, universities, etc." ],
+  [ "Clinical setting", "Community mental health, outpatient, etc" ],
+  [ "Educational setting", "Schools, universities, etc" ],
   [ "Events and conferences", nil ],
   [ "Faith-based setting", nil ],
   [ "Home visits", nil ],
   [ "Hospitals", nil ],
   [ "Law enforcement/court/legal", nil ],
-  [ "Outreach program", "Drop-in services, support groups, etc." ],
+  [ "Outreach program", "Drop-in services, support groups, etc" ],
   [ "Prisons/jails", nil ],
   [ "Private practice", nil ],
-  [ "Residential program", "Emergency shelters, inpatient, etc." ],
+  [ "Residential program", "Emergency shelters, inpatient, etc" ],
   [ "Virtually", nil ],
   [ "With staff", nil ],
   [ "Other", "Please specify below." ]

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -171,13 +171,13 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     it "renders a workshop setting option's description under its checkbox" do
       category_type = create(:category_type, name: "WorkshopEnvironment")
       create(:category, :published, category_type: category_type,
-             name: "Clinical setting", description: "Community mental health, outpatient, etc.")
+             name: "Clinical setting", description: "Community mental health, outpatient, etc")
       create(:form_field, form: form, answer_type: :multiple_choice_checkbox,
              field_identifier: "workshop_environments", name: "Workshop Settings", required: false)
 
       get new_event_public_registration_path(event)
 
-      expect(response.body).to include("Community mental health, outpatient, etc.")
+      expect(response.body).to include("Community mental health, outpatient, etc")
     end
   end
 

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -167,6 +167,18 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).to include("<strong>Please complete all fields below.</strong>")
     end
+
+    it "renders a workshop setting option's description under its checkbox" do
+      category_type = create(:category_type, name: "WorkshopEnvironment")
+      create(:category, :published, category_type: category_type,
+             name: "Clinical setting", description: "Community mental health, outpatient, etc.")
+      create(:form_field, form: form, answer_type: :multiple_choice_checkbox,
+             field_identifier: "workshop_environments", name: "Workshop Settings", required: false)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("Community mental health, outpatient, etc.")
+    end
   end
 
   describe "GET show" do

--- a/spec/views/categories/index.html.erb_spec.rb
+++ b/spec/views/categories/index.html.erb_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe "categories/index", type: :view do
     expect(rendered).to include("Yes") # for first category
     expect(rendered).to include("No")  # for second category
   end
+
+  it "shows a hoverable info icon only for categories that have a description" do
+    assign(:categories, [
+      create(:category, :published, name: "Described", category_type: type_a,
+             description: "Community mental health, outpatient, etc"),
+      create(:category, name: "Plain", category_type: type_b)
+    ])
+
+    render
+
+    expect(rendered).to have_css("i.fa-circle-info[title='Community mental health, outpatient, etc']")
+    expect(rendered).to have_css("i.fa-circle-info", count: 1)
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The workshop setting options (Clinical setting, Outreach program, Residential program, …) are short labels whose meaning isn't always obvious to registrants.
- This gives each setting an optional **description** — the clarifying examples — shown as muted subtext under the option on the public registration form.
- Keeps the option *label* a clean, clickable phrase while the examples live in their own editable field, rather than being baked into the option name.

### How did you approach the change?

- Added a nullable `description` column to `categories` (reversible migration).
- Extended the shared `dynamic_form_field_options` helper to return `[ label, value, description ]` tuples for category-backed fields; the public form's radio and checkbox branches render the description as subtext when present.
- Made `description` editable per category from the Categories admin (form field + show page) and permitted in strong params.
- Seeded the canonical 14 workshop settings with clean names + descriptions, reconciling existing data non-destructively (renumber positions safely; unpublish — never delete — settings no longer offered, so historical taggings survive).
- Updated the `FormBuilderService` hard-coded option names to match.

### Layout

- Each option renders as a checkbox/name row (vertically centered, so the box no longer floats above the label) with the description stacked below, indented to line up under the name.
- Abbreviated examples drop the trailing period after "etc".
- Widened the registration and confirmation containers from `max-w-2xl` to `max-w-3xl` for a bit more breathing room.

### Relationship to #1634

- #1634 landed the same canonical 14 settings but with the examples **baked into the option name** (e.g. `"Clinical setting (community mental health, outpatient, etc.)"`).
- This PR builds on that refactor and moves the parentheticals out of the names into the new `description` column, so labels stay clean and the examples are separately editable.

### Anything else to add?

- Descriptions also render for category-backed fields switched to single-choice (radio), for parity.
- New request spec covers the description rendering; main's dynamic-option radio/checkbox specs and the helper specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)