### PR TITLE
HOLD: Capture known profile data as form answers on registration & bulk payment submissions

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -127,6 +127,17 @@ module EventHelper
     text
   end
 
+  # A small marker shown beside answers that weren't typed on the form but were
+  # filled in from the member's profile at submission time, so reviewers can tell
+  # captured profile data apart from what the person actually entered.
+  def backfilled_indicator(response)
+    return unless response&.backfilled?
+
+    label = "Filled in automatically from the member's profile"
+    tag.i(class: "fa-solid fa-wand-magic-sparkles text-gray-400 ml-1",
+          title: label, "aria-label": label, role: "img")
+  end
+
   # Resolve a stored answer to readable text, mapping the sector/category ids
   # behind the professional fields to their names. Free-text tokens (e.g. an
   # "Other: <text>" answer) aren't ids, so they pass through unchanged. Returns

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -17,7 +17,11 @@ module EventRegistrationServices
     def call
       ActiveRecord::Base.transaction do
         person = find_or_create_person
-        create_phone_contact(person) if field_value("payer_phone").present?
+        if @person
+          backfill_payer_fields(@person)
+        elsif field_value("payer_phone").present?
+          create_phone_contact(person)
+        end
         submission = create_form_submission(person)
         send_notifications(submission, person)
         Result.new(success?: true, form_submission: submission, errors: [])
@@ -54,6 +58,25 @@ module EventRegistrationServices
       field = @form.form_fields.find_by(field_identifier: key)
       return nil unless field
       @form_params[field.id.to_s]
+    end
+
+    # Logged-in payers never see the payer information fields (they're
+    # logged_out_only), so fill those answers from the signed-in person's record
+    # to keep the submission self-describing. Their existing contact methods are
+    # left untouched.
+    def backfill_payer_fields(person)
+      {
+        "payer_first_name" => person.first_name,
+        "payer_last_name" => person.last_name,
+        "payer_email" => person.preferred_email,
+        "payer_phone" => person.phone_number,
+        "payer_organization" => person.primary_organization&.name
+      }.each do |key, value|
+        next if value.blank?
+        field = @form.form_fields.find_by(field_identifier: key)
+        next unless field
+        @form_params[field.id.to_s] = value
+      end
     end
 
     def find_or_create_person

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -11,6 +11,7 @@ module EventRegistrationServices
       @form = form
       @form_params = form_params
       @person = person
+      @backfilled_field_ids = []
       @errors = []
     end
 
@@ -76,6 +77,7 @@ module EventRegistrationServices
         field = @form.form_fields.find_by(field_identifier: key)
         next unless field
         @form_params[field.id.to_s] = value
+        @backfilled_field_ids << field.id
       end
     end
 
@@ -140,7 +142,8 @@ module EventRegistrationServices
         end
 
         record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+        record.update!(submitted_answer: text, question_name_when_answered: field.name,
+                       backfilled: @backfilled_field_ids.include?(field.id))
       end
     end
   end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -38,6 +38,7 @@ module EventRegistrationServices
       @person = person
       @scholarship_form = scholarship_form
       @scholarship_params = scholarship_params || {}
+      @backfilled_field_ids = []
       @errors = []
     end
 
@@ -135,6 +136,7 @@ module EventRegistrationServices
         next unless field
         next if @form_params[field.id.to_s].present?
         @form_params[field.id.to_s] = value
+        @backfilled_field_ids << field.id
       end
     end
 
@@ -432,7 +434,8 @@ module EventRegistrationServices
         end
 
         record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+        record.update!(submitted_answer: text, question_name_when_answered: field.name,
+                       backfilled: @backfilled_field_ids.include?(field.id))
       end
     end
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -54,6 +54,8 @@ module EventRegistrationServices
 
         assign_tags(person, organization)
 
+        backfill_profile_fields(person) if @person
+
         existing = @event.event_registrations.find_by(registrant: person)
         if existing
           existing.update!(scholarship_requested: true) if @scholarship_requested
@@ -118,6 +120,59 @@ module EventRegistrationServices
       else
         { first_name: submitted_first, legal_first_name: nil }
       end
