### PR TITLE
Validate selectable answers against the field's offered options

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -165,27 +165,19 @@ module ApplicationHelper
     "h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"
   end
 
-  # Category types backing the professional form fields whose options are
-  # sourced dynamically (from Sector/Category data) rather than from the
-  # field's own stored answer options.
-  DYNAMIC_FIELD_CATEGORY_TYPES = {
-    "workshop_environments" => "WorkshopEnvironment",
-    "client_life_experiences" => "StoryPopulation",
-    "primary_age_group" => "AgeRange"
-  }.freeze
-
   # Returns the selectable options for a form field as [ label, value, description ]
   # tuples (description is nil for sectors and present only for categories that have
   # one), or nil when the field has no dynamic source (callers fall back to the
   # field's own stored answer options). Shared by the public form's radio and
   # checkbox rendering so a dynamic field renders the same options regardless
-  # of which single/multiple choice type it was set to.
+  # of which single/multiple choice type it was set to. The set of valid submission
+  # values for these is mirrored by FormField#allowed_answer_values.
   def dynamic_form_field_options(field)
     case field.field_identifier
-    when "primary_service_area", "primary_service_area_single"
+    when *FormField::SERVICE_AREA_FIELD_IDENTIFIERS
       Sector.published.order(:name).map { |sector| [ sector.name, sector.id.to_s ] }
