### PR TITLE
Record the event each form submission belongs to

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -179,7 +179,9 @@ module Events
 
       submission = FormSubmission.find_or_create_by!(
         person: person, form: scholarship_form, role: "scholarship"
-      )
+      ) do |record|
+        record.event = @event
+      end
 
       scholarship_params.each do |field_id, raw_value|
         field = scholarship_form.form_fields.find_by(id: field_id)

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -239,9 +239,8 @@ module Events
             answered_field_ids.concat(answered_one_time)
           end
 
-          # Regular fields: hide if answered on forms within this event
-          event_form_ids = @event.forms.ids
-          event_submissions = FormSubmission.where(person: person, form_id: event_form_ids)
+          # Regular fields: hide if answered on a submission for this event
+          event_submissions = FormSubmission.where(person: person, event_id: @event.id)
           if event_submissions.exists?
             regular_field_ids = @form.form_fields.where(visibility: :answers_on_file, one_time: false)
                                      .where.not(answer_type: :group_header).ids

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -123,10 +123,10 @@ class EventsController < ApplicationController
     authorize! @event
 
     @event = @event.decorate
-    @submissions = FormSubmission.joins(form: :event_forms)
-                                 .where(event_forms: { event_id: @event.id, role: "bulk_payment" })
-                                 .includes(:person, form_answers: :form_field, payments: :allocations)
-                                 .order(created_at: :desc)
+    @submissions = @event.form_submissions
+                         .where(role: "bulk_payment")
+                         .includes(:person, form_answers: :form_field, payments: :allocations)
+                         .order(created_at: :desc)
   end
 
   def allocate_bulk_payment
@@ -268,11 +268,18 @@ class EventsController < ApplicationController
 
   def destroy
     authorize! @event
-    @event.destroy
 
