### PR TITLE
Filterable recipient picker and confirm step for bulk event reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~75 files |
-| `app/services/` | Service objects for complex logic | ~24 files |
+| `app/services/` | Service objects for complex logic | ~25 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 14 concerns |
 
@@ -194,6 +194,7 @@ end
 
 - `EventRegistrationServices::ProcessConfirmation` — Registration confirmation flow
 - `EventRegistrationServices::PublicRegistration` — Public registration handling
+- `ReminderRecipientFilter` — Decides which event registrations stay checked on the bulk reminder page given the admin's filters (matches in memory, returns matching ids)
 
 ### Notifications
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show, :staff, :details, :ce_hours ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants details ce_hours staff edit_staff update_staff recipients bulk_payments preview_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
+  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants details ce_hours staff edit_staff update_staff recipients bulk_payments preview_reminder confirm_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
 
   def index
     authorize!
@@ -259,9 +259,23 @@ class EventsController < ApplicationController
     authorize! @event
     @event = @event.decorate
     @event_registrations = @event.event_registrations
-      .includes(registrant: [ :user, :contact_methods ])
+      .includes(
+        :event, :organizations, :comments,
+        { scholarships: { grant: :donor } },
+        registrant: [ :user, :contact_methods ]
+      )
       .joins(:registrant)
       .select { |r| r.registrant.preferred_email.present? }
+
+    # Filters keep every registrant in the list and only flag who still matches,
+    # so the recipient checkboxes pre-check the matched set rather than removing
+    # rows. See app/views/events/_reminder_recipients.html.erb.
+    recipient_filter = ReminderRecipientFilter.new(@event_registrations, params)
+    @matched_ids = recipient_filter.matched_ids
+    @filtering = recipient_filter.filtering?
+
+    return render partial: "events/reminder_recipients" if turbo_frame_request?
+
     @sample_registration = @event_registrations.first
     days_until_event = @event.start_date.present? ? (@event.start_date.to_date - Date.current).to_i : nil
     # Pre-fill the editable message with the standard reminder sentence (days
@@ -281,15 +295,31 @@ class EventsController < ApplicationController
     end
   end
 
+  # Interstitial between picking recipients and actually sending: it lists exactly
+  # who will be emailed and shows the static subject + body composed on the picker,
+  # so the admin confirms against a real preview instead of a browser dialog.
+  def confirm_reminder
+    authorize! @event, to: :send_reminder?
+    @event = @event.decorate
+    @event_registrations = selected_reminder_registrations
+    @custom_message = params[:custom_message].to_s
+    @custom_subject = params[:custom_subject].to_s
+
+    if @event_registrations.empty?
+      redirect_to preview_reminder_event_path(@event, custom_message: @custom_message, custom_subject: @custom_subject), alert: "Please select at least one recipient."
+      return
+    end
+
+    mail = EventMailer.event_registration_reminder(@event_registrations.first, custom_message: @custom_message, custom_subject: @custom_subject)
+    @reminder_subject = mail.subject
+    @reminder_preview_html = mail.html_part&.body&.decoded
+  end
+
   def send_reminder
     authorize! @event, to: :send_reminder?
-    allowed_ids = Array(params[:registration_ids]).map(&:to_i).reject(&:zero?)
     custom_message = params[:custom_message].to_s
     custom_subject = params[:custom_subject].to_s
-    registrations = @event.event_registrations
-      .where(id: allowed_ids)
-      .includes(registrant: [ :user, :contact_methods ])
-      .select { |r| r.registrant.preferred_email.present? }
+    registrations = selected_reminder_registrations
 
     if registrations.empty?
       redirect_to preview_reminder_event_path(@event, custom_message: custom_message, custom_subject: custom_subject), alert: "Please select at least one recipient."
@@ -415,6 +445,17 @@ class EventsController < ApplicationController
   end
 
   private
+
+  # The registrations the admin checked on the recipient picker, narrowed to those
+  # we can actually email. Shared by the confirm interstitial and the send action
+  # so both operate on exactly the same set.
+  def selected_reminder_registrations
+    allowed_ids = Array(params[:registration_ids]).map(&:to_i).reject(&:zero?)
+    @event.event_registrations
+      .where(id: allowed_ids)
+      .includes(registrant: [ :user, :contact_methods ])
+      .select { |r| r.registrant.preferred_email.present? }
+  end
 
   # Reloads the payment and the data its bulk payment card needs, so the
   # allocate turbo stream can re-render the whole card with fresh due/allocated

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,9 +48,8 @@ module ApplicationHelper
   # reminder page (admins can edit it). Mirrors the mailer's fallback subject; the
   # event date is event-level, resolved here in the app default time zone.
   def default_reminder_subject(event)
-    organization = ENV.fetch("ORGANIZATION_NAME", "AWBW")
     date_suffix = event.start_date.present? ? " – #{event.start_date.in_time_zone.strftime('%B %-d, %Y')}" : ""
-    "#{organization} Portal: Reminder: #{event.title}#{date_suffix}"
+    "AWBW Portal: Reminder: #{event.title}#{date_suffix}"
   end
 
   # Tokens an admin can drop into a form header; each is filled from the event the

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -62,7 +62,7 @@ class EventMailer < ApplicationMailer
     # Admins can override the subject from the bulk-reminder page; fall back to
     # the standard portal subject (e.g. on a resend that carries no custom value).
     date_suffix = @event.start_date.present? ? " – #{@event.start_date.in_time_zone(@time_zone).strftime('%B %-d, %Y')}" : ""
