### PR TITLE
Seed registration ticket callouts + scope pay-gate fields to payment_access_*

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -205,8 +205,8 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 ## Migrations
 
-- Name migration files using **UTC timestamps** (e.g., `20260228143000`), not sequential numbers (e.g., `20260228000007`)
-- Multiple branches adding migrations on the same date will collide if they use sequential numbering
+- Name migration files using the **actual current UTC timestamp down to the second** — generate it (`date -u +%Y%m%d%H%M%S`), don't hand-write the number. The minutes and seconds (`…HHMMSS`) must be real, not zero-padded.
+- **Never use round, zero-trailing times** like `20260618030000` or sequential numbers like `20260228000007`. They collide when two branches add a migration the same day, because everyone gravitates to the same round number. Real second-level timestamps (e.g. `20260618034355`) effectively never collide. (This has bitten us: two PRs both shipped `20260618020000`.)
 - **Migrations must be reversible** — always use explicit `up`/`down` methods instead of `change` when the rollback isn't trivially invertible. Guard `down` operations with `if_exists: true`, `column_exists?`, `index_exists?`, and `foreign_key_exists?` so rollbacks are idempotent and recover from partial failures
 
 ## Git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ This codebase (Rails 8.1)
 | `Workshop` | Core content: rich text fields, categories, sectors, bookmarks, variations |
 | `Event` | Events with registrations, featured/published states |
 | `EventStaff` | Join model connecting `Person` to `Event` as staff (title, `expected_to_attend`); drives the "Meet the staff" roster and "My events" |
-| `RegistrationTicketCallout` | Admin-configured call-outs shown on an event's registration ticket (title, subtitle, HTML description, `callout_type` action/reference, icon/colour, `show_if_paid`, draggable `position` via the positioning gem); each links to its own public detail page |
+| `RegistrationTicketCallout` | Admin-configured call-outs shown on an event's registration ticket (title, subtitle, HTML description, `callout_type` action/reference, icon/colour, `payment_access_gated` — only shown once the registrant has `payment_access_granted?` (paid or intends to pay), draggable `position` via the positioning gem); each links to its own public detail page |
 | `Story` | Editorial content with facilitators, primary/gallery assets |
 | `Resource` | Handouts, toolkits, templates with downloadable assets |
 | `Person` | Organization affiliates with contacts, addresses, sectors |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,8 +205,8 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 ## Migrations
 
-- Name migration files using **UTC timestamps** (e.g., `20260228143000`), not sequential numbers (e.g., `20260228000007`)
-- Multiple branches adding migrations on the same date will collide if they use sequential numbering
+- Name migration files using the **actual current UTC timestamp down to the second** — generate it (`date -u +%Y%m%d%H%M%S`), don't hand-write the number. The minutes and seconds (`…HHMMSS`) must be real, not zero-padded.
+- **Never use round, zero-trailing times** like `20260618030000` or sequential numbers like `20260228000007`. They collide when two branches add a migration the same day, because everyone gravitates to the same round number. Real second-level timestamps (e.g. `20260618034355`) effectively never collide. (This has bitten us: two PRs both shipped `20260618020000`.)
 - **Migrations must be reversible** — always use explicit `up`/`down` methods instead of `change` when the rollback isn't trivially invertible. Guard `down` operations with `if_exists: true`, `column_exists?`, `index_exists?`, and `foreign_key_exists?` so rollbacks are idempotent and recover from partial failures
 
 ## Git

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -196,7 +196,7 @@ class EventRegistration < ApplicationRecord
   # or downloads in the future) should gate on this, NOT on `paid?`. Reporting
   # surfaces (rosters, CSV exports, dashboard metrics) must keep using `paid?` /
   # `paid_in_full?` so they still reflect the real balance owed.
-  def access_granted?
+  def payment_access_granted?
     paid? || intends_to_pay?
   end
 
@@ -254,7 +254,7 @@ class EventRegistration < ApplicationRecord
   end
 
   def joinable?
