### PR TITLE
Capture and surface CE hours requested on event registrations

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -263,6 +263,8 @@ class EventRegistrationsController < ApplicationController
       :event_id, :registrant_id, :status,
       :scholarship_requested,
       :ce_credit_requested,
+      :ce_hours_requested,
+      :ce_license_number,
       organization_ids: [],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]

--- a/app/frontend/javascript/controllers/ce_credit_requested_controller.js
+++ b/app/frontend/javascript/controllers/ce_credit_requested_controller.js
@@ -1,12 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Colors the CE-credit "Requested" toggle to signal save state: amber while the
-// choice is pending (changed but not yet saved with the registration form), the
-// continuing-education theme color once it matches the stored "on" value, and
-// neutral gray when stored as off. Mirrors scholarship_requested_controller.
+// Drives the CE-credit box on the registration form. Colors the "Requested"
+// toggle to signal save state: amber while the choice is pending (changed but
+// not yet saved), the continuing-education theme color once it matches the
+// stored "on" value, neutral gray when stored as off. While "Requested" is on it
+// reveals the CE details (license number + hours) and keeps the "Provided" badge
+// and amount-owed total ($rate × hours) in sync as the admin edits them.
 export default class extends Controller {
-  static targets = ["checkbox", "track"]
-  static values = { initial: Boolean }
+  static targets = ["checkbox", "track", "details", "license", "licenseBadge", "hours", "amount"]
+  static values = { initial: Boolean, rate: Number }
 
   connect() {
     this.refresh()
@@ -19,5 +21,31 @@ export default class extends Controller {
     this.trackTarget.classList.toggle("bg-amber-500", pending)
     this.trackTarget.classList.toggle("bg-teal-600", checked && !pending)
     this.trackTarget.classList.toggle("bg-gray-200", !checked && !pending)
+
+    if (this.hasDetailsTarget) this.detailsTarget.classList.toggle("hidden", !checked)
+
+    this.updateLicenseBadge()
+    this.updateAmount()
+  }
+
+  updateLicenseBadge() {
+    if (!this.hasLicenseTarget || !this.hasLicenseBadgeTarget) return
+
+    const provided = this.licenseTarget.value.trim().length > 0
+    this.licenseBadgeTarget.classList.toggle("bg-teal-50", provided)
+    this.licenseBadgeTarget.classList.toggle("text-teal-700", provided)
+    this.licenseBadgeTarget.classList.toggle("bg-gray-100", !provided)
+    this.licenseBadgeTarget.classList.toggle("text-gray-500", !provided)
+    this.licenseBadgeTarget.innerHTML = provided
+      ? '<i class="fa-solid fa-circle-check text-[0.55rem]"></i> Provided'
+      : '<i class="fa-solid fa-circle-minus text-[0.55rem]"></i> Not provided'
+  }
+
+  updateAmount() {
+    if (!this.hasHoursTarget || !this.hasAmountTarget) return
+
+    const hours = Math.max(0, parseInt(this.hoursTarget.value, 10) || 0)
+    const owed = hours * this.rateValue
+    this.amountTarget.textContent = `$${owed.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
   }
 }

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -1,9 +1,10 @@
 module EventHelper
   # The "please specify" placeholder for an option label, or nil when the option
-  # does not reveal a free-text box. Canonical config lives on FormField (shared
-  # with answer validation).
-  def specify_placeholder(label)
-    FormField.specify_placeholder_for(label)
+  # does not reveal a free-text box. Pass the field to honor placeholders scoped
+  # to one field (e.g. the CE question's "Yes"). Canonical config lives on
+  # FormField (shared with answer validation).
+  def specify_placeholder(label, field = nil)
+    FormField.specify_placeholder_for(label, field&.field_identifier)
   end
 
   # True when a stored answer selects the given specify option: the bare label,

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -22,11 +22,16 @@ class EventRegistration < ApplicationRecord
   INACTIVE_STATUSES = %w[ cancelled no_show ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
 
+  # Default price the registrant owes per requested continuing-education hour.
+  # The CE summary on the registration form multiplies it by ce_hours_requested.
+  CE_HOURLY_RATE_DOLLARS = 25
+
   # Validations
   validates :registrant_id, uniqueness: { scope: :event_id }
   validates :event_id, presence: true
   validates :status, inclusion: { in: ATTENDANCE_STATUSES }, allow_nil: false
   validates :slug, uniqueness: true, allow_nil: true
+  validates :ce_hours_requested, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
   # Scopes
   scope :registrant_name, ->(registrant_name) { joins(:registrant).where(
@@ -211,6 +216,17 @@ class EventRegistration < ApplicationRecord
 
   def discounted?
     allocations.where(source_type: "Discount").exists?
+  end
+
+  # True when the registrant has supplied a CE license number.
+  def ce_license_provided?
+    ce_license_number.present?
+  end
+
+  # What the registrant owes for their requested CE hours, in cents, at the
+  # default hourly rate. Zero when no hours were requested.
+  def ce_amount_owed_cents
+    ce_hours_requested.to_i * CE_HOURLY_RATE_DOLLARS * 100
   end
 
   def joinable?

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -55,6 +55,17 @@ class FormField < ApplicationRecord
     "Foundation/Funder" => "Please list the name of the foundation/funder"
   }.freeze
 
+  # Specify options scoped to a single field by its field_identifier, rather than
+  # to an option label everywhere it appears (SPECIFY_OPTION_PLACEHOLDERS). The
+  # CE-interest question's "Yes" reveals a "How many CE hours?" box that only
+  # makes sense there — a bare "Yes" anywhere else must stay a plain choice. The
+  # typed value folds into the answer as "Yes: <hours>", which the registration
+  # service parses onto EventRegistration#ce_hours_requested. The identifier
+  # matches EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER.
+  FIELD_SPECIFY_OPTION_PLACEHOLDERS = {
+    "ce_credit_interest" => { "Yes" => "How many CE hours?" }
+  }.freeze
+
   # Fallback character ceilings applied when a free-form field has no explicit
   # max_characters set. This is a safety net against pathological submissions
   # (megabyte answers that bloat the DB and break admin/email rendering), not a
@@ -295,17 +306,20 @@ class FormField < ApplicationRecord
 
   # The "please specify" placeholder for an option label, or nil when the option
   # does not reveal a free-text box. Matched case- and whitespace-insensitively
-  # against SPECIFY_OPTION_PLACEHOLDERS.
-  def self.specify_placeholder_for(label)
+  # against SPECIFY_OPTION_PLACEHOLDERS, then (when a field_identifier is given)
+  # against that field's FIELD_SPECIFY_OPTION_PLACEHOLDERS, which wins.
+  def self.specify_placeholder_for(label, field_identifier = nil)
     normalized = label.to_s.strip
     return if normalized.blank?
 
-    SPECIFY_OPTION_PLACEHOLDERS.find { |key, _| key.casecmp?(normalized) }&.last
+    field_scoped = FIELD_SPECIFY_OPTION_PLACEHOLDERS[field_identifier]&.find { |key, _| key.casecmp?(normalized) }&.last
+    field_scoped || SPECIFY_OPTION_PLACEHOLDERS.find { |key, _| key.casecmp?(normalized) }&.last
   end
 
-  # True when an option label reveals a free-text "please specify" box.
-  def self.specify_option?(label)
-    specify_placeholder_for(label).present?
+  # True when an option label reveals a free-text "please specify" box, optionally
+  # scoped to a field via its field_identifier.
+  def self.specify_option?(label, field_identifier = nil)
+    specify_placeholder_for(label, field_identifier).present?
   end
 
   # True when an option label is the generic free-text "Other" choice. Unlike
@@ -322,7 +336,7 @@ class FormField < ApplicationRecord
   def specify_option_labels
     return [] if dynamic_options?
 
-    answer_options.map(&:name).select { |name| FormField.specify_option?(name) }
+    answer_options.map(&:name).select { |name| FormField.specify_option?(name, field_identifier) }
   end
 
   # True when a submitted value is a valid "specify" answer for one of this

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -44,7 +44,7 @@ module EventRegistrationServices
         existing = @event.event_registrations.find_by(registrant: person)
         if existing
           existing.update!(scholarship_requested: true) if @scholarship_requested
-          existing.update!(ce_credit_requested: true) if ce_credit_requested?
+          existing.update!(ce_credit_requested: true, ce_hours_requested: ce_hours_requested) if ce_credit_requested?
           existing.update!(w9_requested: true) if w9_requested?
           existing.update!(invoice_requested: true) if invoice_requested?
           if existing.status == "cancelled"
@@ -266,14 +266,31 @@ module EventRegistrationServices
         registrant: person,
         scholarship_requested: @scholarship_requested,
         ce_credit_requested: ce_credit_requested?,
+        ce_hours_requested: ce_hours_requested,
         w9_requested: w9_requested?,
         invoice_requested: invoice_requested?
       )
     end
 
+    # The CE-interest answer, which "Yes" folds an hours specify box into as
+    # "Yes: <hours>". Split off the leading label so a Yes/No check ignores the
+    # folded hours (see FormField::FIELD_SPECIFY_OPTION_PLACEHOLDERS).
+    def ce_answer_label
+      field_value(CE_CREDIT_INTEREST_IDENTIFIER).to_s.split(":", 2).first.to_s.strip
+    end
+
     # True when the registrant answered "Yes" to the seeded CE-interest question.
     def ce_credit_requested?
-      field_value(CE_CREDIT_INTEREST_IDENTIFIER).to_s.strip.casecmp?("yes")
+      ce_answer_label.casecmp?("yes")
+    end
+
+    # The CE hours typed into the "Yes" specify box, as a positive integer, or nil
+    # when CE was not requested or no valid hours were entered.
+    def ce_hours_requested
+      return unless ce_credit_requested?
+
+      hours = field_value(CE_CREDIT_INTEREST_IDENTIFIER).to_s.split(":", 2).last.to_s.strip.to_i
+      hours.positive? ? hours : nil
     end
 
     # The "Additional forms" question is a multi-select, so its submitted value is

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -210,7 +210,10 @@
 
         <%= render "scholarship", event_registration: f.object, scholarship: f.object.scholarships.first %>
 
-        <%# ---- CE status — placeholder scaffold for future continuing-education tracking (no-op for now) ---- %>
+        <%# ---- CE credits — toggled "Requested" flag, plus the registrant's CE
+            details (license number + requested hours) and what they owe at the
+            default hourly rate, recomputed live by the ce-credit-requested
+            controller. The details collapse when CE isn't requested. ---- %>
         <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
           <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
             <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
@@ -219,10 +222,11 @@
             <h2 class="text-sm font-semibold text-gray-700">CE credits</h2>
           </div>
 
-          <div class="space-y-3 p-4">
-            <label class="flex items-center gap-2.5 cursor-pointer"
-                   data-controller="ce-credit-requested"
-                   data-ce-credit-requested-initial-value="<%= f.object.ce_credit_requested %>">
+          <div class="space-y-3 p-4"
+               data-controller="ce-credit-requested"
+               data-ce-credit-requested-initial-value="<%= f.object.ce_credit_requested %>"
+               data-ce-credit-requested-rate-value="<%= EventRegistration::CE_HOURLY_RATE_DOLLARS %>">
+            <label class="flex items-center gap-2.5 cursor-pointer">
               <input type="hidden" name="event_registration[ce_credit_requested]" value="0" autocomplete="off">
               <input type="checkbox"
                      name="event_registration[ce_credit_requested]"
@@ -235,8 +239,38 @@
               <span class="text-sm font-medium text-gray-700">Requested</span>
             </label>
 
-            <div class="flex items-center gap-2 border-t border-gray-100 pt-3">
-              <span class="text-sm font-semibold text-gray-900 tabular-nums">$0.00</span>
+            <div data-ce-credit-requested-target="details" class="space-y-3 border-t border-gray-100 pt-3 <%= "hidden" unless f.object.ce_credit_requested %>">
+              <div>
+                <div class="mb-1 flex items-center justify-between gap-2">
+                  <label class="text-xs font-medium text-gray-500" for="event_registration_ce_license_number">License number</label>
+                  <span data-ce-credit-requested-target="licenseBadge"
+                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.65rem] font-medium <%= f.object.ce_license_provided? ? "bg-teal-50 text-teal-700" : "bg-gray-100 text-gray-500" %>">
+                    <i class="fa-solid <%= f.object.ce_license_provided? ? "fa-circle-check" : "fa-circle-minus" %> text-[0.55rem]"></i>
+                    <%= f.object.ce_license_provided? ? "Provided" : "Not provided" %>
+                  </span>
+                </div>
+                <%= f.text_field :ce_license_number,
+                      class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-teal-500 focus:ring focus:ring-teal-200 focus:outline-none",
+                      placeholder: "Not provided",
+                      data: { "ce-credit-requested-target": "license", action: "input->ce-credit-requested#refresh" } %>
+              </div>
+
+              <div>
+                <label class="mb-1 block text-xs font-medium text-gray-500" for="event_registration_ce_hours_requested">CE hours requested</label>
+                <%= f.number_field :ce_hours_requested,
+                      min: 0, step: 1,
+                      class: "w-28 rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm tabular-nums focus:border-teal-500 focus:ring focus:ring-teal-200 focus:outline-none",
+                      placeholder: "0",
+                      data: { "ce-credit-requested-target": "hours", action: "input->ce-credit-requested#refresh" } %>
+              </div>
+
+              <div class="flex items-center justify-between border-t border-gray-100 pt-3">
+                <span class="text-sm text-gray-500">
+                  Amount owed
+                  <span class="text-xs text-gray-400">($<%= EventRegistration::CE_HOURLY_RATE_DOLLARS %>/hr)</span>
+                </span>
+                <span data-ce-credit-requested-target="amount" class="text-sm font-semibold text-gray-900 tabular-nums"><%= number_to_currency(f.object.ce_amount_owed_cents / 100.0) %></span>
+              </div>
             </div>
           </div>
         </section>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -72,10 +72,10 @@
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <% has_specify = radio_options.any? { |option_label, _option_value| specify_placeholder(option_label).present? } %>
+    <% has_specify = radio_options.any? { |option_label, _option_value| specify_placeholder(option_label, field).present? } %>
     <%= tag.div class: "flex flex-wrap gap-2.5 mt-1", data: (has_specify ? { controller: "specify-option", action: "change->specify-option#update" } : {}) do %>
       <% radio_options.each do |option_label, option_value, option_description| %>
-        <% placeholder = specify_placeholder(option_label) %>
+        <% placeholder = specify_placeholder(option_label, field) %>
         <% is_specify = placeholder.present? %>
         <label class="flex flex-col gap-1 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">
@@ -132,12 +132,12 @@
         Category options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
-    <% has_specify = checkbox_options.any? { |option_label, _option_value| specify_placeholder(option_label).present? } %>
+    <% has_specify = checkbox_options.any? { |option_label, _option_value| specify_placeholder(option_label, field).present? } %>
     <%# Multi-column (not grid) so a sorted option list reads straight down each
         column then onto the next, rather than zig-zagging across rows. %>
     <%= tag.div class: "columns-1 sm:columns-2 gap-2.5 mt-1", data: (has_specify ? { controller: "specify-option", action: "change->specify-option#update" } : {}) do %>
       <% checkbox_options.each do |option_label, option_value, option_description| %>
-        <% placeholder = specify_placeholder(option_label) %>
+        <% placeholder = specify_placeholder(option_label, field) %>
         <% is_specify = placeholder.present? %>
         <label class="flex flex-col gap-1 mb-2.5 break-inside-avoid rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
           <span class="flex items-center gap-2">

--- a/db/migrate/20260617190000_add_ce_hours_and_license_to_event_registrations.rb
+++ b/db/migrate/20260617190000_add_ce_hours_and_license_to_event_registrations.rb
@@ -1,0 +1,11 @@
+class AddCeHoursAndLicenseToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    add_column :event_registrations, :ce_hours_requested, :integer unless column_exists?(:event_registrations, :ce_hours_requested)
+    add_column :event_registrations, :ce_license_number, :string unless column_exists?(:event_registrations, :ce_license_number)
+  end
+
+  def down
+    remove_column :event_registrations, :ce_hours_requested, if_exists: true
+    remove_column :event_registrations, :ce_license_number, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_190000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -448,6 +448,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_180000) do
 
   create_table "event_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "ce_credit_requested", default: false, null: false
+    t.integer "ce_hours_requested"
+    t.string "ce_license_number"
     t.string "checkout_session_id"
     t.datetime "created_at", null: false
     t.bigint "event_id"

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe EventHelper, type: :helper do
       expect(helper.specify_placeholder("Other reasons")).to be_nil
       expect(helper.specify_placeholder(nil)).to be_nil
     end
+
+    it "returns the CE hours placeholder for 'Yes' only on the CE field" do
+      ce_field = FormField.new(field_identifier: "ce_credit_interest")
+      other_field = FormField.new(field_identifier: "interested_in_more")
+      expect(helper.specify_placeholder("Yes", ce_field)).to eq("How many CE hours?")
+      expect(helper.specify_placeholder("Yes", other_field)).to be_nil
+    end
   end
 
   describe "#specify_option_selected?" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -380,6 +380,40 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "continuing education" do
+    let(:reg) { create(:event_registration) }
+
+    describe "#ce_amount_owed_cents" do
+      it "multiplies requested hours by the default hourly rate" do
+        reg.ce_hours_requested = 4
+        expect(reg.ce_amount_owed_cents).to eq(4 * EventRegistration::CE_HOURLY_RATE_DOLLARS * 100)
+      end
+
+      it "is zero when no hours are requested" do
+        reg.ce_hours_requested = nil
+        expect(reg.ce_amount_owed_cents).to eq(0)
+      end
+    end
+
+    describe "#ce_license_provided?" do
+      it "is true only when a license number is present" do
+        reg.ce_license_number = "LIC-123"
+        expect(reg).to be_ce_license_provided
+        reg.ce_license_number = ""
+        expect(reg).not_to be_ce_license_provided
+      end
+    end
+
+    describe "ce_hours_requested validation" do
+      it "rejects negative or non-integer hours but allows nil" do
+        reg.ce_hours_requested = nil
+        expect(reg).to be_valid
+        reg.ce_hours_requested = -1
+        expect(reg).not_to be_valid
+      end
+    end
+  end
+
   describe '.search_by_params' do
     let(:person_alice) { create(:person, first_name: 'Alice', last_name: 'Smith') }
     let(:person_bob) { create(:person, first_name: 'Bob', last_name: 'Jones') }

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -359,6 +359,19 @@ RSpec.describe FormField do
       expect(field.answer_inclusion_error("Foundation/Funder: ACME")).to eq("has an invalid selection")
     end
 
+    it "accepts the CE question's field-scoped 'Yes: <hours>' specify answer" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Yes No])
+      field.update!(field_identifier: "ce_credit_interest")
+      expect(field.answer_inclusion_error("Yes")).to be_nil
+      expect(field.answer_inclusion_error("Yes: 6")).to be_nil
+      expect(field.answer_inclusion_error("No")).to be_nil
+    end
+
+    it "treats a bare 'Yes' as a plain choice on other fields" do
+      field = selectable_field(type: :single_select_radio, option_names: %w[Yes No])
+      expect(field.answer_inclusion_error("Yes: 6")).to eq("has an invalid selection")
+    end
+
     it "rejects an Other answer when the field does not offer Other" do
       field = selectable_field(type: :single_select_radio, option_names: %w[Red Blue])
       expect(field.answer_inclusion_error("Other: chartreuse")).to eq("has an invalid selection")

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -223,6 +223,15 @@ RSpec.describe "EventRegistrations", type: :request do
 
         expect(existing_registration.reload.ce_credit_requested).to be(true)
       end
+
+      it "updates the CE hours and license number" do
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { ce_credit_requested: "1", ce_hours_requested: "5", ce_license_number: "LIC-987" } }
+
+        existing_registration.reload
+        expect(existing_registration.ce_hours_requested).to eq(5)
+        expect(existing_registration.ce_license_number).to eq("LIC-987")
+      end
     end
 
     describe "PATCH /event_registrations/:id scholarship handling" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -108,6 +108,38 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(result.event_registration).to eq(existing)
       expect(existing.reload.ce_credit_requested).to be true
     end
+
+    it "saves the hours folded into a 'Yes: <n>' specify answer" do
+      result = register_with_ce("Yes: 6")
+      expect(result.event_registration.ce_credit_requested).to be true
+      expect(result.event_registration.ce_hours_requested).to eq(6)
+    end
+
+    it "leaves ce_hours_requested nil when Yes carries no hours" do
+      result = register_with_ce("Yes")
+      expect(result.event_registration.ce_hours_requested).to be_nil
+    end
+
+    it "leaves ce_hours_requested nil when answered No" do
+      result = register_with_ce("No")
+      expect(result.event_registration.ce_hours_requested).to be_nil
+    end
+
+    it "ignores non-numeric hours in the specify answer" do
+      result = register_with_ce("Yes: lots")
+      expect(result.event_registration.ce_credit_requested).to be true
+      expect(result.event_registration.ce_hours_requested).to be_nil
+    end
+
+    it "saves the hours onto an existing registration that answers Yes" do
+      person = create(:person, first_name: "Cy", last_name: "Reed", email: "cy@example.com")
+      existing = create(:event_registration, event: event, registrant: person, ce_credit_requested: false)
+
+      register_with_ce("Yes: 4")
+
+      expect(existing.reload.ce_credit_requested).to be true
+      expect(existing.ce_hours_requested).to eq(4)
+    end
   end
 
   describe "Additional forms (multi-select magic question)" do


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
Registrants seeking continuing-education (CE) credit need to tell us how many hours, and admins need to see that — along with the registrant's license number and what they owe — none of which the registration captured before.

### How did you approach the change?
- The CE question's **"Yes"** now reveals a "How many CE hours?" specify box, scoped to that field only (a new `FormField::FIELD_SPECIFY_OPTION_PLACEHOLDERS` map, so a bare "Yes" elsewhere stays a plain choice), folding into the answer as `"Yes: 6"`. The hours detail is **optional** — selecting "Yes" without typing a number is valid and leaves the hours blank.
- `PublicRegistration` parses that onto a new `ce_hours_requested` integer column; a `ce_license_number` column was added too.
- The registration edit form's CE box is now a dynamic summary — license number with a Provided/Not provided badge, editable hours, and live amount owed at the default `$25/hr` rate (`ce_credit_requested_controller.js`).

### Design decision — ship now, graduate to a standalone form later
We considered making CE its own subform/standalone flow like the scholarship app (dropping the "magic text"). We deliberately shipped the lighter version: the stored columns (`ce_credit_requested`, `ce_hours_requested`, `ce_license_number`) are the durable contract and are forward-compatible, so a future standalone CE form can replace the capture mechanism with **no data migration**. Promote CE to its own form when it grows a real lifecycle (per-state/profession rules, license validation, certificate generation, CE payment).

### Known gap
The license number is **admin-entered only** — there is no public-form capture yet. Acceptable for v1; add a normal field to the registration form when registrants should supply it.

### UI Testing Checklist
- [ ] Public form: choosing "Yes" reveals the hours box and saves the integer; "No", or "Yes" with no hours, leaves it blank.
- [ ] Edit page: the CE box shows/collapses with the Requested toggle and amount owed updates live as hours change.
- [ ] Editing the license number flips the Provided/Not provided badge and persists on save.

### Anything else to add?
Specs cover hours parsing, field-scoped specify acceptance, the amount/validation, and param persistence.