### PR TITLE
Remove workshop settings and client life experiences registration questions

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -143,7 +143,7 @@ module EventHelper
     case field&.field_identifier
     when "primary_service_area", "primary_service_area_single"
       resolve.call(Sector)
-    when "workshop_environments", "client_life_experiences", "primary_age_group", "additional_age_group"
+    when "primary_age_group", "additional_age_group"
       resolve.call(Category)
     else
       submitted_answer

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -29,8 +29,6 @@ class FormField < ApplicationRecord
   # CategoryType's published categories. The submitted value is a Category id
   # (as a string). Maps the field identifier to its backing CategoryType name.
   DYNAMIC_FIELD_CATEGORY_TYPES = {
-    "workshop_environments" => "WorkshopEnvironment",
-    "client_life_experiences" => "StoryPopulation",
     "primary_age_group" => "AgeRange",
     "additional_age_group" => "AgeRange"
   }.freeze

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -209,9 +209,9 @@ class Person < ApplicationRecord
 
   # Field identifiers whose "Other" free text maps onto the profile's sectors.
   OTHER_SERVICE_AREA_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
-  # Field identifiers whose "Other" free text maps onto the workshop-setting
-  # categories shown on the edit page.
-  OTHER_WORKSHOP_SETTING_IDENTIFIERS = %w[workshop_environments client_life_experiences primary_age_group additional_age_group].freeze
+  # Field identifiers whose "Other" free text maps onto the category-backed
+  # profile fields shown on the edit page.
+  OTHER_WORKSHOP_SETTING_IDENTIFIERS = %w[primary_age_group additional_age_group].freeze
 
   # Free-text "Other" service areas the person typed on registration forms.
   # They can't be Sector records, so they're surfaced beside the sector tags.

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -229,8 +229,6 @@ module EventRegistrationServices
     def assign_tags(person, organization)
       sector_ids = collect_ids_from_checkboxes("primary_service_area_single") +
                    collect_ids_from_checkboxes("primary_service_area")
-      category_ids = collect_ids_from_checkboxes("workshop_environments") +
-                     collect_ids_from_checkboxes("client_life_experiences")
       primary_age_ids = collect_ids_from_checkboxes("primary_age_group")
       additional_age_ids = collect_ids_from_checkboxes("additional_age_group")
 
@@ -238,12 +236,6 @@ module EventRegistrationServices
         sectors = Sector.where(id: sector_ids)
         assign_primary_sectors(person, sectors)
         organization.sectors = (organization.sectors + sectors).uniq if organization
-      end
-
-      if category_ids.any?
-        categories = Category.where(id: category_ids)
-        person.categories = (person.categories + categories).uniq
-        organization.categories = (organization.categories + categories).uniq if organization
       end
 
       if primary_age_ids.any? || additional_age_ids.any?

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -49,7 +49,7 @@ class FormBuilderService
       agency_state agency_zip agency_type agency_website
     ],
     person_background: %w[racial_ethnic_identity],
-    professional_info: %w[primary_service_area_single primary_service_area workshop_environments client_life_experiences primary_age_group additional_age_group],
+    professional_info: %w[primary_service_area_single primary_service_area primary_age_group additional_age_group],
     marketing: %w[referral_source training_motivation interested_in_more],
     scholarship: %w[scholarship_eligibility impact_description implementation_plan additional_comments],
     payment: %w[payment_method],
@@ -86,7 +86,7 @@ class FormBuilderService
       "Agency Type", "Agency Website"
     ],
     person_background: [ "Racial / Ethnic Identity" ],
