### PR TITLE
Add dynamically generated event invoice with PDF download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This codebase (Rails 8.1)
 | `app/views/` | ERB templates | ~504 files |
 | `app/decorators/` | Draper decorators for view logic | ~37 files |
 | `app/policies/` | ActionPolicy authorization rules | ~49 files |
-| `app/presenters/` | Presentation objects | 1 file |
+| `app/presenters/` | Presentation objects | 2 files |
 | `app/helpers/` | View helpers | ~19 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (70) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (71) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -281,6 +281,7 @@ end
 - `paginated_fields` — Client-side pagination of nested fields
 - `password_toggle` — Show/hide password fields
 - `prefetch_lazy` — Prefetch lazy-loaded content
+- `print` — Triggers the browser print dialog (used by the invoice "Download PDF" button)
 - `print_options` — Print options toggle for analytics
 - `remote_select` — AJAX-powered select dropdown
 - `reveal_section` — Expand a collapsible section and scroll to it when loaded via matching URL hash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (71) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (70) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -281,7 +281,6 @@ end
 - `paginated_fields` — Client-side pagination of nested fields
 - `password_toggle` — Show/hide password fields
 - `prefetch_lazy` — Prefetch lazy-loaded content
-- `print` — Triggers the browser print dialog (used by the invoice "Download PDF" button)
 - `print_options` — Print options toggle for analytics
 - `remote_select` — AJAX-powered select dropdown
 - `reveal_section` — Expand a collapsible section and scroll to it when loaded via matching URL hash

--- a/app/controllers/events/invoices_controller.rb
+++ b/app/controllers/events/invoices_controller.rb
@@ -3,15 +3,20 @@ module Events
   # event's content (line item + cost); when a `submission_id` is supplied it
   # autofills the bill-to/attention from that bulk-payment submission.
   class InvoicesController < ApplicationController
+    # Bulk-payment payers have no account; authorization (below) gates access.
+    skip_before_action :authenticate_user!, only: [ :show ]
     before_action :set_event
 
     def show
-      authorize! @event, to: :invoice?
-
       if params[:submission_id].present?
+        # A bulk-payment submission's invoice is reachable by the payer (who has
+        # no account), matching the public bulk-payment show page they're sent.
         @submission = FormSubmission.find(params[:submission_id])
+        authorize! @submission, to: :show_invoice?
         @invoice = EventInvoice.from_bulk_payment(@submission)
       else
+        # The blank template is an admin tool.
+        authorize! @event, to: :invoice?
         @invoice = EventInvoice.from_event(@event)
       end
 

--- a/app/controllers/events/invoices_controller.rb
+++ b/app/controllers/events/invoices_controller.rb
@@ -1,0 +1,27 @@
+module Events
+  # Admin-side invoice for an event. Renders a blank template prefilled with the
+  # event's content (line item + cost); when a `submission_id` is supplied it
+  # autofills the bill-to/attention from that bulk-payment submission.
+  class InvoicesController < ApplicationController
+    before_action :set_event
+
+    def show
+      authorize! @event, to: :invoice?
+
+      if params[:submission_id].present?
+        @submission = FormSubmission.find(params[:submission_id])
+        @invoice = EventInvoice.from_bulk_payment(@submission)
+      else
+        @invoice = EventInvoice.from_event(@event)
+      end
+
+      @event = @event.decorate
+    end
+
+    private
+
+    def set_event
+      @event = Event.find(params[:event_id])
+    end
+  end
+end

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -3,7 +3,7 @@ module Events
     before_action :authenticate_user!, only: [ :create, :destroy ]
     before_action :set_event, only: [ :create, :destroy ]
     before_action :set_registrant, only: [ :create, :destroy ]
-    before_action :set_event_registration, only: [ :show, :resend_confirmation, :cancel, :reactivate, :pay ]
+    before_action :set_event_registration, only: [ :show, :invoice, :resend_confirmation, :cancel, :reactivate, :pay ]
 
     def show
       authorize! @event_registration, to: :show_public?
@@ -20,6 +20,12 @@ module Events
       when "cancelled"
         flash.now[:alert] = "Payment was cancelled. You are registered for this event but payment may still be due."
       end
+    end
+
+    def invoice
+      authorize! @event_registration, to: :show_public?
+      @event = @event_registration.event
+      @invoice = EventInvoice.from_registration(@event_registration)
     end
 
     def resend_confirmation

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -117,9 +117,6 @@ application.register("search-type-select", SearchTypeSelectController)
 import PrefetchLazyController from "./prefetch_lazy_controller"
 application.register("prefetch-lazy", PrefetchLazyController)
 
-import PrintController from "./print_controller"
-application.register("print", PrintController)
-
 import PrintOptionsController from "./print_options_controller"
 application.register("print-options", PrintOptionsController)
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -117,6 +117,9 @@ application.register("search-type-select", SearchTypeSelectController)
 import PrefetchLazyController from "./prefetch_lazy_controller"
 application.register("prefetch-lazy", PrefetchLazyController)
 
