### PR TITLE
Add intends-to-pay flag to grant ticket access before payment clears

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -262,6 +262,7 @@ class EventRegistrationsController < ApplicationController
     params.require(:event_registration).permit(
       :event_id, :registrant_id, :status,
       :scholarship_requested,
+      :intends_to_pay,
       :ce_credit_requested,
       :ce_hours_requested,
       :ce_license_number,
@@ -296,7 +297,7 @@ class EventRegistrationsController < ApplicationController
           er.attendance_status_label,
           er.scholarships.any? ? "Yes" : "No",
           er.scholarships.completed.any? ? "Yes" : "No",
-          cost_required ? (er.paid_in_full? ? "Paid" : "Due") : "",
+          cost_required ? er.payment_status_label : "",
           total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
         ]
       end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -282,7 +282,7 @@ class EventRegistrationsController < ApplicationController
 
   def csv_export(registrations)
     CSV.generate(headers: true) do |csv|
-      csv << [ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Payment total" ]
+      csv << [ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total" ]
       registrations.find_each do |er|
         r = er.registrant
         e = er.event
@@ -298,6 +298,7 @@ class EventRegistrationsController < ApplicationController
           er.scholarships.any? ? "Yes" : "No",
           er.scholarships.completed.any? ? "Yes" : "No",
           cost_required ? er.payment_status_label : "",
+          er.intends_to_pay? ? "Yes" : "No",
           total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
         ]
       end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -410,7 +410,7 @@ class EventsController < ApplicationController
   def event_registrations_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
-    headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Payment total" ]
+    headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Intends to pay", "Payment total" ]
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
       @event_registrations.each do |registration|
         csv_out << event_registration_csv_row(registration, cost_required)
@@ -436,6 +436,7 @@ class EventsController < ApplicationController
       registration.scholarships.any? ? "Yes" : "No",
       registration.scholarships.completed.any? ? "Yes" : "No",
       payment_status,
+      registration.intends_to_pay? ? "Yes" : "No",
       payment_total
     ]
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -426,7 +426,7 @@ class EventsController < ApplicationController
     org_names = orgs.map(&:name).join("; ")
     total_cents = registration.allocations_sum
     payment_total = total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
-    payment_status = cost_required ? (registration.paid_in_full? ? "Paid" : "Due") : ""
+    payment_status = cost_required ? registration.payment_status_label : ""
     [
       person.first_name,
       person.last_name,

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -190,6 +190,12 @@ class EventRegistration < ApplicationRecord
   # flip the `intends_to_pay` flag when someone commits to paying after the
   # deadline so they aren't locked out in the meantime. This does NOT mark the
   # registration as paid — payment status still shows as due.
+  #
+  # This is the single seam for "may this registrant reach paid content?":
+  # any payment-gated resource (the videoconference join link today, recordings
+  # or downloads in the future) should gate on this, NOT on `paid?`. Reporting
+  # surfaces (rosters, CSV exports, dashboard metrics) must keep using `paid?` /
+  # `paid_in_full?` so they still reflect the real balance owed.
   def access_granted?
     paid? || intends_to_pay?
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -124,6 +124,7 @@ class EventRegistration < ApplicationRecord
     case value
     when "paid" then paid_in_full
     when "unpaid" then not_paid_in_full
+    when "intends_to_pay" then where(intends_to_pay: true)
     else all
     end
   }
@@ -184,6 +185,23 @@ class EventRegistration < ApplicationRecord
     paid_in_full?
   end
 
+  # True when the registrant should be granted access to ticket materials
+  # (training links, etc.) even though they haven't paid in full yet. Admins
+  # flip the `intends_to_pay` flag when someone commits to paying after the
+  # deadline so they aren't locked out in the meantime. This does NOT mark the
+  # registration as paid — payment status still shows as due.
+  def access_granted?
+    paid? || intends_to_pay?
+  end
+
+  # Human-readable payment status for rosters and CSV exports. Assumes the event
+  # has a cost — callers show nothing for free events.
+  def payment_status_label
+    return "Paid" if paid_in_full?
+    return "Intends to pay" if intends_to_pay?
+    "Due"
+  end
+
   def scholarship?
     scholarships.exists?
   end
@@ -230,7 +248,7 @@ class EventRegistration < ApplicationRecord
   end
 
   def joinable?
-    active? && paid? && event.videoconference_window_open?
+    active? && access_granted? && event.videoconference_window_open?
   end
 
   def attendance_status_label

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -11,7 +11,7 @@
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:payments, intensity: 100) %> <%= DomainTheme.text_class_for(:payments, intensity: 600) %>">
       <i class="fa-solid fa-dollar-sign"></i>
     </span>
