### PR TITLE
Unify currency display behind dollars_from_cents / MoneyFormatter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,6 +108,30 @@ This project uses rubocop-rails-omakase. All code MUST follow these rules:
 - Avoid `.titleize` for user-facing labels — it produces title case
 - **Exception:** when a category type name prefixes a category name (e.g., "Age Range: 3-5"), use `.titleize` for the prefix
 
+## Currency display
+
+**Always display money with the `dollars_from_cents(cents)` helper** (`app/helpers/application_helper.rb`),
+which delegates to the **`MoneyFormatter`** PORO (`app/services/money_formatter.rb`).
+It takes an integer **cents** amount and renders `$1,500.50` when there are cents and `$1,500`
+(no trailing `.00`) when the amount is a whole number of dollars. The helper is display-only — keep
+storing and calculating in integer cents. For an abbreviated figure in tight UI (e.g. the grant
+picker), use `MoneyFormatter.compact_from_cents(cents)` (`$12.5k`, `$1.2m`) — also cents-based.
+
+- **Pass cents, not dollars.** Use the `*_cents` column/accessor (`amount_cents`,
+  `amount_cents_remaining`, `allocation.amount`, etc.), not `amount_dollars`. Don't prepend a literal
+  `$` — the helper includes it.
+- **Do NOT use** `number_to_currency`, `format("%.2f", …)`, or the naked `"%.2f" % x` operator to show
+  money. They always print `.00` and reintroduce the inconsistency this helper exists to remove.
+  (`number_to_currency` is fine only inside the helper definition itself.)
+- **In decorators**, call it via `h.dollars_from_cents(...)`; **in controllers**, via
+  `helpers.dollars_from_cents(...)`. In a **model** or other PORO (no view-helper access), call
+  `MoneyFormatter.dollars_from_cents(cents)` directly (e.g. validation messages) — don't fall back to
+  `format("%.2f", …)`, which reprints `.00`.
+- **Mirror the same rule in JavaScript** when a Stimulus controller renders a live money figure: drop
+  the cents for whole-dollar amounts, keep two decimals otherwise (see `formatDollars` in
+  `scholarship_preview_controller.js`). Keep the server-rendered initial value and the JS-updated value
+  formatted identically.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~75 files |
-| `app/services/` | Service objects for complex logic | ~25 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~26 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 15 concerns |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,30 @@ This project uses rubocop-rails-omakase. All code MUST follow these rules:
 - Avoid `.titleize` for user-facing labels — it produces title case
 - **Exception:** when a category type name prefixes a category name (e.g., "Age Range: 3-5"), use `.titleize` for the prefix
 
+## Currency display
+
+**Always display money with the `dollars_from_cents(cents)` helper** (`app/helpers/application_helper.rb`),
+which delegates to the **`MoneyFormatter`** PORO (`app/services/money_formatter.rb`).
+It takes an integer **cents** amount and renders `$1,500.50` when there are cents and `$1,500`
+(no trailing `.00`) when the amount is a whole number of dollars. The helper is display-only — keep
+storing and calculating in integer cents. For an abbreviated figure in tight UI (e.g. the grant
+picker), use `MoneyFormatter.compact_from_cents(cents)` (`$12.5k`, `$1.2m`) — also cents-based.
+
+- **Pass cents, not dollars.** Use the `*_cents` column/accessor (`amount_cents`,
+  `amount_cents_remaining`, `allocation.amount`, etc.), not `amount_dollars`. Don't prepend a literal
+  `$` — the helper includes it.
+- **Do NOT use** `number_to_currency`, `format("%.2f", …)`, or the naked `"%.2f" % x` operator to show
+  money. They always print `.00` and reintroduce the inconsistency this helper exists to remove.
+  (`number_to_currency` is fine only inside the helper definition itself.)
+- **In decorators**, call it via `h.dollars_from_cents(...)`; **in controllers**, via
+  `helpers.dollars_from_cents(...)`. In a **model** or other PORO (no view-helper access), call
+  `MoneyFormatter.dollars_from_cents(cents)` directly (e.g. validation messages) — don't fall back to
+  `format("%.2f", …)`, which reprints `.00`.
+- **Mirror the same rule in JavaScript** when a Stimulus controller renders a live money figure: drop
+  the cents for whole-dollar amounts, keep two decimals otherwise (see `formatDollars` in
+  `scholarship_preview_controller.js`). Keep the server-rendered initial value and the JS-updated value
+  formatted identically.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -51,7 +51,7 @@ class PaymentsController < ApplicationController
 
         process_allocation!(@payment, allocatable)
 
