### PR TITLE
Send confirmation + FYI emails for bulk payment submissions

### DIFF
--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -14,7 +14,9 @@ class NotificationMailerJob < ApplicationJob
       "event_registration_confirmation" => ->(n) { EventMailer.event_registration_confirmation(n.noticeable) },
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
-      "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) }
+      "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) },
+      "bulk_payment_confirmation" => ->(n) { EventMailer.bulk_payment_confirmation(n.noticeable) },
+      "bulk_payment_confirmation_fyi" => ->(n) { NotificationMailer.bulk_payment_confirmation_fyi(n) }
     }
 
     mailer = mailer_map[notification.kind]&.call(notification)

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -19,6 +19,26 @@ class EventMailer < ApplicationMailer
     )
   end
 
+  def bulk_payment_confirmation(form_submission)
+    @submission = form_submission
+    @person = form_submission.person
+    @event = form_submission.event&.decorate
+    @answers = form_submission.answers_by_identifier
+    @attendees = form_submission.bulk_payment_attendees
+
+    @notification_type = "Bulk payment confirmation"
+
+    @submission_url = event_bulk_payment_url(@event, submission_id: @submission.id) if @event
+    @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+
+    mail(
+      to: @person.preferred_email,
+      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      subject: "AWBW Portal: Bulk payment received for #{@event&.title}"
+    )
+  end
+
   def event_registration_reminder(event_registration, days_until_event: nil)
     @event_registration = event_registration
     @event = event_registration.event.decorate

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -27,6 +27,19 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
+  def bulk_payment_confirmation_fyi(notification)
+    @submission = notification.noticeable
+    @person = @submission.person
+    @event = @submission.event&.decorate
+    @answers = @submission.answers_by_identifier
+    @attendees = @submission.bulk_payment_attendees
+    @notification_type = "Bulk payment"
+
+    mail(
+      subject: "#{FYI_PREFIX} New bulk payment by #{@person.full_name} for #{@event&.title}"
+    )
+  end
+
   def idea_submitted(notification)
     @notification = notification
     @noticeable = notification.noticeable.decorate

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -5,4 +5,32 @@ class FormSubmission < ApplicationRecord
   has_many :payments
 
   accepts_nested_attributes_for :form_answers
+
+  # The event this submission belongs to, resolved through the join role that
+  # matches the submission's own role (e.g. a "bulk_payment" submission maps to
+  # the event_form with role "bulk_payment").
+  def event
+    form.events.find_by(event_forms: { role: role })
+  end
+
+  # Answers keyed by their field's identifier. Bulk payment (and similar) forms
+  # address fields by identifier rather than position.
+  def answers_by_identifier
+    form_answers.includes(:form_field).each_with_object({}) do |answer, map|
+      identifier = answer.form_field&.field_identifier
+      map[identifier] = answer.submitted_answer if identifier.present?
+    end
+  end
+
+  # Attendees captured by the bulk payment form, stored as a JSON array under the
+  # "bulk_payment_attendees" field.
+  def bulk_payment_attendees
+    raw = answers_by_identifier["bulk_payment_attendees"]
+    return [] if raw.blank?
+
+    parsed = JSON.parse(raw)
+    parsed.is_a?(Array) ? parsed : []
+  rescue JSON::ParserError
+    []
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,6 +26,8 @@ class Notification < ApplicationRecord
     event_registration_confirmation_fyi
     event_registration_cancelled
     event_registration_cancelled_fyi
+    bulk_payment_confirmation
+    bulk_payment_confirmation_fyi
     idea_submitted
     idea_submitted_fyi
     report_submitted
