### PR TITLE
Rename service-area form fields to sectors and refine sector questions

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -338,19 +338,19 @@ class EventDashboard
   end
 
   # Every sector tagged on registrants (primary + additional), backing the
-  # "All service areas" chart. The "Primary service area" chart instead uses
+  # "All sectors" chart. The "Primary sector" chart instead uses
   # #primary_sectors / #primary_sector_counts, which read only the dropdown.
   def sectors
     @sectors ||= Sector.where(id: registrant_sector_ids).order(:name)
   end
 
-  # Sectors registrants named as their single primary service area (the
-  # registration dropdown), ordered for the "Primary service area" chart.
+  # Sectors registrants named as their single primary sector (the
+  # registration dropdown), ordered for the "Primary sector" chart.
   def primary_sectors
     @primary_sectors ||= Sector.where(id: primary_sector_counts.keys).order(:name)
   end
 
-  # Distinct-registrant count per sector named as the primary service area.
+  # Distinct-registrant count per sector named as the primary sector.
   def primary_sector_counts
     @primary_sector_counts ||= primary_sector_registrant_ids_by_sector.transform_values(&:size)
   end
@@ -380,7 +380,7 @@ class EventDashboard
       .pluck(:sectorable_id)
   end
 
-  # Distinct sectors registrants named as their primary service area, and distinct
+  # Distinct sectors registrants named as their primary sector, and distinct
   # sectors that appear as an additional (non-primary) tag. These OVERLAP — a
   # sector can be primary for one registrant and additional for another, so the
   # two counts can each be up to the sectors total and may sum to more than it.
@@ -790,14 +790,14 @@ class EventDashboard
       .uniq
   end
 
-  # Distinct sector ids registrants named as their primary service area, limited
+  # Distinct sector ids registrants named as their primary sector, limited
   # to sectors actually represented among registrants.
   def primary_sector_ids
     @primary_sector_ids ||= primary_service_area_rows.map(&:last).uniq & registrant_sector_ids
   end
 
   # Distinct sectors a registrant has as a tag without having named that sector as
-  # their own primary service area. Overlaps primary_sector_ids when a sector is
+  # their own primary sector. Overlaps primary_sector_ids when a sector is
   # primary for one registrant and additional for another.
   def additional_sector_ids
     @additional_sector_ids ||= begin
@@ -814,9 +814,9 @@ class EventDashboard
       .pluck(:sectorable_id, :sector_id)
   end
 
-  # [ person_id, sector_id ] pairs from registrants' primary service area answers.
+  # [ person_id, sector_id ] pairs from registrants' primary sector answers.
   # Read from the single-select dropdown ("primary_service_area_single"); the
-  # checkbox "primary_service_area" field collects ADDITIONAL service areas.
+  # checkbox "primary_service_area" field collects the Additional sectors.
   def primary_service_area_rows
     field = registration_form_field("primary_service_area_single")
     return [] unless field

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -86,7 +86,7 @@ class FormBuilderService
       "Agency Type", "Agency Website"
     ],
     person_background: [ "Racial / Ethnic Identity" ],