-    when *DYNAMIC_FIELD_CATEGORY_TYPES.keys
-      type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
+    when *FormField::DYNAMIC_FIELD_CATEGORY_TYPES.keys
+      type = CategoryType.find_by(name: FormField::DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
       (type&.categories&.published&.order(:position, :name) || []).map { |category| [ category.name, category.id.to_s, category.description ] }
     end
   end
@@ -194,9 +186,9 @@ module ApplicationHelper
   # editor badge: a sentence-case label and a link to the filtered admin list
   # that manages those options. Returns nil for fields with stored options.
   def form_field_option_source(field)
-    if field.field_identifier.in?(%w[primary_service_area primary_service_area_single])
+    if field.field_identifier.in?(FormField::SERVICE_AREA_FIELD_IDENTIFIERS)
       { label: "Sectors", path: sectors_path }
-    elsif (type_name = DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
+    elsif (type_name = FormField::DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
       type = CategoryType.find_by(name: type_name)
       return unless type
       { label: "#{type.name.underscore.humanize} categories", path: categories_path(category_type_id: type.id) }

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -1,6 +1,7 @@
 module EventHelper
   # The special free-text option label that reveals a "please specify" input.
-  OTHER_OPTION_PREFIX = "Other"
+  # Canonical definition lives on FormField (shared with answer validation).
+  OTHER_OPTION_PREFIX = FormField::OTHER_OPTION_PREFIX
 
   # True when an option label is the special free-text "Other" choice.
   def other_option?(label)

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -11,6 +11,24 @@ class FormField < ApplicationRecord
   # Answer types that collect free-form text, where a minimum word count applies
   FREE_FORM_TEXT_TYPES = %w[free_form_input_one_line free_form_input_paragraph].freeze
 
+  # Field identifiers whose selectable options are sourced dynamically from
+  # Sector records rather than the field's own stored answer options. The
+  # submitted value for these is a Sector id (as a string).
+  SERVICE_AREA_FIELD_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
+
+  # Field identifiers whose selectable options are sourced dynamically from a
+  # CategoryType's published categories. The submitted value is a Category id
+  # (as a string). Maps the field identifier to its backing CategoryType name.
+  DYNAMIC_FIELD_CATEGORY_TYPES = {
+    "workshop_environments" => "WorkshopEnvironment",
+    "client_life_experiences" => "StoryPopulation",
+    "primary_age_group" => "AgeRange"
+  }.freeze
+
+  # The special free-text option label that lets a respondent supply their own
+  # value; a chosen "Other" answer is stored as "Other" or "Other: <text>".
+  OTHER_OPTION_PREFIX = "Other"
+
   # Fallback character ceilings applied when a free-form field has no explicit
   # max_characters set. This is a safety net against pathological submissions
   # (megabyte answers that bloat the DB and break admin/email rendering), not a
@@ -184,6 +202,63 @@ class FormField < ApplicationRecord
     return if value.to_s.length <= limit
 
     "must be #{limit} #{"character".pluralize(limit)} or fewer"
+  end
+
+  # True when this field's selectable options come from Sector/Category data
+  # rather than its own stored answer options. Dynamic fields never offer "Other".
+  def dynamic_options?
+    field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS) ||
+      DYNAMIC_FIELD_CATEGORY_TYPES.key?(field_identifier)
+  end
+
+  # The set of values a submission may legitimately contain for this selectable
+  # field — stored option names, or dynamic Sector/Category ids as strings —
+  # exactly mirroring what the public form renders. nil for non-selectable
+  # fields. This is the source of truth for both rendering and validation.
+  def allowed_answer_values
+    return unless selectable?
+
+    values = if field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS)
+      Sector.published.pluck(:id).map(&:to_s)
+    elsif (type_name = DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
+      type = CategoryType.find_by(name: type_name)
+      type ? type.categories.published.pluck(:id).map(&:to_s) : []
+    else
+      answer_options.pluck(:name)
+    end
+
+    values.to_set
+  end
+
+  # True when this field offers the free-text "Other" choice (stored fields only).
+  def other_option?
+    return false if dynamic_options?
+
+    answer_options.any? { |option| option.name.to_s.strip.casecmp?(OTHER_OPTION_PREFIX) }
+  end
+
+  # True when a submitted value is a valid "Other" answer for a field that offers
+  # the "Other" choice: bare "Other" or the "Other: <free text>" form.
+  def other_answer?(value)
+    return false unless other_option?
+
+    value == OTHER_OPTION_PREFIX || value.start_with?("#{OTHER_OPTION_PREFIX}:")
+  end
+
+  # Returns a validation error string when a submitted selectable value is not
+  # one of the field's offered options — guarding against tampered/forged
+  # submissions — or nil when it passes / does not apply. Handles single and
+  # multi-select, and allows "Other" / "Other: <text>" when the field offers it.
+  # Blank values are left to the presence (required) check.
+  def answer_inclusion_error(value)
+    allowed = allowed_answer_values
+    return unless allowed
+
+    submitted = Array(value).map(&:to_s).reject(&:blank?)
+    return if submitted.empty?
+    return if submitted.all? { |v| allowed.include?(v) || other_answer?(v) }
+
+    "has an invalid selection"
   end
 
   def html_input_type

--- a/app/services/form_answer_validator.rb
+++ b/app/services/form_answer_validator.rb
@@ -1,7 +1,9 @@
 # Validates submitted answer values against each form field's configuration:
-# presence (required), integer/email format, and the per-field min-words /
-# max-characters settings. Returns a hash of { field_id => error_message } so
-# results from multiple forms (e.g. registration + scholarship) can be merged.
+# presence (required), integer/email format, the per-field min-words /
+# max-characters settings, and — for selectable fields — that the value is one
+# of the field's offered options (guarding against forged submissions). Returns
+# a hash of { field_id => error_message } so results from multiple forms (e.g.
+# registration + scholarship) can be merged.
 #
 # Group headers are skipped here; any other field-specific exclusions (e.g.
 # bulk payment's nested attendees) are the caller's responsibility — pass only
@@ -39,7 +41,7 @@ class FormAnswerValidator
     elsif field.email_field? && value.to_s !~ EMAIL_FORMAT
       "must be a valid email address"
     else
-      field.min_words_error(value) || field.max_characters_error(value)
+      field.min_words_error(value) || field.max_characters_error(value) || field.answer_inclusion_error(value)
     end
   end
 

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -271,6 +271,78 @@ RSpec.describe FormField do
     end
   end
 
+  describe "#answer_inclusion_error" do
+    let(:form) { create(:form) }
+
+    def selectable_field(type:, option_names:)
+      field = create(:form_field, form: form, answer_type: type)
+      option_names.each do |name|
+        create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: name))
+      end
+      field
+    end
+
+    it "returns nil for a value that is one of the offered options" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Red Blue])
+      expect(field.answer_inclusion_error("Red")).to be_nil
+    end
+
+    it "returns an error for a value that was never offered" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Red Blue])
+      expect(field.answer_inclusion_error("Green")).to eq("has an invalid selection")
+    end
+
+    it "leaves blank values to the required check" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Red Blue])
+      expect(field.answer_inclusion_error("")).to be_nil
+      expect(field.answer_inclusion_error(nil)).to be_nil
+    end
+
+    it "validates every value in a multi-select answer" do
+      field = selectable_field(type: :multi_select_checkbox, option_names: %w[Red Blue Green])
+      expect(field.answer_inclusion_error([ "Red", "Blue" ])).to be_nil
+      expect(field.answer_inclusion_error([ "Red", "Purple" ])).to eq("has an invalid selection")
+    end
+
+    it "accepts an Other free-text answer when the field offers Other" do
+      field = selectable_field(type: :single_select_radio, option_names: [ "Red", "Other" ])
+      expect(field.answer_inclusion_error("Other")).to be_nil
+      expect(field.answer_inclusion_error("Other: chartreuse")).to be_nil
+    end
+
+    it "rejects an Other answer when the field does not offer Other" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Red Blue])
+      expect(field.answer_inclusion_error("Other: chartreuse")).to eq("has an invalid selection")
+    end
+
+    it "does not apply to free-form fields" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph)
+      expect(field.answer_inclusion_error("anything at all")).to be_nil
+    end
+
+    context "with dynamically-sourced options" do
+      it "accepts a published Sector id and rejects others for a service-area field" do
+        field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
+        offered = create(:sector, :published)
+        unpublished = create(:sector, :unpublished)
+
+        expect(field.answer_inclusion_error(offered.id.to_s)).to be_nil
+        expect(field.answer_inclusion_error(unpublished.id.to_s)).to eq("has an invalid selection")
+        expect(field.answer_inclusion_error("999999")).to eq("has an invalid selection")
+      end
+
+      it "accepts a published Category id from the backing type for a category field" do
+        type = create(:category_type, name: "WorkshopEnvironment")
+        offered = create(:category, :published, category_type: type)
+        other_type_category = create(:category, :published)
+        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "workshop_environments")
+
+        expect(field.answer_inclusion_error([ offered.id.to_s ])).to be_nil
+        expect(field.answer_inclusion_error([ other_type_category.id.to_s ])).to eq("has an invalid selection")
+      end
+    end
+  end
+
   describe "#selectable?" do
     let(:form) { create(:form) }
 

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -12,9 +12,13 @@ RSpec.describe "Events::BulkPayments", type: :request do
            required: true, min_words: 5)
   end
   let!(:payment_method_field) do
