### PR TITLE
Fix duplicate questions/sections when re-editing form sections after a header rename

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -83,7 +83,7 @@ class FormsController < ApplicationController
     end
 
     removed_custom_ids = removed_custom_section_ids
-    current_sections = (@form.sections || []).map(&:to_sym)
+    current_sections = FormBuilderService.present_section_keys(@form)
     if sections.to_set == current_sections.to_set && removed_custom_ids.empty?
       redirect_to edit_form_path(@form, event_id: params[:event_id]), notice: "No section changes."
       return

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -101,6 +101,17 @@ class FormBuilderService
     end
   end
 
+  # Built-in section keys that currently have fields on the form. This — not the
+  # stored `sections` column — is the source of truth for which sections are
+  # present, so add/remove stays consistent with the edit-sections checkboxes
+  # (which are rendered from the fields) even if the column drifts.
+  def self.present_section_keys(form)
+    group_to_key = SECTION_GROUPS.flat_map { |key, groups| groups.map { |group| [ group, key ] } }.to_h
+    # pluck runs a fresh query rather than reading (and caching) the association,
+    # so repeated calls within a single update see deletions made between them.
+    form.form_fields.pluck(:section).filter_map { |section| group_to_key[section] }.uniq
+  end
+
   # Ordered list of sections for the edit-sections page. Each entry is a hash
   # with a :kind of :builtin or :custom. Built-in sections carry their :label,
   # section :key, and :included state; custom (user-added) sections carry the
@@ -162,22 +173,19 @@ class FormBuilderService
   # user unchecked; each such header and the questions under it are deleted.
   def self.update_sections!(form, new_sections, remove_custom_section_ids: [])
     new_sections = new_sections.map(&:to_sym)
-    old_sections = (form.sections || []).map(&:to_sym)
+    old_sections = present_section_keys(form)
 
     remove_custom_sections!(form, remove_custom_section_ids)
 
     added = new_sections - old_sections
     removed = old_sections - new_sections
 
-    # Remove fields and headers belonging to removed sections
+    # Remove every field belonging to a removed section by its section group.
+    # Keying off the group (not the canonical field_identifier or default header
+    # name) deletes renamed headers too, so nothing is left orphaned to resurface
+    # as a duplicate when the section is added back.
     removed.each do |key|
-      identifiers = SECTION_FIELD_IDENTIFIERS.fetch(key)
-      form.form_fields.where(field_identifier: identifiers).destroy_all
-
-      headers = SECTION_HEADERS.fetch(key)
-      if headers.any?
-        form.form_fields.where(name: headers, answer_type: :group_header).destroy_all
-      end
+      form.form_fields.where(section: SECTION_GROUPS.fetch(key)).destroy_all
     end
 
     # Build fields for newly checked sections (created at the end for now), then

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -271,7 +271,8 @@ RSpec.describe FormBuilderService do
       next_section = form.form_fields.create!(name: "Background Information", answer_type: :group_header,
                                               status: :active, position: 102, section: "background", required: false)
 
-      described_class.update_sections!(form, %i[person_identifier], remove_custom_section_ids: [ header.id ])
+      described_class.update_sections!(form, %i[person_identifier person_background],
+                                       remove_custom_section_ids: [ header.id ])
 
       expect(FormField.where(id: [ header.id, question.id ])).to be_empty
       expect(FormField.where(id: next_section.id)).to exist
@@ -285,6 +286,63 @@ RSpec.describe FormBuilderService do
       described_class.update_sections!(form, %i[person_identifier])
 
       expect(FormField.where(id: header.id)).to exist
+    end
+
+    it "removes a section's header even after it has been renamed" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier scholarship]).call
+      form.form_fields.find_by(answer_type: :group_header, name: "Scholarship Application")
+          .update!(name: "Funding Help")
+
+      described_class.update_sections!(form, %i[person_identifier])
+
+      form.reload
+      expect(form.form_fields.where(answer_type: :group_header, section: "scholarship")).to be_empty
+    end
+
+    it "does not duplicate a header when a renamed section is removed then re-added" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      form.form_fields.find_by(answer_type: :group_header, name: "Consent").update!(name: "Agreement")
+
+      described_class.update_sections!(form, %i[person_identifier])
+      described_class.update_sections!(form, %i[person_identifier consent])
+
+      form.reload
+      expect(form.form_fields.where(answer_type: :group_header, section: "consent").count).to eq(1)
+      expect(form.form_fields.where(field_identifier: "communication_consent").count).to eq(1)
+    end
+
+    it "does not re-add fields when a section already present is submitted again" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      consent_count = form.form_fields.where(section: "consent").count
+
+      # Column drift: the stored sections list lost an entry that still has fields.
+      form.update_column(:sections, %w[person_identifier])
+      described_class.update_sections!(form, %i[person_identifier consent])
+
+      form.reload
+      expect(form.form_fields.where(section: "consent").count).to eq(consent_count)
+    end
+  end
+
+  describe ".present_section_keys" do
+    it "returns the built-in section keys that have fields on the form" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      expect(described_class.present_section_keys(form)).to contain_exactly(:person_identifier, :consent)
+    end
+
+    it "reflects fields present even when a header has been renamed" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier consent]).call
+      form.form_fields.find_by(answer_type: :group_header, name: "Consent").update!(name: "Agreement")
+
+      expect(described_class.present_section_keys(form)).to include(:consent)
+    end
+
+    it "ignores custom sections that are not built-in groups" do
+      form = described_class.new(name: "Test", sections: %i[person_identifier]).call
+      form.form_fields.create!(name: "Custom", answer_type: :group_header,
+                               status: :active, position: 100, required: false)
+
+      expect(described_class.present_section_keys(form)).to contain_exactly(:person_identifier)
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Editing a form's sections could **duplicate section headers and every question under them** — a real risk as admins navigate events, their registration forms, and the edit-sections page.
- The edit-sections page had two disagreeing sources of truth for "which sections does this form have":
  - The checkboxes (`editable_sections`) derive *included* from the **fields actually on the form** (each field's `section` group).
  - `update_sections!` derived its add/remove diff from the stored **`form.sections` column**.
- These drift in one concrete case: **rename a section header, then remove the section.** Removal matched headers by their *default name*, so the renamed header survived as an orphan — keeping the section "present" in the fields but absent from the column. Re-saving then treated it as newly added and rebuilt a **second header plus a second copy of every question.**

### How did you approach the change?

- Made the field set the single source of truth via a new `FormBuilderService.present_section_keys` (uses `pluck` so repeated calls within one update see deletions made between them).
- `update_sections!` now diffs against `present_section_keys` instead of the `sections` column, so a section is only added/removed when its checkbox is **newly checked or newly unchecked**.
- Removal now deletes by **section group** (`where(section: …)`) rather than canonical identifier + default header name, so renamed headers (and any questions added under a section) are removed too — nothing is left orphaned to resurface as a duplicate.
- The controller's "No section changes" short-circuit uses the same basis for consistency.
- Verified the event form-link paths (`build_public_registration_form`, `copy_registration_form`, `assign_event_forms`) are already idempotent, so navigating events doesn't double-link forms.

### Anything else to add?

- Added failing-first specs: renamed header is removed, the rename → remove → re-add round-trip yields exactly one header and one question, re-submitting an already-present section adds nothing despite column drift, plus `present_section_keys` coverage.
- One existing custom-section test was updated: its hand-built `background` header now legitimately counts as a present section under the new truth.
- Tests: `form_builder_service_spec` + `forms_spec` (90), `events_spec` + `event_spec` (146) all pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)