### PR TITLE
Fix "Other" text input not revealing on category/sector-backed fields

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -104,18 +104,23 @@ module EventHelper
   end
 
   # Resolve a stored answer to readable text, mapping the sector/category ids
-  # behind the professional fields to their names. Returns nil for a blank
-  # answer (unlike display_response_text, which renders a placeholder), so it
-  # suits inline header values on the scholarship recipients page.
+  # behind the professional fields to their names. Free-text tokens (e.g. an
+  # "Other: <text>" answer) aren't ids, so they pass through unchanged. Returns
+  # nil for a blank answer (unlike display_response_text, which renders a
+  # placeholder), so it suits inline header values on the scholarship page.
   def resolve_answer_text(field, submitted_answer)
     return if submitted_answer.blank?
 
-    ids = submitted_answer.split(", ")
+    tokens = submitted_answer.split(", ")
+    resolve = ->(klass) {
+      tokens.filter_map { |token| klass.find_by(id: token)&.name || (token unless token.match?(/\A\d+\z/)) }
+            .join(", ").presence || submitted_answer
+    }
     case field&.field_identifier
     when "primary_service_area", "primary_service_area_single"
-      ids.filter_map { |id| Sector.find_by(id: id)&.name }.join(", ").presence || submitted_answer
+      resolve.call(Sector)
     when "workshop_environments", "client_life_experiences", "primary_age_group"
-      ids.filter_map { |id| Category.find_by(id: id)&.name }.join(", ").presence || submitted_answer
+      resolve.call(Category)
     else
       submitted_answer
     end

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -96,7 +96,7 @@
                    value="<%= other_option_text(value) %>"
                    data-other-option-target="text"
                    data-action="input->other-option#typed"
-                   class="ml-6 w-full max-w-xs rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
+                   class="mt-1 w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
           <% end %>
         </label>
       <% end %>
@@ -150,7 +150,7 @@
                    value="<%= other_option_text(value) %>"
                    data-other-option-target="text"
                    data-action="input->other-option#typed"
-                   class="ml-6 w-full max-w-xs rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
+                   class="mt-1 w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 <%= "hidden" unless other_option_selected?(value) %>">
           <% end %>
         </label>
       <% end %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -72,15 +72,15 @@
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <% has_other = radio_options.any? { |option_label, option_value| other_option?(option_value) } %>
+    <% has_other = radio_options.any? { |option_label, option_value| other_option?(option_label) } %>
     <%= tag.div class: "flex flex-wrap gap-2.5 mt-1", data: (has_other ? { controller: "other-option", action: "change->other-option#update" } : {}) do %>
       <% radio_options.each do |option_label, option_value, option_description| %>
-        <% is_other = other_option?(option_value) %>
+        <% is_other = other_option?(option_label) %>
         <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
             <input type="radio"
                    name="<%= field_name %>"
-                   value="<%= option_value %>"
+                   value="<%= is_other ? "Other" : option_value %>"
                    class="text-blue-600 focus:ring-blue-500"
                    <%= "data-other-option-target=\"control\"".html_safe if is_other %>
                    <%= "checked" if (is_other ? other_option_selected?(value) : value == option_value) || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
@@ -125,17 +125,17 @@
         options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <% has_other = checkbox_options.any? { |option_label, option_value| other_option?(option_value) } %>
+    <% has_other = checkbox_options.any? { |option_label, option_value| other_option?(option_label) } %>
     <%# Multi-column (not grid) so a sorted option list reads straight down each
         column then onto the next, rather than zig-zagging across rows. %>
     <%= tag.div class: "columns-1 sm:columns-2 gap-2.5 mt-1", data: (has_other ? { controller: "other-option", action: "change->other-option#update" } : {}) do %>
       <% checkbox_options.each do |option_label, option_value, option_description| %>
-        <% is_other = other_option?(option_value) %>
+        <% is_other = other_option?(option_label) %>
         <label class="flex flex-col gap-1 mb-2.5 break-inside-avoid rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
             <input type="checkbox"
                    name="<%= checkbox_name %>"
-                   value="<%= option_value %>"
+                   value="<%= is_other ? "Other" : option_value %>"
                    class="rounded text-blue-600 focus:ring-blue-500"
                    <%= "data-other-option-target=\"control\"".html_safe if is_other %>
                    <%= "checked" if is_other ? other_option_selected?(value) : selected_values.include?(option_value) %>>

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe EventHelper, type: :helper do
     end
   end
 
+  describe "#resolve_answer_text" do
+    it "maps category ids to names while preserving an 'Other: <text>' token" do
+      category_type = create(:category_type, name: "StoryPopulation")
+      veterans = create(:category, :published, category_type: category_type, name: "Veterans")
+      field = build_stubbed(:form_field, field_identifier: "client_life_experiences")
+
+      result = helper.resolve_answer_text(field, "#{veterans.id}, Other: refugees")
+
+      expect(result).to eq("Veterans, Other: refugees")
+    end
+  end
+
   describe "#other_option_text" do
     it "extracts the custom text from an 'Other: <text>' answer" do
       expect(helper.other_option_text("Other: bright purple")).to eq("bright purple")

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -356,6 +356,24 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include('placeholder="Please specify"')
     end
 
