### PR TITLE
Surface "Other" registration answers on person profile and edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~75 files |
-| `app/services/` | Service objects for complex logic | ~23 files |
+| `app/services/` | Service objects for complex logic | ~24 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 14 concerns |
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -207,7 +207,33 @@ class Person < ApplicationRecord
     }
   end
 
+  # Field identifiers whose "Other" free text maps onto the profile's sectors.
+  OTHER_SERVICE_AREA_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
+  # Field identifiers whose "Other" free text maps onto the workshop-setting
+  # categories shown on the edit page.
+  OTHER_WORKSHOP_SETTING_IDENTIFIERS = %w[workshop_environments client_life_experiences primary_age_group].freeze
+
+  # Free-text "Other" service areas the person typed on registration forms.
+  # They can't be Sector records, so they're surfaced beside the sector tags.
+  def other_service_area_responses
+    other_form_responses(OTHER_SERVICE_AREA_IDENTIFIERS)
+  end
+
+  # Free-text "Other" workshop settings (category-backed fields) from forms.
+  def other_workshop_setting_responses
+    other_form_responses(OTHER_WORKSHOP_SETTING_IDENTIFIERS)
+  end
+
   private
+
+  def other_form_responses(identifiers)
+    form_submissions
+      .joins(form_answers: :form_field)
+      .where(form_fields: { field_identifier: identifiers })
+      .pluck("form_answers.submitted_answer")
+      .flat_map { |answer| OtherOption.texts(answer) }
+      .uniq
+  end
 
   def strip_whitespace
     self.first_name = first_name&.strip

--- a/app/services/other_option.rb
+++ b/app/services/other_option.rb
@@ -1,0 +1,22 @@
+# Extracts free-text "Other" answers out of a stored form answer.
+#
+# When a registrant picks the "Other" option on a form question, their answer is
+# folded into "Other: <text>" (see the other-option Stimulus controller). On the
+# sector/category-backed questions the chosen ids are joined with the free text,
+# e.g. "5, 12, Other: Equine therapy". Those free-text values can't be Sector or
+# Category records, so they never become tags — this pulls them out so they can
+# be surfaced alongside the real tags.
+module OtherOption
+  PREFIX = "Other"
+
+  # The free-text portions of a stored answer, e.g.
+  # "5, Other: Equine therapy" => [ "Equine therapy" ]. A bare "Other" with no
+  # accompanying text yields nothing.
+  def self.texts(submitted_answer)
+    submitted_answer.to_s.split(", ").filter_map do |token|
+      stripped = token.strip
+      next unless stripped.downcase.start_with?("#{PREFIX.downcase}:")
+      stripped[(PREFIX.length + 1)..].strip.presence
+    end
+  end
+end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -130,14 +130,13 @@
                                       .reject { |_, id| (@current_sector_ids || []).include?(id) },
                                               show_admin_flags: true } },
                                   class: "btn btn-secondary-outline" %>
+      <%= render "people/other_responses", responses: @person.other_service_area_responses %>
     </div>
-    <%= render "people/other_responses", responses: @person.other_service_area_responses %>
   </div>
 
   <!-- Profile-specific Categories -->
   <% if @person_categories_grouped.present? %>
     <div class="form-group space-y-4">
-      <%= render "people/other_responses", responses: @person.other_workshop_setting_responses %>
       <% @person_categories_grouped.each do |type, cats| %>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
           <h3 class="font-semibold text-gray-700 mb-3"><%= type.display_label %></h3>
@@ -156,6 +155,12 @@
               </label>
             <% end %>
           </div>
+        </div>
+      <% end %>
+      <% workshop_other = @person.other_workshop_setting_responses %>
+      <% if workshop_other.any? %>
+        <div class="flex flex-wrap gap-2">
+          <%= render "people/other_responses", responses: workshop_other %>
         </div>
       <% end %>
     </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -131,11 +131,13 @@
                                               show_admin_flags: true } },
                                   class: "btn btn-secondary-outline" %>
     </div>
