### PR TITLE
Anchor pre-commit conflict-marker check to avoid false positives

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -13,7 +13,7 @@ fi
 
 # Check for merge conflict markers
 if [ -n "$staged_files" ]; then
-  if echo "$staged_files" | xargs grep -n '<<<<<<<\|>>>>>>>\|=======' 2>/dev/null; then
+  if echo "$staged_files" | xargs grep -nE '^(<<<<<<<|=======|>>>>>>>)( |$)' 2>/dev/null; then
     echo "ERROR: Merge conflict markers found in staged files. Resolve them before committing."
     exit 1
   fi


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The `bin/pre-commit` merge-conflict-marker check used a substring `grep` that flagged any line containing 7+ equals signs.
- Long `=====` comment dividers (common in code) tripped it and blocked legitimate commits, forcing a manual `--no-verify` bypass.

### How did you approach the change?
- Switched to an anchored `grep -E '^(<<<<<<<|=======|>>>>>>>)( |$)'` so a marker only matches at the start of a line, followed by a space or end-of-line.
- Real conflict markers (`=======`, `<<<<<<< HEAD`, `>>>>>>> branch`) are still caught; comment dividers and `#`-prefixed lines are ignored.

### UI Testing Checklist
- N/A — tooling-only change, no UI impact.

### Anything else to add?
- Verified the new pattern against a fixture of real markers vs. dividers; only the genuine markers matched.