-    <h2 class="text-sm font-semibold text-gray-700">Registration allocations</h2>
+    <h2 class="text-sm font-semibold text-gray-700">Registration payments and allocations</h2>
     <%= link_to allocations_path(allocatable_sgid: event_registration.to_sgid.to_s, return_to: "registration"),
                 class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline after:absolute after:inset-0 after:content-['']",
                 target: "_blank", rel: "noopener" do %>
@@ -45,6 +45,23 @@
           </dd>
         </div>
       </dl>
+
+      <%# Intends to pay — grants ticket/material access while the balance above is
+          still owed, for registrants who've committed to paying after the deadline.
+          Does not change the amount due or mark the registration as paid. %>
+      <label class="mt-4 flex items-start gap-2.5 border-t border-gray-100 pt-4 cursor-pointer">
+        <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
+        <input type="checkbox"
+               name="event_registration[intends_to_pay]"
+               value="1"
+               <%= "checked" if event_registration.intends_to_pay %>
+               class="sr-only peer">
+        <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
+        <span>
+          <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
+          <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
+        </span>
+      </label>
     <% else %>
       <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-0.5 text-xs font-medium text-gray-500">
         <i class="fa-solid fa-gift"></i>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -83,6 +83,14 @@
           <div class="text-center mt-2">
             <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800">$<%= "%.2f" % (due_cents / 100.0) %> payment is due</span>
 
+            <% if event_registration.intends_to_pay? %>
+              <div class="mt-2">
+                <span class="inline-flex items-center gap-1 rounded-full text-sm font-medium border px-3 py-1 bg-blue-50 text-blue-700 border-blue-200">
+                  <i class="fa-solid fa-circle-check"></i> Access granted — payment pending
+                </span>
+              </div>
+            <% end %>
+
             <div class="mt-3">
               <%= button_to "Pay with Credit Card",
                             registration_pay_path(event_registration.slug),

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -239,6 +239,13 @@
                       <% end %>
                       <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                     <% end %>
+
+                    <% if !is_paid && registration.intends_to_pay? %>
+                      <div class="mt-1 inline-flex items-center gap-1 whitespace-nowrap text-[0.65rem] font-medium text-blue-600">
+                        <i class="fa-solid fa-hand-holding-dollar"></i>
+                        <span>Intends to pay</span>
+                      </div>
+                    <% end %>
                   </td>
                 <% end %>
 

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -36,7 +36,7 @@
       <%= label_tag :payment_status, "Payment", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :payment_status,
                      options_for_select(
-                       [ [ "Due", "unpaid" ], [ "Paid", "paid" ] ],
+                       [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
                        params[:payment_status]
                      ),
                      include_blank: "Any payment status",

--- a/db/migrate/20260618020000_add_intends_to_pay_to_event_registrations.rb
+++ b/db/migrate/20260618020000_add_intends_to_pay_to_event_registrations.rb
@@ -1,0 +1,11 @@
+class AddIntendsToPayToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:event_registrations, :intends_to_pay)
+      add_column :event_registrations, :intends_to_pay, :boolean, default: false, null: false
+    end
+  end
+
+  def down
+    remove_column :event_registrations, :intends_to_pay, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_020000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -453,6 +453,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
     t.string "checkout_session_id"
     t.datetime "created_at", null: false
     t.bigint "event_id"
+    t.boolean "intends_to_pay", default: false, null: false
     t.boolean "invoice_requested", default: false, null: false
     t.boolean "payment_unresolved"
     t.bigint "registrant_id", null: false

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -374,6 +374,7 @@ rosa_dlc = Person.find_by(first_name: "Rosa", last_name: "De La Cruz")
 mario_j = Person.find_by(first_name: "Mario", last_name: "Johnson") # no user
 angel_g = Person.find_by(first_name: "Angel", last_name: "Garcia") # no user
 linda_w = Person.find_by(first_name: "Linda", last_name: "Williams") # no user
+aisha_person = User.find_by(email: "aisha.user@example.com")&.person
 
 # Events by name for clarity
 facilitator_training = Event.find_by(title: "AWBW Facilitator Training")
@@ -426,13 +427,17 @@ registrations_data = []
 # Anna Garcia: attended, with form submission (has user)
 # Mario Johnson: registered, no form submission (no user)
 # Kim Davis: cancelled (has user)
+# Aisha: registered, intends to pay — no payment recorded, but access is granted
+#   so she can reach her training materials (the intends_to_pay scenario). Pairs
+#   with Amy on this same event, who DOES have payments, for side-by-side review.
 if facilitator_training
   [
     { person: amy_person, status: "registered", scholarship_requested: true, w9_requested: true, invoice_requested: true, ce_credit_requested: true },
     { person: maria_j, status: "registered", invoice_requested: true, ce_credit_requested: true },
     { person: anna_g, status: "attended", ce_credit_requested: true },
     { person: mario_j, status: "registered" },
-    { person: kim_d, status: "cancelled" }
+    { person: kim_d, status: "cancelled" },
+    { person: aisha_person, status: "registered", intends_to_pay: true }
   ].each do |data|
     next unless data[:person]
     registrations_data << data.merge(event: facilitator_training)
