### PR TITLE
Split participant sectors into primary and additional service areas

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -394,7 +394,7 @@ class PeopleController < ApplicationController
       :twitter_url,
       :created_by_id, :updated_by_id,
       category_ids: [],
-      sectorable_items_attributes: [ :id, :sector_id, :is_leader, :_destroy ],
+      sectorable_items_attributes: [ :id, :sector_id, :is_leader, :is_primary, :_destroy ],
       addresses_attributes: [
         :id,
         :address_type,

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -218,7 +218,7 @@ module EventRegistrationServices
 
       if sector_ids.any?
         sectors = Sector.where(id: sector_ids)
-        person.sectors = (person.sectors + sectors).uniq
+        assign_primary_sectors(person, sectors)
         organization.sectors = (organization.sectors + sectors).uniq if organization
       end
 
@@ -226,6 +226,13 @@ module EventRegistrationServices
         categories = Category.where(id: category_ids)
         person.categories = (person.categories + categories).uniq
         organization.categories = (organization.categories + categories).uniq if organization
+      end
+    end
+
+    def assign_primary_sectors(person, sectors)
+      sectors.each do |sector|
+        item = person.sectorable_items.find_or_initialize_by(sector: sector)
+        item.update!(is_primary: true)
       end
     end
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -118,24 +118,42 @@
           <% end %>
           <!-- Sectors -->
           <% if @person.profile_show_sectors? %>
+            <% sectorable_items = @person.sectorable_items.includes(:sector).order("sectors.name") %>
+            <% primary_sector_items = sectorable_items.select(&:is_primary?) %>
+            <% additional_sector_items = sectorable_items.reject(&:is_primary?) %>
             <div class="md:col-span-2 p-3">
-              <h2 class="text-lg font-semibold text-gray-800 mb-3">Sectors</h2>
-              <% if @person.sectorable_items.any? %>
-                <div class="flex flex-wrap gap-2">
-                  <% @person
-                         .sectorable_items
-                         .includes(:sector)
-                         .order("sectors.name")
-                         .each do |si| %>
-                    <%= render "sectors/tagging_label",
-                                 sector: si.sector,
-                                 display_leader: true,
-                                 is_leader: si.is_leader %>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Primary sector</h2>
+                  <% if primary_sector_items.any? %>
+                    <div class="flex flex-wrap gap-2">
+                      <% primary_sector_items.each do |si| %>
+                        <%= render "sectors/tagging_label",
+                                     sector: si.sector,
+                                     display_leader: true,
+                                     is_leader: si.is_leader %>
+                      <% end %>
+                    </div>
+                  <% else %>
+                    <p class="text-gray-500 italic">None selected.</p>
                   <% end %>
                 </div>
-              <% else %>
-                <p class="text-gray-500 italic">None selected.</p>
-              <% end %>
+                <div>
+                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Additional sectors</h2>
+                  <% if additional_sector_items.any? %>
+                    <div class="flex flex-wrap gap-2">
+                      <% additional_sector_items.each do |si| %>
+                        <%= render "sectors/tagging_label",
+                                     sector: si.sector,
+                                     display_leader: true,
+                                     is_leader: si.is_leader %>
+                      <% end %>
+                    </div>
+                  <% else %>
+                    <p class="text-gray-500 italic">None selected.</p>
+                  <% end %>
+                </div>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -26,6 +26,11 @@
                       class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
       <span class="text-sm font-medium text-gray-700">Leader</span>
     </span>
+    <span class="admin-only bg-blue-100 inline-flex items-center gap-1 p-1">
+      <%= f.check_box :is_primary,
+                      class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+      <span class="text-sm font-medium text-gray-700">Primary</span>
+    </span>
   <% end %>
   <%= link_to_remove_association "✖",
                                  f,

--- a/db/migrate/20260612120000_add_is_primary_to_sectorable_items.rb
+++ b/db/migrate/20260612120000_add_is_primary_to_sectorable_items.rb
@@ -1,0 +1,9 @@
+class AddIsPrimaryToSectorableItems < ActiveRecord::Migration[8.1]
+  def up
+    add_column :sectorable_items, :is_primary, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :sectorable_items, :is_primary, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1071,6 +1071,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_130000) do
   create_table "sectorable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.boolean "is_leader", default: false, null: false
+    t.boolean "is_primary", default: false, null: false
     t.integer "sector_id"
     t.integer "sectorable_id"
     t.string "sectorable_type"

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -24,6 +24,41 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     }
   end
 
+  describe "primary service area tagging" do
+    let!(:primary_sector) { create(:sector, name: "Healthcare") }
+    let!(:other_sector) { create(:sector, name: "Education") }
+
+    it "tags the selected primary service area sectors as primary on the person" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+        )
+      )
+
+      expect(result.success?).to be true
+      person = result.event_registration.registrant
+      primary_item = person.sectorable_items.find_by(sector: primary_sector)
+      expect(primary_item.is_primary).to be true
+    end
+
+    it "marks an existing additional sector as primary when later selected" do
+      person = create(:person, first_name: "Pat", last_name: "Lee", email: "pat@example.com")
+      person.sectorable_items.create!(sector: primary_sector, is_primary: false)
+
+      described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+        )
+      )
+
+      expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+    end
+  end
+
   describe "re-registration after cancellation" do
     let(:person) { create(:person, first_name: "Jane", last_name: "Doe", email: "jane@example.com") }
     let!(:cancelled_registration) do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The participant profile showed one flat "Sectors" list, so the sector a person picked as their **primary service area** during registration was indistinguishable from sectors they were tagged with incidentally.
- This surfaces what someone primarily does versus where they also have a footprint, making profiles more informative for staff.

### How did you approach the change?
- Added an `is_primary` flag to `sectorable_items` (migration + schema) and set it from the `primary_service_area` registration answer in `PublicRegistration`, promoting an already-tagged sector to primary if later selected.
- Split the profile "Sectors" block into two side-by-side columns — **Primary sector** and **Additional sectors** — and added a "Primary" checkbox (alongside "Leader") so admins can adjust it manually; permitted the new param.

### UI Testing Checklist
- [ ] Register for a public event selecting a primary service area → that sector appears under **Primary sector** on the registrant's profile.
- [ ] A sector tagged manually (not via registration) appears under **Additional sectors**.
- [ ] Each column shows "None selected." when empty and the two columns stack on mobile.
- [ ] On the person edit form, the new **Primary** checkbox saves correctly.

### Anything else to add?
- `primary_service_area` is a multi-select, so a person can have more than one primary sector; all are rendered in that column.
- Scoped to the profile (show) page — the people listing table's sector column is unchanged.