+    end
+
+    # Logged-in registrants don't see the profile fields they already have on
+    # file (they're hidden as logged_out_only), so those answers would otherwise
+    # be missing from the submission. Capture them from the person's record so
+    # the submission reflects all the data known at the time it was submitted.
+    # Only fields left blank by the registrant are filled, and the person's own
+    # records (addresses, contacts) are not touched.
+    def backfill_profile_fields(person)
+      profile_field_values(person).each do |key, value|
+        next if value.blank?
+        field = @form.form_fields.find_by(field_identifier: key)
+        next unless field
+        next if @form_params[field.id.to_s].present?
+        @form_params[field.id.to_s] = value
+      end
+    end
+
+    def profile_field_values(person)
+      {
+        "first_name" => person.legal_first_name.presence || person.first_name,
+        "last_name" => person.last_name,
+        "primary_email" => person.email,
+        "primary_email_type" => person.email_type&.capitalize,
+        "nickname" => (person.first_name if person.legal_first_name.present?),
+        "pronouns" => person.pronouns,
+        "secondary_email" => person.email_2,
+        "secondary_email_type" => person.email_2_type&.capitalize
+      }.merge(address_field_values(person)).merge(phone_field_values(person))
+    end
+
+    def address_field_values(person)
+      return {} unless person.addresses.exists?
+
+      address = person.addresses.find_by(primary: true) || person.addresses.first
+      {
+        "mailing_street" => address.street_address,
+        "mailing_address_type" => address.address_type&.capitalize,
+        "mailing_city" => address.city,
+        "mailing_state" => address.state,
+        "mailing_zip" => address.zip_code
+      }
+    end
+
+    def phone_field_values(person)
+      phones = person.contact_methods.where(kind: :phone)
+      phone = phones.find_by(primary: true, inactive: false) || phones.where(inactive: false).first || phones.first
+      return {} unless phone
+
+      {
+        "phone" => phone.value,
+        "phone_type" => phone.contact_type&.capitalize
+      }
     end
 
     def find_or_create_person

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -60,7 +60,7 @@
             <div class="<%= field.grid_span_class %> py-2">
               <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
               <dd class="mt-1 text-sm text-gray-900">
-                <%= display_response_text(field, response) %>
+                <%= display_response_text(field, response) %><%= backfilled_indicator(response) %>
               </dd>
             </div>
           <% end %>

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -20,7 +20,7 @@
       <div class="py-2">
         <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= display_question_label(field, response) %></dt>
         <dd class="mt-1 text-sm text-gray-900">
-          <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %>
+          <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %><%= backfilled_indicator(response) %>
         </dd>
       </div>
     <% end %>

--- a/db/migrate/20260622121824_add_backfilled_to_form_answers.rb
+++ b/db/migrate/20260622121824_add_backfilled_to_form_answers.rb
@@ -1,0 +1,9 @@
+class AddBackfilledToFormAnswers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :form_answers, :backfilled, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :form_answers, :backfilled, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_121824) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -578,6 +578,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
   end
 
   create_table "form_answers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.boolean "backfilled", default: false, null: false
     t.datetime "created_at", null: false
     t.integer "form_field_id"
     t.bigint "form_submission_id", null: false

--- a/spec/factories/form_answers.rb
+++ b/spec/factories/form_answers.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     association :form_field
     submitted_answer { Faker::Lorem.sentence }
     question_name_when_answered { nil }
+    backfilled { false }
+
+    trait :backfilled do
+      backfilled { true }
+    end
   end
 end

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -132,6 +132,32 @@ RSpec.describe "Events::BulkPayments", type: :request do
     end
   end
 
+  describe "POST create as a signed-in payer" do
+    let(:admin) { create(:user, :admin, :with_person) }
+
+    before do
+      # Mirror the seeded form: payer fields are hidden from signed-in users, so
+      # they are neither rendered nor validated and must be backfilled.
+      [ org_field, payer_first_name_field, payer_last_name_field, payer_email_field ].each do |f|
+        f.update!(visibility: :logged_out_only, required: false)
+      end
+      admin.person.update!(first_name: "Signed", last_name: "Inn")
+    end
+
+    it "records the payer fields from the signed-in person" do
+      post event_bulk_payment_path(event),
+           params: { bulk_payment: { form_fields: { payment_method_field.id.to_s => "Check" } } }
+
+      expect(response).to have_http_status(:redirect)
+      submission = FormSubmission.last
+      expect(submission.person).to eq(admin.person)
+      answers = submission.answers_by_identifier
+      expect(answers["payer_first_name"]).to eq("Signed")
+      expect(answers["payer_last_name"]).to eq("Inn")
+      expect(answers["payer_email"]).to eq(admin.person.preferred_email)
+    end
+  end
+
   describe "GET new with the seeded bulk payment form" do
     let(:seeded_form) do
       FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("Organization")
         expect(response.body).to include("AWBW")
       end
