### PR TITLE
Show the primary service area consistently with a starred chip

### DIFF
--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -75,7 +75,10 @@
               the avatar stays blank). Calm palette: neutral name/org links, with
               the sector chips as the single accent. %>
           <% dp = person.decorate %>
-          <% has_sectors = person.sectors.any? %>
+          <%# Primary service area first (rendered as a darker-green crowned chip),
+              then the additional sectors alphabetically. %>
+          <% sectorable_items = person.sectorable_items_primary_first %>
+          <% has_sectors = sectorable_items.any? %>
           <div class="relative px-5 py-4 pr-12 <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:scholarships) %>">
             <button type="button" data-action="expandable-card#toggle"
                     aria-label="Toggle <%= person.name %> application"
@@ -119,8 +122,8 @@
                     <% if has_sectors %>
                       <div class="flex flex-wrap items-center gap-2">
                         <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
-                        <% person.sectors.sort_by(&:name).each do |sector| %>
-                          <%= render "sectors/tagging_label", sector: sector %>
+                        <% sectorable_items.each do |si| %>
+                          <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
                         <% end %>
                       </div>
                     <% elsif service_area_text.present? %>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -28,7 +28,9 @@
         <% active_affiliation = person.affiliations.find { |a| !a.inactive? } %>
         <% org = active_affiliation&.organization %>
         <% bio = event_staff.public_bio %>
-        <% sectors = person.profile_show_sectors? ? person.sectors.sort_by(&:name) : [] %>
+        <%# Primary sector first (starred, darker chip), then the rest alphabetically —
+            the same treatment as the recipients page. %>
+        <% sector_items = person.profile_show_sectors? ? person.sectorable_items.includes(:sector).sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } : [] %>
         <%# Facilitator tenure → one experience badge, computed from already-loaded
             affiliations (avoids the decorator's query-heavy badges call). Thresholds
             match PersonDecorator#compute_badges. %>
@@ -93,13 +95,13 @@
                 </span>
               <% end %>
 
-              <% if sectors.any? %>
+              <% if sector_items.any? %>
                 <div class="mt-1.5 flex flex-wrap justify-center gap-1">
-                  <% sectors.first(3).each do |sector| %>
-                    <span class="px-2 py-0.5 rounded-md text-xs font-medium <%= DomainTheme.bg_class_for(:sectors, intensity: 100) %> <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>"><%= sector.name %></span>
+                  <% sector_items.first(3).each do |si| %>
+                    <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
                   <% end %>
-                  <% if sectors.size > 3 %>
-                    <span class="px-2 py-0.5 rounded-md text-xs font-medium text-gray-400">+<%= sectors.size - 3 %></span>
+                  <% if sector_items.size > 3 %>
+                    <span class="px-2 py-0.5 rounded-md text-xs font-medium text-gray-400">+<%= sector_items.size - 3 %></span>
                   <% end %>
                 </div>
               <% end %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -37,13 +37,15 @@
                 </td>
                 <!-- Sectors -->
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% sectors = person.sectorable_items.sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } %>
+                  <%# Index stays scannable: show only the primary sector(s) as the
+                      darker-green starred chip; the full set lives on the profile. %>
+                  <% sectors = person.sectorable_items.select(&:is_primary?).sort_by { |si| si.sector&.name.to_s.downcase } %>
                   <% if sectors.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% sectors.each do |si| %>
                         <%= render "sectors/tagging_label",
                                    sector: si.sector,
-                                   is_primary: si.is_primary?,
+                                   is_primary: true,
                                    display_leader: true,
                                    is_leader: si.is_leader %>
                       <% end %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -37,12 +37,13 @@
                 </td>
                 <!-- Sectors -->
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% sectors = person.sectorable_items.to_a %>
+                  <% sectors = person.sectorable_items.sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } %>
                   <% if sectors.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% sectors.each do |si| %>
                         <%= render "sectors/tagging_label",
                                    sector: si.sector,
+                                   is_primary: si.is_primary?,
                                    display_leader: true,
                                    is_leader: si.is_leader %>
                       <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -124,44 +124,27 @@
           <% end %>
           <!-- Sectors -->
           <% if @person.profile_show_sectors? %>