+    <%= render "people/other_responses", responses: @person.other_service_area_responses %>
   </div>
 
   <!-- Profile-specific Categories -->
   <% if @person_categories_grouped.present? %>
     <div class="form-group space-y-4">
+      <%= render "people/other_responses", responses: @person.other_workshop_setting_responses %>
       <% @person_categories_grouped.each do |type, cats| %>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
           <h3 class="font-semibold text-gray-700 mb-3"><%= type.display_label %></h3>

--- a/app/views/people/_other_responses.html.erb
+++ b/app/views/people/_other_responses.html.erb
@@ -1,15 +1,13 @@
 <%# Read-only chips for free-text "Other" answers pulled from registration form
     responses. These aren't Sector/Category records, so they're shown for
-    reference rather than as editable tags. %>
+    reference rather than as editable tags. Renders bare chips — the caller
+    supplies the surrounding flex container so they sit at the end of the
+    relevant section (sectors box, workshop-settings card, etc.). %>
 <% responses ||= [] %>
-<% if responses.any? %>
-  <div class="mt-2 flex flex-wrap gap-2">
-    <% responses.each do |text| %>
-      <span class="inline-flex items-center rounded-md border border-gray-300 bg-gray-50 text-gray-600 px-3 py-1 text-sm font-medium"
-            title="Other response from registration">
-        <%= text %>
-        <span class="ml-1 text-xs text-gray-400">(other)</span>
-      </span>
-    <% end %>
-  </div>
+<% responses.each do |text| %>
+  <span class="inline-flex items-center rounded-md border border-gray-300 bg-white text-gray-600 px-3 py-1 text-sm font-medium"
+        title="Other response entered during registration">
+    <%= text %>
+    <span class="ml-1 text-xs text-gray-400">(other)</span>
+  </span>
 <% end %>

--- a/app/views/people/_other_responses.html.erb
+++ b/app/views/people/_other_responses.html.erb
@@ -1,0 +1,15 @@
+<%# Read-only chips for free-text "Other" answers pulled from registration form
+    responses. These aren't Sector/Category records, so they're shown for
+    reference rather than as editable tags. %>
+<% responses ||= [] %>
+<% if responses.any? %>
+  <div class="mt-2 flex flex-wrap gap-2">
+    <% responses.each do |text| %>
+      <span class="inline-flex items-center rounded-md border border-gray-300 bg-gray-50 text-gray-600 px-3 py-1 text-sm font-medium"
+            title="Other response from registration">
+        <%= text %>
+        <span class="ml-1 text-xs text-gray-400">(other)</span>
+      </span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -126,7 +126,7 @@
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <h2 class="text-lg font-semibold text-gray-800 mb-3">Primary sector</h2>
-                  <% if primary_sector_items.any? %>
+                  <% if primary_sector_items.any? || other_service_areas.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% primary_sector_items.each do |si| %>
                         <%= render "sectors/tagging_label",
@@ -134,11 +134,11 @@
                                      display_leader: true,
                                      is_leader: si.is_leader %>
                       <% end %>
+                      <%= render "people/other_responses", responses: other_service_areas %>
                     </div>
-                  <% elsif other_service_areas.none? %>
+                  <% else %>
                     <p class="text-gray-500 italic">None selected.</p>
                   <% end %>
-                  <%= render "people/other_responses", responses: other_service_areas %>
                 </div>
                 <div>
                   <h2 class="text-lg font-semibold text-gray-800 mb-3">Additional sectors</h2>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -121,6 +121,7 @@
             <% sectorable_items = @person.sectorable_items.includes(:sector).order("sectors.name") %>
             <% primary_sector_items = sectorable_items.select(&:is_primary?) %>
             <% additional_sector_items = sectorable_items.reject(&:is_primary?) %>
+            <% other_service_areas = @person.other_service_area_responses %>
             <div class="md:col-span-2 p-3">
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
@@ -134,9 +135,10 @@
                                      is_leader: si.is_leader %>
                       <% end %>
                     </div>
