### PR TITLE
Scholarship status badge on registration card + consistent edit return paths

### DIFF
--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -129,11 +129,16 @@ class ScholarshipsController < ApplicationController
   end
 
   # After saving, return to wherever the user came from: the grant, the event
-  # registration (the card's View link carries return_to=registration), or — by
+  # registration's edit page (the card's Edit link carries return_to=registration),
+  # the registrants roster (the roster's links carry no return_to), or — by
   # default — stay on the scholarship's own edit page.
   def scholarship_save_path
     return grant_return_path if grant_context?
-    return edit_event_registration_path(@allocatable) if params[:return_to] == "registration" && @allocatable.respond_to?(:event)
+
+    if @allocatable.respond_to?(:event)
+      return edit_event_registration_path(@allocatable) if params[:return_to] == "registration"
+      return registrants_event_path(@allocatable.event)
+    end
 
     edit_scholarship_path(@scholarship)
   end

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -11,41 +11,48 @@
   </div>
 
   <div class="space-y-3 p-4">
-    <label class="flex items-center gap-2.5 cursor-pointer"
-           data-controller="scholarship-requested"
-           data-scholarship-requested-initial-value="<%= event_registration.scholarship_requested %>">
-      <input type="hidden" name="event_registration[scholarship_requested]" value="0" autocomplete="off">
-      <input type="checkbox"
-             name="event_registration[scholarship_requested]"
-             value="1"
-             <%= "checked" if event_registration.scholarship_requested %>
-             data-scholarship-requested-target="checkbox"
-             data-action="scholarship-requested#refresh"
-             class="sr-only peer">
-      <span data-scholarship-requested-target="track" class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
-      <span class="text-sm font-medium text-gray-700">Requested</span>
-    </label>
+    <% unless scholarship %>
+      <label class="flex items-center gap-2.5 cursor-pointer"
+             data-controller="scholarship-requested"
+             data-scholarship-requested-initial-value="<%= event_registration.scholarship_requested %>">
+        <input type="hidden" name="event_registration[scholarship_requested]" value="0" autocomplete="off">
+        <input type="checkbox"
+               name="event_registration[scholarship_requested]"
+               value="1"
+               <%= "checked" if event_registration.scholarship_requested %>
+               data-scholarship-requested-target="checkbox"
+               data-action="scholarship-requested#refresh"
+               class="sr-only peer">
+        <span data-scholarship-requested-target="track" class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
+        <span class="text-sm font-medium text-gray-700">Requested</span>
+      </label>
+    <% end %>
 
     <% if scholarship %>
-      <div class="space-y-2 border-t border-gray-100 pt-3">
+      <div class="space-y-2">
         <div class="flex items-center gap-2">
           <span class="text-sm font-semibold text-gray-900 tabular-nums">$<%= "%.2f" % (scholarship.amount_cents.to_f / 100) %></span>
           <%= link_to edit_scholarship_path(scholarship, return_to: "registration"),
                       class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
                       target: "_blank", rel: "noopener" do %>
-            View
+            Edit
             <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
           <% end %>
         </div>
 
-        <% if scholarship.tasks_completed? %>
-          <div class="flex flex-wrap items-center gap-1.5">
+        <div class="flex flex-wrap items-center gap-1.5">
+          <% if scholarship.tasks_completed? %>
             <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
               <i class="fa-solid fa-circle-check"></i>
               Tasks completed
             </span>
-          </div>
-        <% end %>
+          <% else %>
+            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
+              <i class="fa-solid fa-clock"></i>
+              Tasks outstanding
+            </span>
+          <% end %>
+        </div>
       </div>
     <% else %>
       <div class="border-t border-gray-100 pt-3">

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -41,7 +41,7 @@
                   <% unless @filtered_event %>
                     <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Event</th>
                   <% end %>
-                  <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 whitespace-nowrap">Registered at</th>
+                  <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 whitespace-nowrap">Date registered</th>
                   <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 whitespace-nowrap w-px">Actions</th>
                 </tr>
                 </thead>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -247,7 +247,7 @@
 <% cancel_path = if grant_nav
      params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)
    elsif @allocatable.respond_to?(:event)
-     registrants_event_path(@allocatable.event)
+     params[:return_to] == "registration" ? edit_event_registration_path(@allocatable) : registrants_event_path(@allocatable.event)
    elsif grant.present?
      grant_path(grant)
    else

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -10,9 +10,13 @@
       <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
