### PR TITLE
Compound payer & additional designation pickers on allocation payment form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ This codebase (Rails 8.1)
 | `app/decorators/` | Draper decorators for view logic | ~38 files |
 | `app/policies/` | ActionPolicy authorization rules | ~49 files |
 | `app/presenters/` | Presentation objects | 3 files |
-| `app/helpers/` | View helpers | ~20 files |
+| `app/helpers/` | View helpers | ~24 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -188,7 +188,7 @@ class PaymentsController < ApplicationController
   end
 
   def payment_params
-    params.require(:payment).permit(:type, :payer_type, :person_id, :organization_id, :amount_dollars, :currency, :check_number, :memo, :allocatable_sgid)
+    params.require(:payment).permit(:type, :payer_type, :person_id, :organization_id, :payer_sgid, :additional_designation_sgid, :amount_dollars, :currency, :check_number, :memo, :allocatable_sgid)
   end
 
   def locate_allocatable

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -251,7 +251,7 @@ class PaymentsController < ApplicationController
   end
 
   def edit_payment_params
-    params.require(:payment).permit(:person_id, :organization_id, :form_submission_id)
+    params.require(:payment).permit(:person_id, :organization_id, :form_submission_id, :payer_sgid, :additional_designation_sgid)
   end
 
   def redirect_path_for(allocatable)

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -98,6 +98,7 @@ class PaymentsController < ApplicationController
     if @payment.update(edit_payment_params)
       redirect_to payment_path(@payment), notice: "Payment was successfully updated."
     else
+      flash.now[:alert] = @payment.errors.full_messages.join(", ")
       render :edit, status: :unprocessable_content
     end
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,13 @@
 class SearchController < ApplicationController
   skip_before_action :preload_current_user_associations, raise: false
 
+  # Virtual "model" that searches people and organizations together, used by the
+  # compound payer / additional-designation pickers on the payment form.
+  COMPOUND_PAYER_MODEL = "person_or_organization".freeze
+
   def index
+    return render json: compound_payer_results if params[:model] == COMPOUND_PAYER_MODEL
+
     model_class = allowed_model(params[:model])
     unless model_class
       skip_verify_authorized!
@@ -32,6 +38,19 @@ class SearchController < ApplicationController
   end
 
   private
+
+  def compound_payer_results
+    authorize! Person, to: :search?
+    authorize! Organization, to: :search?
+
+    query = params[:q].to_s.strip
+    return [] if query.blank?
+
+    records = authorized_scope(Person.remote_search(query)).limit(25).to_a +
+      authorized_scope(Organization.remote_search(query)).limit(25).to_a
+
+    records.map(&:compound_search_label)
+  end
 
   def allowed_model(model_param)
     {

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -1,0 +1,9 @@
+module PaymentsHelper
+  # Builds the single preselected option ([ label, sgid ]) for a compound
+  # people + organizations picker, so the dropdown shows the current selection
+  # before TomSelect loads remote results. Returns [] when nothing is selected.
+  def party_select_options(record, sgid)
+    return [] if record.blank? || sgid.blank?
+    [ [ record.compound_search_label[:label], sgid ] ]
+  end
+end

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -1,9 +1,0 @@
-module PaymentsHelper
-  # Builds the single preselected option ([ label, sgid ]) for a compound
-  # people + organizations picker, so the dropdown shows the current selection
-  # before TomSelect loads remote results. Returns [] when nothing is selected.
-  def party_select_options(record, sgid)
-    return [] if record.blank? || sgid.blank?
-    [ [ record.compound_search_label[:label], sgid ] ]
-  end
-end

--- a/app/models/concerns/remote_searchable.rb
+++ b/app/models/concerns/remote_searchable.rb
@@ -46,4 +46,15 @@ module RemoteSearchable
       label: public_send(self.class.remote_search_columns.first)
     }
   end
+
+  # Label for dropdowns that search across more than one model at once (e.g. the
+  # combined people + organizations payer picker). The value is a signed global
+  # id so the consumer can resolve it back to the right record/type, and the
+  # label is suffixed with the model name to disambiguate same-named records.
+  def compound_search_label
+    {
+      id: to_sgid.to_s,
+      label: "#{remote_search_label[:label]} · #{self.class.model_name.human}"
+    }
+  end
 end

