### PR TITLE
Add intends-to-pay chip to reminder recipients and unify due-amount formatting

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -95,7 +95,7 @@ class EventRegistrationsController < ApplicationController
           when "registrants" then redirect_to registrants_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
           when "index" then redirect_to event_registrations_path, notice: "Registration was successfully updated.", status: :see_other
           when "ticket" then redirect_to registration_ticket_path(@event_registration.slug), notice: "Registration was successfully updated.", status: :see_other
-          when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
+          when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event, helpers.reminder_filter_params(params[:reminder_filters])), notice: "Registration was successfully updated.", status: :see_other
           else
             # No explicit origin: keep admins in the management context (the
             # roster) rather than dropping them on the public registration show.

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -95,7 +95,7 @@ class EventRegistrationsController < ApplicationController
           when "registrants" then redirect_to registrants_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
           when "index" then redirect_to event_registrations_path, notice: "Registration was successfully updated.", status: :see_other
           when "ticket" then redirect_to registration_ticket_path(@event_registration.slug), notice: "Registration was successfully updated.", status: :see_other
-          when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event, helpers.reminder_filter_params(params[:reminder_filters])), notice: "Registration was successfully updated.", status: :see_other
+          when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
           else
             # No explicit origin: keep admins in the management context (the
             # roster) rather than dropping them on the public registration show.

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -95,6 +95,7 @@ class EventRegistrationsController < ApplicationController
           when "registrants" then redirect_to registrants_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
           when "index" then redirect_to event_registrations_path, notice: "Registration was successfully updated.", status: :see_other
           when "ticket" then redirect_to registration_ticket_path(@event_registration.slug), notice: "Registration was successfully updated.", status: :see_other
+          when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event), notice: "Registration was successfully updated.", status: :see_other
           else
             # No explicit origin: keep admins in the management context (the
             # roster) rather than dropping them on the public registration show.

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -71,21 +71,6 @@ module EventHelper
     )
   end
 
-  # Recipient filters the send-reminders page had active, sliced to the known
-  # filter keys so we only ever echo recognized params. Used to carry the filters
-  # into a registration edit (nested under `reminder_filters`) and to re-apply
-  # them when returning. See ReminderRecipientFilter and app/views/events/_reminder_recipients.html.erb.
-  def reminder_filter_params(source = params[:reminder_filters])
-    return {} if source.blank?
-    source.permit(*ReminderRecipientFilter::FILTER_KEYS).to_h.compact_blank
-  end
-
-  # Back link to the send-reminders page, re-applying whatever recipient filters
-  # were active when the admin opened a registration from it.
-  def preview_reminder_return_path(event)
-    preview_reminder_event_path(event, reminder_filter_params)
-  end
-
   def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil)
     bg = DomainTheme.bg_class_for(:events, intensity: 100)
     hover_bg = DomainTheme.bg_class_for(:events, intensity: 100, hover: true)

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -71,6 +71,21 @@ module EventHelper
     )
   end
 
+  # Recipient filters the send-reminders page had active, sliced to the known
+  # filter keys so we only ever echo recognized params. Used to carry the filters
+  # into a registration edit (nested under `reminder_filters`) and to re-apply
+  # them when returning. See ReminderRecipientFilter and app/views/events/_reminder_recipients.html.erb.
+  def reminder_filter_params(source = params[:reminder_filters])
+    return {} if source.blank?
+    source.permit(*ReminderRecipientFilter::FILTER_KEYS).to_h.compact_blank
+  end
+
+  # Back link to the send-reminders page, re-applying whatever recipient filters
+  # were active when the admin opened a registration from it.
+  def preview_reminder_return_path(event)
+    preview_reminder_event_path(event, reminder_filter_params)
+  end
+
   def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil)
     bg = DomainTheme.bg_class_for(:events, intensity: 100)
     hover_bg = DomainTheme.bg_class_for(:events, intensity: 100, hover: true)

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -1,9 +1,5 @@
 <%= simple_form_for(event_registration, data: { turbo: false }) do |f| %>
   <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
-  <%# Carry the send-reminders recipient filters so the page re-applies them on return. %>
-  <% reminder_filter_params.each do |key, value| %>
-    <%= hidden_field_tag "reminder_filters[#{key}]", value %>
-  <% end %>
   <%= render "shared/errors", resource: event_registration if event_registration.errors.any? %>
 
   <div data-controller="org-toggle" data-org-toggle-remote-select-outlet="#org-search" class="space-y-6">
