### PR TITLE
Show "Other" service-area answers as additional sectors on the profile

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -132,7 +132,7 @@
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <h2 class="text-lg font-semibold text-gray-800 mb-3">Primary sector</h2>
-                  <% if primary_sector_items.any? || other_service_areas.any? %>
+                  <% if primary_sector_items.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% primary_sector_items.each do |si| %>
                         <%= render "sectors/tagging_label",
@@ -140,7 +140,6 @@
                                      display_leader: true,
                                      is_leader: si.is_leader %>
                       <% end %>
-                      <%= render "people/other_responses", responses: other_service_areas %>
                     </div>
                   <% else %>
                     <p class="text-gray-500 italic">None selected.</p>
@@ -148,7 +147,7 @@
                 </div>
                 <div>
                   <h2 class="text-lg font-semibold text-gray-800 mb-3">Additional sectors</h2>
-                  <% if additional_sector_items.any? %>
+                  <% if additional_sector_items.any? || other_service_areas.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% additional_sector_items.each do |si| %>
                         <%= render "sectors/tagging_label",
@@ -156,6 +155,7 @@
                                      display_leader: true,
                                      is_leader: si.is_leader %>
                       <% end %>
+                      <%= render "people/other_responses", responses: other_service_areas %>
                     </div>
                   <% else %>
                     <p class="text-gray-500 italic">None selected.</p>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -648,7 +648,10 @@ puts "Recording professional answers (age group / service area) on registration 
 # answered on a submission, and only enriches people who have a submission (so the
 # "registered but didn't fill the form" scenarios stay answer-free).
 age_range_categories = Category.age_ranges.published.order(:position, :name).to_a
-service_area_sectors = Sector.published.order(:name).to_a
+# Exclude the catch-all "Other" sector: it's the free-text fallback registrants
+# type into (surfaced via Person#other_service_area_responses), not a selectable
+# service area. Seeding it as a sector tag would list "Other" as a real service area.
+service_area_sectors = Sector.published.excluding_other.order(:name).to_a
 
 record_professional_answers = ->(submission, i) do
   person = submission.person

--- a/spec/requests/people_other_responses_spec.rb
+++ b/spec/requests/people_other_responses_spec.rb
@@ -14,13 +14,16 @@ RSpec.describe "Person Other form responses", type: :request do
   before { sign_in admin }
 
   describe "profile page" do
-    it "shows the Other service area beside the sector tags" do
+    it "shows the Other service area as an additional sector" do
       person.update!(profile_show_sectors: true)
       answer("primary_service_area", "Other: Equine therapy")
 
       get person_path(person)
 
       expect(response.body).to include("Equine therapy")
+      # The Other chip sits in the "Additional sectors" column, not "Primary sector".
+      additional_section = response.body.split("Additional sectors").last
+      expect(additional_section).to include("Equine therapy")
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
A registrant's free-text "Other" service area isn't a concrete sector, so it shouldn't sit under the single **Primary sector**; it now displays alongside the **Additional sectors** on the person profile, which reads more accurately. This complements #1684, which removed "Other" from the live primary service-area dropdown.

### How did you approach the change?
Moved the read-only "Other" chips from the Primary sector column to the Additional sectors column in `people/show`, and excluded the catch-all "Other" sector from the seeded service-area tags (via the `Sector.excluding_other` scope) so dev data never lists "Other" as a real service area. Updated the request spec to assert the chip renders in the Additional sectors section.

### UI Testing Checklist
- [ ] On a person profile with a free-text "Other" service-area answer, the chip appears under **Additional sectors** (not **Primary sector**).
- [ ] A profile with only an "Other" answer and no additional sector tags still shows the chip under Additional sectors, while Primary sector reads "None selected."

### Anything else to add?
Seeds now use main's `Sector.excluding_other` scope for consistency; Amy's seeded "Other: Equine-assisted therapy" demo answer still exercises the chip display.