@@ -514,6 +519,7 @@ registrations_data.each do |data|
   registration.w9_requested = data[:w9_requested] || false
   registration.invoice_requested = data[:invoice_requested] || false
   registration.ce_credit_requested = data[:ce_credit_requested] || false
+  registration.intends_to_pay = data[:intends_to_pay] || false
   registration.save!
 end
 
@@ -605,7 +611,7 @@ if facilitator_training
   reg_form = facilitator_training.registration_form
   if reg_form
     # People with users who filled out the form
-    [ amy_person, maria_j, anna_g ].compact.each do |person|
+    [ amy_person, maria_j, anna_g, aisha_person ].compact.each do |person|
       form_submissions << { person: person, form: reg_form, event: facilitator_training }
     end
     # Mario Johnson (no user) did NOT fill out the form — registration without form submission

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -290,6 +290,50 @@ RSpec.describe EventRegistration, type: :model do
       create(:allocation, source: payment, allocatable: reg, amount: 100)
       expect(reg).not_to be_joinable
     end
+
+    it "returns true for an unpaid registration flagged intends_to_pay" do
+      reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      expect(reg).not_to be_paid_in_full
+      expect(reg).to be_joinable
+    end
+
+    it "returns false for an unpaid, cancelled registration even when intends_to_pay" do
+      reg = create(:event_registration, event: event, registrant: user.person, status: "cancelled", intends_to_pay: true)
+      expect(reg).not_to be_joinable
+    end
+  end
+
+  describe "#access_granted?" do
+    let(:event) { create(:event, cost_cents: 1099) }
+    let(:user) { create(:user, :with_person) }
+
+    it "is true when paid in full" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      payment = create(:payment, person: user.person, amount_cents: 1099, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 1099)
+      expect(reg.access_granted?).to be true
+    end
+
+    it "is true when unpaid but flagged intends_to_pay" do
+      reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      expect(reg.access_granted?).to be true
+    end
+
+    it "is false when unpaid and not flagged" do
+      reg = create(:event_registration, event: event, registrant: user.person)
+      expect(reg.access_granted?).to be false
+    end
+  end
+
+  describe ".payment_status scope" do
+    let(:event) { create(:event, cost_cents: 1099) }
+    let(:user) { create(:user, :with_person) }
+
+    it "filters to registrations flagged intends_to_pay" do
+      intends = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      create(:event_registration, event: event, registrant: create(:person))
+      expect(EventRegistration.payment_status("intends_to_pay")).to contain_exactly(intends)
+    end
   end
 
   describe "#paid_in_full?" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "EventRegistrations", type: :request do
 
         rows = CSV.parse(response.body)
         expect(rows.size).to be >= 1
-        expect(rows.first).to eq([ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Payment total" ])
+        expect(rows.first).to eq([ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total" ])
 
         data_rows = rows.drop(1)
         expect(data_rows).not_to be_empty
@@ -59,6 +59,7 @@ RSpec.describe "EventRegistrations", type: :request do
           "No",
           "No",
           "Due",
+          "No",
           ""
         ]
         expect(data_rows).to include(expected_row)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Some registrants commit to paying after the deadline but can't pay in time; previously they were locked out of their ticket's training materials and videoconference join link, since access keys off paid status.
- This adds an admin-settable `intends_to_pay` flag that grants that access while keeping the registration's reported payment status as "due" everywhere money is reported.

### How did you approach the change?
- Added an `intends_to_pay` boolean column plus `access_granted?` (`paid? || intends_to_pay?`) on `EventRegistration`, and routed `joinable?` (the only payment-gated access path) through it — so reporting surfaces (roster badge, both CSV exports, dashboard metrics) still reflect the true balance owed.
- Surfaced an "Intends to pay" toggle in the registration's payments/allocations card, an access-granted badge on the ticket, an "Intends to pay" roster marker and payment-status filter option, and a dedicated "Intends to pay" column in both registration CSV exports; seeded Aisha on the Facilitator Training (no payments, flagged) to demo the state alongside Amy.

### UI Testing Checklist
- [ ] Toggle "Intends to pay" on an unpaid registration; confirm the ticket shows the join link/materials and an "Access granted — payment pending" badge while status stays "Due".
- [ ] Confirm the roster badge, payment filter, and CSV exports still report the registrant as owing, and that the new "Intends to pay" CSV column reads Yes/No.

### Anything else to add?
- The `intends_to_pay` naming was kept intentionally; `access_granted?` is the method any future payment-gated resource (e.g. recordings) should use rather than `paid?` — now documented on the method.