@@ -56,6 +58,7 @@ class Notification < ApplicationRecord
 
   NOTICEABLE_TYPES = %w[
     EventRegistration
+    FormSubmission
     Report
     StoryIdea
     User
@@ -69,6 +72,7 @@ class Notification < ApplicationRecord
     [ "Admin FYI (all)", "[FYI]" ],
     [ "Admin FYI: event registration confirmed", "[FYI] New event registration" ],
     [ "Admin FYI: event registration cancelled", "[FYI] Event registration cancelled" ],
+    [ "Admin FYI: bulk payment", "[FYI] New bulk payment" ],
     [ "Admin FYI: idea submitted", "submission by" ],
     [ "Admin FYI: password reset", "[FYI] New password reset" ],
     [ "Admin FYI: workshop log submission", "New WorkshopLog submission" ],
@@ -76,6 +80,7 @@ class Notification < ApplicationRecord
     [ "Contact: form confirmation", "We received your message" ],
     [ "Event: event registration cancelled", "Event registration cancelled" ],
     [ "Event: event registration confirmed", "Event registration confirmed" ],
+    [ "Bulk payment: confirmation", "Bulk payment received" ],
     [ "Idea: confirmation (all)", "has been received" ],
     [ "Idea: confirmation: workshop log", "workshop log has been received" ],
     [ "User: confirm new email", "Confirm your new email address" ],

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -19,6 +19,7 @@ module EventRegistrationServices
         person = find_or_create_person
         create_phone_contact(person) if field_value("payer_phone").present?
         submission = create_form_submission(person)
+        send_notifications(submission, person)
         Result.new(success?: true, form_submission: submission, errors: [])
       end
     rescue ActiveRecord::RecordInvalid => e
@@ -26,6 +27,28 @@ module EventRegistrationServices
     end
 
     private
+
+    # Emails the payer a confirmation and notifies staff with an FYI.
+    def send_notifications(submission, person)
+      payer_email = person.preferred_email.presence || field_value("payer_email")&.strip
+      if payer_email.present?
+        NotificationServices::CreateNotification.call(
+          noticeable: submission,
+          kind: :bulk_payment_confirmation,
+          recipient_role: :person,
+          recipient_email: payer_email,
+          notification_type: 0
+        )
+      end
+
+      NotificationServices::CreateNotification.call(
+        noticeable: submission,
+        kind: :bulk_payment_confirmation_fyi,
+        recipient_role: :admin,
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+        notification_type: 0
+      )
+    end
 
     def field_value(key)
       field = @form.form_fields.find_by(field_identifier: key)

--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -1,0 +1,88 @@
+<h1>Bulk payment received</h1>
+
+<div style="margin-top: 36px; text-align: left;">
+  <p>
+    Hello <strong><%= @person.full_name %></strong>,
+  </p>
+
+  <p>
+    We've received your bulk payment submission<%= " for the following #{@organization_name} event" if @event %>:
+  </p>
+
+  <% if @event %>
+    <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+      <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+        <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+          <%= @event.pre_title %>
+        </p>
+      <% end %>
+
+      <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+        <%= @event.title %>
+      </h2>
+
+      <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+        <%= @event.times(display_day: true, display_date: true) %>
+      </p>
+
+      <% if @event.labelled_cost.present? %>
+        <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+          <%= @event.labelled_cost %>
+        </p>
+      <% end %>
+
+      <% if @event.location.present? %>
+        <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+          <%= @event.location.name %>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+    <% if @answers["payer_organization"].present? %>
+      <tr>
+        <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Organization</td>
+        <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_organization"] %></td>
+      </tr>
+    <% end %>
+    <% if @answers["number_of_attendees"].present? %>
+      <tr>
+        <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Number of attendees</td>
+        <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["number_of_attendees"] %></td>
+      </tr>
+    <% end %>
+    <% if @answers["payment_method"].present? %>
+      <tr>
+        <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Payment method</td>
+        <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payment_method"] %></td>
+      </tr>
+    <% end %>
+  </table>
+
+  <% if @attendees.any? %>
+    <p style="margin-bottom: 4px;"><strong>Attendees</strong></p>
+    <table style="width: 100%; border-collapse: collapse; margin: 8px 0 16px;">
+      <thead>
+        <tr>
+          <th style="text-align: left; border-bottom: 1px solid #e5e7eb; padding: 6px; font-size: 13px; color: #6b7280;">Name</th>
+          <th style="text-align: left; border-bottom: 1px solid #e5e7eb; padding: 6px; font-size: 13px; color: #6b7280;">Email</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @attendees.each do |attendee| %>
+          <tr>
+            <td style="border-bottom: 1px solid #f3f4f6; padding: 6px; font-size: 14px;"><%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %></td>
+            <td style="border-bottom: 1px solid #f3f4f6; padding: 6px; font-size: 14px;"><%= attendee["email"] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>
+
+<% if @submission_url %>
+  <p>
+    <a href="<%= @submission_url %>" class="button">View submission</a>
+  </p>
+<% end %>

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -1,0 +1,25 @@
+Bulk payment received
+
+Hello <%= @person.full_name %>,
+
+We've received your bulk payment submission<%= " for the following event" if @event %>:
+
+<% if @event %><% if @event.respond_to?(:pre_title) && @event.pre_title.present? %><%= @event.pre_title %>
+<% end %><%= @event.title %>
+<%= @event.times(display_day: true, display_date: true) %>
+<% if @event.location.present? %>Location: <%= @event.location.name %>
+<% end %><% if @event.labelled_cost.present? %><%= @event.labelled_cost %>
+<% end %><% end %>
+<% if @answers["payer_organization"].present? %>Organization: <%= @answers["payer_organization"] %>
+<% end %><% if @answers["number_of_attendees"].present? %>Number of attendees: <%= @answers["number_of_attendees"] %>
+<% end %><% if @answers["payment_method"].present? %>Payment method: <%= @answers["payment_method"] %>
+<% end %>
+<% if @attendees.any? %>Attendees:
+<% @attendees.each do |attendee| %>- <%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %><%= " <#{attendee['email']}>" if attendee["email"].present? %>
+<% end %><% end %>
+<% if @submission_url %>View submission:
+<%= @submission_url %>
+<% end %>
+--
+This is an automated confirmation from <%= @organization_name %>.
+If you did not expect this message, you may ignore it.

--- a/app/views/notification_mailer/bulk_payment_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/bulk_payment_confirmation_fyi.html.erb
@@ -1,0 +1,102 @@
+<% profile_url = person_url(@person) %>
+
+<p style="margin-bottom: 6px;">
+  New Bulk Payment
+</p>
+
+<h1 style="margin: 0;">
+  <strong><%= @person.full_name %></strong>
+  (<%= @person.preferred_email %>)
+</h1>
+
+<p style="margin: 4px 0 16px; font-size: 13px; color: #6b7280;">
+  Submitted on
+  <%= @submission.created_at
+                 .in_time_zone("Pacific Time (US & Canada)")
+                 .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
+</p>
+
+<% if @event %>
+  <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+    <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+      <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+        <%= @event.pre_title %>
+      </p>
+    <% end %>
+
+    <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+      <%= @event.title %>
+    </h2>
+
+    <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <%= @event.times(display_day: true, display_date: true) %>
+    </p>
+
+    <% if @event.labelled_cost.present? %>
+      <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+        <%= @event.labelled_cost %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
+
+<table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+  <% if @answers["payer_organization"].present? %>
+    <tr>
+      <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Organization</td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_organization"] %></td>
+    </tr>
+  <% end %>
+  <% if @answers["payer_phone"].present? %>
+    <tr>
+      <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Phone</td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_phone"] %></td>
+    </tr>
+  <% end %>
+  <% if @answers["number_of_attendees"].present? %>
+    <tr>
+      <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Number of attendees</td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["number_of_attendees"] %></td>
+    </tr>
+  <% end %>
+  <% if @answers["payment_method"].present? %>
+    <tr>
+      <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Payment method</td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payment_method"] %></td>
+    </tr>
+  <% end %>
+</table>
+
+<% if @attendees.any? %>
+  <p style="margin-bottom: 4px;"><strong>Attendees</strong></p>
+  <table style="width: 100%; border-collapse: collapse; margin: 8px 0 16px;">
+    <thead>
+      <tr>
+        <th style="text-align: left; border-bottom: 1px solid #e5e7eb; padding: 6px; font-size: 13px; color: #6b7280;">Name</th>
+        <th style="text-align: left; border-bottom: 1px solid #e5e7eb; padding: 6px; font-size: 13px; color: #6b7280;">Email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @attendees.each do |attendee| %>
+        <tr>
+          <td style="border-bottom: 1px solid #f3f4f6; padding: 6px; font-size: 14px;"><%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %></td>
+          <td style="border-bottom: 1px solid #f3f4f6; padding: 6px; font-size: 14px;"><%= attendee["email"] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<p>
+  <% if @event %>
+    <a href="<%= event_bulk_payment_url(@event, submission_id: @submission.id) %>"
+       style="display:inline-block;padding:10px 16px;background:#2563eb;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:bold;">
+      View submission
+    </a>
+  <% end %>
+
+  <a href="<%= profile_url %>"
+     style="display:inline-block;background:#e5e7eb;color:#111827;text-decoration:none;padding:10px 16px;border-radius:6px;font-weight:bold;">
+    View profile
+  </a>
+</p>

--- a/app/views/notification_mailer/bulk_payment_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/bulk_payment_confirmation_fyi.text.erb
@@ -1,0 +1,38 @@
+<% profile_url = person_url(@person) %>
+
+New Bulk Payment
+------------------------------------------------------------
+
+<%= @person.full_name %> (<%= @person.preferred_email %>)
+
+Submitted on
+<%= @submission.created_at
+               .in_time_zone("Pacific Time (US & Canada)")
+               .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
+
+------------------------------------------------------------
+<% if @event %>
+Event
+<%= @event.title %>
+
+Event date
+<%= @event.times(display_day: true, display_date: true) %>
+<% if @event.labelled_cost.present? %>
+Cost
+<%= @event.labelled_cost %>
+<% end %><% end %>
+<% if @answers["payer_organization"].present? %>Organization: <%= @answers["payer_organization"] %>
+<% end %><% if @answers["payer_phone"].present? %>Phone: <%= @answers["payer_phone"] %>
+<% end %><% if @answers["number_of_attendees"].present? %>Number of attendees: <%= @answers["number_of_attendees"] %>
+<% end %><% if @answers["payment_method"].present? %>Payment method: <%= @answers["payment_method"] %>
+<% end %>
+<% if @attendees.any? %>Attendees:
+<% @attendees.each do |attendee| %>- <%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %><%= " <#{attendee['email']}>" if attendee["email"].present? %>
+<% end %><% end %>
+------------------------------------------------------------
+<% if @event %>
+View submission:
+<%= event_bulk_payment_url(@event, submission_id: @submission.id) %>
+<% end %>
+View profile:
+<%= profile_url %>

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -47,6 +47,41 @@ RSpec.describe EventMailer, type: :mailer do
     end
   end
 
+  describe "#bulk_payment_confirmation" do
+    let(:event) { create(:event) }
+    let(:form) do
+      f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+      event.event_forms.create!(form: f, role: "bulk_payment")
+      f
+    end
+    let(:person) { create(:person, first_name: "Pat", last_name: "Payer", email: "pat@example.com") }
+    let(:submission) do
+      s = FormSubmission.create!(form: form, person: person, role: "bulk_payment")
+      s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "number_of_attendees"), submitted_answer: "4")
+      s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "payment_method"), submitted_answer: "Check")
+      s
+    end
+    let(:mail) { described_class.bulk_payment_confirmation(submission) }
+
+    it "renders without raising" do
+      expect { mail.deliver_now }.not_to raise_error
+    end
+
+    it "sends to the payer" do
+      expect(mail.to).to eq([ person.preferred_email ])
+    end
+
+    it "includes the event title in the subject" do
+      expect(mail.subject).to include(event.title)
+    end
+
+    it "includes the number of attendees and payment method in the body" do
+      body = mail.body.encoded
+      expect(body).to include("4")
+      expect(body).to include("Check")
+    end
+  end
+
   describe "#event_registration_reminder" do
     let(:event_registration) { create(:event_registration) }
     let(:mail) { described_class.event_registration_reminder(event_registration, days_until_event: days_until_event) }

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,6 +1,30 @@
 require "rails_helper"
 
 RSpec.describe NotificationMailer, type: :mailer do