-    professional_info: [ "Primary sector", "Additional sectors", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
+    professional_info: [ "Primary sector", "Additional sectors", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
     marketing: [
       "How did you hear about this training?",
       "What motivates you to attend this training?",
@@ -436,19 +436,6 @@ class FormBuilderService
     position = add_field(form, position, "Additional sectors", :multi_select_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
                          subtitle: "Select all options that represent who you intend to serve through the art workshops (check all that apply)")
-    position = add_field(form, position, "Workshop Settings", :multi_select_checkbox,
-                         key: "workshop_environments", group: "professional", required: false,
-                         subtitle: "Select all settings where you facilitate or plan to facilitate workshops.",
-                         options: [
-                           "Clinical setting", "Educational setting", "Events and conferences",
-                           "Faith-based setting", "Home visits", "Hospitals",
-                           "Law enforcement/court/legal", "Outreach program",
-                           "Prisons/jails", "Private practice", "Residential program",
-                           "Virtually", "With staff", "Other"
-                         ])
-    position = add_field(form, position, "Client Life Experiences", :multi_select_checkbox,
-                         key: "client_life_experiences", group: "professional", required: false,
-                         subtitle: "Select all that describe the populations you work with.")
     position = add_field(form, position, "Primary Age Group(s) Served", :multi_select_checkbox,
                          key: "primary_age_group", group: "professional", required: false,
                          subtitle: "Select all age groups you primarily serve.")

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -801,11 +801,15 @@ end
 
 puts "Tagging registrants with life experiences and workshop settings…"
 # The background page charts registrants' StoryPopulation (life experiences) and
-# WorkshopEnvironment (settings) tags — the same tags public registration writes
-# from the "Client life experiences" and "Workshop environments" checkboxes (see
-# PublicRegistration#assign_tags). The seed form submissions above only fill text
-# fields, so without this the data-rich trainings' background charts are empty.
-# Tag each active registrant with a deterministic spread so re-seeding is idempotent.
+# WorkshopEnvironment (settings) tags. Public registration no longer collects these
+# (the "Workshop settings" and "Client life experiences" questions were removed), but
+# the charts are retained for historical data and admin-applied tags, so seed a
+# deterministic spread here so older trainings' background charts aren't empty.
+#
+# These tags live on the Person, not per-registration, so anyone registered for the
+# flagship "AWBW Facilitator Training" (event #1) would surface on its charts too.
+# Keep event #1 clean by never tagging its registrants, and by stripping any such
+# tags a prior seed left on them.
 life_experience_categories = Category.joins(:category_type)
   .where(category_types: { name: "StoryPopulation" })
   .order(:name).to_a
@@ -820,10 +824,17 @@ pick_categories = ->(categories, i, offset) do
   [ categories[i % categories.size], categories[(i + offset) % categories.size] ]
 end
 
-[ facilitator_training, trauma_training ].compact.each do |evt|
+flagship_registrant_ids = facilitator_training&.event_registrations&.active&.pluck(:registrant_id) || []
+CategorizableItem.joins(category: :category_type)
+  .where(categorizable_type: "Person", categorizable_id: flagship_registrant_ids)
+  .where(category_types: { name: [ "WorkshopEnvironment", "StoryPopulation" ] })
+  .destroy_all
+
+[ trauma_training, wellness_day, youth_day, mindful_art, virtual_session, roundtable, family_day ].compact.each do |evt|
   evt.event_registrations.active.includes(:registrant).each_with_index do |registration, i|
     person = registration.registrant
     next unless person
+    next if flagship_registrant_ids.include?(person.id)
 
     # Each registrant gets two life experiences and two settings, offset by their
     # position so the charts show a realistic spread across categories.
@@ -942,20 +953,18 @@ form_submissions.each do |data|
   end
 end
 
-puts "Giving Amy free-text \"Other\" answers on her Facilitator Training submission…"
-# Demo data for the "Other" chips on the person profile + edit pages: a registrant
+puts "Giving Amy a free-text \"Other\" answer on her Facilitator Training submission…"
+# Demo data for the "Other" chip on the person profile + edit pages: a registrant
 # who picked the "Other" option (folded into "Other: <text>") on a sector-backed
-# field (Additional sectors) and a category-backed field (Workshop Settings).
-# These free-text values can't be Sector/Category records, so they only surface
-# via Person#other_service_area_responses / #other_workshop_setting_responses.
+# field (Additional sectors). The free-text value can't be a Sector record, so it
+# only surfaces via Person#other_service_area_responses.
 # Seeded before the professional-answer enrichment below so the primary_service_area
 # value survives its "skip if already answered" guard. Idempotent.
 if facilitator_training && amy_person
   amy_submission = FormSubmission.find_by(person: amy_person, form: facilitator_training.registration_form)
   if amy_submission
     {
-      "primary_service_area" => "Other: Equine-assisted therapy",
-      "workshop_environments" => "Other: Mobile art van"
+      "primary_service_area" => "Other: Equine-assisted therapy"
     }.each do |identifier, value|
       field = amy_submission.form.form_fields.find_by(field_identifier: identifier)
       next unless field

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe EventHelper, type: :helper do
 
   describe "#resolve_answer_text" do
     it "maps category ids to names while preserving an 'Other: <text>' token" do
-      category_type = create(:category_type, name: "StoryPopulation")
-      veterans = create(:category, :published, category_type: category_type, name: "Veterans")
-      field = build_stubbed(:form_field, field_identifier: "client_life_experiences")
+      category_type = create(:category_type, name: "AgeRange")
+      age_group = create(:category, :published, category_type: category_type, name: "3-5")
+      field = build_stubbed(:form_field, field_identifier: "primary_age_group")
 
-      result = helper.resolve_answer_text(field, "#{veterans.id}, Other: refugees")
+      result = helper.resolve_answer_text(field, "#{age_group.id}, Other: toddlers")
 
-      expect(result).to eq("Veterans, Other: refugees")
+      expect(result).to eq("3-5, Other: toddlers")
     end
   end
 

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -403,10 +403,10 @@ RSpec.describe FormField do
       end
 
       it "accepts a published Category id from the backing type for a category field" do
-        type = create(:category_type, name: "WorkshopEnvironment")
-        offered = create(:category, :published, category_type: type)
+        type = create(:category_type, name: "AgeRange")
+        offered = create(:category, :published, category_type: type, name: "3-5")
         other_type_category = create(:category, :published)
-        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "workshop_environments")
+        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_age_group")
 
         expect(field.answer_inclusion_error([ offered.id.to_s ])).to be_nil
         expect(field.answer_inclusion_error([ other_type_category.id.to_s ])).to eq("has an invalid selection")

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe Person, type: :model do
       end
 
       it "does not pull from unrelated fields" do
-        answer("workshop_environments", "Other: School")
+        answer("primary_age_group", "Other: School")
 
         expect(person.other_service_area_responses).to be_empty
       end
@@ -417,12 +417,10 @@ RSpec.describe Person, type: :model do
 
     describe "#other_workshop_setting_responses" do
       it "returns free-text Other values from the category-backed fields" do
-        answer("workshop_environments", "3, Other: Equine center")
-        answer("client_life_experiences", "Other: Refugees")
-        answer("primary_age_group", "Other: Toddlers")
+        answer("primary_age_group", "3, Other: Toddlers")
 
         expect(person.other_workshop_setting_responses)
-          .to contain_exactly("Equine center", "Refugees", "Toddlers")
+          .to contain_exactly("Toddlers")
       end
 
       it "does not pull from the service area fields" do

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -333,16 +333,16 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("<strong>Please complete all fields below.</strong>")
     end
 
-    it "renders a workshop setting option's description under its checkbox" do
-      category_type = create(:category_type, name: "WorkshopEnvironment")
+    it "renders a category option's description under its checkbox" do
+      category_type = create(:category_type, name: "AgeRange")
       create(:category, :published, category_type: category_type,
-             name: "Clinical setting", description: "Community mental health, outpatient, etc")
+             name: "3-5", description: "Preschool and kindergarten")
       create(:form_field, form: form, answer_type: :multi_select_checkbox,
-             field_identifier: "workshop_environments", name: "Workshop Settings", required: false)
+             field_identifier: "primary_age_group", name: "Primary Age Group(s) Served", required: false)
 
       get new_event_public_registration_path(event)
 