-    respond_to do |format|
-      format.html { redirect_to events_path, status: :see_other, notice: "Event was successfully destroyed." }
-      format.json { head :no_content }
+    if @event.destroy
+      respond_to do |format|
+        format.html { redirect_to events_path, status: :see_other, notice: "Event was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    else
+      message = @event.errors.full_messages.to_sentence.presence || "Event could not be destroyed."
+      respond_to do |format|
+        format.html { redirect_to event_path(@event), status: :see_other, alert: message }
+        format.json { render json: { errors: @event.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -264,11 +264,13 @@ module ApplicationHelper
 
   # Where to view a form submission. When the submitter has a public event
   # registration, send the viewer to their registration details page (the public
-  # "ticket"/details view, keyed by the registration slug). Otherwise — bulk
-  # payments and event-less submissions, which have no registration — fall back
-  # to the form submission show page.
+  # "ticket"/details view, keyed by the registration slug). The event is resolved
+  # directly, or indirectly through the form's matching join role for older
+  # submissions without a stored event. Otherwise — bulk payments and event-less
+  # submissions, which have no registration — fall back to the form submission
+  # show page.
   def form_submission_link_path(submission)
-    event = submission.event
+    event = submission.event || submission.form.events.find_by(event_forms: { role: submission.role })
     registration = event && submission.person.event_registrations.find_by(event: event)
     return event_public_registration_path(event, reg: registration.slug) if registration&.slug.present?
     form_submission_path(submission)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,11 @@ class Event < ApplicationRecord
   has_many :event_registrations, dependent: :destroy
   has_many :event_staffs, dependent: :destroy
   has_many :event_forms, dependent: :destroy
+  # Block destroying an event that has submissions (registrations, scholarship
+  # applications, payments). Submissions that were never tied to an event are
+  # unaffected. Destroying instead would orphan the payments that hang off a
+  # submission (payments have an FK to form_submissions and no dependent rule).
+  has_many :form_submissions, dependent: :restrict_with_error
 
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, as: :sectorable, dependent: :destroy

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -1,17 +1,11 @@
 class FormSubmission < ApplicationRecord
   belongs_to :person
   belongs_to :form
+  belongs_to :event, optional: true
   has_many :form_answers, dependent: :destroy
   has_many :payments
 
   accepts_nested_attributes_for :form_answers
-
-  # The event this submission belongs to, resolved through the join role that
-  # matches the submission's own role (e.g. a "bulk_payment" submission maps to
-  # the event_form with role "bulk_payment").
-  def event
-    form.events.find_by(event_forms: { role: role })
-  end
 
   # Answers keyed by their field's identifier. Bulk payment (and similar) forms
   # address fields by identifier rather than position.

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -99,7 +99,7 @@ module EventRegistrationServices
     end
 
     def create_form_submission(person)
-      submission = FormSubmission.create!(person: person, form: @form, role: "bulk_payment")
+      submission = FormSubmission.create!(person: person, form: @form, event: @event, role: "bulk_payment")
       save_form_answers(submission)
       submission
     end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -265,13 +265,15 @@ module EventRegistrationServices
     end
 
     def create_form_submission(person)
-      submission = FormSubmission.create!(person: person, form: @form)
+      submission = FormSubmission.create!(person: person, form: @form, event: @event)
       save_form_answers(submission)
       submission
     end
 
     def update_form_submission(person)
-      submission = FormSubmission.find_or_create_by!(person: person, form: @form)
+      submission = FormSubmission.find_or_create_by!(person: person, form: @form) do |record|
+        record.event = @event
+      end
       save_form_answers(submission)
       submission
     end

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -46,18 +46,19 @@
                 </tr>
                 </thead>
 
-                <% all_event_form_ids = @event_registrations.flat_map { |er| er.event.event_forms.map(&:form_id) }.uniq %>
-                <% submitted_pairs = all_event_form_ids.any? ? FormSubmission.where(form_id: all_event_form_ids, person_id: @event_registrations.map(&:registrant_id).uniq).pluck(:person_id, :form_id).to_set : Set.new %>
+                <% event_ids = @event_registrations.map(&:event_id).uniq %>
+                <% registrant_ids = @event_registrations.map(&:registrant_id).uniq %>
+                <% submitted_pairs = FormSubmission.where(event_id: event_ids, person_id: registrant_ids).pluck(:person_id, :event_id).to_set %>
+                <% events_with_forms = EventForm.where(event_id: event_ids).distinct.pluck(:event_id).to_set %>
                 <tbody class="divide-y divide-gray-200">
                   <% @event_registrations.each do |event_registration| %>
                     <tr id="<%= dom_id(event_registration) %>" class="hover:bg-gray-50 transition-colors duration-150">
                       <td class="px-4 py-2 text-sm text-gray-800 align-top">
                         <div class="flex items-center gap-2">
                           <%= person_profile_button(event_registration.registrant) %>
-                          <% er_form_ids = event_registration.event.event_forms.map(&:form_id) %>
-                          <% if er_form_ids.any? && er_form_ids.any? { |fid| submitted_pairs.include?([ event_registration.registrant_id, fid ]) } %>
+                          <% if submitted_pairs.include?([ event_registration.registrant_id, event_registration.event_id ]) %>
                             <i class="fa-solid fa-file-lines text-green-600 shrink-0" title="Completed registration form"></i>
-                          <% elsif er_form_ids.any? %>
+                          <% elsif events_with_forms.include?(event_registration.event_id) %>
                             <i class="fa-regular fa-file-lines text-gray-300 shrink-0" title="No registration form submitted"></i>
                           <% end %>
                         </div>

--- a/db/migrate/20260615115052_add_event_to_form_submissions.rb
+++ b/db/migrate/20260615115052_add_event_to_form_submissions.rb
@@ -1,19 +1,6 @@
 class AddEventToFormSubmissions < ActiveRecord::Migration[8.0]
   def up
-    add_reference :form_submissions, :event, null: true, index: true
-    add_foreign_key :form_submissions, :events unless foreign_key_exists?(:form_submissions, :events)
-
-    # Backfill the event for existing submissions by matching the join role.
-    # Registration submissions carry no role, so they resolve through the
-    # "registration" event_form.
-    execute(<<~SQL.squish)
-      UPDATE form_submissions fs
-      JOIN event_forms ef
-        ON ef.form_id = fs.form_id
-        AND ef.role = COALESCE(fs.role, 'registration')
-      SET fs.event_id = ef.event_id
-      WHERE fs.event_id IS NULL
-    SQL
+    add_reference :form_submissions, :event, null: true, index: true, foreign_key: true
   end
 
   def down

--- a/db/migrate/20260615115052_add_event_to_form_submissions.rb
+++ b/db/migrate/20260615115052_add_event_to_form_submissions.rb
@@ -1,0 +1,23 @@
+class AddEventToFormSubmissions < ActiveRecord::Migration[8.0]
+  def up
+    add_reference :form_submissions, :event, null: true, index: true
+    add_foreign_key :form_submissions, :events unless foreign_key_exists?(:form_submissions, :events)
+
+    # Backfill the event for existing submissions by matching the join role.
+    # Registration submissions carry no role, so they resolve through the
+    # "registration" event_form.
+    execute(<<~SQL.squish)
+      UPDATE form_submissions fs
+      JOIN event_forms ef
+        ON ef.form_id = fs.form_id
+        AND ef.role = COALESCE(fs.role, 'registration')
+      SET fs.event_id = ef.event_id
+      WHERE fs.event_id IS NULL
+    SQL
+  end
+
+  def down
+    remove_foreign_key :form_submissions, :events if foreign_key_exists?(:form_submissions, :events)
+    remove_reference :form_submissions, :event, index: true if column_exists?(:form_submissions, :event_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_115052) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -599,10 +599,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_190000) do
 
   create_table "form_submissions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.bigint "event_id"
     t.integer "form_id", null: false
     t.bigint "person_id", null: false
     t.string "role"
     t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_form_submissions_on_event_id"
     t.index ["form_id"], name: "index_form_submissions_on_form_id"
     t.index ["person_id"], name: "index_form_submissions_on_person_id"
   end
@@ -1584,6 +1586,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_190000) do
   add_foreign_key "form_field_answer_options", "answer_options"
   add_foreign_key "form_field_answer_options", "form_fields"
   add_foreign_key "form_fields", "forms"
+  add_foreign_key "form_submissions", "events"
   add_foreign_key "form_submissions", "forms"
   add_foreign_key "form_submissions", "people"
   add_foreign_key "forms", "form_builders"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -464,7 +464,7 @@ if facilitator_training
   if reg_form
     # People with users who filled out the form
     [ amy_person, maria_j, anna_g ].compact.each do |person|
-      form_submissions << { person: person, form: reg_form }
+      form_submissions << { person: person, form: reg_form, event: facilitator_training }
     end
     # Mario Johnson (no user) did NOT fill out the form — registration without form submission
   end
@@ -476,10 +476,10 @@ if trauma_training
   if reg_form
     # Sarah Smith (has user) and Jessica Brown (has user) filled out forms
     [ sarah_s, jessica_b ].compact.each do |person|
-      form_submissions << { person: person, form: reg_form }
+      form_submissions << { person: person, form: reg_form, event: trauma_training }
     end
     # Angel Garcia (no user) filled out the form — person without user + form
-    form_submissions << { person: angel_g, form: reg_form } if angel_g
+    form_submissions << { person: angel_g, form: reg_form, event: trauma_training } if angel_g
     # Linda Williams (no user) did NOT fill out the form
   end
 end
@@ -490,10 +490,10 @@ if wellness_day
   if reg_form
     # People with users
     [ amy_person, maria_j, sarah_s, jessica_b, kim_d ].compact.each do |person|
-      form_submissions << { person: person, form: reg_form }
+      form_submissions << { person: person, form: reg_form, event: wellness_day }
     end
     # Rosa (has user) filled it out too
-    form_submissions << { person: rosa_dlc, form: reg_form } if rosa_dlc
+    form_submissions << { person: rosa_dlc, form: reg_form, event: wellness_day } if rosa_dlc
     # Lisa Williams (has user) registered but didn't fill out the form — person with user + no form
   end
 end
@@ -501,20 +501,20 @@ end
 # Mindful Art (short form, has scholarship) — Amy filled out the form
 if mindful_art
   reg_form = mindful_art.registration_form
-  form_submissions << { person: amy_person, form: reg_form } if reg_form && amy_person
+  form_submissions << { person: amy_person, form: reg_form, event: mindful_art } if reg_form && amy_person
 end
 
 # Youth Day (short form) — Maria filled it out
 if youth_day
   reg_form = youth_day.registration_form
-  form_submissions << { person: maria_j, form: reg_form } if reg_form && maria_j
+  form_submissions << { person: maria_j, form: reg_form, event: youth_day } if reg_form && maria_j
 end
 
 # Virtual Session (short form) — Amy (has user) registered but no form submission — person with user + no form
 # Family Day (short form) — Rosa filled it out
 if family_day
   reg_form = family_day.registration_form
-  form_submissions << { person: rosa_dlc, form: reg_form } if reg_form && rosa_dlc
+  form_submissions << { person: rosa_dlc, form: reg_form, event: family_day } if reg_form && rosa_dlc
 end
 
 # Create all form submissions with sample field responses
@@ -522,7 +522,7 @@ form_submissions.each do |data|
   next unless data[:person] && data[:form]
   next if FormSubmission.exists?(person: data[:person], form: data[:form])
 
-  pf = FormSubmission.create!(person: data[:person], form: data[:form])
+  pf = FormSubmission.create!(person: data[:person], form: data[:form], event: data[:event])
 
   # Fill in required text fields with sample data
   data[:form].form_fields.where(answer_type: [ :free_form_input_one_line, :free_form_input_paragraph ]).each do |field|
@@ -600,7 +600,9 @@ if facilitator_training && (reg_form = facilitator_training.registration_form)
   facilitator_training.event_registrations.active.includes(:registrant).each do |registration|
     person = registration.registrant
     next unless person&.email.to_s.start_with?("facilitator.cohort.")
-    FormSubmission.find_or_create_by!(person: person, form: reg_form)
+    FormSubmission.find_or_create_by!(person: person, form: reg_form) do |fs|
+      fs.event = facilitator_training
+    end
   end
 end
 

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -266,7 +266,9 @@ ensure_registration_submission = ->(person, event) do
   reg_form = event.registration_form
   return unless reg_form
 
-  submission = FormSubmission.find_or_create_by!(person: person, form: reg_form)
+  submission = FormSubmission.find_or_create_by!(person: person, form: reg_form) do |fs|
+    fs.event = event
+  end
   reg_form.form_fields.where.not(answer_type: :group_header).each do |field|
     value = case field.field_identifier
     when "first_name" then person.first_name
@@ -312,7 +314,9 @@ setup_recipient = ->(registration, second_form:) do
   ensure_recipient_affiliation.(person, event, set, recipient_orgs[application_index % recipient_orgs.length]) if recipient_orgs.any?
 
   if second_form && scholarship_form
-    separate = FormSubmission.find_or_create_by!(person: person, form: scholarship_form, role: "scholarship")
+    separate = FormSubmission.find_or_create_by!(person: person, form: scholarship_form, role: "scholarship") do |fs|
+      fs.event = event
+    end
     attach_scholarship_answers.(separate, set)
   elsif reg_submission
     attach_scholarship_answers.(reg_submission, set)

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -2,6 +2,10 @@ FactoryBot.define do
   factory :form_submission do
     association :person
     association :form
-    association :event
+
+    # Submissions are event-less by default; opt in when the test needs one.
+    trait :with_event do
+      association :event
+    end
   end
 end

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :form_submission do
     association :person
     association :form
+    association :event
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       create(:event_form, event: event, form: form, role: "registration")
       person = create(:person)
       registration = create(:event_registration, event: event, registrant: person)
-      submission = create(:form_submission, form: form, person: person, role: "registration")
+      submission = create(:form_submission, event: nil, form: form, person: person, role: "registration")
 
       expect(helper.routable_path(submission))
         .to eq(event_public_registration_path(event, reg: registration.slug))

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe EventMailer, type: :mailer do
     end
     let(:person) { create(:person, first_name: "Pat", last_name: "Payer", email: "pat@example.com") }
     let(:submission) do
-      s = FormSubmission.create!(form: form, person: person, role: "bulk_payment")
+      s = FormSubmission.create!(form: form, person: person, event: event, role: "bulk_payment")
       s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "number_of_attendees"), submitted_answer: "4")
       s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "payment_method"), submitted_answer: "Check")
       s

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
     let(:person) { create(:person, first_name: "Pat", last_name: "Payer", email: "pat@example.com") }
     let(:submission) do
