### PR TITLE
Add rake task to migrate legacy sector names to the 2026 taxonomy

### DIFF
--- a/lib/tasks/migrate_sectors.rake
+++ b/lib/tasks/migrate_sectors.rake
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require "set"
+
+# Applies the 2026 sector taxonomy to existing data: a sequence of renames and
+# merges that fold legacy Forms / FileMaker / portal sector names into the
+# canonical Sector::SECTOR_TYPES set, plus the handful of brand-new tags and the
+# Story Share → Portal source aliases.
+#
+# Mechanics:
+#   * Merges reuse ModelDeduper#merge, so all polymorphic taggings
+#     (SectorableItem records on Person, Organization, Workshop, Report, …) are
+#     moved onto the surviving sector before the duplicate is destroyed.
+#   * Every operation is idempotent and tolerant of missing legacy records — a
+#     source name that isn't present in this database is simply skipped, so the
+#     task is safe to re-run and safe across environments with different data.
+#   * Order matters: the operations run in the exact sequence given in the
+#     taxonomy spreadsheet, because several are chains (e.g. A→B→C→canonical)
+#     where each step depends on the previous one having landed.
+#
+# Dry-run by default. Set DRY_RUN=false to write changes.
+#
+#   bin/rails data:migrate_sectors              # preview
+#   DRY_RUN=false bin/rails data:migrate_sectors # execute
+#
+# NOTE on dry runs: because renames aren't persisted in a dry run, a later step
+# in a rename→merge chain may report "source not present". That's expected — the
+# live run resolves each chain in order.
+namespace :data do
+  desc "Apply the 2026 sector taxonomy (sequential renames/merges + new tags). Idempotent. DRY_RUN=false to execute."
+  task migrate_sectors: :environment do
+    logger = Logger.new($stdout)
+    logger.formatter = ->(_severity, _time, _progname, msg) { "#{msg}\n" }
+
+    dry_run = ENV["DRY_RUN"] != "false"
+    deduper = ModelDeduper.new(model_class: Sector, dry_run: dry_run, logger: logger)
+
+    stats = Hash.new(0)
+
+    find_sector = lambda do |name|
+      Sector.where("LOWER(TRIM(name)) = ?", name.to_s.strip.downcase).first
+    end
+
+    # Fold `from`'s data under the canonical name `to`, in place:
+    #   * source missing                 → skip (legacy name absent in this DB)
+    #   * target missing                 → rename the source to `to`
+    #   * source and target same record  → normalize the stored name only
+    #   * both present, distinct records → merge source into target (moves taggings)
+    consolidate = lambda do |from, to|
+      source = find_sector.call(from)
+      unless source
+        logger.info "SKIP    #{from.inspect} → #{to.inspect} (source not present)"
+        stats[:skipped] += 1
+        next
+      end
+
+      target = find_sector.call(to)
+
+      if target.nil?
+        logger.info "RENAME  #{source.name.inspect} → #{to.inspect}"
+        source.update!(name: to) unless dry_run
+        stats[:renamed] += 1
+      elsif target.id == source.id
+        if source.name == to
+          logger.info "OK      #{to.inspect} already canonical"
+        else
+          logger.info "TRIM    #{source.name.inspect} → #{to.inspect}"
+          source.update!(name: to) unless dry_run
+          stats[:renamed] += 1
+        end
+      else
+        logger.info "MERGE   #{source.name.inspect} (##{source.id}) → #{target.name.inspect} (##{target.id})"
+        deduper.merge(target, source)
+        stats[:merged] += 1
+      end
+    end
+
+    ensure_sector = lambda do |name|
+      existing = find_sector.call(name)
+      if existing
+        logger.info "EXISTS  #{name.inspect} (##{existing.id})"
+        existing.update!(published: true) unless dry_run || existing.published?
+        stats[:existing] += 1
+      else
+        logger.info "ADD     #{name.inspect}"
+        Sector.create!(name: name, published: true) unless dry_run
+        stats[:added] += 1
+      end
+    end
+
+    run_op = lambda do |op|
+      case op[0]
+      when :rename, :merge then consolidate.call(op[1], op[2])
+      when :add, :no_change then ensure_sector.call(op[1])
+      end
+    end
+
+    # --- Forms / FileMaker / existing portal data → new sector tags ---------
+    # Sequential, in spreadsheet order. Renames whose target already exists as a
+    # canonical sector become merges (the canonical record survives, taggings move).
+    portal_ops = [
+      [ :rename, "People Who Do Harm/Batterers", "Batterers Intervention" ],
+      [ :rename, "Child abuse", "Child Abuse/Neglect" ],
+      [ :rename, "Climate/Environmental Trauma", "Climate/Environmental" ],
+      [ :add, "Community Engagement" ],
+      [ :rename, "Community oppression/violence", "Community Violence" ],
+      [ :merge, "Victims of Crime", "Law Enforcement/Court" ],
+      [ :merge, "Law Enforcement/Court", "Criminal/Legal" ],
+      [ :rename, "Criminal/legal", "Court/Legal System" ],
+      [ :rename, "Disability", "Disability Services" ],
+      [ :no_change, "Domestic Violence" ],
+      [ :merge, "Education/schools", "Student" ],
+      [ :merge, "Student", "Student-Related Stress" ],
+      [ :merge, "Student-Related Stress", "Educational Setting" ],
+      [ :merge, "Educational Setting", "Student Services" ],
+      [ :rename, "Student Services", "Education" ],
+      [ :rename, "Foster Care", "Foster Care/Adoption" ],
+      [ :add, "Fundraising/Donor Engagement" ],
+      [ :no_change, "Grief/Loss" ],
+      [ :merge, "Pandemic-Related Stress", "Illness" ],
+      [ :merge, "Illness", "Hospitals" ],
+      [ :rename, "Hospitals", "Health/Medical" ],
+      [ :no_change, "Homelessness" ],
+      [ :no_change, "Human Trafficking" ],
+      [ :no_change, "Immigration" ],
+      [ :merge, "Prisons/Jails", "Incarceration" ],
+      [ :no_change, "Indigenous/Tribal Nation" ],
+      [ :merge, "Oppression Against LGBTQIA+", "LGBTQIA+" ],
+      [ :merge, "Suicidality", "Mental Health Needs" ],
+      [ :merge, "Mental Health Needs", "Clinical Setting" ],
+      [ :merge, "Clinical Setting", "Mental Health" ],
+      [ :merge, "Veterans & military", "Military/Veteran" ],
+      [ :rename, "Military/Veteran", "Military/Veterans" ],
+      [ :rename, "Private Practice", "Private Practice/Sole Proprietor" ],
+      [ :rename, "Racism & Marginalization", "Racial/Social Justice" ],
+      [ :merge, "Religious Trauma", "Faith-Based Setting" ],
+      [ :rename, "Faith-Based Setting", "Religious/Faith Based" ],
+      [ :rename, "Reproductive", "Reproductive Services" ],
+      [ :no_change, "Restorative/Transformative Justice" ],
+      [ :add, "Self-Care/Personal Growth" ],
+      [ :no_change, "Sexual Assault" ],
+      [ :merge, "Secondary/Vicarious Trauma", "With Staff" ],
+      [ :merge, "With Staff", "Staff & organizational development" ],
+      [ :rename, "Staff & organizational development", "Staff/Organizational Development" ],
+      [ :merge, "Substance use", "Substance Abuse" ],
+      [ :rename, "Substance Abuse", "Substance Use/Recovery" ],
+      # Spreadsheet reads "Sytems/Policy Change" — corrected to the canonical spelling.
+      [ :add, "Systems/Policy Change" ]
+    ]
+
+    # --- Story Share → Portal migration aliases ----------------------------
+    # Additional legacy source names that fold into the canonical set. Identity
+    # rows are harmless no-ops; the rest move taggings onto the canonical sector.
+    story_share_ops = [
+      [ :merge, "Batterers Intervention", "Batterers Intervention" ],
+      [ :merge, "Child Abuse / Neglect", "Child Abuse/Neglect" ],
+      [ :merge, "Community Engagement", "Community Engagement" ],
+      [ :merge, "Community Violence", "Community Violence" ],
+      [ :merge, "Court & Legal System", "Court/Legal System" ],
+      [ :merge, "Disability Services", "Disability Services" ],
+      [ :merge, "Domestic Violence", "Domestic Violence" ],
+      [ :merge, "Schools & Universities", "Education" ],
+      [ :merge, "Foster Care", "Foster Care/Adoption" ],
+      [ :merge, "Donor Engagement", "Fundraising/Donor Engagement" ],
+      [ :merge, "Grief & Loss", "Grief/Loss" ],
+      [ :merge, "Physical & Terminal Illness", "Health/Medical" ],
+      [ :merge, "Homelessness", "Homelessness" ],
+      [ :merge, "Human Trafficking", "Human Trafficking" ],
+      [ :merge, "Immigration", "Immigration" ],
+      [ :merge, "Incarceration", "Incarceration" ],
+      [ :merge, "LGBTQIA+", "LGBTQIA+" ],
+      [ :merge, "Mental Health", "Mental Health" ],
+      [ :merge, "Military & Veterans", "Military/Veterans" ],
+      [ :merge, "Social Justice", "Racial/Social Justice" ],
+      [ :merge, "Self-Care & Personal Growth", "Self-Care/Personal Growth" ],
+      [ :merge, "Sexual Assault", "Sexual Assault" ],
+      [ :merge, "Staff & Organizational Development", "Staff/Organizational Development" ],
+      [ :merge, "Substance Abuse Recovery", "Substance Use/Recovery" ],
+      # Spreadsheet reads "Sytems/Policy Change" — corrected to the canonical spelling.
+      [ :merge, "Advocacy", "Systems/Policy Change" ]
+    ]
+
+    runner = lambda do
+      logger.info "=== Forms / FileMaker / portal taxonomy (sequential) ==="
+      portal_ops.each { |op| run_op.call(op) }
+      logger.info ""
+      logger.info "=== Story Share → portal aliases ==="
+      story_share_ops.each { |op| run_op.call(op) }
+    end
+
+    logger.info dry_run ? "DRY RUN — no changes written. Set DRY_RUN=false to execute." : "EXECUTING — changes are being written."
+    logger.info ""
+
+    if dry_run
+      runner.call
+    else
+      ActiveRecord::Base.transaction { runner.call }
+    end
+
+    logger.info ""
+    logger.info "Summary: merged=#{stats[:merged]} renamed=#{stats[:renamed]} added=#{stats[:added]} " \
+                "existing=#{stats[:existing]} skipped=#{stats[:skipped]}"
+
+    # Sanity check: flag any still-published sector outside the expected final set.
+    expected = (Sector::SECTOR_TYPES + [ "Community Engagement" ]).map { |n| n.strip.downcase }.to_set
+    stray = Sector.where(published: true).reject { |s| expected.include?(s.name.strip.downcase) }
+    if stray.any?
+      logger.info ""
+      logger.info "NOTE: #{stray.size} published sector(s) not in the expected final taxonomy:"
+      stray.each { |s| logger.info "  - #{s.name.inspect} (##{s.id})" }
+    end
+  end
+end