-      expect(response.body).to include("Community mental health, outpatient, etc")
+      expect(response.body).to include("Preschool and kindergarten")
     end
 
     it "reveals a 'please specify' text input for a radio field's Other option" do
@@ -379,11 +379,11 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     it "reveals the text input for a category-backed dynamic field's Other option" do
       # Dynamic fields source options from Category and use the category id as the
       # option value, so the Other option must be detected by its label, not value.
-      category_type = create(:category_type, name: "StoryPopulation")
-      create(:category, :published, category_type: category_type, name: "Veterans")
+      category_type = create(:category_type, name: "AgeRange")
+      create(:category, :published, category_type: category_type, name: "3-5")
       create(:category, :published, category_type: category_type, name: "Other")
       create(:form_field, form: form, answer_type: :multi_select_checkbox,
-             field_identifier: "client_life_experiences", name: "Populations", required: false)
+             field_identifier: "primary_age_group", name: "Primary Age Group(s) Served", required: false)
 
       get new_event_public_registration_path(event)
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -228,12 +228,12 @@ RSpec.describe "Forms", type: :request do
     end
 
     it "warns when a dynamic (category-backed) dropdown sources an Other option" do
-      category_type = create(:category_type, name: "StoryPopulation")
-      create(:category, :published, category_type: category_type, name: "Veterans")
+      category_type = create(:category_type, name: "AgeRange")
+      create(:category, :published, category_type: category_type, name: "3-5")
       create(:category, :published, category_type: category_type, name: "Other")
       form = create(:form, :standalone)
       create(:form_field, form: form, answer_type: :single_select_dropdown,
-             field_identifier: "client_life_experiences", name: "Populations")
+             field_identifier: "primary_age_group", name: "Primary Age Group(s) Served")
 
       get edit_form_path(form)
 

--- a/spec/requests/people_other_responses_spec.rb
+++ b/spec/requests/people_other_responses_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe "Person Other form responses", type: :request do
     it "shows the Other workshop setting near the category checkboxes" do
       category_type = create(:category_type, :published, profile_specific: true)
       create(:category, :published, category_type: category_type)
-      answer("workshop_environments", "Other: Equine center")
+      answer("primary_age_group", "Other: Toddlers")
 
       get edit_person_path(person)
 
-      expect(response.body).to include("Equine center")
+      expect(response.body).to include("Toddlers")
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The "Workshop Settings" and "Client Life Experiences" professional-info questions are no longer collected, so they are removed from the registration form builder and the code that consumed their submitted answers.

### How did you approach the change?
- Dropped both fields from `FormBuilderService` (builder + section registries) and from `FormField`'s dynamic category-type mapping, and stopped `PublicRegistration` from tagging registrants from them.
- Narrowed `Person`/`EventHelper` handling to the remaining `primary_age_group` field, removed the dev seed's "Other" workshop-setting demo answer, and updated the affected specs.

### Anything else to add?
- The event Background dashboard's "Settings" and "Life experiences" charts are **retained** for historical and admin-applied tags — the `WorkshopEnvironment`/`StoryPopulation` category types and their seeds stay; only the self-service registration questions were removed, so future registrations simply no longer write these tags.