### PR TITLE
Reveal "please specify" text input for form "Other" options

### DIFF
--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -87,6 +87,9 @@ application.register("inactive-toggle", InactiveToggleController)
 import OptimisticBookmarkController from "./optimistic_bookmark_controller"
 application.register("optimistic-bookmark", OptimisticBookmarkController)
 
+import OtherOptionController from "./other_option_controller"
+application.register("other-option", OtherOptionController)
+
 import OrgToggleController from "./org_toggle_controller"
 application.register("org-toggle", OrgToggleController)
 

--- a/app/frontend/javascript/controllers/other_option_controller.js
+++ b/app/frontend/javascript/controllers/other_option_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Reveals a free-text "please specify" input inside an "Other" option box for
+// radio/checkbox form fields. When Other is selected the text input appears,
+// and whatever the user types is folded into the option's submitted value as
+// "Other: <text>" — so the server stores it with no extra params or changes.
+// The text input has no name attribute, so it never submits on its own.
+export default class extends Controller {
+  static targets = ["control", "text"]
+
+  connect() {
+    this.update()
+  }
+
+  // Fires on any change within the field (a radio/checkbox toggling on or off).
+  update() {
+    const selected = this.controlTarget.checked
+    this.textTarget.classList.toggle("hidden", !selected)
+    if (selected) this.foldValue()
+  }
+
+  // Fires while the user types in the Other box — keep Other selected and sync.
+  typed() {
+    if (!this.controlTarget.checked) this.controlTarget.checked = true
+    this.textTarget.classList.remove("hidden")
+    this.foldValue()
+  }
+
+  foldValue() {
+    const text = this.textTarget.value.trim()
+    this.controlTarget.value = text ? `Other: ${text}` : "Other"
+  }
+}

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -1,4 +1,24 @@
 module EventHelper
+  # The special free-text option label that reveals a "please specify" input.
+  OTHER_OPTION_PREFIX = "Other"
+
+  # True when an option label is the special free-text "Other" choice.
+  def other_option?(label)
+    label.to_s.strip.casecmp?(OTHER_OPTION_PREFIX)
+  end
+
+  # True when a stored answer represents the "Other" option being chosen. Works
+  # for both single answers (a string) and multi-select answers (an array).
+  def other_option_selected?(value)
+    Array(value).any? { |v| v.to_s == OTHER_OPTION_PREFIX || v.to_s.start_with?("#{OTHER_OPTION_PREFIX}:") }
+  end
+
+  # Extracts the user's custom text from a stored "Other: <text>" answer.
+  def other_option_text(value)
+    answer = Array(value).find { |v| v.to_s.start_with?(OTHER_OPTION_PREFIX) }
+    answer.to_s.delete_prefix(OTHER_OPTION_PREFIX).delete_prefix(":").strip
+  end
+
   # Splits an ActionText rich text into two HTML-safe fragments by character length.
   # Splits at the nearest block-element boundary after `split_length` plain-text characters.
   # Returns [top_html, bottom_html].

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -72,24 +72,35 @@
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <div class="flex flex-wrap gap-2.5 mt-1">
+    <% has_other = radio_options.any? { |option_label, option_value| other_option?(option_value) } %>
+    <%= tag.div class: "flex flex-wrap gap-2.5 mt-1", data: (has_other ? { controller: "other-option", action: "change->other-option#update" } : {}) do %>
       <% radio_options.each do |option_label, option_value, option_description| %>
+        <% is_other = other_option?(option_value) %>
         <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
             <input type="radio"
                    name="<%= field_name %>"
                    value="<%= option_value %>"
                    class="text-blue-600 focus:ring-blue-500"
-                   <%= "checked" if value == option_value || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
+                   <%= "data-other-option-target=\"control\"".html_safe if is_other %>
+                   <%= "checked" if (is_other ? other_option_selected?(value) : value == option_value) || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
                    <%= "required" if field.required %>>
             <%= option_label %>
           </span>
           <% if option_description.present? %>
             <span class="pl-6 text-xs font-normal text-gray-500"><%= option_description %></span>
           <% end %>
