### PR TITLE
Move generic colour swatches into DomainTheme

### DIFF
--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -5,21 +5,9 @@ class RegistrationTicketCallout < ApplicationRecord
   # group them on the ticket later.
   CALLOUT_TYPES = %w[ action reference ].freeze
 
-  # Colour themes keyed by a short name stored in `color_class`. Every utility is
-  # spelled out as a literal class so Tailwind's JIT scan picks it up — never
-  # interpolate the colour into a class name. Used for the icon today; the border
-  # and background are here so we can tint the whole box later without a migration.
-  COLOR_THEMES = {
-    "amber" => { icon: "text-amber-500", border: "border-amber-300", bg: "bg-amber-50", hover: "hover:bg-amber-100", title: "text-amber-900", subtitle: "text-amber-700" },
-    "orange" => { icon: "text-orange-500", border: "border-orange-300", bg: "bg-orange-50", hover: "hover:bg-orange-100", title: "text-orange-900", subtitle: "text-orange-700" },
-    "indigo" => { icon: "text-indigo-500", border: "border-indigo-300", bg: "bg-indigo-50", hover: "hover:bg-indigo-100", title: "text-indigo-900", subtitle: "text-indigo-700" },
-    "blue" => { icon: "text-blue-500", border: "border-blue-200", bg: "bg-blue-50", hover: "hover:bg-blue-100", title: "text-blue-900", subtitle: "text-blue-700" },
-    "green" => { icon: "text-green-500", border: "border-green-300", bg: "bg-green-50", hover: "hover:bg-green-100", title: "text-green-900", subtitle: "text-green-700" },
-    "purple" => { icon: "text-purple-500", border: "border-purple-300", bg: "bg-purple-50", hover: "hover:bg-purple-100", title: "text-purple-900", subtitle: "text-purple-700" },
-    "rose" => { icon: "text-rose-500", border: "border-rose-300", bg: "bg-rose-50", hover: "hover:bg-rose-100", title: "text-rose-900", subtitle: "text-rose-700" },
-    "gray" => { icon: "text-gray-500", border: "border-gray-200", bg: "bg-gray-50", hover: "hover:bg-gray-100", title: "text-gray-900", subtitle: "text-gray-600" }
-  }.freeze
-
+  # Per-type fallbacks for the icon and colour. These are callout-specific (unlike
+  # the generic colour swatches and palette, which live in DomainTheme so the whole
+  # app can reuse them for tinted boxes — amount-due, scholarship box, etc.).
   DEFAULT_ICONS = { "action" => "fa-solid fa-arrow-right", "reference" => "fa-solid fa-circle-info" }.freeze
   DEFAULT_COLORS = { "action" => "orange", "reference" => "indigo" }.freeze
 
@@ -33,7 +21,7 @@ class RegistrationTicketCallout < ApplicationRecord
 
   validates :title, presence: true
   validates :callout_type, inclusion: { in: CALLOUT_TYPES }
-  validates :color_class, inclusion: { in: COLOR_THEMES.keys }, allow_blank: true
+  validates :color_class, inclusion: { in: DomainTheme::SWATCH_COLORS.map(&:to_s) }, allow_blank: true
   validates :position, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 
   scope :ordered, -> { order(:position, :id) }
@@ -48,10 +36,11 @@ class RegistrationTicketCallout < ApplicationRecord
     icon_class.presence || DEFAULT_ICONS.fetch(callout_type, DEFAULT_ICONS["reference"])
   end
 
-  # The colour theme hash for this callout, falling back to the per-type default.
+  # The colour swatch (icon/border/bg/hover/title/subtitle classes) for this
+  # callout, falling back to the per-type default colour.
   def theme
-    key = color_class.presence || DEFAULT_COLORS.fetch(callout_type, "indigo")
-    COLOR_THEMES.fetch(key, COLOR_THEMES["indigo"])
+    color = color_class.presence || DEFAULT_COLORS.fetch(callout_type, "indigo")
+    DomainTheme.swatch(color)
   end
 
   def to_s

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-colors"
      data-controller="callout-preview"
