### PR TITLE
Hide "Mixed-age groups" from the registration age-group field

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,8 +177,7 @@ module ApplicationHelper
     when *FormField::SERVICE_AREA_FIELD_IDENTIFIERS
       field.service_area_sectors.map { |sector| [ sector.name, sector.id.to_s ] }
     when *FormField::DYNAMIC_FIELD_CATEGORY_TYPES.keys
-      type = CategoryType.find_by(name: FormField::DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
-      (type&.categories&.published&.order(:position, :name) || []).map { |category| [ category.name, category.id.to_s, category.description ] }
+      field.dynamic_categories.map { |category| [ category.name, category.id.to_s, category.description ] }
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,11 @@
 class Category < ApplicationRecord
   include NameFilterable, Publishable
 
+  # The catch-all AgeRange category. Tagged wherever age ranges apply, but not
+  # offered on the registration form's "primary age group" question, where a
+  # respondent names the concrete age groups they serve.
+  MIXED_AGE_RANGE_NAME = "Mixed-age groups"
+
   positioned on: :category_type_id
 
   belongs_to :category_type, class_name: "CategoryType", foreign_key: :category_type_id
@@ -10,6 +15,7 @@ class Category < ApplicationRecord
   # Scopes
   # See NameFilterable, Publishable
   scope :age_ranges, -> { joins(:category_type).where(category_types: { name: "AgeRange" }) }
+  scope :excluding_mixed_age, -> { where.not(name: MIXED_AGE_RANGE_NAME) }
   scope :story_categories, -> { joins(:category_type).where(category_types: { name: "StoryCategory" }) }
   scope :ordered_by_position_and_name, -> { reorder(position: :asc, name: :asc) }
 

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -34,6 +34,11 @@ class FormField < ApplicationRecord
     "primary_age_group" => "AgeRange"
   }.freeze
 
+  # The "primary age group(s) served" field. Backed by AgeRange categories but
+  # omits the catch-all "Mixed-age groups" category — a respondent names the
+  # concrete age groups they serve, not the mixed bucket.
+  PRIMARY_AGE_GROUP_FIELD_IDENTIFIER = "primary_age_group"
+
   # The generic free-text option label that lets a respondent supply their own
   # value; a chosen "Other" answer is stored as "Other" or "Other: <text>".
   OTHER_OPTION_PREFIX = "Other"
@@ -257,9 +262,8 @@ class FormField < ApplicationRecord
 
     values = if field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS)
       service_area_sectors.pluck(:id).map(&:to_s)
-    elsif (type_name = DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
-      type = CategoryType.find_by(name: type_name)
-      type ? type.categories.published.pluck(:id).map(&:to_s) : []
+    elsif DYNAMIC_FIELD_CATEGORY_TYPES.key?(field_identifier)
+      dynamic_categories.pluck(:id).map(&:to_s)
     else
       answer_options.pluck(:name)
     end
@@ -274,6 +278,19 @@ class FormField < ApplicationRecord
   def service_area_sectors
     scope = Sector.published.order(:name)
     field_identifier == PRIMARY_SERVICE_AREA_FIELD_IDENTIFIER ? scope.excluding_other : scope
+  end
+
+  # The published Category records a category-backed dynamic field offers, in
+  # position/name order. The "primary age group" field omits the catch-all
+  # "Mixed-age groups" AgeRange category — a respondent names the concrete age
+  # groups they serve. Empty when the backing CategoryType is missing. Source of
+  # truth shared by the public form's rendering and submission validation.
+  def dynamic_categories
+    type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
+    return Category.none unless type
+
+    scope = type.categories.published.order(:position, :name)
+    field_identifier == PRIMARY_AGE_GROUP_FIELD_IDENTIFIER ? scope.excluding_mixed_age : scope
   end
 
   # The "please specify" placeholder for an option label, or nil when the option

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -422,5 +422,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       labels = helper.dynamic_form_field_options(field).map(&:first)
       expect(labels).to include("Other")
     end
+
+    it "omits the Mixed-age groups category for the primary age group field" do
+      type = create(:category_type, name: "AgeRange")
+      create(:category, :published, category_type: type, name: "3-5")
+      create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
+      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_age_group")
+
+      labels = helper.dynamic_form_field_options(field).map(&:first)
+      expect(labels).to include("3-5")
+      expect(labels).not_to include(Category::MIXED_AGE_RANGE_NAME)
+    end
   end
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -398,6 +398,16 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error([ offered.id.to_s ])).to be_nil
         expect(field.answer_inclusion_error([ other_type_category.id.to_s ])).to eq("has an invalid selection")
       end
+
+      it "rejects the Mixed-age groups category for the primary age group field" do
+        type = create(:category_type, name: "AgeRange")
+        concrete = create(:category, :published, category_type: type, name: "3-5")
+        mixed = create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
+        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_age_group")
+
+        expect(field.answer_inclusion_error([ concrete.id.to_s ])).to be_nil
+        expect(field.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
+      end
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The registration form's "Primary Age Group(s) Served" question asks respondents to name the concrete age groups they serve, so the catch-all "Mixed-age groups" AgeRange category shouldn't be selectable there.
- It still needs to stay available everywhere else age ranges are tagged (workshops, windows types, reporting), so it can't simply be unpublished.

### How did you approach the change?
- Added a `Category.excluding_mixed_age` scope and a `FormField#dynamic_categories` method, mirroring the existing `Sector.excluding_other` / `service_area_sectors` pattern that omits "Other" from the primary service-area field.
- Routed both the public form rendering (and editor preview) and submission validation through this one source of truth, so a forged "Mixed-age groups" answer is rejected just as it's hidden from the UI.

### UI Testing Checklist
- [ ] On the registration form, the "Primary Age Group(s) Served" field no longer lists "Mixed-age groups".
- [ ] "Mixed-age groups" still appears wherever age ranges are tagged elsewhere (workshops, windows types).

### Anything else to add?
- This is a hardcoded exclusion (matching the "Other" sector precedent) rather than a per-category admin toggle.