### PR TITLE
Hide "Other" option on dropdown form fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,6 +182,19 @@ module ApplicationHelper
     end
   end
 
+  # True when a dropdown field carries an "Other" option that the public form
+  # strips (dropdowns have no free-text input). Checks the field's effective
+  # options — dynamic sources (sectors/categories) as well as author-managed
+  # stored options — so the editor and preview warn wherever "Other" would
+  # silently disappear.
+  def dropdown_hides_other?(field)
+    return false unless field.answer_type == "single_select_dropdown"
+
+    options = dynamic_form_field_options(field) ||
+      field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name ] }
+    options.any? { |label, _| other_option?(label) }
+  end
+
   # Describes where a dynamic-option field's choices come from, for the form
   # editor badge: a sentence-case label and a link to the filtered admin list
   # that manages those options. Returns nil for fields with stored options.

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -105,8 +105,10 @@
   <% when "single_select_dropdown" %>
     <%# Dynamic fields (e.g. primary_service_area_single) source options from
         Sector/Category data; everything else uses the field's own stored options. %>
-    <% dropdown_options = dynamic_form_field_options(field) ||
-         field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
+    <%# Dropdowns have no free-text input, so the "Other" option is omitted here. %>
+    <% dropdown_options = (dynamic_form_field_options(field) ||
+         field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] })
+         .reject { |option_label, _| other_option?(option_label) } %>
     <select name="<%= field_name %>"
             id="<%= field_id %>"
             class="<%= input_classes %>"

--- a/app/views/forms/_dropdown_other_warning.html.erb
+++ b/app/views/forms/_dropdown_other_warning.html.erb
@@ -1,6 +1,7 @@
 <%# Dropdowns can't collect free text, so the public form strips the "Other" option.
-    Warn the author whenever a dropdown still carries an "Other" option. %>
-<% if field.answer_type == "single_select_dropdown" && field.other_option? %>
+    Warn the author whenever a dropdown still carries an "Other" option —
+    including dynamic dropdowns sourced from sectors/categories. %>
+<% if dropdown_hides_other?(field) %>
   <p class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-700">
     <i class="fa-solid fa-triangle-exclamation mt-0.5 text-amber-500"></i>
     <span>The "Other" option is hidden on dropdown fields because dropdowns can't collect free text. Switch to radio buttons or checkboxes to offer "Other".</span>

--- a/app/views/forms/_dropdown_other_warning.html.erb
+++ b/app/views/forms/_dropdown_other_warning.html.erb
@@ -1,0 +1,8 @@
+<%# Dropdowns can't collect free text, so the public form strips the "Other" option.
+    Warn the author whenever a dropdown still carries an "Other" option. %>
+<% if field.answer_type == "single_select_dropdown" && field.other_option? %>
+  <p class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-700">
+    <i class="fa-solid fa-triangle-exclamation mt-0.5 text-amber-500"></i>
+    <span>The "Other" option is hidden on dropdown fields because dropdowns can't collect free text. Switch to radio buttons or checkboxes to offer "Other".</span>
+  </p>
+<% end %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -92,6 +92,8 @@
         </button>
       </div>
 
+      <%= render "forms/dropdown_other_warning", field: field %>
+
       <% option_source = form_field_option_source(field) %>
       <div class="hidden mt-2 pb-2 flex flex-col gap-3" data-field-options-target="panel">
         <div class="flex flex-wrap items-center gap-2">

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -104,6 +104,7 @@
                 <% else %>
                   <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier], show_option_source: true %>
                 <% end %>
+                <%= render "forms/dropdown_other_warning", field: field %>
               </div>
             <% end %>
           <% end %>

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -378,6 +378,20 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to match(/data-other-option-target="control"[\s\S]*?value="Other"|value="Other"[\s\S]*?data-other-option-target="control"/)
     end
 
+    it "omits the Other option from a dropdown field" do
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown,
+             name: "Favorite color", required: false)
+      [ "Red", "Other" ].each_with_index do |name, i|
+        option = create(:answer_option, name: name, position: i)
+        create(:form_field_answer_option, form_field: field, answer_option: option)
+      end
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("<option value=\"Red\"")
+      expect(response.body).not_to include("<option value=\"Other\"")
+    end
+
     it "does not add the Other controller to fields without an Other option" do
       field = create(:form_field, form: form, answer_type: :single_select_radio,
              name: "Favorite color", required: false)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -227,6 +227,19 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("The \"Other\" option is hidden on dropdown fields")
     end
 
