### PR TITLE
Manage registrant organizations & affiliations from an editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (62) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (70) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -257,6 +257,7 @@ end
 ### Stimulus Controllers
 
 - `affiliation_dates` — Recalculate affiliation date ranges
+- `affiliation_title_edit` — Inline-edit an affiliation title pill on the org-link editor
 - `anchor_highlight` — Highlight anchored elements
 - `asset_picker` — Asset selection UI
 - `autosave` — Auto-save form state

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -1,5 +1,20 @@
 class AffiliationsController < ApplicationController
-  before_action :set_affiliation, only: %i[ destroy ]
+  before_action :set_affiliation, only: %i[ destroy update ]
+
+  # Inline title edit from the event-registration org-link editor.
+  def update
+    authorize! @affiliation, to: :update?
+    updated = @affiliation.update(affiliation_params)
+    notice = updated ? "Affiliation title updated." : nil
+    alert = updated ? nil : "Could not update the affiliation title."
+
+    if params[:event_registration_id].present?
+      redirect_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:return_to].presence),
+                  notice: notice, alert: alert
+    else
+      redirect_back fallback_location: root_path, notice: notice, alert: alert
+    end
+  end
 
   def destroy
     authorize! @affiliation, to: :destroy?
@@ -32,5 +47,9 @@ class AffiliationsController < ApplicationController
 
   def set_affiliation
     @affiliation = Affiliation.find(params[:id])
+  end
+
+  def affiliation_params
+    params.require(:affiliation).permit(:title)
   end
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -159,6 +159,10 @@ class EventRegistrationsController < ApplicationController
     # The job title/position the registrant typed on the form, to compare against
     # the title on any existing affiliation for a linked org.
     @submitted_position = find_submitted_answer(@event_registration, "agency_position")
+    # The registrant's submission of the event's registration form, so we can link
+    # out to the public-facing form view.
+    reg_form = @event_registration.event.registration_form
+    @form_submission = reg_form && @person.form_submissions.find_by(form: reg_form)
     @potential_matches = if @submitted_org_name.present?
       Organization.remote_search(@submitted_org_name).where.not(id: @linked_organizations.ids).limit(10)
     else

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -294,7 +294,7 @@ class EventRegistrationsController < ApplicationController
           er.attendance_status_label,
           er.scholarships.any? ? "Yes" : "No",
           er.scholarships.completed.any? ? "Yes" : "No",
-          cost_required ? (er.paid_in_full? ? "Nothing owed" : "Monies due") : "",
+          cost_required ? (er.paid_in_full? ? "Paid" : "Due") : "",
           total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
         ]
       end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -151,7 +151,14 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration, to: :link_organization?
     @person = @event_registration.registrant
     @linked_organizations = @event_registration.organizations.order(:name)
+    # The registrant's global affiliations, keyed by org, so the editor can show
+    # whether each linked org is also an active/inactive affiliation (removing a
+    # link here leaves the affiliation untouched).
+    @affiliations_by_org = @person.affiliations.group_by(&:organization_id)
     @submitted_org_name = find_submitted_agency_name(@event_registration)
+    # The job title/position the registrant typed on the form, to compare against
+    # the title on any existing affiliation for a linked org.
+    @submitted_position = find_submitted_answer(@event_registration, "agency_position")
     @potential_matches = if @submitted_org_name.present?
       Organization.remote_search(@submitted_org_name).where.not(id: @linked_organizations.ids).limit(10)
     else
@@ -263,10 +270,14 @@ class EventRegistrationsController < ApplicationController
   end
 
   def find_submitted_agency_name(registration)
+    find_submitted_answer(registration, "agency_name")
+  end
+
+  def find_submitted_answer(registration, field_identifier)
     form = registration.event.registration_form
     return nil unless form
 
-    field = form.form_fields.find_by(field_identifier: "agency_name")
+    field = form.form_fields.find_by(field_identifier: field_identifier)
     return nil unless field
 
     FormAnswer

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -156,6 +156,11 @@ class EventRegistrationsController < ApplicationController
     # link here leaves the affiliation untouched).
     @affiliations_by_org = @person.affiliations.group_by(&:organization_id)
     @submitted_org_name = find_submitted_agency_name(@event_registration)
+    # Whether an org with the submitted name already exists — if so, there's
+    # nothing to create (the admin links the existing one), so the "Create org
+    # & link" button is hidden.
+    @submitted_org_exists = @submitted_org_name.present? &&
+      Organization.where("LOWER(name) = ?", @submitted_org_name.strip.downcase).exists?
     # The job title/position the registrant typed on the form, to compare against
     # the title on any existing affiliation for a linked org.
     @submitted_position = find_submitted_answer(@event_registration, "agency_position")
@@ -196,12 +201,15 @@ class EventRegistrationsController < ApplicationController
       return
     end
 
-    organization = Organization.create!(name: name, organization_status: OrganizationStatus.find_by(name: "Active"))
+    # Reuse an existing org with that name rather than creating a duplicate.
+    existing = Organization.where("LOWER(name) = ?", name.strip.downcase).first
+    organization = existing || Organization.create!(name: name.strip, organization_status: OrganizationStatus.find_by(name: "Active"))
 
     Affiliation.find_or_create_by!(person: @person, organization: organization)
     @event_registration.event_registration_organizations.find_or_create_by!(organization: organization)
 
-    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} created and linked."
+    notice = existing ? "#{organization.name} linked." : "#{organization.name} created and linked."
+    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: notice
   end
 
   def unlink_organization

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -184,6 +184,26 @@ class EventRegistrationsController < ApplicationController
     redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} linked."
   end
 
+  def create_organization
+    @event_registration = EventRegistration.find(params[:id])
+    authorize! @event_registration, to: :create_organization?
+    @person = @event_registration.registrant
+    # Build the org from the name the registrant typed on the form, so the button
+    # can't be used to create an arbitrary org — it only resolves the pending name.
+    name = find_submitted_agency_name(@event_registration)
+    if name.blank?
+      redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), alert: "No submitted organization name to create from."
+      return
+    end
+
+    organization = Organization.create!(name: name, organization_status: OrganizationStatus.find_by(name: "Active"))
+
+    Affiliation.find_or_create_by!(person: @person, organization: organization)
+    @event_registration.event_registration_organizations.find_or_create_by!(organization: organization)
+
+    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} created and linked."
+  end
+
   def unlink_organization
     @event_registration = EventRegistration.find(params[:id])
     authorize! @event_registration, to: :unlink_organization?

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -147,12 +147,13 @@ class EventRegistrationsController < ApplicationController
   end
 
   def link_organization
-    @event_registration = EventRegistration.includes(:event, registrant: :form_submissions).find(params[:id])
+    @event_registration = EventRegistration.includes(:event, :organizations, registrant: :form_submissions).find(params[:id])
     authorize! @event_registration, to: :link_organization?
     @person = @event_registration.registrant
+    @linked_organizations = @event_registration.organizations.order(:name)
     @submitted_org_name = find_submitted_agency_name(@event_registration)
     @potential_matches = if @submitted_org_name.present?
-      Organization.remote_search(@submitted_org_name).limit(10)
+      Organization.remote_search(@submitted_org_name).where.not(id: @linked_organizations.ids).limit(10)
     else
       Organization.none
     end
@@ -169,7 +170,18 @@ class EventRegistrationsController < ApplicationController
     @event_registration.event_registration_organizations
       .find_or_create_by!(organization: organization)
 
-    redirect_to registrants_event_path(@event_registration.event), notice: "Organization linked successfully."
+    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} linked."
+  end
+
+  def unlink_organization
+    @event_registration = EventRegistration.find(params[:id])
+    authorize! @event_registration, to: :unlink_organization?
+    organization = Organization.find(params[:organization_id])
+
+    # Removes only the registration-scoped link; the person's global affiliation is left intact.
+    @event_registration.event_registration_organizations.where(organization_id: organization.id).destroy_all
+
+    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} removed from this registration."
   end
 
   def destroy

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -294,7 +294,7 @@ class EventRegistrationsController < ApplicationController
           er.attendance_status_label,
           er.scholarships.any? ? "Yes" : "No",
           er.scholarships.completed.any? ? "Yes" : "No",
-          cost_required ? (er.paid_in_full? ? "Paid in full" : "Not paid in full") : "",
+          cost_required ? (er.paid_in_full? ? "Nothing owed" : "Monies due") : "",
           total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
         ]
       end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -311,7 +311,7 @@ class EventsController < ApplicationController
     org_names = orgs.map(&:name).join("; ")
     total_cents = registration.allocations_sum
     payment_total = total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
