### PR TITLE
Warn before adding, removing, or editing facilitator affiliations

### DIFF
--- a/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
@@ -1,0 +1,100 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="affiliation-facilitator-warning"
+//
+// Warns before saving when a facilitator affiliation (one with "facilitator"
+// in its title) is added, removed, or edited. Those affiliations — together
+// with their start and end dates — determine the organization's status with
+// AWBW, which is calculated dynamically, so the user is asked to confirm
+// the change before the form submits.
+//
+// Attach to the <form> element. Snapshots the affiliation rows on connect and
+// compares them against the current state on submit; if a facilitator-relevant
+// change is detected the user must confirm or the submission is cancelled.
+export default class extends Controller {
+  connect() {
+    this.snapshots = this.captureSnapshots();
+    this.handleSubmit = (event) => this.guardSubmit(event);
+    // Capture phase so this runs before other submit listeners (e.g. dirty-form).
+    this.element.addEventListener("submit", this.handleSubmit, true);
+  }
+
+  disconnect() {
+    this.element.removeEventListener("submit", this.handleSubmit, true);
+  }
+
+  guardSubmit(event) {
+    if (!this.facilitatorChangePresent()) return;
+
+    const message =
+      "You're adding, removing, or editing a facilitator affiliation. " +
+      "This affects the organization's status with AWBW, which is calculated " +
+      "from facilitator affiliations and their start and end dates.\n\n" +
+      "Are you sure you want to save this change?";
+
+    if (!window.confirm(message)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  rows() {
+    return Array.from(this.element.querySelectorAll(".nested-fields"));
+  }
+
+  keyFor(row) {
+    const field = row.querySelector("[name*='affiliations_attributes']");
+    const match = field?.name.match(/\[affiliations_attributes\]\[([^\]]+)\]/);
+    return match ? match[1] : null;
+  }
+
+  stateFor(row) {
+    const title = row.querySelector("[name*='[title]']")?.value || "";
+    const startDate = row.querySelector("[name*='[start_date]']")?.value || "";
+    const endDate = row.querySelector("[name*='[end_date]']")?.value || "";
+    const destroyInput = row.querySelector("input[name*='_destroy']");
+    const destroyed =
+      (destroyInput && destroyInput.value === "1") ||
+      row.style.display === "none";
+
+    return {
+      title,
+      startDate,
+      endDate,
+      destroyed,
+      facilitator: title.toLowerCase().includes("facilitator"),
+    };
+  }
+
+  captureSnapshots() {
+    const snapshots = {};
+    this.rows().forEach((row) => {
+      const key = this.keyFor(row);
+      if (key) snapshots[key] = this.stateFor(row);
+    });
+    return snapshots;
+  }
+
+  facilitatorChangePresent() {
+    return this.rows().some((row) => {
+      const key = this.keyFor(row);
+      const current = this.stateFor(row);
+      const previous = key ? this.snapshots[key] : null;
+
+      // New row added in this session — relevant if it's a non-removed facilitator.
+      if (!previous) return current.facilitator && !current.destroyed;
+
+      // Removal — relevant only if the row was a facilitator before.
+      if (current.destroyed) return previous.facilitator && !previous.destroyed;
+
+      // Edit — relevant if the row is (or was) a facilitator and any field changed.
+      const involvesFacilitator = previous.facilitator || current.facilitator;
+      const changed =
+        current.title !== previous.title ||
+        current.startDate !== previous.startDate ||
+        current.endDate !== previous.endDate;
+
+      return involvesFacilitator && changed;
+    });
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -3,6 +3,9 @@ import { application } from "./application"
 import AffiliationDatesController from "./affiliation_dates_controller"
 application.register("affiliation-dates", AffiliationDatesController)
 
+import AffiliationFacilitatorWarningController from "./affiliation_facilitator_warning_controller"
+application.register("affiliation-facilitator-warning", AffiliationFacilitatorWarningController)
+
 import AllocationRefController from "./allocation_ref_controller"
 application.register("allocation-ref", AllocationRefController)
 

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(@organization, html: { data: { controller: "affiliation-dates" } }) do |f| %>
+<%= simple_form_for(@organization, html: { data: { controller: "affiliation-dates affiliation-facilitator-warning" } }) do |f| %>
   <%= render 'shared/errors', resource: @organization if @organization.errors.any? %>
   <%= render "duplicate_organizations_warning" %>
   <% has_affiliations = f.object.persisted? && f.object.affiliations.any? %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @person, html: { multipart: true, class: "space-y-8",
-                                          data: { controller: "dirty-form affiliation-dates" } } do |f| %>
+                                          data: { controller: "dirty-form affiliation-dates affiliation-facilitator-warning" } } do |f| %>
   <%= render 'shared/errors', resource: @person if @person.errors.any? %>
   <%= render "duplicate_people_warning" %>
 

--- a/spec/system/organization_facilitator_warning_spec.rb
+++ b/spec/system/organization_facilitator_warning_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "Facilitator affiliation change warning", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:admin_person) { create(:person, user: admin) }
+  let!(:facilitator_person) { create(:person) }
+  let!(:volunteer_person) { create(:person) }
+  let!(:organization) { create(:organization) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    create(:affiliation, organization: organization, person: facilitator_person, title: "Facilitator", start_date: "2019-05-01", end_date: nil)
+    create(:affiliation, organization: organization, person: volunteer_person, title: "Volunteer", start_date: "2021-09-15", end_date: nil)
+    sign_in admin
+  end
+
+  def visit_and_wait(path)
+    visit path
+    expect(page).to have_css("[data-affiliation-dates-ready]", wait: 10)
+  end
+
+  def set_date_input(input, value)
+    page.execute_script(
+      "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('change', { bubbles: true }))",
+      input, value
+    )
+  end
+
+  def row_for(title)
+    all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
+      f.find("textarea[name*='title']").value.include?(title)
+    }
+  end
+
+  it "warns and saves when a facilitator affiliation's date is edited and confirmed" do
+    visit_and_wait edit_organization_path(organization, admin: true)
+
+    start_input = row_for("Facilitator").find("input[name*='start_date']")
+    set_date_input(start_input, "2017-02-01")
+
+    accept_confirm(/status with AWBW/) do
+      find("[type='submit']").click
+    end
+
+    expect(page).to have_current_path(organization_path(organization), wait: 10)
+    expect(organization.affiliations.facilitators.first.reload.start_date).to eq(Date.new(2017, 2, 1))
+  end
+
+  it "cancels the save when the warning is dismissed" do
+    visit_and_wait edit_organization_path(organization, admin: true)
+
+    start_input = row_for("Facilitator").find("input[name*='start_date']")
+    set_date_input(start_input, "2017-02-01")
+
+    dismiss_confirm(/status with AWBW/) do
+      find("[type='submit']").click
+    end
+
+    expect(page).to have_css("[type='submit']", wait: 5) # still on the edit form
+    expect(organization.affiliations.facilitators.first.reload.start_date).to eq(Date.new(2019, 5, 1))
+  end
+
+  it "warns when a facilitator affiliation is removed" do
+    visit_and_wait edit_organization_path(organization, admin: true)
+
+    row_for("Facilitator").find("a", text: "Remove").click
+
+    accept_confirm(/status with AWBW/) do
+      find("[type='submit']").click
+    end
+
+    expect(page).to have_current_path(organization_path(organization), wait: 10)
+    expect(organization.affiliations.facilitators).to be_empty
+  end
+
+  it "does not warn when only a non-facilitator affiliation is edited" do
+    visit_and_wait edit_organization_path(organization, admin: true)
+
+    start_input = row_for("Volunteer").find("input[name*='start_date']")
+    set_date_input(start_input, "2020-01-01")
+
+    find("[type='submit']").click
+
+    expect(page).to have_current_path(organization_path(organization), wait: 10)
+    expect(organization.affiliations.find_by(person: volunteer_person).reload.start_date).to eq(Date.new(2020, 1, 1))
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
A facilitator affiliation's title and start/end dates drive the organization's status with AWBW, which is recalculated automatically by the `Affiliation` model's save/destroy callbacks. Today an admin can add, remove, or edit one of these rows and silently flip the org's status without realizing it.

### How did you approach the change?
Added a `affiliation-facilitator-warning` Stimulus controller on the Organization and Person edit forms that snapshots the affiliation rows on connect and, on submit, shows a confirmation if a facilitator affiliation was added, removed, or edited (title/start/end changed) — gating at submit time since that's when the DB write and status recalculation actually happen. Cancelling aborts the save while preserving the unsaved-changes guard.

### UI Testing Checklist
- [ ] Editing a facilitator affiliation's dates and saving prompts a confirmation; confirming saves, cancelling stays on the form
- [ ] Removing a facilitator affiliation and saving prompts a confirmation
- [ ] Adding a new affiliation (defaults to "Facilitator") and saving prompts a confirmation
- [ ] Editing only a non-facilitator affiliation saves with no prompt

### Anything else to add?
Covered by `spec/system/organization_facilitator_warning_spec.rb`. The same controller is wired to both the organization and person forms since affiliations are editable from either side.