### PR TITLE
Extract FormAnswerValidator and drop FormField position default_scope

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       safely_block (>= 0.4)
     bootsnap (1.22.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bullet (8.1.0)
@@ -865,7 +865,7 @@ CHECKSUMS
   binding_of_caller (1.0.1)
   blazer (3.3.0) sha256=01e151091ce1e7d27c156243916b2f13109ef2ef1a16cfa62bef67f4c5fd169f
   bootsnap (1.22.0) sha256=5820c9d42c2efef095bee6565484bdc511f1223bf950140449c9385ae775793e
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.1.0) sha256=604b7e2636ec2137dcab3ba61a56248c39a0004a0c9405d58bad0686d23b98ff
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -96,34 +96,9 @@ module Events
     end
 
     def validate_required_fields
-      errors = {}
-      visible_fields = visible_form_fields
-
-      visible_fields.find_each do |field|
-        next if field.group_header?
-        next if field.field_identifier == "bulk_payment_attendees"
-
-        value = @form_params[field.id.to_s]
-
-        if field.required && (value.blank? || (value.is_a?(Array) && value.reject(&:blank?).empty?))
-          errors[field.id] = "can't be blank"
-          next
-        end
-
-        next if value.blank?
-
-        if field.number_integer? && value.to_s !~ /\A\d+\z/
-          errors[field.id] = "must be a whole number"
-        elsif field.field_identifier == "payer_email" && value.to_s !~ /\A[^@\s]+@[^@\s]+\z/
-          errors[field.id] = "must be a valid email address"
-        elsif (word_error = field.min_words_error(value))
-          errors[field.id] = word_error
-        elsif (char_error = field.max_characters_error(value))
-          errors[field.id] = char_error
-        end
-      end
-
-      errors
+      # The nested attendees field is validated separately, so exclude it here.
+      fields = visible_form_fields.reject { |field| field.field_identifier == "bulk_payment_attendees" }
+      FormAnswerValidator.call(fields, @form_params)
     end
 
     def credit_card_payment?(form_params)

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -42,7 +42,7 @@ module Events
       @field_errors = validate_required_fields(registration_params)
       if @scholarship_form
         scholarship_fields = @scholarship_form.form_fields.where.not(answer_type: :group_header).to_a
-        @field_errors = @field_errors.merge(collect_field_errors(scholarship_fields, scholarship_params))
+        @field_errors = @field_errors.merge(FormAnswerValidator.call(scholarship_fields, scholarship_params))
       end
       if @field_errors.any?
         @form_fields = visible_form_fields
@@ -315,7 +315,7 @@ module Events
 
     def validate_required_fields(form_params)
       fields = visible_form_fields.to_a
-      errors = collect_field_errors(fields, form_params)
+      errors = FormAnswerValidator.call(fields, form_params)
 
       fields_by_identifier = fields.select { |f| f.field_identifier.present? }.index_by(&:field_identifier)
       confirm_field = fields_by_identifier["confirm_email"]
@@ -325,38 +325,6 @@ module Events
         email_value = form_params[email_field.id.to_s].to_s.strip
         if confirm_value.present? && confirm_value != email_value
           errors[confirm_field.id] = "must match email"
-        end
-      end
-
-      errors
-    end
-
-    # Per-field validation shared by every form role (registration, scholarship):
-    # presence, number/email format, and the per-field min-words / max-characters
-    # settings. Keyed by field id so results from multiple forms can be merged.
-    def collect_field_errors(fields, form_params)
-      errors = {}
-
-      fields.each do |field|
-        next if field.group_header?
-
-        value = form_params[field.id.to_s]
-
-        if field.required && (value.blank? || (value.is_a?(Array) && value.reject(&:blank?).empty?))
-          errors[field.id] = "can't be blank"
-          next
-        end
-
-        next if value.blank?
-
-        if field.number_integer? && value.to_s !~ /\A\d+\z/
-          errors[field.id] = "must be a whole number"
-        elsif field.field_identifier&.match?(/email(?!_type|_confirmation)/) && value.to_s !~ /\A[^@\s]+@[^@\s]+\z/
-          errors[field.id] = "must be a valid email address"
-        elsif (word_error = field.min_words_error(value))
-          errors[field.id] = word_error
-        elsif (char_error = field.max_characters_error(value))
-          errors[field.id] = char_error
         end
       end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -199,7 +199,7 @@ class ReportsController < ApplicationController
   def build_report_form_fields
     return unless @form_builder.form_fields
 
