### PR TITLE
Add admin-configurable registration ticket callouts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -181,6 +181,7 @@ it needs a `page_bg_class` and register it:**
 - Prefer Turbo for navigation and form submissions before reaching for Stimulus
 - Controller naming: `[name]_controller.js`
 - Keep controllers focused and small
+- **Before adding a new JS/Stimulus controller, check whether an existing one already covers the behavior or can be lightly adapted** — search `app/frontend/javascript/controllers/` for similar names/behavior (e.g. sorting, toggling, autocomplete). Prefer reusing it, or generalizing it with a new value/target/class so both callers share it, over creating a near-duplicate. Only add a new controller when the behavior is genuinely distinct. If a small change to an existing controller would make it reusable, do that (and re-verify its existing callers)
 
 ### Stimulus Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ This codebase (Rails 8.1)
 | `Workshop` | Core content: rich text fields, categories, sectors, bookmarks, variations |
 | `Event` | Events with registrations, featured/published states |
 | `EventStaff` | Join model connecting `Person` to `Event` as staff (title, `expected_to_attend`); drives the "Meet the staff" roster and "My events" |
+| `RegistrationTicketCallout` | Admin-configured call-outs shown on an event's registration ticket (title, subtitle, HTML description, `callout_type` action/reference, icon/colour, `show_if_paid`, draggable `position` via the positioning gem); each links to its own public detail page |
 | `Story` | Editorial content with facilitators, primary/gallery assets |
 | `Resource` | Handouts, toolkits, templates with downloadable assets |
 | `Person` | Organization affiliates with contacts, addresses, sectors |
@@ -141,7 +142,7 @@ This codebase (Rails 8.1)
 
 ### Namespaces
 
-- **Root level** (~51 controllers): Workshops, stories, resources, events, people, organizations, etc.
+- **Root level** (~52 controllers): Workshops, stories, resources, events, people, organizations, registration ticket callouts, etc.
 - **`admin/`**: HomeController, AnalyticsController, AhoyActivitiesController
 - **`events/`**: Registrations sub-resource (create/destroy + slug-based show at `/registration/:slug`)
 - **Devise overrides**: Registrations, Confirmations, Passwords
@@ -289,7 +290,7 @@ end
 - `searchable_checkbox` — TomSelect checkbox-style multi-select
 - `searchable_select` — Tom Select autocomplete
 - `share_url` — URL sharing/copying
-- `sortable` — Drag-drop sorting (SortableJS)
+- `sortable` — Drag-drop sorting (SortableJS); persists order via a per-row PUT (used by categories index and the registration ticket callouts editor)
 - `submit_once` — Disables a form's submit button after submit to block duplicate submissions; re-enables on Back/bfcache/Turbo restore
 - `tabs` — Tab panel navigation
 - `tag_link_loading` — Loading state for tag links

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ it needs a `page_bg_class` and register it:**
 - Prefer Turbo for navigation and form submissions before reaching for Stimulus
 - Controller naming: `[name]_controller.js`
 - Keep controllers focused and small
+- **Before adding a new JS/Stimulus controller, check whether an existing one already covers the behavior or can be lightly adapted** — search `app/frontend/javascript/controllers/` for similar names/behavior (e.g. sorting, toggling, autocomplete). Prefer reusing it, or generalizing it with a new value/target/class so both callers share it, over creating a near-duplicate. Only add a new controller when the behavior is genuinely distinct. If a small change to an existing controller would make it reusable, do that (and re-verify its existing callers)
 
 ### Stimulus Conventions
 

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -1,0 +1,44 @@
+class RegistrationTicketCalloutsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [ :show ]
+  before_action :set_event
+
+  # Public detail page for a single registration ticket callout, linked from the
+  # call-out on the registration ticket (mirrors the events#details / #ce_hours
+  # pages). When the callout has no description there is nothing to read, so fall
+  # back to the event page.
+  def show
+    authorize! @event, to: :show?
+    @callout = @event.registration_ticket_callouts.find(params[:id])
+
+    if @callout.description.blank?
+      redirect_to event_path(@event, reg: params[:reg].presence)
+      return
+    end
+
+    @event = @event.decorate
+  end
+
+  # Drag-reorder persistence. The shared `sortable` Stimulus controller PUTs the
+  # new 1-based position for a single moved callout; the positioning gem reflows
+  # the rest. Only event managers can reorder (matches editing the event).
+  def update
+    authorize! @event, to: :manage?
+    @callout = @event.registration_ticket_callouts.find(params[:id])
+
+    if @callout.update(callout_params)
+      head :ok
+    else
+      head :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:event_id])
+  end
+
+  def callout_params
+    params.permit(:position)
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,7 @@ class Event < ApplicationRecord
   has_many :event_registrations, dependent: :destroy
   has_many :event_staffs, dependent: :destroy
   has_many :event_forms, dependent: :destroy