--- a/spec/lib/tasks/migrate_sectors_rake_spec.rb
+++ b/spec/lib/tasks/migrate_sectors_rake_spec.rb
@@ -1,0 +1,206 @@
+require "rails_helper"
+require "rake"
+
+# These specs exist to prove the data migration is SAFE to run against live data:
+# it must never silently drop sectors or their taggings, must be a no-op in
+# dry-run, must leave unrelated data alone, and must be safe to re-run.
+RSpec.describe "data:migrate_sectors" do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("data:migrate_sectors")
+  end
+
+  around do |example|
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    example.run
+  ensure
+    $stdout = original_stdout
+  end
+
+  def invoke_task
+    Rake::Task["data:migrate_sectors"].reenable
+    Rake::Task["data:migrate_sectors"].invoke
+  end
+
+  def with_env(key, value)
+    previous = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    ENV[key] = previous
+  end
+
+  # Tag a sector against a polymorphic taggable (default: a fresh workshop).
+  def tag(sector, taggable = create(:workshop))
+    create(:sectorable_item, sector: sector, sectorable: taggable)
+  end
+
+  describe "dry run (default)" do
+    let!(:legacy) { create(:sector, name: "Child abuse", published: false) }
+    let!(:canonical) { create(:sector, :published, name: "Child Abuse/Neglect") }
+    let!(:tagging) { tag(legacy) }
+
+    it "does not create, rename, or destroy any sectors" do
+      with_env("DRY_RUN", nil) { invoke_task }
+
+      expect(Sector.pluck(:name)).to contain_exactly("Child abuse", "Child Abuse/Neglect")
+      expect(legacy.reload.name).to eq("Child abuse")
+    end
+
+    it "does not move or delete any taggings" do
+      with_env("DRY_RUN", nil) { invoke_task }
+
+      expect(tagging.reload.sector_id).to eq(legacy.id)
+      expect(SectorableItem.count).to eq(1)
+    end
+  end
+
+  describe "execute (DRY_RUN=false)" do
+    describe "merge when the canonical target already exists" do
+      let!(:legacy) { create(:sector, name: "Child abuse", published: false) }
+      let!(:canonical) { create(:sector, :published, name: "Child Abuse/Neglect") }
+
+      it "moves the legacy taggings onto the canonical sector and destroys the legacy record" do
+        tagging = tag(legacy)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        expect(Sector.exists?(legacy.id)).to be(false)
+        expect(tagging.reload.sector_id).to eq(canonical.id)
+      end
+
+      it "collapses a duplicate tagging when the same item is tagged on both sectors" do
+        workshop = create(:workshop)
+        tag(legacy, workshop)
+        tag(canonical, workshop)
+
+        expect { with_env("DRY_RUN", "false") { invoke_task } }
+          .to change(SectorableItem, :count).from(2).to(1)
+
+        expect(canonical.reload.sectorable_items.count).to eq(1)
+      end
+
+      it "never leaves a tagging pointing at a destroyed sector" do
+        tag(legacy)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        expect(SectorableItem.where(sector_id: legacy.id)).to be_empty
+        expect(SectorableItem.where.not(sector_id: Sector.select(:id))).to be_empty
+      end
+    end
+
+    describe "rename when the target does not yet exist" do
+      let!(:legacy) { create(:sector, :published, name: "Disability") }
+
+      it "renames the record in place, preserves taggings, and creates no duplicate" do
+        tagging = tag(legacy)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        # Same record id, renamed — not destroyed-and-recreated.
+        expect(legacy.reload.name).to eq("Disability Services")
+        expect(Sector.where(name: "Disability")).to be_empty
+        expect(Sector.where(name: "Disability Services").pluck(:id)).to eq([ legacy.id ])
+        expect(tagging.reload.sector_id).to eq(legacy.id)
+      end
+    end
+
+    describe "brand-new tags" do
+      it "creates Community Engagement as a published sector" do
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        sector = Sector.find_by(name: "Community Engagement")
+        expect(sector).to be_present
+        expect(sector).to be_published
+      end
+    end
+
+    describe "chained merges" do
+      it "folds a multi-step chain onto the final canonical name, carrying taggings" do
+        # Ops 44–45: "Substance use" -> "Substance Abuse" -> "Substance Use/Recovery".
+        # Only the first legacy record exists, so the chain renames it forward.
+        source = create(:sector, :published, name: "Substance use")
+        tagging = tag(source)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        expect(Sector.where(name: [ "Substance use", "Substance Abuse" ])).to be_empty
+        final = Sector.find_by(name: "Substance Use/Recovery")
+        expect(final).to be_present
+        expect(tagging.reload.sector_id).to eq(final.id)
+      end
+    end
+
+    describe "spreadsheet typo correction" do
+      it "lands 'Advocacy' on the correctly spelled 'Systems/Policy Change'" do
+        advocacy = create(:sector, :published, name: "Advocacy")
+        tagging = tag(advocacy)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        expect(Sector.find_by(name: "Sytems/Policy Change")).to be_nil
+        canonical = Sector.find_by(name: "Systems/Policy Change")
+        expect(canonical).to be_present
+        expect(tagging.reload.sector_id).to eq(canonical.id)
+      end
+    end
+
+    describe "sectors not named in the mapping" do
+      it "leaves an unrelated sector and its taggings completely untouched" do
+        unrelated = create(:sector, :published, name: "Totally Unrelated Sector")
+        tagging = tag(unrelated)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+
+        expect(unrelated.reload.name).to eq("Totally Unrelated Sector")
+        expect(tagging.reload.sector_id).to eq(unrelated.id)
+      end
+    end
+
+    describe "missing legacy sources" do
+      it "skips absent sources without error and creates only the ADD tags" do
+        # No legacy records at all: every rename/merge is a no-op, only the
+        # brand-new / canonical tags get created.
+        expect { with_env("DRY_RUN", "false") { invoke_task } }.not_to raise_error
+
+        expect(Sector.find_by(name: "Community Engagement")).to be_present
+        expect(Sector.find_by(name: "Self-Care/Personal Growth")).to be_present
+      end
+    end
+
+    describe "idempotency" do
+      it "is safe to run twice and produces no further changes on the second run" do
+        legacy = create(:sector, name: "Child abuse", published: false)
+        canonical = create(:sector, :published, name: "Child Abuse/Neglect")
+        tag(legacy)
+
+        with_env("DRY_RUN", "false") { invoke_task }
+        snapshot = { sectors: Sector.order(:name).pluck(:name), taggings: SectorableItem.count }
+
+        expect { with_env("DRY_RUN", "false") { invoke_task } }
+          .not_to change(SectorableItem, :count)
+        expect(Sector.order(:name).pluck(:name)).to eq(snapshot[:sectors])
+        expect(SectorableItem.count).to eq(snapshot[:taggings])
+        expect(canonical.reload.sectorable_items.count).to eq(1)
+      end
+    end
+
+    describe "no tagging is lost across a full run" do
+      it "preserves every tagging except intentional duplicate collapses" do
+        # Two legacy sources merging into one canonical, each tagged with a
+        # distinct workshop -> both taggings survive on the canonical record.
+        canonical = create(:sector, :published, name: "Education")
+        student_services = create(:sector, name: "Student Services", published: false)
+        tag(student_services)
+        tag(canonical)
+
+        expect { with_env("DRY_RUN", "false") { invoke_task } }
+          .not_to change(SectorableItem, :count)
+
+        expect(Sector.find_by(name: "Education").sectorable_items.count).to eq(2)
+        expect(Sector.exists?(student_services.id)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Legacy Forms/FileMaker/portal sector names need to be folded into the canonical `Sector::SECTOR_TYPES` set, but the only existing dedupe paths (the `Dedupable` admin UI and `ModelDeduper#call`) match solely on normalized name and so can't connect *renamed* sectors, while `db/seeds.rb` merely unpublishes off-list sectors and strands their taggings.

### How did you approach the change?
Added `data:migrate_sectors`, which drives the explicit rename/merge/add mapping (plus Story Share aliases) in spreadsheet order via `ModelDeduper#merge` so all polymorphic taggings move onto the surviving sector; it's dry-run by default (`DRY_RUN=false` to execute), idempotent, tolerant of missing legacy records, and wraps the live run in a transaction. The sheet's "Sytems/Policy Change" typo is corrected to the canonical "Systems/Policy Change". Added 13 data-safety specs covering dry-run no-op, tagging moves/dedupe/no-orphans, in-place renames, chained merges, untouched unrelated sectors, and idempotency.

### Anything else to add?
Heads-up unrelated to this PR: two already-merged migrations (#1719 and #1721) share version `20260618020000`, which blocks the full spec suite from loading and means only one of the two actually ran where migrated — worth renumbering one and reconciling `schema_migrations` separately.