-    professional_info: [ "Primary service area", "Additional service areas", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
+    professional_info: [ "Primary sector", "Additional sectors", "Workshop Settings", "Client Life Experiences", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
     marketing: [
       "How did you hear about this training?",
       "What motivates you to attend this training?",
@@ -430,12 +430,12 @@ class FormBuilderService
   def build_professional_info_fields(form, position)
     position = add_header(form, position, "Professional Information", group: "professional")
 
-    position = add_field(form, position, "Primary service area", :single_select_dropdown,
+    position = add_field(form, position, "Primary sector", :single_select_dropdown,
                          key: "primary_service_area_single", group: "professional", required: false,
-                         subtitle: "Select the sector you primarily serve.")
-    position = add_field(form, position, "Additional service areas", :multi_select_checkbox,
+                         subtitle: "Select the option that best represents those you primarily intend to serve through the art workshops")
+    position = add_field(form, position, "Additional sectors", :multi_select_checkbox,
                          key: "primary_service_area", group: "professional", required: false,
-                         subtitle: "Select all that apply. These represent the other sectors you serve.")
+                         subtitle: "Select all options that represent who you intend to serve through the art workshops (check all that apply)")
     position = add_field(form, position, "Workshop Settings", :multi_select_checkbox,
                          key: "workshop_environments", group: "professional", required: false,
                          subtitle: "Select all settings where you facilitate or plan to facilitate workshops.",

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -212,15 +212,15 @@
   <% org_paths = @dashboard.organizations.to_h { |o| [ o.name, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(o.id, []).to_a.join("-")) ] } %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
     <% if primary_sector_data.any? %>
-      <%= render "breakdown_card", title: "Primary service area", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
+      <%= render "breakdown_card", title: "Primary sector", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
     <% end %>
     <% if sector_data.any? %>
-      <%= render "breakdown_card", title: "All service areas", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
+      <%= render "breakdown_card", title: "All sectors", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
     <% end %>
     <%# States and countries use the addresses theme color (slate) for their map ramps. %>
     <% addresses_color = "#475569" %>
     <%# Age group and Countries are both short; stack them in one column so the pair
-        fits within the height of the taller Primary service area pie card. %>
+        fits within the height of the taller Primary sector pie card. %>
     <div class="flex flex-col gap-6">
       <%# Primary age group comes from the registration "ages served" answers;
           always show the card (with a no-data box when empty). %>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (field:, value: nil, label: nil, show_option_source: false) %>
+<%# locals: (field:, value: nil, label: nil, show_option_source: false, show_dropdown_warning: false) %>
 <% return if field.group_header? %>
 
 <% error = @field_errors&.dig(field.id) %>
@@ -20,6 +20,12 @@
 
   <% if field.subtitle.present? %>
     <p class="rich-label text-xs text-gray-500 mb-1.5"><%= form_label_html(field.subtitle) %></p>
+  <% end %>
+
+  <%# Author-only guidance, shown as part of the dropdown's hint area so it sits
+      inside this field's bottom margin rather than butting against the next one. %>
+  <% if show_dropdown_warning %>
+    <%= render "forms/dropdown_other_warning", field: field %>
   <% end %>
 
   <% field_name = "public_registration[form_fields][#{field.id}]" %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -75,7 +75,7 @@
               the avatar stays blank). Calm palette: neutral name/org links, with
               the sector chips as the single accent. %>
           <% dp = person.decorate %>
-          <%# Primary service area first (rendered as a darker-green crowned chip),
+          <%# Primary sector first (rendered as a darker-green crowned chip),
               then the additional sectors alphabetically. %>
           <% sectorable_items = person.sectorable_items_primary_first %>
           <% has_sectors = sectorable_items.any? %>

--- a/app/views/forms/_dropdown_other_warning.html.erb
+++ b/app/views/forms/_dropdown_other_warning.html.erb
@@ -2,7 +2,7 @@
     Warn the author whenever a dropdown still carries an "Other" option —
     including dynamic dropdowns sourced from sectors/categories. %>
 <% if dropdown_hides_other?(field) %>
-  <p class="mt-1.5 flex items-start gap-1.5 text-xs text-amber-700">
+  <p class="mt-1.5 mb-1.5 flex items-start gap-1.5 text-xs text-amber-700">
     <i class="fa-solid fa-triangle-exclamation mt-0.5 text-amber-500"></i>
     <span>The "Other" option is hidden on dropdown fields because dropdowns can't collect free text. Switch to radio buttons or checkboxes to offer "Other".</span>
   </p>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -99,12 +99,11 @@
                       <span class="text-xs rounded-full border px-2 py-0.5 <%= visibility_badge_styles[field.visibility] %>"><%= field.visibility_label %></span>
                       <%= render "forms/option_source_link", field: field %>
                     </div>
-                    <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier] %>
+                    <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier], show_dropdown_warning: true %>
                   </div>
                 <% else %>
-                  <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier], show_option_source: true %>
+                  <%= render "events/public_registrations/form_field", field: field, value: nil, label: email_label_overrides[field.field_identifier], show_option_source: true, show_dropdown_warning: true %>
                 <% end %>
-                <%= render "forms/dropdown_other_warning", field: field %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -11,7 +11,7 @@
     used on password fields — to flag at a glance what the public can't see. %>
 <% is_hidden = sector.respond_to?(:published?) && !sector.published? %>
 
-<%# Primary service areas read as a darker-green chip with a star so they stand
+<%# Primary sectors read as a darker-green chip with a star so they stand
     out from the additional sectors, matching the star used in the chip editor;
     everyone else keeps the light-lime default. %>
 <% bg_color ||= is_primary ? "bg-lime-200" : DomainTheme.bg_class_for(:sectors) %>
@@ -45,7 +45,7 @@
                       px-3 py-1
                       text-sm font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary service area"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
+    <span data-tag-link-loading-target="text"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary sector"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -22,7 +22,7 @@
                 } %>
   <% end %>
   <% if show_admin_flags && allowed_to?(:manage?, Person) %>
-    <label class="admin-only cursor-pointer leading-none" title="Mark as primary service area">
+    <label class="admin-only cursor-pointer leading-none" title="Mark as primary sector">
       <%= f.check_box :is_primary,
                       class: "peer sr-only",
                       data: { primary_sector_target: "primary", action: "primary-sector#selectPrimary" } %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -945,7 +945,7 @@ end
 puts "Giving Amy free-text \"Other\" answers on her Facilitator Training submission…"
 # Demo data for the "Other" chips on the person profile + edit pages: a registrant
 # who picked the "Other" option (folded into "Other: <text>") on a sector-backed
