### PR TITLE
Append newly added form fields to the bottom of the list

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -91,6 +91,12 @@ class FormField < ApplicationRecord
   validate :max_characters_allows_min_words
   validate :non_input_types_cannot_be_required
 
+  # New fields submitted without a position (e.g. added in the form editor and
+  # not dragged) would otherwise save with a nil position and sort to the top of
+  # the list. Append them to the bottom instead. Dragged fields arrive with an
+  # explicit position and are left untouched.
+  before_validation :append_to_bottom, on: :create, if: -> { position.blank? }
+
   # Enum
   enum :status, [ :inactive, :active ]
   enum :visibility, [ :always_ask, :scholarship_only, :logged_out_only, :answers_on_file ]
@@ -235,6 +241,12 @@ class FormField < ApplicationRecord
     return unless required?
 
     errors.add(:required, "is not available for #{answer_type_label.downcase} fields")
+  end
+
+  # Places a positionless new field after the current last field on its form, so
+  # newly added fields land at the bottom of the editor list rather than the top.
+  def append_to_bottom
+    self.position = (form&.form_fields&.maximum(:position) || 0) + 1
   end
 
   # The character ceiling actually enforced for this field: the explicit

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -396,6 +396,22 @@ RSpec.describe "Forms", type: :request do
       expect(form.hide_answered_form_questions).to be true
     end
 
+    it "appends a newly added field to the bottom of the list, not the top" do
+      form = create(:form, :standalone)
+      first = create(:form_field, form: form, name: "First", position: 1)
+      second = create(:form_field, form: form, name: "Second", position: 2)
+
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { name: "Brand new", answer_type: "free_form_input_one_line" } } }
+      }
+      expect(response).to redirect_to(edit_form_path(form))
+
+      new_field = form.form_fields.find_by(name: "Brand new")
+      expect(new_field.position).to be > second.position
+      ordered = form.form_fields.reorder(position: :asc).pluck(:name)
+      expect(ordered).to eq([ first.name, second.name, "Brand new" ])
+    end
+
     it "saves a long, multi-sentence question name" do
       form = create(:form, :standalone)
       long_name = "AWBW workshops are used in a variety of ways. " * 8


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- In the form editor, a newly added field jumped to the **top** of the question list instead of staying where the admin added it.
- The cause: a new `FormField` saved without a `position` (the column is nullable), and the list is ordered by `position: :asc`, so `nil` sorted above every real field.

### How did you approach the change?
- Added a `before_validation` on `FormField` that, when a field is created without a position, assigns it `max(position) + 1` for its form — placing it at the bottom.
- Dragged fields already arrive with an explicit position (written by the sortable controller) and are left untouched, so they stay wherever they were dropped.

### UI Testing Checklist
- [ ] In the form editor, click "+ Add field" — the new field appears at the bottom of the list after saving, not the top.
- [ ] Add a field, drag it to a new spot, and save — it stays where it was dropped.

### Anything else to add?
- Covered by a new request spec asserting a positionless new field lands after existing fields. No JS changes were needed.
