### PR TITLE
Jump-link icons on registrant chips + context-aware back links

### DIFF
--- a/app/views/allocations/index.html.erb
+++ b/app/views/allocations/index.html.erb
@@ -5,7 +5,11 @@
       scholarship page (back link, centered title with event/registrant context). ---- %>
   <div class="mx-auto max-w-5xl <%= DomainTheme.bg_class_for(:payments) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-      <% if @allocatable.is_a?(EventRegistration) %>
+      <% if @allocatable.is_a?(EventRegistration) && params[:return_to] == "registrants" %>
+        <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+          <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
+        <% end %>
+      <% elsif @allocatable.is_a?(EventRegistration) %>
         <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registration
         <% end %>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -12,7 +12,7 @@
       <i class="fa-solid fa-dollar-sign"></i>
     </span>
     <h2 class="text-sm font-semibold text-gray-700">Registration allocations</h2>
-    <%= link_to allocations_path(allocatable_sgid: event_registration.to_sgid.to_s),
+    <%= link_to allocations_path(allocatable_sgid: event_registration.to_sgid.to_s, return_to: "registration"),
                 class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline after:absolute after:inset-0 after:content-['']",
                 target: "_blank", rel: "noopener" do %>
       View all

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -136,34 +136,38 @@
                 <td class="px-4 py-2 text-sm text-center">
                   <% if (s = registration.scholarships.first) %>
                     <% if s.tasks_completed? %>
-                      <%= link_to edit_scholarship_path(s),
+                      <%= link_to edit_scholarship_path(s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-green-50 text-green-700 border-green-200 hover:opacity-80",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Completed</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% else %>
-                      <%= link_to edit_scholarship_path(s),
+                      <%= link_to edit_scholarship_path(s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-blue-50 text-blue-700 border-blue-200 hover:opacity-80",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Recipient</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                   <% else %>
                     <% if registration.scholarship_requested? %>
-                      <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s),
+                      <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Requested</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% else %>
-                      <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s),
+                      <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-gray-50 text-gray-400 border-gray-200 hover:opacity-80",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Create</span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                   <% end %>
@@ -190,7 +194,7 @@
                          "fa-circle-exclamation"
                        end %>
 
-                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
+                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
                       <% if is_paid %>
                         <span>Paid</span>
@@ -199,6 +203,7 @@
                       <% else %>
                         <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
                       <% end %>
+                      <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                     <% end %>
                   </td>
                 <% end %>

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -8,9 +8,13 @@
       <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
-    <% elsif @allocatable.respond_to?(:event) %>
+    <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
       <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+      <% end %>
+    <% elsif @allocatable.respond_to?(:event) %>
+      <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% else %>
       <%= link_to scholarships_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>

--- a/spec/requests/allocations_spec.rb
+++ b/spec/requests/allocations_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe "Allocations", type: :request do
 
       expect(response).to have_http_status(:success)
     end
+
+    it "links the back link to the registrants roster when return_to=registrants" do
+      get allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "registrants")
+
+      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+    end
+
+    it "links the back link to the registration by default" do
+      get allocations_path(allocatable_sgid: reg.to_sgid.to_s)
+
+      expect(response.body).to include("href=\"#{edit_event_registration_path(reg)}\"")
+    end
   end
 
   describe "POST /allocations" do

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -112,6 +112,33 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 
+  describe "back link follows the page the user came from" do
+    it "links the new page back to the registrants roster when return_to=registrants" do
+      get new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants")
+
+      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+      expect(response.body).not_to include("href=\"#{edit_event_registration_path(registration)}\"")
+    end
+
+    it "links the new page back to the registration when return_to=registration" do
+      get new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registration")
+
+      expect(response.body).to include("href=\"#{edit_event_registration_path(registration)}\"")
+    end
+
+    it "links the edit page back to the registrants roster when return_to=registrants" do
+      get edit_scholarship_path(scholarship, return_to: "registrants")
+
+      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+    end
+
+    it "links the edit page back to the registration when return_to=registration" do
+      get edit_scholarship_path(scholarship, return_to: "registration")
+
+      expect(response.body).to include("href=\"#{edit_event_registration_path(registration)}\"")
+    end
+  end
+
   describe "comments and communications on the edit page" do
     it "renders the comments section" do
       get edit_scholarship_path(scholarship)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the event registrants roster, the scholarship and payment chips jump to separate admin pages, but nothing signaled that — so this adds the standard jump-link icon (the same one used elsewhere) to all scholarship chips (Completed, Recipient, Requested, Create) and the payment chips.
- It also fixes a navigation papercut: those destination pages always sent the "back" link to the registration edit page, even when the user arrived from the registrants roster.

### How did you approach the change?
- Each registrants-roster chip now passes `return_to: "registrants"`, and the scholarship `new`/`edit` and allocations pages honor that to send the back link to the registrants roster, while arriving from a registration still returns to the registration.
- Added request specs covering both back-link contexts on the scholarship and allocations pages.

### UI Testing Checklist
- [ ] Scholarship and payment chips on `events/:id/registrants` show the jump-link icon.
- [ ] From the registrants roster, opening a scholarship or payment page shows a "← Registrants" back link.
- [ ] From a registration, opening a scholarship or payment page shows a "← Registration" back link.

### Anything else to add?
- The jump-link icon is on all payment states (including "Paid") for visual consistency within the column.
