### PR TITLE
Flatten event location searchable-select to match sibling inputs

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -94,6 +94,34 @@
   @apply bg-gray-100;
 }
 
+/* Tom Select "flat" variant: the wrapper inherits the field's bordered box,
+   so the inner control is transparent and borderless — no box-within-a-box.
+   Used for optional searchable-selects (e.g. the event location) so the field
+   reads as not-required. */
+.ts-wrapper.ts-flat {
+  @apply bg-transparent;
+}
+
+.ts-wrapper.ts-flat .ts-control,
+.ts-wrapper.ts-flat.focus .ts-control {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  min-height: 1.5rem;
+}
+
+/* Match the height of sibling text inputs (py-2 + 1.5rem line-height) */
+.ts-wrapper.ts-flat .ts-control,
+.ts-wrapper.ts-flat .ts-control input {
+  line-height: 1.5rem;
+  font-size: 1rem;
+}
+
+.ts-wrapper.ts-flat.focus {
+  @apply ring-1 ring-blue-500 border-blue-500;
+}
+
 .readonly {
   @apply bg-gray-100 text-gray-500 cursor-not-allowed border-gray-300;
 }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -200,7 +200,7 @@
                       value_method: :id,
                       include_blank: true,
                       input_html: {
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                        class: "ts-flat w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                         data: { searchable_select_target: "select" },
                       } %>
         </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The location searchable-select on the event edit form rendered as a **box-within-a-box** with a filled background, looking inconsistent with the neighboring text inputs and visually reading as a required/distinct field when it's optional.

### How did you approach the change?

- Root cause: Tom Select copies the original `<select>`'s utility classes onto its generated `.ts-wrapper`, then renders its own bordered, filled `.ts-control` inside it — two stacked boxes.
- Added a `ts-flat` marker class to the location select so the change is **scoped to the event form** (the other 7 searchable-selects keep their current look).
- Added a `.ts-flat` Tom Select variant in `application.tailwind.css` that makes the inner control transparent and borderless, leaving the single wrapper box; matched its content height to the sibling `px-3 py-2` text inputs and kept a blue focus ring for keyboard focus.

### UI Testing Checklist

- [ ] Event edit form: location field is a single, transparent box with no inner border
- [ ] Location field is the same height as the Videoconference URL input beside it
- [ ] Keyboard-focusing the location field shows a visible blue focus ring
- [ ] Search/select still works and the chosen location persists on save

### Anything else to add?

- Scoped to the event form via the `ts-flat` class; happy to make it the default for all searchable-selects if we want the flat look everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)