-            <% sectorable_items = @person.sectorable_items.includes(:sector).order("sectors.name") %>
-            <% primary_sector_items = sectorable_items.select(&:is_primary?) %>
-            <% additional_sector_items = sectorable_items.reject(&:is_primary?) %>
+            <%# One combined list: the primary sector leads as a darker-green starred
+                chip, followed by the additional sectors alphabetically and any
+                free-text "Other" responses. %>
+            <% sectorable_items = @person.sectorable_items.includes(:sector).sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } %>
             <% other_service_areas = @person.other_service_area_responses %>
             <div class="md:col-span-2 p-3">
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Primary sector</h2>
-                  <% if primary_sector_items.any? %>
-                    <div class="flex flex-wrap gap-2">
-                      <% primary_sector_items.each do |si| %>
-                        <%= render "sectors/tagging_label",
-                                     sector: si.sector,
-                                     display_leader: true,
-                                     is_leader: si.is_leader %>
-                      <% end %>
-                    </div>
-                  <% else %>
-                    <p class="text-gray-500 italic">None selected.</p>
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Sectors</h2>
+              <% if sectorable_items.any? || other_service_areas.any? %>
+                <div class="flex flex-wrap gap-2">
+                  <% sectorable_items.each do |si| %>
+                    <%= render "sectors/tagging_label",
+                                 sector: si.sector,
+                                 is_primary: si.is_primary?,
+                                 display_leader: true,
+                                 is_leader: si.is_leader %>
                   <% end %>
+                  <%= render "people/other_responses", responses: other_service_areas %>
                 </div>
-                <div>
-                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Additional sectors</h2>
-                  <% if additional_sector_items.any? || other_service_areas.any? %>
-                    <div class="flex flex-wrap gap-2">
-                      <% additional_sector_items.each do |si| %>
-                        <%= render "sectors/tagging_label",
-                                     sector: si.sector,
-                                     display_leader: true,
-                                     is_leader: si.is_leader %>
-                      <% end %>
-                      <%= render "people/other_responses", responses: other_service_areas %>
-                    </div>
-                  <% else %>
-                    <p class="text-gray-500 italic">None selected.</p>
-                  <% end %>
-                </div>
-              </div>
+              <% else %>
+                <p class="text-gray-500 italic">None selected.</p>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -4,11 +4,18 @@
 
 <% display_leader ||= false %>
 
-<% bg_color ||= DomainTheme.bg_class_for(:sectors) %>
+<% is_primary ||= false %>
+
+<%# Primary service areas read as a darker-green chip with a star so they stand
+    out from the additional sectors, matching the star used in the chip editor;
+    everyone else keeps the light-lime default. %>
+<% bg_color ||= is_primary ? "bg-lime-200" : DomainTheme.bg_class_for(:sectors) %>
 
 <%# bg_hover_color ||= DomainTheme.bg_class_for(:sectors, hover: true) %>
 
-<% bg_hover_color ||= "bg-lime-200" %>
+<% bg_hover_color ||= is_primary ? "bg-lime-300" : "bg-lime-200" %>
+
+<% text_color ||= is_primary ? "text-lime-800" : "text-gray-500" %>
 
 <% if sector %>
   <%= link_to taggings_path(sector_names_all: sector.name),
@@ -17,11 +24,11 @@
                       rounded-md
                       border #{ DomainTheme.border_class_for(:sectors) } hover:#{ DomainTheme.border_class_for(:sectors, intensity: 500) }
                       #{ bg_color } hover:#{ bg_hover_color }
-                      text-gray-500
+                      #{ text_color }
                       px-3 py-1
                       text-sm font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text"><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
+    <span data-tag-link-loading-target="text"><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary service area"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -674,6 +674,15 @@ record_professional_answers = ->(submission, i) do
   end
   # Service area chart reads SectorableItem tags, mirroring assign_tags.
   sectors.each { |sector| SectorableItem.find_or_create_by!(sector: sector, sectorable: person) }
+  # Make the first submitted service area the person's single primary sector, so the
+  # recipients page + profile crown a primary that matches what they selected on the
+  # registration form. Demote any other primary first to keep exactly one (a person
+  # registered for several events is enriched once per event). Idempotent.
+  primary_sector = sectors.first
+  if primary_sector
+    person.sectorable_items.where(is_primary: true).where.not(sector: primary_sector).update_all(is_primary: false)
+    person.sectorable_items.find_by(sector: primary_sector)&.update!(is_primary: true)
+  end
 end
 
 # Give the flagship cohort registration submissions so its Background charts have

--- a/spec/requests/people_other_responses_spec.rb
+++ b/spec/requests/people_other_responses_spec.rb
@@ -14,16 +14,17 @@ RSpec.describe "Person Other form responses", type: :request do
   before { sign_in admin }
 
   describe "profile page" do
-    it "shows the Other service area as an additional sector" do
+    it "shows the Other service area as a free-text chip, not the primary sector" do
       person.update!(profile_show_sectors: true)
       answer("primary_service_area", "Other: Equine therapy")
 
       get person_path(person)
 
       expect(response.body).to include("Equine therapy")
