### PR TITLE
Gate videoconference link to a 30-min window around the event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,10 @@ class Event < ApplicationRecord
   include ActionText::Attachable
   include RemoteSearchable
 
+  # Grace window on either side of the event during which the videoconference
+  # link is available to paid registrants.
+  VIDEOCONFERENCE_JOIN_BUFFER = 30.minutes
+
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
@@ -117,6 +121,12 @@ class Event < ApplicationRecord
 
   def ended?
     end_date < Time.current
+  end
+
+  def videoconference_window_open?
+    return false unless start_date && end_date
+    now = Time.current
+    now >= start_date - VIDEOCONFERENCE_JOIN_BUFFER && now <= end_date + VIDEOCONFERENCE_JOIN_BUFFER
   end
 
   def registerable?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -210,7 +210,7 @@ class EventRegistration < ApplicationRecord
   end
 
   def joinable?
-    active? && paid?
+    active? && paid? && event.videoconference_window_open?
   end
 
   def attendance_status_label

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe EventRegistration, type: :model do
   end
 
   describe "#joinable?" do
-    let(:event) { create(:event, cost_cents: 1099) }
+    let(:event) { create(:event, cost_cents: 1099, start_date: 1.hour.ago, end_date: 1.hour.from_now) }
     let(:user) { create(:user, :with_person) }
 
     it "returns true for active, paid, non-scholarship registration" do
@@ -256,9 +256,21 @@ RSpec.describe EventRegistration, type: :model do
     end
 
     it "returns true for free event with active registration" do
-      free_event = create(:event, cost_cents: 0)
+      free_event = create(:event, cost_cents: 0, start_date: 1.hour.ago, end_date: 1.hour.from_now)
       reg = create(:event_registration, event: free_event, registrant: user.person)
       expect(reg).to be_joinable
+    end
+
+    it "returns false when the event has not entered the join window yet" do
+      upcoming = create(:event, cost_cents: 0, start_date: 31.minutes.from_now, end_date: 2.hours.from_now)
+      reg = create(:event_registration, event: upcoming, registrant: user.person)
+      expect(reg).not_to be_joinable
+    end
+
+    it "returns false once the event's join window has closed" do
+      finished = create(:event, cost_cents: 0, start_date: 2.hours.ago, end_date: 31.minutes.ago)
+      reg = create(:event_registration, event: finished, registrant: user.person)
+      expect(reg).not_to be_joinable
     end
 
     it "returns true for partial scholarship + partial payment covering full cost" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -61,6 +61,33 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#videoconference_window_open?" do
+    it "returns false more than 30 minutes before the start" do
+      event = build(:event, start_date: 31.minutes.from_now, end_date: 2.hours.from_now)
+      expect(event.videoconference_window_open?).to be false
+    end
+
+    it "returns true within 30 minutes before the start" do
+      event = build(:event, start_date: 29.minutes.from_now, end_date: 2.hours.from_now)
+      expect(event.videoconference_window_open?).to be true
+    end
+
+    it "returns true while the event is in progress" do
+      event = build(:event, start_date: 1.hour.ago, end_date: 1.hour.from_now)
+      expect(event.videoconference_window_open?).to be true
+    end
+
+    it "returns true within 30 minutes after the end" do
+      event = build(:event, start_date: 2.hours.ago, end_date: 29.minutes.ago)
+      expect(event.videoconference_window_open?).to be true
+    end
+
+    it "returns false more than 30 minutes after the end" do
+      event = build(:event, start_date: 2.hours.ago, end_date: 31.minutes.ago)
+      expect(event.videoconference_window_open?).to be false
+    end
+  end
+
   describe "#registerable?" do
     it "returns true when registration_close_date is in the future" do
       event = build(:event, published: true, registration_close_date: 5.days.from_now)

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -327,6 +327,21 @@ RSpec.describe "Event show page", type: :system do
   end
 
   describe "videoconference link" do
+    # The join link is only available within the event's join window, so the
+    # event under test is in progress unless a context says otherwise.
+    let(:event) do
+      create(
+        :event,
+        :published,
+        :publicly_visible,
+        title: "My Event",
+        cost: 10.99,
+        videoconference_url: "https://www.example_zoom.com/123",
+        start_date: 1.hour.ago,
+        end_date: 1.hour.from_now
+      )
+    end
+
     context "user not registered" do
       it "does not show the join link" do
         sign_in(user)
@@ -342,8 +357,8 @@ RSpec.describe "Event show page", type: :system do
                title: "Free Event",
                cost_cents: 0,
                videoconference_url: "https://www.zoom.us/123",
-               start_date: 2.days.from_now,
-               end_date: 2.days.from_now + 2.hours)
+               start_date: 1.hour.ago,
+               end_date: 1.hour.from_now)
       end
 
       before { create(:event_registration, event: free_event, registrant: user.person) }
@@ -379,6 +394,35 @@ RSpec.describe "Event show page", type: :system do
         visit event_path(event)
 
         expect(page).to have_link("Join on Example_zoom", href: "https://www.example_zoom.com/123")
+      end
+    end
+
+    context "event is outside the join window" do
+      let(:event) do
+        create(
+          :event,
+          :published,
+          :publicly_visible,
+          title: "My Event",
+          cost: 10.99,
+          videoconference_url: "https://www.example_zoom.com/123",
+          start_date: 2.days.from_now,
+          end_date: 2.days.from_now + 2.hours
+        )
+      end
+
+      before do
+        registration = create(:event_registration, event: event, registrant: user.person)
+        payment = create(:payment, person: user.person, amount_cents: event.cost_cents, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: registration, amount: event.cost_cents)
+      end
+
+      it "hides the join link for a paid registrant until the window opens" do
+        sign_in(user)
+        visit event_path(event)
+
+        expect(page).to have_text("Virtual event")
+        expect(page).not_to have_link("Join on Example_zoom")
       end
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The Zoom/videoconference link was shown to any paid registrant at all times — days before the event and indefinitely after — even though the link is only useful right around the event.
- This restricts the link to a join window so attendees see it when they need it and not before/after.

### How did you approach the change?
- Added `Event#videoconference_window_open?` plus a `VIDEOCONFERENCE_JOIN_BUFFER = 30.minutes` constant: the window runs from 30 min before `start_date` through 30 min after `end_date`.
- Wired it into `EventRegistration#joinable?` (`active? && paid? && event.videoconference_window_open?`), so every view that gates on `joinable?` (event show page and registration ticket) hides the link outside the window. Payment-in-full gating is unchanged.

### UI Testing Checklist
- [ ] As a paid registrant, the join link is hidden more than 30 minutes before start.
- [ ] The join link appears from 30 minutes before start through 30 minutes after end.
- [ ] The join link is hidden more than 30 minutes after end.
- [ ] Unpaid / partially-paid / cancelled registrants still never see the link.

### Anything else to add?
- Covered by model specs (window boundaries + `joinable?`) and a system spec asserting a fully-paid registrant is blocked until the window opens. Followed red→green TDD.