-    <% elsif @allocatable.respond_to?(:event) %>
+    <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
       <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+      <% end %>
+    <% elsif @allocatable.respond_to?(:event) %>
+      <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% elsif grant.present? %>
       <%= link_to grant_path(grant), class: "text-sm text-gray-500 hover:text-gray-700" do %>

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -83,12 +83,21 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 
-  describe "PATCH /scholarships/:id from the registration View link" do
+  describe "PATCH /scholarships/:id from the registration Edit link" do
     it "returns to the event registration edit page" do
       patch scholarship_path(scholarship, return_to: "registration"),
             params: { scholarship: { amount_dollars: "40" } }
 
       expect(response).to redirect_to(edit_event_registration_path(registration))
+    end
+  end
+
+  describe "PATCH /scholarships/:id from the registrants roster (no return_to)" do
+    it "returns to the registrants roster" do
+      patch scholarship_path(scholarship),
+            params: { scholarship: { amount_dollars: "40" } }
+
+      expect(response).to redirect_to(registrants_event_path(event))
     end
   end
 

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Event registration edit page", type: :system do
       expect(registration.scholarships.count).to eq(0)
     end
 
-    it "keeps the View jump link and shows the tasks-completed chip in the scholarship theme color at the bottom" do
+    it "keeps the Edit jump link and shows the tasks-completed chip in the scholarship theme color at the bottom" do
       scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, tasks_completed: true)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
 
@@ -87,10 +87,23 @@ RSpec.describe "Event registration edit page", type: :system do
       visit edit_event_registration_path(registration)
 
       within("section", text: "Scholarship") do
-        expect(page).to have_link("View", href: edit_scholarship_path(scholarship, return_to: "registration"))
+        expect(page).to have_link("Edit", href: edit_scholarship_path(scholarship, return_to: "registration"))
         # Tasks-completed chip uses the scholarships theme (fuchsia), not green.
         expect(page).to have_css("span.bg-fuchsia-50.text-fuchsia-700", text: "Tasks completed")
         expect(page).to have_no_css("span.bg-green-50.text-green-700", text: "Tasks completed")
+      end
+    end
+
+    it "shows an orange tasks-outstanding chip when the scholarship's tasks are incomplete" do
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, tasks_completed: false)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Scholarship") do
+        expect(page).to have_css("span.bg-amber-50.text-amber-700", text: "Tasks outstanding")
+        expect(page).to have_no_css("span", text: "Tasks completed")
       end
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Make a registration's scholarship state legible at a glance, so admins don't have to open the scholarship to know whether tasks are still outstanding
- Fix scholarship-edit navigation so you return to wherever you started, rather than always landing on the registrants roster

### How did you approach the change?

- **Status badge:** the registration scholarship card now always shows a status pill — green "Tasks completed" (unchanged) or a new orange "Tasks outstanding" (amber, `fa-clock`, mirroring the existing `_tasks_status` partial) whenever a scholarship is connected
- **Card layout:** once a scholarship exists, the "Requested" toggle is replaced by the amount + Edit link, since the award is no longer just a request; the toggle still shows when no scholarship exists
- **Jump link:** renamed the card link from "View" to "Edit" (it already targets `edit_scholarship_path`)
- **Return paths:** scholarship-edit exits (top back-link, Cancel, and post-save redirect) now resolve consistently — to the registration's edit page when entered via the registration card (`return_to=registration`), and to the registrants roster when entered from the roster (no `return_to`)
- **Label:** renamed the "Registered at" column to "Date registered" on the event registrations index

### UI Testing Checklist

- [ ] Registration with an outstanding scholarship shows the orange "Tasks outstanding" badge
- [ ] Registration with a completed scholarship still shows the green "Tasks completed" badge
- [ ] With a scholarship present, the card shows amount + Edit (no "Requested" toggle); without one, the toggle + "Add scholarship" appears
- [ ] Editing a scholarship from the registration card returns to the registration edit page (back-link, Cancel, and Save)
- [ ] Editing a scholarship from the registrants roster returns to the registrants roster (back-link, Cancel, and Save)
- [ ] Event registrations index column header reads "Date registered"

### Anything else to add?

Pure view/controller-navigation changes; no schema or model behavior changes.