-    create(:form_field, form: form, answer_type: :single_select_radio,
-           field_identifier: "payment_method", name: "Payment method",
-           required: false)
+    field = create(:form_field, form: form, answer_type: :single_select_radio,
+                   field_identifier: "payment_method", name: "Payment method",
+                   required: false)
+    FormBuilderService::PAYMENT_METHOD_OPTIONS.each do |option_name|
+      field.form_field_answer_options.create!(answer_option: AnswerOption.find_or_create_by!(name: option_name))
+    end
+    field
   end
   let!(:payer_first_name_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
@@ -107,7 +111,7 @@ RSpec.describe "Events::BulkPayments", type: :request do
       post event_bulk_payment_path(event),
            params: { bulk_payment: { form_fields: payer_params.merge(
              org_field.id.to_s => "this answer has enough words for validation",
-             payment_method_field.id.to_s => "Pay later"
+             payment_method_field.id.to_s => "Check"
            ) } }
 
       expect(response).to have_http_status(:redirect)

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -109,9 +109,13 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
              name: "Tell us why", required: true, min_words: 5)
     end
     let!(:payment_method_field) do
-      create(:form_field, form: form, answer_type: :single_select_radio,
-             field_identifier: "payment_method", name: "Payment method",
-             required: false)
+      field = create(:form_field, form: form, answer_type: :single_select_radio,
+                     field_identifier: "payment_method", name: "Payment method",
+                     required: false)
+      FormBuilderService::PAYMENT_METHOD_OPTIONS.each do |option_name|
+        field.form_field_answer_options.create!(answer_option: AnswerOption.find_or_create_by!(name: option_name))
+      end
+      field
     end
     let(:fake_session) { double(url: "https://checkout.stripe.com/test", id: "cs_test_123") }
 