-     data-callout-preview-themes-value="<%= RegistrationTicketCallout::COLOR_THEMES.to_json %>"
+     data-callout-preview-themes-value="<%= DomainTheme.swatches.to_json %>"
      data-callout-preview-defaults-value="<%= RegistrationTicketCallout::DEFAULT_COLORS.to_json %>"
      <% if f.object.persisted? %>data-sortable-id="<%= f.object.id %>"<% end %>>
   <% if f.object.persisted? %>
@@ -53,7 +53,7 @@
       <div>
         <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.select :color_class,
-              RegistrationTicketCallout::COLOR_THEMES.keys.map { |c| [ c.humanize, c ] },
+              DomainTheme::SWATCH_COLORS.map { |c| [ c.to_s.humanize, c ] },
               { include_blank: "Default (by type)" },
               class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -52,8 +52,45 @@ module DomainTheme
     affiliated_person:        :slate
   }
 
+  # Ordered palette of colours offered as user-pickable swatches (e.g. the
+  # callout colour dropdown). A curated subset of the full theme palette that
+  # reads well as tinted boxes — add a colour here once and every picker updates.
+  SWATCH_COLORS = %i[ amber orange indigo blue green purple rose gray ].freeze
+
+  # Semantic roles for a colour "swatch" — the full set of Tailwind utilities for
+  # tinting a boxed UI element (callout cards today; the amount-due / scholarship
+  # boxes, etc. tomorrow). Each role is a single intensity off one base colour, so
+  # the app's box-theming lives here rather than scattered across models and views.
+  # The literal classes these produce are safelisted via the @source inline(...)
+  # block in application.tailwind.css — change an intensity here and update it there.
+  SWATCH_ROLES = {
+    icon:     "text-%<color>s-500",
+    border:   "border-%<color>s-300",
+    bg:       "bg-%<color>s-50",
+    hover:    "hover:bg-%<color>s-100",
+    title:    "text-%<color>s-900",
+    subtitle: "text-%<color>s-700"
+  }.freeze
+
   def self.color_for(key)
     COLORS[key.to_sym] || :gray
+  end
+
+  # Full colour swatch (role => Tailwind class) for a raw base colour.
+  def self.swatch(color)
+    SWATCH_ROLES.transform_values { |template| format(template, color:) }
+  end
+
+  # Full colour swatch for a domain key, resolving the key to its theme colour
+  # first (e.g. swatch_for(:scholarships) tints a box with the scholarships colour).
+  def self.swatch_for(key)
+    swatch(color_for(key))
+  end
+
+  # Every pickable swatch keyed by colour name — handy for serialising the whole
+  # palette to JS (e.g. the callout editor's live colour preview).
+  def self.swatches
+    SWATCH_COLORS.index_with { |color| swatch(color) }
   end
 
   def self.bg_class_for(key, intensity: 50, hover: false)

--- a/spec/lib/domain_theme_spec.rb
+++ b/spec/lib/domain_theme_spec.rb
@@ -50,4 +50,39 @@ RSpec.describe DomainTheme do
       expect(DomainTheme.color_for(:missing)).to eq(:gray)
     end
   end
