### PR TITLE
Render form field subtitle as HTML and add a separate hint

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -137,7 +137,7 @@ class FormsController < ApplicationController
     params.require(:form).permit(
       :name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions,
       form_fields_attributes: [
-        :id, :name, :answer_type, :required, :hint_text,
+        :id, :name, :answer_type, :required, :subtitle, :hint_text,
         :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy,
         form_field_answer_options_attributes: [ :id, :option_name, :_destroy ]
       ]

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -316,7 +316,7 @@ class FormBuilderService
     position
   end
 
-  def add_field(form, position, field_name, answer_type, key:, group:, required: true, hint: nil, options: nil, datatype: nil, visibility: nil, width: :full)
+  def add_field(form, position, field_name, answer_type, key:, group:, required: true, subtitle: nil, options: nil, datatype: nil, visibility: nil, width: :full)
     position += 1
     field = form.form_fields.create!(
       name: field_name,
@@ -325,7 +325,7 @@ class FormBuilderService
       status: :active,
       position: position,
       required: required,
-      hint_text: hint,
+      subtitle: subtitle,
       field_identifier: key,
       section: group,
       visibility: visibility || SECTION_VISIBILITY.fetch(group, :always_ask),
@@ -423,7 +423,7 @@ class FormBuilderService
 
     position = add_field(form, position, "Racial / Ethnic Identity", :free_form_input_one_line,
                          key: "racial_ethnic_identity", group: "background", required: false,
-                         hint: "This information helps us understand the diversity of our community.")
+                         subtitle: "This information helps us understand the diversity of our community.")
     position
   end
 
@@ -432,13 +432,13 @@ class FormBuilderService
 
     position = add_field(form, position, "Primary service area", :single_select_dropdown,
                          key: "primary_service_area_single", group: "professional", required: false,
-                         hint: "Select the sector you primarily serve.")
+                         subtitle: "Select the sector you primarily serve.")
     position = add_field(form, position, "Additional service areas", :multi_select_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
-                         hint: "Select all that apply. These represent the other sectors you serve.")
+                         subtitle: "Select all that apply. These represent the other sectors you serve.")
     position = add_field(form, position, "Workshop Settings", :multi_select_checkbox,
                          key: "workshop_environments", group: "professional", required: false,
-                         hint: "Select all settings where you facilitate or plan to facilitate workshops.",
+                         subtitle: "Select all settings where you facilitate or plan to facilitate workshops.",
                          options: [
                            "Clinical setting", "Educational setting", "Events and conferences",
                            "Faith-based setting", "Home visits", "Hospitals",
@@ -448,10 +448,10 @@ class FormBuilderService
                          ])
     position = add_field(form, position, "Client Life Experiences", :multi_select_checkbox,
                          key: "client_life_experiences", group: "professional", required: false,
-                         hint: "Select all that describe the populations you work with.")
+                         subtitle: "Select all that describe the populations you work with.")
     position = add_field(form, position, "Primary Age Group(s) Served", :multi_select_checkbox,
                          key: "primary_age_group", group: "professional", required: false,
-                         hint: "Select all age groups you primarily serve.")
+                         subtitle: "Select all age groups you primarily serve.")
     position
   end
 
@@ -481,12 +481,12 @@ class FormBuilderService
                          "How will what you gain from this training directly impact the people you serve?",
                          :free_form_input_paragraph,
                          key: "impact_description", group: "scholarship", required: true,
-                         hint: "Please describe in 3-5+ sentences.")
+                         subtitle: "Please describe in 3-5+ sentences.")
     position = add_field(form, position,
                          "Please describe one way in which you plan to use art workshops and how you envision it will help.",
                          :free_form_input_paragraph,
                          key: "implementation_plan", group: "scholarship", required: true,
-                         hint: "Please describe in 3-5+ sentences.")
+                         subtitle: "Please describe in 3-5+ sentences.")
     position = add_field(form, position, "Anything else you'd like to share with us?", :free_form_input_paragraph,
                          key: "additional_comments", group: "scholarship", required: false)
     position