@@ -407,7 +403,7 @@
       <% cancel_path = case params[:return_to]
                        when "registrants" then registrants_event_path(event_registration.event)
                        when "index" then event_registrations_path
-                       when "preview_reminder" then preview_reminder_return_path(event_registration.event)
+                       when "preview_reminder" then preview_reminder_event_path(event_registration.event)
                        else allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path
                        end %>
 

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -1,5 +1,9 @@
 <%= simple_form_for(event_registration, data: { turbo: false }) do |f| %>
   <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
+  <%# Carry the send-reminders recipient filters so the page re-applies them on return. %>
+  <% reminder_filter_params.each do |key, value| %>
+    <%= hidden_field_tag "reminder_filters[#{key}]", value %>
+  <% end %>
   <%= render "shared/errors", resource: event_registration if event_registration.errors.any? %>
 
   <div data-controller="org-toggle" data-org-toggle-remote-select-outlet="#org-search" class="space-y-6">
@@ -403,7 +407,7 @@
       <% cancel_path = case params[:return_to]
                        when "registrants" then registrants_event_path(event_registration.event)
                        when "index" then event_registrations_path
-                       when "preview_reminder" then preview_reminder_event_path(event_registration.event)
+                       when "preview_reminder" then preview_reminder_return_path(event_registration.event)
                        else allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path
                        end %>
 

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -403,6 +403,7 @@
       <% cancel_path = case params[:return_to]
                        when "registrants" then registrants_event_path(event_registration.event)
                        when "index" then event_registrations_path
+                       when "preview_reminder" then preview_reminder_event_path(event_registration.event)
                        else allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path
                        end %>
 

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -81,7 +81,7 @@
         <% else %>
           <% due_cents = event_registration.remaining_cost %>
           <div class="text-center mt-2">
-            <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800">$<%= "%.2f" % (due_cents / 100.0) %> payment is due</span>
+            <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800"><%= dollars_from_cents(due_cents) %> payment is due</span>
 
             <% if event_registration.intends_to_pay? %>
               <div class="mt-2">

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -11,7 +11,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
       <% end %>
     <% elsif params[:return_to] == "preview_reminder" %>
-      <%= link_to preview_reminder_return_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Send reminders
       <% end %>
     <% else %>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -11,7 +11,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
       <% end %>
     <% elsif params[:return_to] == "preview_reminder" %>
-      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to preview_reminder_return_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Send reminders
       <% end %>
     <% else %>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -10,6 +10,10 @@
       <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
       <% end %>
+    <% elsif params[:return_to] == "preview_reminder" %>
+      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Send reminders
+      <% end %>
     <% else %>
       <%= link_to registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -80,7 +80,7 @@
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
                                     class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
                           <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.text_class_for(:event_registrations, intensity: 700)} shadow-sm">
-                            <i class="fa-solid fa-user-pen"></i>
+                            <i class="fa-solid fa-clipboard-list"></i>
                           </span>
                           <span class="truncate font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
                         <% end %>

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -110,7 +110,7 @@
                         <%= link_to edit_event_registration_path(reg, return_to: "bulk_payments", expand: submission.id),
                                     title: "View #{reg.registrant.name}'s registration for #{@event.title}",
                                     class: "inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
-                          <i class="fa-solid fa-pen-to-square text-gray-400"></i>
+                          <i class="fa-solid fa-clipboard-list text-gray-400"></i>
                           <% if remaining_cents.zero? %>
                             <span class="font-semibold text-gray-500 whitespace-nowrap">Paid</span>
                           <% else %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -240,15 +240,15 @@
                       <% elsif is_discounted %>
                         <span class="flex flex-col leading-tight text-left">
                           <span>Discounted</span>
-                          <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                          <span><%= dollars_from_cents(due_cents) %> due</span>
                         </span>
                       <% elsif is_partial %>
                         <span class="flex flex-col leading-tight text-left">
                           <span>Partial payment</span>
-                          <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                          <span><%= dollars_from_cents(due_cents) %> due</span>
                         </span>
                       <% else %>
-                        <span><%= "$%.2f due" % (due_cents / 100.0) %></span>
+                        <span><%= dollars_from_cents(due_cents) %> due</span>
                       <% end %>
                       <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                     <% end %>

--- a/app/views/events/_reminder_recipients.html.erb
+++ b/app/views/events/_reminder_recipients.html.erb
@@ -50,8 +50,10 @@
               <% end %>
             </td>
             <td class="px-4 py-2 text-right">