+  has_many :registration_ticket_callouts, -> { ordered }, dependent: :destroy, inverse_of: :event
   # Block destroying an event that has submissions (registrations, scholarship
   # applications, payments). Submissions that were never tied to an event are
   # unaffected. Destroying instead would orphan the payments that hang off a
@@ -39,6 +40,8 @@ class Event < ApplicationRecord
 
   accepts_nested_attributes_for :event_staffs, allow_destroy: true,
     reject_if: proc { |attrs| attrs["person_id"].blank? }
+  accepts_nested_attributes_for :registration_ticket_callouts, allow_destroy: true,
+    reject_if: proc { |attrs| attrs["title"].blank? }
 
   # Callbacks
   after_commit :build_public_registration_form, if: :public_registration_just_enabled?

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -1,0 +1,59 @@
+class RegistrationTicketCallout < ApplicationRecord
+  # "Action" callouts prompt the registrant to do something (download a form,
+  # pay a balance); "Reference" callouts are informational reading (policies, CE
+  # requirements). The distinction drives the default icon/colour and lets us
+  # group them on the ticket later.
+  CALLOUT_TYPES = %w[ action reference ].freeze
+
+  # Colour themes keyed by a short name stored in `color_class`. Every utility is
+  # spelled out as a literal class so Tailwind's JIT scan picks it up — never
+  # interpolate the colour into a class name. Used for the icon today; the border
+  # and background are here so we can tint the whole box later without a migration.
+  COLOR_THEMES = {
+    "amber" => { icon: "text-amber-500", border: "border-amber-300", bg: "bg-amber-50", hover: "hover:bg-amber-100", title: "text-amber-900", subtitle: "text-amber-700" },
+    "indigo" => { icon: "text-indigo-500", border: "border-indigo-300", bg: "bg-indigo-50", hover: "hover:bg-indigo-100", title: "text-indigo-900", subtitle: "text-indigo-700" },
+    "blue" => { icon: "text-blue-500", border: "border-blue-200", bg: "bg-blue-50", hover: "hover:bg-blue-100", title: "text-blue-900", subtitle: "text-blue-700" },
+    "green" => { icon: "text-green-500", border: "border-green-300", bg: "bg-green-50", hover: "hover:bg-green-100", title: "text-green-900", subtitle: "text-green-700" },
+    "purple" => { icon: "text-purple-500", border: "border-purple-300", bg: "bg-purple-50", hover: "hover:bg-purple-100", title: "text-purple-900", subtitle: "text-purple-700" },
+    "rose" => { icon: "text-rose-500", border: "border-rose-300", bg: "bg-rose-50", hover: "hover:bg-rose-100", title: "text-rose-900", subtitle: "text-rose-700" },
+    "gray" => { icon: "text-gray-500", border: "border-gray-200", bg: "bg-gray-50", hover: "hover:bg-gray-100", title: "text-gray-900", subtitle: "text-gray-600" }
+  }.freeze
+
+  DEFAULT_ICONS = { "action" => "fa-solid fa-arrow-right", "reference" => "fa-solid fa-circle-info" }.freeze
+  DEFAULT_COLORS = { "action" => "blue", "reference" => "indigo" }.freeze
+
+  belongs_to :event
+
+  # Per-event ordering, drag-reordered after save via the shared `sortable`
+  # Stimulus controller (a per-row PUT to #update). The gem reflows the other
+  # callouts' positions on each move, exactly like Category. It assigns position
+  # after validations, so position must allow nil here.
+  positioned on: :event_id
+
+  validates :title, presence: true
+  validates :callout_type, inclusion: { in: CALLOUT_TYPES }
+  validates :color_class, inclusion: { in: COLOR_THEMES.keys }, allow_blank: true
+  validates :position, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+
+  scope :ordered, -> { order(:position, :id) }
+
+  def action?
+    callout_type == "action"
+  end
+
+  # Font Awesome class for the leading icon, falling back to a sensible default
+  # per callout type so a callout never renders without an icon.
+  def display_icon_class
+    icon_class.presence || DEFAULT_ICONS.fetch(callout_type, DEFAULT_ICONS["reference"])
+  end
+
+  # The colour theme hash for this callout, falling back to the per-type default.
+  def theme
+    key = color_class.presence || DEFAULT_COLORS.fetch(callout_type, "indigo")
+    COLOR_THEMES.fetch(key, COLOR_THEMES["indigo"])
+  end
+
+  def to_s
+    title
+  end
+end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -142,7 +142,8 @@ class EventPolicy < ApplicationPolicy
                   category_ids: [],
                   sector_ids: [],
                   primary_asset_attributes: [ :id, :file, :_destroy ],