@@ -507,7 +507,7 @@ class FormBuilderService
                          "I agree to receive email communications from A Window Between Worlds.",
                          :multi_select_checkbox,
                          key: "communication_consent", group: "consent", required: true,
-                         hint: "By submitting this form, I consent to receive updates from A Window Between Worlds, " \
+                         subtitle: "By submitting this form, I consent to receive updates from A Window Between Worlds, " \
                                "including information about this event as well as upcoming events, training opportunities, resources, " \
                                "impact stories, and ways to support our mission. I understand I can unsubscribe at any time.",
                          options: [ "Yes" ])

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -88,8 +88,8 @@
                     <%= form_label_html(field.name) %>
                     <% if field.required %><span class="text-red-500">*</span><% end %>
                   </label>
-                  <% if field.hint_text.present? %>
-                    <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>
+                  <% if field.subtitle.present? %>
+                    <p class="rich-label text-xs text-gray-500 mb-1.5"><%= form_label_html(field.subtitle) %></p>
                   <% end %>
                   <%
                     html_type = case field.field_identifier
@@ -108,6 +108,9 @@
                          class="<%= input_classes %>"
                          <%= "required" if field.required %>
                          <%= raw(extra_attrs.join(" ")) %>>
+                  <% if field.hint_text.present? %>
+                    <p class="rich-label text-xs text-gray-500 mt-1.5"><%= form_label_html(field.hint_text) %></p>
+                  <% end %>
                   <% if field.free_form_text? && field.min_words.to_i.positive? %>
                     <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
                   <% end %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -18,8 +18,8 @@
     <% end %>
   </div>
 
-  <% if field.hint_text.present? %>
-    <p class="text-xs text-gray-500 mb-1.5"><%= field.hint_text %></p>
+  <% if field.subtitle.present? %>
+    <p class="rich-label text-xs text-gray-500 mb-1.5"><%= form_label_html(field.subtitle) %></p>
   <% end %>
 
   <% field_name = "public_registration[form_fields][#{field.id}]" %>
@@ -164,6 +164,10 @@
       <% end %>
     <% end %>
 
+  <% end %>
+
+  <% if field.hint_text.present? %>
+    <p class="rich-label text-xs text-gray-500 mt-1.5"><%= form_label_html(field.hint_text) %></p>
   <% end %>
 
   <% if field.free_form_text? && field.min_words.to_i.positive? %>

--- a/app/views/events/public_registrations/_group_header.html.erb
+++ b/app/views/events/public_registrations/_group_header.html.erb
@@ -3,7 +3,7 @@
   <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
     <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
   </h3>
-  <% if field.hint_text.present? %>
-    <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
+  <% if field.subtitle.present? %>
+    <p class="rich-label mt-1.5 text-sm text-gray-500"><%= form_label_html(field.subtitle) %></p>
   <% end %>
 </div>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -55,7 +55,7 @@
       </div>
 
       <div class="hidden mt-2 pb-2 flex flex-col gap-2" data-field-options-target="panel">
-        <%= f.text_area :hint_text, rows: 2,
+        <%= f.text_area :subtitle, rows: 2,
               class: "w-full text-sm text-gray-600 rounded border-gray-300 shadow-sm px-2 py-1",
               placeholder: "Subtitle" %>
         <%= link_to_remove_association "Remove", f,
@@ -130,9 +130,12 @@
               [ "Quarter width", "quarter" ]
             ]
           %>
-          <%= f.text_area :hint_text, rows: 1, placeholder: "Subtitle",
+          <%= f.text_area :subtitle, rows: 1, placeholder: "Subtitle",
                 class: "min-w-0 flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional subtitle shown under the field label" %>
+          <%= f.text_area :hint_text, rows: 1, placeholder: "Hint",
+                class: "min-w-0 flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                title: "Optional hint shown below the field input" %>
           <%= f.select :width, width_options,
                 {},
                 class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -87,8 +87,8 @@
                     <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
                   <% end %>
                 </div>