-    payment_status = cost_required ? (registration.paid_in_full? ? "Nothing owed" : "Monies due") : ""
+    payment_status = cost_required ? (registration.paid_in_full? ? "Paid" : "Due") : ""
     [
       person.first_name,
       person.last_name,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -311,7 +311,7 @@ class EventsController < ApplicationController
     org_names = orgs.map(&:name).join("; ")
     total_cents = registration.allocations_sum
     payment_total = total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
-    payment_status = cost_required ? (registration.paid_in_full? ? "Paid in full" : "Not paid in full") : ""
+    payment_status = cost_required ? (registration.paid_in_full? ? "Nothing owed" : "Monies due") : ""
     [
       person.first_name,
       person.last_name,

--- a/app/frontend/javascript/controllers/affiliation_title_edit_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_title_edit_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="affiliation-title-edit"
+//
+// Toggles an affiliation-title pill between its display pill and an inline edit
+// form (a text input + Save). Used on the event-registration org-link editor.
+export default class extends Controller {
+  static targets = ["display", "form", "input"];
+
+  edit() {
+    this.displayTarget.classList.add("hidden");
+    this.formTarget.classList.remove("hidden");
+    if (this.hasInputTarget) {
+      this.inputTarget.focus();
+      this.inputTarget.select();
+    }
+  }
+
+  cancel() {
+    this.formTarget.classList.add("hidden");
+    this.displayTarget.classList.remove("hidden");
+  }
+}

--- a/app/frontend/javascript/controllers/affiliation_title_edit_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_title_edit_controller.js
@@ -4,12 +4,14 @@ import { Controller } from "@hotwired/stimulus";
 //
 // Toggles an affiliation-title pill between its display pill and an inline edit
 // form (a text input + Save). Used on the event-registration org-link editor.
+// Uses inline display styles so it wins over the elements' Tailwind display
+// utilities (e.g. inline-flex), which would otherwise override a `hidden` class.
 export default class extends Controller {
   static targets = ["display", "form", "input"];
 
   edit() {
-    this.displayTarget.classList.add("hidden");
-    this.formTarget.classList.remove("hidden");
+    this.displayTarget.style.display = "none";
+    this.formTarget.style.display = "inline-flex";
     if (this.hasInputTarget) {
       this.inputTarget.focus();
       this.inputTarget.select();
@@ -17,7 +19,7 @@ export default class extends Controller {
   }
 
   cancel() {
-    this.formTarget.classList.add("hidden");
-    this.displayTarget.classList.remove("hidden");
+    this.formTarget.style.display = "none";
+    this.displayTarget.style.display = "";
   }
 }

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -6,6 +6,9 @@ application.register("affiliation-dates", AffiliationDatesController)
 import AffiliationFacilitatorWarningController from "./affiliation_facilitator_warning_controller"
 application.register("affiliation-facilitator-warning", AffiliationFacilitatorWarningController)
 
+import AffiliationTitleEditController from "./affiliation_title_edit_controller"
+application.register("affiliation-title-edit", AffiliationTitleEditController)
+
 import AllocationRefController from "./allocation_ref_controller"
 application.register("allocation-ref", AllocationRefController)
 

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -43,6 +43,10 @@ export default class extends Controller {
       }
       .remote-select-container {
         position: relative;
+        width: 100%;
+      }
+      .remote-select-container .ts-wrapper {
+        width: 100%;
       }
       .remote-select-container .remote-select-icon {
         position: absolute;

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -209,6 +209,10 @@ class EventRegistration < ApplicationRecord
     !paid_in_full? && payments_sum.to_i.positive?
   end
 
+  def discounted?
+    allocations.where(source_type: "Discount").exists?
+  end
+
   def joinable?
     active? && paid?
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -151,7 +151,7 @@ class Organization < ApplicationRecord
     else
       addresses.active.first
     end
-    "#{organization_locality}, #{first_active&.state}"
+    [ organization_locality, first_active&.state ].compact_blank.join(", ")
   end
 
   def type_name

--- a/app/policies/affiliation_policy.rb
+++ b/app/policies/affiliation_policy.rb
@@ -5,6 +5,10 @@ class AffiliationPolicy < ApplicationPolicy
     record.persisted? && admin? # we don't allow users to edit their own
   end
 
+  def update?
+    record.persisted? && admin? # we don't allow users to edit their own
+  end
+
   # Scoping
   # See https://actionpolicy.evilmartians.io/#/scoping
 

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -13,6 +13,7 @@ class EventRegistrationPolicy < ApplicationPolicy
   def process_confirm? = admin?
   def link_organization? = admin?
   def select_organization? = admin?
+  def unlink_organization? = admin?
 
 
   relation_scope do |relation|

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -13,6 +13,7 @@ class EventRegistrationPolicy < ApplicationPolicy
   def process_confirm? = admin?
   def link_organization? = admin?
   def select_organization? = admin?
+  def create_organization? = admin?
   def unlink_organization? = admin?
 
 

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -1,6 +1,7 @@
 <%# Renders affiliation-status pills for one org's affiliations. Shows nothing
-    when the person has no affiliation for the org.
-    Locals: org, affiliations, submitted_org_name, submitted_position %>
+    when the person has no affiliation for the org. Non-Facilitator titles are
+    editable inline.
+    Locals: org, affiliations, submitted_org_name, submitted_position, event_registration %>
 <% if affiliations.any? %>
   <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
   <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
@@ -11,10 +12,28 @@
     <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
     <% affiliations.each do |a| %>
       <% a_active = active.call(a) %>
-      <span class="<%= badge %> <%= a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>"
-            title="<%= a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : "Affiliation title" %>">
-        <%= a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled") %> — <%= a_active ? "active" : "inactive" %>
-      </span>
+      <% color = a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
+      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled")}#{" — inactive" unless a_active}" %>
+      <% if a.facilitator? %>
+        <span class="<%= badge %> <%= color %>" title="Facilitator role — determines whether the org is active with AWBW"><%= label %></span>
+      <% else %>
+        <span data-controller="affiliation-title-edit" class="inline-flex">
+          <button type="button" data-action="affiliation-title-edit#edit" data-affiliation-title-edit-target="display"
+                  class="<%= badge %> <%= color %> cursor-pointer hover:opacity-80" title="Edit affiliation title">
+            <%= label %>
+            <i class="fa-solid fa-pen text-[0.55rem] opacity-60"></i>
+          </button>
+          <%= form_with model: a, data: { turbo_frame: "_top", affiliation_title_edit_target: "form" }, class: "hidden inline-flex items-center gap-1" do |f| %>
+            <%= hidden_field_tag :event_registration_id, event_registration&.id %>
+            <%= hidden_field_tag :return_to, params[:return_to] %>
+            <%= f.text_field :title, value: a.title,
+                             data: { affiliation_title_edit_target: "input" },
+                             class: "w-32 rounded-md border border-gray-300 px-2 py-0.5 text-xs text-gray-800 focus:border-blue-500 focus:outline-none" %>
+            <%= f.submit "Save", class: "rounded-md bg-blue-900 px-2 py-0.5 text-white text-xs font-medium hover:bg-blue-800 cursor-pointer" %>
+            <button type="button" data-action="affiliation-title-edit#cancel" class="text-xs text-gray-500 underline hover:no-underline">Cancel</button>
+          <% end %>
+        </span>
+      <% end %>
     <% end %>
     <% if is_submitted_org && position.present? %>
       <% if role_affiliations.any? { |a| a.title.to_s.casecmp?(position) } %>

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -23,7 +23,7 @@
             <%= label %>
             <i class="fa-solid fa-pen text-[0.55rem] opacity-60"></i>
           </button>
-          <%= form_with model: a, data: { turbo_frame: "_top", affiliation_title_edit_target: "form" }, class: "hidden inline-flex items-center gap-1" do |f| %>
+          <%= form_with model: a, data: { turbo_frame: "_top", affiliation_title_edit_target: "form" }, class: "hidden items-center gap-1" do |f| %>
             <%= hidden_field_tag :event_registration_id, event_registration&.id %>
             <%= hidden_field_tag :return_to, params[:return_to] %>
             <%= f.text_field :title, value: a.title,

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -14,7 +14,7 @@
       <% affiliations.each do |a| %>
         <% a_active = active.call(a) %>
         <% color = a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
-        <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled")}#{" — inactive" unless a_active}" %>
+        <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")}#{" — inactive" unless a_active}" %>
         <% if a.facilitator? %>
           <span class="<%= badge %> <%= color %>" title="Facilitator role — determines whether the org is active with AWBW"><%= label %></span>
         <% else %>

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -1,6 +1,6 @@
 <%# Renders affiliation-status pills for one org's affiliations. Shows nothing
     when the person has no affiliation for the org. Non-Facilitator titles are
-    editable inline.
+    editable inline; saving swaps just this frame (no full page reload).
     Locals: org, affiliations, submitted_org_name, submitted_position, event_registration %>
 <% if affiliations.any? %>
   <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
@@ -8,39 +8,37 @@
   <% position = submitted_position.to_s.strip %>
   <% is_submitted_org = submitted_org_name.to_s.strip.present? && org.name.to_s.strip.casecmp?(submitted_org_name.to_s.strip) %>
   <% role_affiliations = affiliations.reject(&:facilitator?) %>
-  <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
-    <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
-    <% affiliations.each do |a| %>
-      <% a_active = active.call(a) %>
-      <% color = a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
-      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled")}#{" — inactive" unless a_active}" %>
-      <% if a.facilitator? %>
-        <span class="<%= badge %> <%= color %>" title="Facilitator role — determines whether the org is active with AWBW"><%= label %></span>
-      <% else %>
-        <span data-controller="affiliation-title-edit" class="inline-flex">
-          <button type="button" data-action="affiliation-title-edit#edit" data-affiliation-title-edit-target="display"
-                  class="<%= badge %> <%= color %> cursor-pointer hover:opacity-80" title="Edit affiliation title">
-            <%= label %>
-            <i class="fa-solid fa-pen text-[0.55rem] opacity-60"></i>
-          </button>
-          <%= form_with model: a, data: { turbo_frame: "_top", affiliation_title_edit_target: "form" }, class: "hidden items-center gap-1" do |f| %>
-            <%= hidden_field_tag :event_registration_id, event_registration&.id %>
-            <%= hidden_field_tag :return_to, params[:return_to] %>
-            <%= f.text_field :title, value: a.title,
-                             data: { affiliation_title_edit_target: "input" },
-                             class: "w-32 rounded-md border border-gray-300 px-2 py-0.5 text-xs text-gray-800 focus:border-blue-500 focus:outline-none" %>
-            <%= f.submit "Save", class: "rounded-md bg-blue-900 px-2 py-0.5 text-white text-xs font-medium hover:bg-blue-800 cursor-pointer" %>
-            <button type="button" data-action="affiliation-title-edit#cancel" class="text-xs text-gray-500 underline hover:no-underline">Cancel</button>
-          <% end %>
-        </span>
+  <%= turbo_frame_tag "affiliation_pills_#{org.id}" do %>
+    <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
+      <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
+      <% affiliations.each do |a| %>
+        <% a_active = active.call(a) %>
+        <% color = a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
+        <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled")}#{" — inactive" unless a_active}" %>
+        <% if a.facilitator? %>
+          <span class="<%= badge %> <%= color %>" title="Facilitator role — determines whether the org is active with AWBW"><%= label %></span>
+        <% else %>
+          <span data-controller="affiliation-title-edit" class="inline-flex">
+            <button type="button" data-action="affiliation-title-edit#edit" data-affiliation-title-edit-target="display"
+                    class="<%= badge %> <%= color %> cursor-pointer hover:opacity-80" title="Edit affiliation title">
+              <%= label %>
+              <i class="fa-solid fa-pen-to-square text-xs opacity-70"></i>
+            </button>
+            <%= form_with model: a, data: { affiliation_title_edit_target: "form" }, class: "hidden items-center gap-1" do |f| %>
+              <%= hidden_field_tag :event_registration_id, event_registration&.id %>
+              <%= hidden_field_tag :return_to, params[:return_to] %>
+              <%= f.text_field :title, value: a.title,
+                               data: { affiliation_title_edit_target: "input" },
+                               class: "w-32 rounded-md border border-gray-300 px-2 py-0.5 text-xs text-gray-800 focus:border-blue-500 focus:outline-none" %>
+              <%= f.submit "Save", class: "rounded-md bg-blue-900 px-2 py-0.5 text-white text-xs font-medium hover:bg-blue-800 cursor-pointer" %>
+              <button type="button" data-action="affiliation-title-edit#cancel" class="text-xs text-gray-500 underline hover:no-underline">Cancel</button>
+            <% end %>
+          </span>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if is_submitted_org && position.present? %>
-      <% if role_affiliations.any? { |a| a.title.to_s.casecmp?(position) } %>
-        <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form</span>
-      <% else %>
+      <% if is_submitted_org && position.present? && role_affiliations.none? { |a| a.title.to_s.casecmp?(position) } %>
         <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200" title="Form: <%= position %>">Title differs from form (form: <%= position %>)</span>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -7,7 +7,8 @@
   <% position = submitted_position.to_s.strip %>
   <% is_submitted_org = submitted_org_name.to_s.strip.present? && org.name.to_s.strip.casecmp?(submitted_org_name.to_s.strip) %>
   <% role_affiliations = affiliations.reject(&:facilitator?) %>
-  <div class="flex flex-wrap gap-1.5 mt-1.5">
+  <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
+    <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
     <% affiliations.each do |a| %>
       <% a_active = active.call(a) %>
       <span class="<%= badge %> <%= a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>"

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -1,0 +1,26 @@
+<%# Renders affiliation-status pills for one org's affiliations. Shows nothing
+    when the person has no affiliation for the org.
+    Locals: org, affiliations, submitted_org_name, submitted_position %>
+<% if affiliations.any? %>
+  <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
+  <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
+  <% position = submitted_position.to_s.strip %>
+  <% is_submitted_org = submitted_org_name.to_s.strip.present? && org.name.to_s.strip.casecmp?(submitted_org_name.to_s.strip) %>
+  <% role_affiliations = affiliations.reject(&:facilitator?) %>
+  <div class="flex flex-wrap gap-1.5 mt-1.5">
+    <% affiliations.each do |a| %>
+      <% a_active = active.call(a) %>
+      <span class="<%= badge %> <%= a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>"
+            title="<%= a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : "Affiliation title" %>">
+        <%= a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled") %> — <%= a_active ? "active" : "inactive" %>
+      </span>
+    <% end %>
+    <% if is_submitted_org && position.present? %>
+      <% if role_affiliations.any? { |a| a.title.to_s.casecmp?(position) } %>
+        <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form</span>
+      <% else %>
+        <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200" title="Form: <%= position %>">Title differs from form (form: <%= position %>)</span>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -5,11 +5,11 @@
       <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
     </div>
 
-    <h1 class="text-xl font-semibold text-gray-900 mb-2">Organizations &amp; affiliations</h1>
+    <h1 class="text-2xl font-bold text-gray-900 mb-2">Organizations &amp; affiliations</h1>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
     <%# === Linked organizations (registration–organization associations) === %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-3">Linked organizations</h2>
+    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Linked organizations</h2>
     <% if @linked_organizations.any? %>
       <ul class="space-y-2 mb-6">
         <% @linked_organizations.each do |org| %>
@@ -79,7 +79,7 @@
     </div>
 
     <%# === Registration form submission (what the registrant typed) === %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-3">Registration form submission</h2>
+    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Registration form submission</h2>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
     <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
       <% if @submitted_org_name.present? || @submitted_position.present? %>
@@ -106,7 +106,7 @@
     </div>
 
     <%# === The person's affiliations to orgs NOT linked to this registration === %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-3"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
+    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
     <% linked_org_ids = @linked_organizations.map(&:id) %>
     <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
     <% if other_affiliations.any? %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -20,13 +20,21 @@
                 <p class="text-xs text-gray-500"><%= org.city_state %></p>
               <% end %>
               <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
-                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
+                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
+                                                  event_registration: @event_registration %>
             </div>
-            <%= button_to "Remove",
-                          unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
-                          method: :delete,
-                          form: { class: "shrink-0", data: { turbo_frame: "_top" } },
-                          class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
+            <div class="shrink-0 flex flex-col items-end gap-1">
+              <%= button_to "Remove",
+                            unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
+                            method: :delete,
+                            form: { data: { turbo_frame: "_top" } },
+                            class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
+              <%= link_to organization_path(org, anchor: "affiliations"), target: "_blank", rel: "noopener",
+                          class: "inline-flex items-center gap-1 px-3 text-sm text-gray-500 underline hover:text-gray-700" do %>
+                View profile
+                <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+              <% end %>
+            </div>
           </li>
         <% end %>
       </ul>
@@ -110,7 +118,8 @@
               <p class="text-xs text-gray-500"><%= org.city_state %></p>
             <% end %>
             <%= render "org_affiliation_pills", org: org, affiliations: affs,
-                                                submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
+                                                submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
+                                                event_registration: @event_registration %>
           </li>
         <% end %>
       </ul>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -9,7 +9,14 @@
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
     <%# === Linked organizations (registration–organization associations) === %>
-    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Linked organizations</h2>
+    <div class="flex items-center justify-between gap-3 mb-3">
+      <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Linked organizations</h2>
+      <%= link_to person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
+                  class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700" do %>
+        View profile affiliations
+        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+      <% end %>
+    </div>
     <% if @linked_organizations.any? %>
       <ul class="space-y-2 mb-6">
         <% @linked_organizations.each do |org| %>
@@ -23,18 +30,11 @@
                                                   submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
                                                   event_registration: @event_registration %>
             </div>
-            <div class="shrink-0 flex flex-col items-end gap-1">
-              <%= button_to "Remove",
-                            unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
-                            method: :delete,
-                            form: { data: { turbo_frame: "_top" } },
-                            class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
-              <%= link_to organization_path(org, anchor: "affiliations"), target: "_blank", rel: "noopener",
-                          class: "inline-flex items-center gap-1 px-3 text-sm text-gray-500 underline hover:text-gray-700" do %>
-                View profile
-                <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
-              <% end %>
-            </div>
+            <%= button_to "Remove",
+                          unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
+                          method: :delete,
+                          form: { class: "shrink-0", data: { turbo_frame: "_top" } },
+                          class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
           </li>
         <% end %>
       </ul>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -5,47 +5,21 @@
       <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
     </div>
 
-    <h1 class="text-xl font-semibold text-gray-900 mb-2">Link Organization</h1>
+    <h1 class="text-xl font-semibold text-gray-900 mb-2">Link organization</h1>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
+    <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
+    <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
+
+    <%# === Linked organizations (registration–organization associations) === %>
     <h2 class="text-lg font-semibold text-gray-800 mb-3">Linked organizations</h2>
     <% if @linked_organizations.any? %>
-      <ul class="space-y-2 mb-8">
-        <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
-        <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
+      <ul class="space-y-2 mb-6">
         <% @linked_organizations.each do |org| %>
-          <% affiliations = @affiliations_by_org[org.id] || [] %>
-          <% facilitator_affiliations = affiliations.select(&:facilitator?) %>
-          <% role_affiliations = affiliations - facilitator_affiliations %>
-          <% active_facilitator = facilitator_affiliations.find(&active) %>
-          <% submitted_position = @submitted_position.to_s.strip %>
-          <% role_titles = role_affiliations.filter_map { |a| a.title.presence }.uniq %>
-          <% title_matches_form = submitted_position.present? && role_titles.any? { |t| t.casecmp?(submitted_position) } %>
-          <li class="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
+          <li class="flex items-center justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
             <div class="min-w-0">
               <p class="font-medium text-gray-800"><%= org.name %></p>
-              <p class="text-xs text-gray-500 mb-1.5"><%= org.city_state %></p>
-              <div class="flex flex-wrap gap-1.5">
-                <%# 1. Does an affiliation exist, and does its title match the form? %>
-                <% if affiliations.empty? %>
-                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200">No affiliation on record</span>
-                <% elsif submitted_position.blank? %>
-                  <span class="<%= badge %> bg-gray-100 text-gray-600 border-gray-200">On record: <%= role_titles.join(", ").presence || "no title" %></span>
-                <% elsif title_matches_form %>
-                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form: <%= submitted_position %></span>
-                <% else %>
-                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200"
-                        title="Form: <%= submitted_position %>">Title differs — form: <%= submitted_position %>; on record: <%= role_titles.join(", ").presence || "none" %></span>
-                <% end %>
-                <%# 2. Facilitator affiliation — this is what marks the org active with AWBW. %>
-                <% if active_facilitator %>
-                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200" title="Active with AWBW">Facilitator: active</span>
-                <% elsif facilitator_affiliations.any? %>
-                  <span class="<%= badge %> bg-gray-100 text-gray-600 border-gray-200">Facilitator: inactive</span>
-                <% else %>
-                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200">No facilitator affiliation</span>
-                <% end %>
-              </div>
+              <p class="text-xs text-gray-500"><%= org.city_state %></p>
             </div>
             <%= button_to "Remove",
                           unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
@@ -56,57 +30,114 @@
         <% end %>
       </ul>
     <% else %>
-      <p class="text-gray-500 mb-8">No organizations are linked to this registration yet.</p>
+      <p class="text-gray-500 mb-6">No organizations are linked to this registration yet.</p>
     <% end %>
 
-    <% if @submitted_org_name.present? %>
-      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
-        <p class="text-sm text-gray-500 mb-1">Submitted organization name on registration form:</p>
-        <p class="text-base font-medium text-gray-800"><%= @submitted_org_name %></p>
-      </div>
-    <% else %>
-      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
-        <p class="text-sm text-gray-500">No organization was submitted on the registration form.</p>
-      </div>
-    <% end %>
+    <%# Adding an org is part of managing the links, so it's nested here. %>
+    <div class="border-t border-gray-100 pt-4 pl-4 mb-8">
+      <h3 class="text-sm font-semibold text-gray-700 mb-3">Add an organization</h3>
 
-    <% if @potential_matches.any? %>
-      <h2 class="text-lg font-semibold text-gray-800 mb-3">Potential matches</h2>
-      <div class="space-y-2 mb-8">
-        <% @potential_matches.each do |org| %>
-          <%= form_with url: select_organization_event_registration_path(@event_registration),
-                        method: :post,
-                        data: { turbo_frame: "_top" },
-                        class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
-            <%= hidden_field_tag :organization_id, org.id %>
-            <%= hidden_field_tag :return_to, params[:return_to] %>
-            <div>
-              <p class="font-medium text-gray-800"><%= org.name %></p>
-              <p class="text-xs text-gray-500"><%= org.city_state %></p>
-            </div>
-            <%= submit_tag "Select", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+      <% if @potential_matches.any? %>
+        <p class="text-xs text-gray-500 mb-2">Suggested matches for the submitted name:</p>
+        <div class="space-y-2 mb-4">
+          <% @potential_matches.each do |org| %>
+            <%= form_with url: select_organization_event_registration_path(@event_registration),
+                          method: :post,
+                          data: { turbo_frame: "_top" },
+                          class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
+              <%= hidden_field_tag :organization_id, org.id %>
+              <%= hidden_field_tag :return_to, params[:return_to] %>
+              <div>
+                <p class="font-medium text-gray-800"><%= org.name %></p>
+                <p class="text-xs text-gray-500"><%= org.city_state %></p>
+              </div>
+              <%= submit_tag "Select", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+            <% end %>
           <% end %>
+        </div>
+      <% end %>
+
+      <%= form_with url: select_organization_event_registration_path(@event_registration),
+                    method: :post,
+                    data: { turbo_frame: "_top" },
+                    class: "space-y-4" do %>
+        <%= hidden_field_tag :return_to, params[:return_to] %>
+        <div>
+          <%= label_tag :organization_id, "Search all organizations", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= select_tag :organization_id,
+                         options_from_collection_for_select([], :id, :name),
+                         include_blank: true,
+                         class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                         data: { controller: "remote-select", remote_select_model_value: "organization" },
+                         prompt: "Type to search organizations…" %>
+        </div>
+        <%= submit_tag "Link organization",
+                       class: "rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+      <% end %>
+    </div>
+
+    <%# === Affiliations (the person's global org relationships) === %>
+    <h2 class="text-lg font-semibold text-gray-800 mb-3">Affiliations</h2>
+    <% if @affiliations_by_org.any? %>
+      <% submitted_org = @submitted_org_name.to_s.strip.downcase %>
+      <% submitted_position = @submitted_position.to_s.strip %>
+      <ul class="space-y-2 mb-8">
+        <% @affiliations_by_org.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
+          <% org = affs.first.organization %>
+          <% next unless org %>
+          <% role_affiliations = affs.reject(&:facilitator?) %>
+          <% is_submitted_org = submitted_org.present? && org.name.to_s.strip.downcase == submitted_org %>
+          <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+            <p class="font-medium text-gray-800"><%= org.name %></p>
+            <p class="text-xs text-gray-500 mb-1.5"><%= org.city_state %></p>
+            <div class="flex flex-wrap gap-1.5">
+              <% affs.each do |a| %>
+                <% a_active = active.call(a) %>
+                <span class="<%= badge %> <%= a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>"
+                      title="<%= a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : "Affiliation title" %>">
+                  <%= a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled") %> — <%= a_active ? "active" : "inactive" %>
+                </span>
+              <% end %>
+              <% if is_submitted_org && submitted_position.present? %>
+                <% if role_affiliations.any? { |a| a.title.to_s.casecmp?(submitted_position) } %>
+                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form</span>
+                <% else %>
+                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200" title="Form: <%= submitted_position %>">Title differs from form (form: <%= submitted_position %>)</span>
+                <% end %>
+              <% end %>
+            </div>
+          </li>
         <% end %>
-      </div>
+      </ul>
+    <% else %>
+      <p class="text-gray-500 mb-8">No affiliations on record for this person.</p>
     <% end %>
 
-    <h2 class="text-lg font-semibold text-gray-800 mb-3">Or search all organizations</h2>
-    <%= form_with url: select_organization_event_registration_path(@event_registration),
-                  method: :post,
-                  data: { turbo_frame: "_top" },
-                  class: "space-y-4" do %>
-      <%= hidden_field_tag :return_to, params[:return_to] %>
-      <div>
-        <%= label_tag :organization_id, "Organization", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= select_tag :organization_id,
-                       options_from_collection_for_select([], :id, :name),
-                       include_blank: true,
-                       class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                       data: { controller: "remote-select", remote_select_model_value: "organization" },
-                       prompt: "Type to search organizations…" %>
-      </div>
-      <%= submit_tag "Link organization",
-                     class: "rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
-    <% end %>
+    <%# === Registration form submission (what the registrant typed) === %>
+    <h2 class="text-lg font-semibold text-gray-800 mb-3">Registration form submission</h2>
+    <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
+    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+      <% if @submitted_org_name.present? || @submitted_position.present? %>
+        <p class="text-sm text-gray-500 mb-2">
+          On the
+          <% if @form_submission %>
+            <%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>
+          <% else %>
+            registration form
+          <% end %>, the registrant entered:
+        </p>
+        <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
+        <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
+      <% else %>
+        <p class="text-sm text-gray-500">
+          No organization was submitted on the
+          <% if @form_submission %>
+            <%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>
+          <% else %>
+            registration form
+          <% end %>.
+        </p>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -86,56 +86,69 @@
       <% end %>
     </div>
 
-    <%# === Registration form submission (what the registrant typed) === %>
-    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Registration form submission</h2>
+    <%# === Registration form submission (what the registrant typed). Collapsed by
+        default; expanded when the submitted org isn't in the DB (needs attention). === %>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
-    <div class="flex items-stretch gap-3 mb-8">
-      <div class="flex-1 min-w-0 bg-gray-50 border border-gray-200 rounded-lg p-4">
-        <% if @submitted_org_name.present? || @submitted_position.present? %>
-          <p class="text-sm text-gray-500 mb-2">
-            On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
-          </p>
-          <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
-          <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
-        <% else %>
-          <p class="text-sm text-gray-500">
-            No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
-          </p>
+    <% submitted_org_unmatched = @submitted_org_name.present? && !@submitted_org_exists %>
+    <details class="mb-8"<%= " open" if submitted_org_unmatched %>>
+      <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
+        <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+      </summary>
+      <div class="flex items-stretch gap-3">
+        <div class="flex-1 min-w-0 bg-gray-50 border border-gray-200 rounded-lg p-4">
+          <% if @submitted_org_name.present? || @submitted_position.present? %>
+            <p class="text-sm text-gray-500 mb-2">
+              On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
+            </p>
+            <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
+            <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
+          <% else %>
+            <p class="text-sm text-gray-500">
+              No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
+            </p>
+          <% end %>
+        </div>
+        <% if submitted_org_unmatched %>
+          <%# Creates an org from the typed name and links it in one step, for names with no existing match. %>
+          <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
+                        method: :post,
+                        form: { class: "shrink-0 self-center", data: { turbo_frame: "_top" } },
+                        class: "inline-flex items-center rounded-md border border-blue-900 px-5 py-2 text-blue-900 font-semibold hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
+            Create org &amp; link
+          <% end %>
         <% end %>
       </div>
-      <% if @submitted_org_name.present? && !@submitted_org_exists %>
-        <%# Creates an org from the typed name and links it in one step, for names with no existing match. %>
-        <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
-                      method: :post,
-                      form: { class: "shrink-0 self-center", data: { turbo_frame: "_top" } },
-                      class: "inline-flex items-center rounded-md border border-blue-900 px-5 py-2 text-blue-900 font-semibold hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
-          Create org &amp; link
-        <% end %>
-      <% end %>
-    </div>
+    </details>
 
-    <%# === The person's affiliations to orgs NOT linked to this registration === %>
-    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
+    <%# === The person's affiliations to orgs NOT linked to this registration.
+        Collapsed by default. === %>
     <% linked_org_ids = @linked_organizations.map(&:id) %>
     <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
-    <% if other_affiliations.any? %>
-      <ul class="space-y-2">
-        <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
-          <% org = affs.first.organization %>
-          <% next unless org %>
-          <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-            <p class="font-medium text-gray-800"><%= org.name %></p>
-            <% if org.city_state.present? %>
-              <p class="text-xs text-gray-500"><%= org.city_state %></p>
-            <% end %>
-            <%= render "org_affiliation_pills", org: org, affiliations: affs,
-                                                submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
-                                                event_registration: @event_registration %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="text-gray-500">No other affiliations on record.</p>
-    <% end %>
+    <details>
+      <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
+        <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+      </summary>
+      <% if other_affiliations.any? %>
+        <ul class="space-y-2">
+          <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
+            <% org = affs.first.organization %>
+            <% next unless org %>
+            <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+              <p class="font-medium text-gray-800"><%= org.name %></p>
+              <% if org.city_state.present? %>
+                <p class="text-xs text-gray-500"><%= org.city_state %></p>
+              <% end %>
+              <%= render "org_affiliation_pills", org: org, affiliations: affs,
+                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
+                                                  event_registration: @event_registration %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-gray-500">No other affiliations on record.</p>
+      <% end %>
+    </details>
   </div>
 </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -8,24 +8,25 @@
     <h1 class="text-xl font-semibold text-gray-900 mb-2">Link organization</h1>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
-    <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
-    <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
-
     <%# === Linked organizations (registration–organization associations) === %>
     <h2 class="text-lg font-semibold text-gray-800 mb-3">Linked organizations</h2>
     <% if @linked_organizations.any? %>
       <ul class="space-y-2 mb-6">
         <% @linked_organizations.each do |org| %>
-          <li class="flex items-center justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
+          <li class="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
             <div class="min-w-0">
               <p class="font-medium text-gray-800"><%= org.name %></p>
-              <p class="text-xs text-gray-500"><%= org.city_state %></p>
+              <% if org.city_state.present? %>
+                <p class="text-xs text-gray-500"><%= org.city_state %></p>
+              <% end %>
+              <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
+                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
             </div>
             <%= button_to "Remove",
                           unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
                           method: :delete,
-                          form: { data: { turbo_frame: "_top" } },
-                          class: "rounded-md bg-red-50 px-4 py-1.5 text-red-700 text-sm font-medium border border-red-200 hover:bg-red-100 transition cursor-pointer" %>
+                          form: { class: "shrink-0", data: { turbo_frame: "_top" } },
+                          class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
           </li>
         <% end %>
       </ul>
@@ -49,7 +50,9 @@
               <%= hidden_field_tag :return_to, params[:return_to] %>
               <div>
                 <p class="font-medium text-gray-800"><%= org.name %></p>
-                <p class="text-xs text-gray-500"><%= org.city_state %></p>
+                <% if org.city_state.present? %>
+                  <p class="text-xs text-gray-500"><%= org.city_state %></p>
+                <% end %>
               </div>
               <%= submit_tag "Select", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
             <% end %>
@@ -60,63 +63,23 @@
       <%= form_with url: select_organization_event_registration_path(@event_registration),
                     method: :post,
                     data: { turbo_frame: "_top" },
-                    class: "space-y-1" do %>
+                    class: "flex items-stretch gap-2" do %>
         <%= hidden_field_tag :return_to, params[:return_to] %>
-        <%= label_tag :organization_id, "Search all organizations", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <div class="flex items-stretch gap-2">
-          <%= select_tag :organization_id,
-                         options_from_collection_for_select([], :id, :name),
-                         include_blank: true,
-                         class: "flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                         data: { controller: "remote-select", remote_select_model_value: "organization" },
-                         prompt: "Type to search organizations…" %>
-          <%= submit_tag "Link organization",
-                         class: "shrink-0 rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
-        </div>
+        <%= select_tag :organization_id,
+                       options_from_collection_for_select([], :id, :name),
+                       include_blank: true,
+                       class: "flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                       data: { controller: "remote-select", remote_select_model_value: "organization" },
+                       prompt: "Type to search organizations…" %>
+        <%= submit_tag "Link organization",
+                       class: "shrink-0 rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
       <% end %>
     </div>
-
-    <%# === Affiliations (the person's global org relationships) === %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-3">Affiliations</h2>
-    <% if @affiliations_by_org.any? %>
-      <% submitted_org = @submitted_org_name.to_s.strip.downcase %>
-      <% submitted_position = @submitted_position.to_s.strip %>
-      <ul class="space-y-2 mb-8">
-        <% @affiliations_by_org.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
-          <% org = affs.first.organization %>
-          <% next unless org %>
-          <% role_affiliations = affs.reject(&:facilitator?) %>
-          <% is_submitted_org = submitted_org.present? && org.name.to_s.strip.downcase == submitted_org %>
-          <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-            <p class="font-medium text-gray-800"><%= org.name %></p>
-            <p class="text-xs text-gray-500 mb-1.5"><%= org.city_state %></p>
-            <div class="flex flex-wrap gap-1.5">
-              <% affs.each do |a| %>
-                <% a_active = active.call(a) %>
-                <span class="<%= badge %> <%= a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>"
-                      title="<%= a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : "Affiliation title" %>">
-                  <%= a.facilitator? ? "Facilitator" : (a.title.presence || "Untitled") %> — <%= a_active ? "active" : "inactive" %>
-                </span>
-              <% end %>
-              <% if is_submitted_org && submitted_position.present? %>
-                <% if role_affiliations.any? { |a| a.title.to_s.casecmp?(submitted_position) } %>
-                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form</span>
-                <% else %>
-                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200" title="Form: <%= submitted_position %>">Title differs from form (form: <%= submitted_position %>)</span>
-                <% end %>
-              <% end %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="text-gray-500 mb-8">No affiliations on record for this person.</p>
-    <% end %>
 
     <%# === Registration form submission (what the registrant typed) === %>
     <h2 class="text-lg font-semibold text-gray-800 mb-3">Registration form submission</h2>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
-    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
       <% if @submitted_org_name.present? || @submitted_position.present? %>
         <p class="text-sm text-gray-500 mb-2">
           On the
@@ -139,5 +102,28 @@
         </p>
       <% end %>
     </div>
+
+    <%# === The person's affiliations to orgs NOT linked to this registration === %>
+    <h2 class="text-lg font-semibold text-gray-800 mb-3"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
+    <% linked_org_ids = @linked_organizations.map(&:id) %>
+    <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
+    <% if other_affiliations.any? %>
+      <ul class="space-y-2">
+        <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
+          <% org = affs.first.organization %>
+          <% next unless org %>
+          <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
+            <p class="font-medium text-gray-800"><%= org.name %></p>
+            <% if org.city_state.present? %>
+              <p class="text-xs text-gray-500"><%= org.city_state %></p>
+            <% end %>
+            <%= render "org_affiliation_pills", org: org, affiliations: affs,
+                                                submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-gray-500">No other affiliations on record.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -8,6 +8,27 @@
     <h1 class="text-xl font-semibold text-gray-900 mb-2">Link Organization</h1>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
+    <h2 class="text-lg font-semibold text-gray-800 mb-3">Linked organizations</h2>
+    <% if @linked_organizations.any? %>
+      <ul class="space-y-2 mb-8">
+        <% @linked_organizations.each do |org| %>
+          <li class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg p-3">
+            <div>
+              <p class="font-medium text-gray-800"><%= org.name %></p>
+              <p class="text-xs text-gray-500"><%= org.city_state %></p>
+            </div>
+            <%= button_to "Remove",
+                          unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
+                          method: :delete,
+                          form: { data: { turbo_frame: "_top" } },
+                          class: "rounded-md bg-red-50 px-4 py-1.5 text-red-700 text-sm font-medium border border-red-200 hover:bg-red-100 transition cursor-pointer" %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-gray-500 mb-8">No organizations are linked to this registration yet.</p>
+    <% end %>
+
     <% if @submitted_org_name.present? %>
       <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
         <p class="text-sm text-gray-500 mb-1">Submitted organization name on registration form:</p>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -103,7 +103,7 @@
           </p>
         <% end %>
       </div>
-      <% if @submitted_org_name.present? %>
+      <% if @submitted_org_name.present? && !@submitted_org_exists %>
         <%# Creates an org from the typed name and links it in one step, for names with no existing match. %>
         <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
                       method: :post,

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -84,23 +84,13 @@
     <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
       <% if @submitted_org_name.present? || @submitted_position.present? %>
         <p class="text-sm text-gray-500 mb-2">
-          On the
-          <% if @form_submission %>
-            <%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>
-          <% else %>
-            registration form
-          <% end %>, the registrant entered:
+          On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
         </p>
         <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
         <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
       <% else %>
         <p class="text-sm text-gray-500">
-          No organization was submitted on the
-          <% if @form_submission %>
-            <%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>
-          <% else %>
-            registration form
-          <% end %>.
+          No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
         </p>
       <% end %>
     </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -11,11 +11,41 @@
     <h2 class="text-lg font-semibold text-gray-800 mb-3">Linked organizations</h2>
     <% if @linked_organizations.any? %>
       <ul class="space-y-2 mb-8">
+        <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
+        <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
         <% @linked_organizations.each do |org| %>
-          <li class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg p-3">
-            <div>
+          <% affiliations = @affiliations_by_org[org.id] || [] %>
+          <% facilitator_affiliations = affiliations.select(&:facilitator?) %>
+          <% role_affiliations = affiliations - facilitator_affiliations %>
+          <% active_facilitator = facilitator_affiliations.find(&active) %>
+          <% submitted_position = @submitted_position.to_s.strip %>
+          <% role_titles = role_affiliations.filter_map { |a| a.title.presence }.uniq %>
+          <% title_matches_form = submitted_position.present? && role_titles.any? { |t| t.casecmp?(submitted_position) } %>
+          <li class="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
+            <div class="min-w-0">
               <p class="font-medium text-gray-800"><%= org.name %></p>
-              <p class="text-xs text-gray-500"><%= org.city_state %></p>
+              <p class="text-xs text-gray-500 mb-1.5"><%= org.city_state %></p>
+              <div class="flex flex-wrap gap-1.5">
+                <%# 1. Does an affiliation exist, and does its title match the form? %>
+                <% if affiliations.empty? %>
+                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200">No affiliation on record</span>
+                <% elsif submitted_position.blank? %>
+                  <span class="<%= badge %> bg-gray-100 text-gray-600 border-gray-200">On record: <%= role_titles.join(", ").presence || "no title" %></span>
+                <% elsif title_matches_form %>
+                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200">Title matches form: <%= submitted_position %></span>
+                <% else %>
+                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200"
+                        title="Form: <%= submitted_position %>">Title differs — form: <%= submitted_position %>; on record: <%= role_titles.join(", ").presence || "none" %></span>
+                <% end %>
+                <%# 2. Facilitator affiliation — this is what marks the org active with AWBW. %>
+                <% if active_facilitator %>
+                  <span class="<%= badge %> bg-green-50 text-green-700 border-green-200" title="Active with AWBW">Facilitator: active</span>
+                <% elsif facilitator_affiliations.any? %>
+                  <span class="<%= badge %> bg-gray-100 text-gray-600 border-gray-200">Facilitator: inactive</span>
+                <% else %>
+                  <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200">No facilitator affiliation</span>
+                <% end %>
+              </div>
             </div>
             <%= button_to "Remove",
                           unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -60,19 +60,19 @@
       <%= form_with url: select_organization_event_registration_path(@event_registration),
                     method: :post,
                     data: { turbo_frame: "_top" },
-                    class: "space-y-4" do %>
+                    class: "space-y-1" do %>
         <%= hidden_field_tag :return_to, params[:return_to] %>
-        <div>
-          <%= label_tag :organization_id, "Search all organizations", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= label_tag :organization_id, "Search all organizations", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <div class="flex items-stretch gap-2">
           <%= select_tag :organization_id,
                          options_from_collection_for_select([], :id, :name),
                          include_blank: true,
-                         class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                         class: "flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
                          data: { controller: "remote-select", remote_select_model_value: "organization" },
                          prompt: "Type to search organizations…" %>
+          <%= submit_tag "Link organization",
+                         class: "shrink-0 rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
         </div>
-        <%= submit_tag "Link organization",
-                       class: "rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
       <% end %>
     </div>
 

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -11,7 +11,7 @@
     <%# === Linked organizations (registration–organization associations) === %>
     <div class="flex items-center justify-between gap-3 mb-3">
       <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Linked organizations</h2>
-      <%= link_to person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
+      <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700" do %>
         View profile affiliations
         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
@@ -89,17 +89,28 @@
     <%# === Registration form submission (what the registrant typed) === %>
     <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Registration form submission</h2>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
-    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
-      <% if @submitted_org_name.present? || @submitted_position.present? %>
-        <p class="text-sm text-gray-500 mb-2">
-          On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
-        </p>
-        <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
-        <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
-      <% else %>
-        <p class="text-sm text-gray-500">
-          No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
-        </p>
+    <div class="flex items-stretch gap-3 mb-8">
+      <div class="flex-1 min-w-0 bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <% if @submitted_org_name.present? || @submitted_position.present? %>
+          <p class="text-sm text-gray-500 mb-2">
+            On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
+          </p>
+          <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
+          <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
+        <% else %>
+          <p class="text-sm text-gray-500">
+            No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
+          </p>
+        <% end %>
+      </div>
+      <% if @submitted_org_name.present? %>
+        <%# Creates an org from the typed name and links it in one step, for names with no existing match. %>
+        <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
+                      method: :post,
+                      form: { class: "shrink-0 self-center", data: { turbo_frame: "_top" } },
+                      class: "inline-flex items-center rounded-md border border-blue-900 px-5 py-2 text-blue-900 font-semibold hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
+          Create org &amp; link
+        <% end %>
       <% end %>
     </div>
 

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -10,7 +10,7 @@
 
     <%# === Linked organizations (registration–organization associations) === %>
     <div class="flex items-center justify-between gap-3 mb-3">
-      <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Linked organizations</h2>
+      <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration-linked organizations</h2>
       <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700" do %>
         View profile affiliations
@@ -90,7 +90,9 @@
         default; expanded when the submitted org isn't in the DB (needs attention). === %>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
     <% submitted_org_unmatched = @submitted_org_name.present? && !@submitted_org_exists %>
-    <details class="mb-8"<%= " open" if submitted_org_unmatched %>>
+    <%# Expand unless the submitted org is resolved (matches an existing org), so it
+        opens both when nothing was submitted and when the name has no DB match. %>
+    <details class="mb-8"<%= " open" unless @submitted_org_exists %>>
       <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
@@ -122,10 +124,10 @@
     </details>
 
     <%# === The person's affiliations to orgs NOT linked to this registration.
-        Collapsed by default. === %>
+        Collapsed by default; expanded when there are none (to show that state). === %>
     <% linked_org_ids = @linked_organizations.map(&:id) %>
     <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
-    <details>
+    <details<%= " open" if other_affiliations.empty? %>>
       <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -5,7 +5,7 @@
       <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
     </div>
 
-    <h1 class="text-xl font-semibold text-gray-900 mb-2">Link organization</h1>
+    <h1 class="text-xl font-semibold text-gray-900 mb-2">Organizations &amp; affiliations</h1>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
     <%# === Linked organizations (registration–organization associations) === %>
@@ -65,12 +65,14 @@
                     data: { turbo_frame: "_top" },
                     class: "flex items-stretch gap-2" do %>
         <%= hidden_field_tag :return_to, params[:return_to] %>
-        <%= select_tag :organization_id,
-                       options_from_collection_for_select([], :id, :name),
-                       include_blank: true,
-                       class: "flex-1 min-w-0 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                       data: { controller: "remote-select", remote_select_model_value: "organization" },
-                       prompt: "Type to search organizations…" %>
+        <div class="flex-1 min-w-0">
+          <%= select_tag :organization_id,
+                         options_from_collection_for_select([], :id, :name),
+                         include_blank: true,
+                         class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                         data: { controller: "remote-select", remote_select_model_value: "organization" },
+                         prompt: "Type to search organizations…" %>
+        </div>
         <%= submit_tag "Link organization",
                        class: "shrink-0 rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
       <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -116,25 +116,39 @@
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% if registration.organizations.any? %>
+                  <% linked_orgs = registration.organizations %>
+                  <% submitted_org_name = submitted_org_names[registration.registrant_id].to_s.strip %>
+                  <% linked_org_names = linked_orgs.map { |org| org.name.to_s.strip.downcase } %>
+                  <%# A submitted name not represented among the linked orgs still needs admin
+                      attention; a name matching a linked org is already resolved. %>
+                  <% needs_linking = submitted_org_name.present? && linked_org_names.exclude?(submitted_org_name.downcase) %>
+                  <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
+                  <% if linked_orgs.any? %>
                     <ul class="space-y-0.5">
-                      <% registration.organizations.each do |org| %>
+                      <% linked_orgs.each do |org| %>
                         <li>
-                          <%= link_to truncate(org.name, length: 40), link_organization_event_registration_path(registration, return_to: "registrants"),
+                          <%= link_to truncate(org.name, length: 40), editor_path,
                                       title: org.name,
                                       class: "text-gray-800 hover:text-gray-900 hover:underline",
                                       data: { turbo_frame: "_top" } %>
                         </li>
                       <% end %>
                     </ul>
+                    <% if needs_linking %>
+                      <%= link_to editor_path,
+                                  title: submitted_org_name,
+                                  class: "mt-1 inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
+                                  data: { turbo_frame: "_top" } do %>
+                        <span>Pending</span>
+                      <% end %>
+                    <% end %>
                   <% else %>
-                    <% submitted_org_name = submitted_org_names[registration.registrant_id].presence %>
-                    <% chip_classes = submitted_org_name ? "bg-amber-50 text-amber-700 border-amber-200" : "bg-gray-50 text-gray-500 border-gray-200" %>
-                    <%= link_to link_organization_event_registration_path(registration, return_to: "registrants"),
-                                title: submitted_org_name,
+                    <% chip_classes = needs_linking ? "bg-amber-50 text-amber-700 border-amber-200" : "bg-gray-50 text-gray-500 border-gray-200" %>
+                    <%= link_to editor_path,
+                                title: submitted_org_name.presence,
                                 class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 #{chip_classes} hover:opacity-80",
                                 data: { turbo_frame: "_top" } do %>
-                      <span><%= submitted_org_name ? "Pending" : "None" %></span>
+                      <span><%= needs_linking ? "Pending" : "None" %></span>
                     <% end %>
                   <% end %>
                 </td>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -131,6 +131,7 @@
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span><%= truncate(org.name, length: 40) %></span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                     <% if needs_linking %>
@@ -139,6 +140,7 @@
                                   class: "#{pill_classes} bg-amber-50 text-amber-700 border-amber-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span>Pending</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                     <% if linked_orgs.none? && !needs_linking %>
@@ -146,6 +148,7 @@
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span>None</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                   </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -123,34 +123,32 @@
                       attention; a name matching a linked org is already resolved. %>
                   <% needs_linking = submitted_org_name.present? && linked_org_names.exclude?(submitted_org_name.downcase) %>
                   <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
-                  <% if linked_orgs.any? %>
-                    <ul class="space-y-0.5">
-                      <% linked_orgs.each do |org| %>
-                        <li>
-                          <%= link_to truncate(org.name, length: 40), editor_path,
-                                      title: org.name,
-                                      class: "text-gray-800 hover:text-gray-900 hover:underline",
-                                      data: { turbo_frame: "_top" } %>
-                        </li>
+                  <% pill_classes = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 hover:opacity-80" %>
+                  <div class="flex flex-wrap gap-1.5">
+                    <% linked_orgs.each do |org| %>
+                      <%= link_to editor_path,
+                                  title: org.name,
+                                  class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
+                                  data: { turbo_frame: "_top" } do %>
+                        <span><%= truncate(org.name, length: 40) %></span>
                       <% end %>
-                    </ul>
+                    <% end %>
                     <% if needs_linking %>
                       <%= link_to editor_path,
                                   title: submitted_org_name,
-                                  class: "mt-1 inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
+                                  class: "#{pill_classes} bg-amber-50 text-amber-700 border-amber-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span>Pending</span>
                       <% end %>
                     <% end %>
-                  <% else %>
-                    <% chip_classes = needs_linking ? "bg-amber-50 text-amber-700 border-amber-200" : "bg-gray-50 text-gray-500 border-gray-200" %>
-                    <%= link_to editor_path,
-                                title: submitted_org_name.presence,
-                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 #{chip_classes} hover:opacity-80",
-                                data: { turbo_frame: "_top" } do %>
-                      <span><%= needs_linking ? "Pending" : "None" %></span>
+                    <% if linked_orgs.none? && !needs_linking %>
+                      <%= link_to editor_path,
+                                  class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
+                                  data: { turbo_frame: "_top" } do %>
+                        <span>None</span>
+                      <% end %>
                     <% end %>
-                  <% end %>
+                  </div>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-center">
@@ -198,9 +196,12 @@
                   <% due_cents = @event.cost_cents - paid_cents %>
                   <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= due_cents %>">
                     <% is_paid = registration.paid_in_full? %>
-                    <% is_partial = registration.partially_paid? %>
+                    <% is_discounted = !is_paid && registration.discounted? %>
+                    <% is_partial = !is_discounted && registration.partially_paid? %>
                     <% badge_classes = if is_paid
                          "bg-green-50 text-green-700 border-green-200"
+                       elsif is_discounted
+                         "bg-purple-50 text-purple-700 border-purple-200"
                        elsif is_partial
                          "bg-blue-50 text-blue-700 border-blue-200"
                        else
@@ -208,18 +209,28 @@
                        end %>
                     <% badge_icon = if is_paid
                          "fa-circle-check"
+                       elsif is_discounted
+                         "fa-tag"
                        elsif is_partial
                          "fa-circle-half-stroke"
                        else
                          "fa-circle-exclamation"
                        end %>
 
-                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
+                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
                       <% if is_paid %>
-                        <span>Paid</span>
+                        <span>Nothing owed</span>
+                      <% elsif is_discounted %>
+                        <span class="flex flex-col leading-tight text-left">
+                          <span>Discounted</span>
+                          <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                        </span>
                       <% elsif is_partial %>
-                        <span>Partial · <%= "$%.2f due" % (due_cents / 100.0) %></span>
+                        <span class="flex flex-col leading-tight text-left">
+                          <span>Partial payment</span>
+                          <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                        </span>
                       <% else %>
                         <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
                       <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -223,7 +223,7 @@
                     <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
                       <% if is_paid %>
-                        <span>Nothing owed</span>
+                        <span>Paid</span>
                       <% elsif is_discounted %>
                         <span class="flex flex-col leading-tight text-left">
                           <span>Discounted</span>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -126,9 +126,9 @@
                     </ul>
                   <% else %>
                     <%= link_to link_organization_event_registration_path(registration, return_to: "registrants"),
-                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
+                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-gray-50 text-gray-500 border-gray-200 hover:opacity-80",
                                 data: { turbo_frame: "_top" } do %>
-                      <span>Pending</span>
+                      <span>None</span>
                     <% end %>
                   <% end %>
                 </td>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -34,6 +34,9 @@
 
     <% event_form_ids = @event.form_ids %>
     <% form_submissions = event_form_ids.any? ? FormSubmission.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
+    <% registration_form = @event.registration_form %>
+    <% agency_name_field = registration_form&.form_fields&.find_by(field_identifier: "agency_name") %>
+    <% submitted_org_names = agency_name_field ? FormAnswer.joins(:form_submission).where(form_submissions: { person_id: @event_registrations.map(&:registrant_id), form_id: registration_form.id }, form_field_id: agency_name_field.id).pluck(Arel.sql("form_submissions.person_id"), :submitted_answer).to_h : {} %>
     <% if @event_registrations.any? %>
       <div class="overflow-x-auto">
         <% payment_col = @event.cost_cents.to_i > 0 %>
@@ -117,7 +120,7 @@
                     <ul class="space-y-0.5">
                       <% registration.organizations.each do |org| %>
                         <li>
-                          <%= link_to truncate(org.name, length: 40), organization_path(org),
+                          <%= link_to truncate(org.name, length: 40), link_organization_event_registration_path(registration, return_to: "registrants"),
                                       title: org.name,
                                       class: "text-gray-800 hover:text-gray-900 hover:underline",
                                       data: { turbo_frame: "_top" } %>
@@ -125,10 +128,13 @@
                       <% end %>
                     </ul>
                   <% else %>
+                    <% submitted_org_name = submitted_org_names[registration.registrant_id].presence %>
+                    <% chip_classes = submitted_org_name ? "bg-amber-50 text-amber-700 border-amber-200" : "bg-gray-50 text-gray-500 border-gray-200" %>
                     <%= link_to link_organization_event_registration_path(registration, return_to: "registrants"),
-                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 bg-gray-50 text-gray-500 border-gray-200 hover:opacity-80",
+                                title: submitted_org_name,
+                                class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 #{chip_classes} hover:opacity-80",
                                 data: { turbo_frame: "_top" } do %>
-                      <span>None</span>
+                      <span><%= submitted_org_name ? "Pending" : "None" %></span>
                     <% end %>
                   <% end %>
                 </td>

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -36,7 +36,7 @@
       <%= label_tag :payment_status, "Payment", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :payment_status,
                      options_for_select(
-                       [ [ "Paid in full", "paid" ], [ "Not paid in full", "unpaid" ] ],
+                       [ [ "Monies due", "unpaid" ], [ "Nothing owed", "paid" ] ],
                        params[:payment_status]
                      ),
                      include_blank: "Any payment status",

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -36,7 +36,7 @@
       <%= label_tag :payment_status, "Payment", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :payment_status,
                      options_for_select(
-                       [ [ "Monies due", "unpaid" ], [ "Nothing owed", "paid" ] ],
+                       [ [ "Due", "unpaid" ], [ "Paid", "paid" ] ],
                        params[:payment_status]
                      ),
                      include_blank: "Any payment status",

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -115,7 +115,7 @@
     <!-- Info grid -->
     <div class="grid grid-cols-1 md:grid-cols-5 gap-8">
         <!-- Organization affiliations -->
-        <div class="md:col-span-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
+        <div id="affiliations" class="md:col-span-3 scroll-mt-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
           <h2 class="text-lg font-semibold text-gray-800 mb-2">
             Affiliations
           </h2>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -162,7 +162,7 @@
   <!-- Organization Affiliations -->
   <% person = f.object.respond_to?(:object) ? f.object.object : f.object %>
   <% decorated = person.decorate %>
-  <div class="form-group space-y-4">
+  <div id="affiliations" class="form-group space-y-4 scroll-mt-4">
     <div class="font-semibold text-gray-700 mb-2">
       Affiliations<span class="text-sm font-normal text-gray-500"> (only editable by admins)</span>
     </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -109,7 +109,7 @@
         <div class="grid grid-cols-1 md:grid-cols-5 gap-8">
           <!-- Organization affiliations -->
           <% if @person.profile_show_affiliations? %>
-            <div class="md:col-span-3 p-3">
+            <div id="affiliations" class="md:col-span-3 p-3 scroll-mt-4">
               <h2 class="text-lg font-semibold text-gray-800 mb-3">Affiliations</h2>
               <%= turbo_frame_tag "person_affiliations_section", src: person_path(@person, section: "affiliations"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading affiliations...</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       post :process_confirm
       get :link_organization
       post :select_organization
+      post :create_organization
       delete :unlink_organization
     end
     resources :comments, only: [ :index, :create, :update ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       post :process_confirm
       get :link_organization
       post :select_organization
+      delete :unlink_organization
     end
     resources :comments, only: [ :index, :create, :update ]
   end

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -867,7 +867,7 @@ if facilitator_training && registration_form
 
   aff_scenarios.each_with_index do |scenario, i|
     next unless aff_org
-    person = Person.create!(email: "affdemo.#{i + 1}@seed.example.com", first_name: "Aff Demo", last_name: scenario[:last])
+    person = Person.create!(email: "affdemo.#{i + 1}@seed.example.com", first_name: "Demo Affiliation", last_name: scenario[:last])
     registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
     registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
     add_affiliation.call(person, aff_org, title: scenario[:job])
@@ -879,7 +879,7 @@ if facilitator_training && registration_form
   # An affiliation to an org NOT linked to the registration → shows under the
   # registrant's "other affiliations" section.
   if aff_org && other_org
-    person = Person.create!(email: "affdemo.4@seed.example.com", first_name: "Aff Demo", last_name: "A4 Other affiliation")
+    person = Person.create!(email: "affdemo.4@seed.example.com", first_name: "Demo Affiliation", last_name: "A4 Other affiliation")
     registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
     registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
     add_affiliation.call(person, aff_org, title: "Facilitator")

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -816,9 +816,9 @@ if facilitator_training && registration_form
   scenarios = [
     { last: "1 Linked one org",       orgs: demo_orgs.first(1) },
     { last: "2 Linked three orgs",    orgs: demo_orgs.first(3) },
-    { last: "3 Pending no match",     agency: "Riverside Healing Arts Collective (unlisted)" },
+    { last: "3 Pending no match",     agency: "Riverside Healing Arts Collective" },
     { last: "4 Matched name auto-linked", orgs: demo_orgs.first(1), agency: matched_org&.name },
-    { last: "5 Mixed linked + pending", orgs: demo_orgs.first(1), agency: "Some Other Unlisted Agency" },
+    { last: "5 Mixed linked + pending", orgs: demo_orgs.first(1), agency: "Westview Community Healing" },
     { last: "6 None blank typed",     agency: "" },
     { last: "7 None nothing typed" },
     { last: "8 Pending matches existing org", agency: matched_org&.name }

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -803,7 +803,8 @@ if facilitator_training && registration_form
   end
 
   # Recreate from scratch each run so re-seeding refreshes labels and link state.
-  Person.where("email LIKE ?", "orgchip.demo.%@seed.example.com").find_each(&:destroy)
+  Person.where("email LIKE ? OR email LIKE ?",
+    "orgchip.demo.%@seed.example.com", "affdemo.%@seed.example.com").find_each(&:destroy)
 
   # Each scenario => one registrant. :orgs link real orgs (→ chip shows links);
   # :agency stores a submitted name. A typed name matching an existing org is linked
@@ -835,5 +836,53 @@ if facilitator_training && registration_form
 
     Array(scenario[:orgs]).each { |org| link_org.call(registration, org) }
     submit_agency_name.call(registration, scenario[:agency]) if scenario.key?(:agency)
+  end
+
+  # --- Affiliation-status demo: two affiliations per org (a real job title plus the
+  # Facilitator role that gates AWBW-active), plus the position typed on the form, so
+  # the org-link editor's affiliation pills can be seen across their states. ---
+  position_field = registration_form.form_fields.find_by(field_identifier: "agency_position")
+  submit_field = ->(registration, field, value) do
+    if field
+      submission = FormSubmission.find_or_create_by!(person: registration.registrant, form: registration_form)
+      answer = submission.form_answers.find_or_initialize_by(form_field: field)
+      answer.update!(submitted_answer: value.to_s, question_name_when_answered: field.name)
+    end
+  end
+  add_affiliation = ->(person, organization, title:, end_date: nil) do
+    Affiliation.find_or_create_by!(person: person, organization: organization, title: title) do |aff|
+      aff.start_date = Date.current - 1.year
+      aff.end_date = end_date
+    end
+  end
+
+  aff_org = demo_orgs.first
+  other_org = demo_orgs[1] || demo_orgs.first
+
+  aff_scenarios = [
+    { last: "A1 Title matches form",      job: "Counselor", position: "Counselor", facilitator_end: nil },
+    { last: "A2 Title differs from form", job: "Counselor", position: "Director",  facilitator_end: nil },
+    { last: "A3 Facilitator inactive",    job: "Counselor", position: "Counselor", facilitator_end: Date.current - 1.month }
+  ]
+
+  aff_scenarios.each_with_index do |scenario, i|
+    next unless aff_org
+    person = Person.create!(email: "affdemo.#{i + 1}@seed.example.com", first_name: "Aff Demo", last_name: scenario[:last])
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
+    registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
+    add_affiliation.call(person, aff_org, title: scenario[:job])
+    add_affiliation.call(person, aff_org, title: "Facilitator", end_date: scenario[:facilitator_end])
+    submit_field.call(registration, agency_field, aff_org.name)
+    submit_field.call(registration, position_field, scenario[:position])
+  end
+
+  # An affiliation to an org NOT linked to the registration → shows under the
+  # registrant's "other affiliations" section.
+  if aff_org && other_org
+    person = Person.create!(email: "affdemo.4@seed.example.com", first_name: "Aff Demo", last_name: "A4 Other affiliation")
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
+    registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
+    add_affiliation.call(person, aff_org, title: "Facilitator")
+    add_affiliation.call(person, other_org, title: "Board Member")
   end
 end

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -762,3 +762,78 @@ school_district_names = [ "Los Angeles Unified", "Garden Grove Unified", "Compto
     address.update!(district: school_district_names[(i / 2) % school_district_names.size])
   end
 end
+
+puts "Creating organization-link demo registrants on the flagship training…"
+# Exercises every state of the registrants Organization column and the Link
+# Organization editor: linked org(s), the amber "Pending" chip (the registrant
+# typed an agency name that is not linked to an org), and the grey "None" chip
+# (nothing submitted). Deterministic, clearly-named people so each state is easy
+# to spot in the browser at the flagship event's registrants page. Runs last so
+# the earlier affiliation backfill / form-fill passes leave these registrants
+# exactly as configured here.
+if facilitator_training && registration_form
+  # "Pending" only exists when the form has the Agency / Organization Name field,
+  # which lives in the person_contact_info section the dev form otherwise omits.
+  unless registration_form.form_fields.exists?(field_identifier: "agency_name")
+    FormBuilderService.update_sections!(
+      registration_form,
+      (registration_form.sections || []).map(&:to_sym) | [ :person_contact_info ]
+    )
+  end
+  agency_field = registration_form.form_fields.find_by(field_identifier: "agency_name")
+
+  # Real, existing orgs to link against / match on (skip the AWBW house org).
+  demo_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
+  matched_org = demo_orgs.first
+
+  link_org = ->(registration, organization) do
+    Affiliation.find_or_create_by!(person: registration.registrant, organization: organization) do |aff|
+      aff.title = "Facilitator"
+      aff.start_date = Date.current
+    end
+    registration.event_registration_organizations.find_or_create_by!(organization: organization)
+  end
+
+  submit_agency_name = ->(registration, value) do
+    submission = FormSubmission.find_or_create_by!(person: registration.registrant, form: registration_form)
+    if agency_field
+      answer = submission.form_answers.find_or_initialize_by(form_field: agency_field)
+      answer.update!(submitted_answer: value.to_s, question_name_when_answered: agency_field.name)
+    end
+  end
+
+  # Recreate from scratch each run so re-seeding refreshes labels and link state.
+  Person.where("email LIKE ?", "orgchip.demo.%@seed.example.com").find_each(&:destroy)
+
+  # Each scenario => one registrant. :orgs link real orgs (→ chip shows links);
+  # :agency stores a submitted name. A typed name matching an existing org is linked
+  # (as registration does), so "Pending" only shows for names not among the linked
+  # orgs — on its own (case 3) or alongside linked orgs (case 5). "None" = nothing typed.
+  # Case 8 is the stale edge case: a typed name that matches an existing org but was
+  # never linked (e.g. the org was created after the person registered) — it reads as
+  # "Pending", and the editor offers that org as a one-click match to select.
+  scenarios = [
+    { last: "1 Linked one org",       orgs: demo_orgs.first(1) },
+    { last: "2 Linked three orgs",    orgs: demo_orgs.first(3) },
+    { last: "3 Pending no match",     agency: "Riverside Healing Arts Collective (unlisted)" },
+    { last: "4 Matched name auto-linked", orgs: demo_orgs.first(1), agency: matched_org&.name },
+    { last: "5 Mixed linked + pending", orgs: demo_orgs.first(1), agency: "Some Other Unlisted Agency" },
+    { last: "6 None blank typed",     agency: "" },
+    { last: "7 None nothing typed" },
+    { last: "8 Pending matches existing org", agency: matched_org&.name }
+  ]
+
+  scenarios.each_with_index do |scenario, i|
+    person = Person.create!(
+      email: "orgchip.demo.#{i + 1}@seed.example.com",
+      first_name: "Org Demo",
+      last_name: scenario[:last]
+    )
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) do |reg|
+      reg.status = "registered"
+    end
+
+    Array(scenario[:orgs]).each { |org| link_org.call(registration, org) }
+    submit_agency_name.call(registration, scenario[:agency]) if scenario.key?(:agency)
+  end
+end

--- a/db/seeds/dev/payments.rb
+++ b/db/seeds/dev/payments.rb
@@ -225,14 +225,23 @@ record_payment = ->(registration, payer:, amount_cents:, kind: :cash) do
   Allocation.create!(source: payment, allocatable: registration, amount: amount_cents, created_at: created_at)
 end
 
-# Funds a registration once. `scholarship` and `payments` describe what to build.
-fund_registration = ->(event, person, scholarship: nil, payments: []) do
+# Applies a discount to a registration — a Discount-sourced allocation that
+# reduces the amount owed (drives the "Discounted $X due" / "Nothing owed" chip).
+record_discount = ->(registration, amount_cents:) do
+  created_at = rand(3..30).days.ago
+  discount = Discount.create!(amount_cents: amount_cents)
+  Allocation.create!(source: discount, allocatable: registration, amount: amount_cents, created_at: created_at)
+end
+
+# Funds a registration once. `scholarship`, `discount`, and `payments` describe what to build.
+fund_registration = ->(event, person, scholarship: nil, discount: nil, payments: []) do
   return unless event && person
   registration = EventRegistration.find_by(event: event, registrant: person)
   return unless registration
   return if registration.allocations.exists?
 
   award_scholarship.(registration, **scholarship) if scholarship
+  record_discount.(registration, **discount) if discount
   payments.each { |payment| record_payment.(registration, **payment) }
 end
 
@@ -268,14 +277,13 @@ fund_registration.(trauma_training, angel_g,
 fund_registration.(mindful_art, amy_person,
   payments: [ { payer: amy_person, amount_cents: 5_000, kind: :cash } ])
 
-# --- AWBW Facilitator Training ($1,500): registrants with MORE THAN ONE payment ---
-# The scenarios above all fund a registration with a single payment. These four
-# brand-new people each have two or more payment records (some also carrying a
-# completed scholarship), split across paid-in-full and still-owing, so the
-# registrants payment-status column ("Paid" vs "Partial · $X due") can be
-# exercised against multi-payment registrations. Amounts target the event's real
-# $1,500 cost so the paid-in-full / partial split is genuine.
-register_with_payments = ->(event, first_name:, last_name:, email:, scholarship: nil, payments: []) do
+# --- AWBW Facilitator Training ($1,500): discount + multi-payment chip states ---
+# Getting more than one payment from a single registrant is rare, so only Nina
+# keeps that shape (it still exercises multi-payment allocations). The rest are
+# single-payment, and three carry a Discount so the payment-status column shows
+# the "Discounted $X due" / fully-discounted "Nothing owed" chips. Amounts target
+# the event's real $1,500 cost.
+register_with_payments = ->(event, first_name:, last_name:, email:, scholarship: nil, discount: nil, payments: []) do
   return unless event
   person = Person.find_or_create_by!(email: email) do |p|
     p.first_name = first_name
@@ -285,40 +293,42 @@ register_with_payments = ->(event, first_name:, last_name:, email:, scholarship:
   return registration if registration.allocations.exists?
 
   award_scholarship.(registration, **scholarship) if scholarship
+  record_discount.(registration, **discount) if discount
   payments.each { |payment| record_payment.(registration, **{ payer: person }.merge(payment)) }
   registration
 end
 
-# Nina: paid in full via two payments (cash $1,000 + check $500)
+# Recreate the demo registrants from scratch each run so re-seeding refreshes
+# their scenarios (e.g. when the set of multipay/discount examples changes).
+# Drop their registrations (cascades the allocations) and payments before the
+# person, since payments reference the person without a destroy cascade.
+Person.where("email LIKE ? OR email LIKE ?",
+  "%.multipay@seed.example.com", "%.discount@seed.example.com").find_each do |demo_person|
+  demo_person.event_registrations.destroy_all
+  Payment.where(person: demo_person).destroy_all
+  demo_person.destroy
+end
+
+# Nina: the one multi-payment registrant — paid in full via cash $1,000 + check $500
 register_with_payments.(facilitator_training,
   first_name: "Nina", last_name: "Multipay", email: "nina.multipay@seed.example.com",
   payments: [
     { amount_cents: 100_000, kind: :cash },
     { amount_cents: 50_000, kind: :check }
   ])
-# Omar: paid in full via completed scholarship ($500) + two cash payments ($600 + $400)
+# Dana: $300 discount, no payment → still owes $1,200 ("Discounted $1200.00 due")
 register_with_payments.(facilitator_training,
-  first_name: "Omar", last_name: "Multipay", email: "omar.multipay@seed.example.com",
-  scholarship: { amount_cents: 50_000, tasks_completed: true },
-  payments: [
-    { amount_cents: 60_000, kind: :cash },
-    { amount_cents: 40_000, kind: :cash }
-  ])
-# Priya: still owes — two cash payments ($500 + $400) of the $1,500 cost
+  first_name: "Dana", last_name: "Discount", email: "dana.discount@seed.example.com",
+  discount: { amount_cents: 30_000 })
+# Dexter: fully discounted ($1,500) → "Nothing owed"
 register_with_payments.(facilitator_training,
-  first_name: "Priya", last_name: "Multipay", email: "priya.multipay@seed.example.com",
-  payments: [
-    { amount_cents: 50_000, kind: :cash },
-    { amount_cents: 40_000, kind: :cash }
-  ])
-# Quincy: still owes — completed scholarship ($300) + cash $400 + check $200 of the $1,500 cost
+  first_name: "Dexter", last_name: "Discount", email: "dexter.discount@seed.example.com",
+  discount: { amount_cents: 150_000 })
+# Delia: $500 discount + single $200 cash payment → still owes $800 ("Discounted $800.00 due")
 register_with_payments.(facilitator_training,
-  first_name: "Quincy", last_name: "Multipay", email: "quincy.multipay@seed.example.com",
-  scholarship: { amount_cents: 30_000, tasks_completed: true },
-  payments: [
-    { amount_cents: 40_000, kind: :cash },
-    { amount_cents: 20_000, kind: :check }
-  ])
+  first_name: "Delia", last_name: "Discount", email: "delia.discount@seed.example.com",
+  discount: { amount_cents: 50_000 },
+  payments: [ { amount_cents: 20_000, kind: :cash } ])
 
 [ facilitator_training, trauma_training, mindful_art ].compact.each do |event|
   dashboard = EventDashboard.new(event)

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -349,6 +349,25 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#discounted?" do
+    let(:event) { create(:event, cost_cents: 1000) }
+    let(:user) { create(:user, :with_person) }
+
+    it "returns true when a discount allocation exists" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      discount = Discount.create!(amount_cents: 400)
+      create(:allocation, source: discount, allocatable: reg, amount: 400)
+      expect(reg).to be_discounted
+    end
+
+    it "returns false when only a payment covers part of the cost" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      payment = create(:payment, person: user.person, amount_cents: 400, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 400)
+      expect(reg).not_to be_discounted
+    end
+  end
+
   describe '.search_by_params' do
     let(:person_alice) { create(:person, first_name: 'Alice', last_name: 'Smith') }
     let(:person_bob) { create(:person, first_name: 'Bob', last_name: 'Jones') }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Organization do
     # expect(build(:organization)).to be_valid
   end
 
+  describe "#city_state" do
+    it "joins locality and state with a comma" do
+      org = create(:organization)
+      org.addresses.destroy_all
+      create(:address, addressable: org, locality: "Los Angeles", state: "CA")
+
+      expect(org.reload.city_state).to eq("Los Angeles, CA")
+    end
+
+    it "omits the comma when there is no locality or state" do
+      org = create(:organization)
+      org.addresses.destroy_all
+
+      expect(org.reload.city_state).to eq("")
+    end
+  end
+
   describe '#facilitator_status' do
     let(:organization) { create(:organization) }
     let(:current) do

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Affiliations", type: :request do
+  let(:admin) { create(:user, :with_person, super_user: true) }
+  let(:organization) { create(:organization) }
+  let(:person) { create(:person) }
+  let(:event) { create(:event) }
+  let!(:registration) { create(:event_registration, event: event, registrant: person) }
+  let!(:affiliation) { create(:affiliation, person: person, organization: organization, title: "Counselor") }
+
+  describe "PATCH /affiliations/:id" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "updates the affiliation title and returns to the org-link editor" do
+        patch affiliation_path(affiliation),
+          params: { affiliation: { title: "Director" }, event_registration_id: registration.id, return_to: "registrants" }
+
+        expect(affiliation.reload.title).to eq("Director")
+        expect(response).to redirect_to(link_organization_event_registration_path(registration, return_to: "registrants"))
+      end
+    end
+
+    context "as a regular user" do
+      before { sign_in create(:user, :with_person) }
+
+      it "is not authorized" do
+        patch affiliation_path(affiliation), params: { affiliation: { title: "Director" } }
+
+        expect(affiliation.reload.title).to eq("Counselor")
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "EventRegistrations", type: :request do
           "Registered",
           "No",
           "No",
-          "Not paid in full",
+          "Monies due",
           ""
         ]
         expect(data_rows).to include(expected_row)

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -300,66 +300,90 @@ RSpec.describe "EventRegistrations", type: :request do
           create(:event_registration_organization, event_registration: existing_registration, organization: organization)
         end
 
-        # Records the position/title the registrant "typed on the form" so the
-        # editor can compare it to the title on an existing affiliation.
-        def submit_position(value)
+        # Records what the registrant "typed on the form" so the editor can show
+        # the submission and compare its position to an existing affiliation title.
+        def submit_form(org_name: nil, position: nil)
           reg_form = Form.find_by(name: "Reg form") || create(:form, name: "Reg form")
-          field = reg_form.form_fields.find_by(field_identifier: "agency_position") ||
-            create(:form_field, form: reg_form, field_identifier: "agency_position")
           create(:event_form, :registration, event: event, form: reg_form) unless event.registration_form
           submission = create(:form_submission, person: regular_user.person, form: reg_form)
-          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+          {  "agency_name" => org_name, "agency_position" => position }.each do |identifier, value|
+            next if value.nil?
+            field = reg_form.form_fields.find_by(field_identifier: identifier) ||
+              create(:form_field, form: reg_form, field_identifier: identifier)
+            create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+          end
+          submission
         end
 
-        it "shows 'No affiliation on record' when the org is linked but the person has none" do
+        it "shows 'No affiliations on record' when the person has none" do
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("No affiliation on record")
+          expect(response.body).to include("No affiliations on record")
         end
 
-        it "shows the recorded title and no-facilitator state for a non-facilitator affiliation" do
+        it "lists an affiliation with its title and active status" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("On record: Counselor")
-          expect(response.body).to include("No facilitator affiliation")
+          expect(response.body).to include("Counselor")
+          expect(response.body).to include("active")
         end
 
-        it "shows 'Title matches form' when the affiliation title equals the submitted position" do
-          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
-          submit_position("Counselor")
-
-          get link_organization_event_registration_path(existing_registration)
-
-          expect(response.body).to include("Title matches form: Counselor")
-        end
-
-        it "shows 'Title differs' when the affiliation title differs from the submitted position" do
-          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
-          submit_position("Director")
-
-          get link_organization_event_registration_path(existing_registration)
-
-          expect(response.body).to include("Title differs")
-          expect(response.body).to include("Director")
-        end
-
-        it "shows 'Facilitator: active' for an active facilitator affiliation" do
+        it "shows 'Facilitator' active for an active facilitator affiliation" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Facilitator")
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Facilitator: active")
+          expect(response.body).to include("Facilitator")
+          expect(response.body).to include("active")
         end
 
-        it "shows 'Facilitator: inactive' for an ended facilitator affiliation" do
+        it "shows a facilitator affiliation as inactive once it has ended" do
           create(:affiliation, person: regular_user.person, organization: organization,
                                title: "Facilitator", end_date: 1.month.ago.to_date)
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Facilitator: inactive")
+          expect(response.body).to include("Facilitator")
+          expect(response.body).to include("inactive")
+        end
+
+        it "shows 'Title matches form' when the affiliation title equals the submitted position for the submitted org" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+          submit_form(org_name: organization.name, position: "Counselor")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Title matches form")
+        end
+
+        it "shows 'Title differs from form' when the affiliation title differs from the submitted position" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+          submit_form(org_name: organization.name, position: "Director")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Title differs from form")
+          expect(response.body).to include("Director")
+        end
+
+        it "renders the submitted form values" do
+          submit_form(org_name: "Typed Agency", position: "Volunteer")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Typed Agency")
+          expect(response.body).to include("Volunteer")
+        end
+
+        it "links the registration form submission to the public form view" do
+          submit_form(org_name: "Typed Agency")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("registration form submission")
+          expect(response.body).to include(event_public_registration_path(event, reg: existing_registration.slug))
         end
       end
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -315,6 +315,12 @@ RSpec.describe "EventRegistrations", type: :request do
           submission
         end
 
+        # Whether the <details> section whose text contains `heading` is expanded.
+        def details_open?(body, heading)
+          element = Nokogiri::HTML(body).css("details").find { |d| d.text.include?(heading) }
+          element&.key?("open")
+        end
+
         it "shows 'No other affiliations on record' when the person has none" do
           get link_organization_event_registration_path(existing_registration)
 
@@ -436,6 +442,44 @@ RSpec.describe "EventRegistrations", type: :request do
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).not_to include(create_organization_event_registration_path(existing_registration))
+        end
+
+        context "section collapse state" do
+          it "expands the form submission section when nothing was submitted" do
+            get link_organization_event_registration_path(existing_registration)
+
+            expect(details_open?(response.body, "Registration form submission")).to be true
+          end
+
+          it "expands the form submission section when the submitted org has no match" do
+            submit_form(org_name: "Nonexistent Agency XYZ")
+
+            get link_organization_event_registration_path(existing_registration)
+
+            expect(details_open?(response.body, "Registration form submission")).to be true
+          end
+
+          it "collapses the form submission section when the submitted org already exists" do
+            submit_form(org_name: organization.name)
+
+            get link_organization_event_registration_path(existing_registration)
+
+            expect(details_open?(response.body, "Registration form submission")).to be false
+          end
+
+          it "expands the other-affiliations section when there are none" do
+            get link_organization_event_registration_path(existing_registration)
+
+            expect(details_open?(response.body, "other affiliations")).to be true
+          end
+
+          it "collapses the other-affiliations section when the person has other affiliations" do
+            create(:affiliation, person: regular_user.person, organization: create(:organization, name: "Unlinked Co"), title: "Member")
+
+            get link_organization_event_registration_path(existing_registration)
+
+            expect(details_open?(response.body, "other affiliations")).to be false
+          end
         end
       end
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "EventRegistrations", type: :request do
           "Registered",
           "No",
           "No",
-          "Monies due",
+          "Due",
           ""
         ]
         expect(data_rows).to include(expected_row)
@@ -525,6 +525,16 @@ RSpec.describe "EventRegistrations", type: :request do
           }.not_to change(Organization, :count)
 
           expect(existing_registration.organizations).to include(existing)
+        end
+
+        it "does nothing when no organization name was submitted" do
+          expect {
+            post create_organization_event_registration_path(existing_registration)
+          }.not_to change(Organization, :count)
+
+          expect(existing_registration.organizations).to be_empty
+          expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+          expect(flash[:alert]).to be_present
         end
       end
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -346,11 +346,11 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include('name="affiliation[title]"')
         end
 
-        it "links 'View profile' to the org profile affiliations anchor in a new tab" do
+        it "links 'View profile affiliations' to the registrant profile affiliations anchor" do
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("View profile")
-          expect(response.body).to include("#{organization_path(organization)}#affiliations")
+          expect(response.body).to include("View profile affiliations")
+          expect(response.body).to include("#{person_path(regular_user.person)}#affiliations")
         end
 
         it "lists affiliations for non-linked orgs under the registrant's other affiliations" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -327,7 +327,30 @@ RSpec.describe "EventRegistrations", type: :request do
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).to include("Counselor")
-          expect(response.body).to include("active")
+          expect(response.body).not_to include("Counselor — inactive")
+        end
+
+        it "renders an inline editable title field for a non-facilitator affiliation" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include('name="affiliation[title]"')
+        end
+
+        it "does not render an editable field for a Facilitator affiliation" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Facilitator")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).not_to include('name="affiliation[title]"')
+        end
+
+        it "links 'View profile' to the org profile affiliations anchor in a new tab" do
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("View profile")
+          expect(response.body).to include("#{organization_path(organization)}#affiliations")
         end
 
         it "lists affiliations for non-linked orgs under the registrant's other affiliations" do
@@ -342,13 +365,13 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).to include("Board Member")
         end
 
-        it "shows 'Facilitator' active for an active facilitator affiliation" do
+        it "shows 'Facilitator' for an active facilitator affiliation" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Facilitator")
 
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).to include("Facilitator")
-          expect(response.body).to include("active")
+          expect(response.body).not_to include("Facilitator — inactive")
         end
 
         it "shows a facilitator affiliation as inactive once it has ended" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -315,19 +315,31 @@ RSpec.describe "EventRegistrations", type: :request do
           submission
         end
 