-        flash[:notice] = "Allocation created. $#{'%.2f' % @payment.reload.remaining_dollars} remaining on payment."
+        flash[:notice] = "Allocation created. #{helpers.dollars_from_cents(@payment.reload.amount_cents_remaining)} remaining on payment."
         redirect_path = allocations_path(allocatable_sgid: allocatable.to_sgid.to_s)
       else
         @payment = payment_class.new(payment_params.except(:allocatable_sgid, :type))

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -1,14 +1,14 @@
 class GrantDecorator < ApplicationDecorator
   def amount
-    h.number_to_currency(object.amount_dollars)
+    h.dollars_from_cents(object.amount_cents)
   end
 
   def allocated
-    h.number_to_currency(object.scholarships_total_cents.to_d / 100)
+    h.dollars_from_cents(object.scholarships_total_cents)
   end
 
   def remaining
-    h.number_to_currency(object.remaining_dollars)
+    h.dollars_from_cents(object.remaining_cents)
   end
 
   def application_deadline
@@ -64,37 +64,17 @@ class GrantDecorator < ApplicationDecorator
   # Short human-readable remaining balance for the grant picker, e.g. "$750" or
   # "$12.5k". The picker bolds this as the figure that matters most.
   def remaining_compact
-    compact_amount(object.remaining_dollars)
+    MoneyFormatter.compact_from_cents(object.remaining_cents)
   end
 
   # Short human-readable total donation for the grant picker, e.g. "$10k".
   def amount_compact
-    compact_amount(object.amount_dollars)
+    MoneyFormatter.compact_from_cents(object.amount_cents)
   end
 
   # Plain-text remaining-of-total summary (e.g. "$750 of $12.5k available"),
   # used as the picker pill's accessible title/tooltip.
   def funds_remaining_summary
     "#{remaining_compact} of #{amount_compact} available"
-  end
-
-  private
-
-  # Abbreviate dollar amounts: plain under $1k ("$750"), k for thousands
-  # ("$12.5k"), m for millions ("$1.2m"). One decimal place, trailing .0 dropped.
-  def compact_amount(dollars)
-    amount = dollars.to_d
-    if amount >= 1_000_000
-      "$#{trim_decimal(amount / 1_000_000)}m"
-    elsif amount >= 1_000
-      "$#{trim_decimal(amount / 1_000)}k"
-    else
-      "$#{amount.to_i}"
-    end
-  end
-
-  def trim_decimal(value)
-    rounded = value.round(1)
-    rounded.frac.zero? ? rounded.to_i.to_s : rounded.to_s("F")
   end
 end