-              <%= link_to edit_event_registration_path(reg, return_to: "preview_reminder", reminder_filters: reminder_filter_params(params)),
-                          title: "View #{person.full_name}'s registration for #{@event.title}",
+              <%# Opens in a new tab so the in-progress subject/message draft on this page isn't lost. %>
+              <%= link_to edit_event_registration_path(reg, return_to: "preview_reminder"),
+                          title: "View #{person.full_name}'s registration for #{@event.title} (opens in a new tab)",
+                          target: "_blank", rel: "noopener",
                           class: "inline-flex items-center shrink-0 rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
                 <i class="fa-solid fa-clipboard-list text-gray-400"></i>
               <% end %>

--- a/app/views/events/_reminder_recipients.html.erb
+++ b/app/views/events/_reminder_recipients.html.erb
@@ -13,9 +13,9 @@
             <input type="checkbox" id="recipients_select_all" class="rounded border-gray-300" <%= "checked" if all_matched %> aria-label="Select all" onclick="document.querySelectorAll('.recipient-checkbox').forEach(function(c){ c.checked = document.getElementById('recipients_select_all').checked })">
           </th>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Email</th>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Payment status</th>
+          <th class="px-4 py-2 text-right text-sm font-semibold text-gray-700 w-10"><span class="sr-only">Registration</span></th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
@@ -26,22 +26,34 @@
             <td class="px-4 py-2">
               <%= check_box_tag "registration_ids[]", reg.id, matched, class: "recipient-checkbox rounded border-gray-300", id: "registration_ids_#{reg.id}" %>
             </td>
-            <td class="px-4 py-2 text-sm"><%= person.full_name %></td>
-            <td class="px-4 py-2 text-sm"><%= person.preferred_email %></td>
+            <td class="px-4 py-2 text-sm">
+              <%= person.full_name %>
+              <span class="text-xs text-gray-500">(<%= person.preferred_email %>)</span>
+            </td>
             <td class="px-4 py-2 text-sm">
               <% org_names = reg.organizations.map(&:name).compact_blank %>
               <%= org_names.any? ? org_names.join(", ") : content_tag(:span, "—", class: "text-gray-400") %>
             </td>
-            <td class="px-4 py-2 text-sm">
+            <td class="px-4 py-2 text-sm whitespace-nowrap">
               <% if @event.object.cost_cents.to_i > 0 %>
                 <% if reg.paid_in_full? %>
                   <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-green-50 text-green-700 border-green-200">Paid</span>
                 <% else %>
                   <% due_cents = @event.object.cost_cents - reg.allocations_sum %>
-                  <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-amber-50 text-amber-700 border-amber-200">$<%= "%.2f" % (due_cents / 100.0) %> due</span>
+                  <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-amber-50 text-amber-700 border-amber-200"><%= dollars_from_cents(due_cents) %> due</span>
+                  <% if reg.intends_to_pay? %>
+                    <span class="inline-flex items-center rounded-full text-xs font-medium border px-2 py-0.5 bg-blue-50 text-blue-700 border-blue-200" title="Intends to pay"><i class="fa-solid fa-hand-holding-dollar"></i></span>
+                  <% end %>
                 <% end %>
               <% else %>
                 <span class="text-gray-400">—</span>
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-right">
+              <%= link_to edit_event_registration_path(reg, return_to: "preview_reminder"),
+                          title: "View #{person.full_name}'s registration for #{@event.title}",
+                          class: "inline-flex items-center shrink-0 rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
+                <i class="fa-solid fa-clipboard-list text-gray-400"></i>
               <% end %>
             </td>
           </tr>

--- a/app/views/events/_reminder_recipients.html.erb
+++ b/app/views/events/_reminder_recipients.html.erb
@@ -50,7 +50,7 @@
               <% end %>
             </td>
             <td class="px-4 py-2 text-right">
-              <%= link_to edit_event_registration_path(reg, return_to: "preview_reminder"),
+              <%= link_to edit_event_registration_path(reg, return_to: "preview_reminder", reminder_filters: reminder_filter_params(params)),
                           title: "View #{person.full_name}'s registration for #{@event.title}",
                           class: "inline-flex items-center shrink-0 rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
                 <i class="fa-solid fa-clipboard-list text-gray-400"></i>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -203,7 +203,7 @@
       "cwe_id": [
         79
       ],
