### PR TITLE
Render option-source links as chips in the form preview

### DIFF
--- a/app/views/forms/_option_source_link.html.erb
+++ b/app/views/forms/_option_source_link.html.erb
@@ -1,9 +1,13 @@
 <%# locals: (field:) %>
+<%# Admin-only preview chip mirroring the visibility chips (Logged out only, etc.)
+    so a centrally-managed option source reads as the same kind of badge. The jump
+    link to the managed list is an admin convenience: this partial renders only in
+    the admin preview, never on the public registration form. %>
 <% source = form_field_option_source(field) %>
 <% if source %>
   <%= link_to source[:path], target: "_blank", rel: "noopener",
-        class: "inline-flex items-center gap-1 text-xs font-medium text-purple-700 hover:text-purple-900" do %>
-    <span class="underline">Options from <%= source[:label] %></span>
-    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+        class: "inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
+    Options from <%= source[:label] %>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
   <% end %>
 <% end %>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- In the admin form preview, a field whose options are centrally managed shows an "Options from Sectors" / "Options from Age range categories" indicator.
- It rendered as a plain underlined link, which read differently from the visibility badges (e.g. "Logged out only") it sits next to — even though both are read-only metadata about the field.
- Making it a matching chip lets a field's option source read as the same kind of badge, so the preview is visually coherent.

### How did you approach the change?

- Restyled `forms/_option_source_link` from an underlined link into a rounded pill chip mirroring the visibility badges (`rounded-full border px-2 py-0.5 text-xs`, sky palette).
- Kept the admin jump link to the managed list, but shrank and dimmed its external-link icon (`text-[0.6rem] opacity-70`) to match the registrant jump-link chips.
- No behavior change to visibility: this partial renders only in the admin preview (and the editor), never on the public registration form — documented in the partial so it doesn't regress.

### UI Testing Checklist

- [ ] Open the admin form preview for a form with a dynamic-option field (e.g. Primary age group, Primary service area) and confirm the "Options from …" indicator shows as a chip alongside the visibility chips.
- [ ] Confirm the chip still links to the managed list (Sectors / Categories) in a new tab.
- [ ] Confirm the public registration form shows no "Options from …" chip or jump link.

### Anything else to add?

- `spec/requests/forms_spec.rb` passes (56 examples, 0 failures); it already asserts the "Options from … categories" text and managed-list link in both the editor and preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)