-    default_subject = "#{@organization_name} Portal: Reminder: #{@event.title}#{date_suffix}"
+    default_subject = "AWBW Portal: Reminder: #{@event.title}#{date_suffix}"
     mail(
       to: @person.preferred_email,
       from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -257,6 +257,19 @@ class EventRegistration < ApplicationRecord
     active? && payment_access_granted? && event.videoconference_window_open?
   end
 
+  # Bucket the registrant's login account into one of four states for the bulk
+  # reminder filters. Precedence matters: a confirmed, unlocked, active account
+  # has access regardless of when it was invited; a still-pending account counts
+  # as "invited" only while it hasn't gained access. Returns one of
+  # "none", "has_access", "invited", "no_access".
+  def account_status
+    account = registrant&.user
+    return "none" if account.nil?
+    return "has_access" if account.has_access?
+    return "invited" if account.welcome_instructions_sent_at.present?
+    "no_access"
+  end
+
   def attendance_status_label
     return "—" if status.blank?
     case status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,12 @@ class User < ApplicationRecord
     super && !inactive?
   end
 
+  # Instance-level mirror of the `has_access` scope: the account can sign in —
+  # confirmed, not locked, not deactivated.
+  def has_access?
+    locked_at.nil? && !inactive? && confirmed_at.present?
+  end
+
   def bookmark_for(record)
     if bookmarks.loaded?
       bookmarks.detect { |b| b.bookmarkable_type == record.class.name && b.bookmarkable_id == record.id && !b.destroyed? }

--- a/app/services/reminder_recipient_filter.rb
+++ b/app/services/reminder_recipient_filter.rb
@@ -1,0 +1,134 @@
+# Decides which event registrations on the bulk reminder page still match the
+# admin's filters. The page keeps every registrant visible and only unchecks the
+# ones that don't match, so this returns the set of matching ids rather than a
+# narrowed list. Matching runs in memory against the already-loaded registrations
+# (the action loads them all up front) so the predicates can lean on associations
+# like scholarships, grants, organizations, comments and the registrant's user
+# account without extra per-filter SQL.
+class ReminderRecipientFilter
+  FILTER_KEYS = %i[
+    name reg_org grantor comment email payment_status scholarship_status
+    account_status ce_status
+  ].freeze
+
+  def initialize(event_registrations, params)
+    @event_registrations = event_registrations
+    @params = params
+  end
+
+  def matched_ids
+    @event_registrations.select { |reg| matches?(reg) }.map(&:id).to_set
+  end
+
+  # True when at least one filter is narrowing the list. The view uses this to
+  # keep "select all" checked by default and to avoid implying a filter is active
+  # when none is.
+  def filtering?
+    FILTER_KEYS.any? { |key| @params[key].present? }
+  end
+
+  private
+
+  def matches?(reg)
+    matches_name?(reg) &&
+      matches_reg_org?(reg) &&
+      matches_grantor?(reg) &&
+      matches_comment?(reg) &&
+      matches_email?(reg) &&
+      matches_payment_status?(reg) &&
+      matches_scholarship_status?(reg) &&
+      matches_account_status?(reg) &&
+      matches_ce_status?(reg)
+  end
+
+  def matches_name?(reg)
+    any_term?(:name) { |term| reg.registrant.full_name.downcase.include?(term) }
+  end
+
+  def matches_reg_org?(reg)
+    any_term?(:reg_org) do |term|
+      reg.organizations.any? { |org| org.name.to_s.downcase.include?(term) }
+    end
+  end
+
+  # Grantor = the funder behind a scholarship's grant. Only registrants who hold a
+  # scholarship drawn from a grant can match, per the filter label.
+  def matches_grantor?(reg)
+    any_term?(:grantor) do |term|
+      reg.scholarships.any? do |scholarship|
+        grant = scholarship.grant
+        grant.present? && grant.funder_name.to_s.downcase.include?(term)
+      end
+    end
+  end
+
+  def matches_comment?(reg)
+    any_term?(:comment) do |term|
+      reg.comments.any? { |comment| comment.body.to_s.downcase.include?(term) }
+    end
+  end
+
+  # Matches against every email we hold for the registrant (their account email,
+  # contact email and secondary email), so a search hits whichever address the
+  # admin remembers.
+  def matches_email?(reg)
+    any_term?(:email) do |term|
+      registrant_emails(reg).any? { |email| email.include?(term) }
+    end
+  end
+
+  def registrant_emails(reg)
+    person = reg.registrant
+    [ person.preferred_email, person.email, person.email_2, person.user&.email ]
+      .compact_blank.map(&:downcase)
+  end
+
+  def matches_payment_status?(reg)
+    case @params[:payment_status].presence
+    when "paid" then reg.paid_in_full?
+    when "unpaid" then reg.event.cost_cents.to_i > 0 && !reg.paid_in_full?
+    when "intends_to_pay" then reg.intends_to_pay?
+    when "paid_or_intends" then reg.payment_access_granted?
+    else true
+    end
+  end
+
+  def matches_scholarship_status?(reg)
+    case @params[:scholarship_status].presence
+    when "requested" then reg.scholarship_requested?
+    when "allocated" then reg.scholarships.any?
+    when "tasks_completed"
+      reg.scholarships.any? && reg.scholarships.all?(&:tasks_completed?)
+    else true
+    end
+  end
+
+  def matches_account_status?(reg)
+    status = @params[:account_status].presence
+    return true if status.blank?
+    reg.account_status == status
+  end
+
+  # CE sub-statuses (missing license / missing hours) only make sense for someone
+  # who actually requested CE credit, so they're gated on that. "paid" has no
+  # CE-specific payment record yet, so it falls back to the registrant being paid
+  # in full.
+  def matches_ce_status?(reg)
+    case @params[:ce_status].presence
+    when "requested" then reg.ce_credit_requested?
+    when "license_not_provided" then reg.ce_credit_requested? && !reg.ce_license_provided?
+    when "hours_not_provided" then reg.ce_credit_requested? && reg.ce_hours_requested.to_i <= 0
+    when "paid" then reg.ce_credit_requested? && reg.paid_in_full?
+    else true
+    end
+  end
+
+  # Text filters accept several values separated by "--" and match a registrant
+  # when ANY of them hits (e.g. "amy--aisha" keeps both Amy and Aisha). Single
+  # hyphens inside a value are preserved. Returns true when no term was typed.
+  def any_term?(key)
+    tokens = @params[key].to_s.downcase.split("--").map(&:strip).reject(&:blank?)
+    return true if tokens.empty?
+    tokens.any? { |token| yield token }
+  end
+end

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -1,0 +1,82 @@
+<%# Filters for the bulk reminder recipient list. They do not remove rows — the
+    list stays whole and only the matching registrants stay checked. The form
+    auto-submits into the reminder_recipients turbo frame via the collection
+    controller, mirroring the workshops and registrants filters. %>
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<%# Grey the dropdown text only while the include_blank placeholder (the first
+    option) is the one selected, so a chosen value still reads in dark text. %>
+<% select_class = "#{field_class} has-[option:first-child:checked]:text-gray-400" %>
+<% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
+<%= form_with url: preview_reminder_event_path(@event), method: :get,
+  data: { controller: "collection", turbo_frame: "reminder_recipients" },
+  autocomplete: "off",
+  class: "bg-white border border-gray-200 rounded-xl shadow-sm p-4 mb-6" do %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-4 items-end">
+    <div>
+      <%= label_tag :name, "Name", class: label_class %>
+      <%= text_field_tag :name, params[:name], class: field_class, placeholder: "Registrant name" %>
+    </div>
+    <div>
+      <%= label_tag :reg_org, "Organization", class: label_class %>
+      <%= text_field_tag :reg_org, params[:reg_org], class: field_class, placeholder: "Organization name" %>
+    </div>
+    <div>
+      <%= label_tag :grantor, "Grantor", class: label_class %>
+      <%= text_field_tag :grantor, params[:grantor], class: field_class, placeholder: "Grantor name" %>
+    </div>
+    <div>
+      <%= label_tag :comment, "Comment", class: label_class %>
+      <%= text_field_tag :comment, params[:comment], class: field_class, placeholder: "Comment text" %>
+    </div>
+    <div>
+      <%= label_tag :email, "Email", class: label_class %>
+      <%= text_field_tag :email, params[:email], class: field_class, placeholder: "Email address" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 items-end">
+    <% if @event.cost_cents.to_i > 0 %>
+      <div>
+        <%= label_tag :payment_status, "Payment", class: label_class %>
+        <%= select_tag :payment_status,
+              options_for_select(
+                [ [ "Paid", "paid" ], [ "Due", "unpaid" ], [ "Intends to pay", "intends_to_pay" ], [ "Paid + intends", "paid_or_intends" ] ],
+                params[:payment_status]
+              ),
+              include_blank: "Any payment status", class: select_class %>
+      </div>
+    <% end %>
+    <div>
+      <%= label_tag :scholarship_status, "Scholarship", class: label_class %>
+      <%= select_tag :scholarship_status,
+            options_for_select(
+              [ [ "Requested", "requested" ], [ "Allocated", "allocated" ], [ "Tasks completed", "tasks_completed" ] ],
+              params[:scholarship_status]
+            ),
+            include_blank: "Any scholarship status", class: select_class %>
+    </div>
+    <div>
+      <%= label_tag :ce_status, "CE", class: label_class %>
+      <%= select_tag :ce_status,
+            options_for_select(
+              [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+              params[:ce_status]
+            ),
+            include_blank: "Any CE status", class: select_class %>
+    </div>
+    <div>
+      <%= label_tag :account_status, "User account", class: label_class %>
+      <%= select_tag :account_status,
+            options_for_select(
+              [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+              params[:account_status]
+            ),
+            include_blank: "Any account status", class: select_class %>
+    </div>
+    <div class="flex items-end">
+      <%= link_to "Clear filters", preview_reminder_event_path(@event),
+            class: "btn btn-utility-outline",
+            data: { action: "collection#clearAndSubmit" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/events/_reminder_recipients.html.erb
+++ b/app/views/events/_reminder_recipients.html.erb
@@ -1,0 +1,52 @@
+<%= turbo_frame_tag "reminder_recipients" do %>
+  <% matched_count = @event_registrations.count { |reg| @matched_ids.include?(reg.id) } %>
+  <% all_matched = matched_count == @event_registrations.size %>
+  <p class="text-sm text-gray-600 mb-2">
+    <span class="font-medium text-gray-800"><%= matched_count %></span>
+    of <%= @event_registrations.size %> selected<%= " by filters" if @filtering %>
+  </p>
+  <div class="overflow-x-auto border border-gray-200 rounded-lg mb-6">
+    <table class="w-full border-collapse">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-10">
+            <input type="checkbox" id="recipients_select_all" class="rounded border-gray-300" <%= "checked" if all_matched %> aria-label="Select all" onclick="document.querySelectorAll('.recipient-checkbox').forEach(function(c){ c.checked = document.getElementById('recipients_select_all').checked })">
+          </th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Email</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Payment status</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white">
+        <% @event_registrations.each do |reg| %>
+          <% person = reg.registrant %>
+          <% matched = @matched_ids.include?(reg.id) %>
+          <tr class="hover:bg-gray-50 <%= "bg-gray-50/60 text-gray-400" unless matched %>">
+            <td class="px-4 py-2">
+              <%= check_box_tag "registration_ids[]", reg.id, matched, class: "recipient-checkbox rounded border-gray-300", id: "registration_ids_#{reg.id}" %>
+            </td>
+            <td class="px-4 py-2 text-sm"><%= person.full_name %></td>
+            <td class="px-4 py-2 text-sm"><%= person.preferred_email %></td>
+            <td class="px-4 py-2 text-sm">
+              <% org_names = reg.organizations.map(&:name).compact_blank %>
+              <%= org_names.any? ? org_names.join(", ") : content_tag(:span, "—", class: "text-gray-400") %>
+            </td>
+            <td class="px-4 py-2 text-sm">
+              <% if @event.object.cost_cents.to_i > 0 %>
+                <% if reg.paid_in_full? %>
+                  <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-green-50 text-green-700 border-green-200">Paid</span>
+                <% else %>
+                  <% due_cents = @event.object.cost_cents - reg.allocations_sum %>
+                  <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-amber-50 text-amber-700 border-amber-200">$<%= "%.2f" % (due_cents / 100.0) %> due</span>
+                <% end %>
+              <% else %>
+                <span class="text-gray-400">—</span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -1,0 +1,69 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
+      returns to the recipient picker so the admin can adjust the selection. %>
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, custom_subject: @custom_subject, custom_message: @custom_message), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= render "events/subnav", event: @event, current: nil %>
+  </div>
+
+  <div class="mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Send reminder emails</h1>
+    <p class="text-gray-600 mt-1">
+      <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
+    </p>
+  </div>
+
+  <% count = @event_registrations.size %>
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+    <div class="flex items-start gap-2">
+      <i class="fa-solid fa-circle-info text-blue-500 mt-0.5"></i>
+      <div class="text-sm text-blue-800">
+        <p class="font-medium">You're about to email <%= count %> registrant<%= "s" if count != 1 %>.</p>
+        <p class="mt-1">Review the recipients and the message below, then send. Each person receives their own copy, and one FYI email will be sent to the admin.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="bg-white border border-gray-200 rounded-lg p-4 mb-6">
+    <h2 class="text-lg font-semibold text-gray-800 mb-3">Recipients <span class="text-gray-400 font-normal">(<%= count %>)</span></h2>
+
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated</h3>
+    <p class="text-sm text-gray-700 mb-4 break-words">
+      <%= @event_registrations.map { |reg| reg.registrant.full_name }.join(", ") %>
+    </p>
+
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Full list</h3>
+    <ul class="columns-1 sm:columns-2 gap-x-8 text-sm">
+      <% @event_registrations.each do |reg| %>
+        <li class="break-inside-avoid mb-1">
+          <span class="text-gray-900"><%= reg.registrant.full_name %></span>
+          <span class="text-gray-400">&lt;<%= reg.registrant.preferred_email %>&gt;</span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="bg-white border border-gray-200 rounded-lg overflow-hidden mb-6">
+    <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
+      <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Subject</p>
+      <p class="text-sm font-medium text-gray-900"><%= @reminder_subject %></p>
+    </div>
+    <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
+      <%= raw @reminder_preview_html %>
+    </div>
+  </div>
+
+  <%= form_with url: send_reminder_event_path(@event), method: :post, data: { turbo: false } do |f| %>
+    <% @event_registrations.each do |reg| %>
+      <%= hidden_field_tag "registration_ids[]", reg.id %>
+    <% end %>
+    <%# Carry the composed subject/message through to the send untouched. %>
+    <%= hidden_field_tag :custom_subject, @custom_subject %>
+    <%= hidden_field_tag :custom_message, @custom_message %>
+    <div class="flex justify-center gap-3">
+      <%= link_to "Cancel", preview_reminder_event_path(@event, custom_subject: @custom_subject, custom_message: @custom_message), class: "btn btn-secondary-outline" %>
+      <%= f.submit "Send reminder", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -11,56 +11,26 @@
       Send reminder emails
     </h1>
     <p class="text-gray-600 mt-1">
-      <%= @event.title %>
+      <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
   </div>
   <% if @event_registrations.empty? %>
     <p class="text-gray-600 mb-4">There are no registrants with an email address to send a reminder to.</p>
     <%= link_to "Back to registrants", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
   <% else %>
-    <%= form_with url: send_reminder_event_path(@event), method: :post, local: true, data: { controller: "reminder-preview" } do |f| %>
-      <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
-      <p class="text-gray-600 mb-3">
-        Choose who will receive this reminder:
-      </p>
-      <div class="overflow-x-auto border border-gray-200 rounded-lg mb-6">
-        <table class="w-full border-collapse">
-          <thead class="bg-gray-100">
-            <tr>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-10">
-                <input type="checkbox" id="recipients_select_all" class="rounded border-gray-300" checked aria-label="Select all" onclick="document.querySelectorAll('.recipient-checkbox').forEach(function(c){ c.checked = document.getElementById('recipients_select_all').checked })">
-              </th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Email</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Payment status</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200 bg-white">
-            <% @event_registrations.each do |reg| %>
-              <% person = reg.registrant %>
-              <tr class="hover:bg-gray-50">
-                <td class="px-4 py-2">
-                  <%= check_box_tag "registration_ids[]", reg.id, true, class: "recipient-checkbox rounded border-gray-300", id: "registration_ids_#{reg.id}" %>
-                </td>
-                <td class="px-4 py-2 text-sm text-gray-900"><%= person.full_name %></td>
-                <td class="px-4 py-2 text-sm text-gray-700"><%= person.preferred_email %></td>
-                <td class="px-4 py-2 text-sm">
-                  <% if @event.object.cost_cents.to_i > 0 %>
-                    <% if reg.paid_in_full? %>
-                      <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-green-50 text-green-700 border-green-200">Paid</span>
-                    <% else %>
-                      <% due_cents = @event.object.cost_cents - reg.allocations_sum %>
-                      <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-amber-50 text-amber-700 border-amber-200">$<%= "%.2f" % (due_cents / 100.0) %> due</span>
-                    <% end %>
-                  <% else %>
-                    <span class="text-gray-400">—</span>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+    <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
+    <p class="text-gray-600 mb-3">
+      Choose who will receive this reminder. Filters keep everyone in the list and
+      simply check the registrants who match. Separate multiple values with
+      <code class="font-mono">--</code> to match any of them (e.g.
+      <code class="font-mono">amy--aisha</code>).
+    </p>
+    <%= render "events/reminder_recipient_filters" %>
+    <%# Turbo disabled: this POST renders the confirmation interstitial (a full
+        page), not a redirect, so a normal browser navigation is what we want.
+        reminder-preview drives the live message/subject preview as the admin types. %>
+    <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
+      <%= render "events/reminder_recipients" %>
       <div class="mb-6">
         <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Subject</h2>
         <p class="text-gray-600 mb-2">
@@ -73,7 +43,7 @@
       <div class="mb-6">
         <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Message</h2>
         <p class="text-gray-600 mb-2">
-          The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" / "View event" buttons are always included.
+          The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
         </p>
         <p class="text-xs text-gray-500 mb-2">
           Accepts basic HTML — bold, italics, links, lists, and line breaks.
@@ -97,7 +67,10 @@
           </div>
         </div>
       <% end %>
-      <%= f.submit "Send reminder", class: "btn btn-primary", data: { turbo_confirm: "Send reminder emails to the selected registrant(s)?" } %>
+      <div class="mt-8 flex justify-center gap-3">
+        <%= link_to "Cancel", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
+        <%= f.submit "Review & send", class: "btn btn-primary" %>
+      </div>
     <% end %>
   <% end %>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -238,6 +238,40 @@
         79
       ],
       "note": "Admin-only reminder preview. The raw value is the server-rendered email HTML; the custom message it embeds is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "343336d81aa87ab12862c5f9ca2b0f9ac4155488c053c1ce9c7ed27c456e3dba",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/events/confirm_reminder.html.erb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "EventMailer.event_registration_reminder(selected_reminder_registrations.first, :custom_message => params[:custom_message].to_s, :custom_subject => params[:custom_subject].to_s).html_part.body.decoded",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "EventsController",