+import PrintController from "./print_controller"
+application.register("print", PrintController)
+
 import PrintOptionsController from "./print_options_controller"
 application.register("print-options", PrintOptionsController)
 

--- a/app/frontend/javascript/controllers/print_controller.js
+++ b/app/frontend/javascript/controllers/print_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-
-// Connects to data-controller="print"
-// Opens the browser's print dialog so the page can be saved as a PDF.
-export default class extends Controller {
-  print() {
-    window.print();
-  }
-}

--- a/app/frontend/javascript/controllers/print_controller.js
+++ b/app/frontend/javascript/controllers/print_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="print"
+// Opens the browser's print dialog so the page can be saved as a PDF.
+export default class extends Controller {
+  print() {
+    window.print();
+  }
+}

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -83,6 +83,10 @@ class EventPolicy < ApplicationPolicy
     manage?
   end
 
+  def invoice?
+    manage?
+  end
+
   def preview_reminder?
     manage?
   end

--- a/app/policies/form_submission_policy.rb
+++ b/app/policies/form_submission_policy.rb
@@ -3,4 +3,11 @@ class FormSubmissionPolicy < ApplicationPolicy
   def show?
     admin?
   end
+
+  # Bulk-payment payers have no account but are emailed a link to their public
+  # submission, so they can reach its invoice too. Other submission types stay
+  # admin-only.
+  def show_invoice?
+    record.role == "bulk_payment" || admin?
+  end
 end

--- a/app/presenters/event_invoice.rb
+++ b/app/presenters/event_invoice.rb
@@ -1,0 +1,139 @@
+# Normalizes the data needed to render an event invoice from either source it
+# can be generated for: a single person's EventRegistration, or an
+# organization's bulk-payment FormSubmission. Both resolve to the same shape
+# (bill-to, attention, line items, total) so one view renders both.
+class EventInvoice
+  ISSUER_NAME = "A Window Between Worlds".freeze
+  ISSUER_ADDRESS_LINES = [ "1029 1/2 W 24th St", "Los Angeles, CA 90007" ].freeze
+  ISSUER_EMAIL = "info@awbw.org".freeze
+  PAYABLE_TO_NOTE = "Please make checks payable to A Window Between Worlds".freeze
+
+  LineItem = Struct.new(:date, :description, :quantity, :unit_price_cents, keyword_init: true) do
+    def amount_cents
+      unit_price_cents.to_i * quantity.to_i
+    end
+  end
+
+  attr_reader :event, :number, :date, :reference, :client_id,
+              :bill_to_name, :bill_to_address_lines, :bill_to_email,
+              :attention, :line_items
+
+  # One registration → one attendee billed at the event cost. The registrant's
+  # snapshotted organization (if any) is the bill-to; otherwise bill the person.
+  def self.from_registration(registration)
+    event = registration.event
+    registrant = registration.registrant
+    organization = registration.organizations.first
+    addressable = organization || registrant
+
+    new(
+      event: event,
+      number: "R-#{registration.id}",
+      date: registration.created_at.to_date,
+      client_id: organization&.id || registrant.id,
+      bill_to_name: organization&.name.presence || registrant.full_name,
+      bill_to_address_lines: address_lines_for(addressable),
+      bill_to_email: organization&.email.presence || registrant.preferred_email,
+      attention: registrant.full_name,
+      line_items: [
+        LineItem.new(
+          date: registration.created_at.to_date,
+          description: event.title,
+          quantity: 1,
+          unit_price_cents: event.cost_cents.to_i
+        )
+      ]
+    )
+  end
+
+  # A blank invoice template carrying only the event's content (one attendee at
+  # the event cost). The bill-to and attention are left empty to be filled in.
+  def self.from_event(event)
+    new(
+      event: event,
+      number: nil,
+      date: Date.current,
+      client_id: nil,
+      bill_to_name: nil,
+      bill_to_address_lines: [],
+      bill_to_email: nil,
+      attention: nil,
+      line_items: [
+        LineItem.new(
+          date: nil,
+          description: event.title,
+          quantity: 1,
+          unit_price_cents: event.cost_cents.to_i
+        )
+      ]
+    )
+  end
+
+  # A bulk payment bills the payer's organization for every attendee submitted.
+  # The form captures the payer/org as free text (no Organization record), so
+  # there is no structured address to show.
+  def self.from_bulk_payment(submission)
+    event = submission.resolved_event
+    answers = submission.answers_by_identifier
+    payer = submission.person
+    payer_name = [ answers["payer_first_name"], answers["payer_last_name"] ]
+      .map(&:presence).compact.join(" ").presence || payer&.full_name
+    quantity = [ submission.bulk_payment_attendee_count, 1 ].max
+
+    new(
+      event: event,
+      number: "B-#{submission.id}",
+      date: submission.created_at.to_date,
+      client_id: submission.id,
+      bill_to_name: answers["payer_organization"].presence || payer_name,
+      bill_to_address_lines: [],
+      bill_to_email: answers["payer_email"].presence || payer&.preferred_email,
+      attention: payer_name,
+      line_items: [
+        LineItem.new(
+          date: submission.created_at.to_date,
+          description: event&.title,
+          quantity: quantity,
+          unit_price_cents: event&.cost_cents.to_i
+        )
+      ]
+    )
+  end
+
+  def initialize(event:, number:, date:, client_id:, bill_to_name:,
+                 bill_to_address_lines:, bill_to_email:, attention:, line_items:,
+                 reference: nil)
+    @event = event
+    @number = number
+    @date = date
+    @client_id = client_id
+    @bill_to_name = bill_to_name
+    @bill_to_address_lines = bill_to_address_lines
+    @bill_to_email = bill_to_email
+    @attention = attention
+    @line_items = line_items
+    @reference = reference
+  end
+
+  def total_cents
+    line_items.sum(&:amount_cents)
+  end
+
+  def issuer_name = ISSUER_NAME
+  def issuer_address_lines = ISSUER_ADDRESS_LINES
+  def issuer_email = ISSUER_EMAIL
+  def payable_to_note = PAYABLE_TO_NOTE
+
+  def self.address_lines_for(addressable)
+    return [] unless addressable.respond_to?(:addresses)
+
+    address = addressable.addresses.active.first
+    return [] unless address
+
+    city_line = [ address.city.presence,
+                  [ address.state.presence, address.zip_code.presence ].compact.join(" ").presence ]
+      .compact.join(", ")
+    [ address.street_address.presence, city_line.presence ].compact
+  end
+  private_class_method :address_lines_for
+end

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -128,6 +128,15 @@
       <!-- Divider -->
       <div class="border-t border-gray-200"></div>
 