+          <% if is_other %>
+            <input type="text"
+                   placeholder="Please specify"
+                   value="<%= other_option_text(value) %>"
+                   data-other-option-target="text"
+                   data-action="input->other-option#typed"
+                   class="ml-6 w-full max-w-xs rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
+          <% end %>
         </label>
       <% end %>
-    </div>
+    <% end %>
 
   <% when "single_select_dropdown" %>
     <%# Dynamic fields (e.g. primary_service_area_single) source options from
@@ -114,25 +125,36 @@
         options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
+    <% has_other = checkbox_options.any? { |option_label, option_value| other_option?(option_value) } %>
     <%# Multi-column (not grid) so a sorted option list reads straight down each
         column then onto the next, rather than zig-zagging across rows. %>
-    <div class="columns-1 sm:columns-2 gap-2.5 mt-1">
+    <%= tag.div class: "columns-1 sm:columns-2 gap-2.5 mt-1", data: (has_other ? { controller: "other-option", action: "change->other-option#update" } : {}) do %>
       <% checkbox_options.each do |option_label, option_value, option_description| %>
+        <% is_other = other_option?(option_value) %>
         <label class="flex flex-col gap-1 mb-2.5 break-inside-avoid rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
             <input type="checkbox"
                    name="<%= checkbox_name %>"
                    value="<%= option_value %>"
                    class="rounded text-blue-600 focus:ring-blue-500"
-                   <%= "checked" if selected_values.include?(option_value) %>>
+                   <%= "data-other-option-target=\"control\"".html_safe if is_other %>
+                   <%= "checked" if is_other ? other_option_selected?(value) : selected_values.include?(option_value) %>>
             <%= option_label %>
           </span>
           <% if option_description.present? %>
             <span class="pl-6 text-xs font-normal text-gray-500"><%= option_description %></span>
           <% end %>
+          <% if is_other %>
+            <input type="text"
+                   placeholder="Please specify"
+                   value="<%= other_option_text(value) %>"
+                   data-other-option-target="text"
+                   data-action="input->other-option#typed"
+                   class="ml-6 w-full max-w-xs rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
+          <% end %>
         </label>
       <% end %>
-    </div>
+    <% end %>
 
   <% end %>
 

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe EventHelper, type: :helper do
+  describe "#other_option?" do
+    it "matches the 'Other' label case- and whitespace-insensitively" do
+      expect(helper.other_option?("Other")).to be true
+      expect(helper.other_option?("other")).to be true
+      expect(helper.other_option?("  OTHER  ")).to be true
+    end
+
+    it "does not match other labels" do
+      expect(helper.other_option?("Yes")).to be false
+      expect(helper.other_option?("Other reasons")).to be false
+      expect(helper.other_option?(nil)).to be false
+    end
+  end
+
+  describe "#other_option_selected?" do
+    it "is true for a bare 'Other' answer" do
+      expect(helper.other_option_selected?("Other")).to be true
+    end
+
+    it "is true for an 'Other: <text>' answer" do
+      expect(helper.other_option_selected?("Other: purple")).to be true
+    end
+
+    it "is true when an array of answers includes the Other choice" do
+      expect(helper.other_option_selected?([ "Red", "Other: teal" ])).to be true
+    end
+
+    it "is false when no answer represents the Other choice" do
+      expect(helper.other_option_selected?("Yes")).to be false
+      expect(helper.other_option_selected?([ "Red", "Blue" ])).to be false
+      expect(helper.other_option_selected?(nil)).to be false
+    end
+  end
+
+  describe "#other_option_text" do
+    it "extracts the custom text from an 'Other: <text>' answer" do
+      expect(helper.other_option_text("Other: bright purple")).to eq("bright purple")
+    end
+
+    it "extracts the custom text from a multi-select answer array" do
+      expect(helper.other_option_text([ "Red", "Other: teal" ])).to eq("teal")
+    end
+
+    it "returns an empty string for a bare 'Other' answer" do
+      expect(helper.other_option_text("Other")).to eq("")
+    end
+
+    it "returns an empty string when there is no Other answer" do
+      expect(helper.other_option_text("Yes")).to eq("")
+      expect(helper.other_option_text(nil)).to eq("")
+    end
+  end
+end

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -340,6 +340,54 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).to include("Community mental health, outpatient, etc")
     end