-                  gallery_assets_attributes: [ :id, :file, :_destroy ]
+                  gallery_assets_attributes: [ :id, :file, :_destroy ],
+                  registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :show_if_paid, :_destroy ]
         ]
 
     permitted.prepend(:ga4_snippet, :gtm_head_snippet, :gtm_body_snippet) if admin?

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -155,6 +155,26 @@
         <% end %>
       <% end %>
 
+      <!-- Custom ticket callouts (admin-configured: actions & reference reading) -->
+      <% paid = event_registration.paid_in_full? || @checkout_payment_status == "paid" %>
+      <% event_registration.event.registration_ticket_callouts.each do |callout| %>
+        <% next if callout.show_if_paid && !paid %>
+        <% theme = callout.theme %>
+        <%= link_to event_registration_ticket_callout_path(event_registration.event, callout, reg: event_registration.slug),
+                      class: "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" do %>
+          <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
+
+          <div class="flex-1 min-w-0 text-left">
+            <p class="font-semibold <%= theme[:title] %>"><%= callout.title %></p>
+            <% if callout.subtitle.present? %>
+              <p class="text-sm <%= theme[:subtitle] %>"><%= callout.subtitle %></p>
+            <% end %>
+          </div>
+
+          <i class="fa-solid <%= callout.action? ? "fa-arrow-right" : "fa-circle-info" %> <%= theme[:icon] %> shrink-0"></i>
+        <% end %>
+      <% end %>
+
       <!-- Divider -->
       <div class="border-t border-gray-200"></div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -491,6 +491,40 @@
       </div>
     </div>
 