@@ -137,7 +141,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       post event_public_registration_path(event),
            params: { public_registration: { form_fields: {
              essay_field.id.to_s => "this answer has enough words for validation",
-             payment_method_field.id.to_s => "Pay later"
+             payment_method_field.id.to_s => "Check"
            } } }
 
       expect(response).to have_http_status(:redirect)

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -98,6 +98,28 @@ RSpec.describe FormAnswerValidator do
     end
   end
 
+  describe "selectable option inclusion" do
+    def radio_field_with_options(*names)
+      field = create(:form_field, form: form, answer_type: :single_select_radio)
+      names.each do |name|
+        create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: name))
+      end
+      field
+    end
+
+    it "passes an offered option" do
+      field = radio_field_with_options("Red", "Blue")
+
+      expect(validate(field, "Red")).to eq({})
+    end
+
+    it "surfaces an error for a value that was never offered" do
+      field = radio_field_with_options("Red", "Blue")
+
+      expect(validate(field, "Green")).to eq(field.id => "has an invalid selection")
+    end
+  end
+
   describe "skipping" do
     it "ignores group header fields entirely" do
       header = create(:form_field, form: form, answer_type: :group_header, required: true)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Follow-up to #1672. Answers to **selectable fields** (radio / dropdown / checkbox) were stored verbatim with **no server-side check** that the value was actually one of the options the form presented.
- A tampered/forged request could submit an arbitrary value — or a **valid-but-unoffered Sector/Category id** — which would be stored and then counted in dashboard analytics and shown to admins, polluting registrant data.
- Not an XSS or auth issue (output is auto-escaped; an attacker can only affect their own registration), but a real **data-integrity** gap. This closes it with a server-side allowlist check.

### How did you approach the change?

- Added `FormField#answer_inclusion_error(value)` (mirroring `min_words_error` / `max_characters_error`) and wired it into `FormAnswerValidator`'s error chain. It rejects any submitted selectable value that isn't one of the field's offered options.
- Handles **single and multi-select**, and still allows **"Other" / "Other: \<text>"** free-text answers when the field offers an Other option.
- **Single source of truth:** to guarantee validation matches exactly what the form *renders* (so it can never reject a legitimate submission), the option-source knowledge is now centralized on `FormField`:
  - Relocated `DYNAMIC_FIELD_CATEGORY_TYPES`, `SERVICE_AREA_FIELD_IDENTIFIERS`, and `OTHER_OPTION_PREFIX` onto the model.
  - Pointed the view helpers (`dynamic_form_field_options`, `form_field_option_source`, `EventHelper`) at the relocated constants.
  - `FormField#allowed_answer_values` derives the valid set the same way the form builds its options (stored option names, or published Sector/Category ids).
- **Strictness decision:** if an option is renamed/removed mid-session, the submission is rejected (strict — favors data correctness; the form re-renders current options on load). Easy to soften later if it proves user-facing.

### UI Testing Checklist

- [ ] Submitting a normal radio/dropdown/checkbox selection still works
- [ ] A forged value (not in the option list) is rejected with "has an invalid selection"
- [ ] An "Other: \<text>" answer still submits on fields that offer Other
- [ ] Dynamic fields (service area, age range, etc.) still render and accept valid selections

### Anything else to add?

- No DB or schema change; validation only.
- Tests: `spec/models/form_field_spec.rb` (`#answer_inclusion_error`, incl. dynamic Sector/Category cases and Other handling) and `spec/services/form_answer_validator_spec.rb` (inclusion surfaces on submission). Full registration request + system specs, helper specs, lint, and Brakeman all green.
- Based on `main` (which already includes #1672); independent of that PR.