-                  <% else %>
+                  <% elsif other_service_areas.none? %>
                     <p class="text-gray-500 italic">None selected.</p>
                   <% end %>
+                  <%= render "people/other_responses", responses: other_service_areas %>
                 </div>
                 <div>
                   <h2 class="text-lg font-semibold text-gray-800 mb-3">Additional sectors</h2>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -559,6 +559,29 @@ form_submissions.each do |data|
   end
 end
 
+puts "Giving Amy free-text \"Other\" answers on her Facilitator Training submission…"
+# Demo data for the "Other" chips on the person profile + edit pages: a registrant
+# who picked the "Other" option (folded into "Other: <text>") on a sector-backed
+# field (Primary service area) and a category-backed field (Workshop Settings).
+# These free-text values can't be Sector/Category records, so they only surface
+# via Person#other_service_area_responses / #other_workshop_setting_responses.
+# Seeded before the professional-answer enrichment below so the primary_service_area
+# value survives its "skip if already answered" guard. Idempotent.
+if facilitator_training && amy_person
+  amy_submission = FormSubmission.find_by(person: amy_person, form: facilitator_training.registration_form)
+  if amy_submission
+    {
+      "primary_service_area" => "Other: Equine-assisted therapy",
+      "workshop_environments" => "Other: Mobile art van"
+    }.each do |identifier, value|
+      field = amy_submission.form.form_fields.find_by(field_identifier: identifier)
+      next unless field
+      answer = amy_submission.form_answers.find_or_initialize_by(form_field: field)
+      answer.update!(submitted_answer: value, question_name_when_answered: field.name)
+    end
+  end
+end
+
 puts "Recording professional answers (age group / service area) on registration submissions…"
 # The Background page charts the registrants' "Primary Age Group(s) Served" and
 # "Primary Service Area(s)" registration answers. Public registration stores

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -383,4 +383,53 @@ RSpec.describe Person, type: :model do
       expect(Person.published).not_to include(not_searchable_with_active)
     end
   end
+
+  describe "Other form responses" do
+    let(:person) { create(:person) }
+    let(:form) { create(:form) }
+    let(:submission) { create(:form_submission, person: person, form: form) }
+
+    def answer(identifier, value)
+      field = create(:form_field, form: form, field_identifier: identifier)
+      create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+    end
+
+    describe "#other_service_area_responses" do
+      it "returns free-text Other values from primary service area fields" do
+        answer("primary_service_area", "5, Other: Equine therapy")
+        answer("primary_service_area_single", "Other: Music therapy")
+
+        expect(person.other_service_area_responses).to contain_exactly("Equine therapy", "Music therapy")
+      end
+
+      it "ignores answers without an Other value" do
+        answer("primary_service_area", "5, 12")
+
+        expect(person.other_service_area_responses).to be_empty
+      end
+
+      it "does not pull from unrelated fields" do
+        answer("workshop_environments", "Other: School")
+
+        expect(person.other_service_area_responses).to be_empty
+      end
+    end
+
+    describe "#other_workshop_setting_responses" do
+      it "returns free-text Other values from the category-backed fields" do
+        answer("workshop_environments", "3, Other: Equine center")
+        answer("client_life_experiences", "Other: Refugees")
+        answer("primary_age_group", "Other: Toddlers")
+
+        expect(person.other_workshop_setting_responses)
+          .to contain_exactly("Equine center", "Refugees", "Toddlers")
+      end
+
+      it "does not pull from the service area fields" do
+        answer("primary_service_area", "Other: Equine therapy")
+
+        expect(person.other_workshop_setting_responses).to be_empty
+      end
+    end
+  end
 end

