### PR TITLE
Add facilitator_training flag to events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -83,6 +83,9 @@ class Event < ApplicationRecord
   scope :registerable, -> { where("registration_close_date IS NULL OR registration_close_date >= ?", Time.current) }
   scope :using_form, ->(form_id) { joins(:event_forms).where(event_forms: { form_id: form_id }).distinct }
   scope :staffed_by, ->(person) { joins(:event_staffs).where(event_staffs: { person_id: person }).distinct }
+  # Events flagged as facilitator trainings (the "TAC" a scholarship recipient
+  # attends). Drives the scholarship index's training column.
+  scope :facilitator_trainings, -> { where(facilitator_training: true) }
 
   def self.search_by_params(params)
     stories = is_a?(ActiveRecord::Relation) ? self : all

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -132,6 +132,7 @@ class EventPolicy < ApplicationPolicy
                   :hint_registration_cost,
                   :pre_title,
                   :pre_date_text,
+                  :facilitator_training,
                   :featured,
                   :start_date, :start_date_date, :start_date_time,
                   :end_date, :end_date_date, :end_date_time,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -8,8 +8,10 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
     <div>
       <label class="block font-medium mb-1 text-gray-700">Event title</label>
-      <div class="border border-gray-200 rounded-lg grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
-        <div>
+      <div class="border border-gray-200 rounded-lg p-4">
+        <%# Inputs and checkboxes are split into two parallel grid rows so each %>
+        <%# checkbox lines up with its sibling regardless of the Pre-title hint height %>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <%= f.input :title,
                   label: "Title",
                   required: true,
@@ -21,9 +23,6 @@
                       "w-full rounded border-gray-300 shadow-sm px-3 py-2
                                                 focus:ring-blue-500 focus:border-blue-500",
                   } %>
-          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0!" } %>
-        </div>
-        <div>
           <%= f.input :pre_title,
                   label: "Pre-title",
                   hint: "Displays above the title",
@@ -31,6 +30,10 @@
                     class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                     placeholder: "e.g. Facilitator Training Series"
                   } %>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0!" } %>
+          <%= f.input :facilitator_training, as: :boolean, label: "Facilitator training event", wrapper_html: { class: "mb-0!" } %>
         </div>
       </div>
     </div>
@@ -190,7 +193,6 @@
                         placeholder: "Virtual event",
                         class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                       } %>
-          <%= f.input :facilitator_training, as: :boolean, label: "Facilitator training event", wrapper_html: { class: "mb-0!" } %>
         </div>
 
         <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -8,7 +8,7 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
     <div>
       <label class="block font-medium mb-1 text-gray-700">Event title</label>
-      <div class="border border-gray-200 rounded-lg p-4">
+      <div class="border border-gray-200 rounded-lg grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
         <div>
           <%= f.input :title,
                   label: "Title",
@@ -21,8 +21,8 @@
                       "w-full rounded border-gray-300 shadow-sm px-3 py-2
                                                 focus:ring-blue-500 focus:border-blue-500",
                   } %>
+          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0!" } %>
         </div>
-        <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page" %>
         <div>
           <%= f.input :pre_title,
                   label: "Pre-title",
@@ -64,6 +64,14 @@
     </button>
 
     <div id="event_details" class="bg-gray-50 border border-gray-300 rounded-b-md p-6">
+      <div class="form-group mb-6">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <%= f.check_box :facilitator_training %>
+          <span class="text-sm font-medium text-gray-700">This event is a facilitator training (TAC)</span>
+        </label>
+        <p class="text-xs text-gray-500 mt-1">Marks the event as a facilitator training. Drives the training column on the scholarship index.</p>
+      </div>
+
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <%# LEFT: Date/time, cost + pre-date text, videoconference + location %>
       <div class="md:col-span-2 space-y-6">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -31,7 +31,7 @@
                     class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                     placeholder: "e.g. Facilitator Training Series"
                   } %>
