### PR TITLE
Custom message & subject for event reminders, batch FYI, facilitator orgs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (70) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (71) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -283,6 +283,7 @@ end
 - `password_toggle` — Show/hide password fields
 - `prefetch_lazy` — Prefetch lazy-loaded content
 - `print_options` — Print options toggle for analytics
+- `reminder_preview` — Live-preview a custom message in the reminder email as the admin types it on the bulk-reminder page
 - `remote_select` — AJAX-powered select dropdown
 - `reveal_section` — Expand a collapsible section and scroll to it when loaded via matching URL hash
 - `rhino_source` — Rich text editor integration

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -52,7 +52,7 @@ class EventsController < ApplicationController
     authorize! @event, to: :registrants?
     @event = @event.decorate
     scope = @event.event_registrations
-      .includes(:comments, :organizations, registrant: [ :user, :contact_methods, { avatar_attachment: :blob } ])
+      .includes(:comments, :organizations, registrant: [ :user, :contact_methods, { avatar_attachment: :blob }, { affiliations: :organization } ])
       .joins(:registrant)
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
     scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?
@@ -263,10 +263,16 @@ class EventsController < ApplicationController
       .joins(:registrant)
       .select { |r| r.registrant.preferred_email.present? }
     @sample_registration = @event_registrations.first
-    @days_until_event = @event.start_date.present? ? (@event.start_date.to_date - Date.current).to_i : nil
+    days_until_event = @event.start_date.present? ? (@event.start_date.to_date - Date.current).to_i : nil
+    # Pre-fill the editable message with the standard reminder sentence (days
+    # resolved now). Absent param = first load → default; a present-but-blank
+    # param = the admin cleared it (e.g. bounced back here) → respect the blank.
+    @custom_message = params.key?(:custom_message) ? params[:custom_message].to_s : helpers.default_reminder_message(days_until_event)
 
     if @sample_registration
-      mail = EventMailer.event_registration_reminder(@sample_registration, days_until_event: @days_until_event)
+      # Render in preview mode so the custom-message container is always present
+      # in the markup for the live preview, even before any text is typed.
+      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, preview: true)
       @reminder_preview_html = mail.html_part&.body&.decoded
     end
   end
@@ -274,20 +280,36 @@ class EventsController < ApplicationController
   def send_reminder
     authorize! @event, to: :send_reminder?
     allowed_ids = Array(params[:registration_ids]).map(&:to_i).reject(&:zero?)
+    custom_message = params[:custom_message].to_s
     registrations = @event.event_registrations
       .where(id: allowed_ids)
       .includes(registrant: [ :user, :contact_methods ])
       .select { |r| r.registrant.preferred_email.present? }
-    days_until = @event.start_date.present? ? (@event.start_date.to_date - Date.current).to_i : nil
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, custom_message: custom_message), alert: "Please select at least one recipient."
       return
     end
 
+    # Record an individual notification per recipient (delivered + persisted via
+    # NotificationMailerJob), so each reminder shows up in that person's
+    # communication history and can be resent — like confirmations/cancellations.
     registrations.each do |event_registration|
-      EventMailer.event_registration_reminder(event_registration, days_until_event: days_until).deliver_later
+      NotificationServices::CreateNotification.call(
+        noticeable: event_registration,
+        kind: "event_registration_reminder",
+        recipient_role: :person,
+        recipient_email: event_registration.registrant.preferred_email,
+        notification_type: 0,
+        custom_message: custom_message.presence
+      )
     end
+
+    # One admin summary for the whole batch: count, roster, and a copy of what
+    # was sent. Roster passed as plain "Name <email>" labels so the delivery job
+    # needs no record lookups.
+    recipient_labels = registrations.map { |r| "#{r.registrant.full_name} <#{r.registrant.preferred_email}>" }
+    EventMailer.event_registration_reminder_fyi(@event, recipient_labels, custom_message: custom_message.presence).deliver_later
 
     redirect_to registrants_event_path(@event), notice: "Reminder emails are being sent to #{registrations.size} registrant#{'s' if registrations.size != 1}."
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -268,11 +268,15 @@ class EventsController < ApplicationController
     # resolved now). Absent param = first load → default; a present-but-blank
     # param = the admin cleared it (e.g. bounced back here) → respect the blank.
     @custom_message = params.key?(:custom_message) ? params[:custom_message].to_s : helpers.default_reminder_message(days_until_event)
+    # Pre-fill the editable subject with the standard portal subject. Same
+    # absent-vs-present logic as the message, so a bounce-back keeps the admin's
+    # edit; a blank subject falls back to the default at send time.
+    @custom_subject = params.key?(:custom_subject) ? params[:custom_subject].to_s : helpers.default_reminder_subject(@event)
 
     if @sample_registration
       # Render in preview mode so the custom-message container is always present
       # in the markup for the live preview, even before any text is typed.
-      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, preview: true)
+      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, custom_subject: @custom_subject, preview: true)
       @reminder_preview_html = mail.html_part&.body&.decoded
     end
   end
@@ -281,13 +285,14 @@ class EventsController < ApplicationController
     authorize! @event, to: :send_reminder?
     allowed_ids = Array(params[:registration_ids]).map(&:to_i).reject(&:zero?)
     custom_message = params[:custom_message].to_s
+    custom_subject = params[:custom_subject].to_s
     registrations = @event.event_registrations
       .where(id: allowed_ids)
       .includes(registrant: [ :user, :contact_methods ])
       .select { |r| r.registrant.preferred_email.present? }
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event, custom_message: custom_message), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, custom_message: custom_message, custom_subject: custom_subject), alert: "Please select at least one recipient."
       return
     end
 
@@ -301,7 +306,8 @@ class EventsController < ApplicationController
         recipient_role: :person,
         recipient_email: event_registration.registrant.preferred_email,
         notification_type: 0,
-        custom_message: custom_message.presence
+        custom_message: custom_message.presence,
+        custom_subject: custom_subject.presence
       )
     end
 

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -30,6 +30,18 @@ class PersonDecorator < ApplicationDecorator
     affiliations.maximum(:end_date)
   end
 
+  # Org names where this person is currently an active facilitator. Filters the
+  # affiliations in Ruby (rather than re-querying via the .facilitators.active
+  # scopes) so list pages that preload `affiliations: :organization` pay no
+  # per-row query cost.
+  def active_facilitator_organization_names
+    affiliations
+      .select { |affiliation| affiliation.facilitator? && affiliation.active? }
+      .filter_map { |affiliation| affiliation.organization&.name }
+      .uniq
+      .sort
+  end
+
   def facilitation_end_date
     facilitator_affiliations = affiliations.facilitators
     return nil if facilitator_affiliations.active.exists?

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -123,6 +123,9 @@ application.register("prefetch-lazy", PrefetchLazyController)
 import PrintOptionsController from "./print_options_controller"
 application.register("print-options", PrintOptionsController)
 
+import ReminderPreviewController from "./reminder_preview_controller"
+application.register("reminder-preview", ReminderPreviewController)
+
 import RevealSectionController from "./reveal_section_controller"
 application.register("reveal-section", RevealSectionController)
 

