### PR TITLE
Add intro and contact link to art supplies event details

### DIFF
--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -268,6 +268,10 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
 flagship = Event.find_by(title: "AWBW Facilitator Training")
 if flagship && flagship.event_details.blank?
   flagship.update!(event_details_label: "Art supplies & what to bring", event_details: <<~HTML.strip)
+    <p>Thank you for registering to join us for AWBW's Art Facilitator Training!</p>
+    <p>Below you'll find information about the art supplies used in each of the five hands-on workshops included in the training, along with optional printable workshop worksheets. We're sharing these materials in advance in case you'd like to gather supplies or print resources ahead of time.</p>
+    <p>You will receive additional training information as we get closer to the training dates.</p>
+    <p>Have a question? <a href="/contact_us">Reach out through our contact form</a> and we'll be happy to help.</p>
     <p>We will be facilitating five hands-on art workshops, all of which can be done with paper, writing utensils (crayons, colored pencils, markers, etc.) and scissors.</p>
     <ul>
       <li>You'll receive printable workshop worksheets once your training fees are paid — printing them is optional.</li>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Registrants reach the "Art supplies & what to bring" event-details page without any framing for what it is or why they're seeing it.
- Adds a welcoming intro, an explanation that materials are shared in advance, a note that more training info is coming, and a path to ask questions.

### How did you approach the change?
- Prepended four paragraphs to the flagship Facilitator Training `event_details` seed: a thank-you, the "below you'll find" overview, a "more info to come" line, and a contact-form link (`/contact_us`).
- Kept the existing supplies content unchanged; the seed still only writes when `event_details` is blank, so admin edits survive a re-seed.

### UI Testing Checklist
- [ ] Re-seed (or clear the event's `event_details`) and confirm the intro paragraphs render above the workshop supplies list.
- [ ] Confirm the "Reach out through our contact form" link navigates to the contact us page.

### Anything else to add?
- Content-only change to a dev seed; no schema, model, or behavior changes.
