### PR TITLE
Add default max-characters safety net for free-form answers

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -1,3 +1,12 @@
+# `submitted_answer` is stored verbatim — exactly what the applicant typed — so
+# their words are never silently altered (e.g. "revenue < $5k" or "C++ <T>"
+# survive intact). It is NOT HTML-sanitized on write.
+#
+# Safety is enforced at render time instead: every place that displays an answer
+# uses plain `<%= %>`, which auto-escapes, so any markup shows as inert text.
+# Do NOT render a submitted_answer through `raw`, `html_safe`, `<%==`, or
+# `simple_format` — that would reintroduce an XSS hole. Volume abuse (giant
+# answers) is bounded separately by FormField's effective max-characters cap.
 class FormAnswer < ApplicationRecord
   belongs_to :form_field, optional: true
   belongs_to :form_submission

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -11,6 +11,16 @@ class FormField < ApplicationRecord
   # Answer types that collect free-form text, where a minimum word count applies
   FREE_FORM_TEXT_TYPES = %w[free_form_input_one_line free_form_input_paragraph].freeze
 
+  # Fallback character ceilings applied when a free-form field has no explicit
+  # max_characters set. This is a safety net against pathological submissions
+  # (megabyte answers that bloat the DB and break admin/email rendering), not a
+  # UX limit — the values are far above any realistic answer, and an explicit
+  # per-field max_characters always wins, including when it is larger.
+  DEFAULT_MAX_CHARACTERS = {
+    "free_form_input_one_line" => 1_000,
+    "free_form_input_paragraph" => 10_000
+  }.freeze
+
   # Validations
   validates_presence_of :name
   # Keeps an over-long name as a friendly validation error instead of a
@@ -136,15 +146,24 @@ class FormField < ApplicationRecord
     "must be at least #{min_words} #{"word".pluralize(min_words)}"
   end
 
-  # Returns a validation error string when a submitted value exceeds the
-  # configured maximum character count, or nil when it passes / does not apply.
-  def max_characters_error(value)
+  # The character ceiling actually enforced for this field: the explicit
+  # max_characters when set, otherwise the per-type default safety net. Returns
+  # nil for non-free-form fields (no cap applies).
+  def effective_max_characters
     return unless free_form_text?
-    return unless max_characters.to_i.positive?
-    return if value.blank?
-    return if value.to_s.length <= max_characters
 
-    "must be #{max_characters} #{"character".pluralize(max_characters)} or fewer"
+    max_characters || DEFAULT_MAX_CHARACTERS[answer_type]
+  end
+
+  # Returns a validation error string when a submitted value exceeds the
+  # effective maximum character count, or nil when it passes / does not apply.
+  def max_characters_error(value)
+    limit = effective_max_characters
+    return unless limit
+    return if value.blank?
+    return if value.to_s.length <= limit
+
+    "must be #{limit} #{"character".pluralize(limit)} or fewer"
   end
 
   def html_input_type

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -21,6 +21,11 @@ class FormField < ApplicationRecord
     "free_form_input_paragraph" => 10_000
   }.freeze
 
+  # Rough lower bound on characters a word consumes (average English word length
+  # plus a separating space). Used to flag a max_characters that can't possibly
+  # hold the min_words minimum, which would make the field impossible to submit.
+  MIN_CHARS_PER_WORD = 6
+
   # Validations
   validates_presence_of :name
   # Keeps an over-long name as a friendly validation error instead of a
@@ -28,6 +33,7 @@ class FormField < ApplicationRecord
   validates :name, length: { maximum: 1000 }
   validates :min_words, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :max_characters, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validate :max_characters_allows_min_words
 
   # Enum
   enum :status, [ :inactive, :active ]
@@ -144,6 +150,20 @@ class FormField < ApplicationRecord
     return if word_count(value) >= min_words
 
     "must be at least #{min_words} #{"word".pluralize(min_words)}"
