### PR TITLE
Show captured question wording for historical form answers

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -113,6 +113,14 @@ module EventHelper
     end
   end
 
+  # The question label to show next to a stored answer: the wording captured at
+  # submission time (so editing a question later doesn't rewrite history), falling
+  # back to the field's current name when there's no answer on file — e.g. a
+  # question added after this person submitted.
+  def display_question_label(field, response)
+    response&.question_name_when_answered.presence || field&.name
+  end
+
   def display_response_text(field, response)
     text = resolve_answer_text(field, response&.submitted_answer)
     return tag.span("—", class: "text-gray-400") if text.blank?

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -50,7 +50,7 @@
           <% else %>
             <% response = @responses[field.id] %>
             <div class="<%= field.grid_span_class %> py-2">
-              <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(field.name) %></dt>
+              <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
               <dd class="mt-1 text-sm text-gray-900">
                 <%= display_response_text(field, response) %>
               </dd>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -174,7 +174,7 @@
               <dl class="space-y-4">
                 <% answers.each do |answer| %>
                   <div>
-                    <dt class="text-sm font-semibold text-gray-800"><%= answer.question_name_when_answered.presence || answer.form_field&.name %></dt>
+                    <dt class="text-sm font-semibold text-gray-800"><%= display_question_label(answer.form_field, answer) %></dt>
                     <dd class="mt-1 text-sm text-gray-700 whitespace-pre-line"><%= resolve_answer_text(answer.form_field, answer.submitted_answer) %></dd>
                   </div>
                 <% end %>

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -18,7 +18,7 @@
       </div>
     <% else %>
       <div class="py-2">
-        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= field.name %></dt>
+        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= display_question_label(field, response) %></dt>
         <dd class="mt-1 text-sm text-gray-900">
           <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %>
         </dd>

--- a/app/views/scholarships/_form_submission.html.erb
+++ b/app/views/scholarships/_form_submission.html.erb
@@ -24,7 +24,7 @@
       <dl class="space-y-3">
         <% @scholarship_answers.each do |field, response| %>
           <div>
-            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400"><%= field.name %></dt>
+            <dt class="text-xs font-medium uppercase tracking-wide text-gray-400"><%= display_question_label(field, response) %></dt>
             <dd class="mt-0.5 text-sm text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
           </div>
         <% end %>

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -51,6 +51,28 @@ RSpec.describe EventHelper, type: :helper do
     end
   end
 
+  describe "#display_question_label" do
+    it "uses the question wording captured at submission time" do
+      field = build_stubbed(:form_field, name: "Current wording")
+      response = build_stubbed(:form_answer, question_name_when_answered: "Wording when answered")
+
+      expect(helper.display_question_label(field, response)).to eq("Wording when answered")
+    end
+
+    it "falls back to the field's current name when no answer is on file" do
+      field = build_stubbed(:form_field, name: "Current wording")
+
+      expect(helper.display_question_label(field, nil)).to eq("Current wording")
+    end
+
+    it "falls back to the field's current name when the snapshot is blank" do
+      field = build_stubbed(:form_field, name: "Current wording")
+      response = build_stubbed(:form_answer, question_name_when_answered: "")
+
+      expect(helper.display_question_label(field, response)).to eq("Current wording")
+    end
+  end
+
   describe "#resolve_answer_text" do
     it "maps category ids to names while preserving an 'Other: <text>' token" do
       category_type = create(:category_type, name: "StoryPopulation")

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -489,5 +489,17 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("<strong>Your details</strong>")
       expect(response.body).to include("<em>Name</em>")
     end
+
+    it "shows the question wording captured at submission time, not the reworded label" do
+      submission = FormSubmission.find_by(person: person, form: form)
+      submission.form_answers.create!(form_field: essay_field, submitted_answer: "my reasons",
+                                      question_name_when_answered: "Why do you want to attend?")
+      essay_field.update!(name: "Reworded after submission")
+
+      get event_public_registration_path(event, person_id: person.id)
+
+      expect(response.body).to include("Why do you want to attend?")
+      expect(response.body).not_to include("Reworded after submission")
+    end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
When a question's name is edited later, historical submission views were retroactively relabeling already-submitted answers, misrepresenting what each respondent was actually asked. This PR makes every submission view render the wording snapshotted at submission time so editing a question no longer rewrites history.

### How did you approach the change?
Added a `display_question_label(field, response)` helper that returns `question_name_when_answered` (the wording captured when the answer was saved), falling back to the field's current name only when no snapshot exists (e.g. a question added after this person submitted). Wired it into the public registration show, recipients, form submission, and scholarship submission views so the logic is centralized and consistent.

### UI Testing Checklist
- [ ] On a form submission view, reword a question after a response exists and confirm the original wording still shows next to that answer.
- [ ] Add a new question after a submission and confirm it falls back to the current field name.

### Anything else to add?
Note: answers created before the `question_name_when_answered` column existed have a blank snapshot, so they still fall back to the current field name (no backfill). Covered by new helper and request specs.