+    <%# ---- REGISTRATION TICKET CALLOUTS (custom ticket call-outs, drag to reorder) ---- %>
+    <div class="registration-ticket-callouts-section" data-controller="dropdown">
+      <button
+        type="button"
+        id="registration_ticket_callouts_button"
+        class="
+          flex items-center justify-between cursor-pointer w-full
+          bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
+        data-action="dropdown#toggle"
+        data-dropdown-payload-param='[{"registration_ticket_callouts_panel":"hidden"}, {"registration_ticket_callouts_arrow":"rotate-180"}, {"registration_ticket_callouts_button":"rounded-md rounded-t-md"}]'>
+        Registration ticket callouts
+        <i id="registration_ticket_callouts_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
+      </button>
+
+      <div id="registration_ticket_callouts_panel" class="hidden border border-gray-300 p-4 rounded-b-md">
+        <p class="text-sm text-gray-500 mb-4">Custom call-outs shown on the registration ticket — each links to its own page. Use them for actions (forms to download, balances to pay) or reference reading (parking, policies, what to bring). New callouts save in the order shown; drag the handle to reorder saved callouts.</p>
+
+        <div id="registration_ticket_callouts_list" class="space-y-3"
+             data-controller="sortable"
+             data-sortable-url-value="<%= @event.persisted? ? event_registration_ticket_callout_path(@event, ":id") : "" %>">
+          <%= f.fields_for :registration_ticket_callouts do |rts| %>
+            <%= render "events/registration_ticket_callout_fields", f: rts %>
+          <% end %>
+        </div>
+
+        <div class="mt-3">
+          <%= link_to_add_association "+ Add callout", f, :registration_ticket_callouts,
+                partial: "events/registration_ticket_callout_fields",
+                class: "text-sm font-medium text-purple-600 hover:text-purple-800",
+                data: { association_insertion_node: "#registration_ticket_callouts_list", association_insertion_method: "append" } %>
+        </div>
+      </div>
+    </div>
+
     <div class="images-section" data-controller="dropdown">
       <button
         type="button"

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -1,0 +1,66 @@
+<div class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
+     <% if f.object.persisted? %>data-sortable-id="<%= f.object.id %>"<% end %>>
+  <% if f.object.persisted? %>
+    <div class="cursor-grab text-gray-400 hover:text-gray-600 pt-2 shrink-0" data-sortable-handle title="Drag to reorder">
+      <i class="fa-solid fa-grip-vertical"></i>
+    </div>
+  <% else %>
+    <div class="pt-2 shrink-0 text-gray-200" title="Save the event to enable drag-reordering">
+      <i class="fa-solid fa-grip-vertical"></i>
+    </div>
+  <% end %>
+
+  <div class="flex-1 min-w-0 space-y-3">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div>
+        <%= f.label :title, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_field :title, required: true, placeholder: "e.g. Parking & directions",
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+      </div>
+      <div>
+        <%= f.label :subtitle, "Subtitle", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_field :subtitle, placeholder: "Short line shown under the title on the ticket",
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+      <div>
+        <%= f.label :callout_type, "Type", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.select :callout_type,
+              RegistrationTicketCallout::CALLOUT_TYPES.map { |t| [ t.humanize, t ] },
+              {},
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+      </div>
+      <div>
+        <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.select :color_class,
+              RegistrationTicketCallout::COLOR_THEMES.keys.map { |c| [ c.humanize, c ] },
+              { include_blank: "Default (by type)" },
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+      </div>
+      <div>
+        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :description, "Content", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+      <p class="text-xs text-gray-500 mb-1">Shown on its own page linked from the ticket. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
+      <%= f.text_area :description, rows: 4,
+            placeholder: "e.g. <p>Enter through the north lot…</p>",
+            class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
+    </div>
+
+    <div class="flex items-center justify-between">
+      <label class="flex items-center gap-2 text-sm text-gray-600">
+        <%= f.check_box :show_if_paid, class: "rounded border-gray-300 text-purple-600" %>
+        Only show once the registration is paid
+      </label>
+      <%= link_to_remove_association "Remove", f,
+            class: "text-sm text-gray-400 hover:text-red-600 underline" %>
+    </div>
+  </div>
+</div>

--- a/app/views/registration_ticket_callouts/show.html.erb
+++ b/app/views/registration_ticket_callouts/show.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:page_bg_class, "public") %>
+
+<% reg_slug = params[:reg].presence %>
+<% back_path = reg_slug ? registration_ticket_path(reg_slug) : event_path(@event) %>
+<% back_label = reg_slug ? "Back to ticket" : "Back to event" %>
+<div class="max-w-3xl mx-auto px-4 pt-4">
+  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
+  <% end %>
+</div>
+
+<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
+  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+      <div class="flex items-center gap-5">
+        <div class="shrink-0">
+          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
+        </div>
+        <div class="flex-1">
+          <h1 class="text-xl font-semibold tracking-wide leading-tight"><%= @callout.title %></h1>
+          <p class="text-sm text-blue-200"><%= @event.title %></p>
+        </div>
+      </div>
+      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+    </div>
+
+    <div class="px-6 sm:px-8 py-7">
+      <% if @callout.subtitle.present? %>
+        <p class="text-base text-gray-500 mb-4"><%= @callout.subtitle %></p>
+      <% end %>
+
+      <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
+        <%= form_label_html(@callout.description) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
       post :allocate_bulk_payment
       post :create_bulk_payment
     end
+    resources :registration_ticket_callouts, only: [ :show, :update ]
     resource :registrations, only: %i[ create destroy ], module: :events, as: :registrant_registration
     resource :public_registration, only: [ :new, :create, :show ], module: :events
     resource :bulk_payment, only: [ :new, :create, :show ], module: :events