-        it "shows 'No affiliations on record' when the person has none" do
+        it "shows 'No other affiliations on record' when the person has none" do
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("No affiliations on record")
+          expect(response.body).to include("No other affiliations on record")
         end
 
-        it "lists an affiliation with its title and active status" do
+        it "shows the affiliation pill inline on the linked org" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
 
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).to include("Counselor")
           expect(response.body).to include("active")
+        end
+
+        it "lists affiliations for non-linked orgs under the registrant's other affiliations" do
+          other_org = create(:organization, name: "Unlinked Org Co")
+          create(:affiliation, person: regular_user.person, organization: other_org, title: "Board Member")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("other affiliations")
+          expect(response.body).to include(regular_user.person.first_name)
+          expect(response.body).to include("Unlinked Org Co")
+          expect(response.body).to include("Board Member")
         end
 
         it "shows 'Facilitator' active for an active facilitator affiliation" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -420,6 +420,23 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).to include("registration form submission")
           expect(response.body).to include(event_public_registration_path(event, reg: existing_registration.slug))
         end
+
+        it "shows 'Create org & link' when the submitted org has no existing match" do
+          submit_form(org_name: "Brand New Unlisted Org")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include(create_organization_event_registration_path(existing_registration))
+        end
+
+        it "hides 'Create org & link' when an org with the submitted name already exists" do
+          create(:organization, name: "Already Exists Org")
+          submit_form(org_name: "Already Exists Org")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).not_to include(create_organization_event_registration_path(existing_registration))
+        end
       end
 
       describe "POST /event_registrations/:id/select_organization" do