+          "method": "confirm_reminder",
+          "line": 316,
+          "file": "app/controllers/events_controller.rb",
+          "rendered": {
+            "name": "events/confirm_reminder",
+            "file": "app/views/events/confirm_reminder.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "events/confirm_reminder"
+      },
+      "user_input": "params[:custom_message].to_s",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Admin-only reminder confirmation. Same as preview_reminder: the raw value is the server-rendered email HTML; the embedded custom message is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
     }
   ],
   "brakeman_version": "8.0.4"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
       get :preview_reminder
       patch :preview
       post :copy_registration_form
+      post :confirm_reminder
       post :send_reminder
       post :allocate_bulk_payment
       post :create_bulk_payment

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -329,21 +329,16 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#default_reminder_subject" do
-    before do
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("ORGANIZATION_NAME", "AWBW").and_return("A Window Between Worlds")
-    end
-
-    it "names the organization, event title, and formatted start date" do
+    it "uses the AWBW Portal prefix with the event title and formatted start date" do
       event = build(:event, title: "Healing Workshop", start_date: Time.zone.local(2026, 8, 7, 18, 0))
       expect(helper.default_reminder_subject(event))
-        .to eq("A Window Between Worlds Portal: Reminder: Healing Workshop – August 7, 2026")
+        .to eq("AWBW Portal: Reminder: Healing Workshop – August 7, 2026")
     end
 
     it "omits the date suffix when the event has no start date" do
       event = build(:event, title: "Healing Workshop", start_date: nil)
       expect(helper.default_reminder_subject(event))
