### PR TITLE
Notifications index: link form submission noticeables to a viewable page

### DIFF
--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -60,15 +60,7 @@ module Events
       authorize! :bulk_payment, to: :show?
 
       @submission = FormSubmission.find(params[:submission_id])
-      @form = @submission.form
-      @form_fields = @form.form_fields.reorder(position: :asc)
-      @responses = @submission.form_answers.index_by(&:form_field_id)
       @event = @event.decorate
-
-      attendee_answer = @responses.values.find { |a|
-        a.form_field&.field_identifier == "bulk_payment_attendees"
-      }
-      @attendees = parse_attendees(attendee_answer&.submitted_answer)
     end
 
     private
@@ -141,14 +133,6 @@ module Events
         success_url: event_bulk_payment_url(@event, submission_id: submission.id, checkout: "success"),
         cancel_url: event_bulk_payment_url(@event, submission_id: submission.id, checkout: "cancelled")
       )
-    end
-
-    def parse_attendees(json)
-      return [] if json.blank?
-      parsed = JSON.parse(json)
-      parsed.is_a?(Array) ? parsed : []
-    rescue JSON::ParserError
-      []
     end
   end
 end

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -1,0 +1,6 @@
+class FormSubmissionsController < ApplicationController
+  def show
+    @form_submission = FormSubmission.find(params[:id])
+    authorize! @form_submission
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -260,6 +260,15 @@ module ApplicationHelper
     end
   end
 
+  # polymorphic_path for a record, or nil when the record's model has no route
+  # (e.g. FormSubmission, which is referenced as a notification's noticeable but
+  # has no controller/show page). Lets views link only when a route exists.
+  def routable_path(record)
+    polymorphic_path(record)
+  rescue NoMethodError
+    nil
+  end
+
   def search_page(params)
     params[:search] ? params[:search][:page] : 1
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -260,13 +260,26 @@ module ApplicationHelper
     end
   end
 
-  # polymorphic_path for a record, or nil when the record's model has no route
-  # (e.g. FormSubmission, which is referenced as a notification's noticeable but
-  # has no controller/show page). Lets views link only when a route exists.
+  # Best viewable path for a record (e.g. a notification's noticeable), or nil
+  # when its model has no route. FormSubmissions have no polymorphic route, so
+  # they get a tailored destination via form_submission_link_path.
   def routable_path(record)
+    return form_submission_link_path(record) if record.is_a?(FormSubmission)
     polymorphic_path(record)
   rescue NoMethodError
     nil
+  end
+
+  # Where to view a form submission. When the submitter has a public event
+  # registration, send the viewer to their registration details page (the public
+  # "ticket"/details view, keyed by the registration slug). Otherwise — bulk
+  # payments and event-less submissions, which have no registration — fall back
+  # to the form submission show page.
+  def form_submission_link_path(submission)
+    event = submission.event
+    registration = event && submission.person.event_registrations.find_by(event: event)
+    return event_public_registration_path(event, reg: registration.slug) if registration&.slug.present?
+    form_submission_path(submission)
   end
 
   def search_page(params)

--- a/app/policies/form_submission_policy.rb
+++ b/app/policies/form_submission_policy.rb
@@ -1,0 +1,6 @@
+class FormSubmissionPolicy < ApplicationPolicy
+  # See https://actionpolicy.evilmartians.io/#/writing_policies
+  def show?
+    admin?
+  end
+end

--- a/app/views/events/bulk_payments/show.html.erb
+++ b/app/views/events/bulk_payments/show.html.erb
@@ -37,67 +37,7 @@
           <span>Payment was cancelled. Your bulk payment information has been saved but payment is still pending.</span>
         </div>
       <% end %>
