### PR TITLE
Show scholarship form's headers and name in registration section

### DIFF
--- a/app/views/events/public_registrations/_group_header.html.erb
+++ b/app/views/events/public_registrations/_group_header.html.erb
@@ -1,0 +1,9 @@
+<%# Renders a form section header inside the 12-column form grid. locals: field %>
+<div class="md:col-span-12 pt-7 pb-4">
+  <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
+    <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
+  </h3>
+  <% if field.hint_text.present? %>
+    <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
+  <% end %>
+</div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -118,14 +118,7 @@
         <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
           <% @form_fields.each do |field| %>
             <% if field.group_header? %>
-              <div class="md:col-span-12 pt-7 pb-4">
-                <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
-                  <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
-                </h3>
-                <% if field.hint_text.present? %>
-                  <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
-                <% end %>
-              </div>
+              <%= render "events/public_registrations/group_header", field: field %>
             <% else %>
               <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
               <% if submitted_value.blank? && field.field_identifier == "payment_method" %>
@@ -141,16 +134,21 @@
         <% if @scholarship_form && @scholarship_form.form_fields.any? %>
           <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">
             <h3 class="flex items-center gap-2.5 text-lg font-bold text-purple-900 mb-5">
-              <i class="fa-solid fa-hand-holding-heart text-accent"></i>Scholarship application
+              <i class="fa-solid fa-hand-holding-heart text-accent"></i><%= @scholarship_form.display_name %>
             </h3>
             <%= render "forms/header", form: @scholarship_form, event: @event %>
             <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
               <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
-                <% next if field.group_header? %>
-                <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
-                <div class="<%= field.grid_span_class %>">
-                  <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
-                </div>
+                <% if field.group_header? %>
+                  <%# Skip a section header that just repeats the form name shown as the title above %>
+                  <% next if field.name.to_s.strip.casecmp?(@scholarship_form.display_name.to_s.strip) %>
+                  <%= render "events/public_registrations/group_header", field: field %>
+                <% else %>
+                  <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
+                  <div class="<%= field.grid_span_class %>">
+                    <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+                  </div>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -39,21 +39,52 @@ RSpec.describe "Public registration new page", type: :system do
     end
   end
 
-  describe "scholarship form header" do
+  describe "scholarship section" do
     let(:scholarship_form) do
-      create(:form, :standalone, :scholarship, :with_fields,
+      create(:form, :standalone, :scholarship, name: "Financial aid request",
              header: "<p>Scholarship intro for {{event_month_year}}.</p>")
     end
 
     before do
+      create(:form_field, form: scholarship_form, answer_type: :group_header,
+             name: "Eligibility questions", position: 1)
+      create(:form_field, form: scholarship_form,
+             name: "Why do you need a scholarship?", position: 2)
+      create(:form_field, form: scholarship_form, answer_type: :group_header,
+             name: "Financial details", position: 3)
+      create(:form_field, form: scholarship_form,
+             name: "Annual household income", position: 4)
       EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+    end
+
+    it "titles the section with the scholarship form's name" do
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      expect(page).to have_css("i.fa-hand-holding-heart")
+      expect(page).to have_text("Financial aid request")
     end
 
     it "renders the scholarship form's header above the scholarship questions" do
       visit new_event_public_registration_path(event, scholarship_requested: true)
 
-      expect(page).to have_text("Scholarship application")
       expect(page).to have_text("Scholarship intro for #{event.start_date.strftime("%B %Y")}.")
+    end
+
+    it "renders the scholarship form's section headers from the form" do
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      expect(page).to have_text("Eligibility questions")
+      expect(page).to have_text("Financial details")
+    end
+
+    it "does not repeat a section header that matches the form name" do
+      scholarship_form.update!(name: "Eligibility questions")
+
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      within(".bg-blue-50\\/50") do
+        expect(page).to have_text("Eligibility questions", count: 1)
+      end
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The public registration **scholarship section** ignored the scholarship form's own data:
  - The section **title was hard-coded** ("Scholarship application") instead of using the form's name.
  - Every **group header in the scholarship form was skipped** (`next if field.group_header?`), so admin-defined section headers never appeared.
- This made the scholarship section inconsistent with the rest of the form and unable to reflect how an admin configured the scholarship form.

### How did you approach the change?

- **Title is now the form's name** — the heart icon is shown beside `@scholarship_form.display_name` rather than a hard-coded string.
- **Section headers render from the form** — group headers in the scholarship form now display using the shared section-header partial (rainbow bar, no heart).
- **No duplicate title** — the default standalone scholarship form (built by `FormBuilderService`) has both a form name *and* a leading "Scholarship Application" group header. A leading header whose text matches the form name is skipped so the title isn't shown twice; genuine sub-section headers still render.
- **Extracted `_group_header.html.erb`** — the section-header markup is now a partial reused by both the main registration loop and the scholarship loop (DRY).
- The heart icon appears **only** on the section title, not on group headers.

### Anything else to add?

- Heads-up: the shared scholarship form's name is currently "Scholarship Application" (title case). The title now renders the form's name verbatim, so to match sentence-case UI conventions it can be renamed under `/forms` (data change, not code).
- Tests in `spec/system/public_registration_new_spec.rb` cover: title shows the form name + heart, the form's intro header renders, the form's section headers render, and a header matching the form name is not repeated.