-        .to eq("A Window Between Worlds Portal: Reminder: Healing Workshop")
+        .to eq("AWBW Portal: Reminder: Healing Workshop")
     end
   end
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -596,4 +596,30 @@ RSpec.describe EventRegistration, type: :model do
       expect(slugs.uniq.size).to eq(10)
     end
   end
+
+  describe "#account_status" do
+    def registration_for(person)
+      create(:event_registration, registrant: person)
+    end
+
+    it "is none when the registrant has no user account" do
+      expect(registration_for(create(:person, user: nil)).account_status).to eq("none")
+    end
+
+    it "is has_access for a confirmed, unlocked, active account" do
+      expect(registration_for(create(:person)).account_status).to eq("has_access")
+    end
+
+    it "is invited when the account is pending but was sent a welcome" do
+      person = create(:person)
+      person.user.update!(confirmed_at: nil, welcome_instructions_sent_at: Time.current)
+      expect(registration_for(person).account_status).to eq("invited")
+    end
+
+    it "is no_access when the account cannot sign in and has no pending invite" do
+      person = create(:person)
+      person.user.update!(confirmed_at: nil, welcome_instructions_sent_at: nil)
+      expect(registration_for(person).account_status).to eq("no_access")
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe User do
     end
   end
 
+  describe "#has_access?" do
+    it "is true for a confirmed, unlocked, active account" do
+      expect(build(:user, confirmed_at: Time.current, locked_at: nil, inactive: false).has_access?).to be(true)
+    end
+
+    it "is false when unconfirmed" do
+      expect(build(:user, confirmed_at: nil).has_access?).to be(false)
+    end
+
+    it "is false when locked" do
+      expect(build(:user, confirmed_at: Time.current, locked_at: Time.current).has_access?).to be(false)
+    end
+
+    it "is false when deactivated" do
+      expect(build(:user, confirmed_at: Time.current, inactive: true).has_access?).to be(false)
+    end
+  end
+
   describe '#bookmark_for' do
     let(:user) { create(:user) }
     let(:workshop) { create(:workshop) }

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# The bulk reminder page keeps every emailable registrant in the list and uses
+# the filters only to decide who stays checked. These specs lock in that
+# "filter checks, never hides" behaviour and the turbo-frame auto-refresh.
+RSpec.describe "Events::BulkReminders", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, cost_cents: 10_000) }
+  let!(:jane) { create(:event_registration, event: event, registrant: create(:person, first_name: "Jane", last_name: "Adams")) }
+  let!(:sam) { create(:event_registration, event: event, registrant: create(:person, first_name: "Sam", last_name: "Cole")) }
+
+  before { sign_in admin }
+
+  def checked?(body, registration)
+    node = Nokogiri::HTML(body).at_css("#registration_ids_#{registration.id}")
+    node.present? && node["checked"].present?
+  end
+
+  it "checks every registrant by default" do
+    get preview_reminder_event_path(event)
+
+    expect(response).to have_http_status(:ok)
+    expect(checked?(response.body, jane)).to be(true)
+    expect(checked?(response.body, sam)).to be(true)
+  end
+
+  it "keeps all registrants visible but only checks the matches when filtered" do
+    get preview_reminder_event_path(event, name: "jane"),
+        headers: { "Turbo-Frame" => "reminder_recipients" }
+
+    expect(response).to have_http_status(:ok)
+    # Both rows still render...
+    expect(response.body).to include("Jane Adams")
+    expect(response.body).to include("Sam Cole")
+    # ...but only the matching registrant stays checked.
+    expect(checked?(response.body, jane)).to be(true)
+    expect(checked?(response.body, sam)).to be(false)
+  end
+
+  describe "confirm interstitial" do
+    it "lists the selected recipients and the message preview without sending yet" do
+      expect {
+        post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ], custom_message: "See you soon!" }
+      }.not_to change(Notification, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Jane Adams")
+      expect(response.body).not_to include("Sam Cole")
+      # Subject line and the composed message are shown on the interstitial.
+      expect(response.body).to include("Reminder: #{event.title}")
+      expect(response.body).to include("See you soon!")
+      # The selection + composed content carry forward as hidden fields.
+      expect(response.body).to include("value=\"#{jane.id}\"")
+    end
+
+    it "redirects back to the picker when nothing is selected" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [] }
+
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: ""))
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "sending" do
+    it "creates one reminder notification per selected registrant and one admin FYI" do
+      expect {
+        post send_reminder_event_path(event), params: { registration_ids: [ jane.id, sam.id ], custom_message: "See you soon!" }
+      }.to change { Notification.where(kind: "event_registration_reminder").count }.by(2)
+        .and have_enqueued_mail(EventMailer, :event_registration_reminder_fyi).once
+
+      expect(response).to redirect_to(registrants_event_path(event))
+    end
+  end
+end