--- a/app/frontend/javascript/controllers/ce_credit_requested_controller.js
+++ b/app/frontend/javascript/controllers/ce_credit_requested_controller.js
@@ -46,6 +46,9 @@ export default class extends Controller {
 
     const hours = Math.max(0, parseInt(this.hoursTarget.value, 10) || 0)
     const owed = hours * this.rateValue
-    this.amountTarget.textContent = `$${owed.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    // Mirror the dollars_from_cents helper: drop the cents when the amount is a
+    // whole number of dollars, keep two decimals otherwise.
+    const fractionDigits = Number.isInteger(owed) ? 0 : 2
+    this.amountTarget.textContent = `$${owed.toLocaleString("en-US", { minimumFractionDigits: fractionDigits, maximumFractionDigits: 2 })}`
   }
 }

--- a/app/frontend/javascript/controllers/scholarship_preview_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_preview_controller.js
@@ -47,7 +47,7 @@ export default class extends Controller {
       if (!allocated) {
         this.allocatedHintTarget.innerHTML = `<span class="text-xs text-gray-500">$0 allocated to registration</span>`
       } else {
-        const amount = `$${(allocatedCents / 100).toFixed(2)}`
+        const amount = this.formatDollars(allocatedCents)
         this.allocatedHintTarget.innerHTML = `<span class="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-100 px-2 py-0.5 text-[0.65rem] font-medium text-fuchsia-700"><i class="fa-solid fa-circle-check text-[0.55rem]"></i>${amount} allocated to registration</span>`
       }
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -448,9 +448,7 @@ module ApplicationHelper
   # Currency for an amount given in cents, dropping the cents when the amount is
   # a whole number of dollars: 150000 → "$1,500", 75050 → "$750.50".
   def dollars_from_cents(cents)
-    cents = cents.to_i
-    precision = (cents % 100).zero? ? 0 : 2
-    number_to_currency(cents / 100.0, precision: precision)
+    MoneyFormatter.dollars_from_cents(cents)
   end
 
   def navbar_bg_class

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -104,7 +104,7 @@ class Allocation < ApplicationRecord
         errors.add(:base, "Event registration is already fully paid.")
       elsif other_total + amount > cost_cents
         remaining = cost_cents - other_total
-        errors.add(:base, "Cannot allocate more than remaining event cost. Remaining: $#{'%.2f' % (remaining / 100.0)}")
+        errors.add(:base, "Cannot allocate more than remaining event cost. Remaining: #{MoneyFormatter.dollars_from_cents(remaining)}")
       end
     end
   end

--- a/app/services/money_formatter.rb
+++ b/app/services/money_formatter.rb
@@ -1,0 +1,33 @@
+# Centralizes how a cents amount renders as currency so models, helpers, and
+# decorators all format money the same way. Every method takes integer cents.
+# View code should call the `dollars_from_cents` helper, which delegates here;
+# models and other POROs (no view-helper access) call MoneyFormatter directly.
+class MoneyFormatter
+  # Full amount with a thousands delimiter, dropping the cents when the amount is
+  # a whole number of dollars: 150000 => "$1,500", 75050 => "$750.50".
+  def self.dollars_from_cents(cents)
+    cents = cents.to_i
+    precision = (cents % 100).zero? ? 0 : 2
+    ActiveSupport::NumberHelper.number_to_currency(cents / 100.0, precision: precision)
+  end
+
+  # Abbreviated for tight UI like the grant picker: plain under $1k ("$750"),
+  # "k" for thousands ("$12.5k"), "m" for millions ("$1.2m"). One decimal place,
+  # trailing .0 dropped. Lossy on purpose — use dollars_from_cents for exact values.
+  def self.compact_from_cents(cents)
+    amount = cents.to_i.to_d / 100
+    if amount >= 1_000_000
+      "$#{trim_decimal(amount / 1_000_000)}m"
+    elsif amount >= 1_000
+      "$#{trim_decimal(amount / 1_000)}k"
+    else
+      "$#{amount.to_i}"
+    end
+  end
+
+  def self.trim_decimal(value)
+    rounded = value.round(1)
+    rounded.frac.zero? ? rounded.to_i.to_s : rounded.to_s("F")
+  end
+  private_class_method :trim_decimal
+end

--- a/app/views/allocations/allocation_results.html.erb
+++ b/app/views/allocations/allocation_results.html.erb
@@ -6,7 +6,7 @@
         <p class="text-sm text-gray-500"><%= total %> allocation<%= "s" if total != 1 %></p>
         <% if @allocations_total_cents %>
           <p class="text-sm text-gray-500">
-            Total <span class="font-semibold text-gray-900 tabular-nums">$<%= "%.2f" % (@allocations_total_cents.to_i / 100.0) %></span>
+            Total <span class="font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(@allocations_total_cents) %></span>
           </p>
         <% end %>
       </div>
@@ -45,7 +45,7 @@
                     name = allocation.source.payer&.name || "Unknown"
                     remaining = allocation.source.amount_cents_remaining
                     if remaining.present? && remaining > 0
-                      "#{name} ($#{'%.2f' % (remaining / 100.0)} remaining)"
+                      "#{name} (#{dollars_from_cents(remaining)} remaining)"
                     else
                       name
                     end
@@ -61,7 +61,7 @@
                   </td>
                 <% end %>
 
-                <td class="px-4 py-2 text-sm font-medium text-gray-900 tabular-nums">$<%= "%.2f" % allocation.amount_dollars %></td>
+                <td class="px-4 py-2 text-sm font-medium text-gray-900 tabular-nums"><%= dollars_from_cents(allocation.amount) %></td>
 
                 <td class="px-4 py-2 text-sm text-gray-500">
                   <% ref_id = allocation.amount.to_i < 0 ? Allocation.find_by(reverted_id: allocation.id)&.id : allocation.reverted_id %>

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -7,8 +7,8 @@
     <% if source.present? && source.is_a?(Payment) %>
       <div class="mb-4 p-4 bg-gray-50 rounded-lg">
         <p class="text-sm font-medium text-gray-700">From Payment</p>
-        <p class="text-lg text-gray-900">$<%= "%.2f" % source.amount_dollars %></p>
-        <p class="text-sm text-gray-500">Remaining: $<%= "%.2f" % source.remaining_dollars %></p>
+        <p class="text-lg text-gray-900"><%= dollars_from_cents(source.amount_cents) %></p>
+        <p class="text-sm text-gray-500">Remaining: <%= dollars_from_cents(source.amount_cents_remaining) %></p>
       </div>
     <% else %>
       <div class="mb-4 p-4 bg-red-50 rounded-lg">

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -15,7 +15,7 @@
   <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
     <div>
       <dt class="text-sm font-medium text-gray-500">Amount</dt>
-      <dd class="mt-1 text-sm text-gray-900"><%= number_to_currency(@discount.amount_dollars) %></dd>
+      <dd class="mt-1 text-sm text-gray-900"><%= dollars_from_cents(@discount.amount_cents) %></dd>
     </div>
 
     <div>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -269,7 +269,7 @@
                   Amount owed
                   <span class="text-xs text-gray-400">($<%= EventRegistration::CE_HOURLY_RATE_DOLLARS %>/hr)</span>
                 </span>
-                <span data-ce-credit-requested-target="amount" class="text-sm font-semibold text-gray-900 tabular-nums"><%= number_to_currency(f.object.ce_amount_owed_cents / 100.0) %></span>
+                <span data-ce-credit-requested-target="amount" class="text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(f.object.ce_amount_owed_cents) %></span>
               </div>
             </div>
           </div>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -25,11 +25,11 @@
       <dl class="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div class="rounded-lg border border-gray-300 bg-gray-50 px-4 py-3">
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Registration cost</dt>
-          <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums">$<%= "%.2f" % (cost_cents / 100.0) %></dd>
+          <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(cost_cents) %></dd>
         </div>
         <div class="rounded-lg border border-gray-300 bg-gray-50 px-4 py-3">
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount allocated</dt>
-          <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums">$<%= "%.2f" % (paid_cents / 100.0) %></dd>
+          <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(paid_cents) %></dd>
         </div>
         <% amount_due = due_cents > 0 %>
         <div class="rounded-lg border px-4 py-3 <%= amount_due ? "border-amber-300 bg-amber-50" : "border-gray-300 bg-gray-50" %>">
@@ -37,7 +37,7 @@
           <dd class="mt-1 flex items-center gap-1.5 text-sm font-semibold tabular-nums <%= amount_due ? "text-amber-700" : "text-gray-500" %>">
             <% if amount_due %>
               <i class="fa-solid fa-circle-exclamation"></i>
-              $<%= "%.2f" % (due_cents / 100.0) %>
+              <%= dollars_from_cents(due_cents) %>
             <% else %>
               <i class="fa-solid fa-thumbs-up"></i>
               Nothing

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -31,7 +31,7 @@
     <% if scholarship %>
       <div class="space-y-2">
         <div class="flex items-center gap-2">
-          <span class="text-sm font-semibold text-gray-900 tabular-nums">$<%= "%.2f" % (scholarship.amount_cents.to_f / 100) %></span>
+          <span class="text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(scholarship.amount_cents) %></span>
           <%= link_to edit_scholarship_path(scholarship, return_to: "registration"),
                       class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
                       target: "_blank", rel: "noopener" do %>

--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -36,7 +36,7 @@
         <%= label %>
       </span>
       <span class="flex items-center gap-2">
-        <span class="text-sm font-semibold tabular-nums <%= amount_color %>"><%= number_to_currency(amount_cents / 100.0) %></span>
+        <span class="text-sm font-semibold tabular-nums <%= amount_color %>"><%= dollars_from_cents(amount_cents) %></span>
         <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 transition-transform group-open/row:rotate-180"></i>
       </span>
     </summary>
@@ -49,7 +49,7 @@
                   class: "truncate min-w-0 hover:underline" %>
             <% person_cents = amounts_by_registrant_id&.[](registrant.id) %>
             <% if person_cents %>
-              <span class="shrink-0 tabular-nums text-gray-500"><%= number_to_currency(person_cents / 100.0) %></span>
+              <span class="shrink-0 tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/events/_payment_allocations.html.erb
+++ b/app/views/events/_payment_allocations.html.erb
@@ -23,7 +23,7 @@
             <td class="px-3 py-2 text-gray-800">
               <%= render "allocations/allocatable_link", allocation: allocation, return_params: local_assigns.fetch(:return_params, {}) %>
             </td>
-            <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap tabular-nums">$<%= "%.2f" % allocation.amount_dollars %></td>
+            <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap tabular-nums"><%= dollars_from_cents(allocation.amount) %></td>
             <td class="px-3 py-2 text-gray-500 whitespace-nowrap"><%= allocation.created_at.strftime("%b %-d, %Y") %></td>
             <td class="px-3 py-2 text-right whitespace-nowrap">
               <% unless allocation.reverted? || allocation.amount.to_i < 0 %>
@@ -41,8 +41,8 @@
     </table>
   </div>
   <div class="text-sm text-gray-500 font-medium text-right">
-    $<%= format("%.2f", payment.remaining_dollars) %> remaining
+    <%= dollars_from_cents(payment.amount_cents_remaining) %> remaining
   </div>
 <% else %>
-  <p class="text-sm text-gray-400 italic">No allocations yet. $<%= format("%.2f", payment.remaining_dollars) %> remaining.</p>
+  <p class="text-sm text-gray-400 italic">No allocations yet. <%= dollars_from_cents(payment.amount_cents_remaining) %> remaining.</p>
 <% end %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -95,22 +95,22 @@
               Each addend links to where its money is managed. %>
           <div class="lg:shrink-0 lg:pt-2">
             <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
-              <%= link_to number_to_currency(@dashboard.grand_total_cents / 100.0), registrants_event_path(@event),
+              <%= link_to dollars_from_cents(@dashboard.grand_total_cents), registrants_event_path(@event),
                     class: "text-3xl sm:text-4xl font-bold #{DomainTheme.text_class_for(:event_dashboard, intensity: 700)} tabular-nums #{addend_class.call(:event_dashboard)}",
                     title: "View all registrants" %>
               <span class="text-2xl font-light text-gray-300 select-none">=</span>
               <%= link_to registrants_event_path(@event), class: addend_class.call(:payments), title: "Manage registrants" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></p>
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></p>
                 <p class="hidden lg:block text-xs text-gray-500">Registration fees</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
               <%= link_to recipients_event_path(@event), class: addend_class.call(:scholarships), title: "View scholarships" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></p>
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></p>
                 <p class="hidden lg:block text-xs text-gray-500">Scholarships</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
               <%= link_to registrants_event_path(@event), class: "#{addend_class.call(:continuing_education)} whitespace-nowrap", title: "Manage registrants" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></p>
+                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></p>
                 <p class="hidden lg:block text-xs text-gray-500">CE fees</p>
               <% end %>
               <% if show_bulk_payments %>
@@ -121,7 +121,7 @@
                 <%= link_to bulk_payments_event_path(@event), class: "whitespace-nowrap leading-tight rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 hover:bg-amber-100 transition-colors", title: "Allocate bulk payments" do %>
                   <p class="flex items-center gap-1.5 text-lg sm:text-xl font-semibold text-amber-700 tabular-nums">
                     <i class="fa-solid fa-circle-exclamation"></i>
-                    <%= number_to_currency(@dashboard.unallocated_bulk_payment_cents / 100.0) %>
+                    <%= dollars_from_cents(@dashboard.unallocated_bulk_payment_cents) %>
                   </p>
                   <p class="hidden lg:block text-xs text-gray-500">Unallocated bulk payments</p>
                 <% end %>
@@ -137,15 +137,15 @@
           <div class="lg:shrink-0 lg:border-l lg:border-gray-200 lg:pl-6 flex flex-col gap-1 text-xs text-gray-500">
             <span class="flex items-center justify-between gap-3">
               <span>Collected</span>
-              <span class="font-semibold text-gray-500 tabular-nums"><%= number_to_currency(@dashboard.collected_cents / 100.0) %></span>
+              <span class="font-semibold text-gray-500 tabular-nums"><%= dollars_from_cents(@dashboard.collected_cents) %></span>
             </span>
             <span class="flex items-center justify-between gap-3">
               <span>Due</span>
-              <span class="font-semibold text-gray-500 tabular-nums"><%= number_to_currency(@dashboard.due_cents / 100.0) %></span>
+              <span class="font-semibold text-gray-500 tabular-nums"><%= dollars_from_cents(@dashboard.due_cents) %></span>
             </span>
             <span class="flex items-center justify-between gap-3 mt-1 pt-1 border-t border-gray-200">
               <span class="font-bold text-gray-700">Monies</span>
-              <span class="font-bold text-gray-700 tabular-nums"><%= number_to_currency(@dashboard.monies_made_cents / 100.0) %></span>
+              <span class="font-bold text-gray-700 tabular-nums"><%= dollars_from_cents(@dashboard.monies_made_cents) %></span>
             </span>
           </div>
         </div>
@@ -171,7 +171,7 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.registration_subtotal_cents / 100.0) %></span>
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
@@ -211,7 +211,7 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.scholarship_total_cents / 100.0) %></span>
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
@@ -243,7 +243,7 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= number_to_currency(@dashboard.cont_ed_total_cents / 100.0) %></span>
+                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -155,7 +155,7 @@
                 <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Scholarship</span>
                 <span class="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-900">
                   <i class="fa-solid fa-sack-dollar text-gray-400"></i>
-                  <%= number_to_currency(scholarship.amount_dollars) %>
+                  <%= dollars_from_cents(scholarship.amount_cents) %>
                 </span>
                 <% if scholarship.grant&.funder_name.present? %>
                   <span class="inline-flex items-center gap-1.5 text-sm text-gray-600">

--- a/app/views/grants/_scholarships.html.erb
+++ b/app/views/grants/_scholarships.html.erb
@@ -29,7 +29,7 @@
                 <%= scholarship.recipient&.full_name || "Unknown recipient" %>
               </td>
               <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900 text-right">
-                <%= number_to_currency(scholarship.amount_dollars) %>
+                <%= dollars_from_cents(scholarship.amount_cents) %>
               </td>
               <td class="px-4 py-2 whitespace-nowrap text-sm text-center">
                 <% if scholarship.tasks_completed? %>

--- a/app/views/payments/payment_results.html.erb
+++ b/app/views/payments/payment_results.html.erb
@@ -17,8 +17,8 @@
             <tr>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.type.underscore.titleize.gsub(" Payment", "").gsub("External Processor", "Stripe") %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.payer.name %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">$<%= "%.2f" % payment.amount_dollars %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">$<%= "%.2f" % payment.remaining_dollars %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents) %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents_remaining) %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= payment.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"><%= link_to "View", payment_path(payment), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top"} %></td>
             </tr>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -28,11 +28,11 @@
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500">Amount</dt>
-      <dd class="mt-1 text-sm text-gray-900">$<%= "%.2f" % @payment.amount_dollars %></dd>
+      <dd class="mt-1 text-sm text-gray-900"><%= dollars_from_cents(@payment.amount_cents) %></dd>
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500">Amount remaining to allocate</dt>
-      <dd class="mt-1 text-sm text-gray-900">$<%= "%.2f" % @payment.remaining_dollars %></dd>
+      <dd class="mt-1 text-sm text-gray-900"><%= dollars_from_cents(@payment.amount_cents_remaining) %></dd>
     </div>
     <% if @payment.check_number.present? %>
       <div>
@@ -123,7 +123,7 @@
                   <% end %>
                 </td>
 
-                <td class="px-4 py-3 text-sm text-gray-900">$<%= "%.2f" % (allocation.amount.to_d / 100) %></td>
+                <td class="px-4 py-3 text-sm text-gray-900"><%= dollars_from_cents(allocation.amount) %></td>
                 <td class="px-4 py-3 text-sm text-gray-500"><%= allocation.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>
 
                 <td class="px-4 py-3 text-right text-sm font-medium">
@@ -163,7 +163,7 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-3 text-sm text-gray-900"><%= refund.method.titleize %></td>
-                <td class="px-4 py-3 text-sm text-gray-900">$<%= "%.2f" % refund.amount_dollars %></td>
+                <td class="px-4 py-3 text-sm text-gray-900"><%= dollars_from_cents(refund.amount_cents) %></td>
                 <td class="px-4 py-3 text-sm text-gray-500"><%= refund.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>
               </tr>
             <% end %>

--- a/app/views/refunds/new.html.erb
+++ b/app/views/refunds/new.html.erb
@@ -6,8 +6,8 @@
     <% if @payment.present? %>
       <div class="mb-4 p-4 bg-gray-50 rounded-lg">
         <p class="text-sm font-medium text-gray-700">For Payment</p>
-        <p class="text-lg text-gray-900">$<%= "%.2f" % @payment.amount_dollars %></p>
-        <p class="text-sm text-gray-500">Remaining: $<%= "%.2f" % @payment.remaining_dollars %></p>
+        <p class="text-lg text-gray-900"><%= dollars_from_cents(@payment.amount_cents) %></p>
+        <p class="text-sm text-gray-500">Remaining: <%= dollars_from_cents(@payment.amount_cents_remaining) %></p>
       </div>
     <% else %>
       <div class="mb-4 p-4 bg-red-50 rounded-lg">

--- a/app/views/refunds/show.html.erb
+++ b/app/views/refunds/show.html.erb
@@ -10,7 +10,7 @@
   <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
     <div>
       <dt class="text-sm font-medium text-gray-500">Amount</dt>
-      <dd class="mt-1 text-sm text-gray-900"><%= number_to_currency(@refund.amount_dollars) %></dd>
+      <dd class="mt-1 text-sm text-gray-900"><%= dollars_from_cents(@refund.amount_cents) %></dd>
     </div>
 
     <div>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -66,7 +66,7 @@
             <% if allocated_cents > 0 %>
               <span class="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-100 px-2 py-0.5 text-[0.65rem] font-medium text-fuchsia-700">
                 <i class="fa-solid fa-circle-check text-[0.55rem]"></i>
-                $<%= "%.2f" % (allocated_cents.to_f / 100) %> allocated to registration
+                <%= dollars_from_cents(allocated_cents) %> allocated to registration
               </span>
             <% else %>
               <span class="text-xs text-gray-500">$0 allocated to registration</span>

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -12,7 +12,7 @@
   <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
     <div>
       <dt class="text-sm font-medium text-gray-500">Amount</dt>
-      <dd class="mt-1 text-sm text-gray-900"><%= number_to_currency(@scholarship.amount_dollars) %></dd>
+      <dd class="mt-1 text-sm text-gray-900"><%= dollars_from_cents(@scholarship.amount_cents) %></dd>
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500">Tasks Completed</dt>

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe GrantDecorator, type: :decorator do
     let(:grant) { create(:grant, amount_cents: 100_000).decorate }
 
     it "formats the donation amount" do
-      expect(grant.amount).to eq("$1,000.00")
+      expect(grant.amount).to eq("$1,000")
     end
 
     it "formats the remaining balance" do
       create(:scholarship, grant: grant.object, amount_cents: 40_000)
-      expect(grant.remaining).to eq("$600.00")
+      expect(grant.remaining).to eq("$600")
     end
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -856,7 +856,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Registration fees")
         expect(response.body).to include("CE fees")
         expect(response.body).to include("Paid")
-        expect(response.body).to include("$60.00")
+        expect(response.body).to include("$60")
       end
 
       it "shows unallocated bulk payments in the equation, linking to the bulk payments page" do
@@ -1182,7 +1182,7 @@ RSpec.describe "Events", type: :request do
         get recipients_event_path(event)
 
         expect(response.body).to include('data-scholarship-status-toggle-target="status"')
-        expect(response.body).to include("$500.00")
+        expect(response.body).to include("$500")
         expect(response.body).to include("Tasks completed")
       end
 
@@ -1216,7 +1216,7 @@ RSpec.describe "Events", type: :request do
 
         get recipients_event_path(event)
 
-        expect(response.body).to include("$10.00")
+        expect(response.body).to include("$10")
         expect(response.body).to include("Tasks outstanding")
       end
 

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe "Scholarships", type: :request do
 
       expect(response.body).to include("scholarship-preview")
       expect(response.body).to include("scholarship-preview-target=\"amountBox\"")
-      # Tasks completed → the $50.00 amount is allocated to the registration.
-      expect(response.body).to include("$50.00 allocated to registration")
-      # Event cost $100.00 with $50.00 allocated leaves $50.00 owed.
-      expect(response.body).to include("$50.00")
+      # Tasks completed → the $50 amount is allocated to the registration.
+      expect(response.body).to include("$50 allocated to registration")
+      # Event cost $100 with $50 allocated leaves $50 owed.
+      expect(response.body).to include("$50")
     end
 
     it "renders the scholarship amount field with a non-negative minimum" do

--- a/spec/services/money_formatter_spec.rb
+++ b/spec/services/money_formatter_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe MoneyFormatter do
+  describe ".dollars_from_cents" do
+    it "drops the cents for whole-dollar amounts" do
+      expect(described_class.dollars_from_cents(150_000)).to eq("$1,500")
+      expect(described_class.dollars_from_cents(5_000)).to eq("$50")
+      expect(described_class.dollars_from_cents(0)).to eq("$0")
+    end
+
+    it "keeps the cents when present" do
+      expect(described_class.dollars_from_cents(75_050)).to eq("$750.50")
+      expect(described_class.dollars_from_cents(1_099)).to eq("$10.99")
+      expect(described_class.dollars_from_cents(1_234_556)).to eq("$12,345.56")
+    end
+
+    it "coerces nil to zero" do
+      expect(described_class.dollars_from_cents(nil)).to eq("$0")
+    end
+  end
+
+  describe ".compact_from_cents" do
+    it "uses plain dollars under a thousand" do
+      expect(described_class.compact_from_cents(75_000)).to eq("$750")
+      expect(described_class.compact_from_cents(90_000)).to eq("$900")
+    end
+
+    it "abbreviates thousands and millions, trimming trailing zeros" do
+      expect(described_class.compact_from_cents(750_000)).to eq("$7.5k")
+      expect(described_class.compact_from_cents(1_000_000)).to eq("$10k")
+      expect(described_class.compact_from_cents(120_000_000)).to eq("$1.2m")
+    end
+  end
+end

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Event registration edit page", type: :system do
         expect(page).to have_text(/amount allocated/i)
         expect(page).to have_text(/amount due/i)
         expect(page).to have_text("$10.99")
-        expect(page).to have_text("$0.00")
+        expect(page).to have_text("$0")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe "Event registration edit page", type: :system do
 
       within("section", text: "Registration payments and allocations") do
         expect(page).to have_text(/amount allocated/i)
-        expect(page).to have_text("$10.00")
+        expect(page).to have_text("$10")
         expect(page).to have_no_text("Source")
       end
     end

--- a/spec/views/discounts/show.html.erb_spec.rb
+++ b/spec/views/discounts/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "discounts/show", type: :view do
   end
 
   it "shows discount amount" do
-    expect(rendered).to have_content("$10.00")
+    expect(rendered).to have_content("$10")
   end
 
   it "links to allocations" do

--- a/spec/views/refunds/show.html.erb_spec.rb
+++ b/spec/views/refunds/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "refunds/show", type: :view do
   end
 
   it "shows refund details" do
-    expect(rendered).to have_content("$10.00")
+    expect(rendered).to have_content("$10")
     expect(rendered).to have_content("Check")
     expect(rendered).to have_content(person.name)
   end

--- a/spec/views/scholarships/show.html.erb_spec.rb
+++ b/spec/views/scholarships/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "scholarships/show", type: :view do
   end
 
   it "shows scholarship details" do
-    expect(rendered).to have_content("$10.00")
+    expect(rendered).to have_content("$10")
     expect(rendered).to have_content("No")
     expect(rendered).to have_content(scholarship.recipient.full_name)
     expect(rendered).to have_content(allocatable.event.title)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Money was rendered inconsistently — naked `"%.2f" % x` (Rubocop-forbidden), `format("%.2f", …)`, and `number_to_currency` all coexisted, and whole-dollar amounts always printed a redundant `.00`.
- This standardizes every UI money display on one rule: show cents when present (`$100.50`), drop `.00` when whole (`$100`), keeping integer cents as the source of truth for all math.

### How did you approach the change?
- Routed every currency display (payments, allocations, refunds, scholarships, grants, discounts, the event dashboard/recipients, and the CE-credit field) through the `dollars_from_cents` helper, and consolidated the logic into a new `MoneyFormatter` PORO so models and decorators format the same way as views without coupling to view helpers; `compact_from_cents` (`$12.5k`) lives there too.
- Mirrored the rule in the live-updating Stimulus controllers so server-rendered and JS-updated figures match, documented the convention in `CLAUDE.md`/`copilot-instructions.md`/`AGENTS.md`, and updated the affected specs; CSV export cells intentionally keep plain `%.2f` numerics (no `$`/commas) so spreadsheets parse them.

### UI Testing Checklist
- [ ] Payment, allocation, and refund show/new pages render amounts (whole dollars without `.00`, cents preserved)
- [ ] Event dashboard totals and recipients/scholarship amounts display correctly
- [ ] Registration CE-credit "Amount owed" updates live and matches the initial server render
- [ ] Scholarship form live preview ("Still owed" / "allocated to registration") formats consistently
- [ ] Registrant/reminder "due" badges and grant picker compact amounts (`$12.5k`) look right

### Anything else to add?
- The full local test suite was not run end-to-end (targeted specs for all touched areas pass; CI runs the rest). The two CSV export `format("%.2f")` calls are deliberate and were confirmed to stay.