### PR TITLE
Tidy allocations index action column

### DIFF
--- a/app/views/allocations/allocation_results.html.erb
+++ b/app/views/allocations/allocation_results.html.erb
@@ -80,7 +80,7 @@
 
                 <td class="px-4 py-2 text-sm text-gray-500 text-nowrap"><%= allocation.created_at.strftime("%B %d, %Y") %></td>
 
-                <td class="px-4 py-2 text-right text-sm font-medium">
+                <td class="px-4 py-2 text-left text-sm font-medium">
                   <% link_class = "inline-flex items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 cursor-pointer" %>
                   <% if allocation.source.respond_to?(:payer) %>
                     <%= link_to payment_path(allocation.source), data: { turbo_frame: "_top" }, class: link_class do %>
@@ -89,10 +89,10 @@
                     <% end %>
                   <% elsif allocation.source.is_a?(Discount) %>
                     <%= button_to discount_path(allocation.source), method: :delete,
-                          class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 cursor-pointer",
+                          class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700 cursor-pointer",
                           data: { turbo_confirm: "Remove this discount?", turbo_frame: "_top" } do %>
                       <i class="fa-solid fa-trash-can text-[0.7rem]"></i>
-                      Remove
+                      Remove discount
                     <% end %>
                   <% else %>
                     <%= link_to edit_scholarship_path(allocation.source), data: { turbo_frame: "_top" }, class: link_class do %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

Small polish to the **all allocations** index table so the action column reads more naturally:

- The action links sat right-aligned, visually detached from the rest of the row data.
- The discount **Remove** button defaulted to red, reading as a destructive warning even at rest.

### How did you approach the change?

In `app/views/allocations/allocation_results.html.erb`:

- Left-aligned the action column (`text-right` → `text-left`) so View/Remove links group with the row.
- Discount removal is now grey by default (`text-gray-600`) and only turns red on hover.
- Relabeled the button **Remove discount** so its target is unambiguous.

### UI Testing Checklist

- [ ] Visit the all-allocations index and confirm action links are left-aligned.
- [ ] Confirm the discount "Remove discount" button is grey at rest and red on hover.
- [ ] Confirm removing a discount still works.

### Anything else to add?

View-only change; no logic or behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)