### PR TITLE
Rename "My team" to "My organization" in profile dropdown

### DIFF
--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -55,7 +55,7 @@
                       class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>
             <i class="fas fa-users"></i>
             <span>
-              My team
+              My organization
               <% if active_affiliations.many? %>
                 (<%= affiliation.organization.name.truncate(12) %>)
               <% end %>

--- a/spec/views/shared/_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_navbar.html.erb_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe "shared/_navbar", type: :view do
       allow(view).to receive(:current_user).and_return(admin_user)
       allow(view).to receive(:user_signed_in?).and_return(true)
       allow(view).to receive(:allowed_to?).and_return(true)
+      assign(:current_user_active_affiliations, [ create(:affiliation) ])
       render_nav
     end
 
@@ -80,8 +81,9 @@ RSpec.describe "shared/_navbar", type: :view do
       expect(rendered).to include("Admin")
     end
 
-    it "shows profile and team links" do
+    it "shows profile and organization links" do
       expect(rendered).to include("My profile")
+      expect(rendered).to include("My organization")
     end
 
     it "shows admin-only New dropdown items" do

--- a/spec/views/shared/_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_navbar.html.erb_spec.rb
@@ -93,6 +93,27 @@ RSpec.describe "shared/_navbar", type: :view do
     end
   end
 
+  context "when admin has multiple active affiliations" do
+    before do
+      create(:person, user: admin_user)
+      admin_user.reload
+      allow(view).to receive(:current_user).and_return(admin_user)
+      allow(view).to receive(:user_signed_in?).and_return(true)
+      allow(view).to receive(:allowed_to?).and_return(true)
+      affiliations = [
+        create(:affiliation, organization: create(:organization, name: "Org Alpha")),
+        create(:affiliation, organization: create(:organization, name: "Org Beta"))
+      ]
+      assign(:current_user_active_affiliations, affiliations)
+      render_nav
+    end
+
+    it "shows an organization link per affiliation, each labelled with its name" do
+      expect(rendered).to have_css("a[href]", text: /My organization\s+\(Org Alpha\)/)
+      expect(rendered).to have_css("a[href]", text: /My organization\s+\(Org Beta\)/)
+    end
+  end
+
   context "when in staging environment" do
     before do
       allow(ENV).to receive(:[]).and_call_original


### PR DESCRIPTION
## Why

- The profile-dropdown link labeled "My team" navigates to the user's affiliated **organization** (`organization_path`), so the label should describe its destination.
- This link is the only "My team" string in the navbar; it renders in both desktop and mobile views (shared profile dropdown), so the single change covers both.

## What

- Renamed "My team" → "My organization" in `app/views/shared/_navbar_user.html.erb`.

## Notes

- The mobile menu's separate "Organizations" link is the admin index of *all* organizations (gated by `:index?, Organization`) — a different concept — and was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)