-    active? && access_granted? && event.videoconference_window_open?
+    active? && payment_access_granted? && event.videoconference_window_open?
   end
 
   def attendance_status_label

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -143,7 +143,7 @@ class EventPolicy < ApplicationPolicy
                   sector_ids: [],
                   primary_asset_attributes: [ :id, :file, :_destroy ],
                   gallery_assets_attributes: [ :id, :file, :_destroy ],
-                  registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :show_if_paid, :_destroy ]
+                  registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :payment_access_gated, :_destroy ]
         ]
 
     permitted.prepend(:ga4_snippet, :gtm_head_snippet, :gtm_body_snippet) if admin?

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -164,9 +164,9 @@
       <% end %>
 
       <!-- Custom ticket callouts (admin-configured: actions & reference reading) -->
-      <% paid = event_registration.paid_in_full? || @checkout_payment_status == "paid" %>
+      <% payment_access = event_registration.payment_access_granted? || @checkout_payment_status == "paid" %>
       <% event_registration.event.registration_ticket_callouts.each do |callout| %>
-        <% next if callout.show_if_paid && !paid %>
+        <% next if callout.payment_access_gated && !payment_access %>
         <% theme = callout.theme %>
         <%= link_to event_registration_ticket_callout_path(event_registration.event, callout, reg: event_registration.slug),
                       class: "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" do %>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -56,8 +56,8 @@
 
     <div class="flex items-center justify-between">
       <label class="flex items-center gap-2 text-sm text-gray-600">
-        <%= f.check_box :show_if_paid, class: "rounded border-gray-300 text-purple-600" %>
-        Only show once the registration is paid
+        <%= f.check_box :payment_access_gated, class: "rounded border-gray-300 text-purple-600" %>
+        Only show once payment is made or committed
       </label>
       <%= link_to_remove_association "Remove", f,
             class: "text-sm text-gray-400 hover:text-red-600 underline" %>

--- a/db/migrate/20260618034355_rename_show_if_paid_to_payment_access_gated_on_registration_ticket_callouts.rb
+++ b/db/migrate/20260618034355_rename_show_if_paid_to_payment_access_gated_on_registration_ticket_callouts.rb
@@ -1,0 +1,13 @@
+class RenameShowIfPaidToPaymentAccessGatedOnRegistrationTicketCallouts < ActiveRecord::Migration[7.2]
+  def up
+    return unless column_exists?(:registration_ticket_callouts, :show_if_paid)
+
+    rename_column :registration_ticket_callouts, :show_if_paid, :payment_access_gated
+  end
+
+  def down
+    return unless column_exists?(:registration_ticket_callouts, :payment_access_gated)
+
+    rename_column :registration_ticket_callouts, :payment_access_gated, :show_if_paid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_034355) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1013,8 +1013,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_030000) do
     t.text "description"
     t.bigint "event_id", null: false
     t.string "icon_class"
+    t.boolean "payment_access_gated", default: false, null: false
     t.integer "position", null: false
-    t.boolean "show_if_paid", default: false, null: false
     t.string "subtitle"
     t.string "title", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -414,6 +414,182 @@ if art_workshop && art_workshop.registration_ticket_callouts.none?
   )
 end
 
