### PR TITLE
Surface event "Before you attend" details on the registration ticket

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -96,7 +96,7 @@ class EventsController < ApplicationController
   def details
     authorize! @event, to: :details?
 
-    if @event.rhino_event_details.blank?
+    if @event.event_details.blank?
       redirect_to event_path(@event, reg: params[:reg].presence)
       return
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,8 +1,8 @@
 class EventsController < ApplicationController
   include AhoyTracking, TagAssignable
-  skip_before_action :authenticate_user!, only: [ :index, :show, :staff ]
+  skip_before_action :authenticate_user!, only: [ :index, :show, :staff, :details ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants staff edit_staff update_staff recipients bulk_payments preview_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
+  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants details staff edit_staff update_staff recipients bulk_payments preview_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
 
   def index
     authorize!
@@ -88,6 +88,20 @@ class EventsController < ApplicationController
           disposition: "attachment"
       end
     end
+  end
+
+  # Public "Before you attend" page (materials, supplies, policies). Linked from
+  # the registration ticket. When no details are set there is nothing to show, so
+  # fall back to the event page.
+  def details
+    authorize! @event, to: :details?
+
+    if @event.rhino_event_details.blank?
+      redirect_to event_path(@event, reg: params[:reg].presence)
+      return
+    end
+
+    @event = @event.decorate
   end
 
   def staff

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,10 @@ class Event < ApplicationRecord
 
   has_rich_text :rhino_header
   has_rich_text :rhino_description
+  # Free-form "Before you attend" content (materials, supplies, what to bring,
+  # policies) shown on its own ticket-linked page so registrants stop missing the
+  # details that used to live in a long confirmation email.
+  has_rich_text :rhino_event_details
 
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :location, optional: true
@@ -147,6 +151,12 @@ class Event < ApplicationRecord
 
   def name
     title
+  end
+
+  # Heading shown on the ticket call-out and the details page. Falls back to the
+  # default even when an admin clears it, so the section never renders unlabelled.
+  def event_details_label
+    super.presence || "Before you attend"
   end
 
   # Virtual attribute for cost in dollars (converts to/from cost_cents)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,10 +9,6 @@ class Event < ApplicationRecord
 
   has_rich_text :rhino_header
   has_rich_text :rhino_description
-  # Free-form "Before you attend" content (materials, supplies, what to bring,
-  # policies) shown on its own ticket-linked page so registrants stop missing the
-  # details that used to live in a long confirmation email.
-  has_rich_text :rhino_event_details
 
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :location, optional: true

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -106,6 +106,8 @@ class EventPolicy < ApplicationPolicy
                   :videoconference_label,
                   :rhino_header,
                   :rhino_description,
+                  :rhino_event_details,
+                  :event_details_label,
                   :autoshow_cost,
                   :autoshow_date,
                   :autoshow_location,
@@ -142,6 +144,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   alias_rule :preview?, to: :edit?
+  alias_rule :details?, to: :show?
 
   private
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -106,7 +106,7 @@ class EventPolicy < ApplicationPolicy
                   :videoconference_label,
                   :rhino_header,
                   :rhino_description,
-                  :rhino_event_details,
+                  :event_details,
                   :event_details_label,
                   :autoshow_cost,
                   :autoshow_date,

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -95,7 +95,7 @@
       <% end %>
 
       <!-- Before you attend (materials / supplies / what to bring) -->
-      <% if event_registration.event.rhino_event_details.present? %>
+      <% if event_registration.event.event_details.present? %>
         <%= link_to details_event_path(event_registration.event, reg: event_registration.slug),
                       class: "flex items-center gap-3 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3 hover:bg-amber-100 transition-colors" do %>
           <i class="fa-solid fa-circle-info text-amber-500 text-xl shrink-0"></i>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -94,6 +94,21 @@
         <% end %>
       <% end %>
 
+      <!-- Before you attend (materials / supplies / what to bring) -->
+      <% if event_registration.event.rhino_event_details.present? %>
+        <%= link_to details_event_path(event_registration.event, reg: event_registration.slug),
+                      class: "flex items-center gap-3 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3 hover:bg-amber-100 transition-colors" do %>
+          <i class="fa-solid fa-circle-info text-amber-500 text-xl shrink-0"></i>
+
+          <div class="flex-1 min-w-0 text-left">
+            <p class="font-semibold text-amber-900"><%= event_registration.event.event_details_label %></p>
+            <p class="text-sm text-amber-700">Important info for this event — please read</p>
+          </div>
+
+          <i class="fa-solid fa-arrow-right text-amber-500 shrink-0"></i>
+        <% end %>
+      <% end %>
+
       <!-- Divider -->
       <div class="border-t border-gray-200"></div>
 
@@ -118,7 +133,7 @@
           <% registration_form = event_registration.event.registration_form %>
 
           <% if registration_form && registration_form.form_submissions.exists?(person: event_registration.registrant) %>
-            <%= link_to "View registration details",
+            <%= link_to "View your form responses",
                           event_public_registration_path(event_registration.event, reg: event_registration.slug),
                           class: "text-sm text-gray-500 hover:text-blue-600 underline" %>
           <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -410,9 +410,13 @@
         </div>
 
         <div class="form-group mt-6">
-          <%= rhino_editor(f, :event_details,
-                label: "Details content",
-                hint: "Materials, supplies, what to bring, and policies — shown on its own page linked prominently from the ticket. Leave blank to hide it entirely.") %>
+          <%= f.label :event_details, "Details content", class: "block font-medium mb-1 text-gray-700" %>
+          <p class="text-xs text-gray-500 mb-1">
+            Materials, supplies, what to bring, and policies — shown on its own page linked prominently from the ticket. Leave blank to hide it entirely. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.
+          </p>
+          <%= f.text_area :event_details, rows: 8,
+                placeholder: "e.g. <h3>Workshop 1</h3><ul><li>Clear glass stones</li></ul>",
+                class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
         </div>
       </div>
     </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -400,8 +400,27 @@
         <div class="form-group mt-12">
           <%= rhino_editor(f, :description, label: "Description") %>
         </div>
+      </div>
+    </div>
 
-        <div class="form-group mt-12">
+    <%# ---- BEFORE YOU ATTEND (ticket call-out + details page) ---- %>
+    <div class="ticket-details-section" data-controller="dropdown">
+      <button
+        type="button"
+        id="ticket_details_button"
+        class="
+          flex items-center justify-between cursor-pointer w-full
+          bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
+        data-action="dropdown#toggle"
+        data-dropdown-payload-param='[{"ticket_details":"hidden"}, {"ticket_details_arrow":"rotate-180"}, {"ticket_details_button":"rounded-md rounded-t-md"}]'>
+        Before you attend
+        <i id="ticket_details_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
+      </button>
+
+      <div id="ticket_details" class="hidden border border-gray-300 p-4 rounded-b-md">
+        <p class="text-sm text-gray-500 mb-4">Extra info shown on the registration ticket as a prominent call-out linking to its own details page — for materials, supplies, what to bring, and policies (the kind of thing that used to live in a long confirmation email).</p>
+
+        <div class="form-group">
           <%= f.label :event_details_label, "Details section label", class: "block font-medium mb-1 text-gray-700" %>
           <%= f.text_field :event_details_label,
                        placeholder: "Before you attend",

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -400,6 +400,20 @@
         <div class="form-group mt-12">
           <%= rhino_editor(f, :description, label: "Description") %>
         </div>
+
+        <div class="form-group mt-12">
+          <%= f.label :event_details_label, "Details section label", class: "block font-medium mb-1 text-gray-700" %>
+          <%= f.text_field :event_details_label,
+                       placeholder: "Before you attend",
+                       class: "w-full rounded border-gray-300 shadow-sm px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500" %>
+          <p class="text-gray-500 text-sm mt-1">Heading for the details call-out on the ticket and the details page (e.g. "Before you attend", "Art supplies &amp; materials").</p>
+        </div>
+
+        <div class="form-group mt-6">
+          <%= rhino_editor(f, :event_details,
+                label: "Details content",
+                hint: "Materials, supplies, what to bring, and policies — shown on its own page linked prominently from the ticket. Leave blank to hide it entirely.") %>
+        </div>
       </div>
     </div>
 

--- a/app/views/events/details.html.erb
+++ b/app/views/events/details.html.erb
@@ -1,0 +1,33 @@
+<% content_for(:page_bg_class, "public") %>
+
+<% reg_slug = params[:reg].presence %>
+<% back_path = reg_slug ? registration_ticket_path(reg_slug) : event_path(@event) %>
+<% back_label = reg_slug ? "Back to ticket" : "Back to event" %>
+<div class="max-w-3xl mx-auto px-4 pt-4">
+  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
+  <% end %>
+</div>
+
+<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
+        <div class="shrink-0">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
+        </div>
+        <div class="flex-1">
+          <h1 class="text-xl font-semibold tracking-wide leading-tight"><%= @event.event_details_label %></h1>
+          <p class="text-sm text-blue-200"><%= @event.title %></p>
+        </div>
+      </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+    </div>
+
+    <div class="px-6 sm:px-8 py-7">
+      <div class="prose max-w-none prose-headings:text-gray-800 prose-a:text-blue-700">
+        <%= @event.rhino_event_details %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/details.html.erb
+++ b/app/views/events/details.html.erb
@@ -25,8 +25,8 @@
     </div>
 
     <div class="px-6 sm:px-8 py-7">
-      <div class="prose max-w-none prose-headings:text-gray-800 prose-a:text-blue-700">
-        <%= @event.rhino_event_details %>
+      <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
+        <%= form_label_html(@event.event_details) %>
       </div>
     </div>
   </div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -26,7 +26,7 @@
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Registration details</h1>
+          <h1 class="text-xl font-semibold tracking-wide leading-tight">Your form responses</h1>
           <p class="text-sm text-blue-200"><%= @event.title %></p>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
       get :dashboard
       get :background
       get :registrants
+      get :details
       get :staff
       get "staff/edit", action: :edit_staff, as: :edit_staff
       patch "staff", action: :update_staff

--- a/db/migrate/20260616120000_add_event_details_label_to_events.rb
+++ b/db/migrate/20260616120000_add_event_details_label_to_events.rb
@@ -1,0 +1,9 @@
+class AddEventDetailsLabelToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :event_details_label, :string, default: "Before you attend", null: false
+  end
+
+  def down
+    remove_column :events, :event_details_label, if_exists: true
+  end
+end

--- a/db/migrate/20260616120000_add_event_details_to_events.rb
+++ b/db/migrate/20260616120000_add_event_details_to_events.rb
@@ -1,9 +1,11 @@
-class AddEventDetailsLabelToEvents < ActiveRecord::Migration[8.1]
+class AddEventDetailsToEvents < ActiveRecord::Migration[8.1]
   def up
+    add_column :events, :event_details, :text
     add_column :events, :event_details_label, :string, default: "Before you attend", null: false
   end
 
   def down
+    remove_column :events, :event_details, if_exists: true
     remove_column :events, :event_details_label, if_exists: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_115052) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_120000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -495,6 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_115052) do
     t.integer "created_by_id"
     t.text "description"
     t.datetime "end_date", precision: nil