-      # The Other chip sits in the "Additional sectors" column, not "Primary sector".
-      additional_section = response.body.split("Additional sectors").last
-      expect(additional_section).to include("Equine therapy")
+      # The combined Sectors list renders it via the free-text "(other)" chip rather
+      # than promoting it to the starred primary sector.
+      equine_chip = response.body[/Equine therapy.{0,80}/m]
+      expect(equine_chip).to include("(other)")
     end
   end
 

--- a/spec/requests/people_profile_flags_spec.rb
+++ b/spec/requests/people_profile_flags_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Person profile flag visibility", type: :request do
     profile_show_member_since: "Facilitator since",
     profile_show_phone: "555-123-4567",
     profile_show_affiliations: "Affiliations",
-    profile_show_sectors: "mb-3\">Primary sector</h2>",
+    profile_show_sectors: "mb-3\">Sectors</h2>",
     profile_show_bio: "mb-3\">Bio</h2>",
     profile_show_workshops: "mb-3\">Workshops authored</h2>",
     profile_show_workshop_variations: "Workshop variations authored",

--- a/spec/views/sectors/_tagging_label.html.erb_spec.rb
+++ b/spec/views/sectors/_tagging_label.html.erb_spec.rb
@@ -9,4 +9,18 @@ RSpec.describe "sectors/_tagging_label", type: :view do
     expect(rendered).to include("Survivors")
     expect(rendered).to include("sector_names_all=Survivors")
   end
+
+  it "renders a plain lime chip without a star by default" do
+    render partial: "sectors/tagging_label", locals: { sector: sector }
+
+    expect(rendered).not_to include("fa-star")
+    expect(rendered).to include(DomainTheme.bg_class_for(:sectors))
+  end
+
+  it "marks a primary sector with a darker-green chip and a star" do
+    render partial: "sectors/tagging_label", locals: { sector: sector, is_primary: true }
+
+    expect(rendered).to include("fa-star")
+    expect(rendered).to include("bg-lime-200")
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- A person's **primary service area** — the one they singled out on their registration form — was displayed inconsistently and often indistinguishable from their other sectors.
- This gives the primary sector one consistent treatment everywhere it appears: a darker-green chip led by a gold star (matching the chip editor, where star = primary) with the standard hover state.

### How did you approach the change?
- **Shared chip** (`sectors/_tagging_label`): added an `is_primary` local (defaults false). When set, the chip renders with a gold star (`fa-star`) + darker-green fill (`bg-lime-200`) and a "Primary service area" tooltip. All other callers are unaffected.
- **Scholarship recipients page**: sectors render primary-first (`sectorable_items_primary_first`), with the primary starred — read-only.
- **Person profile**: collapsed the two-column "Primary sector / Additional sectors" layout into one primary-first "Sectors" list; primary leads as the starred chip, followed by additional sectors and any free-text "Other" responses.
- **People index/search**: shows **only** the primary sector as the starred chip, keeping the table scannable (the full set lives on the profile).
- **Event staff cards**: replaced the plain compact sector badges with the same shared chip — primary first and starred.
- **Seed** (`record_professional_answers`): the first submitted service area becomes each registrant's single primary `SectorableItem` (demoting any other first), so demo data matches what they selected on the form.

### Rebase note
Rebased onto main, which now includes #1700 ("Show 'Other' service-area answers as additional sectors"). That's **not** a duplicate — it tweaked the old two-column profile layout to move the "Other" chip into the Additional column. Our single combined list already achieves that intent (the "Other" free-text chip renders after all sectors, never under/with the primary), so we kept our layout and realigned #1700's request spec to assert the Other chip renders as a free-text `(other)` chip rather than keying off the now-removed "Additional sectors" heading. #1700's seed change (`excluding_other`) is complementary and preserved.

### Out of scope (follow-up PRs)
- Event **Background/Dashboard** primary-sector charts — left as-is per request.
- **Organization** sector views — left as-is per request.

### UI Testing Checklist
- [ ] Recipients page: primary shows first as a darker-green starred chip; others light-lime
- [ ] Person profile: single "Sectors" list, primary first and starred, "Other" responses still shown
- [ ] People index: only the primary sector renders, as the starred chip
- [ ] Event staff cards: primary sector first and starred
- [ ] Other sector listings (workshops, logs, taggings) unchanged

### Anything else to add?
- Branch name says "crown" — the marker is a **star** (star = primary, crown = leader in this codebase); renaming post-creation would close the PR, so it's left as-is.
- Added view specs for the default and primary (starred) chip.