+
+      it "marks a backfilled answer with the profile indicator icon" do
+        typed = create(:form_field, form: submission.form, name: "Typed")
+        from_profile = create(:form_field, form: submission.form, name: "From profile")
+        create(:form_answer, form_submission: submission, form_field: typed, submitted_answer: "Typed value")
+        create(:form_answer, :backfilled, form_submission: submission, form_field: from_profile,
+                                          submitted_answer: "Profile value")
+
+        get form_submission_path(submission)
+
+        expect(response.body).to include("fa-wand-magic-sparkles")
+        expect(response.body).to include("Filled in automatically from the member&#39;s profile")
+      end
     end
 
     context "when arriving from the bulk payments index" do

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -86,6 +86,20 @@ RSpec.describe EventRegistrationServices::BulkPayment do
       expect(answers["payer_organization"]).to eq(person.primary_organization.name)
     end
 
+    it "flags the backfilled answers as backfilled and leaves typed ones unflagged" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: logged_in_params,
+        person: person
+      )
+
+      answers = result.form_submission.form_answers.includes(:form_field).index_by { |a| a.form_field.field_identifier }
+      expect(answers["payer_first_name"]).to be_backfilled
+      expect(answers["payer_email"]).to be_backfilled
+      expect(answers["payment_method"]).not_to be_backfilled
+    end
+
     it "does not alter the logged-in person's existing phone contact methods" do
       expect {
         described_class.call(event: event, form: form, form_params: logged_in_params, person: person)

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -49,6 +49,50 @@ RSpec.describe EventRegistrationServices::BulkPayment do
     end
   end
 
+  describe "logged-in payer" do
+    let(:person) do
+      create(:person, :with_organization, first_name: "Logged", last_name: "In",
+             user: create(:user, email: "loggedin@example.com"))
+    end
+
+    before do
+      person.contact_methods.create!(kind: :phone, value: "555-987-6543", contact_type: "personal", primary: true)
+    end
+
+    def logged_in_params
+      {
+        field_id("payment_method") => "Check",
+        field_id("number_of_attendees") => "2"
+      }
+    end
+
+    it "records the payer fields from the logged-in person's data" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: logged_in_params,
+        person: person
+      )
+
+      expect(result.success?).to be true
+      submission = result.form_submission
+      expect(submission.person).to eq(person)
+
+      answers = submission.answers_by_identifier
+      expect(answers["payer_first_name"]).to eq("Logged")
+      expect(answers["payer_last_name"]).to eq("In")
+      expect(answers["payer_email"]).to eq("loggedin@example.com")
+      expect(answers["payer_phone"]).to eq("555-987-6543")
+      expect(answers["payer_organization"]).to eq(person.primary_organization.name)
+    end
+
+    it "does not alter the logged-in person's existing phone contact methods" do
+      expect {
+        described_class.call(event: event, form: form, form_params: logged_in_params, person: person)
+      }.not_to change { person.contact_methods.where(kind: :phone).count }
+    end
+  end
+
   describe "notifications" do
     it "sends the payer confirmation and the staff FYI" do
       expect(NotificationServices::CreateNotification).to receive(:call).with(

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
 
       expect(result.form_submission.answers_by_identifier["pronouns"]).to eq("she/her")
     end
+
+    it "flags backfilled answers as backfilled and leaves typed ones unflagged" do
+      result = described_class.call(event: event, form: form,
+                                    form_params: { field_id("pronouns") => "she/her" }, person: person)
+
+      answers = result.form_submission.form_answers.includes(:form_field).index_by { |a| a.form_field.field_identifier }
+      expect(answers["first_name"]).to be_backfilled
+      expect(answers["mailing_city"]).to be_backfilled
+      expect(answers["pronouns"]).not_to be_backfilled
+    end
   end
 
   describe "affiliation creation" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -24,6 +24,63 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     }
   end
 