+      <% if event_registration.event.cost_cents.to_i > 0 %>
+        <div class="text-center">
+          <%= link_to registration_invoice_path(event_registration.slug),
+                        class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 underline" do %>
+            <i class="fa-solid fa-file-invoice-dollar text-xs"></i> View invoice
+          <% end %>
+        </div>
+      <% end %>
+
       <!-- Status -->
       <div class="text-center space-y-2">
         <% if event_registration.checked_in? %>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -125,17 +125,23 @@
         <% end %>
       <% end %>
 
+      <% if event_registration.invoice_requested? %>
+        <%= link_to registration_invoice_path(event_registration.slug),
+                      target: "_blank", rel: "noopener",
+                      class: "flex items-center gap-3 rounded-xl border-2 border-blue-200 bg-blue-50 px-4 py-3 hover:bg-blue-100 transition-colors" do %>
+          <i class="fa-solid fa-file-invoice-dollar text-blue-500 text-xl shrink-0"></i>
+
+          <div class="flex-1 min-w-0 text-left">
+            <p class="font-semibold text-blue-900">View invoice</p>
+            <p class="text-sm text-blue-700">Itemized invoice for this registration</p>
+          </div>
+
+          <i class="fa-solid fa-arrow-right text-blue-500 shrink-0"></i>
+        <% end %>
+      <% end %>
+
       <!-- Divider -->
       <div class="border-t border-gray-200"></div>
-
-      <% if event_registration.event.cost_cents.to_i > 0 %>
-        <div class="text-center">
-          <%= link_to registration_invoice_path(event_registration.slug),
-                        class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-600 underline" do %>
-            <i class="fa-solid fa-file-invoice-dollar text-xs"></i> View invoice
-          <% end %>
-        </div>
-      <% end %>
 
       <!-- Status -->
       <div class="text-center space-y-2">

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -34,11 +34,18 @@
       <%= render "payment_badge", payment: payment %>
     </span>
     <span class="text-sm text-gray-500 whitespace-nowrap"><%= submission.created_at.strftime("%b %-d, %Y") %></span>
-    <%= link_to form_submission_path(submission, return_to: "bulk_payments", expand: submission.id),
-                title: "View form submission",
-                class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
-      <i class="fa-solid fa-file-lines text-xs"></i> Submission
-    <% end %>
+    <div class="flex items-center gap-2">
+      <%= link_to form_submission_path(submission, return_to: "bulk_payments", expand: submission.id),
+                  title: "View form submission",
+                  class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
+        <i class="fa-solid fa-file-lines text-xs"></i> Submission
+      <% end %>
+      <%= link_to event_invoice_path(@event, submission_id: submission.id),
+                  title: "View invoice",
+                  class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
+        <i class="fa-solid fa-file-invoice-dollar text-xs"></i> Invoice
+      <% end %>
+    </div>
 
     <button type="button"
             data-action="dropdown#toggle"

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -40,7 +40,7 @@
                   class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
         <i class="fa-solid fa-file-lines text-xs"></i> Submission
       <% end %>
-      <%= link_to event_invoice_path(@event, submission_id: submission.id),
+      <%= link_to event_invoice_path(@event, submission_id: submission.id, return_to: "bulk_payments"),
                   title: "View invoice",
                   class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
         <i class="fa-solid fa-file-invoice-dollar text-xs"></i> Invoice

--- a/app/views/events/bulk_payments.html.erb
+++ b/app/views/events/bulk_payments.html.erb
@@ -9,7 +9,13 @@
 
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
     <h1 class="text-2xl font-semibold text-gray-900">Bulk payments</h1>