-      s = FormSubmission.create!(form: form, person: person, role: "bulk_payment")
+      s = FormSubmission.create!(form: form, person: person, event: event, role: "bulk_payment")
       s.form_answers.create!(form_field: form.form_fields.find_by(field_identifier: "number_of_attendees"), submitted_answer: "4")
       s
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe Event, type: :model do
     it { should validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0).allow_nil }
   end
 
+  describe "destroying with form submissions" do
+    it "is blocked and keeps the submission when the event has one" do
+      event = create(:event)
+      create(:form_submission, :with_event, event: event)
+
+      expect(event.destroy).to be(false)
+      expect(event.errors[:base]).to be_present
+      expect(Event.exists?(event.id)).to be(true)
+    end
+
+    it "is allowed when the event has no submissions" do
+      event = create(:event)
+
+      expect(event.destroy).to be_truthy
+      expect(Event.exists?(event.id)).to be(false)
+    end
+  end
+
   describe "staff uniqueness on update" do
     it "rejects two staff rows for the same person added in one update" do
       event = create(:event)

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -4,19 +4,9 @@ RSpec.describe FormSubmission do
   describe "associations" do
     it { should belong_to(:person) }
     it { should belong_to(:form) }
+    it { should belong_to(:event).optional }
     it { should have_many(:form_answers).dependent(:destroy) }
     it { should accept_nested_attributes_for(:form_answers) }