+
+    it "reveals a 'please specify' text input for a radio field's Other option" do
+      field = create(:form_field, form: form, answer_type: :single_select_radio,
+             name: "Favorite color", required: false)
+      [ "Red", "Other" ].each_with_index do |name, i|
+        option = create(:answer_option, name: name, position: i)
+        create(:form_field_answer_option, form_field: field, answer_option: option)
+      end
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include('data-controller="other-option"')
+      expect(response.body).to include('data-other-option-target="control"')
+      expect(response.body).to include('placeholder="Please specify"')
+    end
+
+    it "does not add the Other controller to fields without an Other option" do
+      field = create(:form_field, form: form, answer_type: :single_select_radio,
+             name: "Favorite color", required: false)
+      option = create(:answer_option, name: "Red", position: 0)
+      create(:form_field_answer_option, form_field: field, answer_option: option)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).not_to include('data-controller="other-option"')
+    end
+
+    it "re-checks Other and prefills the text input after a validation error" do
+      field = create(:form_field, form: form, answer_type: :single_select_radio,
+             name: "Favorite color", required: true)
+      [ "Red", "Other" ].each_with_index do |name, i|
+        option = create(:answer_option, name: name, position: i)
+        create(:form_field_answer_option, form_field: field, answer_option: option)
+      end
+      required = create(:form_field, form: form, answer_type: :free_form_input_one_line,
+             name: "Name", required: true)
+
+      post event_public_registration_path(event),
+           params: { public_registration: { form_fields: {
+             field.id.to_s => "Other: chartreuse",
+             required.id.to_s => ""
+           } } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('value="chartreuse"')
+      # The Other radio is re-checked and its text input is not hidden.
+      expect(response.body).not_to match(/placeholder="Please specify"[^>]*\bhidden\b/)
+    end
   end
 
   describe "GET show" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- When a form field (radio or checkbox) has an option literally named **Other**, selecting it now reveals an inline "Please specify" text input inside that option's box so the form filler can describe their choice.
- Previously organizers had to add a separate free-text question to capture this, leaving the bare "Other" answer meaningless on submissions.

### How did you approach the change?

- Added an `other-option` Stimulus controller that shows/hides the text input as the Other control is toggled and folds the typed text into the control's submitted value as `Other: <text>` — no extra form params.
- The text input has **no `name`**, so it never submits on its own; only its folded value reaches the server. This means **no controller, service, or schema changes** — the answer stores and displays through the existing `submitted_answer` path.
- Updated `app/views/events/public_registrations/_form_field.html.erb` to render the controller wrapper (only when an Other option exists), the control target, and the revealed text input for both radio and checkbox fields.
- Added `EventHelper#other_option?`, `#other_option_selected?`, and `#other_option_text` to detect the Other option and parse a stored `Other: <text>` answer back into a checked state + prefilled text after a validation error re-render.

### UI Testing Checklist

- [ ] Radio field with an "Other" option: selecting Other reveals the text box; typing stores `Other: <text>`; selecting another option hides it.
- [ ] Checkbox field with an "Other" option: same reveal/hide behavior; submitted alongside other checked values.
- [ ] Submitting with validation errors re-checks Other and keeps the typed text.
- [ ] Fields without an "Other" option are unaffected (no controller attached).

### Anything else to add?

- Covered by helper specs (`spec/helpers/event_helper_spec.rb`) and request specs for render + error re-render. JS reveal behavior is driven by Stimulus; the request specs assert the markup/targets are present since the suite's public-registration specs run under `rack_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)