### PR TITLE
Add optional event-specific staff bio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (61) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (62) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -270,6 +270,7 @@ end
 - `dirty_form` — Unsaved changes detection
 - `dismiss` — Dismissable elements
 - `dropdown` — Dropdown menus with keyboard/click-outside handling
+- `event_staff_bio` — Loads a selected person's read-only profile bio (with edit link) alongside the editable event-specific bio on the staff form
 - `file_preview` — File upload preview
 - `grant_details` — Swaps a grant's eligibility criteria + tasks when the grant picker changes
 - `grant_select` — Tom Select grant picker showing each grant's remaining-of-total funds

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -350,7 +350,7 @@ class EventsController < ApplicationController
 
   def event_staff_params
     params.require(:event).permit(
-      event_staffs_attributes: [ :id, :person_id, :title, :expected_to_attend, :_destroy ]
+      event_staffs_attributes: [ :id, :person_id, :title, :expected_to_attend, :bio, :_destroy ]
     )
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,6 +1,6 @@
 class PeopleController < ApplicationController
   include AhoyTracking, TagAssignable
-  before_action :set_person, only: %i[ show edit update destroy workshop_logs checkout ]
+  before_action :set_person, only: %i[ show edit update destroy workshop_logs checkout bio ]
 
   def index
     authorize!
@@ -87,6 +87,21 @@ class PeopleController < ApplicationController
     elsif params[:external_title].present?
       @filtered_logs = all_logs.select { |log| log.external_workshop_title == params[:external_title] }
     end
+  end
+
+  # Read-only profile bio for the event-staff editor, fetched when a person is
+  # picked for a new staff row. Returns sanitized HTML so the client can render
+  # it directly. Person search is admin-gated, so show? (admin or owner) is the
+  # right authorization here.
+  def bio
+    authorize! @person, to: :show?
+    has_bio = @person.profile_show_bio? && @person.bio.present?
+    render json: {
+      show_bio: @person.profile_show_bio?,
+      has_bio: has_bio,
+      bio_html: (helpers.sanitize(@person.bio, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) if has_bio),
+      edit_path: (edit_person_path(@person) if allowed_to?(:edit?, @person))
+    }
   end
 
   def checkout

