### PR TITLE
Prevent display-only form fields from being marked required

### DIFF
--- a/app/frontend/javascript/controllers/answer_options_controller.js
+++ b/app/frontend/javascript/controllers/answer_options_controller.js
@@ -7,8 +7,13 @@ import { Controller } from "@hotwired/stimulus"
 // "Single select radio" would save with no options and render nothing on the
 // public form. The chevron toggle expands/collapses the option list itself.
 export default class extends Controller {
-  static targets = ["type", "section", "list", "icon"]
+  static targets = ["type", "section", "list", "icon", "required", "requiredLabel"]
   static values = { expanded: Boolean }
+
+  // Display-only answer types (informational text, section headers) never
+  // collect a response, so they can't be required — mirrors FormField's
+  // NON_INPUT_ANSWER_TYPES on the server.
+  nonInputTypes = ["no_user_input", "group_header"]
 
   connect() {
     this.render()
@@ -32,11 +37,27 @@ export default class extends Controller {
     return this.hasTypeTarget && this.typeTarget.value.includes("select")
   }
 
+  get nonInput() {
+    return this.hasTypeTarget && this.nonInputTypes.includes(this.typeTarget.value)
+  }
+
   render() {
     const showOptions = this.selectable
     this.sectionTargets.forEach((el) => el.classList.toggle("hidden", !showOptions))
     // Dynamic-option fields render a source badge instead of the editable list.
     if (this.hasListTarget) this.listTarget.classList.toggle("hidden", !(showOptions && this.expandedValue))
     if (this.hasIconTarget) this.iconTarget.classList.toggle("rotate-90", showOptions && this.expandedValue)
+    this.renderRequired()
+  }
+
+  // Display-only fields (informational text, section headers) can't be
+  // required, so hide the Required box entirely — like section headers, but
+  // without their heading font. Unchecking leaves the check_box helper's
+  // hidden "0" field to record the field as not required.
+  renderRequired() {
+    if (this.hasRequiredTarget && this.nonInput) this.requiredTarget.checked = false
+    if (this.hasRequiredLabelTarget) {
+      this.requiredLabelTarget.classList.toggle("hidden", this.nonInput)
+    }
   }
 }

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -11,6 +11,10 @@ class FormField < ApplicationRecord
   # Answer types that collect free-form text, where a minimum word count applies
   FREE_FORM_TEXT_TYPES = %w[free_form_input_one_line free_form_input_paragraph].freeze
 
+  # Answer types that display text only and never collect a response — so a
+  # "required" flag is meaningless for them (nothing to fill in).
+  NON_INPUT_ANSWER_TYPES = %w[no_user_input group_header].freeze
+
   # Field identifiers whose selectable options are sourced dynamically from
   # Sector records rather than the field's own stored answer options. The
   # submitted value for these is a Sector id (as a string).
@@ -52,6 +56,7 @@ class FormField < ApplicationRecord
   validates :min_words, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :max_characters, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validate :max_characters_allows_min_words
+  validate :non_input_types_cannot_be_required
 
   # Enum
   enum :status, [ :inactive, :active ]
@@ -144,6 +149,12 @@ class FormField < ApplicationRecord
     FREE_FORM_TEXT_TYPES.include?(answer_type)
   end
 
+  # False for display-only types (informational text, section headers) that
+  # never collect an answer; true for every field a respondent fills in.
+  def collects_input?
+    NON_INPUT_ANSWER_TYPES.exclude?(answer_type)
+  end
+
   # Field identifiers (system-assigned by FormBuilderService) that collect an
   # email address, so a submitted value should be format-checked. The "*_type"
   # selector fields are deliberately excluded — this is an exact allowlist, not
@@ -182,6 +193,15 @@ class FormField < ApplicationRecord
     return if max_characters >= required
 
     errors.add(:max_characters, "is too low for a #{min_words}-word minimum (allow at least #{required})")
+  end
+
+  # Display-only fields (informational text, section headers) have nothing to
+  # fill in, so they can't be marked required.
+  def non_input_types_cannot_be_required
+    return if collects_input?
+    return unless required?
+
+    errors.add(:required, "is not available for #{answer_type_label.downcase} fields")
   end
 
   # The character ceiling actually enforced for this field: the explicit

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -33,6 +33,8 @@
   <%= f.hidden_field :position, value: field.position %>
 
   <% if field.group_header? %>
+    <%# Section headers never collect an answer, so they're never required. %>
+    <%= f.hidden_field :required, value: false %>
     <div class="flex-1 min-w-0" data-controller="field-options">
       <div class="flex items-start gap-3">
         <div class="flex-1 min-w-0">
@@ -72,8 +74,9 @@
               {},
               class: "flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               data: { answer_options_target: "type", action: "answer-options#typeChanged" } %>
-        <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0">
-          <%= f.check_box :required, class: "rounded border-gray-300 text-purple-600" %>
+        <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0" data-answer-options-target="requiredLabel">
+          <%= f.check_box :required, class: "rounded border-gray-300 text-purple-600",
+                data: { answer_options_target: "required" } %>
           Required
         </label>
         <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0 ml-auto" title="Ask only the first time — hide if the person already answered it on any form, not just this event">

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -1,7 +1,8 @@
 <% case field.html_input_type %>
 <% when :label %>
   <div class="label-plus-comment">
-    <label><%= field.name %> <%= "*" if field.required? %></label>
+    <%# Display-only field — never collects input, so no required marker. %>
+    <label><%= field.name %></label>
     <div class="custom-smaller"> <%= field.hint_text %> </div>
   </div>
 

--- a/app/views/shared/_report_form_field_answers.html.erb
+++ b/app/views/shared/_report_form_field_answers.html.erb
@@ -8,7 +8,7 @@
 
   <div class="label-plus-comment">
     <% unless answers.include?(log_field.id) %>
-      <label class='bold'><%= "#{log_field.name}" %><% if log_field.required %><%= " *" %><% end %></label>
+      <label class='bold'><%= log_field.name %><% if log_field.required && log_field.collects_input? %><%= " *" %><% end %></label>
     <% end %>
 
     <% unless answers.include?(log_field.hint_text) %>

--- a/spec/factories/form_fields.rb
+++ b/spec/factories/form_fields.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     input_type { :text_alphanumeric } # Default datatype
     sequence(:position) { |n| n }
     parent_id { nil }
+    # Display-only types (informational text, section headers) can't be required.
+    required { FormField::NON_INPUT_ANSWER_TYPES.exclude?(answer_type.to_s) }
 
     # Add other attributes based on schema if needed
   end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -27,6 +27,44 @@ RSpec.describe FormField do
       field = build(:form_field, form: create(:form), name: "A. " * 100)
       expect(field).to be_valid
     end
+
+    describe "required flag on display-only types" do
+      let(:form) { create(:form) }
+
+      %i[no_user_input group_header].each do |type|
+        it "rejects a required #{type} field" do
+          field = build(:form_field, form: form, answer_type: type, required: true)
+          expect(field).not_to be_valid
+          expect(field.errors[:required]).to be_present
+        end
+
+        it "allows a non-required #{type} field" do
+          field = build(:form_field, form: form, answer_type: type, required: false)
+          expect(field).to be_valid
+        end
+      end
+
+      it "still allows a required input field" do
+        field = build(:form_field, form: form, answer_type: :free_form_input_one_line, required: true)
+        expect(field).to be_valid
+      end
+    end
+  end
+
+  describe "#collects_input?" do
+    let(:form) { create(:form) }
+
+    %i[no_user_input group_header].each do |type|
+      it "is false for #{type}" do
+        expect(build(:form_field, form: form, answer_type: type).collects_input?).to be false
+      end
+    end
+
+    %i[free_form_input_one_line single_select_radio multi_select_checkbox].each do |type|
+      it "is true for #{type}" do
+        expect(build(:form_field, form: form, answer_type: type).collects_input?).to be true
+      end
+    end
   end
 
   describe 'enums' do

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe FormAnswerValidator do
 
   describe "skipping" do
     it "ignores group header fields entirely" do
-      header = create(:form_field, form: form, answer_type: :group_header, required: true)
+      header = create(:form_field, form: form, answer_type: :group_header)
 
       expect(validate(header, "")).to eq({})
     end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Informational-only and section-header form fields collect no answer, so marking them "required" is meaningless — it produced a stray asterisk and, for informational-only, an unsatisfiable presence check that could block submissions.
- This makes "required" unavailable for those display-only types across the model, the form builder, and the public/report views.

### How did you approach the change?
- Added a `FormField` validation (`non_input_types_cannot_be_required`) plus a `collects_input?` helper and `NON_INPUT_ANSWER_TYPES` constant as the server-side backstop.
- In the form builder, section headers get a hidden `required: false`, while the shared field row hides + unchecks the Required toggle via the `answer-options` Stimulus controller when the type is display-only (the type can be switched live there, so a static hidden field would be wrong).
- Stopped rendering the required marker for display-only fields on the public form and report views, and updated the factory/specs so display-only fields default to not-required.

### UI Testing Checklist
- [ ] In the form builder, select "Informational-only" or "Section header" as a field type and confirm the Required checkbox disappears.
- [ ] Switch the field back to an input type and confirm the Required checkbox reappears.
- [ ] Confirm no asterisk renders next to display-only fields on the public form and report views.

### Anything else to add?
The model validation guarantees correctness even with JavaScript disabled; the Stimulus controller and hidden field are UX/data conveniences layered on top.