+  describe "logged-in registrant profile backfill" do
+    let(:person) do
+      p = create(:person, user: create(:user, email: "u@example.com"),
+                 first_name: "Sam", legal_first_name: "Samuel", last_name: "Stone",
+                 email: "sam@example.com", email_type: "personal",
+                 email_2: "sam2@example.com", email_2_type: "work",
+                 pronouns: "they/them")
+      p.addresses.create!(street_address: "1 Main St", city: "Townsville", state: "CA",
+                          zip_code: "90001", locality: "Unknown", address_type: "personal", primary: true)
+      p.contact_methods.create!(kind: :phone, value: "555-111-2222", contact_type: "work", primary: true)
+      p
+    end
+
+    it "records the known profile data as form answers even though the fields are hidden" do
+      result = described_class.call(event: event, form: form, form_params: {}, person: person)
+
+      expect(result.success?).to be true
+      answers = result.form_submission.answers_by_identifier
+      expect(answers).to include(
+        "first_name" => "Samuel",
+        "nickname" => "Sam",
+        "last_name" => "Stone",
+        "primary_email" => "sam@example.com",
+        "primary_email_type" => "Personal",
+        "secondary_email" => "sam2@example.com",
+        "secondary_email_type" => "Work",
+        "pronouns" => "they/them",
+        "mailing_street" => "1 Main St",
+        "mailing_city" => "Townsville",
+        "mailing_state" => "CA",
+        "mailing_zip" => "90001",
+        "mailing_address_type" => "Personal",
+        "phone" => "555-111-2222",
+        "phone_type" => "Work"
+      )
+    end
+
+    it "does not save the confirm_email helper field" do
+      result = described_class.call(event: event, form: form, form_params: {}, person: person)
+
+      expect(result.form_submission.answers_by_identifier).not_to have_key("confirm_email")
+    end
+
+    it "does not duplicate or mutate the person's address and phone records" do
+      expect {
+        described_class.call(event: event, form: form, form_params: {}, person: person)
+      }.not_to change { [ person.addresses.count, person.contact_methods.count ] }
+    end
+
+    it "does not overwrite values the registrant explicitly submitted" do
+      result = described_class.call(event: event, form: form,
+                                    form_params: { field_id("pronouns") => "she/her" }, person: person)
+
+      expect(result.form_submission.answers_by_identifier["pronouns"]).to eq("she/her")
+    end
+  end
+
   describe "affiliation creation" do
     let!(:organization) { create(:organization, name: "Helping Hands") }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- When a logged-in user submits an event registration or bulk payment form, the profile fields they already have on file are hidden (`logged_out_only`) and never re-asked.
- As a result, those answers were **missing from the form submission** — the submission didn't record who paid or registered.
- This makes each submission self-describing: it captures everything we already know about the registrant/payer at submission time, and clearly marks which answers came from their profile vs. what they typed.

### How did you approach the change?

- **Bulk payment** (`bulk_payment.rb`): when a signed-in `person` is present, backfill the hidden payer fields (`payer_first_name`, `payer_last_name`, `payer_email`, `payer_phone`, `payer_organization`) from their profile before saving form answers.
- **Public registration** (`public_registration.rb`): added `backfill_profile_fields`, mirroring the controller's `person_known_identifiers` mapping, to fill hidden identity/contact fields (name, nickname, emails + types, pronouns, mailing address, phone + type) from the person's record.
- Both backfills only run for logged-in users, only fill fields the registrant left blank (never overwrite a typed value), and do **not** mutate the person's own records (addresses, contact methods).
- **Designation + UI icon**: new `form_answers.backfilled` boolean column. Backfilled answers are flagged at save time, and a small profile icon (`fa-wand-magic-sparkles`, tooltip "Filled in automatically from the member's profile") is shown beside them wherever submissions are viewed — the shared `form_submissions/_submission` partial (admin + bulk payment views) and the public registration show page.

### Scope note (which hidden fields are covered)

- Covers exactly the `logged_out_only` profile fields that get hidden because the data is already on file (matches `person_known_identifiers`).
- Agency fields and `racial_ethnic_identity` are `logged_out_only` but stay visible to logged-in users, so they're answered normally — nothing to backfill.
- `answers_on_file` fields (professional info, marketing, consent, feedback) are out of scope: they're hidden only when `hide_answered_form_questions` is on and already answered, and they come from prior submissions, not the profile.

### Anything else to add?

- TDD: failing specs written first, then implementation.
- Coverage: backfill correctness + `backfilled` flag in both service specs; profile-icon rendering in the admin submission request spec. Full service + request suites green; RuboCop clean.
- Migration is reversible (`up`/`down` with `if_exists`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)