@@ -449,6 +466,21 @@ RSpec.describe "EventRegistrations", type: :request do
 
           expect(existing_registration.organizations.pluck(:name)).to include("Brand New Org")
           expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+        end
+
+        it "links an existing org instead of creating a duplicate" do
+          existing = create(:organization, name: "Existing Org")
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Existing Org")
+
+          expect {
+            post create_organization_event_registration_path(existing_registration)
+          }.not_to change(Organization, :count)
+
+          expect(existing_registration.organizations).to include(existing)
         end
       end
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe "EventRegistrations", type: :request do
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).to include("View profile affiliations")
-          expect(response.body).to include("#{person_path(regular_user.person)}#affiliations")
+          expect(response.body).to include("#{edit_person_path(regular_user.person)}#affiliations")
         end
 
         it "lists affiliations for non-linked orgs under the registrant's other affiliations" do
@@ -384,13 +384,13 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).to include("inactive")
         end
 
-        it "shows 'Title matches form' when the affiliation title equals the submitted position for the submitted org" do
+        it "does not show a title-comparison badge when the affiliation title matches the submitted position" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
           submit_form(org_name: organization.name, position: "Counselor")
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Title matches form")
+          expect(response.body).not_to include("Title differs from form")
         end
 
         it "shows 'Title differs from form' when the affiliation title differs from the submitted position" do