--- a/app/frontend/javascript/controllers/reminder_preview_controller.js
+++ b/app/frontend/javascript/controllers/reminder_preview_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="reminder-preview"
+// Live-updates the reminder email preview as the admin types a custom message.
+// The message target lives inside the server-rendered preview email markup (only
+// emitted in preview mode); the input target is the message textarea. The actual
+// send re-sanitizes the message server-side, so injecting the raw value here is
+// only for the on-page preview.
+export default class extends Controller {
+  static targets = ["input", "message"]
+
+  inputTargetConnected() {
+    this.update()
+  }
+
+  messageTargetConnected() {
+    this.update()
+  }
+
+  update() {
+    if (!this.hasMessageTarget || !this.hasInputTarget) return
+
+    const value = this.inputTarget.value.trim()
+    this.messageTarget.innerHTML = value
+    this.messageTarget.style.display = value ? "" : "none"
+  }
+}

--- a/app/frontend/javascript/controllers/reminder_preview_controller.js
+++ b/app/frontend/javascript/controllers/reminder_preview_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="reminder-preview"
-// Live-updates the reminder email preview as the admin types a custom message.
-// The message target lives inside the server-rendered preview email markup (only
-// emitted in preview mode); the input target is the message textarea. The actual
-// send re-sanitizes the message server-side, so injecting the raw value here is
-// only for the on-page preview.
+// Live-updates the reminder email preview as the admin edits the custom message
+// and subject. The message target lives inside the server-rendered preview email
+// markup (only emitted in preview mode); subjectPreview is the subject line shown
+// above the rendered email. The actual send re-sanitizes the message server-side,
+// so injecting the raw values here is only for the on-page preview.
 export default class extends Controller {
-  static targets = ["input", "message"]
+  static targets = ["input", "message", "subjectInput", "subjectPreview"]
 
   inputTargetConnected() {
     this.update()
@@ -17,11 +17,25 @@ export default class extends Controller {
     this.update()
   }
 
+  subjectInputTargetConnected() {
+    this.updateSubject()
+  }
+
+  subjectPreviewTargetConnected() {
+    this.updateSubject()
+  }
+
   update() {
     if (!this.hasMessageTarget || !this.hasInputTarget) return
 
     const value = this.inputTarget.value.trim()
     this.messageTarget.innerHTML = value
     this.messageTarget.style.display = value ? "" : "none"
+  }
+
+  updateSubject() {
+    if (!this.hasSubjectPreviewTarget || !this.hasSubjectInputTarget) return
+
+    this.subjectPreviewTarget.textContent = this.subjectInputTarget.value.trim()
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,36 @@ module ApplicationHelper
     sanitize(text.to_s, tags: FORM_LABEL_TAGS, attributes: FORM_LABEL_ATTRIBUTES)
   end
 
+  # Render an admin-authored custom message included in a reminder email with the
+  # same safe subset of HTML as form labels (bold, italics, links, lists, line
+  # breaks). Reuses form_label_html so the allowlist — and its XSS scrubbing —
+  # stays in one place. Available to mailer views via `helper ApplicationHelper`.
+  def reminder_message_html(text)
+    form_label_html(text)
+  end
+
+  # The day-relative phrase appended to the default reminder message: " today",
+  # " tomorrow", " in N days", or "" when the day count isn't known. Leads with a
+  # space so it can be concatenated directly after "...event". The day count is
+  # wrapped in <strong> (the message field renders sanitized HTML), so it lands
+  # bold in the email.
+  def reminder_days_phrase(days_until_event)
+    return "" unless days_until_event.is_a?(Integer)
+    case days_until_event
+    when 0 then " <strong>today</strong>"
+    when 1 then " <strong>tomorrow</strong>"
+    else " in <strong>#{days_until_event} days</strong>"
+    end
+  end
+
+  # Default text pre-filled into the editable reminder message on the bulk
+  # reminder page (admins can edit or clear it). The day count is resolved when
+  # the page renders — it's event-level, so the same for every recipient.
+  def default_reminder_message(days_until_event)
+    organization = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+    "This is a reminder that you're registered for the following #{organization} event#{reminder_days_phrase(days_until_event)}."
+  end
+
   # Tokens an admin can drop into a form header; each is filled from the event the
   # form is rendered for (see form_header_html). A standalone registration form is
   # shared across events, so the header can't hard-code event specifics. Each entry:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,6 +44,15 @@ module ApplicationHelper
     "This is a reminder that you're registered for the following #{organization} event#{reminder_days_phrase(days_until_event)}."
   end
 
+  # Default subject line pre-filled into the editable subject field on the bulk
+  # reminder page (admins can edit it). Mirrors the mailer's fallback subject; the
+  # event date is event-level, resolved here in the app default time zone.
+  def default_reminder_subject(event)
+    organization = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+    date_suffix = event.start_date.present? ? " – #{event.start_date.in_time_zone.strftime('%B %-d, %Y')}" : ""
+    "#{organization} Portal: Reminder: #{event.title}#{date_suffix}"
+  end
+
   # Tokens an admin can drop into a form header; each is filled from the event the
   # form is rendered for (see form_header_html). A standalone registration form is
   # shared across events, so the header can't hard-code event specifics. Each entry:

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -15,7 +15,7 @@ class NotificationMailerJob < ApplicationJob
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
       "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) },
-      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message) },
+      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message, custom_subject: n.custom_subject) },
       "bulk_payment_confirmation" => ->(n) { EventMailer.bulk_payment_confirmation(n.noticeable) },
       "bulk_payment_confirmation_fyi" => ->(n) { NotificationMailer.bulk_payment_confirmation_fyi(n) }
     }

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -15,6 +15,7 @@ class NotificationMailerJob < ApplicationJob
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
       "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) },
+      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message) },
       "bulk_payment_confirmation" => ->(n) { EventMailer.bulk_payment_confirmation(n.noticeable) },
       "bulk_payment_confirmation_fyi" => ->(n) { NotificationMailer.bulk_payment_confirmation_fyi(n) }
     }

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -42,11 +42,12 @@ class EventMailer < ApplicationMailer
     )
   end
 
-  def event_registration_reminder(event_registration, custom_message: nil, preview: false)
+  def event_registration_reminder(event_registration, custom_message: nil, custom_subject: nil, preview: false)
     @event_registration = event_registration
     @event = event_registration.event.decorate
     @person = event_registration.registrant
     @custom_message = custom_message.presence
+    @custom_subject = custom_subject.presence
     # When true, the HTML body always renders the custom-message container (even
     # when blank) with hooks the on-page preview's Stimulus controller fills in
     # live. Never set on a real send.
@@ -58,12 +59,15 @@ class EventMailer < ApplicationMailer
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
     @organization_website = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 
