### PR TITLE
Declutter registration ticket footer and hide payment prompt on cancelled tickets

### DIFF
--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -7,7 +7,7 @@
         <div class="shrink-0"><%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %></div>
 
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Event registration ticket</h1>
+          <h1 class="text-xl font-semibold tracking-wide leading-tight">Registration ticket</h1>
         </div>
       </div>
 
@@ -98,9 +98,9 @@
       <div class="border-t border-gray-200"></div>
 
       <!-- Status -->
-      <div class="mt-4 text-center space-y-2">
+      <div class="text-center space-y-2">
         <% if event_registration.checked_in? %>
-          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800"> Checked In </span>
+          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800"> Checked in </span>
         <% elsif event_registration.status == "cancelled" %>
           <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800"> Registration cancelled </span>
           <% if event_registration.event.registerable? %>
@@ -108,39 +108,38 @@
                               class: "text-sm text-gray-500 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %></div>
           <% end %>
         <% else %>
-          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">Registered on <%= event_registration.created_at.strftime("%B %-d, %Y") %></span>
+          <p class="text-sm text-gray-500">Registered on <%= event_registration.created_at.strftime("%B %-d, %Y") %></p>
         <% end %>
       </div>
 
       <% if event_registration.active? %>
-        <!-- CALENDAR LINKS -->
-        <div class="flex flex-col items-center mt-4 pt-3 border-t border-gray-100">
-          <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
-            Add to Your Calendar
-          </p>
-
-          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links %></div>
-        </div>
-      <% end %>
-
-      <% if event_registration.active? %>
-        <div class="flex flex-col items-center gap-1">
+        <!-- Manage registration -->
+        <div class="flex flex-col items-center gap-1.5">
           <% registration_form = event_registration.event.registration_form %>
 
           <% if registration_form && registration_form.form_submissions.exists?(person: event_registration.registrant) %>
             <%= link_to "View registration details",
                           event_public_registration_path(event_registration.event, reg: event_registration.slug),
-                          class: "text-xs text-gray-400 hover:text-blue-600 underline" %>
+                          class: "text-sm text-gray-500 hover:text-blue-600 underline" %>
           <% end %>
 
           <%= button_to "Resend confirmation email",
                           registration_resend_confirmation_path(event_registration.slug),
-                          class: "text-xs text-gray-400 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+                          class: "text-sm text-gray-500 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %>
 
           <%= button_to "Cancel registration",
                           registration_cancel_path(event_registration.slug),
                           data: { turbo_confirm: "Are you sure you want to cancel your registration?" },
-                          class: "text-xs text-gray-400 hover:text-red-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+                          class: "text-sm text-gray-500 hover:text-red-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+        </div>
+
+        <!-- Add to calendar (secondary utility, kept at the bottom) -->
+        <div class="flex flex-col items-center pt-5 border-t border-gray-100">
+          <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
+            Add to your calendar
+          </p>
+
+          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -75,7 +75,7 @@
         <%= render "events/videoconference_link", event: event_registration.event.decorate, joinable: event_registration.joinable? %>
       </div>
 
-      <% if event_registration.event.cost_cents.to_i > 0 %>
+      <% if event_registration.event.cost_cents.to_i > 0 && event_registration.status != "cancelled" %>
         <% if event_registration.amount_due_cents <= 0 || @checkout_payment_status == "paid" %>
           <div class="text-center mt-2"><span class="inline-flex items-center gap-1 rounded-full text-sm font-medium border px-3 py-1 bg-green-50 text-green-700 border-green-200"> Paid </span></div>
         <% else %>

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -38,13 +38,23 @@ RSpec.describe "Event registration show page", type: :system do
   end
 
   describe "calendar links" do
-    it "shows Add to Your Calendar header and calendar links" do
+    it "shows Add to your calendar header and calendar links" do
       sign_in(user)
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_text("Add to Your Calendar")
+      expect(page).to have_text("Add to your calendar")
       expect(page).to have_link("Google")
       expect(page).to have_link("Office 365")
+    end
+  end
+
+  describe "payment due" do
+    it "shows the payment-due badge and pay button for an active registration with a balance" do
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_text("payment is due")
+      expect(page).to have_button("Pay with Credit Card")
     end
   end
 
@@ -105,13 +115,21 @@ RSpec.describe "Event registration show page", type: :system do
       expect(page).to have_text("Registration cancelled")
       expect(page).not_to have_button("Register again")
     end
+
+    it "does not show the payment-due badge or pay button" do
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).not_to have_text("payment is due")
+      expect(page).not_to have_button("Pay with Credit Card")
+    end
   end
 
   describe "guest access" do
     it "allows guests to view the ticket via slug" do
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_text("Event registration")
+      expect(page).to have_text("Registration ticket")
       expect(page).to have_text(registration.registrant.full_name)
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The registration ticket footer felt busy: a green "Registered on…" pill competed with the amber "payment is due" badge, pulling attention away from the actual payment CTA.
- The "Add to calendar" links sat between the payment block and the manage-registration links, fracturing the natural grouping of registration actions.
- A **cancelled** registration still showed the "$X payment is due" badge and "Pay with Credit Card" button whenever the event had a cost — inviting payment for a registration that no longer stands.

### How did you approach the change?
- Renamed the header from "Event registration ticket" to "Registration ticket".
- Demoted the passive "Registered on…" confirmation from a green pill to quiet gray text. The meaningful states ("Checked in" green, "Registration cancelled" red) keep their badges since color carries real signal there.
- Grouped the manage-registration links together and moved "Add to calendar" to the bottom as a low-frequency utility, giving a clean top-to-bottom hierarchy: ticket info → pay → confirmation → manage → add to calendar.
- Guarded the payment block so the due badge and pay button no longer render on cancelled tickets.
- Replaced stacked dividers with spacing rhythm and normalized "Checked In" to sentence case.

### Testing
- Added a failing-first system spec for the cancelled-ticket payment fix (verified red before the guard, green after).
- Updated the existing ticket specs for the renamed header and sentence-case calendar heading.
- `spec/system/event_registration_show_spec.rb` — 11 examples, 0 failures.

### Anything else to add?
- Changes are limited to `app/views/event_registrations/_ticket.html.erb` and its system spec; no model/controller/logic changes.
- Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)