+# Reusable registration-ticket callout "components" drawn from the real AWBW
+# facilitator-training emails. Each entry is one callout; events pick the subset
+# they need from COMPONENT_CALLOUTS below. The flagship training shows all of
+# them (so the ticket exercises every colour, icon, type, and the paid-only gate);
+# other trainings mix and match a generic subset. `show_if_paid` callouts stay
+# hidden until the registration is paid. Idempotent: an event is only seeded when
+# it has no callouts yet, so admin edits survive a re-seed.
+component_callouts = {
+  art_supply_info: {
+    title: "Art supply info",
+    subtitle: "Optional supplies for the five hands-on workshops",
+    callout_type: "reference", color_class: "amber", icon_class: "fa-solid fa-palette",
+    description: <<~HTML.strip
+      <p>We'll facilitate five hands-on art workshops, all of which can be done with paper, writing utensils (crayons, colored pencils, markers, etc.) and scissors.</p>
+      <ul>
+        <li>Use any art supplies you like — oil/chalk pastels, paints, watercolors, collage materials, etc.</li>
+        <li>You may want a journal or lined paper for writing.</li>
+      </ul>
+      <p>The list below, grouped by workshop, is <strong>optional</strong> — we'll demonstrate how to use everything at the training.</p>
+      <ul>
+        <li><strong>Workshop 1:</strong> clear glass stones; cabochon settings and swivel hooks; a 1" circle punch; white/colored cardstock or printmaking paper; Aleene's Clear Gel Tacky Glue; packing tape; scissors.</li>
+        <li><strong>Workshop 2:</strong> Rough &amp; Ready Shrinky Dink paper; permanent markers; Prismacolor colored pencils; a hole punch; thin ribbon or wire; an oven (a toaster oven, not a toaster).</li>
+        <li><strong>Workshop 3:</strong> a glue stick; scotch tape; two copies of the dice handout printed on cardstock.</li>
+        <li><strong>Workshop 4:</strong> Cray-Pas oil pastels; card/heavy stock or watercolor paper; Prang watercolors; cups for water; a paintbrush; painter's tape.</li>
+        <li><strong>Workshop 5:</strong> card/heavy stock paper; collage materials; tissue paper.</li>
+      </ul>
+    HTML
+  },
+  training_workshop_worksheets: {
+    title: "Training workshop worksheets",
+    subtitle: "Print these before the training (optional)",
+    callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-file-lines",
+    show_if_paid: true,
+    description: <<~HTML.strip
+      <p>You're welcome to print the 2-day training workshop worksheets to use as you create — printing is optional.</p>
+      <p>Your worksheets are available now that your training fee is paid.</p>
+    HTML
+  },
+  aha_moments_worksheet: {
+    title: "AHA Moments worksheet",
+    subtitle: "Capture your reflections as you create",
+    callout_type: "action", color_class: "green", icon_class: "fa-solid fa-lightbulb",
+    description: <<~HTML.strip
+      <p>We encourage you to print the AHA Moments worksheet to capture your thoughts about how the art workshops may shift things for you personally — and how you might use them to serve others.</p>
+    HTML
+  },
+  participation_requirements: {
+    title: "Participation requirements",
+    subtitle: "Both full days are required for certification",
+    callout_type: "reference", color_class: "purple", icon_class: "fa-solid fa-certificate",
+    description: <<~HTML.strip
+      <p>Participating in <strong>both full training days</strong> (9am–4:30pm Pacific Time each day) is required to receive certification as an AWBW facilitator.</p>
+      <p>If you're unable to attend both full days, please <a href="/contact_us">let us know</a> as soon as possible.</p>
+    HTML
+  },
+  letter_to_supervisors: {
+    title: "Letter to supervisors",
+    subtitle: "Share to request release time",
+    callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-file-arrow-down",
+    description: <<~HTML.strip
+      <p>We recommend sharing a letter with your supervisor (if applicable) to request relief from other duties during the two training days — being fully relieved helps you stay present.</p>
+      <p>The letter is available to download and share.</p>
+    HTML
+  },
+  ce_hours: {
+    title: "Continuing education (CE) hours",
+    subtitle: "Requirements, fee, and sign-in rules",
+    callout_type: "reference", color_class: "indigo", icon_class: "fa-solid fa-graduation-cap",
+    description: <<~HTML.strip
+      <p>Licensed LMFTs, LCSWs, LPCCs, and LEPs can earn up to <strong>12 Continuing Education hours</strong> for the training.</p>
+      <ul>
+        <li>Let us know by Monday, July 20 so we can send the required materials.</li>
+        <li>CE hour fee: $120 ($10 per hour).</li>
+        <li>You must be on time each day; payment is due by 9:00 AM PT on July 22.</li>
+      </ul>
+    HTML
+  },
+  facilitator_portal: {
+    title: "Facilitator Portal access",
+    subtitle: "Available once attendance & payment are complete",
+    callout_type: "reference", color_class: "rose", icon_class: "fa-solid fa-right-to-bracket",
+    show_if_paid: true,
+    description: <<~HTML.strip
+      <p>Access to the Facilitator Portal is provided once your attendance requirements are met and your training fee is paid.</p>
+      <p>You're all set — watch for your portal invitation.</p>
+    HTML
+  },
+  add_to_calendar: {
+    title: "Add to your calendar",
+    subtitle: "Save both training days",
+    callout_type: "action", color_class: "green", icon_class: "fa-solid fa-calendar-plus",
+    description: <<~HTML.strip
+      <p>Save both training days to your calendar so you don't miss a moment — you'll find an add-to-calendar link at the bottom of this ticket too.</p>
+    HTML
+  },
+  self_care_engagement: {
+    title: "Self-care & engagement",
+    subtitle: "Be on your own device and care for yourself",
+    callout_type: "reference", color_class: "rose", icon_class: "fa-solid fa-heart",
+    description: <<~HTML.strip
+      <p>Please log on at 8:50am Pacific Time so we can start promptly at 9am.</p>
+      <ul>
+        <li>This training is interactive — come ready to participate and connect.</li>
+        <li>If possible, <strong>be on your own individual device</strong> and keep your camera on; you're welcome to turn it off for personal needs.</li>
+        <li>It's important to <strong>practice self-care</strong> — have water, snacks, and whatever helps you feel comfortable nearby.</li>
+      </ul>
+    HTML
+  },
+  all_training_handouts: {
+    title: "All training handouts",
+    subtitle: "Agenda, worksheets, and resources in one place",
+    callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-folder-open",
+    show_if_paid: true,
+    description: <<~HTML.strip
+      <p>All of the handouts for the training — including the agenda for both days and the art workshop worksheets — are available in one place.</p>
+    HTML
+  },
+  inviting_responding_sharing: {
+    title: "Inviting & responding to sharing",
+    subtitle: "Holding space in breakout rooms",
+    callout_type: "reference", color_class: "purple", icon_class: "fa-solid fa-comments",
+    description: <<~HTML.strip
+      <p>Throughout the training you'll be invited to hold space, share, and witness others. This resource offers guidance on doing so with openness and care during breakout rooms.</p>
+      <p>Sharing is part of the art — together we co-create a space where everyone feels supported.</p>
+    HTML
+  },
+  training_agenda: {
+    title: "Training agenda",
+    subtitle: "What to expect across the two days",
+    callout_type: "reference", color_class: "amber", icon_class: "fa-solid fa-calendar-days",
+    description: <<~HTML.strip
+      <p>Our agenda covers both training days, including an hour-long food break around 12:00pm PT each day.</p>
+    HTML
+  },
+  zoom_connection_info: {
+    title: "Zoom connection info",
+    subtitle: "Join link, meeting ID, and passcode",
+    callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-video",
+    show_if_paid: true,
+    description: <<~HTML.strip
+      <p>Join us on Zoom for both training days. You'll find the join link in this ticket's videoconference section.</p>
+      <ul>
+        <li><strong>Meeting ID:</strong> 882 8541 1273</li>
+        <li><strong>Passcode:</strong> awbwmarch</li>
+      </ul>
+      <p>Please update Zoom to the latest version beforehand to avoid delays getting in.</p>
+    HTML
+  },
+  questions_next_steps: {
+    title: "Questions & next steps",
+    subtitle: "More details are on the way",
+    callout_type: "reference", color_class: "gray", icon_class: "fa-solid fa-envelope",
+    description: <<~HTML.strip
+      <p>You'll receive more details as we get closer to the training dates.</p>
+      <p>In the meantime, please <a href="/contact_us">reach out</a> with any questions — we're always happy to help. We look forward to creating and connecting with you!</p>
+    HTML
+  }
+}
+
+# The flagship training (event 1) gets every component; the trauma-informed
+# training gets a generic subset that doesn't assume the five-workshop supplies.
+callouts_by_event = {
+  "AWBW Facilitator Training" => component_callouts.keys,
+  "Facilitator Training: Trauma-Informed Art Practices" =>
+    %i[participation_requirements letter_to_supervisors add_to_calendar self_care_engagement questions_next_steps]
+}
+
+callouts_by_event.each do |event_title, component_keys|
+  event = Event.find_by(title: event_title)
+  next unless event && event.registration_ticket_callouts.none?
+
+  component_keys.each_with_index do |key, i|
+    event.registration_ticket_callouts.create!(component_callouts.fetch(key).merge(position: i + 1))
+  end
+end
+
 puts "Creating Event Registrations…"
 
 # Key people for named scenarios

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -403,7 +403,7 @@ if art_workshop && art_workshop.registration_ticket_callouts.none?
         callout_type: "action",
         color_class: "blue",
         icon_class: "fa-solid fa-file-pdf",
