### PR TITLE
Keep event datetime fields readable and rebalance the details form layout

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -67,7 +67,7 @@
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <%# LEFT: Date/time, cost + pre-date text, videoconference + location %>
       <div class="md:col-span-2 space-y-6">
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] gap-3">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13rem),1fr))] gap-3">
         <div>
           <%= f.label :start_date,
                   "Start time",

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -76,7 +76,7 @@
                 } %>
       </div>
 
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,16rem),1fr))] gap-4">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] gap-3">
         <div>
           <%= f.label :start_date,
                   "Start time",

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -65,17 +65,8 @@
 
     <div id="event_details" class="bg-gray-50 border border-gray-300 rounded-b-md p-6">
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-      <%# LEFT: Date/time, location, videoconference, cost %>
+      <%# LEFT: Date/time, cost + pre-date text, videoconference + location %>
       <div class="md:col-span-2 space-y-6">
-      <div>
-        <%= f.input :pre_date_text,
-                label: "Pre-date text",
-                input_html: {
-                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                  placeholder: "e.g. Upcoming Workshop"
-                } %>
-      </div>
-
       <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,15rem),1fr))] gap-3">
         <div>
           <%= f.label :start_date,
@@ -134,36 +125,6 @@
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">
-          <%= f.input :location_id,
-                      label: "Location",
-                      collection: @locations,
-                      label_method: :name,
-                      value_method: :id,
-                      include_blank: true,
-                      input_html: {
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                        data: { searchable_select_target: "select" },
-                      } %>
-        </div>
-
-        <div>
-          <%= f.input :videoconference_url,
-                      label: "Videoconference URL",
-                      as: :url,
-                      input_html: {
-                        placeholder: "https://…",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-          <%= f.input :videoconference_label,
-                      label: "Videoconference label",
-                      input_html: {
-                        placeholder: "Virtual event",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-        </div>
-      </div>
-
         <div>
           <div class="flex items-center justify-between gap-2 mb-1">
             <%= f.label :cost, "Event Cost", class: "block font-medium" %>
@@ -189,6 +150,47 @@
               <%= f.object.errors[:cost].join(", ") %></p>
           <% end %>
         </div>
+
+        <div>
+          <%= f.input :pre_date_text,
+                  label: "Pre-date text",
+                  input_html: {
+                    class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                    placeholder: "e.g. Upcoming Workshop"
+                  } %>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <%= f.input :videoconference_url,
+                      label: "Videoconference URL",
+                      as: :url,
+                      input_html: {
+                        placeholder: "https://…",
+                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                      } %>
+          <%= f.input :videoconference_label,
+                      label: "Videoconference label",
+                      input_html: {
+                        placeholder: "Virtual event",
+                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                      } %>
+        </div>
+
+        <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">
+          <%= f.input :location_id,
+                      label: "Location",
+                      collection: @locations,
+                      label_method: :name,
+                      value_method: :id,
+                      include_blank: true,
+                      input_html: {
+                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                        data: { searchable_select_target: "select" },
+                      } %>
+        </div>
+      </div>
 
     </div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -76,7 +76,7 @@
                 } %>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,16rem),1fr))] gap-4">
         <div>
           <%= f.label :start_date,
                   "Start time",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The event details form had two layout problems:
  - The **Start / End / Registration-close** datetime row used a fixed 3-column grid, so at narrower viewports each `datetime-local` input was squeezed until its value truncated (e.g. `08/13/202`), **hiding the time** and making it look like the time couldn't be edited (the registration-close field is a full `datetime`).
  - Conversely, when only two fields fit, they stretched far wider than their value, leaving a large gap between the value and the calendar icon.
  - The surrounding fields (pre-date text, cost, location, videoconference) were laid out in unbalanced rows.

### How did you approach the change?

- **Datetime row** — replaced the fixed grid with an auto-fit grid + per-field minimum (`grid-cols-[repeat(auto-fit,minmax(min(100%,13rem),1fr))] gap-3`):
  - Three fields now pack onto one row inside the 2/3-width left column; `1fr` sizes them evenly so there's no leftover whitespace.
  - 13rem is still wide enough to show the full `MM/DD/YYYY, HH:MM AM` value plus the calendar icon.
  - The row reflows 3 → 2 → 1 columns as the viewport narrows instead of truncating.
  - `min(100%, …)` prevents overflow on very narrow screens.
- **Field layout** — reorganized the left column into balanced 50/50 rows:
  - **Event cost** (left) paired with **Pre-date text** (right).
  - **Videoconference** (left) paired with **Location** (right), moved below the cost row.

### UI Testing Checklist

- [ ] Wide viewport: all three datetime fields sit on one row with no large gap; cost+pre-date and videoconference+location each form a 50/50 row
- [ ] Narrowing the window reflows the datetime fields to 2, then 1 per row (no truncation of the time)
- [ ] The time portion of each datetime field is visible and editable at every width

### Anything else to add?

- No model, migration, or behavior changes — purely a layout fix. The registration-close field was already a `datetime` column with a `datetime-local` input.