+
+  describe ".swatch" do
+    it "builds the full set of role classes from one base colour" do
+      expect(DomainTheme.swatch(:amber)).to eq(
+        icon: "text-amber-500",
+        border: "border-amber-300",
+        bg: "bg-amber-50",
+        hover: "hover:bg-amber-100",
+        title: "text-amber-900",
+        subtitle: "text-amber-700"
+      )
+    end
+
+    it "accepts a string colour" do
+      expect(DomainTheme.swatch("blue")).to eq(DomainTheme.swatch(:blue))
+    end
+  end
+
+  describe ".swatch_for" do
+    it "resolves a domain key to its colour swatch" do
+      expect(DomainTheme.swatch_for(:scholarships))
+        .to eq(DomainTheme.swatch(DomainTheme.color_for(:scholarships)))
+    end
+
+    it "falls back to gray for unknown keys" do
+      expect(DomainTheme.swatch_for(:missing)).to eq(DomainTheme.swatch(:gray))
+    end
+  end
+
+  describe ".swatches" do
+    it "returns every pickable colour keyed by name" do
+      expect(DomainTheme.swatches.keys).to eq(DomainTheme::SWATCH_COLORS)
+      expect(DomainTheme.swatches[:amber]).to eq(DomainTheme.swatch(:amber))
+    end
+  end
 end

--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -65,16 +65,16 @@ RSpec.describe RegistrationTicketCallout, type: :model do
   end
 
   describe "#theme" do
-    it "returns the configured colour theme" do
+    it "returns the configured colour swatch" do
       callout.color_class = "amber"
-      expect(callout.theme).to eq(RegistrationTicketCallout::COLOR_THEMES["amber"])
+      expect(callout.theme).to eq(DomainTheme.swatch("amber"))
     end
 
     it "falls back to the per-type default colour when blank" do
       callout.color_class = ""
       callout.callout_type = "reference"
-      default_key = RegistrationTicketCallout::DEFAULT_COLORS["reference"]
-      expect(callout.theme).to eq(RegistrationTicketCallout::COLOR_THEMES[default_key])
+      default_color = RegistrationTicketCallout::DEFAULT_COLORS["reference"]
+      expect(callout.theme).to eq(DomainTheme.swatch(default_color))
     end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The callout model (`RegistrationTicketCallout`) held a generic colour-swatch palette (`COLOR_THEMES`) alongside callout-specific defaults. That mixes two concerns.
- Theme colours buried in a model are the wrong place to look when re-theming the app, and the swatches couldn't be reused — boxes like "amount due" and the scholarship box still hard-code Tailwind class lists.
- This consolidates all generic colour theming in one place (`DomainTheme`), so a single edit re-themes the app and any feature can reuse the swatches.

### How did you approach the change?
- Moved the swatch palette and colour list out of the callout model into `DomainTheme`:
  - `SWATCH_COLORS` — the curated, user-pickable palette (the callout colour dropdown).
  - `SWATCH_ROLES` — role → intensity templates (`icon` 500, `border` 300, `bg` 50, `hover` bg-100, `title` 900, `subtitle` 700).
  - `DomainTheme.swatch(color)` — full role→class hash for a raw colour.
  - `DomainTheme.swatch_for(key)` — resolves a **domain key** to its swatch via its theme colour (e.g. `swatch_for(:scholarships)` → fuchsia box). Works for every key in `COLORS`, not just the pickable 8.
  - `DomainTheme.swatches` — whole palette keyed by name, for serialising to JS (the callout editor live preview).
- The callout model now keeps only the callout-specific `DEFAULT_ICONS` / `DEFAULT_COLORS`; `#theme` and the editor form/preview delegate to `DomainTheme`.
- No Tailwind/CSS changes needed — every class the swatches produce is already safelisted by the `@source inline(...)` block in `application.tailwind.css` (full palette at all swatch intensities).
- One deliberate normalization: the old hash had two cosmetic one-offs (blue/gray used `border-200`, gray used `subtitle-600`); the generic builder standardizes everyone to `border-300` / `subtitle-700`.

### Anything else to add?
- `swatch` is fixed-intensity per role today. Converting existing hard-coded boxes (amount-due, scholarship) is a natural follow-up; if a box needs a punchier fill than `bg-50`, we'd add an `intensity:` option to `swatch` then.
- Tests: added swatch/`swatch_for`/`swatches` coverage in `domain_theme_spec`; updated callout model spec to assert against `DomainTheme.swatch`. Callout model + request specs and RuboCop all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)