-        show_if_paid: true,
+        payment_access_gated: true,
         position: 3,
         description: <<~HTML.strip
           <p>Thanks for completing your payment! Your printable workbook is ready.</p>
@@ -418,7 +418,7 @@ end
 # facilitator-training emails. Each entry is one callout; events pick the subset
 # they need from COMPONENT_CALLOUTS below. The flagship training shows all of
 # them (so the ticket exercises every colour, icon, type, and the paid-only gate);
-# other trainings mix and match a generic subset. `show_if_paid` callouts stay
+# other trainings mix and match a generic subset. `payment_access_gated` callouts stay
 # hidden until the registration is paid. Idempotent: an event is only seeded when
 # it has no callouts yet, so admin edits survive a re-seed.
 component_callouts = {
@@ -446,7 +446,7 @@ component_callouts = {
     title: "Training workshop worksheets",
     subtitle: "Print these before the training (optional)",
     callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-file-lines",
-    show_if_paid: true,
+    payment_access_gated: true,
     description: <<~HTML.strip
       <p>You're welcome to print the 2-day training workshop worksheets to use as you create — printing is optional.</p>
       <p>Your worksheets are available now that your training fee is paid.</p>
@@ -495,7 +495,7 @@ component_callouts = {
     title: "Facilitator Portal access",
     subtitle: "Available once attendance & payment are complete",
     callout_type: "reference", color_class: "rose", icon_class: "fa-solid fa-right-to-bracket",
-    show_if_paid: true,
+    payment_access_gated: true,
     description: <<~HTML.strip
       <p>Access to the Facilitator Portal is provided once your attendance requirements are met and your training fee is paid.</p>
       <p>You're all set — watch for your portal invitation.</p>
@@ -526,7 +526,7 @@ component_callouts = {
     title: "All training handouts",
     subtitle: "Agenda, worksheets, and resources in one place",
     callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-folder-open",
-    show_if_paid: true,
+    payment_access_gated: true,
     description: <<~HTML.strip
       <p>All of the handouts for the training — including the agenda for both days and the art workshop worksheets — are available in one place.</p>
     HTML
@@ -552,7 +552,7 @@ component_callouts = {
     title: "Zoom connection info",
     subtitle: "Join link, meeting ID, and passcode",
     callout_type: "action", color_class: "blue", icon_class: "fa-solid fa-video",
-    show_if_paid: true,
+    payment_access_gated: true,
     description: <<~HTML.strip
       <p>Join us on Zoom for both training days. You'll find the join link in this ticket's videoconference section.</p>
       <ul>

--- a/spec/factories/registration_ticket_callouts.rb
+++ b/spec/factories/registration_ticket_callouts.rb
@@ -5,15 +5,15 @@ FactoryBot.define do
     subtitle { "A short supporting line" }
     description { "<p>Details for this callout.</p>" }
     callout_type { "reference" }
-    show_if_paid { false }
+    payment_access_gated { false }
     # position is assigned by the positioning gem on save (appended within the event)
 
     trait :action do
       callout_type { "action" }
     end
 
-    trait :paid_only do
-      show_if_paid { true }
+    trait :payment_access_gated do
+      payment_access_gated { true }
     end
   end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
-  describe "#access_granted?" do
+  describe "#payment_access_granted?" do
     let(:event) { create(:event, cost_cents: 1099) }
     let(:user) { create(:user, :with_person) }
 
@@ -311,17 +311,17 @@ RSpec.describe EventRegistration, type: :model do
       reg = create(:event_registration, event: event, registrant: user.person)
       payment = create(:payment, person: user.person, amount_cents: 1099, amount_cents_remaining: nil)
       create(:allocation, source: payment, allocatable: reg, amount: 1099)
-      expect(reg.access_granted?).to be true
+      expect(reg.payment_access_granted?).to be true
     end
 
     it "is true when unpaid but flagged intends_to_pay" do
       reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
-      expect(reg.access_granted?).to be true
+      expect(reg.payment_access_granted?).to be true
     end
 
     it "is false when unpaid and not flagged" do
       reg = create(:event_registration, event: event, registrant: user.person)
-      expect(reg.access_granted?).to be false
+      expect(reg.payment_access_granted?).to be false
     end
   end
 

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe "Event registration show page", type: :system do
       expect(page).to have_text("Where to park")
     end
 
-    it "hides a paid-only callout until the registration is paid in full" do
-      paid_only = create(:registration_ticket_callout, :paid_only, event: event, title: "Your workbook")
+    it "hides a payment-gated callout until the registration is paid in full" do
+      gated_callout = create(:registration_ticket_callout, :payment_access_gated, event: event, title: "Your workbook")
 
       sign_in(user)
       visit registration_ticket_path(registration.slug)
@@ -101,7 +101,7 @@ RSpec.describe "Event registration show page", type: :system do
       visit registration_ticket_path(registration.slug)
 
       expect(page).to have_link("Your workbook",
-        href: event_registration_ticket_callout_path(event, paid_only, reg: registration.slug))
+        href: event_registration_ticket_callout_path(event, gated_callout, reg: registration.slug))
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Gives the registration ticket realistic, varied **callout** seed data so the admin-configurable callouts feature (#1721) has something meaningful to render in dev.
- Renames the just-merged pay-gate fields so their intent is unambiguous — the old `access_granted?` / `show_if_paid` names were too generic and didn't read as a payment gate.
- Hardens the migration-naming guidance after two PRs collided on the same timestamp.

### How did you approach the change?

**Callout seed data** (`db/seeds/dev/events_management.rb`)
- Turned the recurring AWBW facilitator-training email sections into a reusable `component_callouts` hash (14 components: art supplies, worksheets, AHA moments, participation requirements, supervisor letter, CE hours, portal access, calendar, self-care, handouts, breakout-room sharing, agenda, Zoom, questions).
- The flagship **AWBW Facilitator Training** gets all 14 (exercising every colour, icon, type, and the pay-gate); the trauma training takes a generic subset; the existing Mindful Art example is untouched. Idempotent.

**Naming** (scopes the #1719/#1721 fields to payment)
- `EventRegistration#access_granted?` → **`payment_access_granted?`** (`paid? || intends_to_pay?`).
- Callout column `show_if_paid` → **`payment_access_gated`** (rename migration).
- The ticket gate now reads the `payment_access_granted?` seam instead of bare `paid?`, so an *intends-to-pay* registrant correctly sees pay-gated callouts. Updated the policy permit param, form checkbox + label, factory trait, and specs.

**Migration-naming guidance** (`CLAUDE.md`, `.github/copilot-instructions.md`)
- #1719 and #1721 both shipped `20260618020000`, breaking `db:migrate`. The old rule said "use UTC timestamps, not sequential" but never forbade round, zero-trailing times — which is what everyone reaches for. Now requires generating the **real current timestamp down to the second** (`date -u +%Y%m%d%H%M%S`).

### UI Testing Checklist

- [ ] Registration ticket for the **AWBW Facilitator Training** shows all 14 callouts with correct colours/icons.
- [ ] Pay-gated callouts (worksheets, portal, handouts, Zoom) are **hidden until paid or intends-to-pay**, and appear once either is true.
- [ ] Admin event form: the callout checkbox label reads "Only show once payment is made or committed".

### Anything else to add?

- The duplicate-migration-version bug itself was fixed separately on main in #1724; this branch only adds the guidance to prevent a recurrence (and renumbered its own rename migration to a real timestamp, `…034355`).
- Specs: 99 examples, 0 failures (model + system + callout request); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)