### PR TITLE
Age ranges: single primary like sectors + visibility toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (71) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (74) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -124,7 +124,7 @@ This codebase (Rails 8.1)
 
 | Concern | Purpose |
 |---|---|
-| `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
+| `AgeGroupTaggable` | Marks one primary AgeRange tagging (the rest additional) via `categorizable_items.is_primary`, enforcing a single primary (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
 | `AuthorCreditable` | Author attribution |
 | `Featureable` | `featured`, `publicly_featured` scopes |

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -212,7 +212,7 @@ class OrganizationsController < ApplicationController
       :name, :description, :start_date, :end_date, :mission_vision_values,
       :agency_type, :agency_type_other, :filemaker_code, :logo, :notes, :email, :website_url,
       :organization_status_id, :location_id, :windows_type_id,
-      :profile_show_sectors, :profile_show_email, :profile_show_phone,
+      :profile_show_sectors, :profile_show_age_ranges, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,
       :profile_show_stories, :profile_show_events_registered, :profile_show_workshop_logs,
       category_ids: [],

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -393,6 +393,7 @@ class PeopleController < ApplicationController
       :profile_show_phone,
       :profile_show_member_since,
       :profile_show_sectors,
+      :profile_show_age_ranges,
       :profile_show_affiliations,
       :profile_show_social_media,
       :profile_show_events_registered,

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -153,6 +153,9 @@ application.register("searchable-checkbox", SearchableCheckboxController)
 import SearchableSelectController from "./searchable_select_controller"
 application.register("searchable-select", SearchableSelectController)
 
+import SingleSelectCheckboxController from "./single_select_checkbox_controller"
+application.register("single-select-checkbox", SingleSelectCheckboxController)
+
 import SectionFilterController from "./section_filter_controller"
 application.register("section-filter", SectionFilterController)
 

--- a/app/frontend/javascript/controllers/single_select_checkbox_controller.js
+++ b/app/frontend/javascript/controllers/single_select_checkbox_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Keeps at most one checkbox in a group checked (radio-like), while still
+// allowing every option to be unchecked. Used for the single "Primary" age
+// range toggle on the person/organization edit forms — picking a new primary
+// clears the previous one, mirroring the single primary sector.
+export default class extends Controller {
+  static targets = ["option"]
+
+  connect() {
+    this.enforce()
+  }
+
+  select(event) {
+    if (!event.target.checked) return
+    this.optionTargets.forEach((checkbox) => {
+      if (checkbox !== event.target) checkbox.checked = false
+    })
+  }
+
+  // On load, keep only the first checked option set (defensive against legacy
+  // data that marked several primaries before the single-primary rule).
+  enforce() {
+    this.optionTargets.filter((checkbox) => checkbox.checked).slice(1).forEach((checkbox) => {
+      checkbox.checked = false
+    })
+  }
+}

--- a/app/models/concerns/age_group_taggable.rb
+++ b/app/models/concerns/age_group_taggable.rb
@@ -1,12 +1,16 @@
 # Shared age-group tagging for records that carry categorizable_items
 # (Person, Organization). AgeRange categories are tagged like any other
-# category; the categorizable_items.is_primary flag splits them into the
-# "primary" age groups a respondent serves and the "additional" ones — the same
-# primary/additional distinction sectors get via sectorable_items.is_primary.
+# category; the categorizable_items.is_primary flag marks the single "primary"
+# age range a respondent serves, with the rest "additional" — the same
+# one-primary distinction sectors get via sectorable_items.is_primary.
 module AgeGroupTaggable
   extend ActiveSupport::Concern
 
   AGE_RANGE_CATEGORY_TYPE = "AgeRange"
+
+  included do
+    validate :at_most_one_primary_age_group
+  end
 
   # AgeRange categories tagged on this record, split by the primary flag and
   # returned in display order. Filters the categorizable_items association in
@@ -27,31 +31,45 @@ module AgeGroupTaggable
     primary_age_groups.map(&:id)
   end
 
-  # Flip is_primary on the AgeRange categorizable_items to match the given set.
+  # Mark the single primary AgeRange categorizable_item, demoting the rest.
   # Runs after category membership has been assigned (the edit-form flow), so it
-  # only updates existing items rather than creating them.
+  # only updates existing items rather than creating them. At most one category
+  # is primary, mirroring sectors — only the first id given is honored.
   def apply_primary_age_groups!(primary_category_ids)
-    primary = sanitize_age_ids(primary_category_ids).to_set
+    primary = sanitize_age_ids(primary_category_ids).first
     age_range_categorizable_items.includes(:category).find_each do |item|
-      desired = primary.include?(item.category_id)
+      desired = item.category_id == primary
       item.update!(is_primary: desired) if item.is_primary? != desired
     end
     categorizable_items.reset
   end
 
-  # Additively tag AgeRange categories as primary/additional without disturbing
-  # other taggings — used by registration, where a respondent may add to age
-  # groups recorded on a prior submission. A category named in both lists is
-  # treated as primary.
+  # Additively tag AgeRange categories without disturbing other taggings — used
+  # by registration, where a respondent may add to age groups recorded on a
+  # prior submission. Only one category is primary (the single-select dropdown
+  # answer); choosing a new primary demotes any previous one.
   def tag_age_groups(primary_ids:, additional_ids:)
-    primary = sanitize_age_ids(primary_ids)
-    additional = sanitize_age_ids(additional_ids) - primary
-    upsert_age_items(primary, is_primary: true)
+    primary = sanitize_age_ids(primary_ids).first
+    additional = sanitize_age_ids(additional_ids) - [ primary ].compact
+    if primary
+      age_range_categorizable_items.where(is_primary: true)
+        .where.not(category_id: primary)
+        .find_each { |item| item.update!(is_primary: false) }
+      upsert_age_items([ primary ], is_primary: true)
+    end
     upsert_age_items(additional, is_primary: false)
     categorizable_items.reset
   end
 
   private
+
+  # Mirrors sectors: at most one age range may be primary. The edit and
+  # registration paths enforce this directly; this guards console/import writes.
+  def at_most_one_primary_age_group
+    return if age_range_categorizable_items.where(is_primary: true).count <= 1
+
+    errors.add(:base, "Only one age range can be marked as primary")
+  end
 
   def age_range_categories(primary:)
     categorizable_items

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -800,19 +800,22 @@ class EventDashboard
   end
 
   # [ person_id, age_group_category_id ] for every AgeRange selection in active
-  # registrants' "primary_age_group" registration answers. The answer text is a
-  # ", "-joined list of category ids (the checkbox values); non-numeric tokens
-  # (legacy free text) are ignored. Deduped per [ person, category ].
+  # registrants' age-range registration answers — both the single "primary age
+  # range" and the multi "additional ages served" questions, so the breakdown
+  # reflects every age range served. The answer text is a ", "-joined list of
+  # category ids; non-numeric tokens (legacy free text) are ignored. Deduped per
+  # [ person, category ].
   def age_group_answer_rows
     @age_group_answer_rows ||= compute_age_group_answer_rows
   end
 
   def compute_age_group_answer_rows
-    field = registration_form_field("primary_age_group")
-    return [] unless field
+    field_ids = FormField::AGE_GROUP_FIELD_IDENTIFIERS
+      .filter_map { |identifier| registration_form_field(identifier)&.id }
+    return [] if field_ids.empty?
 
     FormAnswer
-      .where(form_field_id: field.id)
+      .where(form_field_id: field_ids)
       .joins(:form_submission)
       .where(form_submissions: { person_id: registrant_ids })
       .pluck(Arel.sql("form_submissions.person_id"), :submitted_answer)

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -86,7 +86,7 @@ class FormBuilderService
       "Agency Type", "Agency Website"
     ],
     person_background: [ "Racial / Ethnic Identity" ],
-    professional_info: [ "Primary sector", "Additional sectors", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
+    professional_info: [ "Primary sector", "Additional sectors", "Primary age range", "Additional ages served" ],
     marketing: [
       "How did you hear about this training?",
       "What motivates you to attend this training?",
@@ -436,12 +436,12 @@ class FormBuilderService
     position = add_field(form, position, "Additional sectors", :multi_select_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
                          subtitle: "Select all options that represent who you intend to serve through the art workshops (check all that apply)")
-    position = add_field(form, position, "Primary Age Group(s) Served", :multi_select_checkbox,
+    position = add_field(form, position, "Primary age range", :single_select_dropdown,
                          key: "primary_age_group", group: "professional", required: false,
-                         subtitle: "Select all age groups you primarily serve.")
-    position = add_field(form, position, "Additional Age Group(s) Served", :multi_select_checkbox,
+                         subtitle: "Select the age range you primarily serve.")
+    position = add_field(form, position, "Additional ages served", :multi_select_checkbox,
                          key: "additional_age_group", group: "professional", required: false,
-                         subtitle: "Select all that apply. These represent the other age groups you serve.")
+                         subtitle: "Select all that apply. These represent the other age ranges you serve.")
     position
   end
 

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -80,9 +80,9 @@
         <div class="font-semibold text-gray-700 mb-2"><%= type.display_label %></div>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
           <% if is_age %>
-            <p class="text-sm text-gray-500 mb-3">Check every age group served, then mark the primary ones.</p>
+            <p class="text-sm text-gray-500 mb-3">Check every age range served, then mark the one primary.</p>
           <% end %>
-          <div class="flex flex-wrap gap-3">
+          <div class="flex flex-wrap gap-3"<%= ' data-controller="single-select-checkbox"'.html_safe if is_age %>>
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "organization", category: category,
                          checked: @organization.category_ids.include?(category.id),
@@ -365,6 +365,7 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-3">
           <%= f.input :profile_show_sectors, label: "Show sectors" %>
+          <%= f.input :profile_show_age_ranges, label: "Show age ranges" %>
           <%= f.input :profile_show_workshops, label: "Show workshops" %>
           <%= f.input :profile_show_stories, label: "Show stories" %>
           <%= f.input :profile_show_events_registered, label: "Show events hosted" %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -168,14 +168,16 @@
             </div>
           </div>
         <% end %>
-        <!-- Age groups served (deduped across the org and its affiliated people) -->
-        <% primary_age_groups = @organization.all_primary_age_groups %>
-        <% additional_age_groups = @organization.all_additional_age_groups %>
-        <% if primary_age_groups.any? || additional_age_groups.any? %>
-          <div class="md:col-span-2 p-3">
-            <h2 class="text-lg font-semibold text-gray-800 mb-3">Age groups served</h2>
-            <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
-          </div>
+        <!-- Age ranges served (deduped across the org and its affiliated people) -->
+        <% if @organization.profile_show_age_ranges? %>
+          <% primary_age_groups = @organization.all_primary_age_groups %>
+          <% additional_age_groups = @organization.all_additional_age_groups %>
+          <% if primary_age_groups.any? || additional_age_groups.any? %>
+            <div class="md:col-span-2 p-3">
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Age ranges served</h2>
+              <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
+            </div>
+          <% end %>
         <% end %>
       </div>
     <hr class="my-8 border-gray-200">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -146,9 +146,9 @@
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
           <h3 class="font-semibold text-gray-700 mb-3"><%= type.display_label %></h3>
           <% if is_age %>
-            <p class="text-sm text-gray-500 mb-3">Check every age group served, then mark the primary ones.</p>
+            <p class="text-sm text-gray-500 mb-3">Check every age range served, then mark the one primary.</p>
           <% end %>
-          <div class="flex flex-wrap gap-3">
+          <div class="flex flex-wrap gap-3"<%= ' data-controller="single-select-checkbox"'.html_safe if is_age %>>
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "person", category: category,
                          checked: @person.category_ids.include?(category.id),
@@ -409,6 +409,7 @@
           <%= f.input :profile_show_bio, label: "Show bio" %>
           <%= f.input :profile_show_affiliations, label: "Show affiliations" %>
           <%= f.input :profile_show_sectors, label: "Show sectors" %>
+          <%= f.input :profile_show_age_ranges, label: "Show age ranges" %>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-3">

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -147,14 +147,16 @@
               <% end %>
             </div>
           <% end %>
-          <!-- Age groups served -->
-          <% primary_age_groups = @person.primary_age_groups.to_a %>
-          <% additional_age_groups = @person.additional_age_groups.to_a %>
-          <% if primary_age_groups.any? || additional_age_groups.any? %>
-            <div class="md:col-span-2 p-3">
-              <h2 class="text-lg font-semibold text-gray-800 mb-3">Age groups served</h2>
-              <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
-            </div>
+          <!-- Age ranges served -->
+          <% if @person.profile_show_age_ranges? %>
+            <% primary_age_groups = @person.primary_age_groups.to_a %>
+            <% additional_age_groups = @person.additional_age_groups.to_a %>
+            <% if primary_age_groups.any? || additional_age_groups.any? %>
+              <div class="md:col-span-2 p-3">
+                <h2 class="text-lg font-semibold text-gray-800 mb-3">Age ranges served</h2>
+                <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_category_checkbox.html.erb
+++ b/app/views/shared/_category_checkbox.html.erb
@@ -1,9 +1,10 @@
 <%# A profile-specific category checkbox shared by the person and organization
     edit forms. param_key is "person" or "organization". For AgeRange categories
-    (is_age), it also renders a "Primary" toggle that submits
-    [param_key][primary_age_category_ids][] so the tagging is split into the
-    primary vs additional age groups served. The primary toggle sits outside the
-    membership label so the two checkboxes never toggle each other. %>
+    (is_age), it also renders a single "Primary" toggle that submits
+    [param_key][primary_age_category_ids][] so the tagging is split into the one
+    primary vs the additional age ranges served. The primary toggle sits outside
+    the membership label so the two checkboxes never toggle each other; the
+    single-select-checkbox controller keeps only one primary checked at a time. %>
 <% id = "#{param_key}_category_ids_#{category.id}" %>
 <div class="flex items-center gap-2 p-3 w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
   <label for="<%= id %>" class="flex items-center gap-2 cursor-pointer">
@@ -24,7 +25,8 @@
                         category.id,
                         primary_checked,
                         id: primary_id,
-                        class: "h-3.5 w-3.5 text-amber-600 rounded" %>
+                        class: "h-3.5 w-3.5 text-amber-600 rounded",
+                        data: { single_select_checkbox_target: "option", action: "single-select-checkbox#select" } %>
       Primary
     </label>
   <% end %>

--- a/db/migrate/20260618191943_add_profile_show_age_ranges.rb
+++ b/db/migrate/20260618191943_add_profile_show_age_ranges.rb
@@ -1,0 +1,11 @@
+class AddProfileShowAgeRanges < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :profile_show_age_ranges, :boolean, default: true, null: false unless column_exists?(:people, :profile_show_age_ranges)
+    add_column :organizations, :profile_show_age_ranges, :boolean, default: true, null: false unless column_exists?(:organizations, :profile_show_age_ranges)
+  end
+
+  def down
+    remove_column :people, :profile_show_age_ranges, if_exists: true
+    remove_column :organizations, :profile_show_age_ranges, if_exists: true
+  end
+end

--- a/db/migrate/20260618191944_make_primary_age_group_single_select.rb
+++ b/db/migrate/20260618191944_make_primary_age_group_single_select.rb
@@ -1,0 +1,50 @@
+# Reshapes age ranges to mirror sectors: the "primary age range" question becomes
+# a single-select dropdown (one primary), the "additional ages served" question
+# stays multi-select. Also renames both to the new labels and normalizes any
+# existing data that marked more than one primary age range down to one.
+class MakePrimaryAgeGroupSingleSelect < ActiveRecord::Migration[8.1]
+  def up
+    return unless table_exists?(:form_fields)
+
+    FormField.reset_column_information
+
+    FormField.where(field_identifier: "primary_age_group").find_each do |field|
+      field.update!(answer_type: :single_select_dropdown, name: "Primary age range")
+    end
+    FormField.where(field_identifier: "additional_age_group").find_each do |field|
+      field.update!(name: "Additional ages served")
+    end
+
+    normalize_primary_age_groups
+  end
+
+  def down
+    return unless table_exists?(:form_fields)
+
+    FormField.reset_column_information
+
+    FormField.where(field_identifier: "primary_age_group").find_each do |field|
+      field.update!(answer_type: :multi_select_checkbox, name: "Primary Age Group(s) Served")
+    end
+    FormField.where(field_identifier: "additional_age_group").find_each do |field|
+      field.update!(name: "Additional Age Group(s) Served")
+    end
+  end
+
+  # Keep one primary age range per owner (the first by category position/name),
+  # demoting the rest so the new single-primary rule holds for existing data.
+  def normalize_primary_age_groups
+    CategorizableItem
+      .joins(category: :category_type)
+      .where(category_types: { name: "AgeRange" }, is_primary: true)
+      .includes(category: :category_type)
+      .group_by { |item| [ item.categorizable_type, item.categorizable_id ] }
+      .each_value do |items|
+        next if items.size <= 1
+
+        items.sort_by { |item| [ item.category&.position || 0, item.category&.name.to_s ] }
+             .drop(1)
+             .each { |item| item.update_columns(is_primary: false) }
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_182729) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_191944) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -776,6 +776,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_182729) do
     t.string "name"
     t.text "notes", size: :long
     t.integer "organization_status_id"
+    t.boolean "profile_show_age_ranges", default: true, null: false
     t.boolean "profile_show_description", default: true, null: false
     t.boolean "profile_show_email", default: true, null: false
     t.boolean "profile_show_events_registered", default: true, null: false
@@ -943,6 +944,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_182729) do
     t.text "notes"
     t.boolean "profile_is_searchable", default: true, null: false
     t.boolean "profile_show_affiliations", default: true, null: false
+    t.boolean "profile_show_age_ranges", default: true, null: false
     t.boolean "profile_show_bio", default: true, null: false
     t.boolean "profile_show_email", default: true, null: false
     t.boolean "profile_show_events_registered", default: true, null: false

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -993,13 +993,27 @@ record_professional_answers = ->(submission, i) do
   person = submission.person
   form = submission.form
 
-  age_field = form.form_fields.find_by(field_identifier: "primary_age_group")
   ages = pick_categories.call(age_range_categories, i, 2)
-  if age_field && ages.present? && submission.form_answers.where(form_field: age_field).none?
-    submission.form_answers.create!(form_field: age_field,
-                                    submitted_answer: ages.map(&:id).join(", "),
-                                    question_name_when_answered: age_field.name)
+  primary_age = ages.first
+  additional_ages = ages.drop(1)
+
+  primary_age_field = form.form_fields.find_by(field_identifier: "primary_age_group")
+  if primary_age_field && primary_age && submission.form_answers.where(form_field: primary_age_field).none?
+    submission.form_answers.create!(form_field: primary_age_field,
+                                    submitted_answer: primary_age.id.to_s,
+                                    question_name_when_answered: primary_age_field.name)
   end
+
+  additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_group")
+  if additional_age_field && additional_ages.present? && submission.form_answers.where(form_field: additional_age_field).none?
+    submission.form_answers.create!(form_field: additional_age_field,
+                                    submitted_answer: additional_ages.map(&:id).join(", "),
+                                    question_name_when_answered: additional_age_field.name)
+  end
+
+  # Age chips read categorizable_items, mirroring registration's tag_age_groups:
+  # one primary (starred), the rest additional.
+  person.tag_age_groups(primary_ids: [ primary_age&.id ].compact, additional_ids: additional_ages.map(&:id))
 
   service_field = form.form_fields.find_by(field_identifier: "primary_service_area")
   sectors = service_area_sectors.empty? ? [] : [ service_area_sectors[i % service_area_sectors.size], service_area_sectors[(i + 4) % service_area_sectors.size] ].uniq

--- a/spec/models/concerns/age_group_taggable_spec.rb
+++ b/spec/models/concerns/age_group_taggable_spec.rb
@@ -37,16 +37,24 @@ RSpec.describe AgeGroupTaggable do
       expect(person.additional_age_groups).to contain_exactly(teen)
       expect(person.categories).to include(clinical)
     end
+
+    it "keeps only one primary — a newly chosen primary demotes the previous one" do
+      person.tag_age_groups(primary_ids: [ young.id ], additional_ids: [])
+      person.tag_age_groups(primary_ids: [ teen.id ], additional_ids: [])
+
+      expect(person.primary_age_groups).to contain_exactly(teen)
+      expect(person.additional_age_groups).to contain_exactly(young)
+    end
   end
 
   describe "#apply_primary_age_groups!" do
-    it "flips is_primary on already-tagged age categories to match the given set" do
+    it "marks a single primary age category, demoting the rest, honoring only the first id" do
       person.categories = [ young, teen, adult ]
 
       person.apply_primary_age_groups!([ young.id, teen.id ])
 
-      expect(person.primary_age_groups).to contain_exactly(young, teen)
-      expect(person.additional_age_groups).to contain_exactly(adult)
+      expect(person.primary_age_groups).to contain_exactly(young)
+      expect(person.additional_age_groups).to contain_exactly(teen, adult)
     end
 
     it "clears primary when the set is empty and never creates new taggings" do
@@ -56,6 +64,22 @@ RSpec.describe AgeGroupTaggable do
 
       expect(person.primary_age_groups).to be_empty
       expect(person.additional_age_groups).to contain_exactly(young)
+    end
+  end
+
+  describe "single-primary validation" do
+    it "is invalid when more than one age range is marked primary" do
+      person.categorizable_items.create!(category: young, is_primary: true)
+      person.categorizable_items.create!(category: teen, is_primary: true)
+
+      expect(person.reload).not_to be_valid
+      expect(person.errors[:base]).to include("Only one age range can be marked as primary")
+    end
+
+    it "is valid with a single primary age range" do
+      person.tag_age_groups(primary_ids: [ young.id ], additional_ids: [ teen.id ])
+
+      expect(person.reload).to be_valid
     end
   end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -130,6 +130,15 @@ RSpec.describe FormBuilderService do
         expect(additional).to have_attributes(name: "Additional sectors", answer_type: "multi_select_checkbox")
         expect(primary.position).to be < additional.position
       end
+
+      it "asks for a single primary age range via a dropdown before the additional ages checkboxes" do
+        primary = form.form_fields.find_by(field_identifier: "primary_age_group")
+        additional = form.form_fields.find_by(field_identifier: "additional_age_group")
+
+        expect(primary).to have_attributes(name: "Primary age range", answer_type: "single_select_dropdown")
+        expect(additional).to have_attributes(name: "Additional ages served", answer_type: "multi_select_checkbox")
+        expect(primary.position).to be < additional.position
+      end
     end
 
     context "marketing section" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Builds on #1717's primary/additional age groups, reshaping them to match **sectors** exactly and adding a per-profile **visibility toggle**.
- On the registration form a respondent now picks **one** primary age range from a dropdown and **many** additional ones from a multi-select — same shape as the primary/additional sector questions.

### How did you approach the change?
**Registration form**
- "Primary age range" is now a **single-select dropdown** (one primary); "Additional ages served" stays **multi-select**.
- A data migration converts existing forms' `primary_age_group` field to a dropdown and renames both questions.

**Single primary (sector parity)**
- `AgeGroupTaggable#tag_age_groups` and `#apply_primary_age_groups!` keep exactly one primary — choosing a new primary demotes the previous one — backed by an `at_most_one_primary_age_group` validation.
- A migration normalizes any existing data that marked several primaries down to one.
- Edit forms keep a single "Primary" toggle checked at a time via a new `single-select-checkbox` Stimulus controller (allows zero or one, like the star toggle on sectors).

**Visibility toggle**
- `profile_show_age_ranges` on people + organizations gates the "Age ranges served" section, mirroring `profile_show_sectors`. Added a "Show age ranges" checkbox to both edit forms.

**Reporting**
- The event dashboard age breakdown now reads **both** the primary and additional age-range answers (previously only the primary question), so the chart reflects every age range served.

### Anything else to add?
- This branch was previously a parallel implementation of #1717; it has been rebased onto main and reduced to just the deltas above (single-primary + visibility toggle + dashboard fix). Everything else from the old version was superseded by #1717.
- Specs: updated `AgeGroupTaggable` spec (single-primary, demote, validation), added a builder spec for the new age field types. Full affected suite green; rubocop clean; dev seed + Vite dev build run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)