### PR TITLE
Single-select dropdown answer type, enum cleanup, and primary/additional sector editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ This codebase (Rails 8.1)
 | `app/models/` | ActiveRecord models | ~75 files |
 | `app/services/` | Service objects for complex logic | ~23 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
-| `app/models/concerns/` | Shared model modules | 13 concerns |
+| `app/models/concerns/` | Shared model modules | 14 concerns |
 
 ### Presentation
 
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (60) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (61) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -132,6 +132,7 @@ This codebase (Rails 8.1)
 | `PunctuationStrippable` | Strips punctuation from strings |
 | `RemoteSearchable` | AJAX remote search by column |
 | `RichTextSearchable` | Full-text search on ActionText rich_text fields |
+| `SectorsTaggable` | Enforces a single primary sector for sector-tagged owners |
 | `TagFilterable` | Scope-based filtering by tag names |
 | `Trendable` | Trending metrics tracking |
 | `WindowsTypeFilterable` | Filter by WindowsType association |

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -200,7 +200,7 @@ class ReportsController < ApplicationController
     return unless @form_builder.form_fields
 
     @form_builder.form_fields.where(status: 1).order(:position).each do |field|
-      if field.multiple_choice?
+      if field.selectable?
         field.answer_options.each do |option|
           @report.report_form_field_answers.new(
             form_field: field,

--- a/app/frontend/javascript/controllers/answer_options_controller.js
+++ b/app/frontend/javascript/controllers/answer_options_controller.js
@@ -1,11 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Manages a form field's answer options. The editable option list only makes
-// sense for multiple-choice fields, so this controller watches the answer-type
+// sense for options-based fields, so this controller watches the answer-type
 // select and reveals the answer-options section when the field becomes a
-// single/multiple choice type — otherwise a field switched to "Single choice
-// radio" would save with no options and render nothing on the public form.
-// The chevron toggle expands/collapses the option list itself.
+// select type (radio, dropdown, or checkbox) — otherwise a field switched to
+// "Single select radio" would save with no options and render nothing on the
+// public form. The chevron toggle expands/collapses the option list itself.
 export default class extends Controller {
   static targets = ["type", "section", "list", "icon"]
   static values = { expanded: Boolean }
@@ -26,15 +26,17 @@ export default class extends Controller {
     this.render()
   }
 
-  get multipleChoice() {
-    return this.hasTypeTarget && this.typeTarget.value.includes("multiple_choice")
+  // Selectable answer types (radio, dropdown, checkbox) all carry "select"
+  // in their value; free-form and header types do not.
+  get selectable() {
+    return this.hasTypeTarget && this.typeTarget.value.includes("select")
   }
 
   render() {
-    const isMultipleChoice = this.multipleChoice
-    this.sectionTargets.forEach((el) => el.classList.toggle("hidden", !isMultipleChoice))
+    const showOptions = this.selectable
+    this.sectionTargets.forEach((el) => el.classList.toggle("hidden", !showOptions))
     // Dynamic-option fields render a source badge instead of the editable list.
-    if (this.hasListTarget) this.listTarget.classList.toggle("hidden", !(isMultipleChoice && this.expandedValue))
-    if (this.hasIconTarget) this.iconTarget.classList.toggle("rotate-90", isMultipleChoice && this.expandedValue)
+    if (this.hasListTarget) this.listTarget.classList.toggle("hidden", !(showOptions && this.expandedValue))
+    if (this.hasIconTarget) this.iconTarget.classList.toggle("rotate-90", showOptions && this.expandedValue)
   }
 }

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -138,6 +138,9 @@ application.register("searchable-select", SearchableSelectController)
 import SectionFilterController from "./section_filter_controller"
 application.register("section-filter", SectionFilterController)
 
+import SectorChipsController from "./sector_chips_controller"
+application.register("sector-chips", SectorChipsController)
+
 import FormSectionToggleController from "./form_section_toggle_controller"
 application.register("form-section-toggle", FormSectionToggleController)
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -138,8 +138,8 @@ application.register("searchable-select", SearchableSelectController)
 import SectionFilterController from "./section_filter_controller"
 application.register("section-filter", SectionFilterController)
 
-import SectorChipsController from "./sector_chips_controller"
-application.register("sector-chips", SectorChipsController)
+import PrimarySectorController from "./primary_sector_controller"
+application.register("primary-sector", PrimarySectorController)
 
 import FormSectionToggleController from "./form_section_toggle_controller"
 application.register("form-section-toggle", FormSectionToggleController)

--- a/app/frontend/javascript/controllers/primary_sector_controller.js
+++ b/app/frontend/javascript/controllers/primary_sector_controller.js
@@ -24,14 +24,14 @@ export default class extends Controller {
   // Jump the newly-primary chip to the front, mirroring the primary-first order
   // the server renders on save.
   moveToFront(checkbox) {
-    const chip = checkbox.closest("[data-sector-chips-target='chip']")
+    const chip = checkbox.closest("[data-primary-sector-target='chip']")
     if (chip) this.element.prepend(chip)
   }
 
   // Reflect each chip's primary state: darker fill and stronger border when set.
   style() {
     this.primaryTargets.forEach((checkbox) => {
-      const chip = checkbox.closest("[data-sector-chips-target='chip']")
+      const chip = checkbox.closest("[data-primary-sector-target='chip']")
       if (!chip) return
       const primary = checkbox.checked
       chip.classList.toggle("bg-lime-200", primary)

--- a/app/frontend/javascript/controllers/sector_chips_controller.js
+++ b/app/frontend/javascript/controllers/sector_chips_controller.js
@@ -16,8 +16,16 @@ export default class extends Controller {
       this.primaryTargets.forEach((checkbox) => {
         if (checkbox !== event.target) checkbox.checked = false
       })
+      this.moveToFront(event.target)
     }
     this.style()
+  }
+
+  // Jump the newly-primary chip to the front, mirroring the primary-first order
+  // the server renders on save.
+  moveToFront(checkbox) {
+    const chip = checkbox.closest("[data-sector-chips-target='chip']")
+    if (chip) this.element.prepend(chip)
   }
 
   // Reflect each chip's primary state: darker fill and stronger border when set.

--- a/app/frontend/javascript/controllers/sector_chips_controller.js
+++ b/app/frontend/javascript/controllers/sector_chips_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the sector chip editor on the person/organization form. Enforces a
+// single primary sector — lighting one star clears the others — and darkens
+// the starred chip. The leader (crown) flag is independent and multi-select,
+// so it needs no JS and is styled purely via CSS (peer-checked).
+export default class extends Controller {
+  static targets = ["chip", "primary"]
+
+  connect() {
+    this.style()
+  }
+
+  selectPrimary(event) {
+    if (event.target.checked) {
+      this.primaryTargets.forEach((checkbox) => {
+        if (checkbox !== event.target) checkbox.checked = false
+      })
+    }
+    this.style()
+  }
+
+  // Reflect each chip's primary state: darker fill and stronger border when set.
+  style() {
+    this.primaryTargets.forEach((checkbox) => {
+      const chip = checkbox.closest("[data-sector-chips-target='chip']")
+      if (!chip) return
+      const primary = checkbox.checked
+      chip.classList.toggle("bg-lime-200", primary)
+      chip.classList.toggle("border-lime-500", primary)
+      chip.classList.toggle("bg-white", !primary)
+      chip.classList.toggle("border-gray-300", !primary)
+    })
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,7 +149,7 @@ module ApplicationHelper
   # of which single/multiple choice type it was set to.
   def dynamic_form_field_options(field)
     case field.field_identifier
-    when "primary_service_area"
+    when "primary_service_area", "primary_service_area_single"
       Sector.published.order(:name).map { |sector| [ sector.name, sector.id.to_s ] }
     when *DYNAMIC_FIELD_CATEGORY_TYPES.keys
       type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
@@ -161,7 +161,7 @@ module ApplicationHelper
   # editor badge: a sentence-case label and a link to the filtered admin list
   # that manages those options. Returns nil for fields with stored options.
   def form_field_option_source(field)
-    if field.field_identifier == "primary_service_area"
+    if field.field_identifier.in?(%w[primary_service_area primary_service_area_single])
       { label: "Sectors", path: sectors_path }
     elsif (type_name = DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
       type = CategoryType.find_by(name: type_name)

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -92,7 +92,7 @@ module EventHelper
 
     ids = submitted_answer.split(", ")
     case field&.field_identifier
-    when "primary_service_area"
+    when "primary_service_area", "primary_service_area_single"
       ids.filter_map { |id| Sector.find_by(id: id)&.name }.join(", ").presence || submitted_answer
     when "workshop_environments", "client_life_experiences", "primary_age_group"
       ids.filter_map { |id| Category.find_by(id: id)&.name }.join(", ").presence || submitted_answer

--- a/app/models/concerns/sectors_taggable.rb
+++ b/app/models/concerns/sectors_taggable.rb
@@ -1,0 +1,31 @@
+# Shared sector-tagging rules for models that own sectorable_items (Person,
+# Organization). Currently enforces that at most one tagged sector is marked
+# primary; the chip editor's single-star UI is the first line of defense, this
+# is the data-integrity guarantee for imports, the console, and any future API.
+module SectorsTaggable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :at_most_one_primary_sector
+  end
+
+  # Sectorable items ordered for display: the primary sector first, then the
+  # rest alphabetically by sector name. Sorts the in-memory association rather
+  # than issuing a query, so it stays correct when a form re-renders its
+  # unsaved items after a failed save.
+  def sectorable_items_primary_first
+    sectorable_items.sort_by { |item| [ item.is_primary? ? 0 : 1, item.sector&.name.to_s.downcase ] }
+  end
+
+  private
+
+  def at_most_one_primary_sector
+    # Count the in-memory set (not a DB query): with nested attributes both
+    # primaries are built and saved in one transaction, so a row-level check
+    # would see neither persisted yet and let both through.
+    primary_count = sectorable_items.reject(&:marked_for_destruction?).count(&:is_primary?)
+    return if primary_count <= 1
+
+    errors.add(:base, "Only one sector can be marked as primary")
+  end
+end

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -26,11 +26,11 @@ class FormField < ApplicationRecord
   enum :answer_type, [
     :free_form_input_one_line,
     :free_form_input_paragraph,
-    :multiple_choice_radio,
+    :single_select_radio,
     :no_user_input,
-    :multiple_choice_checkbox,
+    :multi_select_checkbox,
     :group_header,
-    :multiple_choice_dropdown
+    :single_select_dropdown
   ]
 
   enum :input_type, [
@@ -51,14 +51,15 @@ class FormField < ApplicationRecord
     "answers_on_file" => "Answers on file"
   }.freeze
 
-  # Human-friendly labels for answer types (radio is "single choice" because only one option can be picked)
+  # Human-friendly labels for answer types (radio/dropdown are "single select"
+  # because only one option can be picked; checkbox allows several)
   ANSWER_TYPE_LABELS = {
     "group_header" => "Section header",
     "free_form_input_one_line" => "One line",
     "free_form_input_paragraph" => "Paragraph",
-    "multiple_choice_radio" => "Single choice radio",
-    "multiple_choice_dropdown" => "Single choice dropdown",
-    "multiple_choice_checkbox" => "Multiple choice checkbox",
+    "single_select_radio" => "Single select radio",
+    "single_select_dropdown" => "Single select dropdown",
+    "multi_select_checkbox" => "Multiple select checkbox",
     "no_user_input" => "Informational-only"
   }.freeze
 
@@ -77,8 +78,10 @@ class FormField < ApplicationRecord
   scope :published, -> { where(status: "active") }
 
   # Methods
-  def multiple_choice?
-    answer_type ? answer_type.include?("multiple_choice") : false
+  SELECTABLE_ANSWER_TYPES = %w[single_select_radio single_select_dropdown multi_select_checkbox].freeze
+
+  def selectable?
+    answer_type.in?(SELECTABLE_ANSWER_TYPES)
   end
 
   def html_id
@@ -152,9 +155,9 @@ class FormField < ApplicationRecord
       :text
     when "free_form_input_paragraph"
       :textarea
-    when "multiple_choice_checkbox"
+    when "multi_select_checkbox"
       :checkbox
-    when "multiple_choice_radio"
+    when "single_select_radio"
       :radio
     when "no_user_input", "group_header"
       childs.any? ? :group_header : :label
@@ -169,9 +172,9 @@ class FormField < ApplicationRecord
       :text_field
     when "free_form_input_paragraph"
       :text_area
-    when "multiple_choice_checkbox"
+    when "multi_select_checkbox"
       :check_box
-    when "multiple_choice_radio"
+    when "single_select_radio"
       :radio_button
     when "no_user_input", "group_header"
       :label

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -29,7 +29,8 @@ class FormField < ApplicationRecord
     :multiple_choice_radio,
     :no_user_input,
     :multiple_choice_checkbox,
-    :group_header
+    :group_header,
+    :multiple_choice_dropdown
   ]
 
   enum :input_type, [
@@ -56,6 +57,7 @@ class FormField < ApplicationRecord
     "free_form_input_one_line" => "One line",
     "free_form_input_paragraph" => "Paragraph",
     "multiple_choice_radio" => "Single choice radio",
+    "multiple_choice_dropdown" => "Single choice dropdown",
     "multiple_choice_checkbox" => "Multiple choice checkbox",
     "no_user_input" => "Informational-only"
   }.freeze

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,5 @@
 class Organization < ApplicationRecord
-  include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable # Publishable
+  include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, SectorsTaggable # Publishable
   belongs_to :organization_status
   belongs_to :organization_obligation, optional: true
   belongs_to :location, optional: true # TODO - remove Location if unused

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,5 @@
 class Person < ApplicationRecord
-  include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable
+  include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, SectorsTaggable
 
   pay_customer default_payment_processor: :stripe
 

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -361,8 +361,29 @@ class EventDashboard
       end
   end
 
+  # Every sector tagged on registrants (primary + additional), backing the
+  # "All service areas" chart. The "Primary service area" chart instead uses
+  # #primary_sectors / #primary_sector_counts, which read only the dropdown.
   def sectors
     @sectors ||= Sector.where(id: registrant_sector_ids).order(:name)
+  end
+
+  # Sectors registrants named as their single primary service area (the
+  # registration dropdown), ordered for the "Primary service area" chart.
+  def primary_sectors
+    @primary_sectors ||= Sector.where(id: primary_sector_counts.keys).order(:name)
+  end
+
+  # Distinct-registrant count per sector named as the primary service area.
+  def primary_sector_counts
+    @primary_sector_counts ||= primary_sector_registrant_ids_by_sector.transform_values(&:size)
+  end
+
+  # Registrant ids per primary sector, for the chart's per-row drill-in links.
+  def primary_sector_registrant_ids_by_sector
+    @primary_sector_registrant_ids_by_sector ||= primary_service_area_rows
+      .group_by(&:last)
+      .transform_values { |rows| rows.map(&:first).uniq }
   end
 
   # Distinct registrant count per sector.
@@ -815,9 +836,11 @@ class EventDashboard
       .pluck(:sectorable_id, :sector_id)
   end
 
-  # [ person_id, sector_id ] pairs from registrants' primary_service_area answers.
+  # [ person_id, sector_id ] pairs from registrants' primary service area answers.
+  # Read from the single-select dropdown ("primary_service_area_single"); the
+  # checkbox "primary_service_area" field collects ADDITIONAL service areas.
   def primary_service_area_rows
-    field = registration_form_field("primary_service_area")
+    field = registration_form_field("primary_service_area_single")
     return [] unless field
 
     FormAnswer

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -211,7 +211,8 @@ module EventRegistrationServices
     end
 
     def assign_tags(person, organization)
-      sector_ids = collect_ids_from_checkboxes("primary_service_area")
+      sector_ids = collect_ids_from_checkboxes("primary_service_area_single") +
+                   collect_ids_from_checkboxes("primary_service_area")
       category_ids = collect_ids_from_checkboxes("workshop_environments") +
                      collect_ids_from_checkboxes("client_life_experiences") +
                      collect_ids_from_checkboxes("primary_age_group")

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -49,7 +49,7 @@ class FormBuilderService
       agency_state agency_zip agency_type agency_website
     ],
     person_background: %w[racial_ethnic_identity],
-    professional_info: %w[primary_service_area workshop_environments client_life_experiences primary_age_group],
+    professional_info: %w[primary_service_area_single primary_service_area workshop_environments client_life_experiences primary_age_group],
     marketing: %w[referral_source training_motivation interested_in_more],
     scholarship: %w[scholarship_eligibility impact_description implementation_plan additional_comments],
     payment: %w[payment_method],
@@ -375,9 +375,12 @@ class FormBuilderService
   def build_professional_info_fields(form, position)
     position = add_header(form, position, "Professional Information", group: "professional")
 
-    position = add_field(form, position, "Primary Service Area(s)", :multiple_choice_checkbox,
+    position = add_field(form, position, "Primary service area", :multiple_choice_dropdown,
+                         key: "primary_service_area_single", group: "professional", required: false,
+                         hint: "Select the sector you primarily serve.")
+    position = add_field(form, position, "Additional service areas", :multiple_choice_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
-                         hint: "Select all that apply. These represent the sectors you primarily serve.")
+                         hint: "Select all that apply. These represent the other sectors you serve.")
     position = add_field(form, position, "Workshop Settings", :multiple_choice_checkbox,
                          key: "workshop_environments", group: "professional", required: false,
                          hint: "Select all settings where you facilitate or plan to facilitate workshops.",

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -307,7 +307,7 @@ class FormBuilderService
   def build_person_contact_info_fields(form, position)
     position = add_header(form, position, "Contact Information", group: "person_contact_info")
 
-    position = add_field(form, position, "Primary Email Type", :multiple_choice_radio,
+    position = add_field(form, position, "Primary Email Type", :single_select_radio,
                          key: "primary_email_type", group: "person_contact_info", required: true,
                          options: %w[Personal Work])
     position = add_field(form, position, "Preferred Nickname", :free_form_input_one_line,
@@ -316,14 +316,14 @@ class FormBuilderService
                          key: "pronouns", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Secondary Email", :free_form_input_one_line,
                          key: "secondary_email", group: "person_contact_info", required: false, width: :half)
-    position = add_field(form, position, "Secondary Email Type", :multiple_choice_radio,
+    position = add_field(form, position, "Secondary Email Type", :single_select_radio,
                          key: "secondary_email_type", group: "person_contact_info", required: false,
                          width: :half, options: %w[Personal Work])
 
     position = add_header(form, position, "Mailing Address", group: "person_contact_info")
     position = add_field(form, position, "Street Address", :free_form_input_one_line,
                          key: "mailing_street", group: "person_contact_info", required: true, width: :half)
-    position = add_field(form, position, "Address Type", :multiple_choice_radio,
+    position = add_field(form, position, "Address Type", :single_select_radio,
                          key: "mailing_address_type", group: "person_contact_info", required: true,
                          width: :half, options: %w[Work Personal])
     position = add_field(form, position, "City", :free_form_input_one_line,
@@ -335,7 +335,7 @@ class FormBuilderService
 
     position = add_field(form, position, "Phone", :free_form_input_one_line,
                          key: "phone", group: "person_contact_info", required: true, width: :half)
-    position = add_field(form, position, "Phone Type", :multiple_choice_radio,
+    position = add_field(form, position, "Phone Type", :single_select_radio,
                         key: "phone_type", group: "person_contact_info", required: true,
                         width: :half, options: %w[Work Personal])
 
@@ -352,7 +352,7 @@ class FormBuilderService
                          key: "agency_state", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Agency Zip / Postal Code", :free_form_input_one_line,
                          key: "agency_zip", group: "person_contact_info", required: false, width: :third)
-    position = add_field(form, position, "Agency Type", :multiple_choice_radio,
+    position = add_field(form, position, "Agency Type", :single_select_radio,
                          key: "agency_type", group: "person_contact_info", required: false,
                          options: [
                            "501c3/nonprofit", "For-profit", "Government agency",
@@ -375,13 +375,13 @@ class FormBuilderService
   def build_professional_info_fields(form, position)
     position = add_header(form, position, "Professional Information", group: "professional")
 
-    position = add_field(form, position, "Primary service area", :multiple_choice_dropdown,
+    position = add_field(form, position, "Primary service area", :single_select_dropdown,
                          key: "primary_service_area_single", group: "professional", required: false,
                          hint: "Select the sector you primarily serve.")
-    position = add_field(form, position, "Additional service areas", :multiple_choice_checkbox,
+    position = add_field(form, position, "Additional service areas", :multi_select_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
                          hint: "Select all that apply. These represent the other sectors you serve.")
-    position = add_field(form, position, "Workshop Settings", :multiple_choice_checkbox,
+    position = add_field(form, position, "Workshop Settings", :multi_select_checkbox,
                          key: "workshop_environments", group: "professional", required: false,
                          hint: "Select all settings where you facilitate or plan to facilitate workshops.",
                          options: [
@@ -391,10 +391,10 @@ class FormBuilderService
                            "Prisons/jails", "Private practice", "Residential program",
                            "Virtually", "With staff", "Other"
                          ])
-    position = add_field(form, position, "Client Life Experiences", :multiple_choice_checkbox,
+    position = add_field(form, position, "Client Life Experiences", :multi_select_checkbox,
                          key: "client_life_experiences", group: "professional", required: false,
                          hint: "Select all that describe the populations you work with.")
-    position = add_field(form, position, "Primary Age Group(s) Served", :multiple_choice_checkbox,
+    position = add_field(form, position, "Primary Age Group(s) Served", :multi_select_checkbox,
                          key: "primary_age_group", group: "professional", required: false,
                          hint: "Select all age groups you primarily serve.")
     position
@@ -408,7 +408,7 @@ class FormBuilderService
     position = add_field(form, position, "What motivates you to attend this training?", :free_form_input_paragraph,
                          key: "training_motivation", group: "marketing", required: false)
     position = add_field(form, position, "Are you interested in learning more about upcoming trainings or resources?",
-                         :multiple_choice_radio,
+                         :single_select_radio,
                          key: "interested_in_more", group: "marketing", required: true,
                          options: %w[Yes No])
     position
@@ -419,7 +419,7 @@ class FormBuilderService
 
     position = add_field(form, position,
                          "I / my agency cannot afford the full training cost and need a scholarship to attend.",
-                         :multiple_choice_checkbox,
+                         :multi_select_checkbox,
                          key: "scholarship_eligibility", group: "scholarship", required: true,
                          options: [ "Yes" ])
     position = add_field(form, position,
@@ -440,7 +440,7 @@ class FormBuilderService
   def build_payment_fields(form, position)
     position = add_header(form, position, "Payment Information", group: "payment")
 
-    position = add_field(form, position, "Payment method", :multiple_choice_radio,
+    position = add_field(form, position, "Payment method", :single_select_radio,
                          key: "payment_method", group: "payment", required: true,
                          options: PAYMENT_METHOD_OPTIONS)
     position
@@ -450,7 +450,7 @@ class FormBuilderService
     position = add_header(form, position, "Consent", group: "consent")
     position = add_field(form, position,
                          "I agree to receive email communications from A Window Between Worlds.",
-                         :multiple_choice_checkbox,
+                         :multi_select_checkbox,
                          key: "communication_consent", group: "consent", required: true,
                          hint: "By submitting this form, I consent to receive updates from A Window Between Worlds, " \
                                "including information about this event as well as upcoming events, training opportunities, resources, " \
@@ -462,7 +462,7 @@ class FormBuilderService
   def build_post_event_feedback_fields(form, position)
     position = add_header(form, position, "Post-Event Feedback", group: "post_event_feedback")
 
-    position = add_field(form, position, "How would you rate this event?", :multiple_choice_radio,
+    position = add_field(form, position, "How would you rate this event?", :single_select_radio,
                          key: "event_rating", group: "post_event_feedback", required: true,
                          options: [ "Excellent", "Good", "Fair", "Poor" ])
     position = add_field(form, position, "What did you find most valuable?", :free_form_input_paragraph,
@@ -492,7 +492,7 @@ class FormBuilderService
                          visibility: :logged_out_only)
 
     position = add_header(form, position, "Payment Information", group: "bulk_payment")
-    position = add_field(form, position, "Payment method", :multiple_choice_radio,
+    position = add_field(form, position, "Payment method", :single_select_radio,
                          key: "payment_method", group: "bulk_payment", required: true,
                          options: PAYMENT_METHOD_OPTIONS)
 

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
+<% primary_sector_data = @dashboard.primary_sectors.map { |s| [ s.name, @dashboard.primary_sector_counts.fetch(s.id, 0) ] }.sort_by { |_, count| -count } %>
 <% sector_data = @dashboard.sectors.map { |s| [ s.name, @dashboard.sector_counts.fetch(s.id, 0) ] }.sort_by { |_, count| -count } %>
 <% age_group_data = @dashboard.age_groups.map { |c| [ c.name, @dashboard.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% state_data = @dashboard.state_counts.sort_by { |_, count| -count } %>
@@ -200,6 +201,7 @@
   <%# Per-row drill-ins: each breakdown row links to the registrant list filtered
       to the people behind it (sectors/states use their named filters, the rest use
       the matching registrant_ids set). %>
+  <% primary_sector_paths = @dashboard.primary_sectors.to_h { |s| [ s.name, registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids_by_sector.fetch(s.id, []).join("-")) ] } %>
   <% sector_paths = @dashboard.sectors.to_h { |s| [ s.name, registrants_event_path(@event, sector: s.id) ] } %>
   <% age_group_paths = @dashboard.age_groups.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.age_group_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% state_paths = @dashboard.states.index_with { |state| registrants_event_path(@event, state: state) } %>
@@ -209,8 +211,11 @@
   <% settings_paths = @dashboard.settings.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.settings_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% org_paths = @dashboard.organizations.to_h { |o| [ o.name, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(o.id, []).to_a.join("-")) ] } %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
+    <% if primary_sector_data.any? %>
+      <%= render "breakdown_card", title: "Primary service area", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
+    <% end %>
     <% if sector_data.any? %>
-      <%= render "breakdown_card", title: "Primary service area", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
+      <%= render "breakdown_card", title: "All service areas", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
     <% end %>
     <%# States and countries use the addresses theme color (slate) for their map ramps. %>
     <% addresses_color = "#475569" %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -86,6 +86,21 @@
       <% end %>
     </div>
 
+  <% when "multiple_choice_dropdown" %>
+    <%# Dynamic fields (e.g. primary_service_area_single) source options from
+        Sector/Category data; everything else uses the field's own stored options. %>
+    <% dropdown_options = dynamic_form_field_options(field) ||
+         field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
+    <select name="<%= field_name %>"
+            id="<%= field_id %>"
+            class="<%= input_classes %>"
+            <%= "required" if field.required %>>
+      <option value="">Select one</option>
+      <% dropdown_options.each do |option_label, option_value| %>
+        <option value="<%= option_value %>" <%= "selected" if value == option_value %>><%= option_label %></option>
+      <% end %>
+    </select>
+
   <% when "multiple_choice_checkbox" %>
     <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
     <% selected_values = Array(value) %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -62,7 +62,7 @@
               <%= "maxlength=\"#{field.max_characters}\"".html_safe if field.max_characters.to_i.positive? %>
               <%= "required" if field.required %>><%= value %></textarea>
 
-  <% when "multiple_choice_radio" %>
+  <% when "single_select_radio" %>
     <%# Dynamic fields (e.g. primary_service_area) source options from Sector/Category
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
@@ -86,7 +86,7 @@
       <% end %>
     </div>
 
-  <% when "multiple_choice_dropdown" %>
+  <% when "single_select_dropdown" %>
     <%# Dynamic fields (e.g. primary_service_area_single) source options from
         Sector/Category data; everything else uses the field's own stored options. %>
     <% dropdown_options = dynamic_form_field_options(field) ||
@@ -101,7 +101,7 @@
       <% end %>
     </select>
 
-  <% when "multiple_choice_checkbox" %>
+  <% when "multi_select_checkbox" %>
     <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
     <% selected_values = Array(value) %>
     <%# Dynamic fields (e.g. primary_service_area) source options from Sector/Category

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -65,7 +65,7 @@
       <div class="flex flex-wrap items-center gap-2">
         <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         <%
-          type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_checkbox no_user_input group_header]
+          type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_dropdown multiple_choice_checkbox no_user_input group_header]
           type_options = type_order.map { |t| [ FormField::ANSWER_TYPE_LABELS[t] || t.titleize, t ] }
         %>
         <%= f.select :answer_type, type_options,

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -65,7 +65,7 @@
       <div class="flex flex-wrap items-center gap-2">
         <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         <%
-          type_order = %w[free_form_input_one_line free_form_input_paragraph multiple_choice_radio multiple_choice_dropdown multiple_choice_checkbox no_user_input group_header]
+          type_order = %w[free_form_input_one_line free_form_input_paragraph single_select_radio single_select_dropdown multi_select_checkbox no_user_input group_header]
           type_options = type_order.map { |t| [ FormField::ANSWER_TYPE_LABELS[t] || t.titleize, t ] }
         %>
         <%= f.select :answer_type, type_options,
@@ -108,7 +108,7 @@
               </span>
             <% else %>
               <button type="button"
-                      class="<%= "hidden" unless field.multiple_choice? %> flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
+                      class="<%= "hidden" unless field.selectable? %> flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 cursor-pointer"
                       data-answer-options-target="section"
                       data-action="answer-options#toggle">
                 <i class="fa-solid fa-chevron-right text-xs transition-transform" data-answer-options-target="icon"></i>

--- a/app/views/monthly_reports/_report_form_field_answers.html.erb
+++ b/app/views/monthly_reports/_report_form_field_answers.html.erb
@@ -20,7 +20,7 @@
 
   <%= form.hidden_field :answer_option_id, id: "log-field-#{log_field.id}" %>
 
-  <% if log_field.multiple_choice? %>
+  <% if log_field.selectable? %>
     <% answer_option = answer.answer_option %>
     <% if log_field.form_helper_type == :radio_button %>
       <% log_field.answer_options.each do |answer_option| %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -113,9 +113,12 @@
     <div class="font-semibold text-gray-700 mb-2">
       Sectors
     </div>
-    <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> p-4 mb-4 shadow-sm">
-      <%= f.simple_fields_for :sectorable_items do |sfi| %>
-        <%= render "shared/sectorable_item_fields", f: sfi, show_is_leader: true %>
+    <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> p-4 mb-4 shadow-sm
+                flex flex-wrap items-center gap-2"
+         data-controller="sector-chips">
+      <% sectors_owner = f.object.respond_to?(:object) ? f.object.object : f.object %>
+      <%= f.simple_fields_for :sectorable_items, sectors_owner.sectorable_items_primary_first do |sfi| %>
+        <%= render "shared/sectorable_item_fields", f: sfi, show_admin_flags: true %>
       <% end %>
 
       <%= link_to_add_association "➕ Add Sector",
@@ -125,7 +128,7 @@
                                   render_options: {
                                     locals: { collection: (@sectors_collection || [])
                                       .reject { |_, id| (@current_sector_ids || []).include?(id) },
-                                              show_is_leader: true } },
+                                              show_admin_flags: true } },
                                   class: "btn btn-secondary-outline" %>
     </div>
   </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -115,7 +115,7 @@
     </div>
     <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> p-4 mb-4 shadow-sm
                 flex flex-wrap items-center gap-2"
-         data-controller="sector-chips">
+         data-controller="primary-sector">
       <% sectors_owner = f.object.respond_to?(:object) ? f.object.object : f.object %>
       <%= f.simple_fields_for :sectorable_items, sectors_owner.sectorable_items_primary_first do |sfi| %>
         <%= render "shared/sectorable_item_fields", f: sfi, show_admin_flags: true %>

--- a/app/views/shared/_report_form_field_answers.html.erb
+++ b/app/views/shared/_report_form_field_answers.html.erb
@@ -20,7 +20,7 @@
 
   <%= form.hidden_field :answer_option_id, id: "log-field-#{log_field.id}" %>
 
-  <% if log_field.multiple_choice? %>
+  <% if log_field.selectable? %>
     <% answer_option = answer.answer_option %>
     <% if log_field.form_helper_type == :radio_button %>
       <% log_field.answer_options.each do |answer_option| %>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -5,7 +5,7 @@
 <div class="nested-fields inline-flex items-center gap-2
             rounded-md border <%= is_primary ? "border-lime-500 bg-lime-200" : "border-gray-300 bg-white" %>
             text-gray-700 px-3 py-1 text-sm font-medium transition"
-     data-sector-chips-target="chip">
+     data-primary-sector-target="chip">
   <% if f.object&.sector_id.present? %>
     <%= f.hidden_field :sector_id %>
     <span><%= f.object.sector&.name %></span>
@@ -25,7 +25,7 @@
     <label class="admin-only cursor-pointer leading-none" title="Mark as primary service area">
       <%= f.check_box :is_primary,
                       class: "peer sr-only",
-                      data: { sector_chips_target: "primary", action: "sector-chips#selectPrimary" } %>
+                      data: { primary_sector_target: "primary", action: "primary-sector#selectPrimary" } %>
       <i class="fa-solid fa-star text-base text-gray-300 peer-checked:text-amber-400 transition-colors" aria-hidden="true"></i>
       <span class="sr-only">Primary</span>
     </label>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -1,10 +1,11 @@
 <% collection ||= @sectors_collection || Sector.published.order(:name).pluck(:name, :id) %>
-<% show_is_leader = local_assigns.fetch(:show_is_leader, false) %>
+<% show_admin_flags = local_assigns.fetch(:show_admin_flags, false) %>
+<% is_primary = f.object&.is_primary? %>
 
-<div class="nested-fields inline-flex items-center
-            rounded-md border border-gray-300 hover:border-gray-400
-            <%= DomainTheme.bg_class_for(:sectors) %> hover:bg-lime-200
-            text-gray-500 px-3 py-1 text-sm font-medium transition">
+<div class="nested-fields inline-flex items-center gap-2
+            rounded-md border <%= is_primary ? "border-lime-500 bg-lime-200" : "border-gray-300 bg-white" %>
+            text-gray-700 px-3 py-1 text-sm font-medium transition"
+     data-sector-chips-target="chip">
   <% if f.object&.sector_id.present? %>
     <%= f.hidden_field :sector_id %>
     <span><%= f.object.sector&.name %></span>
@@ -20,20 +21,21 @@
                   class: "bg-transparent border-none focus:ring-0 text-sm text-gray-500 cursor-pointer py-0"
                 } %>
   <% end %>
-  <% if show_is_leader && allowed_to?(:manage?, Person) %>
-    <span class="admin-only bg-blue-100 inline-flex items-center gap-1 p-1">
-      <%= f.check_box :is_leader,
-                      class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
-      <span class="text-sm font-medium text-gray-700">Leader</span>
-    </span>
-    <span class="admin-only bg-blue-100 inline-flex items-center gap-1 p-1">
+  <% if show_admin_flags && allowed_to?(:manage?, Person) %>
+    <label class="admin-only cursor-pointer leading-none" title="Mark as primary service area">
       <%= f.check_box :is_primary,
-                      class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
-      <span class="text-sm font-medium text-gray-700">Primary</span>
-    </span>
+                      class: "peer sr-only",
+                      data: { sector_chips_target: "primary", action: "sector-chips#selectPrimary" } %>
+      <i class="fa-solid fa-star text-base text-gray-300 peer-checked:text-amber-400 transition-colors" aria-hidden="true"></i>
+      <span class="sr-only">Primary</span>
+    </label>
+    <label class="admin-only cursor-pointer leading-none" title="Mark as sector leader">
+      <%= f.check_box :is_leader, class: "peer sr-only" %>
+      <i class="fa-solid fa-crown text-base text-gray-300 peer-checked:text-lime-700 transition-colors" aria-hidden="true"></i>
+      <span class="sr-only">Leader</span>
+    </label>
   <% end %>
   <%= link_to_remove_association "✖",
                                  f,
-                                 class: "ml-1.5 text-gray-400 hover:text-gray-600
-                                 font-bold text-xs transition" %>
+                                 class: "ml-0.5 text-gray-400 hover:text-gray-600 font-bold text-xs transition" %>
 </div>

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe FormField do
   describe 'enums' do
     it { should define_enum_for(:status).with_values([ :inactive, :active ]) }
     it { should define_enum_for(:answer_type).with_values([ :free_form_input_one_line, :free_form_input_paragraph,
-                                                           :multiple_choice_radio, :no_user_input, :multiple_choice_checkbox,
-                                                           :group_header, :multiple_choice_dropdown ]) }
+                                                           :single_select_radio, :no_user_input, :multi_select_checkbox,
+                                                           :group_header, :single_select_dropdown ]) }
     it { should define_enum_for(:input_type).with_values([ :text_alphanumeric, :number_integer, :number_decimal, :date ]) }
   end
 
@@ -133,7 +133,7 @@ RSpec.describe FormField do
     end
 
     it "does not apply to non-text answer types" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio, min_words: 5)
+      field = build(:form_field, form: form, answer_type: :single_select_radio, min_words: 5)
       expect(field.min_words_error("Yes")).to be_nil
     end
   end
@@ -187,7 +187,7 @@ RSpec.describe FormField do
     end
 
     it "does not apply to non-text answer types" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio, max_characters: 1)
+      field = build(:form_field, form: form, answer_type: :single_select_radio, max_characters: 1)
       expect(field.max_characters_error("Yes")).to be_nil
     end
   end
@@ -211,22 +211,22 @@ RSpec.describe FormField do
     end
   end
 
-  describe "#multiple_choice?" do
+  describe "#selectable?" do
     let(:form) { create(:form) }
 
     it "returns true for checkbox fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_checkbox)
-      expect(field.multiple_choice?).to be true
+      field = build(:form_field, form: form, answer_type: :multi_select_checkbox)
+      expect(field.selectable?).to be true
     end
 
     it "returns true for radio fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
-      expect(field.multiple_choice?).to be true
+      field = build(:form_field, form: form, answer_type: :single_select_radio)
+      expect(field.selectable?).to be true
     end
 
     it "returns false for text fields" do
       field = build(:form_field, form: form, answer_type: :free_form_input_one_line)
-      expect(field.multiple_choice?).to be false
+      expect(field.selectable?).to be false
     end
   end
 
@@ -244,12 +244,12 @@ RSpec.describe FormField do
     end
 
     it "returns :checkbox for checkbox fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_checkbox)
+      field = build(:form_field, form: form, answer_type: :multi_select_checkbox)
       expect(field.html_input_type).to eq(:checkbox)
     end
 
     it "returns :radio for radio fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
+      field = build(:form_field, form: form, answer_type: :single_select_radio)
       expect(field.html_input_type).to eq(:radio)
     end
 
@@ -278,12 +278,12 @@ RSpec.describe FormField do
     end
 
     it "returns :check_box for checkbox fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_checkbox)
+      field = build(:form_field, form: form, answer_type: :multi_select_checkbox)
       expect(field.form_helper_type).to eq(:check_box)
     end
 
     it "returns :radio_button for radio fields" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
+      field = build(:form_field, form: form, answer_type: :single_select_radio)
       expect(field.form_helper_type).to eq(:radio_button)
     end
   end
@@ -291,14 +291,14 @@ RSpec.describe FormField do
   describe "#answer_type_label" do
     let(:form) { create(:form) }
 
-    it "calls radio fields single choice" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_radio)
-      expect(field.answer_type_label).to eq("Single choice radio")
+    it "calls radio fields single select" do
+      field = build(:form_field, form: form, answer_type: :single_select_radio)
+      expect(field.answer_type_label).to eq("Single select radio")
     end
 
-    it "calls checkbox fields multiple choice" do
-      field = build(:form_field, form: form, answer_type: :multiple_choice_checkbox)
-      expect(field.answer_type_label).to eq("Multiple choice checkbox")
+    it "calls checkbox fields multiple select" do
+      field = build(:form_field, form: form, answer_type: :multi_select_checkbox)
+      expect(field.answer_type_label).to eq("Multiple select checkbox")
     end
 
     it "falls back to a humanized label for unmapped types" do

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FormField do
     it { should define_enum_for(:status).with_values([ :inactive, :active ]) }
     it { should define_enum_for(:answer_type).with_values([ :free_form_input_one_line, :free_form_input_paragraph,
                                                            :multiple_choice_radio, :no_user_input, :multiple_choice_checkbox,
-                                                           :group_header ]) }
+                                                           :group_header, :multiple_choice_dropdown ]) }
     it { should define_enum_for(:input_type).with_values([ :text_alphanumeric, :number_integer, :number_decimal, :date ]) }
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -108,6 +108,53 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe "primary sector validation (SectorsTaggable)" do
+    let(:person) { build(:person) }
+    let(:sector_a) { create(:sector, :published) }
+    let(:sector_b) { create(:sector, :published) }
+
+    it "is valid with no primary sectors" do
+      person.sectorable_items.build(sector: sector_a, is_primary: false)
+      person.sectorable_items.build(sector: sector_b, is_primary: false)
+      expect(person).to be_valid
+    end
+
+    it "is valid with exactly one primary sector" do
+      person.sectorable_items.build(sector: sector_a, is_primary: true)
+      person.sectorable_items.build(sector: sector_b, is_primary: false)
+      expect(person).to be_valid
+    end
+
+    it "is invalid with more than one primary sector" do
+      person.sectorable_items.build(sector: sector_a, is_primary: true)
+      person.sectorable_items.build(sector: sector_b, is_primary: true)
+      expect(person).not_to be_valid
+      expect(person.errors[:base]).to include("Only one sector can be marked as primary")
+    end
+
+    it "ignores sectorable_items marked for destruction" do
+      person.sectorable_items.build(sector: sector_a, is_primary: true)
+      doomed = person.sectorable_items.build(sector: sector_b, is_primary: true)
+      doomed.mark_for_destruction
+      expect(person).to be_valid
+    end
+  end
+
+  describe "#sectorable_items_primary_first" do
+    it "orders the primary sector first, then the rest alphabetically" do
+      person = create(:person)
+      zebra = create(:sector, :published, name: "Zebra")
+      apple = create(:sector, :published, name: "Apple")
+      mango = create(:sector, :published, name: "Mango")
+      person.sectorable_items.create!(sector: zebra, is_primary: false)
+      person.sectorable_items.create!(sector: mango, is_primary: true)
+      person.sectorable_items.create!(sector: apple, is_primary: false)
+
+      person.reload
+      expect(person.sectorable_items_primary_first.map { |si| si.sector.name }).to eq(%w[Mango Apple Zebra])
+    end
+  end
+
   describe "#name" do
     let(:person) { build(:person, first_name: "Jane", last_name: "Doe") }
 

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       # the dynamic options — otherwise the question shows up blank.
       sector_a = create(:sector, :published, name: "Healthcare")
       sector_b = create(:sector, :published, name: "Education")
-      create(:form_field, form: form, answer_type: :multiple_choice_radio,
+      create(:form_field, form: form, answer_type: :single_select_radio,
              field_identifier: "primary_service_area", name: "Primary service area",
              required: false)
 
@@ -128,7 +128,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     it "still renders a dynamic-option field as checkboxes" do
       create(:sector, :published, name: "Healthcare")
-      create(:form_field, form: form, answer_type: :multiple_choice_checkbox,
+      create(:form_field, form: form, answer_type: :multi_select_checkbox,
              field_identifier: "primary_service_area", name: "Primary service area",
              required: false)
 
@@ -172,7 +172,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       category_type = create(:category_type, name: "WorkshopEnvironment")
       create(:category, :published, category_type: category_type,
              name: "Clinical setting", description: "Community mental health, outpatient, etc")
-      create(:form_field, form: form, answer_type: :multiple_choice_checkbox,
+      create(:form_field, form: form, answer_type: :multi_select_checkbox,
              field_identifier: "workshop_environments", name: "Workshop Settings", required: false)
 
       get new_event_public_registration_path(event)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -761,7 +761,7 @@ RSpec.describe "Events", type: :request do
       it "shows a primary age group breakdown from registration responses" do
         registration_form = create(:form, name: "Registration")
         field = create(:form_field, form: registration_form, field_identifier: "primary_age_group",
-                                    answer_type: :multiple_choice_checkbox)
+                                    answer_type: :multi_select_checkbox)
         create(:event_form, event: event, form: registration_form, role: "registration")
         age_range = create(:category_type, name: "AgeRange")
         adults = create(:category, name: "Adults", category_type: age_range)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe "Forms", type: :request do
       # person_identifier seeds only free-form fields (no multiple-choice).
       # The answer-options UI must still be present (hidden) so the type
       # dropdown can reveal it client-side — otherwise a field changed to
-      # "Single choice radio" saves with no options and shows nothing on the
+      # "Single select radio" saves with no options and shows nothing on the
       # public form.
       form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
-      expect(form.form_fields.none?(&:multiple_choice?)).to be(true)
+      expect(form.form_fields.none?(&:selectable?)).to be(true)
 
       get edit_form_path(form)
 
@@ -142,7 +142,7 @@ RSpec.describe "Forms", type: :request do
     it "shows an option-source badge linking to the managed list for dynamic fields" do
       type = CategoryType.create!(name: "AgeRange", published: true)
       form = create(:form, :standalone)
-      create(:form_field, form: form, answer_type: :multiple_choice_radio,
+      create(:form_field, form: form, answer_type: :single_select_radio,
              field_identifier: "primary_age_group", name: "Primary age group", status: :active)
 
       get edit_form_path(form)

--- a/spec/requests/people_profile_flags_spec.rb
+++ b/spec/requests/people_profile_flags_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Person profile flag visibility", type: :request do
     profile_show_member_since: "Facilitator since",
     profile_show_phone: "555-123-4567",
     profile_show_affiliations: "Affiliations",
-    profile_show_sectors: "mb-3\">Sectors</h2>",
+    profile_show_sectors: "mb-3\">Primary sector</h2>",
     profile_show_bio: "mb-3\">Bio</h2>",
     profile_show_workshops: "mb-3\">Workshops authored</h2>",
     profile_show_workshop_variations: "Workshop variations authored",

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EventDashboard do
     let(:registration_form) { create(:form, name: "Registration") }
     let(:age_group_field) do
       create(:form_field, form: registration_form, field_identifier: "primary_age_group",
-                          name: "Primary Age Group(s) Served", answer_type: :multiple_choice_checkbox)
+                          name: "Primary Age Group(s) Served", answer_type: :multi_select_checkbox)
     end
 
     let!(:reg1) do
@@ -234,7 +234,7 @@ RSpec.describe EventDashboard do
         # primary for person1 AND an additional sector for person2 — the counts
         # overlap (don't partition).
         service_field = create(:form_field, form: registration_form, field_identifier: "primary_service_area_single",
-                                            answer_type: :multiple_choice_dropdown)
+                                            answer_type: :single_select_dropdown)
         create(:form_answer, form_field: service_field, submitted_answer: sector1.id.to_s,
                              form_submission: FormSubmission.find_by!(person: person1, form: registration_form))
         create(:form_answer, form_field: service_field, submitted_answer: sector2.id.to_s,

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -229,11 +229,12 @@ RSpec.describe EventDashboard do
 
     describe "sector primary/additional split (overlapping)" do
       before do
-        # person1 names sector1 as primary; person2 names sector2 as primary. Both
-        # also carry sector1 as a tag, so sector1 is primary for person1 AND an
-        # additional sector for person2 — the counts overlap (don't partition).
-        service_field = create(:form_field, form: registration_form, field_identifier: "primary_service_area",
-                                            answer_type: :multiple_choice_checkbox)
+        # person1 names sector1 as primary; person2 names sector2 as primary via the
+        # single-select dropdown. Both also carry sector1 as a tag, so sector1 is
+        # primary for person1 AND an additional sector for person2 — the counts
+        # overlap (don't partition).
+        service_field = create(:form_field, form: registration_form, field_identifier: "primary_service_area_single",
+                                            answer_type: :multiple_choice_dropdown)
         create(:form_answer, form_field: service_field, submitted_answer: sector1.id.to_s,
                              form_submission: FormSubmission.find_by!(person: person1, form: registration_form))
         create(:form_answer, form_field: service_field, submitted_answer: sector2.id.to_s,
@@ -247,6 +248,20 @@ RSpec.describe EventDashboard do
       it "counts sectors carried as a non-primary tag, overlapping the primary count" do
         # sector1 is a tag for person2, who named sector2 (not sector1) as primary.
         expect(dashboard.additional_sector_count).to eq(1)
+      end
+
+      it "counts distinct registrants per primary sector, from the dropdown only" do
+        expect(dashboard.primary_sector_counts).to eq(sector1.id => 1, sector2.id => 1)
+      end
+
+      it "exposes only the dropdown-named sectors as primary (not every tag)" do
+        expect(dashboard.primary_sectors).to contain_exactly(sector1, sector2)
+      end
+
+      it "maps each primary sector to the registrants who named it, for drill-in" do
+        map = dashboard.primary_sector_registrant_ids_by_sector
+        expect(map[sector1.id]).to contain_exactly(person1.id)
+        expect(map[sector2.id]).to contain_exactly(person2.id)
       end
     end
 

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FormAnswerValidator do
     end
 
     it "treats an array of only blanks as blank" do
-      field = create(:form_field, form: form, required: true, answer_type: :multiple_choice_checkbox)
+      field = create(:form_field, form: form, required: true, answer_type: :multi_select_checkbox)
 
       expect(validate(field, [ "", "" ])).to eq(field.id => "can't be blank")
     end

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -119,6 +119,19 @@ RSpec.describe FormBuilderService do
       end
     end
 
+    context "professional_info section" do
+      let(:form) { described_class.new(name: "Test", sections: %i[professional_info]).call }
+
+      it "asks for a single primary service area via a dropdown before the additional service areas checkboxes" do
+        primary = form.form_fields.find_by(field_identifier: "primary_service_area_single")
+        additional = form.form_fields.find_by(field_identifier: "primary_service_area")
+
+        expect(primary).to have_attributes(name: "Primary service area", answer_type: "multiple_choice_dropdown")
+        expect(additional).to have_attributes(name: "Additional service areas", answer_type: "multiple_choice_checkbox")
+        expect(primary.position).to be < additional.position
+      end
+    end
+
     context "marketing section" do
       let(:form) { described_class.new(name: "Test", sections: %i[marketing]).call }
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe FormBuilderService do
         primary = form.form_fields.find_by(field_identifier: "primary_service_area_single")
         additional = form.form_fields.find_by(field_identifier: "primary_service_area")
 
-        expect(primary).to have_attributes(name: "Primary service area", answer_type: "multiple_choice_dropdown")
-        expect(additional).to have_attributes(name: "Additional service areas", answer_type: "multiple_choice_checkbox")
+        expect(primary).to have_attributes(name: "Primary service area", answer_type: "single_select_dropdown")
+        expect(additional).to have_attributes(name: "Additional service areas", answer_type: "multi_select_checkbox")
         expect(primary.position).to be < additional.position
       end
     end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

Three related strands around how participants pick service areas and how those sectors are managed:

- **Single-select dropdown answer type** — registrants can pick **one** primary service area from a dropdown (`primary_service_area_single`), while the existing checkbox field becomes "Additional service areas".
- **Answer-type enum cleanup** — the old `multiple_choice_radio`/`multiple_choice_dropdown` names were misleading (both pick exactly one). Renamed to say what they mean.
- **Person sector editor redesign** — the old editor crammed a sector name plus two text checkboxes into each pill (hard to read), and let an admin mark several sectors "primary" when only one is allowed.

### How did you approach the change?

**Dropdown answer type**
- Added a `single_select_dropdown` answer type with a render branch in `_form_field.html.erb` that reuses the shared `dynamic_form_field_options` helper (so dynamic Sector/Category options work for dropdowns too).
- `PublicRegistration` recognizes `primary_service_area_single`; registration collects sector ids from both the single dropdown and the additional-areas checkbox.
- Event background page charts the dropdown answers as a new **"Primary service area"** breakdown and renames the combined-tags chart to **"All service areas"**, each with per-row drill-in links.

**Answer-type enum rename (no migration — enum is integer-backed, order preserved)**
- `multiple_choice_radio` → `single_select_radio`, `multiple_choice_dropdown` → `single_select_dropdown`, `multiple_choice_checkbox` → `multi_select_checkbox`.
- Predicate `multiple_choice?` → `selectable?`, backed by an explicit `SELECTABLE_ANSWER_TYPES` list instead of a fragile `"multiple_choice"` substring match.
- The JS editor controller had the **same** substring check (`value.includes("multiple_choice")`) with no test covering it — the rename would have silently broken the "show answer options" toggle. Fixed to `includes("select")`.

**Person sector editor redesign**
- Each sector is now a chip with two Font Awesome toggles: a **star** (primary, single-select — starring one clears the others) and a ghosted **crown** (leader, multi-select, pure CSS). The starred chip darkens and jumps to the front.
- New `primary_sector` Stimulus controller enforces the single primary and the move-to-front.
- New `SectorsTaggable` concern (Person + Organization) validates **at most one primary sector** (checking the in-memory set, so nested-attribute saves are caught), and exposes `sectorable_items_primary_first` so the editor lists the primary first, then the rest alphabetically.
- Renamed the partial's misleading `show_is_leader` local to `show_admin_flags`.

### UI Testing Checklist

- [ ] On the registration form, the primary service area renders as a single-select dropdown and the additional areas as checkboxes.
- [ ] On the person edit form, starring a sector clears any other star, darkens the chip, and moves it to the front; the crown toggles leader independently.
- [ ] Saving a person persists one primary sector; the editor re-renders primary-first then alphabetical.

### Anything else to add?

- Profile-flag spec marker updated for #1645's split `Primary sector` / `Additional sectors` headings.
- Specs: `form_field_spec`, `form_builder_service_spec`, `event_dashboard_spec`, `person_spec` (validation + ordering), and request specs; full sets green, RuboCop clean.
- **Not yet done:** the Organization form renders the shared partial without `show_admin_flags`, so org-side primary editing is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