-                <% if field.hint_text.present? %>
-                  <p class="mt-1.5 text-sm text-gray-500"><%= field.hint_text %></p>
+                <% if field.subtitle.present? %>
+                  <p class="rich-label mt-1.5 text-sm text-gray-500"><%= form_label_html(field.subtitle) %></p>
                 <% end %>
               </div>
             <% else %>

--- a/app/views/monthly_reports/_report_form_field_answers.html.erb
+++ b/app/views/monthly_reports/_report_form_field_answers.html.erb
@@ -11,12 +11,12 @@
       <label class='bold'><%= "#{log_field.name}" %><% if log_field.required %><%= " *" %><% end %></label>
     <% end %>
 
-    <% unless answers.include?(log_field.hint_text) %>
-      <div class='custom-smaller'><%= log_field.hint_text %></div>
+    <% unless answers.include?(log_field.subtitle) %>
+      <div class='custom-smaller'><%= log_field.subtitle %></div>
     <% end %>
   </div>
 
-  <% answers.push(log_field.id, log_field.hint_text) %>
+  <% answers.push(log_field.id, log_field.subtitle) %>
 
   <%= form.hidden_field :answer_option_id, id: "log-field-#{log_field.id}" %>
 

--- a/app/views/shared/_form_field.html.erb
+++ b/app/views/shared/_form_field.html.erb
@@ -3,13 +3,13 @@
   <div class="label-plus-comment">
     <%# Display-only field — never collects input, so no required marker. %>
     <label><%= field.name %></label>
-    <div class="custom-smaller"> <%= field.hint_text %> </div>
+    <div class="custom-smaller"> <%= field.subtitle %> </div>
   </div>
 
 <% when :group_header %>
   <div class="label-plus-comment">
     <label><%= field.name %> </label>
-    <div class="custom-smaller"><%= field.hint_text %></div>
+    <div class="custom-smaller"><%= field.subtitle %></div>
       <div class="custom-smaller">(No percentages please. Enter 1 instead of 1/2)</div>
   </div>
 
@@ -21,7 +21,7 @@
             <div class="label-plus-comment">
               <label><%= f.name %></label>
               <div class="custom-smaller">
-                <%= f.hint_text %>
+                <%= f.subtitle %>
               </div>
             </div>
 
@@ -45,7 +45,7 @@
   <div class="form-group <%= field.html_input_type %>-form-group">
     <div class="label-plus-comment">
       <label><%= field.name %> <%= "*" if field.required? %></label>
-      <div class="custom-smaller"> <%= field.hint_text %> </div>
+      <div class="custom-smaller"> <%= field.subtitle %> </div>
     </div>
 
     <input type="<%= field.html_input_type %>"
@@ -60,7 +60,7 @@
 
     <div class="label-plus-comment">
       <label><%= field.name %> <%= "*" if field.required? %></label>
-      <div class="custom-smaller"> <%= field.hint_text %> </div>
+      <div class="custom-smaller"> <%= field.subtitle %> </div>
     </div>
 
     <textarea name="log_fields[<%= field.id %>]" class="form-control" <%= 'required=required' if field.required %>
@@ -77,7 +77,7 @@
         <% end %>
         <%= field.name %> <%= "*" if field.required? %>
       </label>
-      <div class="custom-smaller"> <%= field.hint_text %> </div>
+      <div class="custom-smaller"> <%= field.subtitle %> </div>
     </div>
 
     <% field.answer_options.each do |answer_option| %>

--- a/app/views/shared/_report_form_field_answers.html.erb
+++ b/app/views/shared/_report_form_field_answers.html.erb
@@ -11,12 +11,12 @@
       <label class='bold'><%= log_field.name %><% if log_field.required && log_field.collects_input? %><%= " *" %><% end %></label>
     <% end %>
 
-    <% unless answers.include?(log_field.hint_text) %>
-      <div class='custom-smaller'><%= log_field.hint_text %></div>
+    <% unless answers.include?(log_field.subtitle) %>
+      <div class='custom-smaller'><%= log_field.subtitle %></div>
     <% end %>
   </div>
 