@@ -430,6 +430,24 @@ RSpec.describe "EventRegistrations", type: :request do
           }.to change { existing_registration.organizations.count }.by(1)
             .and change { regular_user.person.organizations.count }.by(1)
 
+          expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+        end
+      end
+
+      describe "POST /event_registrations/:id/create_organization" do
+        it "creates an org from the submitted name and links it" do
+          create(:organization_status, name: "Active")
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Brand New Org")
+
+          expect {
+            post create_organization_event_registration_path(existing_registration)
+          }.to change(Organization, :count).by(1)
+
+          expect(existing_registration.organizations.pluck(:name)).to include("Brand New Org")
           expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
         end
       end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -295,6 +295,74 @@ RSpec.describe "EventRegistrations", type: :request do
     describe "organization linking" do
       let(:organization) { create(:organization, name: "Helping Hands") }
 
+      describe "GET /event_registrations/:id/link_organization" do
+        before do
+          create(:event_registration_organization, event_registration: existing_registration, organization: organization)
+        end
+
+        # Records the position/title the registrant "typed on the form" so the
+        # editor can compare it to the title on an existing affiliation.
+        def submit_position(value)
+          reg_form = Form.find_by(name: "Reg form") || create(:form, name: "Reg form")
+          field = reg_form.form_fields.find_by(field_identifier: "agency_position") ||
+            create(:form_field, form: reg_form, field_identifier: "agency_position")
+          create(:event_form, :registration, event: event, form: reg_form) unless event.registration_form
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+        end
+
+        it "shows 'No affiliation on record' when the org is linked but the person has none" do
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("No affiliation on record")
+        end
+
+        it "shows the recorded title and no-facilitator state for a non-facilitator affiliation" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("On record: Counselor")
+          expect(response.body).to include("No facilitator affiliation")
+        end
+
+        it "shows 'Title matches form' when the affiliation title equals the submitted position" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+          submit_position("Counselor")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Title matches form: Counselor")
+        end
+
+        it "shows 'Title differs' when the affiliation title differs from the submitted position" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
+          submit_position("Director")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Title differs")
+          expect(response.body).to include("Director")
+        end
+
+        it "shows 'Facilitator: active' for an active facilitator affiliation" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Facilitator")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Facilitator: active")
+        end
+
+        it "shows 'Facilitator: inactive' for an ended facilitator affiliation" do
+          create(:affiliation, person: regular_user.person, organization: organization,
+                               title: "Facilitator", end_date: 1.month.ago.to_date)
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Facilitator: inactive")
+        end
+      end
+
       describe "POST /event_registrations/:id/select_organization" do
         it "links the org to the registration and the person, then returns to the edit page" do
           expect {

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -291,6 +291,39 @@ RSpec.describe "EventRegistrations", type: :request do
         }.to change(EventRegistration, :count).by(-1)
       end
     end