-    subject = "Reminder: #{@event.title} – #{@event.start_date.in_time_zone(@time_zone).strftime('%B %-d, %Y')}"
+    # Admins can override the subject from the bulk-reminder page; fall back to
+    # the standard portal subject (e.g. on a resend that carries no custom value).
+    date_suffix = @event.start_date.present? ? " – #{@event.start_date.in_time_zone(@time_zone).strftime('%B %-d, %Y')}" : ""
+    default_subject = "#{@organization_name} Portal: Reminder: #{@event.title}#{date_suffix}"
     mail(
       to: @person.preferred_email,
       from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
-      subject: "AWBW Portal: #{subject}"
+      subject: @custom_subject || default_subject
     )
   end
 

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -42,16 +42,19 @@ class EventMailer < ApplicationMailer
     )
   end
 
-  def event_registration_reminder(event_registration, days_until_event: nil)
+  def event_registration_reminder(event_registration, custom_message: nil, preview: false)
     @event_registration = event_registration
     @event = event_registration.event.decorate
     @person = event_registration.registrant
-    @days_until_event = days_until_event
+    @custom_message = custom_message.presence
+    # When true, the HTML body always renders the custom-message container (even
+    # when blank) with hooks the on-page preview's Stimulus controller fills in
+    # live. Never set on a real send.
+    @preview = preview
 
     @notification_type = "Event registration reminder"
 
     @time_zone = @person.user&.time_zone || Time.zone.name
-    @event_url = @event_registration.slug.present? ? event_url(@event, reg: @event_registration.slug) : event_url(@event)
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
     @organization_website = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 
@@ -61,6 +64,28 @@ class EventMailer < ApplicationMailer
       from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: "AWBW Portal: #{subject}"
+    )
+  end
+
+  # Single admin summary sent once per bulk-reminder send: how many registrants
+  # were emailed, who they were, and a copy of the reminder content. The roster
+  # is passed as "Name <email>" labels (not records), so the job that delivers
+  # this needs no extra lookups. The per-recipient reminders are tracked
+  # notifications; this is just an at-a-glance heads-up for the team.
+  def event_registration_reminder_fyi(event, recipient_labels, custom_message: nil)
+    @event = event.decorate
+    @recipient_labels = Array(recipient_labels)
+    @custom_message = custom_message.presence
+    @notification_type = "Event registration reminder"
+    @time_zone = Time.zone.name
+    @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+
+    count = @recipient_labels.size
+    mail(
+      to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      subject: "AWBW Portal: [FYI] Reminder sent to #{count} registrant#{'s' if count != 1} for #{@event.title}"
     )
   end
 

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -24,6 +24,13 @@ class Affiliation < ApplicationRecord
     title.to_s.downcase.include?("facilitator")
   end
 
+  # Current: not flagged inactive and not past its end date. Mirrors the `active`
+  # scope so already-loaded affiliations can be filtered in Ruby without another
+  # query (e.g. on list pages that preload affiliations).
+  def active?
+    !inactive? && (end_date.nil? || end_date >= Date.current)
+  end
+
   def name
     "#{person.name}" if person
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,6 +26,7 @@ class Notification < ApplicationRecord
     event_registration_confirmation_fyi
     event_registration_cancelled
     event_registration_cancelled_fyi
+    event_registration_reminder
     bulk_payment_confirmation
     bulk_payment_confirmation_fyi
     idea_submitted

--- a/app/services/notification_services/create_notification.rb
+++ b/app/services/notification_services/create_notification.rb
@@ -7,6 +7,7 @@ module NotificationServices
       kind:,
       notification_type:,
       custom_message: nil,
+      custom_subject: nil,
       deliver: true,
       persist_delivered_email: true
     )
@@ -17,7 +18,8 @@ module NotificationServices
         notification_type: notification_type,
         recipient_role: recipient_role.to_s,
         recipient_email: recipient_email,