--- a/db/migrate/20260618020000_create_registration_ticket_callouts.rb
+++ b/db/migrate/20260618020000_create_registration_ticket_callouts.rb
@@ -1,0 +1,24 @@
+class CreateRegistrationTicketCallouts < ActiveRecord::Migration[8.1]
+  def up
+    create_table :registration_ticket_callouts do |t|
+      t.references :event, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :subtitle
+      t.text :description
+      t.string :callout_type, null: false, default: "reference"
+      t.string :icon_class
+      t.string :color_class
+      t.boolean :show_if_paid, null: false, default: false
+      # No default: the positioning gem assigns position before insert. A default
+      # would let a freshly built record fail the `greater_than: 0` validation.
+      t.integer :position, null: false
+      t.timestamps
+    end
+
+    add_index :registration_ticket_callouts, [ :event_id, :position ]
+  end
+
+  def down
+    drop_table :registration_ticket_callouts, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_020000) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1005,6 +1005,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
     t.index ["stripe_refund_id"], name: "index_refunds_on_stripe_refund_id", unique: true
   end
 
+  create_table "registration_ticket_callouts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "callout_type", default: "reference", null: false
+    t.string "color_class"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.bigint "event_id", null: false
+    t.string "icon_class"
+    t.integer "position", null: false
+    t.boolean "show_if_paid", default: false, null: false
+    t.string "subtitle"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "position"], name: "index_registration_ticket_callouts_on_event_id_and_position"
+    t.index ["event_id"], name: "index_registration_ticket_callouts_on_event_id"
+  end
+
   create_table "report_form_field_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "answer", size: :long
     t.integer "answer_option_id"
@@ -1622,6 +1638,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_014554) do
   add_foreign_key "people", "users", column: "updated_by_id"
   add_foreign_key "quotable_item_quotes", "quotes"
   add_foreign_key "quotes", "workshops"
+  add_foreign_key "registration_ticket_callouts", "events"
   add_foreign_key "report_form_field_answers", "answer_options"
   add_foreign_key "report_form_field_answers", "form_fields"
   add_foreign_key "report_form_field_answers", "reports"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -360,6 +360,60 @@ if trauma && trauma.ce_hours_details.blank?
   HTML
 end
 
+# Seed example registration ticket callouts on the art workshop — admin-configured
+# call-outs that show on the registration ticket and each link to their own page.
+# Demonstrates both types (reference reading + an action), custom colours/icons, a
+# subtitle, and a paid-only callout that stays hidden until the registration is paid.
+# Idempotent: only seeded when the workshop has no callouts yet, so admin edits survive.
+art_workshop = Event.find_by(title: "Mindful Art for Survivors Workshop")
+if art_workshop && art_workshop.registration_ticket_callouts.none?
+  art_workshop.registration_ticket_callouts.create!(
+    [
+      {
+        title: "What to bring",
+        subtitle: "A short list of optional supplies",
+        callout_type: "reference",
+        color_class: "green",
+        icon_class: "fa-solid fa-palette",
+        position: 1,
+        description: <<~HTML.strip
+          <p>Everything is provided, but you're welcome to bring your own supplies if you'd like.</p>
+          <ul>
+            <li>A journal or sketchbook</li>
+            <li>Your favourite pens, markers, or colored pencils</li>
+            <li>A water bottle and anything that helps you feel comfortable</li>
+          </ul>
+        HTML
+      },
+      {
+        title: "Studio location & parking",
+        subtitle: "Getting here on the day",
+        callout_type: "reference",
+        color_class: "amber",
+        icon_class: "fa-solid fa-location-dot",
+        position: 2,
+        description: <<~HTML.strip
+          <p>The studio is on the second floor — take the elevator near the main entrance.</p>
+          <p>Street parking is free after 10am. There is also a paid lot directly across the street.</p>
+        HTML
+      },
+      {
+        title: "Download your workbook",
+        subtitle: "Available once your spot is paid",
+        callout_type: "action",
+        color_class: "blue",
+        icon_class: "fa-solid fa-file-pdf",
+        show_if_paid: true,
+        position: 3,
+        description: <<~HTML.strip
+          <p>Thanks for completing your payment! Your printable workbook is ready.</p>
+          <p>Printing it is optional — we'll have copies available at the studio too.</p>
+        HTML
+      }
+    ]
+  )
+end
+
 puts "Creating Event Registrations…"
 
 # Key people for named scenarios

