### PR TITLE
Rename dedupe merge action and button to "perform"

### DIFF
--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -67,7 +67,7 @@ module Dedupable
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
-  def dedupe_execute
+  def dedupe_perform
     authorize!
     config = dedupe_config
     mc = config[:model_class]

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -27,8 +27,8 @@
           </div>
         </div>
 
-        <!-- Execute Form wraps comparison + warning + buttons -->
-        <%= form_with url: url_for(action: :dedupe_execute), method: :post,
+        <!-- Perform Form wraps comparison + warning + buttons -->
+        <%= form_with url: url_for(action: :dedupe_perform), method: :post,
                       data: { turbo: false,
                               turbo_confirm: "Are you sure you want to merge these #{@dedupe[:model_label_plural].downcase}? This action cannot be undone!" } do |f| %>
           <%= f.hidden_field @dedupe[:delete_id_param].to_sym, value: @record_to_delete.id %>
@@ -62,7 +62,7 @@
 
           <!-- Action Buttons -->
           <div class="flex gap-4 justify-center">
-            <%= f.submit "Execute Merge",
+            <%= f.submit "Perform merge",
                         class: "px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold" %>
 
             <%= link_to "Cancel",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
     collection do
       get :dedupe_index
       get :dedupe_preview
-      post :dedupe_execute
+      post :dedupe_perform
       patch :dedupe_update_keep
     end
   end
@@ -207,7 +207,7 @@ Rails.application.routes.draw do
     collection do
       get :dedupe_index
       get :dedupe_preview
-      post :dedupe_execute
+      post :dedupe_perform
       patch :dedupe_update_keep
     end
   end

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe "Dedupable concern", type: :request do
       end
     end
 
-    describe "POST dedupe_execute" do
+    describe "POST dedupe_perform" do
       let!(:keep) { create(:category, name: "Keeper", category_type: category_type, published: true) }
       let!(:delete_rec) { create(:category, name: "Duplicate", category_type: category_type, published: false) }
       let!(:workshop) { create(:workshop) }
@@ -159,7 +159,7 @@ RSpec.describe "Dedupable concern", type: :request do
         before { sign_in admin }
 
         it "merges and redirects with success notice" do
-          post dedupe_execute_categories_path, params: {
+          post dedupe_perform_categories_path, params: {
             category_to_delete_id: delete_rec.id,
             category_to_keep_id: keep.id
           }
@@ -171,7 +171,7 @@ RSpec.describe "Dedupable concern", type: :request do
 
         it "deletes the duplicate record" do
           expect {
-            post dedupe_execute_categories_path, params: {
+            post dedupe_perform_categories_path, params: {
               category_to_delete_id: delete_rec.id,
               category_to_keep_id: keep.id
             }
@@ -182,7 +182,7 @@ RSpec.describe "Dedupable concern", type: :request do
         end
 
         it "moves taggings to the keeper" do
-          post dedupe_execute_categories_path, params: {
+          post dedupe_perform_categories_path, params: {
             category_to_delete_id: delete_rec.id,
             category_to_keep_id: keep.id
           }
@@ -192,7 +192,7 @@ RSpec.describe "Dedupable concern", type: :request do
         end
 
         it "updates the keeper before merging when keep params provided" do
-          post dedupe_execute_categories_path, params: {
+          post dedupe_perform_categories_path, params: {
             category_to_delete_id: delete_rec.id,
             category_to_keep_id: keep.id,
             category_to_keep: { name: "Better Name" }
@@ -202,7 +202,7 @@ RSpec.describe "Dedupable concern", type: :request do
         end
 
         it "redirects to dedupe_index on error" do
-          post dedupe_execute_categories_path, params: {
+          post dedupe_perform_categories_path, params: {
             category_to_delete_id: 999_999,
             category_to_keep_id: keep.id
           }
@@ -218,7 +218,7 @@ RSpec.describe "Dedupable concern", type: :request do
 
         it "denies access and does not merge" do
           expect {
-            post dedupe_execute_categories_path, params: {
+            post dedupe_perform_categories_path, params: {
               category_to_delete_id: delete_rec.id,
               category_to_keep_id: keep.id
             }
@@ -282,7 +282,7 @@ RSpec.describe "Dedupable concern", type: :request do
       end
     end
 
-    describe "POST dedupe_execute" do
+    describe "POST dedupe_perform" do
       before { sign_in admin }
 
       let!(:keep) { create(:sector, name: "Keep Sector", published: true) }
@@ -292,7 +292,7 @@ RSpec.describe "Dedupable concern", type: :request do
 
       it "merges and redirects with success notice" do
         expect {
-          post dedupe_execute_sectors_path, params: {
+          post dedupe_perform_sectors_path, params: {
             sector_to_delete_id: delete_rec.id,
             sector_to_keep_id: keep.id
           }


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Renames the admin dedupe merge action from "execute" to "perform" — "execute" read as developer jargon for an admin-facing flow, and "perform" is clearer for the people operating it.

### How did you approach the change?
- Changed the button label from "Execute Merge" to "Perform merge" (sentence case, keeping its red `bg-red-600` styling).
- Renamed the `dedupe_execute` controller action to `dedupe_perform` and updated both route declarations (categories + sectors), so the path helpers are now `dedupe_perform_*_path`.
- Updated the preview form's `url_for(action:)` reference and the request spec to match; all 24 dedupable specs pass.

### UI Testing Checklist
- [ ] Open the category/sector dedupe preview and confirm the button reads "Perform merge" and is still red.
- [ ] Confirm performing a merge still works (record merged, duplicate deleted, success notice shown).

### Anything else to add?
- Pure rename; no behavioral changes.