-        custom_message: custom_message
+        custom_message: custom_message,
+        custom_subject: custom_subject
       )
       Rails.logger.info({
                           event: "notification.created",

--- a/app/services/notification_services/create_notification.rb
+++ b/app/services/notification_services/create_notification.rb
@@ -6,6 +6,7 @@ module NotificationServices
       recipient_email:,
       kind:,
       notification_type:,
+      custom_message: nil,
       deliver: true,
       persist_delivered_email: true
     )
@@ -15,7 +16,8 @@ module NotificationServices
         kind: kind.to_s,
         notification_type: notification_type,
         recipient_role: recipient_role.to_s,
-        recipient_email: recipient_email
+        recipient_email: recipient_email,
+        custom_message: custom_message
       )
       Rails.logger.info({
                           event: "notification.created",

--- a/app/views/event_mailer/_event_details_card.html.erb
+++ b/app/views/event_mailer/_event_details_card.html.erb
@@ -1,0 +1,49 @@
+<%# Centered event-details block shared by the reminder email and the admin
+    "reminder sent" FYI. Dates/times mirror the registration form details panel
+    (a single hyphenated range for multi-day events), rendered in the given time
+    zone. Locals: event (decorated), time_zone. %>
+<div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+  <% if event.respond_to?(:pre_title) && event.pre_title.present? %>
+    <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
+      <%= event.pre_title %>
+    </p>
+  <% end %>
+
+  <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
+    <%= event.title %>
+  </h2>
+
+  <% Time.use_zone(time_zone) do %>
+    <% if event_dates_detail_label(event.object).present? %>
+      <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 4px; font-family: Lato, sans-serif;">
+        <%= event_dates_detail_label(event.object) %>
+      </p>
+    <% end %>
+
+    <% if event_times_label(event.object).present? %>
+      <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+        <%= event_times_label(event.object) %>
+      </p>
+    <% end %>
+  <% end %>
+
+  <% if event.labelled_cost.present? %>
+    <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <%= event.labelled_cost %>
+    </p>
+  <% end %>
+
+  <% if event_location_label(event.object).present? %>
+    <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+      <%= event_location_label(event.object) %>
+    </p>
+  <% end %>
+
+  <%# Virtual events show the event's label (e.g. "Zoom") as plain text — the
+      join link lives on the ticket/event pages, not in the reminder. %>
+  <% if event_platform_label(event.object).present? %>
+    <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
+      <%= event_platform_label(event.object) %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -5,55 +5,30 @@
     Hello <strong><%= @person.full_name %></strong>,
   </p>
 
-  <p>
-    This is a reminder that you're registered for the following <%= @organization_name %> event<%= raw(" " + (@days_until_event == 0 ? "<strong>today</strong>" : @days_until_event == 1 ? "<strong>tomorrow</strong>" : "in <strong>#{@days_until_event} days</strong>")) if @days_until_event.is_a?(Integer) %>:
-  </p>
+  <%# Editable intro the admin sets on the bulk-reminder page (defaults to the
+      standard reminder sentence). In preview mode the container always renders
+      (hidden when empty) with hooks the reminder-preview Stimulus controller
+      fills in live; a real send only renders it when a message is present. %>
+  <% if @custom_message.present? || @preview %>
+    <%= content_tag :div,
+          reminder_message_html(@custom_message),
+          id: ("reminder-custom-message" if @preview),
+          data: ({ reminder_preview_target: "message" } if @preview),
+          style: "margin: 8px 0; font-size: 14px; line-height: 1.5;#{' display: none;' if @preview && @custom_message.blank?}" %>
+  <% end %>
 
-  <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
-    <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
-      <p style="font-size: 14px; font-weight: 600; color: #374151; margin: 0 0 4px; font-family: 'Telefon Bold', sans-serif;">
-        <%= @event.pre_title %>
-      </p>
-    <% end %>
-
-    <h2 style="font-size: 28px; font-weight: bold; color: #166534; margin: 0 0 16px; font-family: Lato, sans-serif;">
-      <%= @event.title %>
-    </h2>
-
-    <p style="font-size: 22px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
-      <% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
-    </p>
-
-    <% if @event.labelled_cost.present? %>
-      <p style="font-size: 18px; font-weight: bold; color: #1e3a8c; text-transform: uppercase; margin: 0 0 8px; font-family: Lato, sans-serif;">
-        <%= @event.labelled_cost %>
-      </p>
-    <% end %>
-
-    <% if @event.location.present? %>
-      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
-        <%= @event.location.name %>
-      </p>
-    <% end %>
-
-    <% if @event.videoconference_url.present? %>
-      <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
-        <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= @event.decorate.videoconference_domain %></a>
-      </p>
-    <% end %>
-  </div>
+  <%= render "event_details_card", event: @event, time_zone: @time_zone %>
 </div>
 
-<p>
-  Visit the event page for updates, directions, or calendar links:
-</p>
+<% if @event_registration.persisted? && @event_registration.slug.present? %>
+  <p>
+    View your ticket for event details, directions, and calendar links:
+  </p>
 
-<p>
-  <% if @event_registration.persisted? && @event_registration.slug.present? %>
+  <p>
     <a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a>
-  <% end %>
-  <a href="<%= @event_url %>" class="button">View event</a>
-</p>
+  </p>
+<% end %>
 
 <p style="margin-top: 24px; font-size: 12px; color: #6b7280;">
   This is an automated reminder from <%= @organization_name %>.

--- a/app/views/event_mailer/event_registration_reminder.text.erb
+++ b/app/views/event_mailer/event_registration_reminder.text.erb
@@ -2,19 +2,21 @@ Event reminder
 
 Hello <%= @person.full_name %>,
 
-This is a reminder that you're registered for the following event<%= @days_until_event.is_a?(Integer) ? (@days_until_event == 0 ? " today" : @days_until_event == 1 ? " tomorrow" : " in #{@days_until_event} days") : "" %>:
+<% if @custom_message.present? %>
+<%= strip_tags(@custom_message).strip %>
 
-<% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
+<% end %><% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
 <%= @event.pre_title %>
 <% end %><%= @event.title %>
-<% Time.use_zone(@time_zone) { %><%= @event.times(display_day: true, display_date: true) %><% } %>
-
-<% if @event.location.present? %>
-Location: <%= @event.location.name %>
+<% Time.use_zone(@time_zone) do %><% if event_dates_detail_label(@event.object).present? %><%= event_dates_detail_label(@event.object) %>
+<% end %><% if event_times_label(@event.object).present? %><%= event_times_label(@event.object) %>
+<% end %><% end %>
+<% if event_location_label(@event.object).present? %>
+Location: <%= event_location_label(@event.object) %>
 <% end %>
 
-<% if @event.videoconference_url.present? %>
-Videoconference URL: <%= @event.videoconference_url %>
+<% if event_platform_label(@event.object).present? %>
+<%= event_platform_label(@event.object) %>
 <% end %>
 
 <% if @event.labelled_cost.present? %>
@@ -22,11 +24,9 @@ Videoconference URL: <%= @event.videoconference_url %>
 <% end %>
 
 <% if @event_registration.slug.present? %>
-View your ticket:
+View your ticket for event details, directions, and calendar links:
 <%= registration_ticket_url(@event_registration.slug) %>
-
-<% end %>View the event page:
-<%= @event_url %>
+<% end %>
 
 --
 This is an automated reminder from <%= @organization_name %>.

--- a/app/views/event_mailer/event_registration_reminder_fyi.html.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.html.erb
@@ -1,0 +1,35 @@
+<h1>Reminder sent</h1>
+
+<div style="margin-top: 24px; text-align: left;">
+  <p>
+    A reminder email was sent to <strong><%= @recipient_labels.size %></strong> registrant<%= "s" if @recipient_labels.size != 1 %> for <strong><%= @event.title %></strong>.
+  </p>
+
+  <% if @recipient_labels.any? %>
+    <ul style="font-size: 14px; line-height: 1.6; padding-left: 20px; color: #374151;">
+      <% @recipient_labels.each do |label| %>
+        <li><%= label %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;">
+
+<p style="font-weight: bold; color: #374151;">
+  Reminder content sent to each registrant:
+</p>
+
+<div style="border: 1px solid #e5e7eb; border-radius: 6px; padding: 16px; background-color: #ffffff;">
+  <% if @custom_message.present? %>
+    <div style="margin: 0 0 8px; font-size: 14px; line-height: 1.5;">
+      <%= reminder_message_html(@custom_message) %>
+    </div>
+  <% end %>
+
+  <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+
+  <p style="font-size: 12px; color: #6b7280; margin: 8px 0 0;">
+    Each registrant also received a personalized "View ticket" link.
+  </p>
+</div>

--- a/app/views/event_mailer/event_registration_reminder_fyi.text.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.text.erb
@@ -1,0 +1,23 @@
+Reminder sent
+
+A reminder email was sent to <%= @recipient_labels.size %> registrant<%= "s" if @recipient_labels.size != 1 %> for <%= @event.title %>.
+
+<% @recipient_labels.each do |label| %>- <%= label %>
+<% end %>
+--
+Reminder content sent to each registrant:
+
+<% if @custom_message.present? %><%= strip_tags(@custom_message).strip %>
+
+<% end %><%= @event.title %>
+<% Time.use_zone(@time_zone) do %><% if event_dates_detail_label(@event.object).present? %><%= event_dates_detail_label(@event.object) %>
+<% end %><% if event_times_label(@event.object).present? %><%= event_times_label(@event.object) %>
+<% end %><% end %><% if @event.labelled_cost.present? %>
+<%= @event.labelled_cost %>
+<% end %><% if event_location_label(@event.object).present? %>
+Location: <%= event_location_label(@event.object) %>
+<% end %><% if event_platform_label(@event.object).present? %>
+<%= event_platform_label(@event.object) %>
+<% end %>
+
+Each registrant also received a personalized "View ticket" link.

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -113,6 +113,19 @@
                       <i class="fa-solid fa-triangle-exclamation text-amber-500" title="Multiple registrants share this email address — this may cause login conflicts"></i>
                     <% end %>
                   </div>
+
+                  <%# Organizations where this person is an active facilitator —
+                      distinct from the registration's linked orgs (next column). %>
+                  <% facilitator_orgs = person.decorate.active_facilitator_organization_names %>
+                  <% if facilitator_orgs.any? %>
+                    <div class="mt-1 flex flex-wrap gap-1">
+                      <% facilitator_orgs.each do |org_name| %>
+                        <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-purple-50 text-purple-700 border-purple-200" title="Active facilitator at <%= org_name %>">
+                          <i class="fa-solid fa-chalkboard-user text-[0.6rem]"></i><%= org_name %>
+                        </span>
+                      <% end %>
+                    </div>
+                  <% end %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -18,7 +18,7 @@
     <p class="text-gray-600 mb-4">There are no registrants with an email address to send a reminder to.</p>
     <%= link_to "Back to registrants", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
   <% else %>
-    <%= form_with url: send_reminder_event_path(@event), method: :post, local: true do |f| %>
+    <%= form_with url: send_reminder_event_path(@event), method: :post, local: true, data: { controller: "reminder-preview" } do |f| %>
       <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
       <p class="text-gray-600 mb-3">
         Choose who will receive this reminder:
@@ -60,6 +60,19 @@
             <% end %>
           </tbody>
         </table>
+      </div>
+      <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Message</h2>
+        <p class="text-gray-600 mb-2">
+          The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" / "View event" buttons are always included.
+        </p>
+        <p class="text-xs text-gray-500 mb-2">
+          Accepts basic HTML — bold, italics, links, lists, and line breaks.
+        </p>
+        <%= text_area_tag :custom_message, @custom_message,
+              rows: 4,
+              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono",
+              data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
       </div>
       <% if @reminder_preview_html.present? %>
         <div class="mb-6">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -62,6 +62,15 @@
         </table>
       </div>
       <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Subject</h2>
+        <p class="text-gray-600 mb-2">
+          The subject line recipients will see. Edit it as you like — leave it as is to use the default.
+        </p>
+        <%= text_field_tag :custom_subject, @custom_subject,
+              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm",
+              data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
+      </div>
+      <div class="mb-6">
         <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Message</h2>
         <p class="text-gray-600 mb-2">
           The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" / "View event" buttons are always included.
@@ -78,6 +87,10 @@
         <div class="mb-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">Preview (sample registrant)</h2>
           <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
+            <div class="border-b border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700">
+              <span class="font-semibold text-gray-500">Subject:</span>
+              <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
+            </div>
             <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
               <%= raw @reminder_preview_html %>
             </div>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+<%# Opt out of the layout's max-w-7xl cap so this data-dense table can use more
+    of the screen; the wrapper restores the layout's gutters at a wider bound. %>
+<% content_for(:full_width, true) %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -30,4 +34,5 @@
   <%= render "registrants_search" %>
 
   <%= render "registrants_results" %>
+</div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -204,6 +204,40 @@
         79
       ],
       "note": "sdf"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "31dde319e6775c7f5f4428a32a45835966a2afa4dad760f17400b9115a863809",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/events/preview_reminder.html.erb",