-    <p class="text-sm text-gray-500"><%= @submissions.size %> submission<%= "s" unless @submissions.size == 1 %></p>
+    <div class="flex items-center gap-3">
+      <%= link_to event_invoice_path(@event),
+                  class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
+        <i class="fa-solid fa-file-invoice-dollar text-xs"></i> Blank invoice
+      <% end %>
+      <p class="text-sm text-gray-500"><%= @submissions.size %> submission<%= "s" unless @submissions.size == 1 %></p>
+    </div>
   </div>
 
   <% if @submissions.any? %>

--- a/app/views/events/bulk_payments/show.html.erb
+++ b/app/views/events/bulk_payments/show.html.erb
@@ -45,6 +45,13 @@
       <% end %>
       <%= render "form_submissions/submission", submission: @submission %>
 
+      <div class="mt-6 flex justify-center">
+        <%= link_to event_invoice_path(@event, submission_id: @submission.id, return_to: "bulk_payment_show"),
+                    class: "inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
+          <i class="fa-solid fa-file-invoice-dollar"></i> View invoice
+        <% end %>
+      </div>
+
       <% if allowed_to?(:dashboard?, @event) %>
         <div class="admin-only mt-6 rounded-lg border border-blue-200 bg-blue-50/50 px-4 py-4 space-y-3">
           <div class="flex items-center justify-between gap-2">

--- a/app/views/events/invoices/_actions.html.erb
+++ b/app/views/events/invoices/_actions.html.erb
@@ -5,10 +5,8 @@
   <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
   <% end %>
-  <div class="ml-auto" data-controller="print">
-    <button type="button" data-action="print#print"
-            class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors">
-      <i class="fa-solid fa-file-arrow-down"></i> Download PDF
-    </button>
-  </div>
+  <button onclick="window.print();"
+          class="ml-auto inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors">
+    <i class="fa-solid fa-file-arrow-down"></i> Download PDF
+  </button>
 </div>

--- a/app/views/events/invoices/_actions.html.erb
+++ b/app/views/events/invoices/_actions.html.erb
@@ -1,0 +1,14 @@
+<%# Eyebrow + "Download PDF" controls above an invoice. Hidden when printing so
+    only the invoice document lands in the PDF. `back_path` / `back_label` set
+    the return link to wherever the invoice was opened from. %>
+<div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 sm:px-8 pt-4 print:hidden">
+  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
+  <% end %>
+  <div class="ml-auto" data-controller="print">
+    <button type="button" data-action="print#print"
+            class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors">
+      <i class="fa-solid fa-file-arrow-down"></i> Download PDF
+    </button>
+  </div>
+</div>

--- a/app/views/events/invoices/_invoice.html.erb
+++ b/app/views/events/invoices/_invoice.html.erb
@@ -1,0 +1,92 @@
+<%# Renders one EventInvoice as a printable document. Shared by the per-
+    registration and bulk-payment invoice pages. `invoice` is an EventInvoice. %>
+<article class="mx-auto max-w-3xl bg-white text-gray-800 px-8 py-10 print:px-0 print:py-0 print:max-w-none">
+  <%# Header: issuer details (left) + brand logo (right) %>
+  <header class="flex items-start justify-between gap-6">
+    <address class="not-italic text-sm leading-snug">
+      <p class="font-medium"><%= invoice.issuer_name %></p>
+      <% invoice.issuer_address_lines.each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+      <p><%= invoice.issuer_email %></p>
+    </address>
+    <%= image_tag "logo-with-tagline.png", alt: invoice.issuer_name, class: "h-16 w-auto shrink-0" %>
+  </header>
+
+  <h1 class="text-center text-3xl font-semibold tracking-wide my-8">INVOICE</h1>
+
+  <%# Bill-to %>
+  <div class="space-y-1">
+    <p class="text-sm font-bold">Invoice To:</p>
+    <div class="rounded-2xl border border-gray-300 px-4 py-3 text-sm leading-relaxed">
+      <p class="font-medium"><%= invoice.bill_to_name %></p>
+      <% invoice.bill_to_address_lines.each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+      <% if invoice.bill_to_email.present? %>
+        <p class="text-gray-500"><%= invoice.bill_to_email %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Attention %>
+  <div class="space-y-1 mt-5">
+    <p class="text-sm font-bold">Attention:</p>
+    <div class="rounded-2xl border border-gray-300 px-4 py-3 text-sm">
+      <%= invoice.attention.presence || "—" %>
+    </div>
+  </div>
+
+  <%# Meta row: number / date / reference / client id %>
+  <div class="mt-6 rounded-2xl border border-gray-300 grid grid-cols-2 sm:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200 text-center">
+    <% [
+         [ "Invoice Number", invoice.number ],
+         [ "Invoice Date", invoice.date&.strftime("%-d %b, %Y") ],
+         [ "Your Reference", invoice.reference ],
+         [ "Client ID", invoice.client_id ]
+       ].each do |label, value| %>
+      <div class="px-3 py-3">
+        <p class="text-xs font-bold text-gray-600"><%= label %></p>
+        <p class="text-sm mt-1"><%= value.presence || " " %></p>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Line items %>
+  <table class="w-full mt-8 text-sm">
+    <thead>
+      <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
+        <th class="text-left py-2 pr-3">Date</th>
+        <th class="text-left py-2 pr-3">Job/Item Description</th>
+        <th class="text-right py-2 px-3 whitespace-nowrap">Quantity/Units</th>
+        <th class="text-right py-2 px-3 whitespace-nowrap">Unit Price</th>
+        <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% invoice.line_items.each do |item| %>
+        <tr class="border-b border-gray-100">
+          <td class="py-2 pr-3 whitespace-nowrap align-top"><%= item.date&.strftime("%m/%d/%y") %></td>
+          <td class="py-2 pr-3 align-top"><%= item.description %></td>
+          <td class="py-2 px-3 text-right tabular-nums align-top"><%= item.quantity %></td>
+          <td class="py-2 px-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.unit_price_cents) %></td>
+          <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.amount_cents) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="3"></td>
+        <td class="pt-4 text-right text-sm font-bold">Total</td>
+        <td class="pt-4 text-right">
+          <span class="inline-block rounded-md border border-gray-400 px-3 py-1 text-sm font-bold tabular-nums whitespace-nowrap"><%= dollars_from_cents(invoice.total_cents) %></span>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+
+  <footer class="mt-12 text-sm">
+    <p><%= invoice.payable_to_note %></p>
+    <p class="font-bold mt-1">Thank you.</p>
+  </footer>
+</article>