--- a/app/frontend/javascript/controllers/event_staff_bio_controller.js
+++ b/app/frontend/javascript/controllers/event_staff_bio_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="event-staff-bio"
+// Shows the selected person's read-only profile bio (with a link to edit it on
+// their profile) next to the editable event-specific bio. The profile bio is
+// the fallback the public staff page shows when the event bio is left blank, so
+// the organizer can see it while deciding whether to override it. For a freshly
+// added staff row the person isn't known server-side, so we fetch their bio when
+// they're picked from the person search.
+export default class extends Controller {
+  static targets = ["profile"]
+  static values = { urlTemplate: String }
+
+  personChanged(event) {
+    const id = event.target.value
+    if (!id) return this.renderEmpty()
+    this.load(id)
+  }
+
+  async load(id) {
+    this.profileTarget.innerHTML = this.header() + this.muted("Loading profile bio…")
+    try {
+      const response = await fetch(this.urlTemplateValue.replace("__ID__", id), {
+        headers: { Accept: "application/json" }
+      })
+      if (!response.ok) throw new Error(response.status)
+      this.render(await response.json())
+    } catch {
+      this.profileTarget.innerHTML = this.header() + this.muted("Couldn't load profile bio.")
+    }
+  }
+
+  render(data) {
+    let body
+    if (data.has_bio) {
+      body = `<div class="text-sm text-gray-600">${data.bio_html}</div>`
+    } else if (data.show_bio) {
+      body = this.muted("No profile bio on file.")
+    } else {
+      body = this.muted("This person's profile bio is hidden.")
+    }
+    this.profileTarget.innerHTML = this.header(data.edit_path) + body
+  }
+
+  renderEmpty() {
+    this.profileTarget.innerHTML = this.header() + this.muted("Select a person to see their profile bio.")
+  }
+
+  header(editPath) {
+    const link = editPath
+      ? `<a href="${editPath}" class="text-xs font-medium text-blue-600 hover:text-blue-800">Edit on profile</a>`
+      : ""
+    return `<div class="flex items-center justify-between mb-1"><span class="text-sm font-medium text-gray-700">Profile bio</span>${link}</div>`
+  }
+
+  muted(text) {
+    return `<p class="text-sm text-gray-400 italic">${text}</p>`
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -54,6 +54,9 @@ application.register("dismiss", DismissController)
 import FlipCardController from "./flip_card_controller"
 application.register("flip-card", FlipCardController)
 
+import EventStaffBioController from "./event_staff_bio_controller"
+application.register("event-staff-bio", EventStaffBioController)
+
 import ExpandableCardController from "./expandable_card_controller"
 application.register("expandable-card", ExpandableCardController)
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -38,6 +38,7 @@ class Event < ApplicationRecord
   validates_inclusion_of :published, in: [ true, false ]
   validates_numericality_of :cost_cents, greater_than_or_equal_to: 0, allow_nil: true
   validate :registration_form_required_when_publicly_registerable, on: :update
+  validate :staff_members_are_unique, on: :update
 
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
@@ -159,6 +160,16 @@ class Event < ApplicationRecord
     return if event_forms.registration.exists?
 
     errors.add(:public_registration_enabled, "requires a registration form to be selected")
+  end
+
+  # The event_staffs unique index catches duplicates already persisted, but two
+  # new rows for the same person in one submission both pass the per-record
+  # uniqueness check (neither is saved yet) and would hit the index on save.
+  def staff_members_are_unique
+    person_ids = event_staffs.reject(&:marked_for_destruction?).filter_map(&:person_id)
+    return if person_ids.uniq.length == person_ids.length
+
+    errors.add(:base, "A person can only be added to the staff once.")
   end
 
   def public_registration_just_enabled?

--- a/app/models/event_staff.rb
+++ b/app/models/event_staff.rb
@@ -4,7 +4,17 @@ class EventStaff < ApplicationRecord
 
   validates :person_id, uniqueness: { scope: :event_id }
 
+  normalizes :bio, with: ->(value) { value&.strip.presence }
+
   scope :ordered_by_name, -> {
     joins(:person).order(Arel.sql("people.first_name, people.last_name"))
   }
+
+  # Bio shown on the public staff page. A per-event bio overrides the person's
+  # profile bio; otherwise fall back to the profile bio when the person allows
+  # it to be shown.
+  def public_bio
+    return bio if bio.present?
+    person.bio if person&.profile_show_bio?
+  end
 end

--- a/app/views/events/_event_staff_fields.html.erb
+++ b/app/views/events/_event_staff_fields.html.erb
@@ -1,43 +1,80 @@
-<div class="nested-fields flex flex-wrap items-end gap-x-4 gap-y-2 mb-3 rounded-lg border border-gray-200 bg-white p-3"
+<div class="nested-fields rounded-lg border border-gray-200 bg-white p-3 mb-3"
+     data-controller="event-staff-bio"
+     data-event-staff-bio-url-template-value="<%= bio_person_path("__ID__") %>"
      <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>>
-  <div style="width: 320px; min-width: 320px; flex-shrink: 0;">
-    <% if f.object.persisted? && f.object.person.present? %>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
-      <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
-      <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
-      <%= f.hidden_field :person_id %>
-    <% else %>
-      <%= f.input :person_id,
-        include_blank: true,
-        required: true,
-        input_html: {
-          data: {
-            controller: "remote-select",
-            remote_select_model_value: "person"
-          }
-        },
-        label: "Person" %>
-    <% end %>
+  <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
+    <div style="width: 320px; min-width: 320px; flex-shrink: 0;">
+      <% if f.object.persisted? && f.object.person.present? %>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
+        <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
+        <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
+        <%= f.hidden_field :person_id %>
+      <% else %>
+        <%= f.input :person_id,
+          include_blank: true,
+          required: true,
+          input_html: {
+            data: {
+              controller: "remote-select",
+              remote_select_model_value: "person",
+              action: "change->event-staff-bio#personChanged"
+            }
+          },
+          label: "Person" %>
+      <% end %>
+    </div>
+
+    <div class="w-full sm:w-auto" style="min-width: 200px;">
+      <label class="block text-sm font-medium text-gray-700 mb-1">Title</label>
+      <%= f.text_field :title,
+                       value: f.object.title.presence || "Staff",
+                       class: "w-full h-14 rounded-lg border-gray-300 shadow-sm px-3 focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div class="w-full sm:w-auto pb-2">
+      <label class="block text-sm font-medium text-gray-700 mb-1">Expected to attend</label>
+      <label class="relative inline-flex items-center cursor-pointer">
+        <%= f.check_box :expected_to_attend, class: "sr-only peer" %>
+        <div class="relative w-11 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+      </label>
+    </div>
   </div>
 
-  <div class="w-full sm:w-auto" style="min-width: 200px;">
-    <%= f.input :title,
-                label: "Title",
-                input_html: {
-                  value: f.object.title.presence || "Staff",
-                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500"
-                } %>
+  <%# Event bio (left) overrides the person's profile bio (right) on the public
+      staff page; blank falls back to the profile bio — see EventStaff#public_bio. %>
+  <% staff_person = f.object.person %>
+  <% profile_bio = staff_person.bio if staff_person&.profile_show_bio? %>
+  <div class="w-full border-t border-gray-100 pt-3 mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-1" for="<%= f.field_id(:bio) %>">
+        Bio <span class="font-normal text-gray-400">(optional)</span>
+      </label>
+      <%= f.text_area :bio,
+                      rows: 4,
+                      maxlength: 1650,
+                      placeholder: "Leave blank to use their profile bio",
+                      class: "w-full rounded-md border-gray-300 shadow-sm px-3 py-2 focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50" %>
+      <p class="mt-1 text-xs text-gray-400">Shown on this event's staff page instead of their profile bio.</p>
+    </div>
+
+    <div class="sm:border-l sm:border-gray-100 sm:pl-4" data-event-staff-bio-target="profile">
+      <div class="flex items-center justify-between mb-1">
+        <span class="text-sm font-medium text-gray-700">Profile bio</span>
+        <% if staff_person.present? && allowed_to?(:edit?, staff_person) %>
+          <%= link_to "Edit on profile", edit_person_path(staff_person), class: "text-xs font-medium text-blue-600 hover:text-blue-800" %>
+        <% end %>
+      </div>
+      <% if profile_bio.present? %>
+        <div class="text-sm text-gray-600"><%= sanitize(profile_bio, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %></div>
+      <% elsif staff_person.present? %>
+        <p class="text-sm text-gray-400 italic"><%= staff_person.profile_show_bio? ? "No profile bio on file." : "This person's profile bio is hidden." %></p>
+      <% else %>
+        <p class="text-sm text-gray-400 italic">Select a person to see their profile bio.</p>
+      <% end %>
+    </div>
   </div>
 
-  <div class="w-full sm:w-auto pb-2">
-    <label class="block text-sm font-medium text-gray-700 mb-1">Expected to attend</label>
-    <label class="relative inline-flex items-center cursor-pointer">
-      <%= f.check_box :expected_to_attend, class: "sr-only peer" %>
-      <div class="w-11 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
-    </label>
-  </div>
-
-  <div class="w-full sm:w-auto sm:ml-auto text-right pb-2">
+  <div class="mt-2 text-right">
     <%= link_to_remove_association "Remove",
                                    f,
                                    class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap rounded px-2 py-1" %>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -28,7 +28,7 @@
         <% person = event_staff.person.decorate %>
         <% active_affiliation = person.affiliations.find { |a| !a.inactive? } %>
         <% org = active_affiliation&.organization %>
-        <% has_bio = person.profile_show_bio? && person.bio.present? %>
+        <% bio = event_staff.public_bio %>
         <% sectors = person.profile_show_sectors? ? person.sectors.sort_by(&:name) : [] %>
         <%# Facilitator tenure → one experience badge, computed from already-loaded
             affiliations (avoids the decorator's query-heavy badges call). Thresholds
@@ -118,8 +118,8 @@
                 <div class="h-full overflow-y-auto text-sm text-gray-700 text-left pr-1"
                      data-flip-card-target="bio"
                      data-action="scroll->flip-card#updateFade">
-                  <% if has_bio %>
-                    <%= sanitize(person.bio, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
+                  <% if bio.present? %>
+                    <%= sanitize(bio, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
                   <% else %>
                     <p class="text-gray-400 italic text-center">No bio available.</p>
                   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
     member do
       get :workshop_logs
       get :checkout
+      get :bio
     end
     resources :comments, only: [ :index, :create, :update ]
   end

--- a/db/migrate/20260613173115_add_bio_to_event_staffs.rb
+++ b/db/migrate/20260613173115_add_bio_to_event_staffs.rb
@@ -1,0 +1,9 @@
+class AddBioToEventStaffs < ActiveRecord::Migration[8.1]
+  def up
+    add_column :event_staffs, :bio, :text
+  end
+
+  def down
+    remove_column :event_staffs, :bio, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -462,6 +462,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_180000) do
   end
 
   create_table "event_staffs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "bio"
     t.datetime "created_at", null: false
     t.bigint "event_id", null: false
     t.boolean "expected_to_attend", default: false, null: false

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -211,6 +211,38 @@ roundtable = Event.find_by(title: "Leaders in Creativity: Facilitator Roundtable
 family_day = Event.find_by(title: "Family Creative Expression Day")
 # "Community Open Studio Night" and "Annual Celebration of Voices" have no registration forms — left with zero registrations
 
+puts "Creating Event Staff…"
+# Staff the flagship training (event 1) so its "Meet the staff" page has content.
+# Amy carries an event-specific bio that OVERRIDES her profile bio here, while
+# Maria has no event bio so the page falls back to her profile bio — exercising
+# both sides of the per-event bio feature. Profile bios are set so the fallback
+# (and the edit form's "showing their profile bio" preview) have something to show.
+# Updates run unconditionally so re-seeding keeps the demo bios current.
+amy_person&.update!(
+  bio: "Amy User is a Windows facilitator with a decade of experience bringing trauma-informed art practices to survivors across Los Angeles. She believes the quietest moments at the art table are often the most transformative.",
+  profile_show_bio: true
+)
+maria_j&.update!(
+  bio: "Maria Johnson coordinates community workshops and has supported AWBW programs since 2019, with a focus on youth and family groups.",
+  profile_show_bio: true
+)
+
+if facilitator_training
+  if amy_person
+    amy_staff = EventStaff.find_or_create_by!(event: facilitator_training, person: amy_person)
+    amy_staff.update!(
+      title: "Lead facilitator",
+      expected_to_attend: true,
+      bio: "For the AWBW Facilitator Training, Amy leads the two-day intensive — walking new facilitators through the full Windows model and sharing what a decade at the art table has taught her about holding space."
+    )
+  end
+
+  if maria_j
+    maria_staff = EventStaff.find_or_create_by!(event: facilitator_training, person: maria_j)
+    maria_staff.update!(title: "Facilitator", expected_to_attend: false, bio: nil)
+  end
+end
+
 registrations_data = []
 
 # --- Facilitator Training: multiple registrations from different people, extended form ---

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,29 @@ RSpec.describe Event, type: :model do
     it { should validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0).allow_nil }
   end
 
+  describe "staff uniqueness on update" do
+    it "rejects two staff rows for the same person added in one update" do
+      event = create(:event)
+      person = create(:person)
+      event.update(event_staffs_attributes: {
+        "0" => { person_id: person.id, title: "Lead" },
+        "1" => { person_id: person.id, title: "Assistant" }
+      })
+      expect(event).to be_invalid
+      expect(event.errors[:base]).to include("A person can only be added to the staff once.")
+      expect(event.event_staffs.reload).to be_empty
+    end
+
+    it "allows distinct people in one update" do
+      event = create(:event)
+      expect(event.update(event_staffs_attributes: {
+        "0" => { person_id: create(:person).id, title: "Lead" },
+        "1" => { person_id: create(:person).id, title: "Assistant" }
+      })).to be(true)
+      expect(event.event_staffs.reload.count).to eq(2)
+    end
+  end
+
   describe "#ended?" do
     it "returns true when end_date is in the past" do
       event = build(:event, end_date: 1.day.ago)

--- a/spec/models/event_staff_spec.rb
+++ b/spec/models/event_staff_spec.rb
@@ -35,6 +35,38 @@ RSpec.describe EventStaff, type: :model do
     end
   end
 
+  describe "bio normalization" do
+    it "stores a blank bio as nil" do
+      event_staff = create(:event_staff, bio: "   ")
+      expect(event_staff.bio).to be_nil
+    end
+
+    it "strips surrounding whitespace" do
+      event_staff = create(:event_staff, bio: "  Hello  ")
+      expect(event_staff.bio).to eq("Hello")
+    end
+  end
+
+  describe "#public_bio" do
+    it "returns the event-specific bio when present" do
+      person = create(:person, bio: "Profile bio", profile_show_bio: true)
+      event_staff = build(:event_staff, person: person, bio: "Event bio")
+      expect(event_staff.public_bio).to eq("Event bio")
+    end
+
+    it "falls back to the profile bio when no event bio is set and the person allows it" do
+      person = create(:person, bio: "Profile bio", profile_show_bio: true)
+      event_staff = build(:event_staff, person: person, bio: nil)
+      expect(event_staff.public_bio).to eq("Profile bio")
+    end
+
+    it "returns nil when the person hides their profile bio and no event bio is set" do
+      person = create(:person, bio: "Profile bio", profile_show_bio: false)
+      event_staff = build(:event_staff, person: person, bio: nil)
+      expect(event_staff.public_bio).to be_nil
+    end
+  end
+
   describe ".ordered_by_name" do
     it "orders staff by the person's first then last name" do
       event = create(:event)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1136,6 +1136,16 @@ RSpec.describe "Events", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "renders the bio control and the person's profile bio for an existing staff member" do
+        staffer.update!(bio: "A seasoned facilitator", profile_show_bio: true)
+        create(:event_staff, event: published_event, person: staffer)
+        sign_in admin
+        get edit_staff_event_path(published_event)
+        expect(response.body).to include("event-staff-bio")
+        expect(response.body).to include("Profile bio")
+        expect(response.body).to include("A seasoned facilitator")
+      end
+
       it "redirects a non-admin" do
         sign_in user
         get edit_staff_event_path(published_event)
@@ -1144,6 +1154,21 @@ RSpec.describe "Events", type: :request do
     end
 
     describe "PATCH /staff" do
+      it "rejects adding the same person to the staff twice in one submission" do
+        sign_in admin
+        expect {
+          patch staff_event_path(published_event), params: {
+            event: {
+              event_staffs_attributes: {
+                "0" => { person_id: staffer.id, title: "Lead facilitator" },
+                "1" => { person_id: staffer.id, title: "Assistant" }
+              }
+            }
+          }
+        }.not_to change(EventStaff, :count)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
       it "adds a staff member to the event" do
         sign_in admin
         expect {
@@ -1160,6 +1185,34 @@ RSpec.describe "Events", type: :request do
         expect(staff.title).to eq("Staff")
         expect(staff.expected_to_attend).to be(true)
         expect(response).to redirect_to(staff_event_path(published_event))
+      end
+
+      it "saves an optional event-specific bio that overrides the profile bio" do
+        sign_in admin
+        patch staff_event_path(published_event), params: {
+          event: {
+            event_staffs_attributes: {
+              "0" => { person_id: staffer.id, title: "Staff", bio: "Custom event bio" }
+            }
+          }
+        }
+        expect(published_event.event_staffs.last.bio).to eq("Custom event bio")
+      end
+
+      it "clears the event bio when submitted blank, falling back to the profile bio" do
+        staffer.update!(bio: "Profile bio", profile_show_bio: true)
+        event_staff = create(:event_staff, event: published_event, person: staffer, bio: "Old event bio")
+        sign_in admin
+        patch staff_event_path(published_event), params: {
+          event: {
+            event_staffs_attributes: {
+              "0" => { id: event_staff.id, person_id: staffer.id, bio: "" }
+            }
+          }
+        }
+        expect(event_staff.reload.bio).to be_nil
+        get staff_event_path(published_event)
+        expect(response.body).to include("Profile bio")
       end
 
       it "removes a staff member when _destroy is set" do

--- a/spec/requests/people_bio_spec.rb
+++ b/spec/requests/people_bio_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "People#bio", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  describe "GET /people/:id/bio" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "returns the sanitized profile bio with an edit link when shown" do
+        person = create(:person, bio: "<p>Hello <script>alert(1)</script>world</p>", profile_show_bio: true)
+        get bio_person_path(person)
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["has_bio"]).to be(true)
+        expect(json["show_bio"]).to be(true)
+        expect(json["bio_html"]).to include("Hello").and include("world")
+        expect(json["bio_html"]).not_to include("script")
+        expect(json["edit_path"]).to eq(edit_person_path(person))
+      end
+
+      it "reports no bio when the person hides their profile bio" do
+        person = create(:person, bio: "Hidden bio", profile_show_bio: false)
+        get bio_person_path(person)
+        json = response.parsed_body
+        expect(json["show_bio"]).to be(false)
+        expect(json["has_bio"]).to be(false)
+        expect(json["bio_html"]).to be_nil
+      end
+    end
+
+    it "forbids a non-admin" do
+      person = create(:person, bio: "Some bio", profile_show_bio: true)
+      sign_in create(:user)
+      get bio_person_path(person)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Lets event organizers tailor how a staff member is introduced on a **specific event's** public staff page, instead of being limited to the one profile bio that person carries everywhere.
- The per-event bio is **optional** and **overrides** the profile bio for that event only; left blank, the public staff page falls back to the person's profile bio.

### How did you approach the change?

- **Model/data:** added a `bio` column to `event_staffs`; `EventStaff#public_bio` resolves the event bio first, then the profile bio (only when the person allows it to be shown). Blank event bios normalize to `nil`.
- **Staff form (`/events/:id/staff/edit`):** each staff card now shows the editable **event bio** on the left beside the person's **read-only profile bio** (with an "Edit on profile" link) on the right, so organizers can see what they're overriding.
- **Dynamic profile bio:** for a freshly added row the person isn't known server-side, so the profile bio is fetched when a person is picked, via a new admin-gated `GET /people/:id/bio` endpoint (returns sanitized HTML) wired through the `event-staff-bio` Stimulus controller.
- **Duplicate guard:** adding the same person to a staff twice in one submission previously passed per-record validation and then hit the unique index → 500. Added an Event-level `validate :staff_members_are_unique, on: :update` so it re-renders the form with a clear error instead.
- **Seeds:** Amy (event-bio override) and Maria Johnson (profile-bio fallback) are staffed on the flagship training so both states are visible in dev.

### Anything else to add?

- The "Edit on profile" link targets the person's profile **edit** page (admin-only). Person search on this form is already admin-gated, so that's consistent — but worth noting if non-admin event owners are ever meant to use this page.
- Tests: new `people_bio_spec`, model specs for `public_bio` / duplicate guard, and request specs for saving/clearing the event bio. Migration is reversible; AGENTS.md updated for the new endpoint/controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)