+      "line": 95,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "EventMailer.event_registration_reminder(Event.find(params[:id]).decorate.event_registrations.includes(:registrant => ([:user, :contact_methods])).joins(:registrant).select do\n r.registrant.preferred_email.present?\n end.first, :custom_message => ((params[:custom_message].to_s or helpers.default_reminder_message(((Event.find(params[:id]).decorate.start_date.to_date - Date.current).to_i or nil)))), :custom_subject => ((params[:custom_subject].to_s or helpers.default_reminder_subject(Event.find(params[:id]).decorate))), :preview => true).html_part.body.decoded",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "EventsController",
+          "method": "preview_reminder",
+          "line": 277,
+          "file": "app/controllers/events_controller.rb",
+          "rendered": {
+            "name": "events/preview_reminder",
+            "file": "app/views/events/preview_reminder.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "events/preview_reminder"
+      },
+      "user_input": "params[:custom_message].to_s",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Admin-only reminder preview. The raw value is the server-rendered email HTML; the custom message it embeds is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
     }
   ],
   "brakeman_version": "8.0.4"

--- a/db/migrate/20260618104041_add_custom_message_to_notifications.rb
+++ b/db/migrate/20260618104041_add_custom_message_to_notifications.rb
@@ -1,0 +1,13 @@
+class AddCustomMessageToNotifications < ActiveRecord::Migration[8.1]
+  # Optional admin-authored message included in the email a notification
+  # represents (currently the bulk event reminder). Stored so the async
+  # NotificationMailerJob — and any later resend — can re-render the exact email
+  # the admin composed. NULL means the notification carries no custom message.
+  def up
+    add_column :notifications, :custom_message, :text unless column_exists?(:notifications, :custom_message)
+  end
+
+  def down
+    remove_column :notifications, :custom_message, if_exists: true
+  end
+end

--- a/db/migrate/20260618104042_add_custom_subject_to_notifications.rb
+++ b/db/migrate/20260618104042_add_custom_subject_to_notifications.rb
@@ -1,0 +1,14 @@
+class AddCustomSubjectToNotifications < ActiveRecord::Migration[8.1]
+  # Optional admin-authored subject line for the email a notification represents
+  # (currently the bulk event reminder). Stored alongside custom_message so the
+  # async NotificationMailerJob — and any later resend — can re-send the exact
+  # subject the admin composed. NULL means the email falls back to its default
+  # computed subject.
+  def up
+    add_column :notifications, :custom_subject, :string unless column_exists?(:notifications, :custom_subject)
+  end
+
+  def down
+    remove_column :notifications, :custom_subject, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_034355) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_104041) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -713,6 +713,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_034355) do
   create_table "notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "channel", default: "autoemail", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.text "custom_message"
     t.datetime "delivered_at"
     t.text "email_body_html", size: :medium
     t.text "email_body_text", size: :medium

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_104041) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_104042) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -714,6 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_104041) do
     t.string "channel", default: "autoemail", null: false
     t.datetime "created_at", precision: nil, null: false
     t.text "custom_message"
+    t.string "custom_subject"
     t.datetime "delivered_at"
     t.text "email_body_html", size: :medium
     t.text "email_body_text", size: :medium