+
+    describe "organization linking" do
+      let(:organization) { create(:organization, name: "Helping Hands") }
+
+      describe "POST /event_registrations/:id/select_organization" do
+        it "links the org to the registration and the person, then returns to the edit page" do
+          expect {
+            post select_organization_event_registration_path(existing_registration),
+              params: { organization_id: organization.id }
+          }.to change { existing_registration.organizations.count }.by(1)
+            .and change { regular_user.person.organizations.count }.by(1)
+
+          expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+        end
+      end
+
+      describe "DELETE /event_registrations/:id/unlink_organization" do
+        before do
+          create(:event_registration_organization, event_registration: existing_registration, organization: organization)
+          create(:affiliation, person: regular_user.person, organization: organization)
+        end
+
+        it "removes only the registration link, leaving the person's affiliation intact" do
+          expect {
+            delete unlink_organization_event_registration_path(existing_registration),
+              params: { organization_id: organization.id }
+          }.to change { existing_registration.organizations.count }.by(-1)
+
+          expect(regular_user.person.affiliations.where(organization: organization)).to exist
+          expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+        end
+      end
+    end
   end
 
   # ============================================================

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -574,14 +574,14 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Partial")
       end
 
-      it "shows Nothing owed when paid in full" do
+      it "shows Paid when paid in full" do
         payment = create(:payment, person: person, amount_cents: 1000, amount_cents_remaining: nil)
         create(:allocation, source: payment, allocatable: registration, amount: 1000)
 
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-check")
-        expect(response.body).to include(">Nothing owed</span>")
+        expect(response.body).to include(">Paid</span>")
       end
 
       it "shows a Discounted chip when a discount leaves a balance due" do