+  describe "#bulk_payment_confirmation_fyi" do
+    let(:event) { create(:event) }
+    let(:form) do
+      f = FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+      event.event_forms.create!(form: f, role: "bulk_payment")
+      f
+    end
+    let(:person) { create(:person, first_name: "Pat", last_name: "Payer", email: "pat@example.com") }
+    let(:submission) do
+      s = FormSubmission.create!(form: form, person: person, role: "bulk_payment")
+      s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "number_of_attendees"), submitted_answer: "4")
+      s
+    end
+    let(:notification) { create(:notification, kind: "bulk_payment_confirmation_fyi", noticeable: submission) }
+
+    it "renders without raising" do
+      expect { described_class.bulk_payment_confirmation_fyi(notification).deliver_now }.not_to raise_error
+    end
+
+    it "names the payer in the subject" do
+      expect(described_class.bulk_payment_confirmation_fyi(notification).subject).to include("Pat Payer")
+    end
+  end
+
   describe "#report_submitted_fyi" do
     let(:notification) { create(:notification, kind: :report_submitted_fyi) }
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -7,4 +7,44 @@ RSpec.describe FormSubmission do
     it { should have_many(:form_answers).dependent(:destroy) }
     it { should accept_nested_attributes_for(:form_answers) }
   end
+
+  describe "#event" do
+    it "returns the event whose join role matches the submission role" do
+      event = create(:event)
+      form = create(:form)
+      event.event_forms.create!(form: form, role: "bulk_payment")
+      submission = create(:form_submission, form: form, role: "bulk_payment")
+
+      expect(submission.event).to eq(event)
+    end
+  end
+
+  describe "#answers_by_identifier" do
+    it "maps submitted answers by their field identifier" do
+      form = create(:form)
+      field = create(:form_field, form: form, field_identifier: "payer_email", name: "Payer email")
+      submission = create(:form_submission, form: form)
+      submission.form_answers.create!(form_field: field, submitted_answer: "pat@example.com")
+
+      expect(submission.answers_by_identifier["payer_email"]).to eq("pat@example.com")
+    end
+  end
+
+  describe "#bulk_payment_attendees" do
+    let(:form) { create(:form) }
+    let(:field) { create(:form_field, form: form, field_identifier: "bulk_payment_attendees", name: "Attendees") }
+    let(:submission) { create(:form_submission, form: form) }
+
+    it "parses the attendees JSON array" do
+      submission.form_answers.create!(form_field: field, submitted_answer: [ { first_name: "A", email: "a@example.com" } ].to_json)
+
+      expect(submission.bulk_payment_attendees).to eq([ { "first_name" => "A", "email" => "a@example.com" } ])
+    end
+
+    it "returns an empty array for invalid JSON" do
+      submission.form_answers.create!(form_field: field, submitted_answer: "not json")
+
+      expect(submission.bulk_payment_attendees).to eq([])
+    end
+  end
 end

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -48,4 +48,17 @@ RSpec.describe EventRegistrationServices::BulkPayment do
       expect(result.form_submission.person.contact_methods.where(kind: :phone)).to be_empty
     end
   end