--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -62,3 +62,73 @@ end
 
 puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications " \
      "(#{Notification.where(kind: 'contact_us_fyi', responded: true).count} marked responded)"
+
+# Custom event reminders Amy received. These demonstrate the editable subject and
+# message on the bulk-reminder page: each is a delivered reminder with the
+# admin-authored subject/body persisted (rendered through the real mailer, exactly
+# as NotificationMailerJob does on a live send), so they appear in Amy's
+# registration communications history. Runs after events_management seeds Amy's
+# registrations; skips gracefully if that data is absent.
+amy_person = User.find_by(email: "amy.user@example.com")&.person
+
+if amy_person && amy_person.preferred_email.present?
+  amy_email = amy_person.preferred_email
+  organization = ENV.fetch("ORGANIZATION_NAME", "AWBW")
+
+  # Distinct admin-authored messages; paired with separate event registrations so
+  # each notification is naturally unique on (noticeable, kind) and idempotent on
+  # re-seed.
+  reminder_specs = [
+    {
+      subject: "We can't wait to see you this Saturday 🌿",
+      message: "This is a reminder that you're registered for the following #{organization} event <strong>this Saturday</strong>. Doors open 30 minutes early for check-in, and light refreshments will be provided.",
+      delivered_days_ago: 9
+    },
+    {
+      subject: "A few things to bring to your session tomorrow",
+      message: "Just a friendly nudge ahead of our session <strong>tomorrow</strong>. Please bring an apron and any small keepsake you'd like to work into your art piece.",
+      delivered_days_ago: 2
+    },
+    {
+      subject: "Your join link is on the way — virtual session tomorrow",
+      message: "We're so glad you're joining us! A reminder that this is a <strong>virtual</strong> session — keep an eye out for the join link on your ticket shortly before we begin.",
+      delivered_days_ago: 1
+    }
+  ]
+
+  amy_reminder_regs = EventRegistration.where(registrant: amy_person)
+    .includes(:event)
+    .select { |r| r.event&.start_date.present? }
+    .sort_by { |r| r.event.start_date }
+
+  amy_reminder_regs.first(reminder_specs.size).each_with_index do |registration, i|
+    spec = reminder_specs[i]
+    # Admin-edited subject (keeps the portal prefix the page defaults to).
+    custom_subject = "#{organization} Portal: #{spec[:subject]}"
+
+    notification = Notification.find_or_create_by!(
+      noticeable: registration,
+      kind: "event_registration_reminder",
+      recipient_email: amy_email
+    ) do |n|
+      n.recipient_role = "person"
+      n.notification_type = 0
+      n.custom_message = spec[:message]
+      n.custom_subject = custom_subject
+    end
+
+    next if notification.delivered_at.present?
+
+    mail = EventMailer.event_registration_reminder(
+      registration,
+      custom_message: spec[:message],
+      custom_subject: custom_subject
+    )
+    NotificationServices::PersistDeliveredEmail.call(notification: notification, mail: mail)
+    # Backdate so the history reads like a sequence of past reminders.
+    delivered_at = spec[:delivered_days_ago].days.ago
+    notification.update_columns(delivered_at: delivered_at, created_at: delivered_at)
+  end
+
+  puts "  Created #{Notification.where(kind: 'event_registration_reminder', recipient_email: amy_email).count} custom event reminders for Amy"
+end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe PersonDecorator do
+  describe "#active_facilitator_organization_names" do
+    let(:person) { create(:person) }
+
+    it "returns sorted, unique org names for active facilitator affiliations" do
+      beta = create(:organization, name: "Beta Org")
+      alpha = create(:organization, name: "Alpha Org")
+      create(:affiliation, person: person, organization: beta, title: "Facilitator")
+      create(:affiliation, person: person, organization: alpha, title: "Lead Facilitator")
+
+      expect(person.decorate.active_facilitator_organization_names).to eq([ "Alpha Org", "Beta Org" ])
+    end
+
+    it "excludes non-facilitator affiliations" do
+      org = create(:organization, name: "Board Org")
+      create(:affiliation, person: person, organization: org, title: "Board Member")
+
+      expect(person.decorate.active_facilitator_organization_names).to be_empty
+    end
+
+    it "excludes expired facilitator affiliations" do
+      org = create(:organization, name: "Past Org")
+      create(:affiliation, person: person, organization: org, title: "Facilitator", end_date: 1.day.ago)
+
+      expect(person.decorate.active_facilitator_organization_names).to be_empty
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -328,6 +328,25 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#default_reminder_subject" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ORGANIZATION_NAME", "AWBW").and_return("A Window Between Worlds")
+    end
+
+    it "names the organization, event title, and formatted start date" do
+      event = build(:event, title: "Healing Workshop", start_date: Time.zone.local(2026, 8, 7, 18, 0))
+      expect(helper.default_reminder_subject(event))
+        .to eq("A Window Between Worlds Portal: Reminder: Healing Workshop – August 7, 2026")
+    end
+
+    it "omits the date suffix when the event has no start date" do
+      event = build(:event, title: "Healing Workshop", start_date: nil)
+      expect(helper.default_reminder_subject(event))
+        .to eq("A Window Between Worlds Portal: Reminder: Healing Workshop")
+    end
+  end
+
   describe "#event_registration_close_date_label" do
     it "is the month and day, without year, ordinal, or time" do
       event = build(:event, registration_close_date: Time.zone.local(2026, 8, 7, 8, 45))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -293,6 +293,41 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#reminder_days_phrase" do
+    it "says today for 0 days" do
+      expect(helper.reminder_days_phrase(0)).to eq(" <strong>today</strong>")
+    end
+
+    it "says tomorrow for 1 day" do
+      expect(helper.reminder_days_phrase(1)).to eq(" <strong>tomorrow</strong>")
+    end
+
+    it "bolds the day count for more than one day out" do
+      expect(helper.reminder_days_phrase(60)).to eq(" in <strong>60 days</strong>")
+    end
+
+    it "is blank when the day count is unknown" do
+      expect(helper.reminder_days_phrase(nil)).to eq("")
+    end
+  end
+
+  describe "#default_reminder_message" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ORGANIZATION_NAME", "AWBW").and_return("A Window Between Worlds")
+    end
+
+    it "names the organization and the bolded dynamic day count" do
+      expect(helper.default_reminder_message(60))
+        .to eq("This is a reminder that you're registered for the following A Window Between Worlds event in <strong>60 days</strong>.")
+    end
+
+    it "omits the day phrase when the count is unknown" do
+      expect(helper.default_reminder_message(nil))
+        .to eq("This is a reminder that you're registered for the following A Window Between Worlds event.")
+    end
+  end
+
   describe "#event_registration_close_date_label" do
     it "is the month and day, without year, ordinal, or time" do
       event = build(:event, registration_close_date: Time.zone.local(2026, 8, 7, 8, 45))

--- a/spec/jobs/notification_mailer_job_spec.rb
+++ b/spec/jobs/notification_mailer_job_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe NotificationMailerJob, type: :job do
           noticeable: event_registration,
           recipient_role: "person",
           recipient_email: event_registration.registrant.preferred_email,
-          custom_message: "Bring <strong>your supplies</strong>.")
+          custom_message: "Bring <strong>your supplies</strong>.",
+          custom_subject: "Don't forget us tomorrow!")
       end
 
       it "delivers the reminder and persists the body with the custom message" do
@@ -64,6 +65,12 @@ RSpec.describe NotificationMailerJob, type: :job do
         notification.reload
         expect(notification.delivered_at).to be_present
         expect(notification.email_body_html).to include("Bring <strong>your supplies</strong>.")
+      end
+
+      it "delivers with the notification's custom subject" do
+        described_class.new.perform(notification.id)
+
+        expect(ActionMailer::Base.deliveries.last.subject).to eq("Don't forget us tomorrow!")
       end
     end
   end

--- a/spec/jobs/notification_mailer_job_spec.rb
+++ b/spec/jobs/notification_mailer_job_spec.rb
@@ -44,5 +44,27 @@ RSpec.describe NotificationMailerJob, type: :job do
         described_class.new.perform(notification.id)
       }.to raise_error(/Unknown notification kind/)
     end