--- a/spec/requests/people_other_responses_spec.rb
+++ b/spec/requests/people_other_responses_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Person Other form responses", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+  let(:form) { create(:form) }
+  let(:submission) { create(:form_submission, person: person, form: form) }
+
+  def answer(identifier, value)
+    field = create(:form_field, form: form, field_identifier: identifier)
+    create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+  end
+
+  before { sign_in admin }
+
+  describe "profile page" do
+    it "shows the Other service area beside the sector tags" do
+      person.update!(profile_show_sectors: true)
+      answer("primary_service_area", "Other: Equine therapy")
+
+      get person_path(person)
+
+      expect(response.body).to include("Equine therapy")
+    end
+  end
+
+  describe "edit page" do
+    it "shows the Other service area in the sectors section" do
+      answer("primary_service_area_single", "Other: Music therapy")
+
+      get edit_person_path(person)
+
+      expect(response.body).to include("Music therapy")
+    end
+
+    it "shows the Other workshop setting near the category checkboxes" do
+      category_type = create(:category_type, :published, profile_specific: true)
+      create(:category, :published, category_type: category_type)
+      answer("workshop_environments", "Other: Equine center")
+
+      get edit_person_path(person)
+
+      expect(response.body).to include("Equine center")
+    end
+  end
+end

--- a/spec/services/other_option_spec.rb
+++ b/spec/services/other_option_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe OtherOption do
+  describe ".texts" do
+    it "extracts the free text after the Other prefix" do
+      expect(described_class.texts("Other: Equine therapy")).to eq([ "Equine therapy" ])
+    end
+
+    it "pulls the free text out of an answer joined with selected ids" do
+      expect(described_class.texts("5, 12, Other: Equine therapy")).to eq([ "Equine therapy" ])
+    end
+
+    it "ignores a bare Other with no accompanying text" do
+      expect(described_class.texts("5, Other")).to eq([])
+    end
+
+    it "ignores answers with no Other option" do
+      expect(described_class.texts("5, 12")).to eq([])
+    end
+
+    it "returns nothing for a blank answer" do
+      expect(described_class.texts(nil)).to eq([])
+      expect(described_class.texts("")).to eq([])
+    end
+
+    it "matches the prefix case-insensitively" do
+      expect(described_class.texts("other: Music therapy")).to eq([ "Music therapy" ])
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- On the sector/category-backed registration questions (primary service area, workshop environments, etc.), a registrant can pick **"Other"** and type free text. That gets folded into the stored answer (e.g. `5, Other: Equine therapy`).
- Those free-text values can't be `Sector`/`Category` records, so they were **silently dropped** — they never appeared among the profile's sector tags or the edit page's workshop-setting checkboxes.
- Admins viewing a person had no way to see what the registrant actually entered, even though the value lives in `FormAnswer#submitted_answer`.
- This surfaces those values so the registrant's intent isn't lost.

### How did you approach the change?

- Added `OtherOption.texts` (`app/services/other_option.rb`) to pull the free-text portion(s) out of a stored answer like `5, 12, Other: Equine therapy`.
- Added `Person#other_service_area_responses` and `Person#other_workshop_setting_responses`, which read the relevant form answers by `field_identifier` and return the unique "Other" texts.
- Rendered them as **read-only chips** (`people/_other_responses`) next to the real tags:
  - **Profile** (`people/show`): beside the Primary sector tags.
  - **Person edit** (`people/_form`): in the Sectors section and the workshop-settings (categories) section.
- They're read-only by design — a free-text value can't be promoted to a real `Sector`/`Category`, so the chip flags it for an admin rather than pretending to be a tag.

### Anything else to add?

- The profile only displays sectors (not categories), so the category "Other" texts surface on the **edit** page only — that matches where workshop settings are shown.
- Scoped to a separate branch off `main` (not #1667) so #1667 can merge without retriggering CI.
- Known limitation inherited from the storage format: a free-text answer containing `", "` is split on the comma (answers are stored comma-joined), so such values render truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Demo data

- Seeded Amy User's Facilitator Training (event 1) submission with two free-text "Other" answers — `primary_service_area` = `"Other: Equine-assisted therapy"` and `workshop_environments` = `"Other: Mobile art van"` — so the chips are visible after `rake db:seed:dev`. Amy's profile shows the chip beside her real sector tags; her edit page shows both the service-area and workshop-setting chips.