-  <% answers.push(log_field.id, log_field.hint_text) %>
+  <% answers.push(log_field.id, log_field.subtitle) %>
 
   <%= form.hidden_field :answer_option_id, id: "log-field-#{log_field.id}" %>
 

--- a/app/views/workshop_logs/_report_form_field_answer_fields.html.erb
+++ b/app/views/workshop_logs/_report_form_field_answer_fields.html.erb
@@ -13,7 +13,7 @@
                   include_blank: "Select an option",
                   label: f.object.form_field&.name,
                   required: f.object.form_field&.required?,
-                  hint: f.object.form_field.hint_text,
+                  hint: f.object.form_field.subtitle,
                   input_html: { class: "form-control mb-2" } %>
     <% else %>
       <!-- Freeform text with 3 rows -->
@@ -21,7 +21,7 @@
                   label: f.object.form_field&.name,
                   placeholder: "Enter response...",
                   required: f.object.form_field&.required?,
-                  hint: f.object.form_field.hint_text,
+                  hint: f.object.form_field.subtitle,
                   input_html: { class: "form-control mb-2", rows: 3 } %>
     <% end %>
     <% if f.object.errors[:answer].any? %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
-      "fingerprint": "ed621305ecb26c24fe0cfb0b55955439f0d2a7d0e7ff19e5911657f47bcb3ff1",
+      "fingerprint": "a750b09d4d42ef567df595f7a9035933dc1178c533bf8ae8f8986ae8e837c6b8",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/forms_controller.rb",
-      "line": 121,
+      "line": 138,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:form).permit(:name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
+      "code": "params.require(:form).permit(:name, :role, :header, :hide_answered_person_questions, :hide_answered_form_questions, :form_fields_attributes => ([:id, :name, :answer_type, :required, :subtitle, :hint_text, :field_identifier, :section, :position, :visibility, :one_time, :width, :min_words, :max_characters, :_destroy, { :form_field_answer_options_attributes => ([:id, :option_name, :_destroy]) }]))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/db/migrate/20260618014554_rename_form_field_hint_text_to_subtitle_and_add_hint_text.rb
+++ b/db/migrate/20260618014554_rename_form_field_hint_text_to_subtitle_and_add_hint_text.rb
@@ -1,0 +1,14 @@
+class RenameFormFieldHintTextToSubtitleAndAddHintText < ActiveRecord::Migration[8.0]
+  # The column historically called `hint_text` has always rendered as a subtitle
+  # under the field label, so it is renamed to `subtitle`. A fresh `hint_text`
+  # column is then added for SimpleForm-style hint text shown below the input.
+  def up
+    rename_column :form_fields, :hint_text, :subtitle unless column_exists?(:form_fields, :subtitle)
+    add_column :form_fields, :hint_text, :text unless column_exists?(:form_fields, :hint_text)
+  end
+
+  def down
+    remove_column :form_fields, :hint_text, :text, if_exists: true
+    rename_column :form_fields, :subtitle, :hint_text if column_exists?(:form_fields, :subtitle)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -597,6 +597,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_210000) do
     t.boolean "required", default: true
     t.string "section"
     t.integer "status", default: 1
+    t.text "subtitle"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "visibility", default: 0, null: false
     t.integer "width", default: 0, null: false

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -121,7 +121,7 @@ if registration_form.form_fields.where(field_identifier: ce_identifier).none?
     section: "continuing_education",
     visibility: :always_ask,
     width: :full,
-    hint_text: "CE hours are available for select trainings. Let us know and our team will follow up with details."
+    subtitle: "CE hours are available for select trainings. Let us know and our team will follow up with details."
   )
   %w[Yes No].each_with_index do |opt, idx|
     ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
