### PR TITLE
Fix upside-down chevrons on the event dashboard cards

### DIFF
--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -22,7 +22,7 @@
   amounts_by_registrant_id = local_assigns.fetch(:amounts_by_registrant_id, nil)
 %>
 <div class="flex items-start gap-1.5">
-  <details class="flex-1 min-w-0">
+  <details class="group/row flex-1 min-w-0">
     <summary class="flex items-center justify-between gap-2 rounded px-1 -mx-1 py-1 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden hover:bg-gray-50">
       <span class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
         <% if icon_bg.present? %>
@@ -37,7 +37,7 @@
       </span>
       <span class="flex items-center gap-2">
         <span class="text-sm font-semibold tabular-nums <%= amount_color %>"><%= number_to_currency(amount_cents / 100.0) %></span>
-        <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 transition-transform [[open]_&]:rotate-180"></i>
+        <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 transition-transform group-open/row:rotate-180"></i>
       </span>
     </summary>
     <% if registrants.any? %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -155,7 +155,7 @@
           paid/completed + outstanding sub-rows that expand to the registrants behind the figure. %>
       <div class="flex flex-col md:flex-row md:flex-wrap md:items-stretch gap-3 md:gap-4">
         <%# Payments = Paid + Outstanding %>
-        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
+        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
           <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
@@ -174,7 +174,7 @@
                 <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
-              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
@@ -195,7 +195,7 @@
         </details>
 
         <%# Scholarships = Completed + Outstanding %>
-        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
+        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
           <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
@@ -213,7 +213,7 @@
               <p class="break-words">
                 <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></span>
               </p>
-              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
@@ -227,7 +227,7 @@
         </details>
 
         <%# Continuing education fees = Paid + Outstanding %>
-        <details class="flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
+        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
           <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
@@ -246,7 +246,7 @@
                 <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
-              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+              <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
@@ -269,7 +269,7 @@
 
   <%# Headcount cards — each expands to reveal its full list %>
   <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
@@ -279,7 +279,7 @@
             </span>
             <span class="truncate">Registrants</span>
           </h3>
-          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">Active registrations<% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.inactive_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
       </summary>
@@ -300,7 +300,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
@@ -310,7 +310,7 @@
             </span>
             <span class="truncate">Organizations</span>
           </h3>
-          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">Via registrants</p>
       </summary>
@@ -335,7 +335,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
@@ -345,7 +345,7 @@
             </span>
             <span class="truncate">Sectors</span>
           </h3>
-          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">Via registrants</p>
       </summary>
@@ -367,7 +367,7 @@
       </div>
     </details>
 
-    <details class="bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">
@@ -377,7 +377,7 @@
             </span>
             <span class="truncate">States</span>
           </h3>
-          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">Via registrants</p>
       </summary>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The collapsible cards on the event dashboard (money cards + headcount cards) showed chevrons that flipped upside down when a card was expanded.
- The money cards contain nested `<details>` rows, so opening an outer card incorrectly rotated the collapsed inner-row chevrons too.

### How did you approach the change?
- The chevrons used `[[open]_&]:rotate-180`, which Tailwind compiles to `[open] .…rotate-180` — matching on *any* ancestor with `[open]`, not the chevron's own `<details>`.
- Replaced it with named Tailwind groups: each card `<details>` is `group/card` (chevron `group-open/card:rotate-180`) and each money row `<details>` is `group/row` (chevron `group-open/row:rotate-180`), so every chevron only rotates when its own section is open.
- Verified by compiling the Tailwind v4 CSS and confirming the generated selectors are scoped to each `.group/card` / `.group/row` `[open]` element.

### UI Testing Checklist
- [ ] On the event dashboard, each card's chevron points down when collapsed and up when expanded.
- [ ] Expanding a money card (Registration fees / Scholarships / CE fees) does NOT flip its still-collapsed Paid/Due/Scholarship row chevrons.
- [ ] Expanding an inner money row rotates only that row's chevron.

### Anything else to add?
- The same `[[open]_&]` pattern exists in `forms/edit.html.erb` and `event_registrations/link_organization.html.erb`, but those use flat, non-nested `<details>`, so they don't hit this bug and are left unchanged.