### PR TITLE
Seed admin's favorite event to the flagship training

### DIFF
--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -266,6 +266,11 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
 # A custom label demonstrates that the heading is admin-editable. Only set when
 # blank so admin edits survive a re-seed.
 flagship = Event.find_by(title: "AWBW Facilitator Training")
+
+# Make the flagship training the admin's favorite event so the admin dashboard
+# has a sensible default highlighted event after seeding.
+admin_user.update!(favorite_event: flagship) if admin_user && flagship
+
 if flagship && flagship.event_details.blank?
   flagship.update!(event_details_label: "Art supplies & what to bring", event_details: <<~HTML.strip)
     <p>Thank you for registering to join us for AWBW's Art Facilitator Training!</p>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- After seeding the dev database, the admin user (`umberto.user@example.com`) had no `favorite_event` set, so the admin dashboard had no default highlighted event.
- This sets a sensible default so the favorite-event UI is populated out of the box.

### How did you approach the change?
- In `db/seeds/dev/events_management.rb`, set the admin user's `favorite_event` to the flagship "AWBW Facilitator Training" event, right after it's fetched.
- Referenced the event by title (the existing seed idiom — the seeds never assume `id == 1`) and guarded with `if admin_user && flagship`; `update!` keeps it idempotent across re-seeds.

### Anything else to add?
- Verified by running `ai/seed`: the admin's `favorite_event` resolves to "AWBW Facilitator Training".