-      <% @form_fields.each do |field| %>
-        <% next if field.field_identifier == "bulk_payment_attendees" %>
-        <% next if field.group_header? && field.name == "Attendees" %>
-        <% response = @responses[field.id] %>
-
-        <% if field.group_header? %>
-          <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-            <h3 class="flex items-center gap-2.5 text-lg font-semibold text-gray-800">
-              <span class="<%= form_section_bar_class %>"></span><%= field.name %>
-            </h3>
-          </div>
-        <% else %>
-          <div class="py-2">
-            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= field.name %></dt>
-            <dd class="mt-1 text-sm text-gray-900">
-              <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %>
-            </dd>
-          </div>
-        <% end %>
-      <% end %>
-
-      <% if @submission.person.present? %>
-        <div class="py-2">
-          <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Submitted by</dt>
-          <dd class="mt-1 text-sm text-gray-900">
-            <%= @submission.person.name %> &lt;<%= @submission.person.email %>&gt;
-          </dd>
-        </div>
-      <% end %>
-
-      <% if @attendees.any? %>
-        <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
-          <h3 class="text-lg font-semibold text-gray-800">Attendees</h3>
-        </div>
-        <div class="overflow-hidden border border-gray-200 rounded-lg">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
-              <tr>
-                <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">First Name</th>
-                <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Last Name</th>
-                <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Email</th>
-              </tr>
-            </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-              <% @attendees.each do |attendee| %>
-                <tr>
-                  <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["first_name"] %></td>
-                  <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["last_name"] %></td>
-                  <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["email"] %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      <% end %>
-
-      <div class="pt-4 border-t border-gray-200 mt-4">
-        <p class="text-xs text-gray-500">
-          Submitted on <%= @submission.created_at.strftime("%B %d, %Y at %l:%M %P") %>
-        </p>
-      </div>
+      <%= render "form_submissions/submission", submission: @submission %>
     </div>
   </div>
 </div>

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -1,0 +1,66 @@
+<%# Renders a form submission's answers — field responses, the submitter, and any
+    bulk-payment attendees. Self-contained from the submission so it can be shared
+    by the public bulk payment page and the form submission show page.
+    Locals: submission. %>
+<% form_fields = submission.form.form_fields.reorder(position: :asc) %>
+<% responses = submission.form_answers.index_by(&:form_field_id) %>
+<% attendees = submission.bulk_payment_attendees %>
+<div class="space-y-1">
+  <% form_fields.each do |field| %>
+    <% next if field.field_identifier == "bulk_payment_attendees" %>
+    <% next if field.group_header? && field.name == "Attendees" %>
+    <% response = responses[field.id] %>
+    <% if field.group_header? %>
+      <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
+        <h3 class="flex items-center gap-2.5 text-lg font-semibold text-gray-800">
+          <span class="<%= form_section_bar_class %>"></span><%= field.name %>
+        </h3>
+      </div>
+    <% else %>
+      <div class="py-2">
+        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= field.name %></dt>
+        <dd class="mt-1 text-sm text-gray-900">
+          <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %>
+        </dd>
+      </div>
+    <% end %>
+  <% end %>
+  <% if submission.person.present? %>
+    <div class="py-2">
+      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Submitted by</dt>
+      <dd class="mt-1 text-sm text-gray-900">
+        <%= submission.person.name %> &lt;<%= submission.person.email %>&gt;
+      </dd>
+    </div>
+  <% end %>
+  <% if attendees.any? %>
+    <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
+      <h3 class="text-lg font-semibold text-gray-800">Attendees</h3>
+    </div>
+    <div class="overflow-hidden border border-gray-200 rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">First Name</th>
+            <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Last Name</th>
+            <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Email</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% attendees.each do |attendee| %>
+            <tr>
+              <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["first_name"] %></td>
+              <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["last_name"] %></td>
+              <td class="px-4 py-2.5 text-sm text-gray-900"><%= attendee["email"] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+  <div class="pt-4 border-t border-gray-200 mt-4">
+    <p class="text-xs text-gray-500">
+      Submitted on <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %>
+    </p>
+  </div>
+</div>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -1,0 +1,30 @@
+<% event = @form_submission.event %>
+<div class="max-w-2xl mx-auto px-4 pt-4">
+  <div class="flex flex-wrap items-center gap-2">
+    <% if event %>
+      <%= link_to event_path(event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
+        <div class="shrink-0">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
+        </div>
+        <div class="flex-1">
+          <h1 class="text-xl font-semibold tracking-wide leading-tight">Form submission</h1>
+          <p class="text-sm text-blue-200"><%= @form_submission.form.name %></p>
+        </div>
+      </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+    </div>
+    <div class="px-6 sm:px-8 py-7">
+      <%= render "form_submissions/submission", submission: @form_submission %>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -43,11 +43,14 @@
 
       <!-- Record -->
       <td class="px-4 py-3 text-gray-700">
-        <% if notification.noticeable.present? %>
+        <% record_path = notification.noticeable.present? ? routable_path(notification.noticeable) : nil %>
+        <% if record_path %>
           <%= link_to notification.noticeable.class.name,
-                      polymorphic_path(notification.noticeable),
+                      record_path,
                       data: { turbo_frame: "_top" },
                       class: "btn btn-secondary-outline" %>
+        <% elsif notification.noticeable.present? %>
+          <span class="text-gray-700"><%= notification.noticeable.class.name %></span>
         <% else %>
           <span class="text-gray-400">—</span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
       patch :update_sections
     end
   end
+  resources :form_submissions, only: [ :show ]
   resources :grants
   resources :scholarships, only: [ :new, :create, :show, :edit, :update, :destroy ] do
     member { patch :toggle_tasks }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -341,4 +341,24 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(default.to_date).to eq(2.days.from_now.to_date)
     end
   end
+
+  describe "#routable_path for a form submission" do
+    it "links to the registration details page when the submitter is registered" do
+      event = create(:event)
+      form = create(:form)
+      create(:event_form, event: event, form: form, role: "registration")
+      person = create(:person)
+      registration = create(:event_registration, event: event, registrant: person)
+      submission = create(:form_submission, form: form, person: person, role: "registration")
+
+      expect(helper.routable_path(submission))
+        .to eq(event_public_registration_path(event, reg: registration.slug))
+    end
+
+    it "falls back to the form submission show page without a registration" do
+      submission = create(:form_submission)
+
+      expect(helper.routable_path(submission)).to eq(form_submission_path(submission))
+    end
+  end
 end

--- a/spec/policies/form_submission_policy_spec.rb
+++ b/spec/policies/form_submission_policy_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe FormSubmissionPolicy, type: :policy do
+  let(:admin_user) { build_stubbed :user, :admin }
+  let(:regular_user) { build_stubbed :user }
+  let(:submission) { build_stubbed :form_submission }
+
+  def policy_for(user:, record: submission)
+    described_class.new(record, user: user)
+  end
+
+  describe "#show?" do
+    context "with admin user" do
+      subject { policy_for(user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:show?) }
+    end
+
+    context "with regular user" do
+      subject { policy_for(user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:show?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:show?) }
+    end
+  end
+end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "FormSubmissions", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:submission) { create(:form_submission) }
+
+  describe "GET /form_submissions/:id" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the submission" do
+        field = create(:form_field, form: submission.form, name: "Organization")
+        create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "AWBW")
+
+        get form_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Organization")
+        expect(response.body).to include("AWBW")
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in create(:user) }
+
+      it "redirects away" do
+        get form_submission_path(submission)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Notifications", type: :request do
       expect(response.body).to include('id="notifications_results"')
     end
 