-          <%= f.input :facilitator_training, as: :boolean, label: "This event is a facilitator training", wrapper_html: { class: "mb-0!" } %>
+          <%= f.input :facilitator_training, as: :boolean, label: "Facilitator training event", wrapper_html: { class: "mb-0!" } %>
         </div>
       </div>
     </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -39,9 +39,9 @@
     </div>
 
     <% if allowed_to?(:manage?, @event) %>
-      <div class="admin-only mt-6 md:mt-0">
+      <div class="admin-only mt-6 md:mt-0 flex flex-col">
         <label id="display_settings" class="block font-medium mb-1 text-gray-700">Display settings</label>
-        <div class="bg-blue-50 border border-gray-200 rounded-lg grid grid-cols-2 gap-y-0 p-3 [&_.form-group]:mb-1">
+        <div class="bg-blue-50 border border-gray-200 rounded-lg grid grid-cols-2 content-start gap-y-0 p-3 flex-1 [&_.form-group]:mb-1">
           <%= f.input :published, as: :boolean %>
           <%= f.input :featured, as: :boolean %>
           <%= f.input :publicly_visible, as: :boolean %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -31,6 +31,7 @@
                     class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                     placeholder: "e.g. Facilitator Training Series"
                   } %>
+          <%= f.input :facilitator_training, as: :boolean, label: "This event is a facilitator training", wrapper_html: { class: "mb-0!" } %>
         </div>
       </div>
     </div>
@@ -64,14 +65,6 @@
     </button>
 
     <div id="event_details" class="bg-gray-50 border border-gray-300 rounded-b-md p-6">
-      <div class="form-group mb-6">
-        <label class="flex items-center gap-2 cursor-pointer">
-          <%= f.check_box :facilitator_training %>
-          <span class="text-sm font-medium text-gray-700">This event is a facilitator training (TAC)</span>
-        </label>
-        <p class="text-xs text-gray-500 mt-1">Marks the event as a facilitator training. Drives the training column on the scholarship index.</p>
-      </div>
-
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
       <%# LEFT: Date/time, cost + pre-date text, videoconference + location %>
       <div class="md:col-span-2 space-y-6">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,8 +21,7 @@
                       "w-full rounded border-gray-300 shadow-sm px-3 py-2
                                                 focus:ring-blue-500 focus:border-blue-500",
                   } %>
-          <%# mt-6 offsets the Pre-title hint on the right so this checkbox lines up with "Facilitator training event" %>
-          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0! mt-6" } %>
+          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0!" } %>
         </div>
         <div>
           <%= f.input :pre_title,
@@ -32,7 +31,6 @@
                     class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                     placeholder: "e.g. Facilitator Training Series"
                   } %>
-          <%= f.input :facilitator_training, as: :boolean, label: "Facilitator training event", wrapper_html: { class: "mb-0!" } %>
         </div>
       </div>
     </div>
@@ -192,6 +190,7 @@
                         placeholder: "Virtual event",
                         class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                       } %>
+          <%= f.input :facilitator_training, as: :boolean, label: "Facilitator training event", wrapper_html: { class: "mb-0!" } %>
         </div>
 
         <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,7 +21,8 @@
                       "w-full rounded border-gray-300 shadow-sm px-3 py-2
                                                 focus:ring-blue-500 focus:border-blue-500",
                   } %>
-          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0!" } %>
+          <%# mt-6 offsets the Pre-title hint on the right so this checkbox lines up with "Facilitator training event" %>
+          <%= f.input :autoshow_title, as: :boolean, label: "Show title on event page", wrapper_html: { class: "mb-0! mt-6" } %>
         </div>
         <div>
           <%= f.input :pre_title,