+    t.string "event_details_label", default: "Before you attend", null: false
     t.boolean "featured", default: false, null: false
     t.text "ga4_snippet"
     t.text "gtm_body_snippet"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -495,6 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_120000) do
     t.integer "created_by_id"
     t.text "description"
     t.datetime "end_date", precision: nil
+    t.text "event_details"
     t.string "event_details_label", default: "Before you attend", null: false
     t.boolean "featured", default: false, null: false
     t.text "ga4_snippet"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -226,9 +226,8 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
 # A custom label demonstrates that the heading is admin-editable. Only set when
 # blank so admin edits survive a re-seed.
 flagship = Event.find_by(title: "AWBW Facilitator Training")
-if flagship && flagship.rhino_event_details.blank?
-  flagship.update!(event_details_label: "Art supplies & what to bring")
-  flagship.rhino_event_details = <<~HTML.strip
+if flagship && flagship.event_details.blank?
+  flagship.update!(event_details_label: "Art supplies & what to bring", event_details: <<~HTML.strip)
     <p>We will be facilitating five hands-on art workshops, all of which can be done with paper, writing utensils (crayons, colored pencils, markers, etc.) and scissors.</p>
     <ul>
       <li>You'll receive printable workshop worksheets once your training fees are paid — printing them is optional.</li>