--- a/app/views/events/invoices/show.html.erb
+++ b/app/views/events/invoices/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% content_for(:page_title, "Invoice — #{@event.title}") %>
+<% if @submission %>
+  <%= render "events/invoices/actions",
+        back_path: bulk_payments_event_path(@event, expand: @submission.id, anchor: "payment-card-#{@submission.id}"),
+        back_label: "Back to bulk payments" %>
+<% else %>
+  <%= render "events/invoices/actions",
+        back_path: dashboard_event_path(@event),
+        back_label: "Back to event" %>
+<% end %>
+<div class="px-4 sm:px-8 py-6 print:p-0">
+  <%= render "events/invoices/invoice", invoice: @invoice %>
+</div>

--- a/app/views/events/invoices/show.html.erb
+++ b/app/views/events/invoices/show.html.erb
@@ -1,14 +1,21 @@
-<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% content_for(:page_bg_class, "public") %>
 <% content_for(:page_title, "Invoice — #{@event.title}") %>
-<% if @submission %>
-  <%= render "events/invoices/actions",
-        back_path: bulk_payments_event_path(@event, expand: @submission.id, anchor: "payment-card-#{@submission.id}"),
-        back_label: "Back to bulk payments" %>
-<% else %>
-  <%= render "events/invoices/actions",
-        back_path: dashboard_event_path(@event),
-        back_label: "Back to event" %>
-<% end %>
+<%
+  back_path, back_label =
+    if @submission
+      case params[:return_to]
+      when "bulk_payment_show"
+        [ event_bulk_payment_path(@event, submission_id: @submission.id), "Back to submission" ]
+      when "form_submission"
+        [ form_submission_path(@submission), "Back to submission" ]
+      else
+        [ bulk_payments_event_path(@event, expand: @submission.id, anchor: "payment-card-#{@submission.id}"), "Back to bulk payments" ]
+      end
+    else
+      [ dashboard_event_path(@event), "Back to event" ]
+    end
+%>
+<%= render "events/invoices/actions", back_path: back_path, back_label: back_label %>
 <div class="px-4 sm:px-8 py-6 print:p-0">
   <%= render "events/invoices/invoice", invoice: @invoice %>
 </div>

--- a/app/views/events/registrations/invoice.html.erb
+++ b/app/views/events/registrations/invoice.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:page_bg_class, "public") %>
+<% content_for(:page_title, "Invoice — #{@event.title}") %>
+<%= render "events/invoices/actions",
+      back_path: registration_ticket_path(@event_registration.slug),
+      back_label: "Back to registration" %>
+<div class="px-4 sm:px-8 py-6 print:p-0">
+  <%= render "events/invoices/invoice", invoice: @invoice %>
+</div>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -29,6 +29,15 @@
     </div>
     <div class="px-6 sm:px-8 py-7">
       <%= render "form_submissions/submission", submission: @form_submission %>
+
+      <% if event && @form_submission.role == "bulk_payment" %>
+        <div class="mt-6 flex justify-center">
+          <%= link_to event_invoice_path(event, submission_id: @form_submission.id, return_to: "form_submission"),
+                      class: "inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
+            <i class="fa-solid fa-file-invoice-dollar"></i> View invoice
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
   end
   resources :community_news
   get "registration/:slug", to: "events/registrations#show", as: :registration_ticket
