### PR TITLE
Fix scholarship status toggle knob overflowing track edge

### DIFF
--- a/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
@@ -25,7 +25,8 @@ export default class extends Controller {
       this.trackTarget.classList.toggle("bg-fuchsia-600", this.shownValue)
     }
     if (this.hasKnobTarget) {
-      this.knobTarget.classList.toggle("translate-x-5", this.shownValue)
+      this.knobTarget.classList.toggle("translate-x-[1.125rem]", this.shownValue)
+      this.knobTarget.classList.toggle("translate-x-0.5", !this.shownValue)
     }
   }
 }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The scholarship-status show/hide switch on the event recipients roster looked broken when toggled on: the knob's right edge poked past the rounded track corner.

### How did you approach the change?
- The on-state knob was positioned at `translate-x-5` (20px), pushing its right edge flush with the 36px (`w-9`) track so its square corner overflowed the `rounded-full` track.
- Moved it to `translate-x-[1.125rem]` (18px), the symmetric position, so the knob rests inside the track with equal 2px padding on both sides — matching the 2px left padding of the off state.

### UI Testing Checklist
- [ ] On the event recipients page, toggle "Show scholarship status" on and confirm the knob sits inside the track without overflowing the right edge.

### Anything else to add?
- Tailwind v4 auto-scans the JS controller, so the new arbitrary class is picked up on rebuild.