+  end
+
+  # Blocks an admin from saving a free-form field whose explicit max_characters
+  # is too small to ever satisfy its min_words minimum (e.g. 250 words capped at
+  # 1,000 characters) — otherwise the field could never be submitted. Compared
+  # against the explicit max only; the generous default never conflicts.
+  def max_characters_allows_min_words
+    return unless free_form_text?
+    return unless min_words.to_i.positive? && max_characters.to_i.positive?
+
+    required = min_words * MIN_CHARS_PER_WORD
+    return if max_characters >= required
+
+    errors.add(:max_characters, "is too low for a #{min_words}-word minimum (allow at least #{required})")
   end
 
   # The character ceiling actually enforced for this field: the explicit

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -99,7 +99,7 @@
                                 end
                     extra_attrs = []
                     extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
-                    extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
+                    extra_attrs << %(maxlength="#{field.effective_max_characters}") if field.effective_max_characters
                   %>
                   <input type="<%= html_type %>"
                          name="<%= field_name %>"

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -48,7 +48,7 @@
                      end
         extra_attrs = []
         extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
-        extra_attrs << %(maxlength="#{field.max_characters}") if field.max_characters.to_i.positive?
+        extra_attrs << %(maxlength="#{field.effective_max_characters}") if field.effective_max_characters
       %>
       <input type="<%= html_type %>"
              name="<%= field_name %>"
@@ -64,7 +64,7 @@
               id="<%= field_id %>"
               rows="4"
               class="<%= input_classes %>"
-              <%= "maxlength=\"#{field.max_characters}\"".html_safe if field.max_characters.to_i.positive? %>
+              <%= "maxlength=\"#{field.effective_max_characters}\"".html_safe if field.effective_max_characters %>
               <%= "required" if field.required %>><%= value %></textarea>
 
   <% when "single_select_radio" %>

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -239,6 +239,38 @@ RSpec.describe FormField do
     end
   end
 
+  describe "min_words / max_characters consistency" do
+    let(:form) { create(:form) }
+
+    it "rejects a max too small to hold the word minimum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 250, max_characters: 1_000)
+      expect(field).not_to be_valid
+      expect(field.errors[:max_characters]).to include("is too low for a 250-word minimum (allow at least 1500)")
+    end
+
+    it "allows a max with room for the word minimum" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 250, max_characters: 2_000)
+      expect(field).to be_valid
+    end
+
+    it "allows the exact boundary" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 10, max_characters: 60)
+      expect(field).to be_valid
+    end
+
+    it "does not flag when only one of the two is set" do
+      min_only = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 250, max_characters: nil)
+      max_only = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: nil, max_characters: 50)
+      expect(min_only).to be_valid
+      expect(max_only).to be_valid
+    end
+
+    it "does not apply to non-free-form fields" do
+      field = build(:form_field, form: form, answer_type: :single_select_radio, min_words: 250, max_characters: 1)
+      expect(field).to be_valid
+    end
+  end
+
   describe "#selectable?" do
     let(:form) { create(:form) }
 

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -152,12 +152,40 @@ RSpec.describe FormField do
     end
   end
 
+  describe "#effective_max_characters" do
+    let(:form) { create(:form) }
+
+    it "returns the explicit maximum when one is set" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 250)
+      expect(field.effective_max_characters).to eq(250)
+    end
+
+    it "honors an explicit maximum larger than the default" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: 50_000)
+      expect(field.effective_max_characters).to eq(50_000)
+    end
+
+    it "falls back to the per-type default when none is set" do
+      one_line = build(:form_field, form: form, answer_type: :free_form_input_one_line, max_characters: nil)
+      paragraph = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: nil)
+      expect(one_line.effective_max_characters).to eq(FormField::DEFAULT_MAX_CHARACTERS["free_form_input_one_line"])
+      expect(paragraph.effective_max_characters).to eq(FormField::DEFAULT_MAX_CHARACTERS["free_form_input_paragraph"])
+    end
+
+    it "returns nil for non-free-form fields" do
+      field = build(:form_field, form: form, answer_type: :single_select_radio, max_characters: nil)
+      expect(field.effective_max_characters).to be_nil
+    end
+  end
+
   describe "#max_characters_error" do
     let(:form) { create(:form) }
 