+  get "registration/:slug/invoice", to: "events/registrations#invoice", as: :registration_invoice
   post "registration/:slug/resend_confirmation", to: "events/registrations#resend_confirmation", as: :registration_resend_confirmation
   post "registration/:slug/cancel", to: "events/registrations#cancel", as: :registration_cancel
   post "registration/:slug/reactivate", to: "events/registrations#reactivate", as: :registration_reactivate
@@ -143,6 +144,7 @@ Rails.application.routes.draw do
     resource :registrations, only: %i[ create destroy ], module: :events, as: :registrant_registration
     resource :public_registration, only: [ :new, :create, :show ], module: :events
     resource :bulk_payment, only: [ :new, :create, :show ], module: :events
+    resource :invoice, only: [ :show ], module: :events
   end
   resources :people do
     collection do

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -378,14 +378,14 @@ registrations_data = []
 
 # --- Facilitator Training: multiple registrations from different people, extended form ---
 # Amy: registered, with form submission, scholarship recipient
-# Maria Johnson: registered, with form submission (has user)
+# Maria Johnson: registered, with form submission (has user), requested an invoice
 # Anna Garcia: attended, with form submission (has user)
 # Mario Johnson: registered, no form submission (no user)
 # Kim Davis: cancelled (has user)
 if facilitator_training
   [
     { person: amy_person, status: "registered", scholarship_requested: true },
-    { person: maria_j, status: "registered" },
+    { person: maria_j, status: "registered", invoice_requested: true },
     { person: anna_g, status: "attended" },
     { person: mario_j, status: "registered" },
     { person: kim_d, status: "cancelled" }
@@ -396,13 +396,13 @@ if facilitator_training
 end
 
 # --- Trauma Training: extended form, scholarship ---
-# Sarah Smith: registered with form (has user)
+# Sarah Smith: registered with form (has user), requested an invoice
 # Jessica Brown: registered with form, scholarship (has user)
 # Angel Garcia: registered, no form (no user)
 # Linda Williams: no_show (no user)
 if trauma_training
   [
-    { person: sarah_s, status: "registered" },
+    { person: sarah_s, status: "registered", invoice_requested: true },
     { person: jessica_b, status: "registered", scholarship_requested: true },
     { person: angel_g, status: "registered" },
     { person: linda_w, status: "no_show" }
@@ -467,7 +467,8 @@ registrations_data.each do |data|
     event: data[:event],
     registrant: data[:person],
     status: data[:status] || "registered",
-    scholarship_requested: data[:scholarship_requested] || false
+    scholarship_requested: data[:scholarship_requested] || false,
+    invoice_requested: data[:invoice_requested] || false
   )
 end
 

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -377,14 +377,14 @@ end
 registrations_data = []
 
 # --- Facilitator Training: multiple registrations from different people, extended form ---
-# Amy: registered, with form submission, scholarship recipient
+# Amy: registered, with form submission, scholarship recipient, requested W-9 and invoice
 # Maria Johnson: registered, with form submission (has user), requested an invoice
 # Anna Garcia: attended, with form submission (has user)
 # Mario Johnson: registered, no form submission (no user)
 # Kim Davis: cancelled (has user)
 if facilitator_training
   [
-    { person: amy_person, status: "registered", scholarship_requested: true },
+    { person: amy_person, status: "registered", scholarship_requested: true, w9_requested: true, invoice_requested: true },
     { person: maria_j, status: "registered", invoice_requested: true },
     { person: anna_g, status: "attended" },
     { person: mario_j, status: "registered" },
@@ -468,6 +468,7 @@ registrations_data.each do |data|
     registrant: data[:person],
     status: data[:status] || "registered",
     scholarship_requested: data[:scholarship_requested] || false,
+    w9_requested: data[:w9_requested] || false,
     invoice_requested: data[:invoice_requested] || false
   )
 end

--- a/spec/presenters/event_invoice_spec.rb
+++ b/spec/presenters/event_invoice_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe EventInvoice do
+  describe ".from_registration" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+    let(:registrant) { create(:person, first_name: "Helena", last_name: "Lopez") }
+    let(:registration) { create(:event_registration, event: event, registrant: registrant) }
+
+    it "bills the registrant for one attendee at the event cost" do
+      invoice = described_class.from_registration(registration)
+
+      expect(invoice.event).to eq(event)
+      expect(invoice.attention).to eq("Helena Lopez")
+      expect(invoice.bill_to_name).to eq("Helena Lopez")
+      expect(invoice.line_items.size).to eq(1)
+
+      item = invoice.line_items.first
+      expect(item.description).to eq("AWBW 2-Day Art Facilitator Training")
+      expect(item.quantity).to eq(1)
+      expect(item.unit_price_cents).to eq(150_000)
+      expect(item.amount_cents).to eq(150_000)
+      expect(invoice.total_cents).to eq(150_000)
+    end
+
+    context "with a snapshotted organization" do
+      let(:organization) { create(:organization, name: "A Greater Hope") }
+
+      before do
+        create(:event_registration_organization, event_registration: registration, organization: organization)
+        create(:address, addressable: organization, street_address: "PO Box 1477", city: "Victorville", state: "CA", zip_code: "92393")
+      end
+
+      it "bills the organization with its address but keeps the registrant as attention" do
+        invoice = described_class.from_registration(registration)
+
+        expect(invoice.bill_to_name).to eq("A Greater Hope")
+        expect(invoice.attention).to eq("Helena Lopez")
+        expect(invoice.bill_to_address_lines).to eq([ "PO Box 1477", "Victorville, CA 92393" ])
+        expect(invoice.client_id).to eq(organization.id)
+      end
+    end
+  end
+
+  describe ".from_event" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+
+    it "builds a blank template carrying only the event content" do
+      invoice = described_class.from_event(event)
+
+      expect(invoice.bill_to_name).to be_nil
+      expect(invoice.attention).to be_nil
+      expect(invoice.bill_to_address_lines).to eq([])
+
+      item = invoice.line_items.first
+      expect(item.description).to eq("AWBW 2-Day Art Facilitator Training")
+      expect(item.quantity).to eq(1)
+      expect(item.unit_price_cents).to eq(150_000)
+      expect(invoice.total_cents).to eq(150_000)
+    end
+  end
+
+  describe ".from_bulk_payment" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+    let(:form) { create(:form) }
+    let(:submission) { create(:form_submission, form: form, event: event, role: "bulk_payment") }
+
+    def add_answer(identifier, value)
+      field = create(:form_field, form: form, field_identifier: identifier)
+      create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+    end
+
+    before do
+      add_answer("payer_first_name", "Helena")
+      add_answer("payer_last_name", "Lopez")
+      add_answer("payer_organization", "A Greater Hope")
+      add_answer("number_of_attendees", "8")
+    end
+
+    it "bills the payer's organization for every attendee submitted" do
+      invoice = described_class.from_bulk_payment(submission)
+
+      expect(invoice.bill_to_name).to eq("A Greater Hope")
+      expect(invoice.attention).to eq("Helena Lopez")
+
+      item = invoice.line_items.first
+      expect(item.description).to eq("AWBW 2-Day Art Facilitator Training")
+      expect(item.quantity).to eq(8)
+      expect(item.unit_price_cents).to eq(150_000)
+      expect(invoice.total_cents).to eq(1_200_000)
+    end
+  end
+end

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -209,6 +209,13 @@ RSpec.describe "Events::BulkPayments", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).not_to include("Payment allocations")
       end
