### PR TITLE
Rename "System notifications" to "Notifications"

### DIFF
--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -33,7 +33,7 @@ module AdminCardsHelper
       model_card(:quotes, icon: "💬", intensity: 100),
       model_card(:payments, icon: "💳"),
       custom_card("Scholarships", grants_path, icon: "🎓", color: :fuchsia),
-      custom_card("System notifications", notifications_path, icon: "🔔"),
+      model_card(:notifications, icon: "🔔"),
       model_card(:story_ideas, icon: "✍🏾️", intensity: 100),
       custom_card("Tags", tags_path, icon: "🏷️", color: :lime, intensity: 100),
       model_card(:workshop_ideas, icon: "💡", intensity: 100),

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,7 @@
       <div class="flex justify-between items-center mb-6">
         <section class="w-full">
           <div class="flex flex-col items-start mb-4">
-            <h1 class="text-3xl font-bold text-gray-900 my-2">System notifications</h1>
+            <h1 class="text-3xl font-bold text-gray-900 my-2">Notifications</h1>
           </div>
 
           <%= render "search_boxes" %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -11,7 +11,7 @@
   <div class="flex items-start justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold text-gray-900">
-        System notification
+        Notification
       </h1>
 
       <p class="text-sm text-gray-500">

--- a/spec/requests/unconfirmed_login_spec.rb
+++ b/spec/requests/unconfirmed_login_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Unconfirmed user login", type: :request do
       expect(session[:unconfirmed_email]).to be_nil
     end
 
-    it "creates a system notification" do
+    it "creates a notification" do
       post user_session_path, params: { user: { email: user.email, password: "password123" } }
 
       expect {


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The admin UI labeled these "System notifications," but the "System" qualifier added no meaning beyond the `Notification` model name.
- This relabels the UI to simply "Notifications," matching the model and reducing redundant copy.

### How did you approach the change?
- Updated the two hard-coded headings in the notifications index and show views.
- Replaced the hard-coded dashboard `custom_card("System notifications", notifications_path, …)` with `model_card(:notifications, …)`, so the card's title and path are derived from the model (styling is unchanged — it falls back to the same gray theme).
- Renamed a stale `it "creates a system notification"` test label to match.

### UI Testing Checklist
- [ ] Admin dashboard shows a "Notifications" card linking to `/notifications`.
- [ ] Notifications index heading reads "Notifications".
- [ ] A notification detail page heading reads "Notification".

### Anything else to add?
- No locale/en.yml entries existed for these strings, so nothing to remove there. `DomainTheme` has no `:notifications` key, so the card keeps its existing gray fallback styling.