@@ -158,7 +158,7 @@ if registration_form.form_fields.where(field_identifier: additional_forms_identi
     section: "additional_forms",
     visibility: :always_ask,
     width: :full,
-    hint_text: "If selected, these will be available on your digital registration ticket."
+    subtitle: "If selected, these will be available on your digital registration ticket."
   )
   [
     EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_INVOICE,

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "Forms", type: :request do
 
       get edit_form_path(form)
 
-      expect(response.body).to include("[hint_text]")
+      expect(response.body).to include("[subtitle]")
     end
 
     it "warns that the Other option is hidden on a dropdown field" do
@@ -315,12 +315,32 @@ RSpec.describe "Forms", type: :request do
 
     it "renders a section header's subtext under the heading" do
       form = create(:form, :standalone)
-      create(:form_field, form: form, answer_type: :group_header, name: "Contact info", hint_text: "Tell us how to reach you")
+      create(:form_field, form: form, answer_type: :group_header, name: "Contact info", subtitle: "Tell us how to reach you")
 
       get form_path(form)
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Tell us how to reach you")
+    end
+
+    it "renders a field's subtitle as sanitized HTML under the label" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, name: "Email", subtitle: %(We'll <strong>never</strong> share it))
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("We'll <strong>never</strong> share it")
+    end
+
+    it "renders a field's hint text as sanitized HTML below the input" do
+      form = create(:form, :standalone)
+      create(:form_field, form: form, name: "Phone", hint_text: %(Include your <em>area code</em>))
+
+      get form_path(form)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Include your <em>area code</em>")
     end
 
     it "renders the form header HTML under the title" do
@@ -380,9 +400,19 @@ RSpec.describe "Forms", type: :request do
       form = create(:form, :standalone)
       header = create(:form_field, form: form, answer_type: :group_header, name: "Contact info")
       patch form_path(form), params: {
-        form: { form_fields_attributes: { "0" => { id: header.id, hint_text: "Tell us how to reach you" } } }
+        form: { form_fields_attributes: { "0" => { id: header.id, subtitle: "Tell us how to reach you" } } }
       }
-      expect(header.reload.hint_text).to eq("Tell us how to reach you")
+      expect(header.reload.subtitle).to eq("Tell us how to reach you")
+      expect(response).to redirect_to(edit_form_path(form))
+    end
+
+    it "saves the hint text for a field" do
+      form = create(:form, :standalone)
+      field = create(:form_field, form: form, name: "Phone")
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { id: field.id, hint_text: "Include your area code" } } }
+      }
+      expect(field.reload.hint_text).to eq("Include your area code")
       expect(response).to redirect_to(edit_form_path(form))
     end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- A form field's **subtitle** (the text shown under the field label) now renders sanitized HTML, just like the field title/header already do — so admins can include links, bold, and emphasis instead of seeing escaped tags.
- The historically-misnamed `hint_text` column has always acted as that subtitle, so it is renamed to `subtitle`, and a brand-new `hint_text` field is added for SimpleForm-style hint text shown **below the input**.

### How did you approach the change?
- Migration renames `form_fields.hint_text` → `subtitle` and adds a fresh `hint_text` text column (reversible; verified rollback + re-migrate).
- Updated every display/edit/service/seed reference: modern views render `subtitle` (and the new `hint_text`) via `form_label_html` sanitization; the form editor gains a "Hint" textarea alongside "Subtitle"; legacy report views were repointed to `subtitle` to preserve their existing behavior unchanged.
- The new hint stacks below the input independently of the auto-generated min-words / max-characters notices (which never used this column).

### UI Testing Checklist
- [ ] Subtitle with HTML (e.g. `<strong>`, `<a>`) renders formatted on the public registration form, the admin form preview, and the bulk-payment form.
- [ ] The new "Hint" field saves from the form editor and renders (as HTML) directly below the field input.
- [ ] A free-form field shows hint, min-words, and max-characters notices stacked in that order without overlap.
- [ ] Legacy monthly-report / workshop-log forms still display their subtext as before.

### Anything else to add?
- Both subtitle and the new hint are sanitized through the same `FORM_LABEL_TAGS`/`FORM_LABEL_ATTRIBUTES` allowlist as the title. Refreshed the Brakeman mass-assignment ignore fingerprint after the permitted-params list changed. Specs, RuboCop, and the security scan all pass.