### PR TITLE
Notifications: link noticeable records to viewable pages with friendly names

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -282,6 +282,34 @@ module ApplicationHelper
     form_submission_path(submission)
   end
 
+  # A friendly type name for a noticeable record, e.g. "Registration" or "Bulk
+  # payment" rather than the raw model name ("EventRegistration").
+  def noticeable_type_label(record)
+    return "Registration" if record.is_a?(EventRegistration)
+
+    if record.is_a?(FormSubmission)
+      return record.role == "bulk_payment" ? "Bulk payment" : "Form submission"
+    end
+
+    record.class.name.underscore.humanize
+  end
+
+  # A human-friendly name for a noticeable record (the registrant and event for a
+  # registration, the submitter and form for a submission, otherwise the record's
+  # own title/name), so links read as the thing rather than its model class.
+  def noticeable_label(record)
+    label = case record
+    when EventRegistration
+      [ record.registrant&.name, record.event&.title ].compact_blank.join(" · ")
+    when FormSubmission
+      [ record.person&.name, record.form&.name ].compact_blank.join(" · ")
+    else
+      record.try(:title) || record.try(:name) || record.try(:full_name)
+    end
+
+    label.presence || "##{record.id}"
+  end
+
   def search_page(params)
     params[:search] ? params[:search][:page] : 1
   end

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -43,14 +43,17 @@
 
       <!-- Record -->
       <td class="px-4 py-3 text-gray-700">
-        <% record_path = notification.noticeable.present? ? routable_path(notification.noticeable) : nil %>
-        <% if record_path %>
-          <%= link_to notification.noticeable.class.name,
-                      record_path,
-                      data: { turbo_frame: "_top" },
-                      class: "btn btn-secondary-outline" %>
-        <% elsif notification.noticeable.present? %>
-          <span class="text-gray-700"><%= notification.noticeable.class.name %></span>
+        <% if notification.noticeable.present? %>
+          <% record_path = routable_path(notification.noticeable) %>
+          <div class="text-[10px] uppercase text-gray-400"><%= noticeable_type_label(notification.noticeable) %></div>
+          <% if record_path %>
+            <%= link_to noticeable_label(notification.noticeable),
+                        record_path,
+                        data: { turbo_frame: "_top" },
+                        class: "font-medium text-blue-600 hover:underline" %>
+          <% else %>
+            <span class="font-medium text-gray-700"><%= noticeable_label(notification.noticeable) %></span>
+          <% end %>
         <% else %>
           <span class="text-gray-400">—</span>
         <% end %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -143,13 +143,16 @@
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">Noticeable</dt>
         <dd class="text-gray-900">
-          <% record_path = @notification.noticeable.present? ? routable_path(@notification.noticeable) : nil %>
-          <% if record_path %>
-            <%= link_to @notification.noticeable.class.name,
-                        record_path,
-                        class: "text-blue-600 hover:underline" %>
-          <% elsif @notification.noticeable.present? %>
-            <%= @notification.noticeable.class.name %>
+          <% if @notification.noticeable.present? %>
+            <% record_path = routable_path(@notification.noticeable) %>
+            <span class="text-xs uppercase text-gray-400 mr-2"><%= noticeable_type_label(@notification.noticeable) %></span>
+            <% if record_path %>
+              <%= link_to noticeable_label(@notification.noticeable),
+                          record_path,
+                          class: "font-medium text-blue-600 hover:underline" %>
+            <% else %>
+              <span class="font-medium"><%= noticeable_label(@notification.noticeable) %></span>
+            <% end %>
           <% else %>
             —
           <% end %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -143,10 +143,13 @@
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">Noticeable</dt>
         <dd class="text-gray-900">
-          <% if @notification.noticeable.present? %>
+          <% record_path = @notification.noticeable.present? ? routable_path(@notification.noticeable) : nil %>
+          <% if record_path %>
             <%= link_to @notification.noticeable.class.name,
-                        polymorphic_path(@notification.noticeable),
+                        record_path,
                         class: "text-blue-600 hover:underline" %>
+          <% elsif @notification.noticeable.present? %>
+            <%= @notification.noticeable.class.name %>
           <% else %>
             —
           <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -361,4 +361,44 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.routable_path(submission)).to eq(form_submission_path(submission))
     end
   end
+
+  describe "#noticeable_type_label" do
+    it "names registrations and bulk payments in plain language" do
+      registration = build(:event_registration)
+      bulk = build(:form_submission, role: "bulk_payment")
+      submission = build(:form_submission, role: "registration")
+
+      expect(helper.noticeable_type_label(registration)).to eq("Registration")
+      expect(helper.noticeable_type_label(bulk)).to eq("Bulk payment")
+      expect(helper.noticeable_type_label(submission)).to eq("Form submission")
+    end
+
+    it "humanizes other model names" do
+      expect(helper.noticeable_type_label(build(:user))).to eq("User")
+    end
+  end
+
+  describe "#noticeable_label" do
+    it "describes a registration by registrant and event" do
+      person = create(:person, first_name: "Jane", last_name: "Doe")
+      event = create(:event, title: "Summer Workshop")
+      registration = create(:event_registration, registrant: person, event: event)
+
+      expect(helper.noticeable_label(registration)).to eq("#{person.name} · Summer Workshop")
+    end
+
+    it "describes a form submission by submitter and form" do
+      person = create(:person, first_name: "Jane", last_name: "Doe")
+      form = create(:form, name: "Bulk Payment")
+      submission = create(:form_submission, person: person, form: form)
+
+      expect(helper.noticeable_label(submission)).to eq("#{person.name} · Bulk Payment")
+    end
+
+    it "uses the record's own name for other models" do
+      user = build(:user)
+
+      expect(helper.noticeable_label(user)).to eq(user.name)
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The notifications **Record** column (index) and **Noticeable** field (detail page) previously linked using the raw model class name and `polymorphic_path`, which:
  - **Crashed on the detail page** for `FormSubmission` noticeables (bulk payments) — they have no polymorphic route, so `polymorphic_path` raised.
  - Showed an unhelpful label (`EventRegistration`, `FormSubmission`) that said nothing about *which* record it was.
- This makes notification records traceable to the actual person/event/form they're about, and viewable from both the list and the detail page.

### How did you approach the change?

- **Detail page routing** — reused the existing `routable_path` helper (added by #1656 for the index) on `show.html.erb` so it links the same viewable destinations and degrades to plain text for routeless records, instead of calling `polymorphic_path` unconditionally.
- **Friendly labels** — added two helpers:
  - `noticeable_label` — the record's name (registrant · event, submitter · form, or the record's own `title`/`name`).
  - `noticeable_type_label` — plain-language type (`Registration`, `Bulk payment`, `Form submission`, else humanized model name).
- **Format decision** — rendered as a small uppercase type label over a text link (mirroring the existing **People** column), rather than a button, so it doesn't compete with the row's existing **View** action button.
- **Bulk payments** — no dedicated handling needed: #1656's `form_submission_path` + shared `_submission` partial already render bulk-payment submissions (including the attendee table); they route there automatically.

### UI Testing Checklist

- [ ] Notifications index: Record column shows a type label + record name, links to the right page
- [ ] Notification detail page: Noticeable field links correctly (no crash) for a bulk-payment notification
- [ ] Routeless noticeables fall back to plain text (no link, no error)

### Anything else to add?

- Helper specs cover both new label helpers across registration / bulk payment / submission / other model cases.
- Tests: helper specs 56/56, notifications request specs 28/28, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