@@ -275,7 +274,6 @@ if flagship && flagship.rhino_event_details.blank?
       <li>Collage materials</li>
     </ul>
   HTML
-  flagship.save!
 end
 
 puts "Creating Event Registrations…"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -220,6 +220,64 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
   hint_registration_cost: "due within 3 weeks of registration"
 )
 
+# Seed the "Before you attend" details — the materials/art-supply info that used to
+# live in a long confirmation email and that registrants routinely missed. Shown on
+# its own ticket-linked page (and via the prominent amber call-out on the ticket).
+# A custom label demonstrates that the heading is admin-editable. Only set when
+# blank so admin edits survive a re-seed.
+flagship = Event.find_by(title: "AWBW Facilitator Training")
+if flagship && flagship.rhino_event_details.blank?
+  flagship.update!(event_details_label: "Art supplies & what to bring")
+  flagship.rhino_event_details = <<~HTML.strip
+    <p>We will be facilitating five hands-on art workshops, all of which can be done with paper, writing utensils (crayons, colored pencils, markers, etc.) and scissors.</p>
+    <ul>
+      <li>You'll receive printable workshop worksheets once your training fees are paid — printing them is optional.</li>
+      <li>You're welcome to use any art supplies you like: oil/chalk pastels, paints, watercolors, collage materials, etc.</li>
+      <li>You may want a journal or lined paper for writing.</li>
+    </ul>
+    <p>The lists below, grouped by workshop, are <strong>optional</strong> supplies you may want on hand. We'll demonstrate how to use them during the training.</p>
+    <h3>Workshop 1</h3>
+    <ul>
+      <li>Clear glass stones</li>
+      <li>Pendant settings (cabochon settings and swivel hooks to hold the glass stones)</li>
+      <li>Hole punch to create paper circles — we recommend a 1.25" circle punch</li>
+      <li>Paper for circles — white and/or colored cardstock, or printmaking paper painted with acrylics</li>
+      <li>Glue to adhere paper circles to the glass stones — we recommend Aleene's Clear Gel Tacky Glue</li>
+      <li>Clear packing tape</li>
+    </ul>
+    <h3>Workshop 2</h3>
+    <ul>
+      <li>Rough &amp; Ready Shrinky Dink paper</li>
+      <li>Permanent markers</li>
+      <li>Colored pencils (we recommend Prismacolor)</li>
+      <li>A hole punch (single or three-hole is fine)</li>
+      <li>Thin ribbon or wire (1/8 in. or thinner)</li>
+      <li>An oven to cook the shrink paper (a toaster oven — not a toaster — works well)</li>
+    </ul>
+    <h3>Workshop 3</h3>
+    <ul>
+      <li>A glue stick (used in workshops 3 &amp; 5)</li>
+      <li>Scotch tape</li>
+      <li>Two copies of the dice handout (sent after fees are paid), printed on cardstock</li>
+    </ul>
+    <h3>Workshop 4</h3>
+    <ul>
+      <li>Oil-based pastels (we recommend Cray-Pas)</li>
+      <li>Card/heavy stock or watercolor paper</li>
+      <li>Watercolors (we recommend Prang)</li>
+      <li>Cups for water</li>
+      <li>Paintbrush</li>
+      <li>Painter's tape</li>
+    </ul>
+    <h3>Workshop 5</h3>
+    <ul>
+      <li>Card/heavy stock paper</li>
+      <li>Collage materials</li>
+    </ul>
+  HTML
+  flagship.save!
+end
+
 puts "Creating Event Registrations…"
 
 # Key people for named scenarios

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -94,6 +94,23 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "GET /details" do
+    let(:event) { create(:event, :published, :publicly_visible) }
+
+    it "renders the details page when details are present" do
+      event.update!(event_details_label: "Art supplies", rhino_event_details: "<p>Bring scissors</p>")
+      get details_event_path(event)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Art supplies")
+      expect(response.body).to include("Bring scissors")
+    end
+
+    it "redirects to the event when details are blank" do
+      get details_event_path(event)
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
   describe "GET /new" do
     context "as admin" do
       it "renders successfully" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -149,6 +149,13 @@ RSpec.describe "Events", type: :request do
       expect(response.body).not_to include("Preview scholarship form")
       expect(response.body).not_to include("Preview bulk payment page")
     end