-      "note": "sdf"
+      "note": "email_body_html is the server-rendered HTML of a notification email, generated from trusted mailer templates rather than user-supplied free text. It is rendered intentionally as a preview on notifications/show, which is gated to admin-or-owner (NotificationPolicy#show?), so no untrusted input reaches the page."
     },
     {
       "warning_type": "Cross-Site Scripting",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -208,40 +208,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "31dde319e6775c7f5f4428a32a45835966a2afa4dad760f17400b9115a863809",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped parameter value",
-      "file": "app/views/events/preview_reminder.html.erb",
-      "line": 95,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "EventMailer.event_registration_reminder(Event.find(params[:id]).decorate.event_registrations.includes(:registrant => ([:user, :contact_methods])).joins(:registrant).select do\n r.registrant.preferred_email.present?\n end.first, :custom_message => ((params[:custom_message].to_s or helpers.default_reminder_message(((Event.find(params[:id]).decorate.start_date.to_date - Date.current).to_i or nil)))), :custom_subject => ((params[:custom_subject].to_s or helpers.default_reminder_subject(Event.find(params[:id]).decorate))), :preview => true).html_part.body.decoded",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "EventsController",
-          "method": "preview_reminder",
-          "line": 277,
-          "file": "app/controllers/events_controller.rb",
-          "rendered": {
-            "name": "events/preview_reminder",
-            "file": "app/views/events/preview_reminder.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "events/preview_reminder"
-      },
-      "user_input": "params[:custom_message].to_s",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": "Admin-only reminder preview. The raw value is the server-rendered email HTML; the custom message it embeds is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
       "fingerprint": "343336d81aa87ab12862c5f9ca2b0f9ac4155488c053c1ce9c7ed27c456e3dba",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -668,8 +668,8 @@ registrations_data = []
 if facilitator_training
   [
     { person: amy_person, status: "registered", scholarship_requested: true, w9_requested: true, invoice_requested: true, ce_credit_requested: true },
-    { person: maria_j, status: "registered", invoice_requested: true, ce_credit_requested: true },
-    { person: anna_g, status: "attended", ce_credit_requested: true },
+    { person: maria_j, status: "registered", invoice_requested: true, ce_credit_requested: true, intends_to_pay: true },
+    { person: anna_g, status: "attended", ce_credit_requested: true, intends_to_pay: true },
     { person: mario_j, status: "registered" },
     { person: kim_d, status: "cancelled" },
     { person: aisha_person, status: "registered", intends_to_pay: true }

--- a/db/seeds/dev/payments.rb
+++ b/db/seeds/dev/payments.rb
@@ -250,12 +250,12 @@ end
 fund_registration.(facilitator_training, amy_person,
   scholarship: { amount_cents: 10_000, tasks_completed: false },
   payments: [ { payer: amy_person, amount_cents: 5_000, kind: :cash } ])
-# Maria: paid in full by cash
+# Maria: partial cash → still owes, intends to pay the rest
 fund_registration.(facilitator_training, maria_j,
-  payments: [ { payer: maria_j, amount_cents: 15_000, kind: :cash } ])
-# Anna: paid in full by check from her organization (org-payer scenario)
+  payments: [ { payer: maria_j, amount_cents: 5_000, kind: :cash } ])
+# Anna: partial check from her organization → still owes, intends to pay the rest (org-payer scenario)
 fund_registration.(facilitator_training, anna_g,
-  payments: [ { payer: org_payer || anna_g, amount_cents: 15_000, kind: :check } ])
+  payments: [ { payer: org_payer || anna_g, amount_cents: 5_000, kind: :check } ])
 # Mario: partial cash → still owes
 fund_registration.(facilitator_training, mario_j,
   payments: [ { payer: mario_j, amount_cents: 5_000, kind: :cash } ])

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -62,23 +62,24 @@ RSpec.describe "Events::BulkReminders", type: :request do
   end
 
   describe "editing a registration from the picker" do
-    it "links each registration edit back to the picker carrying the active filters" do
-      get preview_reminder_event_path(event, name: "jane"),
+    # Opens in a new tab so the in-progress subject/message draft on the picker
+    # isn't lost; the picker page stays put while the registration is edited.
+    it "opens each registration edit in a new tab" do
+      get preview_reminder_event_path(event),
           headers: { "Turbo-Frame" => "reminder_recipients" }
 
       link = Nokogiri::HTML(response.body)
         .at_css("a[href*='#{edit_event_registration_path(jane)}']")
       expect(link).to be_present