+
+      it "links to the submission's invoice" do
+        get_show
+
+        expect(response.body).to include("/events/#{event.id}/invoice")
+        expect(response.body).to include("submission_id=#{submission.id}")
+      end
     end
   end
 end

--- a/spec/requests/events/invoices_spec.rb
+++ b/spec/requests/events/invoices_spec.rb
@@ -49,7 +49,29 @@ RSpec.describe "Events::Invoices", type: :request do
     context "as a non-admin" do
       before { sign_in create(:user) }
 
-      it "is denied and redirected" do
+      it "is denied the blank template and redirected" do
+        get event_invoice_path(event)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as a guest (no account)" do
+      let(:form) { create(:form) }
+      let!(:submission) { create(:form_submission, form: form, event: event, role: "bulk_payment") }
+
+      it "can view a bulk-payment submission's invoice (matches the public show page)" do
+        get event_invoice_path(event, submission_id: submission.id)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("INVOICE")
+      end
+
+      it "is denied an invoice for a non-bulk submission" do
+        other = create(:form_submission, form: form, event: event, role: "registration")
+        get event_invoice_path(event, submission_id: other.id)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "is still denied the blank template" do
         get event_invoice_path(event)
         expect(response).to redirect_to(root_path)
       end

--- a/spec/requests/events/invoices_spec.rb
+++ b/spec/requests/events/invoices_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Events::Invoices", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+
+  describe "GET /events/:event_id/invoice" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders a blank invoice template carrying the event's content" do
+        get event_invoice_path(event)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("INVOICE")
+        expect(response.body).to include("AWBW 2-Day Art Facilitator Training")
+        expect(response.body).to include("$1,500")
+      end
+
+      context "with a submission_id" do
+        let(:form) { create(:form) }
+        let(:payer) { create(:person) }
+        let!(:submission) { create(:form_submission, person: payer, form: form, event: event, role: "bulk_payment") }
+
+        def add_answer(identifier, value)
+          field = create(:form_field, form: form, field_identifier: identifier, name: identifier.humanize)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+        end
+
+        before do
+          add_answer("payer_first_name", "Helena")
+          add_answer("payer_last_name", "Lopez")
+          add_answer("payer_organization", "A Greater Hope")
+          add_answer("number_of_attendees", "8")
+        end
+
+        it "autofills the invoice from the bulk-payment submission" do
+          get event_invoice_path(event, submission_id: submission.id)
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("A Greater Hope")
+          expect(response.body).to include("Helena Lopez")
+          # 8 attendees × $1,500 = $12,000
+          expect(response.body).to include("$12,000")
+        end
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in create(:user) }
+
+      it "is denied and redirected" do
+        get event_invoice_path(event)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe "Events::Registrations", type: :request do
       end
     end
 
