### PR TITLE
Make ai/migrate create the database when it's missing

### DIFF
--- a/ai/migrate
+++ b/ai/migrate
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Run database migrations.
+# Create the database if it doesn't exist yet, then run any pending migrations.
+# db:create is a no-op when the database already exists, so this is idempotent.
+# Seeding is intentionally left out (use ai/seed or bin/setup) to mirror bin/setup,
+# which keeps db:create + db:migrate separate from db:seed.
 set -euo pipefail
 source "$(dirname "$0")/.ruby-env"
+bundle exec rails db:create
 bundle exec rails db:migrate "$@"


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `ai/migrate` only ran `db:migrate`, which never creates a database.
- On a fresh workspace it failed with `Unknown database '...'`; on an up-to-date DB it printed nothing — so it looked like the command "did nothing."
- Goal: make `ai/migrate` do what its name implies — create the DB if absent, then run any pending migrations.

### How did you approach the change?

- Added `bundle exec rails db:create` ahead of `db:migrate`, mirroring how `bin/setup` keeps create + migrate as steps.
- `db:create` is a no-op when the DB already exists (prints `already exists`, exits 0, touches no data), so the command stays idempotent.
- Both commands inherit `WORKSPACE_PORT` from the existing `source .ruby-env`, so they resolve the same per-workspace DB name.
- Seeding is intentionally left out (that's `ai/seed` / `bin/setup`) so `ai/migrate` remains a pure migrate.

### Verified

- **Fresh DB** (throwaway port): created `awbw_development_<port>`, schema applied (211 migrations recorded), **not** seeded (users = 0), exit 0.
- **Existing DB**: `already exists`, no changes, exit 0.

### Anything else to add?

Considered `db:prepare`, but it re-runs seeds, which conflicts with the project convention of keeping seeding a separate explicit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)