### PR TITLE
Live-preview ticket callout colour and icon in the event editor

### DIFF
--- a/app/frontend/javascript/controllers/callout_preview_controller.js
+++ b/app/frontend/javascript/controllers/callout_preview_controller.js
@@ -32,14 +32,14 @@ export default class extends Controller {
     this.updateLeadingIcon(theme)
   }
 
-  // Mirror the call-out's leading icon on the left of the card — shown only when
-  // the admin has entered a Font Awesome class — tinted to match the theme.
+  // Mirror the call-out's leading icon in the card's left gutter — drawn only
+  // when the admin has entered a Font Awesome class, tinted to match the theme.
+  // The gutter keeps its width either way so the fields below stay aligned.
   updateLeadingIcon(theme) {
     if (!this.hasLeadingIconTarget || !this.hasIconInputTarget) return
     const glyph = this.iconInputTarget.value.trim()
-    this.leadingIconTarget.className = glyph
-      ? `${glyph} ${theme.icon} shrink-0 text-xl`
-      : "hidden"
+    const base = "w-6 shrink-0 text-center text-xl"
+    this.leadingIconTarget.className = glyph ? `${glyph} ${theme.icon} ${base}` : base
   }
 
   themeKey() {

--- a/app/frontend/javascript/controllers/callout_preview_controller.js
+++ b/app/frontend/javascript/controllers/callout_preview_controller.js
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="callout-preview"
+// Tints a registration ticket callout's editor card with its selected colour
+// theme — falling back to the per-type default when no colour is chosen — so the
+// admin sees how the call-out will look on the ticket while editing. Recomputes
+// whenever the type or colour select changes.
+export default class extends Controller {
+  static targets = ["typeSelect", "colorSelect", "arrow", "iconInput", "leadingIcon"]
+  static values = { themes: Object, defaults: Object }
+
+  connect() {
+    this.element.classList.remove("bg-white", "border-gray-200")
+    if (this.hasArrowTarget) this.arrowTarget.classList.remove("text-gray-300")
+    this.applied = []
+    this.update()
+  }
+
+  update() {
+    const theme = this.themesValue[this.themeKey()] || this.themesValue["indigo"]
+
+    this.element.classList.remove(...this.applied)
+    this.applied = [theme.border, theme.bg]
+    this.element.classList.add(...this.applied)
+
+    if (this.hasArrowTarget) {
+      this.arrowTarget.classList.remove(...this.arrowApplied || [])
+      this.arrowApplied = [theme.icon]
+      this.arrowTarget.classList.add(...this.arrowApplied)
+    }
+
+    this.updateLeadingIcon(theme)
+  }
+
+  // Mirror the call-out's leading icon on the left of the card — shown only when
+  // the admin has entered a Font Awesome class — tinted to match the theme.
+  updateLeadingIcon(theme) {
+    if (!this.hasLeadingIconTarget || !this.hasIconInputTarget) return
+    const glyph = this.iconInputTarget.value.trim()
+    this.leadingIconTarget.className = glyph
+      ? `${glyph} ${theme.icon} self-center shrink-0 text-xl`
+      : "hidden"
+  }
+
+  themeKey() {
+    if (this.hasColorSelectTarget && this.colorSelectTarget.value) {
+      return this.colorSelectTarget.value
+    }
+    const type = this.hasTypeSelectTarget ? this.typeSelectTarget.value : ""
+    return this.defaultsValue[type] || "indigo"
+  }
+}

--- a/app/frontend/javascript/controllers/callout_preview_controller.js
+++ b/app/frontend/javascript/controllers/callout_preview_controller.js
@@ -38,7 +38,7 @@ export default class extends Controller {
     if (!this.hasLeadingIconTarget || !this.hasIconInputTarget) return
     const glyph = this.iconInputTarget.value.trim()
     this.leadingIconTarget.className = glyph
-      ? `${glyph} ${theme.icon} self-center shrink-0 text-xl`
+      ? `${glyph} ${theme.icon} shrink-0 text-xl`
       : "hidden"
   }
 

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -27,6 +27,9 @@ application.register("asset-picker", AssetPickerController)
 import AutosaveController from "./autosave_controller"
 application.register("autosave", AutosaveController)
 
+import CalloutPreviewController from "./callout_preview_controller"
+application.register("callout-preview", CalloutPreviewController)
+
 import CarouselController from "./carousel_controller"
 application.register("carousel", CarouselController)
 

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -11,6 +11,7 @@ class RegistrationTicketCallout < ApplicationRecord
   # and background are here so we can tint the whole box later without a migration.
   COLOR_THEMES = {
     "amber" => { icon: "text-amber-500", border: "border-amber-300", bg: "bg-amber-50", hover: "hover:bg-amber-100", title: "text-amber-900", subtitle: "text-amber-700" },
+    "orange" => { icon: "text-orange-500", border: "border-orange-300", bg: "bg-orange-50", hover: "hover:bg-orange-100", title: "text-orange-900", subtitle: "text-orange-700" },
     "indigo" => { icon: "text-indigo-500", border: "border-indigo-300", bg: "bg-indigo-50", hover: "hover:bg-indigo-100", title: "text-indigo-900", subtitle: "text-indigo-700" },
     "blue" => { icon: "text-blue-500", border: "border-blue-200", bg: "bg-blue-50", hover: "hover:bg-blue-100", title: "text-blue-900", subtitle: "text-blue-700" },
     "green" => { icon: "text-green-500", border: "border-green-300", bg: "bg-green-50", hover: "hover:bg-green-100", title: "text-green-900", subtitle: "text-green-700" },
@@ -20,7 +21,7 @@ class RegistrationTicketCallout < ApplicationRecord
   }.freeze
 
   DEFAULT_ICONS = { "action" => "fa-solid fa-arrow-right", "reference" => "fa-solid fa-circle-info" }.freeze
-  DEFAULT_COLORS = { "action" => "blue", "reference" => "indigo" }.freeze
+  DEFAULT_COLORS = { "action" => "orange", "reference" => "indigo" }.freeze
 
   belongs_to :event
 

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -1,4 +1,7 @@
-<div class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
+<div class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-colors"
+     data-controller="callout-preview"
+     data-callout-preview-themes-value="<%= RegistrationTicketCallout::COLOR_THEMES.to_json %>"
+     data-callout-preview-defaults-value="<%= RegistrationTicketCallout::DEFAULT_COLORS.to_json %>"
      <% if f.object.persisted? %>data-sortable-id="<%= f.object.id %>"<% end %>>
   <% if f.object.persisted? %>
     <div class="cursor-grab text-gray-400 hover:text-gray-600 pt-2 shrink-0" data-sortable-handle title="Drag to reorder">
@@ -9,6 +12,8 @@
       <i class="fa-solid fa-grip-vertical"></i>
     </div>
   <% end %>
+
+  <i class="hidden self-center shrink-0 text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
 
   <div class="flex-1 min-w-0 space-y-3">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -30,19 +35,22 @@
         <%= f.select :callout_type,
               RegistrationTicketCallout::CALLOUT_TYPES.map { |t| [ t.humanize, t ] },
               {},
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+              data: { callout_preview_target: "typeSelect", action: "callout-preview#update" } %>
       </div>
       <div>
         <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.select :color_class,
               RegistrationTicketCallout::COLOR_THEMES.keys.map { |c| [ c.humanize, c ] },
               { include_blank: "Default (by type)" },
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+              data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
       </div>
       <div>
         <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
+              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
       </div>
     </div>
 
@@ -62,5 +70,9 @@
       <%= link_to_remove_association "Remove", f,
             class: "text-sm text-gray-400 hover:text-red-600 underline" %>
     </div>
+  </div>
+
+  <div class="self-center shrink-0 text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
+    <i class="fa-solid fa-arrow-right"></i>
   </div>
 </div>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -45,18 +45,18 @@
               data: { callout_preview_target: "typeSelect", action: "callout-preview#update" } %>
       </div>
       <div>
+        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
+              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
+      </div>
+      <div>
         <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.select :color_class,
               RegistrationTicketCallout::COLOR_THEMES.keys.map { |c| [ c.humanize, c ] },
               { include_blank: "Default (by type)" },
               class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
-      </div>
-      <div>
-        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
-              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
       </div>
     </div>
 

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -13,19 +13,25 @@
     </div>
   <% end %>
 
-  <i class="hidden self-center shrink-0 text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
-
   <div class="flex-1 min-w-0 space-y-3">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-      <div>
-        <%= f.label :title, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.text_field :title, required: true, placeholder: "e.g. Parking & directions",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+    <div class="flex items-center gap-3">
+      <i class="hidden shrink-0 text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3 flex-1 min-w-0">
+        <div>
+          <%= f.label :title, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+          <%= f.text_field :title, required: true, placeholder: "e.g. Parking & directions",
+                class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+        </div>
+        <div>
+          <%= f.label :subtitle, "Subtitle", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+          <%= f.text_field :subtitle, placeholder: "Short line shown under the title on the ticket",
+                class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+        </div>
       </div>
-      <div>
-        <%= f.label :subtitle, "Subtitle", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.text_field :subtitle, placeholder: "Short line shown under the title on the ticket",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+
+      <div class="shrink-0 text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
+        <i class="fa-solid fa-arrow-right"></i>
       </div>
     </div>
 
@@ -56,7 +62,7 @@
 
     <div>
       <%= f.label :description, "Content", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-      <p class="text-xs text-gray-500 mb-1">Shown on its own page linked from the ticket. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
+      <p class="text-xs text-gray-500 mb-1">Shown on its own page. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
       <%= f.text_area :description, rows: 4,
             placeholder: "e.g. <p>Enter through the north lot…</p>",
             class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
@@ -70,9 +76,5 @@
       <%= link_to_remove_association "Remove", f,
             class: "text-sm text-gray-400 hover:text-red-600 underline" %>
     </div>
-  </div>
-
-  <div class="self-center shrink-0 text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
-    <i class="fa-solid fa-arrow-right"></i>
   </div>
 </div>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -15,7 +15,7 @@
 
   <div class="flex-1 min-w-0 space-y-3">
     <div class="flex items-center gap-3">
-      <i class="hidden shrink-0 text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
+      <i class="w-6 shrink-0 text-center text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3 flex-1 min-w-0">
         <div>
@@ -30,12 +30,12 @@
         </div>
       </div>
 
-      <div class="shrink-0 text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
+      <div class="w-6 shrink-0 text-center text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
         <i class="fa-solid fa-arrow-right"></i>
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 pl-9 pr-9">
       <div>
         <%= f.label :callout_type, "Type", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.select :callout_type,
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    <div>
+    <div class="pl-9 pr-9">
       <%= f.label :description, "Content", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
       <p class="text-xs text-gray-500 mb-1">Shown on its own page. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
       <%= f.text_area :description, rows: 4,
@@ -68,7 +68,7 @@
             class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
     </div>
 
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between pl-9 pr-9">
       <label class="flex items-center gap-2 text-sm text-gray-600">
         <%= f.check_box :show_if_paid, class: "rounded border-gray-300 text-purple-600" %>
         Only show once the registration is paid


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The registration ticket callout editor cards gave no sense of how a call-out would look on the actual ticket — admins had to save and reload to check the colour and icon. This previews both inline so they can configure call-outs confidently in one pass.

### How did you approach the change?
A small `callout-preview` Stimulus controller tints each nested editor card with its selected theme (custom colour, or the per-type default) and, mirroring the public ticket row, echoes the call-out's Font Awesome icon on the left and an arrow on the right — all updating live as the type, colour, or icon fields change. The default **action** colour also moves from blue to orange so admin-added actions stand apart from the built-in blue download/invoice rows, which required adding an `orange` entry to `COLOR_THEMES`.

### UI Testing Checklist
- [ ] Editing an event: each callout card is tinted by its chosen colour, falling back to the type default (orange for action, indigo for reference).
- [ ] Changing the Type/Colour selects re-tints the card and arrow live; clearing Colour reverts to the type default.
- [ ] Typing a Font Awesome class in Icon shows it on the left of the card; clearing it hides the icon again.
- [ ] Adding a new callout row and reordering saved rows still works.

### Anything else to add?
Theme classes are already in the Tailwind safelist, so no CSS rebuild is needed. The existing blue theme stays selectable as a custom override — only the action *default* changed.