+
+  describe "notifications" do
+    it "sends the payer confirmation and the staff FYI" do
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :bulk_payment_confirmation, recipient_role: :person)
+      )
+      expect(NotificationServices::CreateNotification).to receive(:call).with(
+        hash_including(kind: :bulk_payment_confirmation_fyi, recipient_role: :admin)
+      )
+
+      described_class.call(event: event, form: form, form_params: base_form_params)
+    end
+  end
 end

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -15,7 +15,17 @@ class EventMailerPreview < ActionMailer::Preview
     EventMailer.event_registration_cancelled(event_registration)
   end
 
+  def bulk_payment_confirmation
+    EventMailer.bulk_payment_confirmation(sample_bulk_payment_submission)
+  end
+
   private
+
+  def sample_bulk_payment_submission
+    FormSubmission.where(role: "bulk_payment").order(id: :desc).find_each.find(&:event) ||
+      FormSubmission.where(role: "bulk_payment").order(id: :desc).first ||
+      raise("Need a bulk_payment FormSubmission to preview")
+  end
 
   def sample_event_registration
     # Try to reuse existing records to avoid duplication

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -39,6 +39,22 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.event_registration_cancelled_fyi(notification)
   end
 
+  def bulk_payment_confirmation_fyi
+    submission = FormSubmission.where(role: "bulk_payment").order(id: :desc).first ||
+      raise("Need a bulk_payment FormSubmission to preview")
+
+    notification = find_valid_notification("bulk_payment_confirmation_fyi") ||
+      Notification.create!(
+        noticeable: submission,
+        notification_type: 0,
+        kind: "bulk_payment_confirmation_fyi",
+        recipient_role: "admin",
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+      )
+
+    NotificationMailer.bulk_payment_confirmation_fyi(notification)
+  end
+
   def idea_submitted
     noticeable = StoryIdea.first || WorkshopVariationIdea.first
     user = noticeable&.created_by || User.first


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- Bulk payment submissions previously sent **no email at all** (unlike event registrations), so a submission could land in the database silently.
- Payers now receive a confirmation and staff receive an FYI for **every** bulk payment submitted.

### How did you approach the change?
- Added `EventMailer#bulk_payment_confirmation` (payer) and `NotificationMailer#bulk_payment_confirmation_fyi` (staff), wired through the existing notification pipeline (new `Notification::KINDS`, `NotificationMailerJob` mappings, mailer previews).
- The `BulkPayment` service sends both notifications after creating the submission; added `FormSubmission#event / #answers_by_identifier / #bulk_payment_attendees` helpers the mailers use to render event + attendee details.
- Drive-by: bumped transitive `net-imap` to 0.6.4.1 (CI scan_ruby advisory) and fixed a stale `answer_type` (`multiple_choice_radio` → `single_select_radio`) in the bulk payments request spec left by the #1644 enum cleanup.

### UI Testing Checklist
- [ ] Submit a bulk payment as a logged-out visitor — the payer receives a confirmation email and staff receive an FYI.
- [ ] FYI lists the payer, event, attendee count, payment method, and attendee table; confirmation links back to the submission.

### Anything else to add?
- Admin opt-out (skip the payer email when staff submit on someone's behalf) is intentionally **not** here — it's a follow-up PR (#1627) stacked on this branch.
- rubocop clean; 70 examples, 0 failures across the touched specs.
