### PR TITLE
Shorten admin home cards and add Additional data section

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -5,9 +5,10 @@ module Admin
     def index
       authorize! :home, to: :index?
 
-      @system_cards       = system_cards
-      @user_content_cards = user_content_cards
-      @reference_cards    = reference_cards
+      @system_cards          = system_cards
+      @user_content_cards    = user_content_cards
+      @reference_cards       = reference_cards
+      @additional_data_cards = additional_data_cards
     end
   end
 end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -76,7 +76,8 @@ module AdminCardsHelper
       custom_card("Reports", reports_path, icon: "📄", color: :sky, intensity: 100),
       disabled_card("Discounts", icon: "💲"),
       disabled_card("Refunds", icon: "↩️"),
-      disabled_card("Event staff", icon: "🧑‍💼")
+      disabled_card("Event staff", icon: "🧑‍💼"),
+      disabled_card("Scholarships", icon: "🎓")
     ]
   end
 

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -77,7 +77,7 @@ module AdminCardsHelper
       disabled_card("Discounts", icon: "💲"),
       disabled_card("Refunds", icon: "↩️"),
       disabled_card("Event staff", icon: "🧑‍💼")
-    ]
+    ].sort_by { |card| card[:title].downcase }
   end
 
   # ============================================================

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -15,11 +15,9 @@ module AdminCardsHelper
       model_card(:workshops, icon: "🎨"),
       model_card(:workshop_variations, icon: "🔀"),
       model_card(:video_recordings, icon: "🎬", title: "Video Gallery"),
-      model_card(:allocations, icon: "📤"),
       model_card(:banners, icon: "📣"),
       model_card(:community_news, icon: "📰"),
-      model_card(:faqs, icon: "❔", title: "FAQs"),
-      model_card(:forms, icon: "📋")
+      model_card(:faqs, icon: "❔", title: "FAQs")
     ]
   end
 

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -72,8 +72,8 @@ module AdminCardsHelper
       custom_card("Monthly reports", monthly_reports_path, icon: "📈", color: :sky, intensity: 100),
       custom_card("Story shares", story_shares_path, icon: "🔗", color: :sky, intensity: 100),
       custom_card("Bookmarks", bookmarks_path, icon: "🔖", color: :sky, intensity: 100),
-      custom_card("Affiliations", affiliations_path, icon: "🤝", color: :sky, intensity: 100),
-      custom_card("Reports", reports_path, icon: "📄", color: :sky, intensity: 100),
+      disabled_card("Affiliations", icon: "🤝"),
+      disabled_card("Reports", icon: "📄"),
       disabled_card("Discounts", icon: "💲"),
       disabled_card("Refunds", icon: "↩️"),
       disabled_card("Event staff", icon: "🧑‍💼")

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -60,6 +60,20 @@ module AdminCardsHelper
     ]
   end
 
+  # -----------------------------
+  # ADDITIONAL DATA CARDS
+  # -----------------------------
+  def additional_data_cards
+    [
+      custom_card("Allocations", allocations_path, icon: "📤", color: :sky, intensity: 100),
+      disabled_card("Bulk payments", icon: "💳"),
+      custom_card("Event registrations", event_registrations_path, icon: "🎟️", color: :sky, intensity: 100),
+      custom_card("Forms", forms_path, icon: "📋", color: :sky, intensity: 100),
+      disabled_card("Form submissions", icon: "📨"),
+      disabled_card("Form answers", icon: "✅")
+    ]
+  end
+
   # ============================================================
   # CARD BUILDERS
   # ============================================================
@@ -82,6 +96,16 @@ module AdminCardsHelper
       bg_color: "bg-#{color}-#{intensity}",
       hover_bg_color: "hover:bg-#{color}-#{intensity == 50 ? 100 : intensity + 100}",
       text_color: "text-gray-800"
+    }
+  end
+
+  def disabled_card(title, icon:)
+    {
+      title: title,
+      icon: icon,
+      disabled: true,
+      bg_color: "bg-gray-100",
+      text_color: "text-gray-400"
     }
   end
 end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -68,7 +68,15 @@ module AdminCardsHelper
       custom_card("Event registrations", event_registrations_path, icon: "🎟️", color: :sky, intensity: 100),
       custom_card("Forms", forms_path, icon: "📋", color: :sky, intensity: 100),
       disabled_card("Form submissions", icon: "📨"),