+
+    it "renders the 'Before you attend' toggle with the details fields" do
+      get edit_event_path(event)
+      expect(response.body).to include("Before you attend")
+      expect(response.body).to include("event[event_details_label]")
+      expect(response.body).to include("event[event_details]")
+    end
   end
 
   describe "POST /create" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Events", type: :request do
     let(:event) { create(:event, :published, :publicly_visible) }
 
     it "renders the details page when details are present" do
-      event.update!(event_details_label: "Art supplies", rhino_event_details: "<p>Bring scissors</p>")
+      event.update!(event_details_label: "Art supplies", event_details: "<p>Bring scissors</p>")
       get details_event_path(event)
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Art supplies")

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe "Event registration show page", type: :system do
     end
   end
 
+  describe "before-you-attend call-out" do
+    it "links to the details page using the event's label when details are present" do
+      event.update!(event_details_label: "Art supplies", rhino_event_details: "<p>Bring scissors</p>")
+
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_link("Art supplies", href: details_event_path(event, reg: registration.slug))
+    end
+
+    it "is hidden when no details are set" do
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_no_link(href: details_event_path(event, reg: registration.slug))
+    end
+  end
+
   describe "view registration form link" do
     it "links to form show with slug param" do
       FormBuilderService.new(
@@ -70,7 +88,7 @@ RSpec.describe "Event registration show page", type: :system do
       sign_in(user)
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_link("View registration details",
+      expect(page).to have_link("View your form responses",
         href: event_public_registration_path(event, reg: registration.slug))
     end
   end

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Event registration show page", type: :system do
 
   describe "before-you-attend call-out" do
     it "links to the details page using the event's label when details are present" do
-      event.update!(event_details_label: "Art supplies", rhino_event_details: "<p>Bring scissors</p>")
+      event.update!(event_details_label: "Art supplies", event_details: "<p>Bring scissors</p>")
 
       sign_in(user)
       visit registration_ticket_path(registration.slug)

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/public_registrations/new.html.erb"  => "public",
     "app/views/events/public_registrations/show.html.erb" => "public",
     "app/views/events/registrations/show.html.erb"        => "public",
+    "app/views/events/details.html.erb"                   => "public",
 
     # ─── bulk payment views ───
     "app/views/events/bulk_payments/new.html.erb"        => "public",


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- Registrants routinely miss the materials, supplies, and policy info that used to live in a long confirmation email.
- This gives events an editable "details" field shown on its own ticket-linked page behind a prominent call-out, so the info is unmissable but the ticket essentials aren't buried.

### How did you approach the change?
- Added an `event_details` field (basic-HTML textarea, edited and sanitized the same way as the existing form-header intro) plus an editable heading (`event_details_label`, default "Before you attend") on events.
- Surfaced it on the registrant ticket as a prominent amber call-out linking to a new public details page (`details_event_path`); both are hidden when no content is set.
- Renamed the registrant-facing "Registration details" to "Your form responses" so it's clear that page shows their submitted form, and seeded the flagship training with the real art-supply copy.

### UI Testing Checklist
- [ ] As an admin, add "Details content" (and optionally change the label) on an event and save.
- [ ] On the registration ticket, confirm the amber "Before you attend" call-out appears and links to the details page, which renders the HTML.
- [ ] Clear the details content and confirm the call-out and page are hidden (the page redirects to the event).
- [ ] Confirm the ticket link now reads "View your form responses" and opens the form-responses page titled "Your form responses".

### Anything else to add?
- Email injection was intentionally left out of scope; the details currently live on the ticket + page only. Covered by new request and system specs.