--- a/db/migrate/20260618160031_add_facilitator_training_to_events.rb
+++ b/db/migrate/20260618160031_add_facilitator_training_to_events.rb
@@ -1,0 +1,11 @@
+class AddFacilitatorTrainingToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :facilitator_training, :boolean, default: false, null: false
+    add_index :events, :facilitator_training
+  end
+
+  def down
+    remove_index :events, :facilitator_training, if_exists: true
+    remove_column :events, :facilitator_training, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_141859) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_160031) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -504,6 +504,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_141859) do
     t.datetime "end_date", precision: nil
     t.text "event_details"
     t.string "event_details_label", default: "Before you attend", null: false
+    t.boolean "facilitator_training", default: false, null: false
     t.boolean "featured", default: false, null: false
     t.text "ga4_snippet"
     t.text "gtm_body_snippet"
@@ -527,6 +528,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_141859) do
     t.string "videoconference_label", default: "Virtual event"
     t.string "videoconference_url"
     t.index ["created_by_id"], name: "index_events_on_created_by_id"
+    t.index ["facilitator_training"], name: "index_events_on_facilitator_training"
     t.index ["location_id"], name: "index_events_on_location_id"
     t.index ["published"], name: "index_events_on_published"
   end

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -223,7 +223,7 @@ dev_events.each_with_index do |(title, form_type, cost_cents, scholarship, visib
   # find_or_create_by! only sets these on create, so without this an existing DB
   # keeps stale dates/cost and neither the index ordering, the multi-day span, nor
   # the registration fee would update.
-  event.update!(start_date: start_date, end_date: end_date, registration_close_date: registration_close, cost_cents: cost_cents)
+  event.update!(start_date: start_date, end_date: end_date, registration_close_date: registration_close, cost_cents: cost_cents, facilitator_training: title.match?(/training/i))
 
   if registerable
     EventForm.find_or_create_by!(event: event, role: "registration") do |ef|

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -321,6 +321,11 @@ RSpec.describe "Events", type: :request do
         expect(event.reload.autoshow_registration_details).to be(true)
       end
 
+      it "persists the facilitator training flag" do
+        patch event_path(event), params: { event: { facilitator_training: "1" } }
+        expect(event.reload.facilitator_training).to be(true)
+      end
+
       it "persists the registration detail hints" do
         patch event_path(event), params: { event: {
           hint_dates: "must attend both days",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Events that train facilitators (the "TAC" a scholarship recipient attends) need a first-class boolean so downstream features can identify them reliably — without fragile title-string matching.
- The immediate consumer is the scholarship index's training column (built on a separate branch); this PR lands the field on its own so it can merge independently and that branch picks it up on rebase.

### How did you approach the change?
- Added `events.facilitator_training` boolean (default `false`, indexed) via a reversible migration, plus an `Event.facilitator_trainings` scope.
- Permitted the attribute in `EventPolicy` and exposed it as a **"This event is a facilitator training"** checkbox in the Event title box, under Pre-title — parallel to the "Show title on event page" checkbox under Title.
- Restructured the **Event title** box into a two-column grid (Title + "Show title on event page" left, Pre-title right) and trimmed the trailing margin under the checkbox (`mb-0!`) so the box height matches the Display-settings box.
- Defaulted the flag **on** for dev-seed events whose title matches `/training/i`, set on every re-seed for determinism.
- Added a request spec covering the permitted attribute.

### UI Testing Checklist
- [ ] Event title box and Display settings box are the same height
- [ ] "Show title on event page" still toggles `autoshow_title`
- [ ] New "This event is a facilitator training (TAC)" checkbox saves correctly
- [ ] Dev seed marks both Facilitator Trainings as trainings, nothing else

### Anything else to add?
- Extracted from the scholarships branch (biarritz). That branch keeps its consumers (`Person#completed_facilitator_trainings`, scholarship decorator/seeds/specs); they reference this column and will resolve once this merges and that branch rebases onto main.
- Padding fix uses the Tailwind v4 important suffix (`mb-0!`) because the simple_form boolean wrapper's base `mb-4` otherwise wins the cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
