### PR TITLE
Stop marking additional service areas as primary on registration

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -227,15 +227,18 @@ module EventRegistrationServices
     end
 
     def assign_tags(person, organization)
-      sector_ids = collect_ids_from_checkboxes("primary_service_area_single") +
-                   collect_ids_from_checkboxes("primary_service_area")
+      # The single-select dropdown names the ONE primary service area; the
+      # checkbox field collects ADDITIONAL areas. A sector named in both is
+      # primary, never duplicated.
+      primary_sector_id = collect_ids_from_checkboxes("primary_service_area_single").first
+      sector_ids = (Array(primary_sector_id) + collect_ids_from_checkboxes("primary_service_area")).uniq
       category_ids = collect_ids_from_checkboxes("workshop_environments") +
                      collect_ids_from_checkboxes("client_life_experiences") +
                      collect_ids_from_checkboxes("primary_age_group")
 
       if sector_ids.any?
         sectors = Sector.where(id: sector_ids)
-        assign_primary_sectors(person, sectors)
+        assign_sectors(person, sectors, primary_sector_id: primary_sector_id)
         organization.sectors = (organization.sectors + sectors).uniq if organization
       end
 
@@ -246,11 +249,20 @@ module EventRegistrationServices
       end
     end
 
-    def assign_primary_sectors(person, sectors)
+    # Tags the person with their submitted service areas — exactly one primary
+    # (the dropdown selection) and the rest additional — without ever leaving two
+    # primaries behind. Each (sector, person) is a single row, so a sector can't
+    # be both primary and additional.
+    def assign_sectors(person, sectors, primary_sector_id:)
       sectors.each do |sector|
         item = person.sectorable_items.find_or_initialize_by(sector: sector)
-        item.update!(is_primary: true)
+        item.update!(is_primary: sector.id == primary_sector_id)
       end
+      return unless primary_sector_id
+
+      person.sectorable_items.where(is_primary: true)
+            .where.not(sector_id: primary_sector_id)
+            .update_all(is_primary: false)
     end
 
     def collect_ids_from_checkboxes(identifier)

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -26,36 +26,72 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
 
   describe "primary service area tagging" do
     let!(:primary_sector) { create(:sector, name: "Healthcare") }
-    let!(:other_sector) { create(:sector, name: "Education") }
+    let!(:additional_sector) { create(:sector, name: "Education") }
 
-    it "tags the selected primary service area sectors as primary on the person" do
+    it "tags only the single-select dropdown sector as primary and the checkbox sectors as additional" do
       result = described_class.call(
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+          field_id("primary_service_area_single") => [ primary_sector.id.to_s ],
+          field_id("primary_service_area") => [ additional_sector.id.to_s ]
         )
       )
 
       expect(result.success?).to be true
       person = result.event_registration.registrant
-      primary_item = person.sectorable_items.find_by(sector: primary_sector)
-      expect(primary_item.is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: additional_sector).is_primary).to be false
     end
 
-    it "marks an existing additional sector as primary when later selected" do
+    it "leaves the person with exactly one primary sector regardless of how many additional are chosen" do
+      extra_sector = create(:sector, name: "Housing")
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+          field_id("primary_service_area_single") => [ primary_sector.id.to_s ],
+          field_id("primary_service_area") => [ additional_sector.id.to_s, extra_sector.id.to_s ]
+        )
+      )
+
+      person = result.event_registration.registrant
+      expect(person.sectorable_items.where(is_primary: true).count).to eq(1)
+      expect(person.sectorable_items.find_by(is_primary: true).sector).to eq(primary_sector)
+    end
+
+    it "does not duplicate a sector named as both primary and additional" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+          field_id("primary_service_area_single") => [ primary_sector.id.to_s ],
+          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+        )
+      )
+
+      person = result.event_registration.registrant
+      items = person.sectorable_items.where(sector: primary_sector)
+      expect(items.count).to eq(1)
+      expect(items.first.is_primary).to be true
+    end
+
+    it "demotes a previously primary sector when a new primary is named" do
       person = create(:person, first_name: "Pat", last_name: "Lee", email: "pat@example.com")
-      person.sectorable_items.create!(sector: primary_sector, is_primary: false)
+      old_primary = create(:sector, name: "Legal")
+      person.sectorable_items.create!(sector: old_primary, is_primary: true)
 
       described_class.call(
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+          field_id("primary_service_area_single") => [ primary_sector.id.to_s ]
         )
       )
 
+      expect(person.sectorable_items.find_by(sector: old_primary).is_primary).to be false
       expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+      expect(person.sectorable_items.where(is_primary: true).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Registrants were ending up with **multiple primary service-area sectors**, which violates the "one primary" rule and crowns every sector on the person/recipients profile.
- Root cause: public registration fed both the single-select "Primary service area" dropdown (`primary_service_area_single`) **and** the multi-select "Additional service areas" checkboxes (`primary_service_area`) into one assignment that set `is_primary: true` on all of them.

### How did you approach the change?
- Only the dropdown selection is marked primary; the checkbox selections become additional (`is_primary: false`).
- A sector named in both is kept as a single primary row (no duplicate), and any previously-primary sector is demoted so exactly one primary survives.
- Renamed `assign_primary_sectors` → `assign_sectors` to reflect that it now assigns both primary and additional.

### UI Testing Checklist
- [ ] Register via the public form picking one primary + several additional service areas; confirm the person shows exactly one starred/primary sector and the rest as additional.
- [ ] Re-register naming a different primary; confirm the old primary demotes to additional.

### Anything else to add?
- The existing specs encoded the bug (submitted the *additional* field and asserted `is_primary: true`); rewritten to assert correct behavior, plus added cases for one-primary, no-duplicate, and demotion. Full service spec green (23 examples).
- Per-person uniqueness (sector-to-person, category-to-person) is already enforced by DB unique indexes, so a sector can't be both primary and additional for one person — this fix addresses the *primary-vs-additional* mislabeling that produced the duplicate primaries.