+      expect(link["target"]).to eq("_blank")
       expect(link["href"]).to include("return_to=preview_reminder")
-      expect(link["href"]).to include("reminder_filters%5Bname%5D=jane")
     end
 
-    it "redirects back to the picker re-applying the filters after save" do
+    it "returns to the picker after save" do
       patch event_registration_path(jane),
-            params: { return_to: "preview_reminder", reminder_filters: { name: "jane" },
-                      event_registration: { ce_credit_requested: "1" } }
+            params: { return_to: "preview_reminder", event_registration: { ce_credit_requested: "1" } }
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, name: "jane"))
+      expect(response).to redirect_to(preview_reminder_event_path(event))
     end
   end
 

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe "Events::BulkReminders", type: :request do
     end
   end
 
+  describe "editing a registration from the picker" do
+    it "links each registration edit back to the picker carrying the active filters" do
+      get preview_reminder_event_path(event, name: "jane"),
+          headers: { "Turbo-Frame" => "reminder_recipients" }
+
+      link = Nokogiri::HTML(response.body)
+        .at_css("a[href*='#{edit_event_registration_path(jane)}']")
+      expect(link).to be_present
+      expect(link["href"]).to include("return_to=preview_reminder")
+      expect(link["href"]).to include("reminder_filters%5Bname%5D=jane")
+    end
+
+    it "redirects back to the picker re-applying the filters after save" do
+      patch event_registration_path(jane),
+            params: { return_to: "preview_reminder", reminder_filters: { name: "jane" },
+                      event_registration: { ce_credit_requested: "1" } }
+
+      expect(response).to redirect_to(preview_reminder_event_path(event, name: "jane"))
+    end
+  end
+
   describe "sending" do
     it "creates one reminder notification per selected registrant and one admin FYI" do
       expect {

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-exclamation")
-        expect(response.body).to include("$10.00 due")
+        expect(response.body).to include("$10 due")
         expect(response.body).not_to include("Partial")
       end
 
@@ -635,7 +635,7 @@ RSpec.describe "Events", type: :request do
 
         expect(response.body).to include("fa-circle-half-stroke")
         expect(response.body).to include("Partial payment")
-        expect(response.body).to include("$6.00 due")
+        expect(response.body).to include("$6 due")
       end
 
       it "does not show the partial badge when only a scholarship covers part of the cost" do
@@ -645,7 +645,7 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-exclamation")
-        expect(response.body).to include("$6.00 due")
+        expect(response.body).to include("$6 due")
         expect(response.body).not_to include("Partial")
       end
 
@@ -667,7 +667,7 @@ RSpec.describe "Events", type: :request do
 
         expect(response.body).to include("fa-tag")
         expect(response.body).to include(">Discounted<")
-        expect(response.body).to include("$6.00 due")
+        expect(response.body).to include("$6 due")
       end
 
       it "shows Paid when a discount fully covers the cost" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the bulk reminder-email recipient table, admins couldn't see whether an unpaid registrant intends to pay, and amounts always rendered trailing `.00` cents.
- They also had no quick way to inspect/fix a registration from that page without losing their in-progress message draft.

### How did you approach the change?
- Added an icon-only "intends to pay" chip (hover tooltip) beside the due amount on the reminders recipient table, moved email inline with the name, and added a registration button.
- The registration button opens in a **new tab** (`target=_blank`/`rel=noopener`) so the picker — including the subject/message draft, which lives only in the DOM and is too long to round-trip through URL params — stays fully intact. A `return_to: preview_reminder` eyebrow gives the new tab a sensible "Send reminders" back link.
- Unified all due-amount chips (reminders, registrants, ticket, bulk payments) to use `dollars_from_cents` so cents only show when non-zero, and standardized the registration-button icon to `fa-clipboard-list`.
- Seeded Maria and Anna on event 1 with a partial balance and `intends_to_pay` so the new chip has dev data.

### UI Testing Checklist
- [ ] Reminders recipient table shows the intends-to-pay chip after the due amount for unpaid registrants who intend to pay.
- [ ] Due amounts show whole dollars (e.g. `$100 due`) but keep cents when present (e.g. `$99.50 due`).
- [ ] The registration button opens the registration editor in a new tab; the picker tab keeps any typed subject/message.

### Anything else to add?
- Because the editor opens in a new tab, payment-status chips on the original picker tab won't reflect an edit until the list is re-filtered (it's a turbo frame). Happy to add a small "refresh" affordance if useful.