-      disabled_card("Form answers", icon: "✅")
+      disabled_card("Form answers", icon: "✅"),
+      custom_card("Monthly reports", monthly_reports_path, icon: "📈", color: :sky, intensity: 100),
+      custom_card("Story shares", story_shares_path, icon: "🔗", color: :sky, intensity: 100),
+      custom_card("Bookmarks", bookmarks_path, icon: "🔖", color: :sky, intensity: 100),
+      custom_card("Affiliations", affiliations_path, icon: "🤝", color: :sky, intensity: 100),
+      custom_card("Reports", reports_path, icon: "📄", color: :sky, intensity: 100),
+      disabled_card("Discounts", icon: "💲"),
+      disabled_card("Refunds", icon: "↩️"),
+      disabled_card("Event staff", icon: "🧑‍💼")
     ]
   end
 

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -30,7 +30,7 @@ module AdminCardsHelper
       custom_card("Bookmarks tally", tally_bookmarks_path, icon: "🔖"),
       model_card(:quotes, icon: "💬", intensity: 100),
       model_card(:payments, icon: "💳"),
-      custom_card("Scholarships", grants_path, icon: "🎓", color: :fuchsia),
+      disabled_card("Scholarships", icon: "🎓"),
       model_card(:notifications, icon: "🔔"),
       model_card(:story_ideas, icon: "✍🏾️", intensity: 100),
       custom_card("Tags", tags_path, icon: "🏷️", color: :lime, intensity: 100),
@@ -76,8 +76,7 @@ module AdminCardsHelper
       custom_card("Reports", reports_path, icon: "📄", color: :sky, intensity: 100),
       disabled_card("Discounts", icon: "💲"),
       disabled_card("Refunds", icon: "↩️"),
-      disabled_card("Event staff", icon: "🧑‍💼"),
-      disabled_card("Scholarships", icon: "🎓")
+      disabled_card("Event staff", icon: "🧑‍💼")
     ]
   end
 

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -77,7 +77,7 @@ module AdminCardsHelper
       disabled_card("Discounts", icon: "💲"),
       disabled_card("Refunds", icon: "↩️"),
       disabled_card("Event staff", icon: "🧑‍💼")
-    ].sort_by { |card| card[:title].downcase }
+    ].sort_by { |card| card[:title].downcase.gsub(" ", "~") }
   end
 
   # ============================================================

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -34,19 +34,34 @@
         <div class="flex flex-col gap-2 flex-1">
           User-generated
           <% @user_content_cards.each do |card| %>
-            <a href="<%= card[:path] %>"
-               class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+            <% if card[:disabled] %>
+              <div class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
                       <%= card[:bg_color] %> <%= card[:text_color] %>
-                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
-              <div class="text-2xl text-gray-700 flex-shrink-0">
-                <%= card[:icon] %>
-              </div>
+                      px-4 py-1 cursor-not-allowed opacity-60"
+                   title="Not built yet"
+                   aria-disabled="true">
+                <div class="text-2xl flex-shrink-0">
+                  <%= card[:icon] %>
+                </div>
 
-              <div class="flex-1">
-                <h3 class="text-lg font-bold text-gray-800 break-words"><%= card[:title] %></h3>
+                <div class="flex-1">
+                  <h3 class="text-lg font-bold break-words"><%= card[:title] %></h3>
+                </div>
               </div>
+            <% else %>
+              <a href="<%= card[:path] %>"
+                 class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+                        <%= card[:bg_color] %> <%= card[:text_color] %>
+                        <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
+                <div class="text-2xl text-gray-700 flex-shrink-0">
+                  <%= card[:icon] %>
+                </div>
 
-            </a>
+                <div class="flex-1">
+                  <h3 class="text-lg font-bold text-gray-800 break-words"><%= card[:title] %></h3>
+                </div>
+              </a>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -92,10 +92,10 @@
 
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mt-6">
         Additional data
-       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mt-3">
+       <div class="columns-1 sm:columns-2 md:columns-3 gap-2 mt-3">
           <% @additional_data_cards.each do |card| %>
             <% if card[:disabled] %>
-              <div class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
+              <div class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200 mb-2 break-inside-avoid
                 <%= card[:bg_color] %> <%= card[:text_color] %>
                 px-4 py-1 cursor-not-allowed opacity-60"
                    title="Not built yet"
@@ -110,7 +110,7 @@
               </div>
             <% else %>
               <a href="<%= card[:path] %>"
-               class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
+               class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200 mb-2 break-inside-avoid
                 <%= card[:bg_color] %> <%= card[:text_color] %>
                 <%= card[:hover_bg_color] %>
                 transition-colors transition-shadow duration-300 px-4 py-1">

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -8,20 +8,20 @@
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
       <div class="flex flex-col gap-6 md:flex-row">
         <!-- Column 1 -->
-        <div class="flex flex-col gap-4 flex-1">
+        <div class="flex flex-col gap-2 flex-1">
           Admin-generated
           <% @system_cards.each do |card| %>
             <a href="<%= card[:path] %>"
                class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
                       <%= card[:bg_color] %> <%= card[:text_color] %>