+    context "invoice link" do
+      it "shows the invoice link when invoice_requested" do
+        registration.update!(invoice_requested: true)
+        get registration_ticket_path(registration.slug)
+        expect(response.body).to include(registration_invoice_path(registration.slug))
+        expect(response.body).to include("View invoice")
+      end
+
+      it "hides the invoice link when not requested" do
+        get registration_ticket_path(registration.slug)
+        expect(response.body).not_to include(registration_invoice_path(registration.slug))
+      end
+    end
+
     context "with an invalid slug" do
       it "returns 404" do
         get registration_ticket_path("nonexistent-slug")

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -69,6 +69,36 @@ RSpec.describe "Events::Registrations", type: :request do
     end
   end
 
+  describe "GET /registration/:slug/invoice" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+    let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+
+    it "renders the invoice for the registrant" do
+      get registration_invoice_path(registration.slug)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("INVOICE")
+      expect(response.body).to include("AWBW 2-Day Art Facilitator Training")
+      expect(response.body).to include("$1,500")
+    end
+
+    context "as a guest" do
+      before { sign_out user }
+
+      it "renders the invoice (slug is authorization)" do
+        get registration_invoice_path(registration.slug)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "with an invalid slug" do
+      it "returns 404" do
+        get registration_invoice_path("nonexistent-slug")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "POST /registration/:slug/resend_confirmation" do
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -190,11 +190,15 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/public_registrations/new.html.erb"  => "public",
     "app/views/events/public_registrations/show.html.erb" => "public",
     "app/views/events/registrations/show.html.erb"        => "public",
+    "app/views/events/registrations/invoice.html.erb"     => "public",
     "app/views/events/details.html.erb"                   => "public",
 
     # ─── bulk payment views ───
     "app/views/events/bulk_payments/new.html.erb"        => "public",
     "app/views/events/bulk_payments/show.html.erb"       => "public",
+
+    # ─── event invoice (slug/submission-reachable; blank template gated in controller) ───
+    "app/views/events/invoices/show.html.erb"            => "public",
 
     # ─── admin-only confirm/interstitial ───
     "app/views/event_registrations/confirm.html.erb"     => "admin-only bg-blue-100",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Provide a printable **invoice for paid events** that's generated from live data instead of a hand-maintained file per event.
- The brand **logo comes from the asset pipeline**, the **recipient name from the registration/payer**, and the **line item (description + price) from the event**.
- Works for both audiences: **registrants** and **bulk-payment payers** (public), and **AWBW staff** (admin).

### How did you approach the change?

- Added an `EventInvoice` presenter (`app/presenters/event_invoice.rb`) that normalizes three sources into one printable layout:
  - `from_registration` — one attendee billed at the event cost; the registrant's snapshotted organization (with address) is the *Invoice To*, falling back to the person.
  - `from_event` — a **blank template** carrying only the event's content.
  - `from_bulk_payment` — bills the payer's organization for every attendee submitted (qty × event cost).
- Routes:
  - `GET /events/:id/invoice` → `events/invoices#show`. Renders the blank template (**admin-only**); **autofills from a bulk-payment submission when `submission_id` is present**, and that case is **public** (gated by `FormSubmissionPolicy#show_invoice?`) — matching that the bulk-payment submission show page is already public by id.
  - `GET /registration/:slug/invoice` → `events/registrations#invoice` (**public**, the secret slug is the authorization).
- **PDF download** reuses the app's existing convention — a "Download PDF" button with inline `onclick="window.print();"` (same as the `recipients`/`background`/social-share views), and the chrome is `print:hidden` so only the invoice document lands in the PDF. No PDF gem/binary and no new Stimulus controller.
- **Entry points:**
  - Registration ticket → "View invoice" (when the event has a cost)
  - Public bulk-payment submission page (the link payers get in their confirmation email) → "View invoice"
  - Admin form-submission page (bulk-payment role) → "View invoice"
  - Admin bulk-payments page → per-submission "Invoice" links + a "Blank invoice" button
  - Return-aware eyebrow via `return_to` so each origin gets the correct back link.

### UI Testing Checklist

- [ ] Registration ticket for a paid event shows "View invoice" → renders the invoice with registrant/org and event line item
- [ ] "Download PDF" opens the print dialog with only the invoice visible (nav, footer, buttons hidden)
- [ ] Public bulk-payment submission page (signed out) shows "View invoice" → renders the org/attendee invoice
- [ ] Admin bulk-payments page: "Blank invoice" renders the empty template; each submission's "Invoice" autofills org/attention and attendee quantity
- [ ] Non-admin hitting `/events/:id/invoice` (blank) or a non-bulk submission's invoice is redirected

### Anything else to add?

- **Bulk submissions have no structured address** (payer/org are free-text form fields), so those invoices show the org name + payer email but no street address; per-registration invoices show the org's real address.
- Per-registration and bulk-payment invoices are intentionally reachable without an account, consistent with the existing registration ticket and bulk-payment submission pages (both gated by a slug / public-by-id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)