+
+    context "for an event registration reminder" do
+      let(:event_registration) { create(:event_registration) }
+      let(:notification) do
+        create(:notification,
+          kind: "event_registration_reminder",
+          noticeable: event_registration,
+          recipient_role: "person",
+          recipient_email: event_registration.registrant.preferred_email,
+          custom_message: "Bring <strong>your supplies</strong>.")
+      end
+
+      it "delivers the reminder and persists the body with the custom message" do
+        expect {
+          described_class.new.perform(notification.id)
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        notification.reload
+        expect(notification.delivered_at).to be_present
+        expect(notification.email_body_html).to include("Bring <strong>your supplies</strong>.")
+      end
+    end
   end
 end

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -84,8 +84,7 @@ RSpec.describe EventMailer, type: :mailer do
 
   describe "#event_registration_reminder" do
     let(:event_registration) { create(:event_registration) }
-    let(:mail) { described_class.event_registration_reminder(event_registration, days_until_event: days_until_event) }
-    let(:days_until_event) { 7 }
+    let(:mail) { described_class.event_registration_reminder(event_registration) }
 
     it "renders without raising" do
       expect { mail.deliver_now }.not_to raise_error
@@ -107,48 +106,98 @@ RSpec.describe EventMailer, type: :mailer do
       expect(mail.body.encoded).to include(event_registration.registrant.full_name)
     end
 
-    it "includes reminder wording in the body" do
-      expect(mail.body.encoded).to include("This is a reminder that you're registered for the following")
-    end
+    context "for a virtual event" do
+      let(:event) { create(:event, videoconference_url: "https://zoom.us/j/123", videoconference_label: "Zoom") }
+      let(:event_registration) { create(:event_registration, event: event) }
 
-    context "when days_until_event is 0" do
-      let(:days_until_event) { 0 }
+      it "shows the event's platform label as plain text" do
+        expect(mail.html_part.body.encoded).to include("Zoom")
+      end
 
-      it "includes today in the body" do
-        expect(mail.body.encoded).to include("today")
+      it "does not link to the videoconference URL" do
+        expect(mail.html_part.body.encoded).not_to include("https://zoom.us/j/123")
       end
     end
 
-    context "when days_until_event is 1" do
-      let(:days_until_event) { 1 }
+    context "for a multi-day event" do
+      let(:event) do
+        create(:event,
+          start_date: Time.zone.local(2026, 8, 16, 19, 0),
+          end_date: Time.zone.local(2026, 8, 17, 21, 0))
+      end
+      let(:event_registration) { create(:event_registration, event: event) }
 
-      it "includes tomorrow in the body" do
-        expect(mail.body.encoded).to include("tomorrow")
+      it "shows the dates as a single hyphenated range, not one line per day" do
+        expect(mail.html_part.body.encoded).to include("August 16-17")
       end
     end
 
-    context "when days_until_event is 7" do
-      let(:days_until_event) { 7 }
+    context "with a custom message" do
+      let(:mail) { described_class.event_registration_reminder(event_registration, custom_message: custom_message) }
+      let(:custom_message) { "Please bring <strong>your art supplies</strong>." }
 
-      it "includes the number of days in the body" do
-        expect(mail.body.encoded).to include("7 days")
+      it "includes the message in the HTML body" do
+        expect(mail.html_part.body.encoded).to include("Please bring <strong>your art supplies</strong>.")
+      end
+
+      it "includes the message text in the plain-text body" do
+        expect(mail.text_part.body.encoded).to include("Please bring your art supplies.")
+      end
+
+      it "strips disallowed HTML from the message" do
+        mail = described_class.event_registration_reminder(event_registration, custom_message: "Hi<script>alert(1)</script>")
+        expect(mail.html_part.body.encoded).to include("Hi")
+        expect(mail.html_part.body.encoded).not_to include("<script>")
       end
     end
 
-    context "when days_until_event is nil" do
-      let(:days_until_event) { nil }
-      let(:mail) { described_class.event_registration_reminder(event_registration) }
-
-      it "renders without raising" do
-        expect { mail.deliver_now }.not_to raise_error
+    context "without a custom message" do
+      it "does not render the custom-message container" do
+        expect(mail.html_part.body.encoded).not_to include("reminder-custom-message")
       end
+    end
 
-      it "does not include today, tomorrow, or in N days in the body" do
-        body = mail.body.encoded
-        expect(body).not_to include("today")
-        expect(body).not_to include("tomorrow")
-        expect(body).not_to match(/\bin \d+ days\b/)
+    context "in preview mode" do
+      let(:mail) { described_class.event_registration_reminder(event_registration, preview: true) }
+
+      it "renders the custom-message container even when blank" do
+        expect(mail.html_part.body.encoded).to include("reminder-custom-message")
       end
+    end
+  end
+
+  describe "#event_registration_reminder_fyi" do
+    let(:event) { create(:event, title: "Art Workshop") }
+    let(:recipient_labels) { [ "Alex Rivera <alex@example.org>", "Sam Lee <sam@example.org>" ] }
+    let(:mail) { described_class.event_registration_reminder_fyi(event, recipient_labels, custom_message: "See you soon!") }
+
+    it "renders without raising" do
+      expect { mail.deliver_now }.not_to raise_error
+    end
+
+    it "is sent to the admin reply-to address" do
+      expect(mail.to).to eq([ ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org") ])
+    end
+
+    it "summarizes the count and event in the subject" do
+      expect(mail.subject).to include("[FYI]")
+      expect(mail.subject).to include("2 registrants")
+      expect(mail.subject).to include("Art Workshop")
+    end
+
+    it "lists every recipient in the body" do
+      expect(mail.html_part.body.encoded).to include("Alex Rivera").and include("Sam Lee")
+      expect(mail.text_part.body.encoded).to include("Alex Rivera <alex@example.org>")
+    end
+
+    it "includes the custom message and event title" do
+      expect(mail.html_part.body.encoded).to include("See you soon!")
+      expect(mail.html_part.body.encoded).to include("Art Workshop")
+    end
+
+    it "uses the singular noun for a single recipient" do
+      mail = described_class.event_registration_reminder_fyi(event, [ "Alex Rivera <alex@example.org>" ])
+      expect(mail.subject).to include("1 registrant ")
     end
   end
 end

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe EventMailer, type: :mailer do
       expect(mail.body.encoded).to include(event_registration.registrant.full_name)
     end
 
+    context "with a custom subject" do
+      let(:mail) { described_class.event_registration_reminder(event_registration, custom_subject: "Don't forget us tomorrow!") }
+
+      it "uses the custom subject verbatim" do
+        expect(mail.subject).to eq("Don't forget us tomorrow!")
+      end
+    end
+
+    context "with a blank custom subject" do
+      let(:mail) { described_class.event_registration_reminder(event_registration, custom_subject: " ") }
+
+      it "falls back to the default portal subject" do
+        expect(mail.subject).to include("Reminder: #{event_registration.event.title}")
+      end
+    end
+
     context "for a virtual event" do
       let(:event) { create(:event, videoconference_url: "https://zoom.us/j/123", videoconference_label: "Zoom") }
       let(:event_registration) { create(:event_registration, event: event) }

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -14,6 +14,24 @@ RSpec.describe Affiliation do
     # it { should validate_presence_of(:person_id) } # we needed to not have this to support nested attrs
   end
 
+  describe '#active?' do
+    it 'is true when not inactive and has no end date' do
+      expect(build(:affiliation, inactive: false, end_date: nil).active?).to be true
+    end
+
+    it 'is true when not inactive and the end date is in the future' do
+      expect(build(:affiliation, inactive: false, end_date: 1.month.from_now).active?).to be true
+    end
+
+    it 'is false when flagged inactive' do
+      expect(build(:affiliation, inactive: true, end_date: nil).active?).to be false
+    end
+
+    it 'is false when the end date has passed' do
+      expect(build(:affiliation, inactive: false, end_date: 1.day.ago).active?).to be false
+    end
+  end
+
   describe '.active' do
     let!(:active_op) { create(:affiliation, inactive: false, end_date: nil) }
     let!(:active_with_future_end) { create(:affiliation, inactive: false, end_date: 1.month.from_now) }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1712,4 +1712,77 @@ RSpec.describe "Events", type: :request do
       expect(response.body).to include("already fully paid")
     end
   end
+
+  describe "POST /send_reminder" do
+    let!(:registration_one) { create(:event_registration, event: event) }
+    let!(:registration_two) { create(:event_registration, event: event) }
+
+    before { sign_in admin }
+
+    it "creates one reminder notification per selected registrant" do
+      expect {
+        post send_reminder_event_path(event), params: {
+          registration_ids: [ registration_one.id, registration_two.id ],
+          custom_message: "See you soon!"
+        }
+      }.to change { Notification.where(kind: "event_registration_reminder").count }.by(2)
+
+      expect(response).to redirect_to(registrants_event_path(event))
+    end
+
+    it "sends a single admin FYI summarizing the batch" do
+      expect {
+        post send_reminder_event_path(event), params: {
+          registration_ids: [ registration_one.id, registration_two.id ],
+          custom_message: "See you soon!"
+        }
+      }.to have_enqueued_mail(EventMailer, :event_registration_reminder_fyi).once
+    end
+
+    it "stores the custom message and recipient on each notification" do
+      post send_reminder_event_path(event), params: {
+        registration_ids: [ registration_one.id ],
+        custom_message: "See you soon!"
+      }
+
+      notification = Notification.find_by(kind: "event_registration_reminder", noticeable: registration_one)
+      expect(notification.custom_message).to eq("See you soon!")
+      expect(notification.recipient_role).to eq("person")
+      expect(notification.recipient_email).to eq(registration_one.registrant.preferred_email)
+    end
+
+    it "creates no notifications when nothing is selected" do
+      expect {
+        post send_reminder_event_path(event), params: { registration_ids: [] }
+      }.not_to change(Notification, :count)
+
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: ""))
+    end
+  end
+
+  describe "GET /registrants" do
+    let!(:registration) { create(:event_registration, event: event) }
+
+    before { sign_in admin }
+
+    it "shows the registrant's active facilitator affiliation organization names" do
+      create(:affiliation, person: registration.registrant,
+        organization: create(:organization, name: "Helping Hands Center"),
+        title: "Facilitator")
+
+      get registrants_event_path(event)
+
+      expect(response.body).to include("Helping Hands Center")
+    end
+
+    it "does not show organizations from non-facilitator affiliations" do
+      create(:affiliation, person: registration.registrant,
+        organization: create(:organization, name: "Board Only Org"),
+        title: "Board Member")
+
+      get registrants_event_path(event)
+
+      expect(response.body).not_to include("Board Only Org")
+    end
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1751,12 +1751,22 @@ RSpec.describe "Events", type: :request do
       expect(notification.recipient_email).to eq(registration_one.registrant.preferred_email)
     end
 
+    it "stores the custom subject on each notification" do
+      post send_reminder_event_path(event), params: {
+        registration_ids: [ registration_one.id ],
+        custom_subject: "Don't miss our event!"
+      }
+
+      notification = Notification.find_by(kind: "event_registration_reminder", noticeable: registration_one)
+      expect(notification.custom_subject).to eq("Don't miss our event!")
+    end
+
     it "creates no notifications when nothing is selected" do
       expect {
         post send_reminder_event_path(event), params: { registration_ids: [] }
       }.not_to change(Notification, :count)
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: ""))
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: ""))
     end
   end
 

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -8,7 +8,8 @@ class EventMailerPreview < ActionMailer::Preview
     event_registration = sample_event_registration
     EventMailer.event_registration_reminder(
       event_registration,
-      custom_message: "This is a reminder that you're registered for the following A Window Between Worlds event <strong>tomorrow</strong>."
+      custom_message: "This is a reminder that you're registered for the following A Window Between Worlds event <strong>tomorrow</strong>.",
+      custom_subject: "A Window Between Worlds Portal: Reminder: see you tomorrow!"
     )
   end
 

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -6,7 +6,19 @@ class EventMailerPreview < ActionMailer::Preview
 
   def event_registration_reminder
     event_registration = sample_event_registration