--- a/spec/services/reminder_recipient_filter_spec.rb
+++ b/spec/services/reminder_recipient_filter_spec.rb
@@ -1,0 +1,213 @@
+require "rails_helper"
+
+RSpec.describe ReminderRecipientFilter do
+  let(:event) { create(:event, cost_cents: 10_000) }
+
+  def registration(first_name: "Jane", last_name: "Doe", **person_attrs)
+    person = create(:person, first_name: first_name, last_name: last_name, **person_attrs)
+    create(:event_registration, event: event, registrant: person)
+  end
+
+  def award_scholarship(reg, grant: nil, tasks_completed: false)
+    scholarship = create(:scholarship, recipient: reg.registrant, grant: grant, tasks_completed: tasks_completed)
+    create(:allocation, allocatable: reg, source: scholarship, amount: scholarship.amount_cents)
+    scholarship
+  end
+
+  def matched(params, registrations)
+    described_class.new(registrations, ActionController::Parameters.new(params)).matched_ids
+  end
+
+  describe "#filtering?" do
+    it "is false with no filter params and true once any filter is set" do
+      expect(described_class.new([], ActionController::Parameters.new({})).filtering?).to be(false)
+      expect(described_class.new([], ActionController::Parameters.new(name: "x")).filtering?).to be(true)
+    end
+  end
+
+  describe "#matched_ids" do
+    it "matches everyone when no filters are applied" do
+      regs = [ registration, registration(first_name: "Sam") ]
+      expect(matched({}, regs)).to eq(regs.map(&:id).to_set)
+    end
+
+    it "filters by registrant name" do
+      jane = registration(first_name: "Jane")
+      sam = registration(first_name: "Samuel")
+      expect(matched({ name: "jane" }, [ jane, sam ])).to eq([ jane.id ].to_set)
+    end
+
+    it "matches any of several names separated by --" do
+      amy = registration(first_name: "Amy")
+      aisha = registration(first_name: "Aisha")
+      sam = registration(first_name: "Sam")
+      expect(matched({ name: "amy--aisha" }, [ amy, aisha, sam ])).to eq([ amy.id, aisha.id ].to_set)
+    end
+
+    it "preserves single hyphens inside a name term" do
+      hyphen = registration(first_name: "Mary", last_name: "Jane-Wells")
+      other = registration(first_name: "Sam")
+      expect(matched({ name: "jane-wells" }, [ hyphen, other ])).to eq([ hyphen.id ].to_set)
+    end
+
+    it "matches any of several organization names separated by --" do
+      hope = registration(first_name: "Hope").tap { |r| r.organizations << create(:organization, name: "Hope Center") }
+      unity = registration(first_name: "Unity").tap { |r| r.organizations << create(:organization, name: "Unity House") }
+      other = registration(first_name: "Sam").tap { |r| r.organizations << create(:organization, name: "Elsewhere") }
+      expect(matched({ reg_org: "hope--unity" }, [ hope, unity, other ])).to eq([ hope.id, unity.id ].to_set)
+    end
+
+    it "filters by registration organization name" do
+      reg = registration
+      reg.organizations << create(:organization, name: "Hope Center")
+      other = registration(first_name: "Sam")
+      expect(matched({ reg_org: "hope" }, [ reg, other ])).to eq([ reg.id ].to_set)
+    end
+
+    it "filters by grantor name of an associated grant" do
+      donor = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, donor: donor)
+      reg = registration
+      award_scholarship(reg, grant: grant)
+      ungranted = registration(first_name: "Sam")
+      award_scholarship(ungranted) # scholarship with no grant
+      expect(matched({ grantor: "acme" }, [ reg, ungranted ])).to eq([ reg.id ].to_set)
+    end
+
+    it "filters by email address" do
+      amy = registration(first_name: "Amy", email: "amy@example.com", user: nil)
+      sam = registration(first_name: "Sam", email: "sam@example.com", user: nil)
+      expect(matched({ email: "amy@example" }, [ amy, sam ])).to eq([ amy.id ].to_set)
+    end
+
+    it "matches any of several emails separated by --" do
+      amy = registration(first_name: "Amy", email: "amy@example.com", user: nil)
+      aisha = registration(first_name: "Aisha", email: "aisha@example.com", user: nil)
+      sam = registration(first_name: "Sam", email: "sam@other.com", user: nil)
+      expect(matched({ email: "amy@--aisha@" }, [ amy, aisha, sam ])).to eq([ amy.id, aisha.id ].to_set)
+    end
+
+    it "filters by registration comment text" do
+      reg = registration
+      create(:comment, :for_event_registration, commentable: reg, body: "Needs a payment plan")
+      other = registration(first_name: "Sam")
+      expect(matched({ comment: "payment plan" }, [ reg, other ])).to eq([ reg.id ].to_set)
+    end
+
+    context "payment status" do
+      let!(:paid) { registration.tap { |r| create(:allocation, allocatable: r, amount: 10_000) } }
+      let!(:due) { registration(first_name: "Due") }
+      let!(:intends) { registration(first_name: "Intends").tap { |r| r.update!(intends_to_pay: true) } }
+
+      it "filters paid registrants" do
+        expect(matched({ payment_status: "paid" }, [ paid, due, intends ])).to eq([ paid.id ].to_set)
+      end
+
+      it "filters due registrants" do
+        expect(matched({ payment_status: "unpaid" }, [ paid, due, intends ])).to eq([ due.id, intends.id ].to_set)
+      end
+
+      it "filters intends-to-pay registrants" do
+        expect(matched({ payment_status: "intends_to_pay" }, [ paid, due, intends ])).to eq([ intends.id ].to_set)
+      end
+
+      it "filters paid + intends registrants" do
+        expect(matched({ payment_status: "paid_or_intends" }, [ paid, due, intends ])).to eq([ paid.id, intends.id ].to_set)
+      end
+    end
+
+    context "scholarship status" do
+      let!(:requested) { registration.tap { |r| r.update!(scholarship_requested: true) } }
+      let!(:allocated) { registration(first_name: "Alloc").tap { |r| award_scholarship(r) } }
+      let!(:completed) { registration(first_name: "Done").tap { |r| award_scholarship(r, tasks_completed: true) } }
+
+      it "filters requested" do
+        expect(matched({ scholarship_status: "requested" }, [ requested, allocated, completed ]))
+          .to eq([ requested.id ].to_set)
+      end
+
+      it "filters allocated" do
+        expect(matched({ scholarship_status: "allocated" }, [ requested, allocated, completed ]))
+          .to eq([ allocated.id, completed.id ].to_set)
+      end
+
+      it "filters tasks completed" do
+        expect(matched({ scholarship_status: "tasks_completed" }, [ requested, allocated, completed ]))
+          .to eq([ completed.id ].to_set)
+      end
+    end
+
+    context "account status" do
+      let!(:no_account) { registration(first_name: "None", user: nil) }
+      let!(:has_access) { registration(first_name: "Open") }
+      let!(:invited) do
+        registration(first_name: "Invited").tap do |r|
+          r.registrant.user.update!(confirmed_at: nil, welcome_instructions_sent_at: Time.current)
+        end
+      end
+      let!(:no_access) do
+        registration(first_name: "Locked").tap do |r|
+          r.registrant.user.update!(confirmed_at: nil, welcome_instructions_sent_at: nil)
+        end
+      end
+      let(:regs) { [ no_account, has_access, invited, no_access ] }
+
+      it "filters no account" do
+        expect(matched({ account_status: "none" }, regs)).to eq([ no_account.id ].to_set)
+      end
+
+      it "filters has access" do
+        expect(matched({ account_status: "has_access" }, regs)).to eq([ has_access.id ].to_set)
+      end
+
+      it "filters invited" do
+        expect(matched({ account_status: "invited" }, regs)).to eq([ invited.id ].to_set)
+      end
+
+      it "filters no access" do
+        expect(matched({ account_status: "no_access" }, regs)).to eq([ no_access.id ].to_set)
+      end
+    end
+
+    context "CE status" do
+      # Requested CE, supplied both license and hours, and paid in full.
+      let!(:complete) do
+        registration(first_name: "Complete").tap do |r|
+          r.update!(ce_credit_requested: true, ce_license_number: "ABC123", ce_hours_requested: 3)
+          create(:allocation, allocatable: r, amount: 10_000)
+        end
+      end
+      # Requested CE but missing license and hours, unpaid.
+      let!(:missing) { registration(first_name: "Missing").tap { |r| r.update!(ce_credit_requested: true) } }
+      # Did not request CE at all.
+      let!(:no_ce) { registration(first_name: "None").tap { |r| r.update!(ce_license_number: nil, ce_hours_requested: nil) } }
+      let(:regs) { [ complete, missing, no_ce ] }
+
+      it "filters CE requested" do
+        expect(matched({ ce_status: "requested" }, regs)).to eq([ complete.id, missing.id ].to_set)
+      end
+
+      it "filters CE license not provided (only among CE requesters)" do
+        expect(matched({ ce_status: "license_not_provided" }, regs)).to eq([ missing.id ].to_set)
+      end
+
+      it "filters CE hours not provided (only among CE requesters)" do
+        expect(matched({ ce_status: "hours_not_provided" }, regs)).to eq([ missing.id ].to_set)
+      end
+
+      it "filters CE paid (requested CE and paid in full)" do
+        expect(matched({ ce_status: "paid" }, regs)).to eq([ complete.id ].to_set)
+      end
+    end
+
+    it "combines filters with AND" do
+      donor = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, donor: donor)
+      match = registration(first_name: "Jane", last_name: "Adams").tap { |r| award_scholarship(r, grant: grant) }
+      name_only = registration(first_name: "Jane", last_name: "Brooks")
+      grantor_only = registration(first_name: "Sam", last_name: "Cole").tap { |r| award_scholarship(r, grant: grant) }
+      expect(matched({ name: "jane", grantor: "acme" }, [ match, name_only, grantor_only ]))
+        .to eq([ match.id ].to_set)
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/recipients.html.erb"             => "admin-only bg-white",
     "app/views/events/registrants.html.erb"         => "admin-only bg-blue-100",
     "app/views/events/preview_reminder.html.erb"       => "admin-only bg-blue-100",
