### PR TITLE
Match user account box height to profile button on reg edit

### DIFF
--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -39,7 +39,7 @@
               red/lock when locked. A "Create user" button shows when there's no
               account. ---- %>
           <% account = f.object.registrant.user %>
-          <% box_base = "flex w-20 shrink-0 flex-col items-center justify-center gap-1 rounded-lg border bg-gray-50 px-1 text-center transition hover:bg-gray-100" %>
+          <% box_base = "flex h-14 w-20 shrink-0 flex-col items-center justify-center gap-1 rounded-lg border bg-gray-50 px-1 text-center transition hover:bg-gray-100" %>
           <% if account %>
             <% account_border, account_icon, account_icon_color, account_status = if account.locked_at.present?
                  [ "border-red-300", "fa-lock", "text-red-600", "Locked" ]


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the event registration edit form, the "User account" box rendered taller than the adjacent person profile button, leaving the header row visually uneven.
- This aligns the two columns so the header reads as a single, tidy row.

### How did you approach the change?
- The account box (`box_base`) had no fixed height, so its icon + two-line label made it taller than the profile button.
- Pinned the box to `h-14` (56px) — the profile button's content height (`h-10` avatar + `py-2` padding). Both have a matching 1px border, so their outer heights now line up.
- Applies to all three box states: existing account, "Create user", and "No account".

### Anything else to add?
- One-line view change; no logic or behavior changes.