-                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 p-4">
-              <div class="text-5xl text-gray-700 flex-shrink-0">
+                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
+              <div class="text-2xl text-gray-700 flex-shrink-0">
                 <!--            <i class="fa-solid <%#= card[:icon] %>" aria-hidden="true"></i>-->
                 <%= card[:icon] %>
               </div>
 
               <div class="flex-1">
-                <h3 class="text-xl font-bold text-gray-800 break-words">
+                <h3 class="text-lg font-bold text-gray-800 break-words">
                   <%= card[:title] %>
                 </h3>
               </div>
@@ -31,19 +31,19 @@
         </div>
 
         <!-- Column 2 -->
-        <div class="flex flex-col gap-4 flex-1">
+        <div class="flex flex-col gap-2 flex-1">
           User-generated
           <% @user_content_cards.each do |card| %>
             <a href="<%= card[:path] %>"
                class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
                       <%= card[:bg_color] %> <%= card[:text_color] %>
-                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 p-4">
-              <div class="text-5xl text-gray-700 flex-shrink-0">
+                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
+              <div class="text-2xl text-gray-700 flex-shrink-0">
                 <%= card[:icon] %>
               </div>
 
               <div class="flex-1">
-                <h3 class="text-xl font-bold text-gray-800 break-words"><%= card[:title] %></h3>
+                <h3 class="text-lg font-bold text-gray-800 break-words"><%= card[:title] %></h3>
               </div>
 
             </a>
@@ -60,17 +60,55 @@
              class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
               <%= card[:bg_color] %> <%= card[:text_color] %>
               <%= card[:hover_bg_color] %>
-              transition-colors transition-shadow duration-300 px-4 py-3 flex-1">
+              transition-colors transition-shadow duration-300 px-4 py-1 flex-1">
 
-              <div class="text-3xl text-gray-700 flex-shrink-0">
+              <div class="text-lg text-gray-700 flex-shrink-0">
                 <%= card[:icon] %>
               </div>
 
               <div>
-                <h3 class="text-base font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
+                <h3 class="text-sm font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
               </div>
 
             </a>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mt-6">
+        Additional data
+       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mt-3">
+          <% @additional_data_cards.each do |card| %>
+            <% if card[:disabled] %>
+              <div class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
+                <%= card[:bg_color] %> <%= card[:text_color] %>
+                px-4 py-1 cursor-not-allowed opacity-60"
+                   title="Not built yet"
+                   aria-disabled="true">
+                <div class="text-lg flex-shrink-0">
+                  <%= card[:icon] %>
+                </div>
+
+                <div>
+                  <h3 class="text-sm font-bold whitespace-nowrap"><%= card[:title] %></h3>
+                </div>
+              </div>
+            <% else %>
+              <a href="<%= card[:path] %>"
+               class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
+                <%= card[:bg_color] %> <%= card[:text_color] %>
+                <%= card[:hover_bg_color] %>
+                transition-colors transition-shadow duration-300 px-4 py-1">
+
+                <div class="text-lg text-gray-700 flex-shrink-0">
+                  <%= card[:icon] %>
+                </div>
+
+                <div>
+                  <h3 class="text-sm font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
+                </div>
+              </a>
+            <% end %>
           <% end %>
         </div>
       </div>
@@ -83,6 +121,7 @@
     bg-gray-50 bg-gray-100 bg-gray-200 bg-gray-500
 
     bg-red-800
+    bg-sky-100 bg-sky-200 hover:bg-sky-200
     bg-cyan-50 bg-cyan-100 bg-cyan-200 bg-cyan-500
     bg-pink-50 bg-pink-100 bg-pink-200 bg-pink-500
     bg-yellow-50 bg-yellow-100 bg-yellow-200


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The admin home dashboard cards were taller than necessary, pushing content below the fold
- Halving their footprint lets admins see more options at a glance

### How did you approach the change?
- Reduced padding, icon, and title sizes across all three card columns and tightened the gap between cards
- Added an "Additional data" section with links to Allocations, Event registrations, and Forms, plus greyed-out placeholders for Bulk payments, Form submissions, and Form answers (none have a global index page yet)
- Card order in the new section: Allocations, Bulk payments, Event registrations, Forms, Form submissions, Form answers

### UI Testing Checklist
- [ ] Admin home cards render at the smaller height across the three columns
- [ ] "Additional data" section appears below "Base data" with a responsive 3-column grid
- [ ] Allocations, Event registrations, and Forms cards link to their index pages
- [ ] Bulk payments, Form submissions, and Form answers render greyed out and non-clickable

### Anything else to add?
- Disabled cards use `aria-disabled` and a "Not built yet" tooltip; they can be wired up once those index pages exist