@@ -595,13 +595,13 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("$6.00 due")
       end
 
-      it "shows Nothing owed when a discount fully covers the cost" do
+      it "shows Paid when a discount fully covers the cost" do
         discount = Discount.create!(amount_cents: 1000)
         create(:allocation, source: discount, allocatable: registration, amount: 1000)
 
         get registrants_event_path(event)
 
-        expect(response.body).to include(">Nothing owed</span>")
+        expect(response.body).to include(">Paid</span>")
         expect(response.body).not_to include(">Discounted<")
       end
     end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -419,6 +419,17 @@ RSpec.describe "Events", type: :request do
     context "organization column" do
       let(:organization) { create(:organization, name: "Helping Hands") }
 
+      # Stores a submitted "agency_name" answer for the registrant, mirroring what
+      # public registration captures, so the Pending/None chip logic has data.
+      def submit_agency_name(name)
+        registration_form = Form.find_by(name: "Registration") || create(:form, name: "Registration")
+        field = registration_form.form_fields.find_by(field_identifier: "agency_name") ||
+          create(:form_field, form: registration_form, field_identifier: "agency_name")
+        create(:event_form, :registration, event: event, form: registration_form) unless event.registration_form
+        submission = create(:form_submission, person: person, form: registration_form)
+        create(:form_answer, form_submission: submission, form_field: field, submitted_answer: name)
+      end
+
       it "links a linked organization to the edit page rather than its profile" do
         create(:event_registration_organization, event_registration: registration, organization: organization)
 