-  end
-
-  describe "#event" do
-    it "returns the event whose join role matches the submission role" do
-      event = create(:event)
-      form = create(:form)
-      event.event_forms.create!(form: form, role: "bulk_payment")
-      submission = create(:form_submission, form: form, role: "bulk_payment")
-
-      expect(submission.event).to eq(event)
-    end
   end
 
   describe "#answers_by_identifier" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "EventRegistrations", type: :request do
 
         it "shows green icon when person submitted the current registration form" do
           create(:event_form, event: event, form: reg_form, role: "registration")
-          create(:form_submission, person: person, form: reg_form)
+          create(:form_submission, person: person, form: reg_form, event: event)
 
           get event_registrations_path
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -340,6 +340,25 @@ RSpec.describe "Events", type: :request do
           delete event_path(event)
         }.to change(Event, :count).by(-1)
       end
+
+      context "when the event has form submissions" do
+        before { create(:form_submission, :with_event, event: event) }
+
+        it "does not destroy the event" do
+          event
+          expect {
+            delete event_path(event)
+          }.not_to change(Event, :count)
+        end
+
+        it "redirects back to the event with an alert" do
+          delete event_path(event)
+
+          expect(response).to redirect_to(event_path(event))
+          follow_redirect!
+          expect(flash[:alert]).to be_present
+        end
+      end
     end
 
     context "as non-admin" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Form submissions had no direct link to their event — the event was inferred through the form's join role, which returned `nil` for role-less registration submissions, so we couldn't reliably tell (or filter by) which event a form was submitted for. This adds an explicit `event_id` and switches event-scoped queries to use it.

### How did you approach the change?
- Added a nullable, indexed `event_id` FK to `form_submissions` and a `belongs_to :event, optional: true`; replaced the indirect `#event` method. Every creation site (bulk payment, registration create/update, scholarship) now sets the event.
- Added `Event#form_submissions` (`dependent: :restrict_with_error`, to avoid orphaning payments) and moved event-scoped queries onto the column: the bulk-payment list, the public-registration "answers on file" hide check, and the registration-form icon on the registrations index.
- These read `event_id` only — pre-existing/genuinely event-less submissions are intentionally **not** backfilled, so the column drives new/forward filtering. A helper (`form_submission_link_path`) still infers the event for older rows when building view links.
- Factory is event-less by default with a `:with_event` trait; seed cohort submissions are linked to their event.

### UI Testing Checklist
- [ ] Event bulk-payments page lists that event's bulk-payment submissions.
- [ ] On the registrations index, registrants who submitted their event's form show the green "completed form" icon.

### Anything else to add?
`event_id` is kept nullable since some submissions legitimately have no event. If we later confirm production data, a follow-up could backfill historical rows so they're filterable too.