--- a/spec/factories/registration_ticket_callouts.rb
+++ b/spec/factories/registration_ticket_callouts.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :registration_ticket_callout do
+    association :event
+    sequence(:title) { |n| "Ticket callout #{n}" }
+    subtitle { "A short supporting line" }
+    description { "<p>Details for this callout.</p>" }
+    callout_type { "reference" }
+    show_if_paid { false }
+    # position is assigned by the positioning gem on save (appended within the event)
+
+    trait :action do
+      callout_type { "action" }
+    end
+
+    trait :paid_only do
+      show_if_paid { true }
+    end
+  end
+end

--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe RegistrationTicketCallout, type: :model do
+  subject(:callout) { build(:registration_ticket_callout) }
+
+  it "has a valid factory" do
+    expect(callout).to be_valid
+  end
+
+  describe "validations" do
+    it "requires a title" do
+      callout.title = ""
+      expect(callout).not_to be_valid
+      expect(callout.errors[:title]).to be_present
+    end
+
+    it "requires a known callout_type" do
+      callout.callout_type = "bogus"
+      expect(callout).not_to be_valid
+      expect(callout.errors[:callout_type]).to be_present
+    end
+
+    it "allows a blank colour but rejects an unknown one" do
+      callout.color_class = ""
+      expect(callout).to be_valid
+
+      callout.color_class = "chartreuse"
+      expect(callout).not_to be_valid
+    end
+  end
+
+  describe "positioning" do
+    it "assigns sequential positions in creation order" do
+      event = create(:event)
+      a = create(:registration_ticket_callout, event:)
+      b = create(:registration_ticket_callout, event:)
+      c = create(:registration_ticket_callout, event:)
+
+      expect([ a.position, b.position, c.position ]).to eq([ 1, 2, 3 ])
+    end
+
+    it "reflows the others when a callout is moved, and #ordered reflects it" do
+      event = create(:event)
+      a = create(:registration_ticket_callout, event:)
+      b = create(:registration_ticket_callout, event:)
+      c = create(:registration_ticket_callout, event:)
+
+      c.update!(position: 1)
+
+      expect(event.registration_ticket_callouts.ordered).to eq([ c, a, b ])
+    end
+  end
+
+  describe "#display_icon_class" do
+    it "uses the configured icon when present" do
+      callout.icon_class = "fa-solid fa-car"
+      expect(callout.display_icon_class).to eq("fa-solid fa-car")
+    end
+
+    it "falls back to a per-type default when blank" do
+      callout.icon_class = ""
+      callout.callout_type = "action"
+      expect(callout.display_icon_class).to eq(RegistrationTicketCallout::DEFAULT_ICONS["action"])
+    end
+  end
+
+  describe "#theme" do
+    it "returns the configured colour theme" do
+      callout.color_class = "amber"
+      expect(callout.theme).to eq(RegistrationTicketCallout::COLOR_THEMES["amber"])
+    end
+
+    it "falls back to the per-type default colour when blank" do
+      callout.color_class = ""
+      callout.callout_type = "reference"
+      default_key = RegistrationTicketCallout::DEFAULT_COLORS["reference"]
+      expect(callout.theme).to eq(RegistrationTicketCallout::COLOR_THEMES[default_key])
+    end
+  end
+end

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Registration ticket callouts", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, :publicly_visible) }
+
+  describe "GET /events/:event_id/registration_ticket_callouts/:id" do
+    it "renders the callout's title and description" do
+      callout = create(:registration_ticket_callout, event:, title: "Parking",
+        description: "<p>Use the north lot.</p>")
+
+      get event_registration_ticket_callout_path(event, callout)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Parking")
+      expect(response.body).to include("Use the north lot.")
+    end
+
+    it "redirects to the event when the callout has no description" do
+      callout = create(:registration_ticket_callout, event:, description: "")
+
+      get event_registration_ticket_callout_path(event, callout)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "does not find a callout belonging to a different event" do
+      other_callout = create(:registration_ticket_callout, description: "<p>Hi.</p>")
+
+      get event_registration_ticket_callout_path(event, other_callout)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "creating callouts through the event form" do
+    before { sign_in admin }
+
+    it "creates callouts from nested attributes and assigns positions in form order" do
+      patch event_path(event), params: {
+        event: {
+          title: event.title,
+          start_date: event.start_date,
+          end_date: event.end_date,
+          registration_ticket_callouts_attributes: {
+            "0" => { title: "First", callout_type: "reference", color_class: "green" },
+            "1" => { title: "Second", callout_type: "action" },
+            "2" => { title: "Third", callout_type: "reference" }
+          }
+        }
+      }
+
+      ordered = event.registration_ticket_callouts.reload.ordered
+      expect(ordered.map(&:title)).to eq(%w[First Second Third])
+      expect(ordered.map(&:position)).to eq([ 1, 2, 3 ])
+    end
+  end
+
+  describe "PATCH /events/:event_id/registration_ticket_callouts/:id (reorder)" do
+    it "moves the callout and reflows the others for an admin" do
+      sign_in admin
+      first = create(:registration_ticket_callout, event:)
+      second = create(:registration_ticket_callout, event:)
+
+      patch event_registration_ticket_callout_path(event, second), params: { position: 1 }
+
+      expect(response).to have_http_status(:ok)
+      expect(event.registration_ticket_callouts.ordered).to eq([ second, first ])
+    end
+
+    it "is not permitted for a non-manager" do
+      sign_in create(:user)
+      create(:registration_ticket_callout, event:)
+      callout = create(:registration_ticket_callout, event:) # position 2
+
+      patch event_registration_ticket_callout_path(event, callout), params: { position: 1 }
+
+      expect(response).to redirect_to(root_path)
+      expect(callout.reload.position).to eq(2)
+    end
+  end
+end

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -76,6 +76,35 @@ RSpec.describe "Event registration show page", type: :system do
     end
   end
 