-    it "returns nil when no maximum is configured" do
+    it "applies the per-type default safety net when no maximum is configured" do
       field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: nil)
-      expect(field.max_characters_error("a" * 500)).to be_nil
+      default = FormField::DEFAULT_MAX_CHARACTERS["free_form_input_paragraph"]
+      expect(field.max_characters_error("a" * default)).to be_nil
+      expect(field.max_characters_error("a" * (default + 1))).to eq("must be #{default} characters or fewer")
     end
 
     it "returns nil when the value is within the maximum" do

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe FormAnswerValidator do
 
       expect(validate(field, "way too long")).to eq(field.id => "must be 5 characters or fewer")
     end
+
+    it "enforces the default max-characters safety net when none is configured" do
+      field = create(:form_field, form: form, answer_type: :free_form_input_paragraph, max_characters: nil)
+      default = FormField::DEFAULT_MAX_CHARACTERS["free_form_input_paragraph"]
+
+      expect(validate(field, "a" * (default + 1))).to eq(field.id => "must be #{default} characters or fewer")
+    end
   end
 
   describe "skipping" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Free-form answer fields (`free_form_input_one_line`, `free_form_input_paragraph`) with no explicit `max_characters` previously accepted **unbounded** text into a TEXT column.
- A single pathological submission (megabyte answer) could bloat the DB and break admin list / email rendering — there was no client-side `maxlength` either.
- Separately, an admin could configure a `min_words`/`max_characters` pair that no applicant could satisfy.
- This adds a generous per-type **default cap as a silent safety net**, a validation against **contradictory min/max settings**, and documents the answer-escaping strategy — without taking away the ability to have long inputs.

### How did you approach the change?

**Default max-characters safety net**
- Added `FormField::DEFAULT_MAX_CHARACTERS` (1,000 for one-line, 10,000 for paragraph) and an `effective_max_characters` method: explicit `max_characters` when set, otherwise the per-type default, `nil` for non-free-form fields.
- Routed `max_characters_error` through `effective_max_characters` so server-side validation enforces the default when nothing is configured.
- Used `effective_max_characters` for the browser `maxlength` attribute in the registration and bulk-payment forms (silent cap).
- **An explicit per-field `max_characters` always wins, including when larger than the default** — so longer answers stay possible by opting in (e.g. set 50,000). The visible "Maximum of X characters" helper text remains tied to the *explicit* value, keeping the default invisible to normal use.

**Contradictory min/max validation**
- Added a `FormField` validation (fires on form-edit save) that blocks an unsatisfiable pair, e.g. min 250 words capped at 1,000 chars — applicants would hit `maxlength` before reaching the word minimum and could never submit.
- Requires `max_characters >= min_words * 6` (a realistic average word length incl. spacing). Checked against the **explicit** max only; the generous default never conflicts.

**Sanitization**
- Confirmed every place an answer is rendered uses plain `<%= %>` auto-escaping (no `raw`/`html_safe`/`simple_format`), so there is no active XSS exposure. Rather than lossy `strip_tags`-on-write (which would mangle legitimate answers like `revenue < $5k`), documented the escape-on-output strategy on `FormAnswer` as a guardrail against future regressions. Brakeman is clean.

### UI Testing Checklist

- [ ] Registration free-form fields with no configured max stop accepting input at the default cap and reject over-length on submit
- [ ] A field with an explicit `max_characters` larger than the default still allows up to that larger value
- [ ] The "Maximum of X characters" helper text only shows when an explicit max is set
- [ ] Saving a form field with min 250 words and max 1,000 chars is blocked with a clear error

### Anything else to add?

- No DB change — the column default stays `nil` so "blank = use default" admin semantics are preserved; the cap is applied at the validation/render layer.
- Tests: `spec/models/form_field_spec.rb` (effective cap, default error, min/max consistency) and `spec/services/form_answer_validator_spec.rb` (default surfaces on submission). Full suite for touched files green; lint and security clean.