--- a/app/models/concerns/remote_searchable.rb
+++ b/app/models/concerns/remote_searchable.rb
@@ -53,8 +53,8 @@ module RemoteSearchable
   # label is suffixed with the model name to disambiguate same-named records.
   def compound_search_label
     {
-      id: to_sgid.to_s,
-      label: "#{remote_search_label[:label]} · #{self.class.model_name.human}"
+      label: "#{remote_search_label[:label]} · #{self.class.model_name.human}",
+      id: to_sgid.to_s
     }
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -16,7 +16,15 @@ class Payment < ApplicationRecord
 
   before_create :set_external_origin
   before_validation :set_amount_cents_remaining, if: :new_record?
+  before_validation :assign_parties_from_sgids, if: :sgid_assigned?
   before_validation :auto_set_payer_type
+
+  # Virtual attributes backing the compound "Payer" and "Additional designation"
+  # dropdowns, which each search across both people and organizations. The
+  # selected value is a signed global id; on submit we resolve it back to a
+  # person/organization, set payer_type from the payer's kind, and fill the
+  # person_id / organization_id slots accordingly.
+  attr_writer :payer_sgid, :additional_designation_sgid
 
   scope :by_type, ->(types) {
     return if types.blank?
@@ -46,6 +54,32 @@ class Payment < ApplicationRecord
     when "Organization" then organization
     else person
     end
+  end
+
+  # The record currently selected in the "Payer" dropdown. Falls back to the
+  # organization (then person) for an unsaved payment that hasn't picked a
+  # payer_type yet, so a form prefilled from a registration defaults sensibly.
+  def form_payer
+    return payer if payer_type.present?
+    organization || person
+  end
+
+  # The other party — whichever of person/organization isn't the payer.
+  def form_additional_designation
+    [ organization, person ].compact.find { |record| record != form_payer }
+  end
+
+  # Memoize the computed default so repeated reads in a single render return the
+  # same string — to_sgid embeds an expiry timestamp and varies per call, which
+  # would otherwise stop the preselected option from matching the field value.
+  def payer_sgid
+    return @payer_sgid if defined?(@payer_sgid)
+    @computed_payer_sgid ||= form_payer&.to_sgid&.to_s
+  end
+
+  def additional_designation_sgid
+    return @additional_designation_sgid if defined?(@additional_designation_sgid)
+    @computed_additional_designation_sgid ||= form_additional_designation&.to_sgid&.to_s
   end
 
   def amount_dollars
@@ -88,6 +122,50 @@ class Payment < ApplicationRecord
     elsif organization_id.present? && person_id.blank?
       self.payer_type = "Organization"
     end
+  end
+
+  def sgid_assigned?
+    defined?(@payer_sgid) || defined?(@additional_designation_sgid)
+  end
+
+  def assign_parties_from_sgids
+    payer_record = defined?(@payer_sgid) ? locate_party(@payer_sgid) : form_payer
+    other_record = defined?(@additional_designation_sgid) ? locate_party(@additional_designation_sgid) : form_additional_designation
+
+    self.person_id = nil
+    self.organization_id = nil
+
+    case payer_record
+    when Organization
+      self.payer_type = "Organization"
+      self.organization_id = payer_record.id
+    when Person
+      self.payer_type = "Person"
+      self.person_id = payer_record.id
+    end
+
+    fill_party_slot(other_record)
+  end
+
+  # Fill whichever of person_id / organization_id the payer didn't already take.
+  # If the additional designation is the same kind as the payer, the single
+  # column for that kind is already used, so it's dropped (the schema only holds
+  # one person and one organization per payment).
+  def fill_party_slot(record)
+    case record
+    when Organization
+      self.organization_id ||= record.id
+    when Person
+      self.person_id ||= record.id
+    end
+  end
+
+  def locate_party(sgid)
+    return if sgid.blank?
+    record = GlobalID::Locator.locate_signed(sgid)
+    record if record.is_a?(Person) || record.is_a?(Organization)
+  rescue StandardError
+    nil
   end
 
   def at_least_one_payer

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -20,12 +20,7 @@ class Payment < ApplicationRecord
   before_validation :assign_parties_from_sgids, if: :sgid_assigned?
   before_validation :auto_set_payer_type
 
-  # Virtual attributes backing the compound "Payer" and "Additional designation"
-  # dropdowns, which each search across both people and organizations. The
-  # selected value is a signed global id; on submit we resolve it back to a
-  # person/organization, set payer_type from the payer's kind, and fill the
-  # person_id / organization_id slots accordingly.
-  attr_writer :payer_sgid, :additional_designation_sgid
+  attr_accessor :payer_sgid, :additional_designation_sgid
 
   scope :by_type, ->(types) {
     return if types.blank?
@@ -81,18 +76,7 @@ class Payment < ApplicationRecord
     defined?(@additional_designation_sgid) ? locate_party(@additional_designation_sgid) : form_additional_designation
   end
 
-  # Memoize the computed default so repeated reads in a single render return the
-  # same string — to_sgid embeds an expiry timestamp and varies per call, which
-  # would otherwise stop the preselected option from matching the field value.
-  def payer_sgid
-    return @payer_sgid if defined?(@payer_sgid)
-    @computed_payer_sgid ||= form_payer&.to_sgid&.to_s
-  end
 
-  def additional_designation_sgid
-    return @additional_designation_sgid if defined?(@additional_designation_sgid)
-    @computed_additional_designation_sgid ||= form_additional_designation&.to_sgid&.to_s
-  end
 
   def amount_dollars
     amount_cents.to_d / 100 if amount_cents

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -13,6 +13,7 @@ class Payment < ApplicationRecord
   validates :payer_type, presence: true, inclusion: { in: PAYER_TYPES }
 
   validate :at_least_one_payer
+  validate :payer_and_designation_distinct_kinds, if: :sgid_assigned?
 
   before_create :set_external_origin
   before_validation :set_amount_cents_remaining, if: :new_record?
@@ -67,6 +68,17 @@ class Payment < ApplicationRecord
   # The other party — whichever of person/organization isn't the payer.
   def form_additional_designation
     [ organization, person ].compact.find { |record| record != form_payer }
+  end
+
+  # The record a submitted sgid resolves to, falling back to the saved/default
+  # selection. Used to set the columns and to re-render the form (with the user's
+  # picks intact) after a validation failure.
+  def selected_payer
+    defined?(@payer_sgid) ? locate_party(@payer_sgid) : form_payer
+  end
+
+  def selected_additional_designation
+    defined?(@additional_designation_sgid) ? locate_party(@additional_designation_sgid) : form_additional_designation
   end
 
   # Memoize the computed default so repeated reads in a single render return the
@@ -129,8 +141,8 @@ class Payment < ApplicationRecord
   end
 
   def assign_parties_from_sgids
-    payer_record = defined?(@payer_sgid) ? locate_party(@payer_sgid) : form_payer
-    other_record = defined?(@additional_designation_sgid) ? locate_party(@additional_designation_sgid) : form_additional_designation
+    payer_record = selected_payer
+    other_record = selected_additional_designation
 
     self.person_id = nil
     self.organization_id = nil
@@ -172,5 +184,21 @@ class Payment < ApplicationRecord
     if person_id.blank? && organization_id.blank?
       errors.add(:base, "At least one payer (person or organization) must be present")
     end
+  end
+
+  # A payment holds one person and one organization, so the payer and the
+  # additional designation can't be the same kind. Reject the submission rather
+  # than silently dropping the designation (fill_party_slot's no-op).
+  def payer_and_designation_distinct_kinds
+    payer_record = selected_payer
+    designation = selected_additional_designation
+    return if payer_record.blank? || designation.blank?
+
+    same_kind = [ Person, Organization ].any? do |klass|
+      payer_record.is_a?(klass) && designation.is_a?(klass)
+    end
+    return unless same_kind
+
+    errors.add(:base, "The payer and additional designation must be different kinds — a payment records one person and one organization, not two of the same.")
   end
 end

--- a/app/views/payments/_allocation_form.html.erb
+++ b/app/views/payments/_allocation_form.html.erb
@@ -1,5 +1,6 @@
 <div class="bg-green-200 border-2 border-green-400 rounded-lg p-4 mb-4">
   <h3 class="text-lg font-medium mb-4">New <%= @payment.type.to_s.underscore.humanize(capitalize: false) %></h3>
+
   <%= simple_form_for @payment, as: :payment, url: payments_path do |f| %>
     <%= hidden_field_tag "payment[allocatable_sgid]", @allocatable&.to_sgid&.to_s || params[:allocatable_sgid] %>
     <%= f.input :type, as: :hidden, input_html: { value: @payment.type } %>
@@ -16,12 +17,13 @@
       <% end %>
     </div>
 
-    <%# Two compound pickers that each search people and organizations. The kind
-        of record chosen for "Payer" sets payer_type on submit; the additional
-        designation fills the other person/organization slot. %>
+    <% payer_label_data = @payment.selected_payer&.compound_search_label %>
+    <% designation_label_data = @payment.selected_additional_designation&.compound_search_label %>
+
     <div class="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
       <%= f.input :payer_sgid,
-        collection: party_select_options(@payment.selected_payer, @payment.payer_sgid),
+        collection: payer_label_data ? [[payer_label_data[:label], payer_label_data[:id]]] : [],
+        selected: payer_label_data&.dig(:id),
         required: true,
         input_html: {
           class: "bg-white",
@@ -33,8 +35,10 @@
         prompt: "Search people and organizations",
         label: "Payer",
         hint: "Whose account is the money coming from?" %>
+
       <%= f.input :additional_designation_sgid,
-        collection: party_select_options(@payment.selected_additional_designation, @payment.additional_designation_sgid),
+        collection: designation_label_data ? [[designation_label_data[:label], designation_label_data[:id]]] : [],
+        selected: designation_label_data&.dig(:id),
         include_blank: true,
         input_html: {
           class: "bg-white",
@@ -52,6 +56,7 @@
         <i class="fa-solid fa-plus text-xs"></i>
         Create payment
       <% end %>
+
       <%= link_to "Cancel", allocations_path(allocatable_sgid: @allocatable&.to_sgid&.to_s || params[:allocatable_sgid]), class: "btn btn-secondary-outline" %>
     </div>
   <% end %>

--- a/app/views/payments/_allocation_form.html.erb
+++ b/app/views/payments/_allocation_form.html.erb
@@ -21,7 +21,7 @@
         designation fills the other person/organization slot. %>
     <div class="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
       <%= f.input :payer_sgid,
-        collection: party_select_options(@payment.form_payer, @payment.payer_sgid),
+        collection: party_select_options(@payment.selected_payer, @payment.payer_sgid),
         required: true,
         input_html: {
           class: "bg-white",
@@ -34,7 +34,7 @@
         label: "Payer",
         hint: "Whose account is the money coming from?" %>
       <%= f.input :additional_designation_sgid,
-        collection: party_select_options(@payment.form_additional_designation, @payment.additional_designation_sgid),
+        collection: party_select_options(@payment.selected_additional_designation, @payment.additional_designation_sgid),
         include_blank: true,
         input_html: {
           class: "bg-white",

--- a/app/views/payments/_allocation_form.html.erb
+++ b/app/views/payments/_allocation_form.html.erb
@@ -16,35 +16,35 @@
       <% end %>
     </div>
 
-    <div class="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-3">
-      <%# Default to Organization; the model's auto_set_payer_type flips this to
-          Person on submit when only a person (no organization) is selected. %>
-      <%= f.input :payer_type, as: :select, collection: Payment::PAYER_TYPES, required: true, prompt: false,
-                  selected: f.object.payer_type.presence || "Organization",
-                  label: "Who is paying?",
-                  input_html: { class: "bg-white" } %>
-      <%= f.input :person_id,
-        collection: @payment.person.present? ? [[@payment.person.full_name, @payment.person.id]] : [],
-        include_blank: true,
+    <%# Two compound pickers that each search people and organizations. The kind
+        of record chosen for "Payer" sets payer_type on submit; the additional
+        designation fills the other person/organization slot. %>
+    <div class="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
+      <%= f.input :payer_sgid,
+        collection: party_select_options(@payment.form_payer, @payment.payer_sgid),
+        required: true,
         input_html: {
+          class: "bg-white",
           data: {
             controller: "remote-select",
-            remote_select_model_value: "person"
+            remote_select_model_value: "person_or_organization"
           }
         },
-        prompt: "Search for a person",
-        label: "Person paying" %>
-      <%= f.input :organization_id,
-        collection: @payment.organization.present? ? [[@payment.organization.name, @payment.organization.id]] : [],
+        prompt: "Search people and organizations",
+        label: "Payer",
+        hint: "Whose account is the money coming from?" %>
+      <%= f.input :additional_designation_sgid,
+        collection: party_select_options(@payment.form_additional_designation, @payment.additional_designation_sgid),
         include_blank: true,
         input_html: {
+          class: "bg-white",
           data: {
             controller: "remote-select",
-            remote_select_model_value: "organization"
+            remote_select_model_value: "person_or_organization"
           }
         },
-        prompt: "Search for an organization",
-        label: "Organization paying" %>
+        prompt: "Search people and organizations",
+        label: "Additional designation" %>
     </div>
 
     <div class="flex gap-2 mt-4">

--- a/app/views/payments/_form.html.erb
+++ b/app/views/payments/_form.html.erb
@@ -2,29 +2,38 @@
   <h1 class="text-2xl font-bold mb-6">New <%= @payment.type.underscore.titleize.gsub(" Payment", "").gsub("External Processor", "Stripe") %></h1>
   <%= simple_form_for @payment, as: :payment, url: payments_path do |f| %>
     <%= f.input :type, as: :hidden %>
-    <%= f.input :payer_type, as: :select, collection: Payment::PAYER_TYPES, required: true, prompt: false %>
-    <%= f.input :person_id,
-      collection: @payment.person.present? ? [[@payment.person.full_name, @payment.person.id]] : [],
-      include_blank: true,
+
+    <% payer_label_data = @payment.selected_payer&.compound_search_label %>
+    <% designation_label_data = @payment.selected_additional_designation&.compound_search_label %>
+
+    <%= f.input :payer_sgid,
+      collection: payer_label_data ? [[payer_label_data[:label], payer_label_data[:id]]] : [],
+      selected: payer_label_data&.dig(:id),
+      required: true,
       input_html: {
+        class: "bg-white",
         data: {
           controller: "remote-select",
-          remote_select_model_value: "person"
+          remote_select_model_value: "person_or_organization"
         }
       },
-      prompt: "Search for a person",
-      label: "Person" %>
-    <%= f.input :organization_id,
-      collection: @payment.organization.present? ? [[@payment.organization.name, @payment.organization.id]] : [],
+      prompt: "Search people and organizations",
+      label: "Payer",
+      hint: "Whose account is the money coming from?" %>
+
+    <%= f.input :additional_designation_sgid,
+      collection: designation_label_data ? [[designation_label_data[:label], designation_label_data[:id]]] : [],
+      selected: designation_label_data&.dig(:id),
       include_blank: true,
       input_html: {
+        class: "bg-white",
         data: {
           controller: "remote-select",
-          remote_select_model_value: "organization"
+          remote_select_model_value: "person_or_organization"
         }
       },
-      prompt: "Search for an organization",
-      label: "Organization" %>
+      prompt: "Search people and organizations",
+      label: "Additional designation" %>
     <%= f.input :amount_dollars, label: "Amount ($)", input_html: { min: 0, step: 0.01, placeholder: "0.00", data: { controller: "currency-input", action: "currency-input#format" } } %>
     <%= f.input :currency, as: :hidden, input_html: { value: "usd" } %>
     <% if @payment.type == "CheckPayment" %>

--- a/app/views/payments/edit.html.erb
+++ b/app/views/payments/edit.html.erb
@@ -4,29 +4,39 @@
   <h1 class="text-2xl font-bold mb-6">Edit Payment</h1>
   <div class="bg-white rounded border border-gray-200 p-6">
     <%= simple_form_for @payment, as: :payment, url: payment_path(@payment), method: :patch do |f| %>
+      <% payer_label_data = @payment.selected_payer&.compound_search_label %>
+      <% designation_label_data = @payment.selected_additional_designation&.compound_search_label %>
+
       <div class="space-y-4">
-        <%= f.input :person_id,
-          collection: @payment.person.present? ? [[@payment.person.full_name, @payment.person.id]] : [],
-          include_blank: true,
+        <%= f.input :payer_sgid,
+          collection: payer_label_data ? [[payer_label_data[:label], payer_label_data[:id]]] : [],
+          selected: payer_label_data&.dig(:id),
+          required: true,
           input_html: {
+            class: "bg-white",
             data: {
               controller: "remote-select",
-              remote_select_model_value: "person"
+              remote_select_model_value: "person_or_organization"
             }
           },
-          prompt: "Search for a person",
-          label: "Person" %>
-        <%= f.input :organization_id,
-          collection: @payment.organization.present? ? [[@payment.organization.name, @payment.organization.id]] : [],
+          prompt: "Search people and organizations",
+          label: "Payer",
+          hint: "Whose account is the money coming from?" %>
+
+        <%= f.input :additional_designation_sgid,
+          collection: designation_label_data ? [[designation_label_data[:label], designation_label_data[:id]]] : [],
+          selected: designation_label_data&.dig(:id),
           include_blank: true,
           input_html: {
+            class: "bg-white",
             data: {
               controller: "remote-select",
-              remote_select_model_value: "organization"
+              remote_select_model_value: "person_or_organization"
             }
           },
-          prompt: "Search for an organization",
-          label: "Organization" %>
+          prompt: "Search people and organizations",
+          label: "Additional designation" %>
+
         <%= f.input :form_submission_id,
           input_html: { class: "bg-white" },
           label: "Form Submission ID" %>

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -109,15 +109,32 @@ RSpec.describe Payment, type: :model do
       expect(payment.person).to be_nil
     end
 
-    it "drops a same-kind designation the single column can't hold" do
+    it "is invalid when the payer and designation are both people" do
       other_person = create(:person)
       payment = build(:payment, person: nil, organization: nil, payer_type: nil)
       payment.payer_sgid = person.to_sgid.to_s
       payment.additional_designation_sgid = other_person.to_sgid.to_s
-      payment.valid?
 
-      expect(payment.payer_type).to eq("Person")
-      expect(payment.person).to eq(person)
+      expect(payment).not_to be_valid
+      expect(payment.errors[:base]).to include(a_string_including("must be different kinds"))
+    end
+
+    it "is invalid when the payer and designation are both organizations" do
+      other_org = create(:organization)
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = org.to_sgid.to_s
+      payment.additional_designation_sgid = other_org.to_sgid.to_s
+
+      expect(payment).not_to be_valid
+      expect(payment.errors[:base]).to include(a_string_including("must be different kinds"))
+    end
+
+    it "is valid when the payer and designation are different kinds" do
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = person.to_sgid.to_s
+      payment.additional_designation_sgid = org.to_sgid.to_s
+
+      expect(payment).to be_valid
     end
 
     it "exposes the current payer/designation as sgids for the form" do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe Payment, type: :model do
 
     it "exposes the current payer/designation as sgids for the form" do
       payment = build(:payment, person: person, organization: org, payer_type: "Organization")
-      expect(GlobalID::Locator.locate_signed(payment.payer_sgid)).to eq(org)
-      expect(GlobalID::Locator.locate_signed(payment.additional_designation_sgid)).to eq(person)
+      expect(GlobalID::Locator.locate_signed(payment.selected_payer.to_sgid.to_s)).to eq(org)
+      expect(GlobalID::Locator.locate_signed(payment.selected_additional_designation.to_sgid.to_s)).to eq(person)
     end
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -72,6 +72,61 @@ RSpec.describe Payment, type: :model do
     end
   end
 
+  describe "compound payer/designation sgids" do
+    let(:person) { create(:person) }
+    let(:org) { create(:organization) }
+
+    it "sets payer_type and organization from an organization payer sgid" do
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = org.to_sgid.to_s
+      payment.additional_designation_sgid = person.to_sgid.to_s
+      expect(payment).to be_valid
+
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(org)
+      expect(payment.person).to eq(person)
+    end
+
+    it "sets payer_type and person from a person payer sgid" do
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = person.to_sgid.to_s
+      payment.additional_designation_sgid = org.to_sgid.to_s
+      payment.valid?
+
+      expect(payment.payer_type).to eq("Person")
+      expect(payment.person).to eq(person)
+      expect(payment.organization).to eq(org)
+    end
+
+    it "clears the slots when an empty additional designation is submitted" do
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = org.to_sgid.to_s
+      payment.additional_designation_sgid = ""
+      payment.valid?
+
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(org)
+      expect(payment.person).to be_nil
+    end
+
+    it "drops a same-kind designation the single column can't hold" do
+      other_person = create(:person)
+      payment = build(:payment, person: nil, organization: nil, payer_type: nil)
+      payment.payer_sgid = person.to_sgid.to_s
+      payment.additional_designation_sgid = other_person.to_sgid.to_s
+      payment.valid?
+
+      expect(payment.payer_type).to eq("Person")
+      expect(payment.person).to eq(person)
+    end
+
+    it "exposes the current payer/designation as sgids for the form" do
+      payment = build(:payment, person: person, organization: org, payer_type: "Organization")
+      expect(GlobalID::Locator.locate_signed(payment.payer_sgid)).to eq(org)
+      expect(GlobalID::Locator.locate_signed(payment.additional_designation_sgid)).to eq(person)
+    end
+  end
+
   describe "scopes" do
     let(:person1) { create(:person) }
     let(:person2) { create(:person) }

--- a/spec/requests/payer_search_spec.rb
+++ b/spec/requests/payer_search_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Payer search (combined people + organizations)", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "GET /search/person_or_organization" do
+    let!(:person) { create(:person, first_name: "Searchable", last_name: "Payer") }
+    let!(:organization) { create(:organization, name: "Searchable Payer Org") }
+
+    it "returns both people and organizations with sgid values" do
+      get "/search/person_or_organization", params: { q: "Searchable" }
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+
+      labels = json.map { |row| row["label"] }
+      expect(labels).to include(a_string_including("Searchable Payer").and(a_string_including("Person")))
+      expect(labels).to include(a_string_including("Searchable Payer Org").and(a_string_including("Organization")))
+
+      # SGIDs carry an expiry, so they vary per call — resolve them instead of
+      # comparing strings.
+      resolved = json.map { |row| GlobalID::Locator.locate_signed(row["id"]) }
+      expect(resolved).to include(person)
+      expect(resolved).to include(organization)
+    end
+
+    it "returns an empty array for a blank query" do
+      get "/search/person_or_organization", params: { q: "" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+  end
+end

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -163,6 +163,25 @@ RSpec.describe "Payments", type: :request do
       expect(payment.person).to eq(registration.registrant)
     end
 
+    it "rejects two people without creating a payment" do
+      other_person = create(:person)
+
+      expect {
+        post payments_path, params: {
+          payment: {
+            type: "CashPayment",
+            payer_sgid: registration.registrant.to_sgid.to_s,
+            additional_designation_sgid: other_person.to_sgid.to_s,
+            amount_dollars: "50.00",
+            allocatable_sgid: registration.to_sgid.to_s
+          }
+        }
+      }.to change(Payment, :count).by(0)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be different kinds")
+    end
+
     it "creates a payment from a person payer with no additional designation" do
       post payments_path, params: {
         payment: {

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -84,13 +84,23 @@ RSpec.describe "Payments", type: :request do
     let(:event) { create(:event, cost_cents: 10_000) }
     let(:registration) { create(:event_registration, event:) }
 
-    it "defaults the payer type to Organization" do
+    it "renders compound payer and additional designation pickers" do
       post allocation_form_payments_path,
         params: { type: "CashPayment", allocatable_sgid: registration.to_sgid.to_s },
         as: :turbo_stream
 
-      expect(response.body).to match(%r{<option[^>]*selected[^>]*>Organization</option>})
-      expect(response.body).not_to match(%r{<option[^>]*selected[^>]*>Person</option>})
+      expect(response.body).to include("Whose account is the money coming from?")
+      expect(response.body).to include("payment[payer_sgid]")
+      expect(response.body).to include("payment[additional_designation_sgid]")
+      expect(response.body).to include("Additional designation")
+    end
+
+    it "preselects the registrant in a compound picker" do
+      post allocation_form_payments_path,
+        params: { type: "CashPayment", allocatable_sgid: registration.to_sgid.to_s },
+        as: :turbo_stream
+
+      expect(response.body).to match(%r{<option[^>]*selected[^>]*>#{Regexp.escape(registration.registrant.full_name)}[^<]*Person</option>})
     end
   end
 
@@ -127,6 +137,47 @@ RSpec.describe "Payments", type: :request do
       }
 
       expect(Payment.last.payer_type).to eq("Person")
+    end
+  end
+
+  describe "payer/additional designation via sgids" do
+    let(:event) { create(:event, cost_cents: 10_000) }
+    let(:registration) { create(:event_registration, event:) }
+    let(:organization) { create(:organization) }
+
+    it "creates a payment from an organization payer and a person designation" do
+      post payments_path, params: {
+        payment: {
+          type: "CheckPayment",
+          check_number: "1234",
+          payer_sgid: organization.to_sgid.to_s,
+          additional_designation_sgid: registration.registrant.to_sgid.to_s,
+          amount_dollars: "50.00",
+          allocatable_sgid: registration.to_sgid.to_s
+        }
+      }
+
+      payment = Payment.last
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(organization)
+      expect(payment.person).to eq(registration.registrant)
+    end
+
+    it "creates a payment from a person payer with no additional designation" do
+      post payments_path, params: {
+        payment: {
+          type: "CashPayment",
+          payer_sgid: registration.registrant.to_sgid.to_s,
+          additional_designation_sgid: "",
+          amount_dollars: "50.00",
+          allocatable_sgid: registration.to_sgid.to_s
+        }
+      }
+
+      payment = Payment.last
+      expect(payment.payer_type).to eq("Person")
+      expect(payment.person).to eq(registration.registrant)
+      expect(payment.organization).to be_nil
     end
   end
 end

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -104,6 +104,72 @@ RSpec.describe "Payments", type: :request do
     end
   end
 
+  describe "PATCH /payments/:id" do
+    let(:organization) { create(:organization) }
+
+    it "updates payer and designation via sgids" do
+      payment = create(:payment, person:, organization: nil)
+
+      patch payment_path(payment), params: {
+        payment: {
+          payer_sgid: organization.to_sgid.to_s,
+          additional_designation_sgid: person.to_sgid.to_s
+        }
+      }
+
+      payment.reload
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(organization)
+      expect(payment.person).to eq(person)
+    end
+
+    it "switches the payer from a person to an organization" do
+      payment = create(:payment, person:, organization: nil)
+
+      patch payment_path(payment), params: {
+        payment: {
+          payer_sgid: organization.to_sgid.to_s,
+          additional_designation_sgid: ""
+        }
+      }
+
+      payment.reload
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(organization)
+      expect(payment.person).to be_nil
+    end
+
+    it "clears the additional designation when blank is sent" do
+      payment = create(:payment, person:, organization:, payer_type: "Organization")
+
+      patch payment_path(payment), params: {
+        payment: {
+          payer_sgid: organization.to_sgid.to_s,
+          additional_designation_sgid: ""
+        }
+      }
+
+      payment.reload
+      expect(payment.organization).to eq(organization)
+      expect(payment.person).to be_nil
+    end
+
+    it "shows a flash alert when validation fails" do
+      payment = create(:payment, person:, organization: nil)
+      other_person = create(:person)
+
+      patch payment_path(payment), params: {
+        payment: {
+          payer_sgid: person.to_sgid.to_s,
+          additional_designation_sgid: other_person.to_sgid.to_s
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(flash[:alert]).to include("must be different kinds")
+    end
+  end
+
   describe "payer type on create" do
     let(:event) { create(:event, cost_cents: 10_000) }
     let(:registration) { create(:event_registration, event:) }
@@ -197,6 +263,25 @@ RSpec.describe "Payments", type: :request do
       expect(payment.payer_type).to eq("Person")
       expect(payment.person).to eq(registration.registrant)
       expect(payment.organization).to be_nil
+    end
+
+    it "creates a standalone payment from sgids without an allocatable" do
+      organization = create(:organization)
+
+      post payments_path, params: {
+        payment: {
+          type: "CashPayment",
+          payer_sgid: organization.to_sgid.to_s,
+          additional_designation_sgid: registration.registrant.to_sgid.to_s,
+          amount_dollars: "25.00"
+        }
+      }
+
+      payment = Payment.last
+      expect(payment.payer_type).to eq("Organization")
+      expect(payment.organization).to eq(organization)
+      expect(payment.person).to eq(registration.registrant)
+      expect(payment.allocations).to be_empty
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The check/cash "add payment" subform on the allocations index made staff declare a payer type and then pick from separate person and organization dropdowns. This replaces those three fields with two compound pickers — **Payer** (hint: "Whose account is the money coming from?") and **Additional designation** — that each search people and organizations together, matching how staff actually think about a payment.

### How did you approach the change?
A new combined `person_or_organization` search endpoint returns both models as SGID-valued options (suffixed with the kind to disambiguate), and the Payment model gains virtual `payer_sgid` / `additional_designation_sgid` accessors that resolve the selection back into `payer_type` + `person_id` / `organization_id` on submit. The database schema is unchanged: the kind picked in **Payer** drives `payer_type`, and **Additional designation** fills the other person/org slot (a same-kind designation is dropped, since the table holds only one of each). Other payment forms that still post `payer_type` directly are untouched.

### UI Testing Checklist
- [ ] On the allocations index, "Add cash payment" / "Add check payment" show **Payer** and **Additional designation** pickers, each searching people and organizations.
- [ ] Opening the form from a registration preselects the registrant/organization sensibly.
- [ ] Submitting saves the correct `payer_type` and person/organization, and allocation succeeds.

### Anything else to add?
Note: `to_sgid` embeds an expiry timestamp and varies per call, so the computed SGID is memoized to keep the preselected option's value matching the field — otherwise prefill silently breaks. Full flexibility (e.g. two people) would require a schema migration and was intentionally left out.