@@ -429,11 +440,7 @@ RSpec.describe "Events", type: :request do
       end
 
       it "shows a 'Pending' chip when a registrant submitted an org name but has no linked org" do
-        registration_form = create(:form, name: "Registration")
-        field = create(:form_field, form: registration_form, field_identifier: "agency_name")
-        create(:event_form, :registration, event: event, form: registration_form)
-        submission = create(:form_submission, person: person, form: registration_form)
-        create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Some Unlisted Org")
+        submit_agency_name("Some Unlisted Org")
 
         get registrants_event_path(event)
 
@@ -445,6 +452,26 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include(">None<")
+        expect(response.body).not_to include(">Pending<")
+      end
+
+      it "shows the linked org AND a 'Pending' chip when the submitted name is not among the linked orgs" do
+        create(:event_registration_organization, event_registration: registration, organization: organization)
+        submit_agency_name("A Different Unlisted Agency")
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(organization.name)
+        expect(response.body).to include(">Pending<")
+      end
+
+      it "does not show 'Pending' when the submitted name matches a linked org" do
+        create(:event_registration_organization, event_registration: registration, organization: organization)
+        submit_agency_name(organization.name)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(organization.name)
         expect(response.body).not_to include(">Pending<")
       end
     end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -559,7 +559,8 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-half-stroke")
-        expect(response.body).to include("Partial · $6.00 due")
+        expect(response.body).to include("Partial payment")
+        expect(response.body).to include("$6.00 due")
       end
 
       it "does not show the partial badge when only a scholarship covers part of the cost" do
@@ -573,14 +574,35 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Partial")
       end
 
-      it "shows Paid when paid in full" do
+      it "shows Nothing owed when paid in full" do
         payment = create(:payment, person: person, amount_cents: 1000, amount_cents_remaining: nil)
         create(:allocation, source: payment, allocatable: registration, amount: 1000)
 
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-check")
-        expect(response.body).to include(">Paid</span>")
+        expect(response.body).to include(">Nothing owed</span>")
+      end
+
+      it "shows a Discounted chip when a discount leaves a balance due" do
+        discount = Discount.create!(amount_cents: 400)
+        create(:allocation, source: discount, allocatable: registration, amount: 400)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include("fa-tag")
+        expect(response.body).to include(">Discounted<")
+        expect(response.body).to include("$6.00 due")
+      end
+
+      it "shows Nothing owed when a discount fully covers the cost" do
+        discount = Discount.create!(amount_cents: 1000)
+        create(:allocation, source: discount, allocatable: registration, amount: 1000)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(">Nothing owed</span>")
+        expect(response.body).not_to include(">Discounted<")
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -416,6 +416,39 @@ RSpec.describe "Events", type: :request do
       end
     end
 
+    context "organization column" do
+      let(:organization) { create(:organization, name: "Helping Hands") }
+
+      it "links a linked organization to the edit page rather than its profile" do
+        create(:event_registration_organization, event_registration: registration, organization: organization)
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(link_organization_event_registration_path(registration, return_to: "registrants"))
+        expect(response.body).not_to include(organization_path(organization))
+      end
+
+      it "shows a 'Pending' chip when a registrant submitted an org name but has no linked org" do
+        registration_form = create(:form, name: "Registration")
+        field = create(:form_field, form: registration_form, field_identifier: "agency_name")
+        create(:event_form, :registration, event: event, form: registration_form)
+        submission = create(:form_submission, person: person, form: registration_form)
+        create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Some Unlisted Org")
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(">Pending<")
+        expect(response.body).not_to include(">None<")
+      end
+
+      it "shows a 'None' chip when a registrant has no linked org and submitted nothing" do
+        get registrants_event_path(event)
+
+        expect(response.body).to include(">None<")
+        expect(response.body).not_to include(">Pending<")
+      end
+    end
+
     context "event heading" do
       it "shows the event title and date range after the heading" do
         event.update!(start_date: Time.zone.local(2026, 6, 2, 9), end_date: Time.zone.local(2026, 6, 2, 17))


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Give admins a clear way to see and manage a registrant's **organizations and affiliations** from the event registrants roster, and to make the roster's org/payment columns read accurately.
- Surface the distinction between a **registration-scoped org link** and the person's **global affiliation**, and make the common fix-ups (link, unlink, create, retitle) possible without leaving the flow.

### How did you approach the change?
**Registrants roster**
- Organization column: each linked org is a grey pill; empty state is context-aware — grey **None** (nothing submitted) vs amber **Pending** (a typed agency name that isn't linked). Pills/links carry a ↗ jump icon.
- Payment column: renamed paid-in-full chip to **"Paid"**, added a purple **"Discounted $X due"** chip (discount wins over partial), two-line **"Partial payment"**; the payment filter and CSV exports now read **"Due" / "Paid"**. (Short single-word labels are far more scannable than "Monies due"/"Nothing owed", which also overclaimed — a $0 balance is often a comp/scholarship/waiver, not an actual payment, but the rare cases don't justify a longer label.)

**Link Organization editor** (`/event_registrations/:id/link_organization`)
- Sections: **Registration-linked organizations** (with Remove + nested "Add an organization" search), **Registration form submission**, and the registrant's **other affiliations**.
- `unlink_organization` removes only the registration↔org link (the global `Affiliation` is left intact); `select_organization` and `create_organization` keep you on the editor.
- **Create org & link** builds an org from the submitted agency name and links it in one step — only shown when no org with that name exists (reuses an existing match instead of duplicating).
- Affiliation pills show title + Facilitator active/inactive and "Title differs from form"; **non-Facilitator titles are editable inline** (Turbo Frame, no full page reload).
- Form-submission and other-affiliations sections are collapsible (`<details>`), auto-expanding when they need attention (unresolved submitted org / no other affiliations). "View profile affiliations" opens the registrant's edit page at its affiliations anchor.

**Data/model**
- `EventRegistration#discounted?`; `Organization#city_state` no longer emits a stray comma; `AffiliationsController#update` (admin-only) for inline title edits.
- Dev seeds: rare multi-payment + discount scenarios, and labeled demo registrants on event 1 covering every chip/affiliation state.

### UI Testing Checklist
- [ ] Roster org column shows None/Pending/linked pills correctly; payment column shows Paid / Partial payment / Discounted / $X due.
- [ ] Editor: link, unlink (affiliation persists), create-org-and-link (hidden when the org exists), inline title edit saves without a page reload.
- [ ] Collapsible sections expand/collapse as described; "View profile affiliations" opens the person edit page at the affiliations section.
- [ ] CSV export shows "Paid" / "Due".

### Anything else to add?
- Remove intentionally keeps the person's global affiliation (per product decision); discount intentionally takes precedence over partial payment in the chip.
- Specs are request/model only (no system specs) and cover the chips, discount, affiliation states, inline edit, create-org gating (including the blank-name guard), and collapse/expand states.
