### PR TITLE
Make user deletion FK-safe: extend deletable? coverage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,6 @@ class User < ApplicationRecord
   after_commit :create_email_changed_notification, on: :update
 
   before_destroy :track_account_deleted
-  before_destroy :reassign_owned_records
 
   # Associations
   belongs_to :person, optional: true
@@ -62,6 +61,36 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :user_forms
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
 
+  # Tables with a RESTRICT foreign key to users that block destruction.
+  # bookmarks and user_forms are omitted: they're removed via dependent: :destroy.
+  OWNED_RECORD_REFERENCES = {
+    Banner => %i[created_by_id updated_by_id],
+    Comment => %i[created_by_id updated_by_id],
+    CommunityNews => %i[author_id created_by_id updated_by_id],
+    Event => %i[created_by_id],
+    Notification => %i[sender_id],
+    Person => %i[created_by_id updated_by_id],
+    Report => %i[created_by_id],
+    Resource => %i[created_by_id],
+    Story => %i[created_by_id updated_by_id],
+    StoryIdea => %i[created_by_id updated_by_id],
+    Affiliation => %i[user_id],
+    User => %i[created_by_id updated_by_id],
+    Workshop => %i[created_by_id],
+    WorkshopIdea => %i[created_by_id updated_by_id],
+    WorkshopLog => %i[created_by_id],
+    WorkshopVariation => %i[created_by_id],
+    WorkshopVariationIdea => %i[created_by_id updated_by_id]
+  }.freeze
+
+  # Legacy tables (no ActiveRecord model) with a RESTRICT foreign key to users.
+  LEGACY_OWNED_RECORD_REFERENCES = {
+    "user_permissions" => "user_id",
+    "blazer_audits" => "user_id",
+    "blazer_checks" => "creator_id",
+    "blazer_dashboards" => "creator_id",
+    "blazer_queries" => "creator_id"
+  }.freeze
 
   before_validation :strip_whitespace
 
@@ -179,16 +208,11 @@ class User < ApplicationRecord
     end
   end
 
+  # A user can only be destroyed when nothing references them via a RESTRICT
+  # foreign key. We check every such reference so the UI reflects deletability
+  # accurately, rather than relying on the controller's InvalidForeignKey rescue.
   def deletable?
-    !reports.exists? &&
-      !workshop_logs.exists? &&
-      !resources.exists? &&
-      !workshops.exists? &&
-      !stories_as_creator.exists? &&
-      !story_ideas_as_creator.exists? &&
-      !workshop_ideas_as_creator.exists? &&
-      !workshop_variations_as_creator.exists? &&
-      !workshop_variation_ideas_creator.exists?
+    !owns_model_records? && !owns_legacy_records?
   end
 
   def name
@@ -269,52 +293,24 @@ class User < ApplicationRecord
     errors.add(:person_id, "cannot be removed once set")
   end
 
-  def reassign_owned_records
-    orphaned_user = User.find_by(email: "orphaned_reports@awbw.org")
-    return unless orphaned_user
-
-    orphaned_id = orphaned_user.id
-
-    # Reassign NOT NULL created_by_id / updated_by_id to orphaned user
-    Banner.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    Banner.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-    CommunityNews.where(author_id: id).update_all(author_id: orphaned_id)
-    CommunityNews.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    CommunityNews.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-    Report.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    Resource.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    Story.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    Story.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-    StoryIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    StoryIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-    WorkshopIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    WorkshopIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-    WorkshopVariationIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
-    WorkshopVariationIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
-
-    # Nullify nullable foreign keys
-    Comment.where(created_by_id: id).update_all(created_by_id: nil)
-    Comment.where(updated_by_id: id).update_all(updated_by_id: nil)
-    Event.where(created_by_id: id).update_all(created_by_id: nil)
-    Person.where(created_by_id: id).update_all(created_by_id: nil)
-    Person.where(updated_by_id: id).update_all(updated_by_id: nil)
-    User.where(created_by_id: id).update_all(created_by_id: nil)
-    User.where(updated_by_id: id).update_all(updated_by_id: nil)
-    Workshop.where(created_by_id: id).update_all(created_by_id: nil)
-    WorkshopVariation.where(created_by_id: id).update_all(created_by_id: nil)
-
-    # Nullify legacy table FK references
-    nullify_legacy_fk("affiliations", "user_id")
-    nullify_legacy_fk("workshop_logs", "user_id")
-    nullify_legacy_fk("user_permissions", "user_id")
+  def owns_model_records?
+    OWNED_RECORD_REFERENCES.any? do |model, columns|
+      columns.any? { |column| model.where(column => id).exists? }
+    end
   end
 
