### PR TITLE
Set ce_credit_requested from the seeded CE-interest question

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,6 +2,11 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
+    # Well-known field_identifier of the "magic" CE question seeded onto the
+    # registration form. Answering it "Yes" toggles the registration's
+    # ce_credit_requested flag. Kept here so the seed, service, and specs agree.
+    CE_CREDIT_INTEREST_IDENTIFIER = "ce_credit_interest".freeze
+
     def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil)
       new(event:, form:, form_params:, scholarship_requested:, person:).call
     end
@@ -31,6 +36,7 @@ module EventRegistrationServices
         existing = @event.event_registrations.find_by(registrant: person)
         if existing
           existing.update!(scholarship_requested: true) if @scholarship_requested
+          existing.update!(ce_credit_requested: true) if ce_credit_requested?
           if existing.status == "cancelled"
             existing.update!(status: "registered")
             send_notifications(existing)
@@ -248,8 +254,14 @@ module EventRegistrationServices
     def create_event_registration(person)
       @event.event_registrations.create!(
         registrant: person,
-        scholarship_requested: @scholarship_requested
+        scholarship_requested: @scholarship_requested,
+        ce_credit_requested: ce_credit_requested?
       )
+    end
+
+    # True when the registrant answered "Yes" to the seeded CE-interest question.
+    def ce_credit_requested?
+      field_value(CE_CREDIT_INTEREST_IDENTIFIER).to_s.strip.casecmp?("yes")
     end
 
     def create_form_submission(person)

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -94,6 +94,41 @@ if registration_form.form_fields.where(field_identifier: "primary_age_group").no
   FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
 end
 
+# The CE-interest "magic question": a single Yes/No whose answer drives the
+# resulting registration's ce_credit_requested flag (see
+# EventRegistrationServices::PublicRegistration). Seeded straight onto the form
+# with its own section so the form builder's add/remove-section logic leaves it
+# alone, and carrying the well-known field_identifier the service keys off.
+ce_identifier = EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER
+if registration_form.form_fields.where(field_identifier: ce_identifier).none?
+  next_position = (registration_form.form_fields.maximum(:position) || 0) + 1
+  registration_form.form_fields.create!(
+    name: "Continuing education",
+    answer_type: :group_header,
+    status: :active,
+    position: next_position,
+    required: false,
+    section: "continuing_education",
+    visibility: :always_ask
+  )
+  ce_field = registration_form.form_fields.create!(
+    name: "Might you be seeking continuing education (CE) hours for attending this training?",
+    answer_type: :single_select_radio,
+    status: :active,
+    position: next_position + 1,
+    required: false,
+    field_identifier: ce_identifier,
+    section: "continuing_education",
+    visibility: :always_ask,
+    width: :full,
+    hint_text: "CE hours are available for select trainings. Let us know and our team will follow up with details."
+  )
+  %w[Yes No].each_with_index do |opt, idx|
+    ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
+    ce_field.form_field_answer_options.create!(answer_option: ao)
+  end
+end
+
 # Each entry: [title, form_type, cost_cents, scholarship?, visibility, span_days]
 # form_type: :long, :short, or :none. span_days (optional) makes a multi-day event.
 dev_events = [

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -59,6 +59,57 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "CE credit interest (magic question)" do
+    let!(:ce_field) do
+      field = form.form_fields.create!(
+        name: "Might you be seeking continuing education (CE) hours for attending this training?",
+        answer_type: :single_select_radio,
+        status: :active,
+        position: (form.form_fields.maximum(:position) || 0) + 1,
+        required: false,
+        field_identifier: described_class::CE_CREDIT_INTEREST_IDENTIFIER,
+        section: "continuing_education",
+        visibility: :always_ask
+      )
+      %w[Yes No].each_with_index do |opt, idx|
+        ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
+        field.form_field_answer_options.create!(answer_option: ao)
+      end
+      field
+    end
+
+    def register_with_ce(answer)
+      params = base_form_params(first_name: "Cy", last_name: "Reed", email: "cy@example.com")
+      params = params.merge(ce_field.id.to_s => answer) unless answer.nil?
+      described_class.call(event: event, form: form, form_params: params)
+    end
+
+    it "toggles ce_credit_requested on when answered Yes" do
+      result = register_with_ce("Yes")
+      expect(result.event_registration.ce_credit_requested).to be true
+    end
+
+    it "leaves ce_credit_requested off when answered No" do
+      result = register_with_ce("No")
+      expect(result.event_registration.ce_credit_requested).to be false
+    end
+
+    it "leaves ce_credit_requested off when unanswered" do
+      result = register_with_ce(nil)
+      expect(result.event_registration.ce_credit_requested).to be false
+    end
+
+    it "toggles ce_credit_requested on for an existing registration that answers Yes" do
+      person = create(:person, first_name: "Cy", last_name: "Reed", email: "cy@example.com")
+      existing = create(:event_registration, event: event, registrant: person, ce_credit_requested: false)
+
+      result = register_with_ce("Yes")
+
+      expect(result.event_registration).to eq(existing)
+      expect(existing.reload.ce_credit_requested).to be true
+    end
+  end
+
   describe "re-registration after cancellation" do
     let(:person) { create(:person, first_name: "Jane", last_name: "Doe", email: "jane@example.com") }
     let!(:cancelled_registration) do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Public registrants seeking **continuing-education (CE) hours** had no way to indicate it on the registration form — admins had to toggle `ce_credit_requested` on each registration by hand.
- This wires a seeded Yes/No "magic question" on the registration form to the registration's CE flag, so the request is captured at submission time.

### How did you approach the change?
- Added `EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER` (`"ce_credit_interest"`) as the single source of truth shared by the seed, service, and specs.
- Seeded a standalone **Continuing education** section + a required-less `single_select_radio` Yes/No question onto the dev registration form, with its own `section` so the form builder's add/remove-section logic leaves it untouched. The seed is idempotent.
- `PublicRegistration` now sets `ce_credit_requested: true` on new registrations when the answer is "Yes" (case-insensitive), and also toggles it on for an existing registration that re-submits with "Yes" — mirroring the existing scholarship-flag pattern (only ever toggles on, never off).
- Added service specs covering Yes / No / unanswered and the existing-registration path.

### UI Testing Checklist
- [ ] On a public registration form, the new "Continuing education" question appears and answering **Yes** results in a registration with CE requested.

### Anything else to add?
- The flag only toggles **on**, never off, consistent with how `scholarship_requested` is handled in the same service.
- No new services/controllers/Stimulus/mailers/rake tasks, so no AGENTS.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)