+  describe "registration ticket callouts" do
+    it "shows a call-out linking to the callout's detail page" do
+      callout = create(:registration_ticket_callout, event: event,
+        title: "Parking", subtitle: "Where to park", description: "<p>North lot</p>")
+
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_link("Parking",
+        href: event_registration_ticket_callout_path(event, callout, reg: registration.slug))
+      expect(page).to have_text("Where to park")
+    end
+
+    it "hides a paid-only callout until the registration is paid in full" do
+      paid_only = create(:registration_ticket_callout, :paid_only, event: event, title: "Your workbook")
+
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_no_link("Your workbook")
+
+      create(:allocation, source: create(:payment), allocatable: registration, amount: event.cost_cents)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_link("Your workbook",
+        href: event_registration_ticket_callout_path(event, paid_only, reg: registration.slug))
+    end
+  end
+
   describe "view registration form link" do
     it "links to form show with slug param" do
       FormBuilderService.new(

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/registrations/invoice.html.erb"     => "public",
     "app/views/events/details.html.erb"                   => "public",
     "app/views/events/ce_hours.html.erb"                  => "public",
+    "app/views/registration_ticket_callouts/show.html.erb" => "public",
 
     # ─── bulk payment views ───
     "app/views/events/bulk_payments/new.html.erb"        => "public",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Events had accreted one-off registration-ticket call-outs (CE hours, "Before you attend"), each requiring its own column, edit toggle, and detail page.
- This generalizes them into a `RegistrationTicketCallout` so admins can add any number of titled call-outs to an event's registration ticket from a single editor, each linking to its own public detail page.

### How did you approach the change?
- Added a `RegistrationTicketCallout` model (belongs_to `:event`) with title, subtitle, HTML body, `callout_type` (action/reference), Font Awesome icon, colour theme, a `show_if_paid` visibility flag, and a positioning-gem `position`.
- Callouts are managed in one collapsible editor in the event form (cocoon add/remove); drag-reordering reuses the existing categories `sortable` Stimulus controller via a per-row PUT, so no new JS controller was added.
- Each callout renders as a colour-themed call-out on the ticket linking to a detail page and honours `show_if_paid`; seeded on the art workshop, with model/request/system specs.

### UI Testing Checklist
- [ ] In an event's edit form, expand "Registration ticket callouts", add one (title, subtitle, type, colour, icon, body) and save.
- [ ] Confirm it appears on the registration ticket with the chosen icon/colour and links to its detail page.
- [ ] Drag to reorder saved callouts and confirm the order persists after reload.
- [ ] Set a callout to "only show once the registration is paid" and confirm it stays hidden until paid in full.

### Anything else to add?
- Renamed from `RegistrationTicketSection` → `RegistrationTicketCallout` (including the `callout_type` column) to match the codebase's existing "call-out" vocabulary.
- Also adds an AI-files rule (CLAUDE.md + copilot-instructions.md) to reuse or lightly adapt an existing JS controller before adding a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