-    EventMailer.event_registration_reminder(event_registration, days_until_event: 1)
+    EventMailer.event_registration_reminder(
+      event_registration,
+      custom_message: "This is a reminder that you're registered for the following A Window Between Worlds event <strong>tomorrow</strong>."
+    )
+  end
+
+  def event_registration_reminder_fyi
+    event = Event.first || create_event
+    EventMailer.event_registration_reminder_fyi(
+      event,
+      [ "Alex Rivera <alex@example.org>", "Sam Lee <sam@example.org>" ],
+      custom_message: "This is a reminder that you're registered for the following A Window Between Worlds event <strong>tomorrow</strong>."
+    )
   end
 
   def event_registration_cancelled


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins sending bulk event reminders couldn't personalize the email or keep a record of what was sent, and the registrants index didn't surface which registrants are active facilitators (or where).

### How did you approach the change?
- **Bulk reminder page:** added an editable, sanitized-HTML **message** (defaults to the standard reminder line with a dynamic, bolded day count) and an editable **subject**, both with a live preview; the email now shows a single hyphenated date range for multi-day events and the videoconference label as plain text (no join link), with only a "View ticket" button.
- **Tracking:** each send creates one Notification per recipient (delivered + persisted via `NotificationMailerJob`, carrying the message/subject through resends) plus a single admin FYI email summarizing the count, recipient roster, and content sent.
- **Registrants index:** widened the page and listed each registrant's active facilitator affiliation organization names.

### UI Testing Checklist
- [ ] Bulk reminder page: editing the message and subject updates the live preview
- [ ] A sent reminder shows the custom message + subject; multi-day dates render as one hyphenated range; no Zoom link; only the "View ticket" button
- [ ] Each selected recipient gets a Notification record; exactly one admin FYI lists all recipients + the content
- [ ] Registrants index is wider and shows active facilitator affiliation org names under each name

### Anything else to add?
- Brakeman: the reminder-preview `raw` output is allowlisted because its embedded custom message is sanitized via `reminder_message_html` (SafeListSanitizer) and the subject is rendered escaped, separately.
- This branch is currently behind `main`; merge/rebase `main` before merging.