### PR TITLE
Reduce flakiness in navbar avatar system spec

### DIFF
--- a/spec/system/navbar_avatar_updates_spec.rb
+++ b/spec/system/navbar_avatar_updates_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe "Navbar avatar behavior", type: :system do
 
       click_button "Save changes"
 
-      expect(page).to have_current_path(person_path(person), wait: 5)
+      # Saving direct-uploads the avatar before submitting, which can take well
+      # over the default 5s wait on a loaded CI runner, so allow extra time for
+      # the redirect rather than racing it.
+      expect(page).to have_current_path(person_path(person), wait: 20)
 
       person.reload
       expect(person.avatar).to be_attached
@@ -49,7 +52,9 @@ RSpec.describe "Navbar avatar behavior", type: :system do
       check "person__destroy"
       click_button "Save changes"
 
-      expect(page).to have_current_path(person_path(person), wait: 5)
+      # Removal still posts the form and redirects; give the redirect the same
+      # generous wait as the upload case so a slow CI runner doesn't flake.
+      expect(page).to have_current_path(person_path(person), wait: 20)
 
       person.reload
       expect(person.avatar).not_to be_attached


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `spec/system/navbar_avatar_updates_spec.rb` intermittently fails CI on `have_current_path(person_path(person), wait: 5)` after saving the avatar form — surfacing as a red `build-and-test` check unrelated to whatever branch is being tested.
- Root cause: saving **direct-uploads the avatar before submitting the form**, and that upload alone takes ~6.5s even on a local machine — *already over* the 5s wait (which is just the Capybara default, so the explicit `wait: 5` added no grace). On a loaded CI runner it tips over the edge and the redirect assertion times out before the page lands.

### How did you approach the change?

- Gave both save→redirect assertions a generous `wait: 20` so the upload has time to finish before the path is checked, with a comment explaining why.
- Capybara returns as soon as the condition is met, so passing runs are not slowed down — only the flaky-timeout ceiling is raised.

### Anything else to add?

- Verified locally: both examples pass, and the upload case clocks ~6.5s — confirming 5s was too tight.
- No app code changes; test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)