### PR TITLE
Flag scholarship_requested when awarding an event scholarship

### DIFF
--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -13,6 +13,7 @@ class Scholarship < ApplicationRecord
   validate :within_grant_budget, if: :grant
 
   after_update :sync_allocation_amount, if: -> { saved_change_to_amount_cents? }
+  after_create_commit :flag_event_registration_scholarship_requested
 
   scope :completed, -> { where(tasks_completed: true) }
 
@@ -47,5 +48,16 @@ class Scholarship < ApplicationRecord
     return unless allocation
 
     allocation.update!(amount: amount_cents.to_i)
+  end
+
+  # When a scholarship is awarded against an event registration, the registration
+  # should reflect that a scholarship was requested. We never clear this on delete:
+  # removing an awarded scholarship doesn't undo the fact that one was requested.
+  def flag_event_registration_scholarship_requested
+    registration = allocation&.allocatable
+    return unless registration.is_a?(EventRegistration)
+    return if registration.scholarship_requested?
+
+    registration.update!(scholarship_requested: true)
   end
 end

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -54,4 +54,32 @@ RSpec.describe Scholarship, type: :model do
       end
     end
   end
+
+  describe "marking the event registration's scholarship_requested flag" do
+    let(:event) { create(:event) }
+    let(:person) { create(:person) }
+    let(:registration) { create(:event_registration, event:, registrant: person, scholarship_requested: false) }
+
+    it "sets scholarship_requested to true on the connected event registration" do
+      scholarship = build(:scholarship, recipient: person)
+      scholarship.build_allocation(allocatable: registration, amount: scholarship.amount_cents)
+      scholarship.save!
+
+      expect(registration.reload.scholarship_requested).to be(true)
+    end
+
+    it "leaves scholarship_requested true when the scholarship is destroyed" do
+      scholarship = build(:scholarship, recipient: person)
+      scholarship.build_allocation(allocatable: registration, amount: scholarship.amount_cents)
+      scholarship.save!
+
+      scholarship.destroy!
+
+      expect(registration.reload.scholarship_requested).to be(true)
+    end
+
+    it "does nothing when the scholarship is not connected to an event registration" do
+      expect { create(:scholarship, grant: create(:grant), recipient: person) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- When a scholarship is awarded against an event registration, the registration's `scholarship_requested` flag should be set to `true` if it wasn't already.
- This keeps the registrant roster and the scholarship-status filters consistent: an awarded scholarship implies one was requested, even when the request flag wasn't previously checked.

### How did you approach the change?
- Added an `after_create_commit` callback on `Scholarship` that flips the connected `EventRegistration`'s `scholarship_requested` to `true` when it's currently `false`.
- Guarded the callback so it only runs when the scholarship's allocation points at an `EventRegistration` (grant-only scholarships are unaffected).
- Deliberately did **not** touch the flag on destroy — removing an awarded scholarship doesn't undo the fact that one was requested, so the flag stays on.

### Anything else to add?
- TDD: added model specs covering the set-on-create, leave-on-destroy, and not-connected cases (failing first, then green).