+    "app/views/events/confirm_reminder.html.erb"       => "admin-only bg-blue-100",
     "app/views/event_registrations/index.html.erb"     => "admin-only bg-blue-100",
     "app/views/forms/index.html.erb"                   => "admin-only bg-blue-100",
     "app/views/forms/show.html.erb"                    => "admin-only bg-blue-100",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins sending bulk event reminders couldn't target a subset of registrants or review exactly who would be emailed before sending — they had to trust a checkbox list and a browser confirm dialog.
- This adds a filterable recipient picker and a confirmation interstitial so admins can precisely scope and verify a reminder send.

### How did you approach the change?
- Added a `ReminderRecipientFilter` service (matched in memory) that filters the recipient list by name, organization, grantor, comment, and payment/scholarship/CE/account status; filters keep everyone visible and only (un)check who matches, rendered into a turbo frame.
- Added a `confirm_reminder` interstitial that lists the selected recipients (comma-separated + full list) and shows the composed subject/body before the final send, with `send_reminder` and confirm sharing one `selected_reminder_registrations` helper.
- Showed each registrant's connected organizations (comma-separated), widened the page to fit the recipient table, and replaced the `ORGANIZATION_NAME` env indirection with the fixed "AWBW Portal" reminder subject.

### UI Testing Checklist
- [ ] Open an event's "Send reminder emails" page; confirm the recipient table shows connected organizations and the filters check/uncheck matching registrants.
- [ ] Apply each filter (name, organization, grantor, comment, payment/scholarship/CE/account status) and verify only matching rows stay checked.
- [ ] Proceed to the confirm step and verify the recipient list and rendered subject/body match the selection before sending.

### Anything else to add?
- The email-preview `raw` on the confirm page is whitelisted in `config/brakeman.ignore` (same accepted pattern as `preview_reminder`); the embedded custom message is sanitized via `reminder_message_html` and the subject is shown escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)