+    it "reveals the text input for a category-backed dynamic field's Other option" do
+      # Dynamic fields source options from Category and use the category id as the
+      # option value, so the Other option must be detected by its label, not value.
+      category_type = create(:category_type, name: "StoryPopulation")
+      create(:category, :published, category_type: category_type, name: "Veterans")
+      create(:category, :published, category_type: category_type, name: "Other")
+      create(:form_field, form: form, answer_type: :multi_select_checkbox,
+             field_identifier: "client_life_experiences", name: "Populations", required: false)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include('data-controller="other-option"')
+      expect(response.body).to include('placeholder="Please specify"')
+      # The Other option submits the literal "Other", not the category id.
+      expect(response.body).to include('data-other-option-target="control"')
+      expect(response.body).to match(/data-other-option-target="control"[\s\S]*?value="Other"|value="Other"[\s\S]*?data-other-option-target="control"/)
+    end
+
     it "does not add the Other controller to fields without an Other option" do
       field = create(:form_field, form: form, answer_type: :single_select_radio,
              name: "Favorite color", required: false)

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -155,4 +155,55 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       )
     end
   end
+
+  describe "saving an \"Other\" answer with custom text" do
+    let!(:radio_field) do
+      field = form.form_fields.create!(
+        name: "How did you hear about us?",
+        answer_type: :single_select_radio,
+        status: :active,
+        position: (form.form_fields.maximum(:position) || 0) + 1,
+        required: false
+      )
+      %w[Email Other].each_with_index do |opt, idx|
+        ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
+        field.form_field_answer_options.create!(answer_option: ao)
+      end
+      field
+    end
+
+    it "stores the folded \"Other: <text>\" value from a radio field" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Jo", last_name: "Vo", email: "jo@example.com").merge(
+          radio_field.id.to_s => "Other: a friend told me"
+        )
+      )
+
+      answer = result.form_submission.form_answers.find_by(form_field: radio_field)
+      expect(answer.submitted_answer).to eq("Other: a friend told me")
+    end
+
+    it "stores the folded \"Other: <text>\" value alongside other checkbox selections" do
+      multi_field = form.form_fields.create!(
+        name: "Which topics interest you?",
+        answer_type: :multi_select_checkbox,
+        status: :active,
+        position: (form.form_fields.maximum(:position) || 0) + 1,
+        required: false
+      )
+
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Mo", last_name: "Vo", email: "mo@example.com").merge(
+          multi_field.id.to_s => [ "Healing", "Other: poetry therapy" ]
+        )
+      )
+
+      answer = result.form_submission.form_answers.find_by(form_field: multi_field)
+      expect(answer.submitted_answer).to eq("Healing, Other: poetry therapy")
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #1665, which merged the first version of the "Other" reveal. That version only worked for fields with their own stored answer options — it never fired for category- or sector-backed dynamic fields (the ones in the bug report), so the text box stayed hidden when "Other" was checked. This PR fixes that, keeps the input inside its box, and locks in that the answer saves correctly.

### What is the goal of this PR and why is this important?

- Dynamic fields (workshop settings, populations, age range, service area) source options from `Category`/`Sector` and use the **record id** as the option value, while the label is the name.
- The reveal logic matched the "Other" choice against the option **value** (an id for these fields), so `has_other`/`is_other` were always false and no text input rendered.
- The revealed input also overflowed its option box on the right, and we want certainty the typed text actually persists.

### How did you approach the change?

- Detect the "Other" option by its **label** instead of its value, so it works for both stored-option and dynamic fields.
- Force the Other option to submit the literal `"Other"` (instead of the category/sector id) so detection, value folding (`Other: <text>`), and re-render all behave identically across field types.
- `resolve_answer_text` now passes through free-text tokens that aren't numeric ids, so an `Other: <text>` answer displays correctly on the submission view instead of being dropped during id→name mapping.
- Fixed the input styling: it combined a left margin with full width and overflowed; now it fills the box width and stays inside.

### Where it saves

- No new params or columns. The folded value reaches the existing save path and is stored on `FormAnswer.submitted_answer` (e.g. `Other: poetry therapy`, or `Healing, Other: poetry therapy` for a multi-select). It then displays through `resolve_answer_text` on the submission show page.

### UI Testing Checklist

- [ ] Category-backed checkbox field (e.g. populations) with an "Other" category: checking Other reveals the "Please specify" input, fully inside the box.
- [ ] Submitting with Other selected stores `Other: <text>` and it shows on the submission's show page.
- [ ] Validation-error re-render keeps Other checked and the typed text prefilled.
- [ ] Stored-option fields with a literal "Other" option still work (unchanged behavior).

### Tests

- Request + helper specs for the dynamic (category-backed) case and the `resolve_answer_text` passthrough.
- Service specs asserting `FormAnswer.submitted_answer` stores the folded `Other: <text>` value for radio and checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)