### PR TITLE
Collapse submitted content section on participant profile by default

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -246,17 +246,25 @@
     <!-- SUBMITTED SECTION -->
     <% if allowed_to?(:show?, @person) %>
       <div class="user-only <%= DomainTheme.bg_class_for(:user_only) %>
-            border <%= DomainTheme.border_class_for(:user_only) %> rounded-lg shadow-sm">
+            border <%= DomainTheme.border_class_for(:user_only) %> rounded-lg shadow-sm"
+           data-controller="expandable-card"
+           data-expandable-card-expanded-value="false">
         <!-- Header -->
-        <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3
+        <button type="button" data-action="expandable-card#toggle"
+                aria-expanded="false"
+                class="section-header w-full flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3 text-left
               border-b <%= DomainTheme.border_class_for(:user_only) %>">
           <h2 class="text-xl font-semibold text-gray-800">
             Submitted content
           </h2>
-          <span class="text-sm text-amber-700 italic">Only visible to you</span>
-        </div>
+          <span class="flex items-center gap-3">
+            <span class="text-sm text-amber-700 italic">Only visible to you</span>
+            <i class="fa-solid fa-chevron-down transition-transform text-gray-400" data-expandable-card-target="icon"></i>
+          </span>
+        </button>
         <!-- Submitted Content -->
-        <div class="section-content px-3 sm:px-4 py-4 sm:py-6 space-y-8 sm:space-y-10">
+        <div class="section-content hidden px-3 sm:px-4 py-4 sm:py-6 space-y-8 sm:space-y-10"
+             data-expandable-card-target="body">
           <!-- Workshop ideas -->
           <% if @person.profile_show_workshop_ideas? %>
             <div class="p-3">


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The "Submitted content" card on a participant profile (workshop ideas, variation ideas, story ideas, workshop logs) is only visible to the profile owner/admin and takes up significant vertical space.
- Collapsing it by default keeps the profile compact while the content stays one click away.

### How did you approach the change?
- Reused the existing `expandable-card` Stimulus controller (already used in `events/recipients.html.erb`) rather than adding new JS.
- Turned the section header into a full-width toggle button with a `fa-chevron-down` icon that rotates when expanded, and set `expanded-value="false"` so it starts collapsed.
- Marked the content as the controller's `body` target with `hidden` for the initial collapsed state; the controller syncs `hidden`, chevron rotation, and `aria-expanded` on connect and on each toggle.

### Anything else to add?
- No new files or JS — purely a markup change in `app/views/people/show.html.erb`.