-    @form_builder.form_fields.where(status: 1).each do |field|
+    @form_builder.form_fields.where(status: 1).order(:position).each do |field|
       if field.multiple_choice?
         field.answer_options.each do |option|
           @report.report_form_field_answers.new(

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -186,7 +186,7 @@ class ResourcesController < ApplicationController
     form = @resource.form
     if form
       @user_form = Report.new(created_by: current_user, owner: @resource)
-      form.form_fields.where(status: 1).each do |field|
+      form.form_fields.where(status: 1).order(:position).each do |field|
         @user_form.report_form_field_answers.build(form_field: field)
       end
     end

--- a/app/decorators/workshop_decorator.rb
+++ b/app/decorators/workshop_decorator.rb
@@ -60,7 +60,7 @@ class WorkshopDecorator < ApplicationDecorator
   end
 
   def log_fields
-    form_builder ? form_builder.forms[0].form_fields : []
+    form_builder ? form_builder.forms[0].form_fields.order(:position) : []
   end
 
   def log_form_header

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -72,7 +72,6 @@ class FormField < ApplicationRecord
   accepts_nested_attributes_for :form_field_answer_options, allow_destroy: true,
     reject_if: ->(attrs) { attrs[:option_name].blank? }
 
-  default_scope { order(position: :desc) }
   scope :published, -> { where(status: "active") }
 
   # Methods
@@ -104,6 +103,16 @@ class FormField < ApplicationRecord
 
   def free_form_text?
     FREE_FORM_TEXT_TYPES.include?(answer_type)
+  end
+
+  # Field identifiers (system-assigned by FormBuilderService) that collect an
+  # email address, so a submitted value should be format-checked. The "*_type"
+  # selector fields are deliberately excluded — this is an exact allowlist, not
+  # a name-pattern match, so an unrelated field can't opt in by accident.
+  EMAIL_FIELD_IDENTIFIERS = %w[primary_email confirm_email secondary_email payer_email].freeze
+
+  def email_field?
+    field_identifier.in?(EMAIL_FIELD_IDENTIFIERS)
   end
 
   def word_count(value)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -121,7 +121,7 @@ class Report < ApplicationRecord
   def log_fields
     if form_builder
       form_builder.forms[0].form_fields.where("position is not null and status = 1")
-        .order(position: :desc).all
+        .order(position: :asc).all
     else
       []
     end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -203,7 +203,7 @@ class Workshop < ApplicationRecord
   def workshop_log_fields
     if form_builder
       form_builder.forms[0].form_fields.where("position is not null and status = 1")
-        .order(position: :desc).all
+        .order(position: :asc).all
     else
       []
     end

--- a/app/services/form_answer_validator.rb
+++ b/app/services/form_answer_validator.rb
@@ -1,0 +1,49 @@
+# Validates submitted answer values against each form field's configuration:
+# presence (required), integer/email format, and the per-field min-words /
+# max-characters settings. Returns a hash of { field_id => error_message } so
+# results from multiple forms (e.g. registration + scholarship) can be merged.
+#
+# Group headers are skipped here; any other field-specific exclusions (e.g.
+# bulk payment's nested attendees) are the caller's responsibility — pass only
+# the fields you want validated.
+class FormAnswerValidator
+  EMAIL_FORMAT = /\A[^@\s]+@[^@\s]+\z/
+  WHOLE_NUMBER_FORMAT = /\A\d+\z/
+
+  def self.call(fields, form_params)
+    new(fields, form_params).call
+  end
+
+  def initialize(fields, form_params)
+    @fields = fields
+    @form_params = form_params
+  end
+
+  def call
+    @fields.each_with_object({}) do |field, errors|
+      next if field.group_header?
+
+      error = error_for(field, @form_params[field.id.to_s])
+      errors[field.id] = error if error
+    end
+  end
+
+  private
+
+  def error_for(field, value)
+    return "can't be blank" if field.required && blank_answer?(value)
+    return if value.blank?
+
+    if field.number_integer? && value.to_s !~ WHOLE_NUMBER_FORMAT
+      "must be a whole number"
+    elsif field.email_field? && value.to_s !~ EMAIL_FORMAT
+      "must be a valid email address"
+    else
+      field.min_words_error(value) || field.max_characters_error(value)
+    end
+  end
+
+  def blank_answer?(value)
+    value.blank? || (value.is_a?(Array) && value.reject(&:blank?).empty?)
+  end
+end

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FormAnswerValidator do
+  let(:form) { create(:form) }
+
+  def validate(field, value)
+    described_class.call([ field ], { field.id.to_s => value })
+  end
+
+  describe "presence" do
+    it "flags a blank value on a required field" do
+      field = create(:form_field, form: form, required: true)
+
+      expect(validate(field, "")).to eq(field.id => "can't be blank")
+    end
+
+    it "treats an array of only blanks as blank" do
+      field = create(:form_field, form: form, required: true, answer_type: :multiple_choice_checkbox)
+
+      expect(validate(field, [ "", "" ])).to eq(field.id => "can't be blank")
+    end
+
+    it "passes a present value on a required field" do
+      field = create(:form_field, form: form, required: true)
+
+      expect(validate(field, "Jane")).to eq({})
+    end
+
+    it "skips format checks when an optional field is left blank" do
+      field = create(:form_field, form: form, required: false, input_type: :number_integer)
+
+      expect(validate(field, "")).to eq({})
+    end
+  end
+
+  describe "whole number format" do
+    let(:field) { create(:form_field, form: form, input_type: :number_integer) }
+
+    it "rejects non-integer input" do
+      expect(validate(field, "12.5")).to eq(field.id => "must be a whole number")
+    end
+
+    it "accepts integer input" do
+      expect(validate(field, "12")).to eq({})
+    end
+  end
+
+  describe "email format" do
+    let(:field) { create(:form_field, form: form, field_identifier: "primary_email") }
+
+    it "rejects a malformed email" do
+      expect(validate(field, "not-an-email")).to eq(field.id => "must be a valid email address")
+    end
+
+    it "accepts a well-formed email" do
+      expect(validate(field, "jane@example.com")).to eq({})
+    end
+
+    it "checks payer_email the same way (unified across forms)" do
+      payer = create(:form_field, form: form, field_identifier: "payer_email")
+
+      expect(validate(payer, "nope")).to eq(payer.id => "must be a valid email address")
+    end
+
+    it "does not email-validate the *_type selector field" do
+      type_field = create(:form_field, form: form, field_identifier: "secondary_email_type")
+
+      expect(validate(type_field, "work")).to eq({})
+    end
+
+    it "does not email-validate a field whose identifier merely contains 'email'" do
+      lookalike = create(:form_field, form: form, field_identifier: "email_preferences")
+
+      expect(validate(lookalike, "anything")).to eq({})
+    end
+  end
+
+  describe "min words / max characters" do
+    it "surfaces the min-words error" do
+      field = create(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 3)
+
+      expect(validate(field, "too short")).to eq(field.id => "must be at least 3 words")
+    end
+
+    it "surfaces the max-characters error" do
+      field = create(:form_field, form: form, answer_type: :free_form_input_one_line, max_characters: 5)
+
+      expect(validate(field, "way too long")).to eq(field.id => "must be 5 characters or fewer")
+    end
+  end
+
+  describe "skipping" do
+    it "ignores group header fields entirely" do
+      header = create(:form_field, form: form, answer_type: :group_header, required: true)
+
+      expect(validate(header, "")).to eq({})
+    end
+  end
+
+  describe "merging multiple forms" do
+    it "returns one entry per failing field, keyed by id" do
+      a = create(:form_field, form: form, required: true)
+      b = create(:form_field, form: form, input_type: :number_integer)
+
+      result = described_class.call([ a, b ], { a.id.to_s => "", b.id.to_s => "x" })
+
+      expect(result).to eq(a.id => "can't be blank", b.id => "must be a whole number")
+    end
+  end
+end

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FormBuilderService do
 
     it "creates fields with sequential positions" do
       form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
-      positions = form.form_fields.unscoped.where(form: form).order(:position).pluck(:position)
+      positions = form.form_fields.order(:position).pluck(:position)
       expect(positions).to eq((1..positions.size).to_a)
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

Follow-up to the custom-forms refactor. Two fragile spots left behind:

- **Duplicated answer validation** — the public-registration and bulk-payment controllers each carried their own inline copy of the same presence / integer / email / min-words / max-characters checks, free to drift apart.
- **Implicit `default_scope`** — `FormField` carried `default_scope { order(position: :desc) }`, which silently reversed field order anywhere it wasn't `unscoped`, leaked into unrelated queries, and made ordering a property of the model rather than the call site that needs it.

### How did you approach the change?

- Add `FormAnswerValidator` service (`app/services/form_answer_validator.rb`): presence (required), integer/email format, and per-field min-words/max-characters. Returns `{ field_id => error_message }` so results from multiple forms (registration + scholarship) merge cleanly. Group headers are skipped; other exclusions (e.g. bulk payment's nested attendees) are the caller's responsibility.
- Both controllers now delegate to it — bulk payments rejects the `bulk_payment_attendees` field before calling, since that nested field is validated separately.
- Add `FormField#email_field?` backed by an explicit identifier allowlist (`EMAIL_FIELD_IDENTIFIERS`), so email format-checking is opt-in by exact match — a `*_type` selector or unrelated field can't trigger it by accident.
- Drop the `position: :desc` `default_scope`; order **explicitly (`:asc`)** at each call site that relied on it — report/workshop log fields, the report-builder controllers, and the workshop decorator. Removed a now-unneeded `.unscoped` in the form-builder spec.

### Anything else to add?

- The signed-in one-click registration path (`Events::RegistrationsController#create`) deliberately does **not** use the validator — it submits no form fields (one-click only), so there's nothing to validate.
- Specs: new `form_answer_validator_spec.rb`, plus the touched model/controller/request specs all green (130 + 111 examples). Rubecop clean; Brakeman 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)