### PR TITLE
Scholarships index grouped by funder → grant → recipient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,10 @@ This codebase (Rails 8.1)
 |---|---|---|
 | `app/controllers/` | Rails controllers (admin/, events/) | ~69 files |
 | `app/views/` | ERB templates | ~504 files |
-| `app/decorators/` | Draper decorators for view logic | ~37 files |
+| `app/decorators/` | Draper decorators for view logic | ~38 files |
 | `app/policies/` | ActionPolicy authorization rules | ~49 files |
-| `app/presenters/` | Presentation objects | 2 files |
-| `app/helpers/` | View helpers | ~19 files |
+| `app/presenters/` | Presentation objects | 3 files |
+| `app/helpers/` | View helpers | ~20 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 
@@ -189,6 +189,7 @@ end
 - `ModelDeduper` — Deduplication logic
 - `RichTextMigrator` — Rich text migration utility
 - `DisplayImagePresenter` — Image display logic
+- `ScholarshipsGrouping` (presenter) — Groups scholarships into the index's funder → grant → recipient hierarchy; grant-free awards collect under a trailing "Unfunded" group
 
 ### Event Registrations
 
@@ -213,7 +214,7 @@ All inherit from `ApplicationDecorator` which provides:
 - `display_image` — selects primary/gallery/downloadable asset intelligently
 - `link_target` — polymorphic path generation
 
-Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator, GrantDecorator.
+Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator, GrantDecorator, ScholarshipDecorator (derives the scholarship index's program/location/training/status columns).
 
 ## Policies (ActionPolicy)
 

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -2,6 +2,21 @@ class ScholarshipsController < ApplicationController
   before_action :set_scholarship, only: [ :show, :edit, :update, :destroy, :toggle_tasks ]
   before_action :set_grant, only: [ :new, :create ]
 
+  def index
+    authorize! Scholarship
+    # Eager-load everything the grid derives so each row's funder, program,
+    # location, training, and status cells add no per-row queries:
+    #   * grant → donor for the funder grouping;
+    #   * recipient → affiliations → organization → addresses for program/location/status;
+    #   * recipient → event_registrations → event for the attended-training column.
+    scholarships = authorized_scope(Scholarship.all).includes(
+      { grant: :donor },
+      { recipient: [ { affiliations: { organization: :addresses } }, { event_registrations: :event } ] }
+    )
+    @funder_groups = ScholarshipsGrouping.new(scholarships).funder_groups
+    @scholarships_count = scholarships.size
+  end
+
   def show
     @scholarship = Scholarship.find(params[:id])
     authorize! @scholarship

--- a/app/decorators/scholarship_decorator.rb
+++ b/app/decorators/scholarship_decorator.rb
@@ -1,0 +1,55 @@
+class ScholarshipDecorator < ApplicationDecorator
+  delegate_all
+
+  def recipient_name
+    object.recipient&.full_name.presence || "Unknown recipient"
+  end
+
+  def amount
+    h.number_to_currency(object.amount_dollars)
+  end
+
+  # The organization the recipient facilitates for — the "program" the
+  # scholarship serves. Memoized so the row's program/location/status cells share
+  # one lookup.
+  def program
+    return @program if defined?(@program)
+
+    @program = object.recipient&.program_organization
+  end
+
+  def program_name
+    program&.name.presence || "—"
+  end
+
+  def program_location
+    program&.program_location.presence || "—"
+  end
+
+  # New / Ongoing / Reinstate relative to this recipient; blank when there's no
+  # program to assess.
+  def program_status
+    program&.program_status(object.recipient).presence || "—"
+  end
+
+  # Tailwind pill classes for the program-status badge.
+  def program_status_classes
+    case program&.program_status(object.recipient)
+    when "Ongoing"   then "bg-blue-50 text-blue-700 border-blue-200"
+    when "New"       then "bg-green-50 text-green-700 border-green-200"
+    when "Reinstate" then "bg-amber-50 text-amber-700 border-amber-200"
+    else "bg-gray-50 text-gray-500 border-gray-200"
+    end
+  end
+
+  # The facilitator-training event(s) the recipient attended ("TAC"); titles
+  # joined when more than one, em dash when none.
+  def training_label
+    titles = object.recipient&.completed_facilitator_trainings.to_a.filter_map(&:title)
+    titles.any? ? titles.join(", ") : "—"
+  end
+
+  def tasks_completed?
+    object.tasks_completed?
+  end
+end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -30,7 +30,7 @@ module AdminCardsHelper
       custom_card("Bookmarks tally", tally_bookmarks_path, icon: "🔖"),
       model_card(:quotes, icon: "💬", intensity: 100),
       model_card(:payments, icon: "💳"),
-      disabled_card("Scholarships", icon: "🎓"),
+      model_card(:scholarships, icon: "🎓"),
       model_card(:notifications, icon: "🔔"),
       model_card(:story_ideas, icon: "✍🏾️", intensity: 100),
       custom_card("Tags", tags_path, icon: "🏷️", color: :lime, intensity: 100),

--- a/app/helpers/scholarship_helper.rb
+++ b/app/helpers/scholarship_helper.rb
@@ -1,0 +1,20 @@
+module ScholarshipHelper
+  # Funder label for a funder group on the scholarship index: the donor's name
+  # with a person/organization icon, mirroring grant_donor_badge. Grant-free
+  # ("Unfunded") groups have no donor, so they render the plain label.
+  def funder_badge(funder_group)
+    donor = funder_group.donor
+    return tag.span(funder_group.name) unless donor
+
+    person = donor.is_a?(Person)
+    icon_name = person ? "fa-user" : "fa-building"
+    color_key = person ? :people : :organizations
+
+    tag.span(class: "inline-flex items-center gap-2") do
+      safe_join([
+        tag.i(class: "fa-solid #{icon_name} #{DomainTheme.text_class_for(color_key)}", aria: { hidden: "true" }),
+        tag.span(funder_group.name)
+      ])
+    end
+  end
+end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -42,6 +42,7 @@ class EventRegistration < ApplicationRecord
   scope :event_title, ->(event_title) { joins(:event).where("LOWER(events.title LIKE ?)", "%#{event_title}%") }
   scope :active, -> { where(status: ACTIVE_STATUSES) }
   scope :inactive, -> { where(status: INACTIVE_STATUSES) }
+  scope :attended, -> { where(status: "attended") }
   scope :registrant_ids, ->(ids) { where(registrant_id: ids.to_s.split("-").map(&:to_i)) }
   scope :attendance_status, ->(status) { where(status: status) }
   scope :registrant_state, ->(state) {

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -154,6 +154,39 @@ class Organization < ApplicationRecord
     [ organization_locality, first_active&.state ].compact_blank.join(", ")
   end
 
+  # Actual "City, State" of the program, from the first active address — the
+  # location column on the scholarship index. (Distinct from #city_state, which
+  # reports the broader locality bucket rather than the literal city.)
+  def program_location
+    first_active = if addresses.loaded?
+      addresses.find { |a| !a.inactive? }
+    else
+      addresses.active.first
+    end
+    return unless first_active
+
+    [ first_active.city, first_active.state ].compact_blank.join(", ").presence
+  end
+
+  # Status of this organization as an AWBW "program," relative to a scholarship
+  # recipient — the New/Ongoing/Reinstate column on the scholarship index:
+  #   * "Reinstate" — the org has facilitator affiliations but none are currently
+  #     active (it is returning after a lapse);
+  #   * "Ongoing"   — the org has facilitator affiliations beyond this recipient
+  #     (an established program);
+  #   * "New"       — no prior facilitator affiliations (this recipient is the
+  #     program's first).
+  # Heuristic based on affiliations (computed in memory to reuse a preloaded
+  # association); confirm the exact business rule with the team.
+  def program_status(recipient = nil)
+    facilitators = affiliations.select(&:facilitator?)
+    return "New" if facilitators.empty?
+    return "Reinstate" if facilitators.none?(&:active?)
+
+    prior = recipient ? facilitators.reject { |a| a.person_id == recipient.id } : facilitators
+    prior.any? ? "Ongoing" : "New"
+  end
+
   def type_name
     "#{name} #{ " (#{windows_type.short_name})" if windows_type}"
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -192,6 +192,27 @@ class Person < ApplicationRecord
       .first&.organization
   end
 
+  # The organization a person facilitates for — the org on their (active, most
+  # recent) facilitator affiliation. This is the "program" a scholarship serves.
+  # Falls back to any facilitator affiliation when none is currently active.
+  # Selects in memory so a preloaded affiliations association (the scholarship
+  # index eager-loads it) is reused rather than re-queried per recipient.
+  def program_organization
+    facilitator_affiliations = affiliations.select(&:facilitator?)
+    active = facilitator_affiliations.select(&:active?).max_by(&:updated_at)
+    (active || facilitator_affiliations.max_by(&:updated_at))&.organization
+  end
+
+  # Facilitator-training events ("TACs") this person registered for and
+  # completed (attended). Drives the training column on the scholarship index.
+  # Filters in memory to reuse a preloaded event_registrations → event chain.
+  def completed_facilitator_trainings
+    event_registrations
+      .select { |r| r.status == "attended" && r.event&.facilitator_training? }
+      .filter_map(&:event)
+      .uniq
+  end
+
   def preferred_email
     user&.email.presence || email.presence || email_2.presence
   end

--- a/app/policies/scholarship_policy.rb
+++ b/app/policies/scholarship_policy.rb
@@ -1,4 +1,12 @@
 class ScholarshipPolicy < ApplicationPolicy
+  # Scholarships are an admin-only resource; the index scope returns nothing to
+  # non-admins (its index? rule already redirects them).
+  relation_scope do |relation|
+    next relation if admin?
+
+    relation.none
+  end
+
   def create?  = admin?
   def update?  = admin?
   def destroy? = admin?

--- a/app/presenters/scholarships_grouping.rb
+++ b/app/presenters/scholarships_grouping.rb
@@ -1,0 +1,67 @@
+# Groups a set of scholarships for the index into the two-level hierarchy the
+# page renders: funder (the grant's donor) → grant → recipient rows. A funder
+# can hold several grants (e.g. a donor who funds a new grant each year), so
+# grants are nested under their shared funder rather than flattened.
+#
+# Scholarships drawn from no grant have no funder; they collect under a single
+# "Unfunded" group, which always sorts last.
+class ScholarshipsGrouping
+  UNFUNDED_LABEL = "Unfunded".freeze
+
+  GrantGroup = Struct.new(:grant, :scholarships, keyword_init: true) do
+    def total_cents = scholarships.sum { |s| s.amount_cents.to_i }
+    def count = scholarships.size
+  end
+
+  FunderGroup = Struct.new(:name, :donor, :grant_groups, keyword_init: true) do
+    def total_cents = grant_groups.sum(&:total_cents)
+    def count = grant_groups.sum(&:count)
+  end
+
+  def initialize(scholarships)
+    @scholarships = scholarships.to_a
+  end
+
+  def funder_groups
+    @funder_groups ||= @scholarships
+      .group_by { |s| funder_key(s) }
+      .map { |_key, scholarships| build_funder_group(scholarships) }
+      .sort_by { |group| sort_key(group) }
+  end
+
+  private
+
+  def build_funder_group(scholarships)
+    sample_grant = scholarships.filter_map(&:grant).first
+    FunderGroup.new(
+      name: sample_grant&.funder_name.presence || UNFUNDED_LABEL,
+      donor: sample_grant&.donor,
+      grant_groups: grant_groups_for(scholarships)
+    )
+  end
+
+  def grant_groups_for(scholarships)
+    scholarships
+      .group_by(&:grant)
+      .map { |grant, schs| GrantGroup.new(grant: grant, scholarships: by_recipient_name(schs)) }
+      .sort_by { |group| group.grant&.name.to_s.downcase }
+  end
+
+  def by_recipient_name(scholarships)
+    scholarships.sort_by { |s| s.recipient&.full_name.to_s.downcase }
+  end
+
+  # Scholarships from grants by the same donor share a funder; grant-free ones
+  # fall into the single unfunded bucket.
+  def funder_key(scholarship)
+    grant = scholarship.grant
+    return :unfunded unless grant
+
+    [ grant.donor_type, grant.donor_id ]
+  end
+
+  # Alphabetical by funder, with the unfunded group pinned last.
+  def sort_key(group)
+    [ group.name == UNFUNDED_LABEL ? 1 : 0, group.name.to_s.downcase ]
+  end
+end

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -22,7 +22,13 @@
         </div>
       </div>
 
-      <div class="shrink-0 text-right text-end">
+      <div class="shrink-0 flex items-center gap-2 text-right text-end">
+        <% if allowed_to?(:index?, Scholarship) %>
+          <%= link_to scholarships_path, class: "btn btn-primary-outline" do %>
+            <i class="fa-solid fa-graduation-cap" aria-hidden="true"></i>
+            <%= Scholarship.model_name.human.pluralize %>
+          <% end %>
+        <% end %>
         <% if allowed_to?(:new?, Grant) %>
           <%= link_to new_grant_path, class: "admin-only bg-blue-100 btn btn-primary-outline" do %>
             <i class="fa-solid fa-plus" aria-hidden="true"></i>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -3,8 +3,16 @@
 
 <div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6 space-y-6">
   <div>
-    <%= link_to grants_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-3" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Grants
+    <%# Eyebrow returns to wherever the grant was opened from: the scholarships
+        index (when linked from a grant group there) or the grants index. %>
+    <% if params[:from_scholarships].present? %>
+      <%= link_to scholarships_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-3" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
+      <% end %>
+    <% else %>
+      <%= link_to grants_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-3" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Grants
+      <% end %>
     <% end %>
     <div class="flex items-start justify-between">
       <div>

--- a/app/views/scholarships/_funder_group.html.erb
+++ b/app/views/scholarships/_funder_group.html.erb
@@ -1,0 +1,18 @@
+<%# Top-level disclosure: one funder, with its grants nested inside. The chevron
+    rotates with this details' own open state (group/card → group-open/card). %>
+<details class="group/card rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white shadow-sm overflow-hidden" open>
+  <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden <%= DomainTheme.bg_class_for(:scholarships) %> px-5 py-4">
+    <div class="flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3 min-w-0 text-gray-900">
+        <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
+        <span class="text-lg font-semibold truncate"><%= funder_badge(funder_group) %></span>
+        <span class="inline-flex items-center rounded-full <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white px-2 py-0.5 text-xs font-semibold tabular-nums"><%= funder_group.count %></span>
+      </div>
+      <div class="shrink-0 text-sm font-semibold text-gray-700 tabular-nums"><%= number_to_currency(funder_group.total_cents / 100.0) %></div>
+    </div>
+  </summary>
+
+  <div class="px-3 sm:px-5 py-4 space-y-3 border-t <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %>">
+    <%= render partial: "grant_group", collection: funder_group.grant_groups, as: :grant_group %>
+  </div>
+</details>

--- a/app/views/scholarships/_grant_group.html.erb
+++ b/app/views/scholarships/_grant_group.html.erb
@@ -1,0 +1,49 @@
+<%# Second-level disclosure: one grant under its funder, with the recipient grid
+    inside. A grant-free ("Unfunded") group has no grant, so it shows a plain
+    label and no grant budget figures. %>
+<% grant = grant_group.grant&.decorate %>
+<details class="group/card rounded-lg border border-gray-200 bg-white" open>
+  <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-4 py-3 hover:bg-gray-50 rounded-lg">
+    <div class="flex items-center justify-between gap-4">
+      <div class="flex items-center gap-2.5 min-w-0">
+        <i class="fa-solid fa-chevron-down text-gray-400 text-xs transition-transform group-open/card:rotate-180"></i>
+        <% if grant %>
+          <%= link_to grant.name, grant_path(grant, from_scholarships: true), class: "font-medium text-gray-900 hover:underline truncate" %>
+        <% else %>
+          <span class="font-medium text-gray-500 italic">No grant</span>
+        <% end %>
+        <span class="inline-flex items-center rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-xs font-semibold tabular-nums"><%= grant_group.count %></span>
+      </div>
+      <div class="shrink-0 text-xs text-gray-500 tabular-nums">
+        <% if grant %>
+          <span class="font-semibold text-gray-700"><%= number_to_currency(grant_group.total_cents / 100.0) %></span>
+          awarded · <%= grant.remaining %> left of <%= grant.amount %>
+        <% else %>
+          <span class="font-semibold text-gray-700"><%= number_to_currency(grant_group.total_cents / 100.0) %></span> awarded
+        <% end %>
+      </div>
+    </div>
+    <% if grant && grant.eligibility_criteria_list.any? %>
+      <p class="mt-1.5 ml-6 text-xs text-gray-500 truncate"><%= grant.eligibility_criteria_list.join(" · ") %></p>
+    <% end %>
+  </summary>
+
+  <div class="overflow-x-auto border-t border-gray-100">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Recipient</th>
+          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Program</th>
+          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Training</th>
+          <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+          <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
+          <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Tasks</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-100">
+        <%= render partial: "recipient_row", collection: grant_group.scholarships, as: :scholarship %>
+      </tbody>
+    </table>
+  </div>
+</details>

--- a/app/views/scholarships/_recipient_row.html.erb
+++ b/app/views/scholarships/_recipient_row.html.erb
@@ -1,0 +1,27 @@
+<% scholarship = scholarship.decorate %>
+<tr class="hover:bg-gray-50">
+  <td class="px-4 py-2 whitespace-nowrap text-sm">
+    <%= link_to scholarship.recipient_name, edit_scholarship_path(scholarship), class: "font-medium text-blue-700 hover:text-blue-900 hover:underline" %>
+  </td>
+  <td class="px-4 py-2 text-sm text-gray-900"><%= scholarship.program_name %></td>
+  <td class="px-4 py-2 text-sm text-gray-600 whitespace-nowrap"><%= scholarship.program_location %></td>
+  <td class="px-4 py-2 text-sm text-gray-600 whitespace-nowrap"><%= scholarship.training_label %></td>
+  <td class="px-4 py-2 text-center text-sm">
+    <% if scholarship.program_status == "—" %>
+      <span class="text-gray-400">—</span>
+    <% else %>
+      <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium <%= scholarship.program_status_classes %>"><%= scholarship.program_status %></span>
+    <% end %>
+  </td>
+  <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900 text-right tabular-nums"><%= scholarship.amount %></td>
+  <td class="px-4 py-2 whitespace-nowrap text-sm text-center">
+    <% if scholarship.tasks_completed? %>
+      <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-3 py-0.5 bg-green-50 text-green-700 border-green-200">
+        <i class="fa-solid fa-graduation-cap text-xs"></i>
+        Yes
+      </span>
+    <% else %>
+      <span class="text-gray-400">No</span>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/scholarships/index.html.erb
+++ b/app/views/scholarships/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="scholarships-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:scholarships) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="w-full">
+    <div class="flex items-start justify-between gap-6 mb-6">
+      <div class="flex items-start gap-4">
+        <span class="hidden sm:flex h-12 w-12 shrink-0 items-center justify-center rounded-xl <%= DomainTheme.bg_class_for(:scholarships) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> shadow-sm">
+          <i class="fa-solid fa-graduation-cap text-xl" aria-hidden="true"></i>
+        </span>
+        <div>
+          <h2 class="text-2xl font-semibold text-gray-900 flex items-center gap-2">
+            <%= Scholarship.model_name.human.pluralize %>
+            <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:scholarships) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> px-2.5 py-0.5 text-sm font-semibold"><%= @scholarships_count %></span>
+          </h2>
+          <p class="text-gray-600 mt-1">Awards to facilitators, grouped by funder and grant.</p>
+        </div>
+      </div>
+
+      <div class="shrink-0 text-right text-end">
+        <%= link_to grants_path, class: "btn btn-primary-outline" do %>
+          <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
+          <%= Grant.model_name.human.pluralize %>
+        <% end %>
+      </div>
+    </div>
+
+    <% if @funder_groups.any? %>
+      <div class="space-y-4">
+        <%= render partial: "funder_group", collection: @funder_groups, as: :funder_group %>
+      </div>
+    <% else %>
+      <div class="bg-white rounded-xl border border-dashed border-gray-300 py-12 text-center">
+        <i class="fa-solid fa-graduation-cap text-3xl text-gray-300" aria-hidden="true"></i>
+        <p class="mt-3 text-gray-500">No scholarships found.</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
   end
   resources :form_submissions, only: [ :show ]
   resources :grants
-  resources :scholarships, only: [ :new, :create, :show, :edit, :update, :destroy ] do
+  resources :scholarships, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     member { patch :toggle_tasks }
   end
   resources :discounts, only: [ :create, :show, :destroy ] do

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -29,6 +29,12 @@ facilitator_training = Event.find_by(title: "AWBW Facilitator Training")
 # Reused below to surface non-flagship applicants and print the per-event summary.
 scholarship_events = Event.joins(:event_forms).where(event_forms: { role: "scholarship" }).distinct.to_a
 
+# These are AWBW facilitator trainings (the "TAC" a recipient attends). Flag them
+# so the scholarship index's training column has data to show.
+(scholarship_events + [ facilitator_training ]).compact.uniq.each do |event|
+  event.update!(facilitator_training: true) unless event.facilitator_training?
+end
+
 # --- Grants (funding sources) ----------------------------------------------
 # Create the grants up front so the event-allocated scholarships below can be
 # drawn from them (recipients page → donor name). Grants cap the total
@@ -259,6 +265,37 @@ ensure_recipient_affiliation = ->(person, event, set, org) do
   person.affiliations.create!(organization: org, title: set["title"], start_date: start_date)
 end
 
+# Rotating real-ish City/State pairs so program orgs have a location to show on
+# the scholarship index (the "Program Location" column reads the org's address).
+address_samples = [
+  [ "Los Angeles", "CA" ], [ "Stockton", "CA" ], [ "Portland", "OR" ], [ "Newport", "VT" ],
+  [ "Bangor", "ME" ], [ "Austin", "TX" ], [ "Chicago", "IL" ], [ "Brooklyn", "NY" ]
+]
+
+# Give an org a primary active address when it has none, so its facilitators'
+# scholarships show a location. Idempotent: skips orgs that already have one.
+ensure_org_address = ->(org) do
+  return unless org
+  return if org.addresses.active.exists?
+
+  city, state = address_samples[org.id % address_samples.length]
+  org.addresses.create!(locality: "Unknown", city: city, state: state,
+                        street_address: "#{100 + (org.id % 900)} Main St", zip_code: "90001", primary: true)
+end
+
+# Also give the recipient a facilitator affiliation at the same org — this is the
+# "program" the scholarship index reports (Person#program_organization), distinct
+# from the agency role above — and make sure that org carries an address so the
+# location column has data. Skips anyone who already facilitates somewhere.
+ensure_facilitator_affiliation = ->(person, event, org) do
+  return unless org
+  ensure_org_address.(org)
+  return if person.affiliations.any?(&:facilitator?)
+
+  start_date = (event.start_date || Time.current).to_date - 1.year
+  person.affiliations.create!(organization: org, title: "Facilitator", start_date: start_date)
+end
+
 # Ensure the recipient has a registration submission (no recipient should have
 # only a scholarship submission), creating a minimal one with their identity
 # fields when missing — most cohort registrants were generated without a form.
@@ -311,7 +348,15 @@ setup_recipient = ->(registration, second_form:) do
 
   reg_submission = ensure_registration_submission.(person, event)
   attach_header_answers.(reg_submission, set) if reg_submission
-  ensure_recipient_affiliation.(person, event, set, recipient_orgs[application_index % recipient_orgs.length]) if recipient_orgs.any?
+  if recipient_orgs.any?
+    org = recipient_orgs[application_index % recipient_orgs.length]
+    ensure_recipient_affiliation.(person, event, set, org)
+    ensure_facilitator_affiliation.(person, event, org)
+  end
+
+  # Mark attendance so the scholarship index shows the recipient completed the
+  # facilitator training ("TAC"). The award amount/allocation is unaffected.
+  registration.update!(status: "attended") unless registration.status == "attended"
 
   if second_form && scholarship_form
     separate = FormSubmission.find_or_create_by!(person: person, form: scholarship_form, role: "scholarship") do |fs|
@@ -420,6 +465,49 @@ grant_plans.each do |(name, _donor_type, _donor_name, _amount_cents, awards, _el
   end
 
   puts "  #{grant.name}: #{grant.scholarships.count} scholarships, remaining #{grant.remaining_dollars}"
+end
+
+# --- Index demo states: multi-grant funder + Reinstate ---------------------
+# The awards above leave three of the index's distinctive states unexercised:
+# a funder holding more than one grant (the reason for the funder → grant
+# nesting), and the "Reinstate" program status. Seed a second grant under an
+# existing funder, with two recipients whose program orgs carry addresses — the
+# second's facilitator affiliation is lapsed, so its org reads as "Reinstate".
+# Idempotent: keyed on the sibling grant's name and its having no awards yet.
+puts "Seeding scholarship index demo states (multi-grant funder, Reinstate)…"
+
+anchor_grant = grants.first
+if anchor_grant && recipient_orgs.any?
+  sibling = Grant.find_or_create_by!(name: "#{anchor_grant.name} (2026)") do |g|
+    g.donor = anchor_grant.donor
+    g.amount_cents = 600_000
+    g.application_deadline = Date.current + 60
+    g.funds_received_on = Date.current - 10
+    g.eligibility_criteria = anchor_grant.eligibility_criteria
+    g.tasks = anchor_grant.tasks
+  end
+
+  if sibling.scholarships.none?
+    # People and orgs with no facilitator yet, so each program's status is
+    # deterministic rather than depending on who else was seeded against the org.
+    demo_people = grant_recipient_pool.reject { |p| p.affiliations.any?(&:facilitator?) }.first(2)
+    demo_orgs = recipient_orgs.select { |o| o.affiliations.none?(&:facilitator?) }.first(2)
+
+    demo_people.each_with_index do |person, i|
+      amount = i.zero? ? 150_000 : 100_000
+      next if sibling.remaining_cents < amount
+
+      org = demo_orgs[i] || recipient_orgs[i % recipient_orgs.length]
+      ensure_org_address.(org)
+      lapsed = i.odd? # the second recipient's affiliation has ended → "Reinstate"
+      attrs = { organization: org, title: "Facilitator", start_date: Date.current - 2.years }
+      attrs[:end_date] = Date.current - 2.months if lapsed
+      person.affiliations.create!(**attrs)
+      Scholarship.create!(recipient: person, grant: sibling, amount_cents: amount, tasks_completed: i.even?)
+    end
+  end
+
+  puts "  #{sibling.funder_name}: now funds #{Grant.where(donor: anchor_grant.donor).count} grants"
 end
 
 puts "  Scholarship seeds complete!"

--- a/spec/decorators/scholarship_decorator_spec.rb
+++ b/spec/decorators/scholarship_decorator_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe ScholarshipDecorator, type: :decorator do
+  let(:recipient) { create(:person, first_name: "Carmen", last_name: "Gomez") }
+
+  it "formats the amount and recipient name" do
+    scholarship = create(:scholarship, recipient: recipient, amount_cents: 150_000).decorate
+    expect(scholarship.amount).to eq("$1,500.00")
+    expect(scholarship.recipient_name).to eq("Carmen Gomez")
+  end
+
+  describe "program columns derived from the recipient's facilitator affiliation" do
+    let(:org) { create(:organization, name: "Prevail") }
+
+    before do
+      create(:address, addressable: org, city: "Stockton", state: "CA")
+      create(:affiliation, person: recipient, organization: org, title: "Facilitator")
+    end
+
+    it "shows the program name, location, and status" do
+      scholarship = create(:scholarship, recipient: recipient).decorate
+
+      expect(scholarship.program_name).to eq("Prevail")
+      expect(scholarship.program_location).to eq("Stockton, CA")
+      expect(scholarship.program_status).to eq("New")
+    end
+  end
+
+  describe "training column" do
+    it "lists the attended facilitator-training event" do
+      training = create(:event, title: "TAC251", facilitator_training: true)
+      create(:event_registration, registrant: recipient, event: training, status: "attended")
+      scholarship = create(:scholarship, recipient: recipient).decorate
+
+      expect(scholarship.training_label).to eq("TAC251")
+    end
+
+    it "falls back to a dash with no completed training" do
+      scholarship = create(:scholarship, recipient: recipient).decorate
+      expect(scholarship.training_label).to eq("—")
+    end
+  end
+
+  it "dashes the program columns when the recipient has no facilitator affiliation" do
+    scholarship = create(:scholarship, recipient: recipient).decorate
+    expect(scholarship.program_name).to eq("—")
+    expect(scholarship.program_location).to eq("—")
+    expect(scholarship.program_status).to eq("—")
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -203,3 +203,46 @@ RSpec.describe Organization do
     end
   end
 end
+
+RSpec.describe Organization, "scholarship index helpers" do
+  describe "#program_location" do
+    it "returns the City, State of the first active address" do
+      org = create(:organization)
+      create(:address, addressable: org, city: "Stockton", state: "CA")
+
+      expect(org.program_location).to eq("Stockton, CA")
+    end
+
+    it "is nil without an active address" do
+      expect(create(:organization).program_location).to be_nil
+    end
+  end
+
+  describe "#program_status" do
+    let(:org) { create(:organization) }
+    let(:recipient) { create(:person) }
+
+    it "is New when the recipient is the org's only facilitator" do
+      create(:affiliation, person: recipient, organization: org, title: "Facilitator")
+
+      expect(org.reload.program_status(recipient)).to eq("New")
+    end
+
+    it "is Ongoing when another facilitator already serves the org" do
+      create(:affiliation, person: recipient, organization: org, title: "Facilitator")
+      create(:affiliation, person: create(:person), organization: org, title: "Facilitator")
+
+      expect(org.reload.program_status(recipient)).to eq("Ongoing")
+    end
+
+    it "is Reinstate when the org's facilitator affiliations have all lapsed" do
+      create(:affiliation, person: recipient, organization: org, title: "Facilitator", end_date: 1.year.ago.to_date)
+
+      expect(org.reload.program_status(recipient)).to eq("Reinstate")
+    end
+
+    it "is New when the org has no facilitator affiliations" do
+      expect(org.program_status(recipient)).to eq("New")
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -433,3 +433,44 @@ RSpec.describe Person, type: :model do
     end
   end
 end
+
+RSpec.describe Person, "scholarship index helpers" do
+  let(:person) { create(:person) }
+
+  describe "#program_organization" do
+    it "returns the organization on the recipient's facilitator affiliation" do
+      org = create(:organization, name: "Prevail")
+      create(:affiliation, person: person, organization: org, title: "Lead Facilitator")
+
+      expect(person.program_organization).to eq(org)
+    end
+
+    it "prefers an active facilitator affiliation over a lapsed one" do
+      lapsed_org = create(:organization, name: "Old Program")
+      active_org = create(:organization, name: "Current Program")
+      create(:affiliation, person: person, organization: lapsed_org, title: "Facilitator", end_date: 1.year.ago.to_date)
+      create(:affiliation, person: person, organization: active_org, title: "Facilitator")
+
+      expect(person.program_organization).to eq(active_org)
+    end
+
+    it "ignores non-facilitator affiliations" do
+      create(:affiliation, person: person, organization: create(:organization), title: "Board Member")
+
+      expect(person.program_organization).to be_nil
+    end
+  end
+
+  describe "#completed_facilitator_trainings" do
+    it "returns only attended facilitator-training events" do
+      training = create(:event, title: "TAC251", facilitator_training: true)
+      other_training = create(:event, title: "TAC252", facilitator_training: true)
+      non_training = create(:event, title: "Webinar", facilitator_training: false)
+      create(:event_registration, registrant: person, event: training, status: "attended")
+      create(:event_registration, registrant: person, event: other_training, status: "registered")
+      create(:event_registration, registrant: person, event: non_training, status: "attended")
+
+      expect(person.completed_facilitator_trainings).to contain_exactly(training)
+    end
+  end
+end

--- a/spec/presenters/scholarships_grouping_spec.rb
+++ b/spec/presenters/scholarships_grouping_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe ScholarshipsGrouping do
+  describe "#funder_groups" do
+    it "nests grants under their shared funder and sums each level" do
+      donor = create(:person, first_name: "Elisa", last_name: "Perlman")
+      grant_2025 = create(:grant, name: "Elisa 2025", donor: donor, amount_cents: 1_000_000)
+      grant_2026 = create(:grant, name: "Elisa 2026", donor: donor, amount_cents: 1_000_000)
+      create(:scholarship, grant: grant_2025, amount_cents: 100_000)
+      create(:scholarship, grant: grant_2026, amount_cents: 50_000)
+
+      groups = described_class.new(Scholarship.all).funder_groups
+
+      expect(groups.map(&:name)).to eq([ "Elisa Perlman" ])
+      funder = groups.first
+      expect(funder.count).to eq(2)
+      expect(funder.total_cents).to eq(150_000)
+      expect(funder.grant_groups.map { |g| g.grant.name }).to eq([ "Elisa 2025", "Elisa 2026" ])
+    end
+
+    it "puts grant-free scholarships in an Unfunded group sorted last" do
+      create(:scholarship, grant: create(:grant, name: "Aardvark Fund", donor: create(:organization, name: "Aardvark")))
+      create(:scholarship, grant: nil)
+
+      names = described_class.new(Scholarship.all).funder_groups.map(&:name)
+
+      expect(names.last).to eq("Unfunded")
+    end
+
+    it "orders recipients within a grant by name" do
+      grant = create(:grant, amount_cents: 1_000_000)
+      create(:scholarship, grant: grant, recipient: create(:person, first_name: "Zoe", last_name: "Z"))
+      create(:scholarship, grant: grant, recipient: create(:person, first_name: "Amy", last_name: "A"))
+
+      grant_group = described_class.new(Scholarship.all).funder_groups.first.grant_groups.first
+
+      expect(grant_group.scholarships.map { |s| s.recipient.full_name }).to eq([ "Amy A", "Zoe Z" ])
+    end
+  end
+end

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -231,6 +231,64 @@ RSpec.describe "Scholarships", type: :request do
   end
 end
 
+RSpec.describe "GET /scholarships (index)", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  describe "authorization" do
+    it "redirects non-admins away from the index" do
+      sign_in create(:user)
+      get scholarships_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "as an admin" do
+    before { sign_in admin }
+
+    it "renders a grid grouped by funder and grant, with each derived column" do
+      org = create(:organization, name: "Prevail")
+      create(:address, addressable: org, city: "Stockton", state: "CA")
+      recipient = create(:person, first_name: "Carmen", last_name: "Gomez")
+      create(:affiliation, person: recipient, organization: org, title: "Facilitator")
+      training = create(:event, title: "TAC251", facilitator_training: true)
+      create(:event_registration, registrant: recipient, event: training, status: "attended")
+
+      donor = create(:organization, name: "JDI Foundation")
+      grant = create(:grant, name: "JDI", donor: donor, amount_cents: 1_000_000)
+      create(:scholarship, grant: grant, recipient: recipient, amount_cents: 150_000)
+
+      get scholarships_path
+
+      expect(response).to be_successful
+      expect(response.body).to include("JDI Foundation")  # funder group
+      expect(response.body).to include("JDI")             # grant group
+      expect(response.body).to include("Carmen Gomez")    # recipient
+      expect(response.body).to include("Prevail")         # program (org via facilitator affiliation)
+      expect(response.body).to include("Stockton, CA")    # program location
+      expect(response.body).to include("TAC251")          # attended facilitator training
+      expect(response.body).to include("New")             # program status — first facilitator for the org
+    end
+
+    it "collects grant-free scholarships under an Unfunded group" do
+      create(:scholarship, grant: nil, recipient: create(:person, first_name: "Jane", last_name: "Doe"))
+
+      get scholarships_path
+
+      expect(response.body).to include("Unfunded")
+      expect(response.body).to include("Jane Doe")
+    end
+
+    it "links a grant group's grant back to the scholarship index via from_scholarships" do
+      grant = create(:grant, name: "Marisla")
+      create(:scholarship, grant: grant)
+
+      get scholarships_path
+
+      expect(response.body).to include(grant_path(grant, from_scholarships: true))
+    end
+  end
+end
+
 RSpec.describe "/scholarships (grant-funded flow)", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:donor) { create(:organization, name: "Helping Hands") }

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/workshop_ideas/index.html.erb"          => "admin-only bg-blue-100",
     "app/views/workshop_variation_ideas/index.html.erb" => "admin-only bg-blue-100",
     "app/views/grants/index.html.erb"                  => "admin-only bg-blue-100",
+    "app/views/scholarships/index.html.erb"            => "admin-only bg-blue-100",
     # show
     "app/views/banners/show.html.erb"                  => "admin-only bg-blue-100",
     "app/views/categories/show.html.erb"               => "admin-only bg-blue-100",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins need a single grid of every scholarship and its recipient, instead of navigating grant-by-grant.
- Adds a `scholarships#index` that groups awards into a **funder → grant → recipient** hierarchy so the money's source and its recipients read top-down.
- Grant-free awards collect under a trailing **"Unfunded"** group so nothing is hidden.
- Re-activates the previously-disabled **Scholarships** card on the admin home so the grid is reachable, parallel to Grants.

### How did you approach the change?

- **`Scholarship#index`** eager-loads `grant → donor` and `recipient → affiliations/org/addresses` + `recipient → event_registrations → event`, so each row's funder, program, location, training, and status cells add no per-row queries.
- **`ScholarshipsGrouping`** presenter builds the funder/grant/recipient tree.
- **`ScholarshipDecorator`** derives the program / location / training / status columns.
- **`ScholarshipHelper`** + `_funder_group` / `_grant_group` / `_recipient_row` partials render the grid.
- **Person / Organization** scholarship-status helpers (+ specs).
- Linked the index from the grants page; enriched the dev scholarship seeds.
- Activated the admin-home Scholarships card (`disabled_card` → `model_card(:scholarships)`).
- Documented the presenter & decorator in `AGENTS.md`.

### Anything else to add?

- Branched on top of the now-merged #1740 (facilitator_training), which this grid's training column consumes.
- UI screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)