### PR TITLE
Show primary/additional age groups as chips on recipients page

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -53,7 +53,9 @@ class EventDashboard
   def scholarship_applicants
     @scholarship_applicants ||= Person
       .where(id: scholarship_applicant_ids)
-      .includes(:sectors, { categories: :category_type }, { affiliations: :organization })
+      .includes(:sectors, { categories: :category_type },
+                { categorizable_items: { category: :category_type } },
+                { affiliations: :organization })
       .sort_by(&:name)
   end
 

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -79,6 +79,13 @@
               then the additional sectors alphabetically. %>
           <% sectorable_items = person.sectorable_items_primary_first %>
           <% has_sectors = sectorable_items.any? %>
+          <%# Primary age groups first (starred amber chips), then the additional
+              ones — matching the sector chips above. Falls back to the form
+              answer / profile text only when the person carries no tagged age
+              groups. %>
+          <% primary_age_groups = person.primary_age_groups.to_a %>
+          <% additional_age_groups = person.additional_age_groups.to_a %>
+          <% has_age_groups = primary_age_groups.any? || additional_age_groups.any? %>
           <div class="relative px-5 py-4 pr-12 <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:scholarships) %>">
             <button type="button" data-action="expandable-card#toggle"
                     aria-label="Toggle <%= person.name %> application"
@@ -117,7 +124,7 @@
                 </div>
 
                 <%# Serves / Ages — parallel with the name %>
-                <% if has_sectors || service_area_text.present? || age_group_text.present? %>
+                <% if has_sectors || service_area_text.present? || has_age_groups || age_group_text.present? %>
                   <div class="flex flex-wrap items-center gap-x-8 gap-y-2">
                     <% if has_sectors %>
                       <div class="flex flex-wrap items-center gap-2">
@@ -132,7 +139,12 @@
                         <%= service_area_text %>
                       </div>
                     <% end %>
-                    <% if age_group_text.present? %>
+                    <% if has_age_groups %>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
+                        <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
+                      </div>
+                    <% elsif age_group_text.present? %>
                       <div class="flex items-center gap-2">
                         <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
                         <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-600"><%= age_group_text %></span>

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -211,3 +211,25 @@ Person.find_each.with_index do |person, i|
     end
   end
 end
+
+puts "Tagging seed users with primary/additional age groups…"
+# A person serves one core age group and sometimes a few others, so the profile
+# and recipients pages show a single starred primary chip plus any additional
+# ones. Give the three demo accounts that shape so the chip display has real data
+# to render. tag_age_groups marks exactly the named primary and treats the rest
+# as additional, and is idempotent on reseed.
+seed_user_age_groups = {
+  "umberto.user@example.com" => { primary: "13-17", additional: [ "18+" ] },
+  "amy.user@example.com" => { primary: "6-12", additional: [ "3-5", "13-17" ] },
+  "aisha.user@example.com" => { primary: "18+", additional: [] }
+}
+seed_user_age_groups.each do |email, groups|
+  person = User.find_by(email: email)&.person
+  next unless person
+
+  primary = Category.age_ranges.published.find_by(name: groups[:primary])
+  next unless primary
+
+  additional = Category.age_ranges.published.where(name: groups[:additional]).to_a
+  person.tag_age_groups(primary_ids: [ primary.id ], additional_ids: additional.map(&:id))
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1255,6 +1255,21 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Pat Plain")
       end
 
+      it "renders each recipient's tagged age groups as chips, primary ones starred" do
+        age_type = create(:category_type, name: "AgeRange", published: true)
+        teens = create(:category, :published, category_type: age_type, name: "13-17")
+        adults = create(:category, :published, category_type: age_type, name: "18+")
+        applicant.tag_age_groups(primary_ids: [ teens.id ], additional_ids: [ adults.id ])
+
+        get recipients_event_path(event)
+
+        page = Capybara.string(response.body)
+        expect(page).to have_content("13-17")
+        expect(page).to have_content("18+")
+        # The primary group leads with the starred amber chip from the shared partial.
+        expect(page).to have_css("span.text-amber-800 i.fa-star")
+      end
+
       it "shows the org linked to its website on the left and the bold recipient name linked to their profile on the right" do
         applicant.update!(shoutout_text: "Grateful to bring art to the survivors we serve.")
         event.event_registrations.find_by(registrant: applicant).update!(shoutout: true)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The scholarship recipients page rendered age ranges as a flat comma-separated string while sectors already showed the primary/additional chip treatment. Now that people carry a primary age-group distinction (`categorizable_items.is_primary`), the "Ages" strip renders the same starred-chip format so it reads in parallel with "Serves".

### How did you approach the change?
`recipients.html.erb` now renders the shared `age_group_tags` partial from the person's `primary_age_groups`/`additional_age_groups`, falling back to the existing form-answer/profile text only when no age groups are tagged. `EventDashboard#scholarship_applicants` eager-loads `categorizable_items` so the chips avoid an N+1. The dev seed (`people_profiles.rb`) now tags the three demo accounts (Umberto, Amy, Aisha) with one primary age group plus a few additional, so the chips have real data to show — modeling the intended shape of one primary, optionally some additional.

### UI Testing Checklist
- [ ] On an event's recipients page, a recipient with tagged age groups shows them as chips (primary starred amber, additional gray), parallel to the sector chips
- [ ] A recipient with no tagged age groups still shows the form-answer / profile text fallback
- [ ] After reseeding dev, Amy/Aisha/Umberto each show a single starred primary age group on their profile and recipient cards

### Anything else to add?
Editing connected age categories (including the primary toggle) already exists on the person edit form via `shared/_category_checkbox`; no change was needed there. Added a request spec asserting the chips render with the primary one starred. Note: the model and edit form currently allow more than one primary age group to be flagged — this PR seeds a single primary but does not enforce a one-primary constraint; happy to add that separately if desired.