### PR TITLE
Omit the "Other" sector from the primary service-area dropdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,7 +175,7 @@ module ApplicationHelper
   def dynamic_form_field_options(field)
     case field.field_identifier
     when *FormField::SERVICE_AREA_FIELD_IDENTIFIERS
-      Sector.published.order(:name).map { |sector| [ sector.name, sector.id.to_s ] }
+      field.service_area_sectors.map { |sector| [ sector.name, sector.id.to_s ] }
     when *FormField::DYNAMIC_FIELD_CATEGORY_TYPES.keys
       type = CategoryType.find_by(name: FormField::DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
       (type&.categories&.published&.order(:position, :name) || []).map { |category| [ category.name, category.id.to_s, category.description ] }

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -16,6 +16,11 @@ class FormField < ApplicationRecord
   # submitted value for these is a Sector id (as a string).
   SERVICE_AREA_FIELD_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
 
+  # The single-select "primary" service-area field. Unlike the multi-select
+  # "additional" field, it omits the catch-all "Other" sector — a respondent's
+  # primary service area must be a concrete sector.
+  PRIMARY_SERVICE_AREA_FIELD_IDENTIFIER = "primary_service_area_single"
+
   # Field identifiers whose selectable options are sourced dynamically from a
   # CategoryType's published categories. The submitted value is a Category id
   # (as a string). Maps the field identifier to its backing CategoryType name.
@@ -219,7 +224,7 @@ class FormField < ApplicationRecord
     return unless selectable?
 
     values = if field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS)
-      Sector.published.pluck(:id).map(&:to_s)
+      service_area_sectors.pluck(:id).map(&:to_s)
     elsif (type_name = DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
       type = CategoryType.find_by(name: type_name)
       type ? type.categories.published.pluck(:id).map(&:to_s) : []
@@ -228,6 +233,15 @@ class FormField < ApplicationRecord
     end
 
     values.to_set
+  end
+
+  # The published Sector records a service-area field offers, in name order. The
+  # single-select "primary" field omits the catch-all "Other" sector; the
+  # multi-select "additional" field includes it. Source of truth shared by the
+  # public form's rendering and submission validation.
+  def service_area_sectors
+    scope = Sector.published.order(:name)
+    field_identifier == PRIMARY_SERVICE_AREA_FIELD_IDENTIFIER ? scope.excluding_other : scope
   end
 
   # True when this field offers the free-text "Other" choice (stored fields only).

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -24,6 +24,10 @@ class Sector < ApplicationRecord
     "Other"
   ]
 
+  # The catch-all sector. Offered for "additional" service areas but not as a
+  # respondent's single "primary" service area.
+  OTHER_SECTOR_NAME = "Other"
+
   STORY_DISPLAY_TEXT = "Which sectors does this story fit into?"
   VIDEO_DISPLAY_TEXT = "Which sectors apply?"
 
@@ -44,6 +48,7 @@ class Sector < ApplicationRecord
   scope :sector_name, ->(sector_name) {
     sector_name.present? ? where("sectors.name LIKE ?", "%#{sector_name}%") : all }
   scope :sector_ids, ->(ids) { where(id: ids.to_s.split("-").map(&:to_i)) }
+  scope :excluding_other, -> { where.not(name: OTHER_SECTOR_NAME) }
   scope :has_taggings, -> { joins(:sectorable_items).distinct }
   scope :has_published_taggings, -> {
     subqueries = Tag::TAGGABLE_META.map do |_key, data|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -401,4 +401,26 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.noticeable_label(user)).to eq(user.name)
     end
   end
+
+  describe "#dynamic_form_field_options" do
+    let(:form) { create(:form) }
+
+    it "omits the Other sector for the primary service-area dropdown" do
+      create(:sector, :published, name: "Domestic Violence")
+      create(:sector, :published, name: "Other")
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
+
+      labels = helper.dynamic_form_field_options(field).map(&:first)
+      expect(labels).to include("Domestic Violence")
+      expect(labels).not_to include("Other")
+    end
+
+    it "includes the Other sector for the additional service-areas field" do
+      create(:sector, :published, name: "Other")
+      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_service_area")
+
+      labels = helper.dynamic_form_field_options(field).map(&:first)
+      expect(labels).to include("Other")
+    end
+  end
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -331,6 +331,15 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error("999999")).to eq("has an invalid selection")
       end
 
+      it "rejects the Other sector for the primary service-area field but accepts it for additional" do
+        other = create(:sector, :published, name: "Other")
+        primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
+        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_service_area")
+
+        expect(primary.answer_inclusion_error(other.id.to_s)).to eq("has an invalid selection")
+        expect(additional.answer_inclusion_error([ other.id.to_s ])).to be_nil
+      end
+
       it "accepts a published Category id from the backing type for a category field" do
         type = create(:category_type, name: "WorkshopEnvironment")
         offered = create(:category, :published, category_type: type)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- A respondent's single **primary** service area must be a concrete sector, so offering the catch-all **Other** choice there is misleading.
- The multi-select **additional** service-areas field still needs **Other**, so the two fields must diverge.

### How did you approach the change?

- Added `Sector.excluding_other` scope and an `OTHER_SECTOR_NAME` constant as the single source of truth for the catch-all sector.
- Centralized the offered sectors in `FormField#service_area_sectors`: the single-select `primary_service_area_single` field excludes **Other**, the multi-select `primary_service_area` field includes it.
- Routed both the public form's dropdown rendering (`dynamic_form_field_options`) and submission validation (`answer_inclusion_error`) through that method so they stay in agreement — a value rejected in the UI is also rejected server-side.

### Anything else to add?

- No migration: this only changes which existing published sectors are offered/accepted for the primary field.