-# field (Primary service area) and a category-backed field (Workshop Settings).
+# field (Additional sectors) and a category-backed field (Workshop Settings).
 # These free-text values can't be Sector/Category records, so they only surface
 # via Person#other_service_area_responses / #other_workshop_setting_responses.
 # Seeded before the professional-answer enrichment below so the primary_service_area

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       sector_a = create(:sector, :published, name: "Healthcare")
       sector_b = create(:sector, :published, name: "Education")
       create(:form_field, form: form, answer_type: :single_select_radio,
-             field_identifier: "primary_service_area", name: "Primary service area",
+             field_identifier: "primary_service_area", name: "Primary sector",
              required: false)
 
       get new_event_public_registration_path(event)
@@ -294,7 +294,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     it "still renders a dynamic-option field as checkboxes" do
       create(:sector, :published, name: "Healthcare")
       create(:form_field, form: form, answer_type: :multi_select_checkbox,
-             field_identifier: "primary_service_area", name: "Primary service area",
+             field_identifier: "primary_service_area", name: "Primary sector",
              required: false)
 
       get new_event_public_registration_path(event)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1124,7 +1124,7 @@ RSpec.describe "Events", type: :request do
                           field_identifier: "impact_description")
     end
     let(:service_area_field) do
-      create(:form_field, form: registration_form, name: "Primary service area", field_identifier: "primary_service_area")
+      create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_service_area")
     end
 
     before do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe EventDashboard do
     end
 
     it "gathers header (service area / age group) answers keyed by applicant and identifier" do
-      service_field = create(:form_field, form: registration_form, name: "Primary service area", field_identifier: "primary_service_area")
+      service_field = create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_service_area")
       reg_submission = FormSubmission.find_by(person: embedded_applicant, form: registration_form)
       create(:form_answer, form_submission: reg_submission, form_field: service_field, submitted_answer: "5")
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -122,12 +122,12 @@ RSpec.describe FormBuilderService do
     context "professional_info section" do
       let(:form) { described_class.new(name: "Test", sections: %i[professional_info]).call }
 
-      it "asks for a single primary service area via a dropdown before the additional service areas checkboxes" do
+      it "asks for a single primary sector via a dropdown before the additional sectors checkboxes" do
         primary = form.form_fields.find_by(field_identifier: "primary_service_area_single")
         additional = form.form_fields.find_by(field_identifier: "primary_service_area")
 
-        expect(primary).to have_attributes(name: "Primary service area", answer_type: "single_select_dropdown")
-        expect(additional).to have_attributes(name: "Additional service areas", answer_type: "multi_select_checkbox")
+        expect(primary).to have_attributes(name: "Primary sector", answer_type: "single_select_dropdown")
+        expect(additional).to have_attributes(name: "Additional sectors", answer_type: "multi_select_checkbox")
         expect(primary.position).to be < additional.position
       end
     end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The professional-info "Primary / Additional service area" questions are really about **sectors** (their options come straight from the Sectors admin), so their labels read inconsistently with the rest of the product.
- This renames them — and every user-facing place that mirrors that data — to "Primary sector" / "Additional sectors" so the terminology lines up end to end.

### How did you approach the change?
- Renamed the form labels in `FormBuilderService` (and the `SECTION_FIELD_NAMES` preview list) and refreshed the seeded subtitles to the new registration copy; the `field_identifier`s (`primary_service_area*`) are unchanged, so seeds, stored answers, and tagging keep working.
- Propagated the rename to the Event Background pie charts ("Primary sector" / "All sectors") and the person sector-tag tooltips ("Primary sector" / "Mark as primary sector"), updating related comments to match.
- Moved the dropdown "Other is hidden" author warning into the field's block (preview only) so it sits inside the field's bottom margin instead of butting against the next question.

### UI Testing Checklist
- [ ] Form preview (`/forms/:id`): "Primary sector" dropdown shows the **Options from Sectors** badge; the amber "Other" warning sits under the dropdown with clear space before "Additional sectors".
- [ ] Event Background dashboard: the two sector pie cards read **"Primary sector"** and **"All sectors"**.
- [ ] Person profile / sector chips: the starred chip tooltip reads **"Primary sector"** and the admin star toggle reads **"Mark as primary sector"**.
- [ ] Public registration form still renders the sector dropdown/checkboxes (no author-only warning shown to registrants).

### Anything else to add?
- No `field_identifier`, method, or column renames — labels/UI copy only — so no migration or data backfill is needed.
- Existing dev forms won't pick up the new labels on a guarded re-seed; reset + `ai/seed` to see them.