-  def nullify_legacy_fk(table, column)
-    self.class.connection.execute(
+  def owns_legacy_records?
+    LEGACY_OWNED_RECORD_REFERENCES.any? do |table, column|
+      legacy_reference_exists?(table, column)
+    end
+  end
+
+  def legacy_reference_exists?(table, column)
+    self.class.connection.select_value(
       ActiveRecord::Base.sanitize_sql_array(
-        [ "UPDATE #{table} SET #{column} = NULL WHERE #{column} = ?", id ]
+        [ "SELECT 1 FROM #{table} WHERE #{column} = ? LIMIT 1", id ]
       )
-    )
+    ).present?
   end
 
   def after_confirmation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   after_commit :create_email_changed_notification, on: :update
 
   before_destroy :track_account_deleted
+  before_destroy :reassign_owned_records
 
   # Associations
   belongs_to :person, optional: true
@@ -268,6 +269,53 @@ class User < ApplicationRecord
     errors.add(:person_id, "cannot be removed once set")
   end
 
+  def reassign_owned_records
+    orphaned_user = User.find_by(email: "orphaned_reports@awbw.org")
+    return unless orphaned_user
+
+    orphaned_id = orphaned_user.id
+
+    # Reassign NOT NULL created_by_id / updated_by_id to orphaned user
+    Banner.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    Banner.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+    CommunityNews.where(author_id: id).update_all(author_id: orphaned_id)
+    CommunityNews.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    CommunityNews.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+    Report.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    Resource.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    Story.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    Story.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+    StoryIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    StoryIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+    WorkshopIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    WorkshopIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+    WorkshopVariationIdea.where(created_by_id: id).update_all(created_by_id: orphaned_id)
+    WorkshopVariationIdea.where(updated_by_id: id).update_all(updated_by_id: orphaned_id)
+
+    # Nullify nullable foreign keys
+    Comment.where(created_by_id: id).update_all(created_by_id: nil)
+    Comment.where(updated_by_id: id).update_all(updated_by_id: nil)
+    Event.where(created_by_id: id).update_all(created_by_id: nil)
+    Person.where(created_by_id: id).update_all(created_by_id: nil)
+    Person.where(updated_by_id: id).update_all(updated_by_id: nil)
+    User.where(created_by_id: id).update_all(created_by_id: nil)
+    User.where(updated_by_id: id).update_all(updated_by_id: nil)
+    Workshop.where(created_by_id: id).update_all(created_by_id: nil)
+    WorkshopVariation.where(created_by_id: id).update_all(created_by_id: nil)
+
+    # Nullify legacy table FK references
+    nullify_legacy_fk("affiliations", "user_id")
+    nullify_legacy_fk("workshop_logs", "user_id")
+    nullify_legacy_fk("user_permissions", "user_id")
+  end
+
+  def nullify_legacy_fk(table, column)
+    self.class.connection.execute(
+      ActiveRecord::Base.sanitize_sql_array(
+        [ "UPDATE #{table} SET #{column} = NULL WHERE #{column} = ?", id ]
+      )
+    )
+  end
 
   def after_confirmation
     super

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -247,6 +247,40 @@ RSpec.describe User do
       resource = create(:resource)
       expect(resource.created_by.deletable?).to be false
     end
+
+    it "returns false when user created a banner" do
+      banner = create(:banner)
+      expect(banner.created_by.deletable?).to be false
+    end
+
+    it "returns false when user authored community news" do
+      news = create(:community_news)
+      expect(news.author.deletable?).to be false
+    end
+
+    it "returns false when user created an event" do
+      event = create(:event)
+      expect(event.created_by.deletable?).to be false
+    end
+
+    it "returns false when user created a person" do
+      person = create(:person)
+      expect(person.created_by.deletable?).to be false
+    end
+
+    it "returns false when user authored a comment" do
+      user = create(:user)
+      create(:comment, created_by: user)
+      expect(user.deletable?).to be false
+    end
+
+    it "returns false when user is referenced by a legacy table" do
+      user = create(:user)
+      User.connection.execute(
+        "INSERT INTO user_permissions (user_id, created_at, updated_at) VALUES (#{user.id}, NOW(), NOW())"
+      )
+      expect(user.deletable?).to be false
+    end
   end
 
   describe '.search_by_params' do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Fixes the Honeybadger error where `UsersController#destroy` raised `ActiveRecord::InvalidForeignKey` (e.g. `resources.created_by_id`) when deleting a user who still owns records.
- Main already prevents deletion via `User#deletable?` (#1295), but `deletable?` only checks 9 creator associations. Many other RESTRICT foreign keys to `users` (banners, authored comments, community news, created events, people, affiliations, user_permissions, self-referential users, blazer) are missed — so the Delete button shows, the user clicks, and only then hits the controller `rescue` and an alert. Misleading UX.

### How did you approach the change?

- **Commit 1 (history):** captures the original *reassignment* approach — reassign/nullify every FK to an orphaned user so the record can be destroyed.
- **Commit 2 (final):** supersedes that in favor of main's prevent-deletion approach, extending `deletable?` to cover the remaining RESTRICT foreign keys so the Delete button is hidden whenever a user owns *any* blocking record, instead of relying on the rescue safety net.

### Anything else to add?

- The reassignment approach in commit 1 is intentionally superseded; it's kept for history per request.