+    it "warns when a dynamic (category-backed) dropdown sources an Other option" do
+      category_type = create(:category_type, name: "StoryPopulation")
+      create(:category, :published, category_type: category_type, name: "Veterans")
+      create(:category, :published, category_type: category_type, name: "Other")
+      form = create(:form, :standalone)
+      create(:form_field, form: form, answer_type: :single_select_dropdown,
+             field_identifier: "client_life_experiences", name: "Populations")
+
+      get edit_form_path(form)
+
+      expect(response.body).to include("The \"Other\" option is hidden on dropdown fields")
+    end
+
     it "does not warn about Other on a dropdown field without an Other option" do
       form = create(:form, :standalone)
       field = create(:form_field, form: form, answer_type: :single_select_dropdown, name: "Favorite color")

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -213,6 +213,30 @@ RSpec.describe "Forms", type: :request do
 
       expect(response.body).to include("[hint_text]")
     end
+
+    it "warns that the Other option is hidden on a dropdown field" do
+      form = create(:form, :standalone)
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown, name: "Favorite color")
+      [ "Red", "Other" ].each_with_index do |name, i|
+        option = create(:answer_option, name: name, position: i)
+        create(:form_field_answer_option, form_field: field, answer_option: option)
+      end
+
+      get edit_form_path(form)
+
+      expect(response.body).to include("The \"Other\" option is hidden on dropdown fields")
+    end
+
+    it "does not warn about Other on a dropdown field without an Other option" do
+      form = create(:form, :standalone)
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown, name: "Favorite color")
+      option = create(:answer_option, name: "Red", position: 0)
+      create(:form_field_answer_option, form_field: field, answer_option: option)
+
+      get edit_form_path(form)
+
+      expect(response.body).not_to include("The \"Other\" option is hidden on dropdown fields")
+    end
   end
 
   describe "GET /forms/:id (preview)" do
@@ -261,6 +285,19 @@ RSpec.describe "Forms", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("<strong>Section</strong>")
       expect(response.body).to include("<em>Your name</em>")
+    end
+
+    it "warns that the Other option is hidden on a dropdown field" do
+      form = create(:form, :standalone)
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown, name: "Favorite color")
+      [ "Red", "Other" ].each_with_index do |name, i|
+        option = create(:answer_option, name: name, position: i)
+        create(:form_field_answer_option, form_field: field, answer_option: option)
+      end
+
+      get form_path(form)
+
+      expect(response.body).to include("The \"Other\" option is hidden on dropdown fields")
     end
 
     it "renders a section header's subtext under the heading" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Dropdown form fields can't capture free text, so a selected "Other" would submit a bare `"Other"` with no way to clarify it — unlike radio/checkbox fields, which reveal a "please specify" input.
- This hides "Other" from dropdowns on the public registration form and warns form authors so they can switch to radio/checkboxes if they need an "Other" choice.

### How did you approach the change?
- In the public form field renderer, the `single_select_dropdown` branch now rejects any "Other" option (detected by label via the existing `other_option?` helper); other field types are untouched.
- Added a shared `_dropdown_other_warning` partial, rendered server-side (no Stimulus, shown on page load) in both the form editor and the form preview whenever a dropdown carries an "Other" option.
- The warning uses a `dropdown_hides_other?` helper that checks the field's *effective* options — dynamic sources (sectors/categories) as well as author-managed stored options — so dynamic dropdowns whose source list includes an "Other" entry warn too.

### UI Testing Checklist
- [ ] On the public registration form, a dropdown field with an "Other" option no longer lists "Other"; its other options still appear.
- [ ] In the form editor and preview, a dropdown field with an "Other" option shows the amber warning.
- [ ] A dynamic dropdown (e.g. service area / sector or a category-backed field) whose source list contains an "Other" entry also shows the warning.
- [ ] No warning shows for dropdowns without an "Other" option, or for radio/checkbox fields (which still reveal the "please specify" input).

### Anything else to add?
- The warning reflects saved state on page load only; switching a field to "dropdown" in the editor surfaces it after a reload (matches the no-Stimulus requirement).
