### PR TITLE
Preserve registration form choices on failed event save

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -235,11 +235,17 @@
         </button>
 
         <div id="registration_form_section" class="border border-gray-300 p-4 rounded-b-md" data-reveal-section-target="content">
+          <%# On a failed save the event_forms aren't persisted, so re-read the
+              admin's registration choices from the submitted params instead of
+              the (now-empty) associations. %>
+          <% resubmitted = params[:event].present? %>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Registration form</label>
               <% current_reg_form = @event.registration_form %>
-              <% default_form_id = if current_reg_form
+              <% default_form_id = if resubmitted
+                                     params.dig(:event, :registration_form_id).presence&.to_i
+                                   elsif current_reg_form
                                      current_reg_form.id
                                    elsif @event.title&.match?(/training/i)
                                      @registration_forms.find { |rf| rf.name == "Extended Event Registration" }&.id
@@ -332,7 +338,7 @@
               </div>
               <div>
                 <label class="flex items-center gap-2 cursor-pointer">
-                  <%= check_box_tag "event[scholarship_enabled]", "1", @event.scholarship_form.present? %>
+                  <%= check_box_tag "event[scholarship_enabled]", "1", resubmitted ? params.dig(:event, :scholarship_enabled) == "1" : @event.scholarship_form.present? %>
                   <span class="text-sm font-medium text-gray-700">Enable scholarship application</span>
                 </label>
                 <p class="text-xs text-gray-500 mt-1">Add a scholarship form so registrants can request financial assistance.</p>
@@ -346,7 +352,7 @@
               </div>
               <div class="pb-4">
                 <label class="flex items-center gap-2 cursor-pointer">
-                  <%= check_box_tag "event[bulk_payment_enabled]", "1", @event.bulk_payment_form.present? %>
+                  <%= check_box_tag "event[bulk_payment_enabled]", "1", resubmitted ? params.dig(:event, :bulk_payment_enabled) == "1" : @event.bulk_payment_form.present? %>
                   <span class="text-sm font-medium text-gray-700">Enable bulk payment</span>
                 </label>
                 <p class="text-xs text-gray-500 mt-1">Let one person register and pay for a group of attendees at once.</p>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -203,6 +203,49 @@ RSpec.describe "Events", type: :request do
         expect(response).to redirect_to(root_path)
       end
     end
+
+    context "when validation fails" do
+      before { sign_in admin }
+
+      it "re-renders the registration form selections the admin had chosen" do
+        reg_form = create(:form, :standalone, role: "registration", name: "Custom Registration")
+        create(:form, :standalone, role: "scholarship")
+        create(:form, :standalone, role: "bulk_payment")
+
+        post events_path, params: { event: {
+          title: "Missing dates",
+          start_date: "",
+          end_date: "",
+          registration_form_id: reg_form.id,
+          scholarship_enabled: "1",
+          bulk_payment_enabled: "1"
+        } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        page = Capybara.string(response.body)
+        expect(page).to have_field("event[scholarship_enabled]", checked: true)
+        expect(page).to have_field("event[bulk_payment_enabled]", checked: true)
+        expect(response.body).to include("value=\"#{reg_form.id}\" selected")
+      end
+
+      it "retains selected sector and category checkboxes" do
+        sector = create(:sector, :published)
+        category = create(:category, :published, category_type: create(:category_type, :published))
+
+        post events_path, params: { event: {
+          title: "Missing dates",
+          start_date: "",
+          end_date: "",
+          sector_ids: [ "", sector.id.to_s ],
+          category_ids: [ "", category.id.to_s ]
+        } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        page = Capybara.string(response.body)
+        expect(page).to have_checked_field("event_sector_ids_#{sector.id}")
+        expect(page).to have_checked_field("event_category_ids_#{category.id}")
+      end
+    end
   end
 
   describe "PATCH /update" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- When an admin saves the event form and validation fails (e.g. `start_date`/`end_date` left blank), their **Registration form**, **Enable scholarship application**, and **Enable bulk payment** selections were silently reset on the re-rendered form.
- These controls aren't Event attributes — they're virtual params turned into `EventForm` join records by `assign_event_forms`, which only runs *after* a successful save. The checkboxes/select read their state from `@event.scholarship_form` / `registration_form` (DB lookups), so on a failed save nothing is written and the controls come back empty.
- Plain model attributes (title, dates, toggles, hints, rich text) and the `sector_ids`/`category_ids` checkboxes already survive via Rails' normal in-memory repopulation — only these post-save-derived controls were affected.

### How did you approach the change?

- In `events/_form.html.erb`, added a `resubmitted = params[:event].present?` guard inside the registration form section.
- On a re-render, the registration-form `<select>`, scholarship checkbox, and bulk-payment checkbox now read back from the submitted params; on a normal new/edit load they still read from the persisted event (unchanged default-form logic preserved).

### Tests

- `spec/requests/events_spec.rb` — new failing-first request spec confirming the registration form select + scholarship/bulk-payment checkboxes are retained after a validation failure.
- Added a companion spec asserting sector/category checkboxes are retained (they already were — locks in the behavior).
- Full `events_spec` passes (112 examples, 0 failures).

### Anything else to add?

- Image uploads (primary/gallery) are still cleared on any failed submit — that's a browser security limitation for file inputs, not something the server can repopulate.