-    it "renders rows whose noticeable has no route without raising" do
+    it "links a form submission noticeable to its show page" do
       submission = create(:form_submission)
       create(:notification, noticeable: submission, recipient_email: "bulk-payer@example.com")
 
@@ -65,6 +65,7 @@ RSpec.describe "Notifications", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("bulk-payer@example.com")
+      expect(response.body).to include(form_submission_path(submission))
     end
 
     context "responded checkbox rendering" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe "Notifications", type: :request do
       expect(response.body).to include('id="notifications_results"')
     end
 
+    it "renders rows whose noticeable has no route without raising" do
+      submission = create(:form_submission)
+      create(:notification, noticeable: submission, recipient_email: "bulk-payer@example.com")
+
+      get notifications_path, headers: turbo_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("bulk-payer@example.com")
+    end
+
     context "responded checkbox rendering" do
       let!(:fyi)             { create(:notification, kind: "contact_us_fyi", responded: false, recipient_email: "fyi@example.com") }
       let!(:fyi_done)        { create(:notification, kind: "contact_us_fyi", responded: true,  recipient_email: "done@example.com") }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The notifications index (`/notifications`) was throwing a production 500: `NoMethodError: undefined method 'form_submission_path'` (reported via Honeybadger).
- Root cause: #1647 began creating `Notification` records with a `FormSubmission` as their `noticeable` (bulk-payment confirmation + FYI emails). `FormSubmission` had **no route**, so the view's `polymorphic_path(notification.noticeable)` resolved to a nonexistent path and raised — breaking the entire index for staff whenever a bulk-payment notification appeared.
- Beyond stopping the crash, a `FormSubmission` noticeable should actually be **viewable** — staff need to click through to see the submission.

### How did you approach the change?

- **Stop the 500 (first commit):** `routable_path` returns a link or `nil`, and the notifications view links only when routable — defensively covering any routeless noticeable.
- **Make it viewable (this work):** `routable_path` now gives a `FormSubmission` a real destination via `form_submission_link_path`:
  - **Registration submissions** (submitter has an `EventRegistration`) → the public **registration details** page, keyed by the registration slug — the same "ticket"/details view the public already sees.
  - **Bulk-payment / event-less submissions** (no registration) → a new RESTful **`form_submissions#show`**, admin-only via `FormSubmissionPolicy`.
- **One display, two pages:** `form_submissions#show` and the public `bulk_payments#show` now render a shared `form_submissions/_submission` partial (fields, submitter, attendees). Removed the now-dead `@form_fields`/`@responses`/`@attendees` setup and `parse_attendees` from `BulkPaymentsController`.

### Anything else to add?

- Test-first throughout: request specs for `form_submissions#show` (admin 200 / non-admin redirect), an updated notifications spec asserting the row now links, a `FormSubmissionPolicy` spec, and helper specs covering both `routable_path` branches.
- No data migration needed — view/routing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)