### PR TITLE
Refresh the registration ticket: thumbnail header, compact details, and status chips

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -287,10 +287,7 @@ class EventDecorator < ApplicationDecorator
     return if cost_cents.blank?
     return "Free event" if cost_cents.zero?
 
-    dollars = cost_cents / 100
-    cents   = cost_cents % 100
-    formatted = cents.zero? ? "$#{dollars}" : "$#{dollars}.#{cents.to_s.rjust(2, '0')}"
-    "Cost: #{formatted}"
+    "Cost: #{MoneyFormatter.dollars_from_cents(cost_cents)}"
   end
 
   def content

--- a/app/frontend/stylesheets/components/buttons.css
+++ b/app/frontend/stylesheets/components/buttons.css
@@ -12,6 +12,13 @@
            hover:bg-white hover:text-primary;
   }
 
+  /* The brand-red "pay" / register action button. Carries its own border/bg so
+     the invert-on-hover works without inline styles overriding it. */
+  .btn-accent {
+    @apply border-2 border-accent bg-accent text-white
+           hover:bg-white hover:text-accent;
+  }
+
   .btn-secondary {
     @apply border border-secondary bg-secondary text-white
            hover:bg-white hover:text-secondary;

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -10,8 +10,15 @@
 class MagicTicketCallouts
   include Rails.application.routes.url_helpers
 
-  Card = Data.define(:icon_class, :color, :title, :subtitle, :href, :target, :trailing_icon, :chip) do
-    def initialize(chip: nil, **) = super
+  # `badge` / `badge_classes` are an optional status chip shown inline in the
+  # subtitle row (the payment card's "$1,350 due" / "Paid", the CE card's amount
+  # owed, the scholarship award). `badge_classes` defaults to amber in the
+  # _callout_card partial; both default to nil so chip-less cards are unchanged.
+  Card = Data.define(:icon_class, :color, :title, :subtitle, :href, :target, :trailing_icon, :badge, :badge_classes) do
+    def initialize(badge: nil, badge_classes: nil, **rest)
+      super(badge:, badge_classes:, **rest)
+    end
+
     def display_icon_class = icon_class
     def theme = DomainTheme.swatch(color)
   end
@@ -67,8 +74,10 @@ class MagicTicketCallouts
     return if event.cost_cents.to_i <= 0
     due = registration.remaining_cost.to_i.positive?
     Card.new(icon_class: "fa-solid fa-credit-card", color: due ? "orange" : "blue",
-             title: "Payment",
-             subtitle: due ? "#{MoneyFormatter.dollars_from_cents(registration.remaining_cost)} due — view your balance" : "Paid in full — view your payment history",
+             title: due ? "Make your payment" : "Payment",
+             subtitle: due ? "view your balance" : "view your payment history",
+             badge: due ? "#{MoneyFormatter.dollars_from_cents(registration.remaining_cost)} due" : "Paid",
+             badge_classes: due ? nil : "bg-green-100 text-green-800",
              href: registration_payment_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
@@ -94,7 +103,7 @@ class MagicTicketCallouts
              subtitle: awarded ? "Your award — amount, funder, and tasks" : "Your scholarship request status",
              href: registration_scholarship_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
-             chip: awarded ? MoneyFormatter.dollars_from_cents(registration.scholarships.sum(:amount_cents)) : nil)
+             badge: awarded ? MoneyFormatter.dollars_from_cents(registration.scholarships.sum(:amount_cents)) : nil)
   end
 
   # CE hours: an action card prompting the registrant to request credit until
@@ -108,7 +117,7 @@ class MagicTicketCallouts
              subtitle: ce_hours_subtitle(complete),
              href: registration_ce_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
-             chip: ce_hours_chip(complete))
+             badge: ce_hours_badge(complete))
   end
 
   def ce_hours_subtitle(complete)
@@ -117,9 +126,9 @@ class MagicTicketCallouts
     "#{registration.ce_hours_requested} hours"
   end
 
-  # Amount owed, shown as an amber chip on the card — matching the ticket's
-  # "payment is due" chip. Only once the request is complete and money is owed.
-  def ce_hours_chip(complete)
+  # Amount owed, shown as the card's amber badge — matching the payment card's
+  # "$X due" chip. Only once the request is complete and money is owed.
+  def ce_hours_badge(complete)
     return unless complete
     amount = registration.ce_amount_owed_cents.to_i
     return unless amount.positive?

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -77,7 +77,7 @@ class MagicTicketCallouts
              title: due ? "Make your payment" : "Payment",
              subtitle: due ? "view your balance" : "view your payment history",
              badge: due ? "#{MoneyFormatter.dollars_from_cents(registration.remaining_cost)} due" : "Paid",
-             badge_classes: due ? nil : "bg-green-100 text-green-800",
+             badge_classes: due ? nil : "bg-blue-100 text-blue-800 border border-blue-300",
              href: registration_payment_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
@@ -94,16 +94,26 @@ class MagicTicketCallouts
   end
 
   # Shown only when the registrant requested a scholarship. Its page surfaces the
-  # award amount, funder, and tasks once awarded.
+  # award amount, funder, and tasks once awarded. Awarded but with tasks still
+  # pending shows an amber "$X · Tasks outstanding" badge (action needed); fully
+  # met shows a fuchsia amount badge.
   def scholarship_status_card
     return unless registration.scholarship_requested?
     awarded = registration.scholarship?
+    tasks_outstanding = awarded && !registration.scholarship_tasks_met?
     Card.new(icon_class: "fa-solid fa-award", color: DomainTheme.color_for(:scholarships).to_s,
              title: "Scholarship",
              subtitle: awarded ? "Your award — amount, funder, and tasks" : "Your scholarship request status",
              href: registration_scholarship_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
-             badge: awarded ? MoneyFormatter.dollars_from_cents(registration.scholarships.sum(:amount_cents)) : nil)
+             badge: scholarship_badge(awarded, tasks_outstanding),
+             badge_classes: tasks_outstanding ? nil : "bg-fuchsia-100 text-fuchsia-800 border border-fuchsia-300")
+  end
+
+  def scholarship_badge(awarded, tasks_outstanding)
+    return unless awarded
+    amount = MoneyFormatter.dollars_from_cents(registration.scholarships.sum(:amount_cents))
+    tasks_outstanding ? "#{amount} · Tasks outstanding" : amount
   end
 
   # CE hours: an action card prompting the registrant to request credit until
@@ -111,28 +121,45 @@ class MagicTicketCallouts
   # number on file. Shown when the event offers CE or the registrant asked for it.
   def ce_hours_card
     return unless registration.ce_credit_requested?
-    complete = registration.ce_credit_requested? && registration.ce_hours_requested.present? && registration.ce_license_provided?
+    complete = registration.ce_hours_requested.present? && registration.ce_license_provided?
     Card.new(icon_class: "fa-solid fa-graduation-cap", color: "teal",
              title: event.ce_hours_details_label,
-             subtitle: ce_hours_subtitle(complete),
+             subtitle: ce_hours_subtitle,
              href: registration_ce_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
-             badge: ce_hours_badge(complete))
+             badge: ce_hours_badge(complete),
+             # Amber while hours/license are still needed, teal once it's just the
+             # amount due (nil badge_classes falls back to amber in _callout_card).
+             badge_classes: complete ? "bg-teal-100 text-teal-800 border border-teal-300" : nil)
   end
 
-  def ce_hours_subtitle(complete)
-    return "Continuing education — requirements & how to request" unless registration.ce_credit_requested?
-    return "Add your CE hours and license number" unless complete
-    "#{registration.ce_hours_requested} hours"
+  def ce_hours_subtitle
+    return "#{registration.ce_hours_requested} hours" if registration.ce_hours_requested.present?
+    "Continuing education credit"
   end
 
-  # Amount owed, shown as the card's amber badge — matching the payment card's
-  # "$X due" chip. Only once the request is complete and money is owed.
+  # Teal "$X due" once hours + license are on file and money is owed; otherwise an
+  # amber chip naming what's still needed, prefixed with the amount when the hours
+  # (and so the fee) are already known — e.g. "$250 · License number needed".
   def ce_hours_badge(complete)
-    return unless complete
-    amount = registration.ce_amount_owed_cents.to_i
-    return unless amount.positive?
-    "#{MoneyFormatter.dollars_from_cents(amount)} due"
+    amount_cents = registration.ce_amount_owed_cents.to_i
+    amount = MoneyFormatter.dollars_from_cents(amount_cents)
+
+    if complete
+      return unless amount_cents.positive?
+      return "#{amount} due"
+    end
+
+    needed = ce_missing_text
+    amount_cents.positive? ? "#{amount} · #{needed}" : needed
+  end
+
+  def ce_missing_text
+    missing_hours = registration.ce_hours_requested.blank?
+    missing_license = !registration.ce_license_provided?
+    return "Hours & license number needed" if missing_hours && missing_license
+    return "Hours needed" if missing_hours
+    "License number needed"
   end
 
   # "Art supplies & what to bring" — the event's own details page.

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -10,7 +10,8 @@
 class MagicTicketCallouts
   include Rails.application.routes.url_helpers
 
-  Card = Data.define(:icon_class, :color, :title, :subtitle, :href, :target, :trailing_icon) do
+  Card = Data.define(:icon_class, :color, :title, :subtitle, :href, :target, :trailing_icon, :chip) do
+    def initialize(chip: nil, **) = super
     def display_icon_class = icon_class
     def theme = DomainTheme.swatch(color)
   end
@@ -105,13 +106,23 @@ class MagicTicketCallouts
              title: event.ce_hours_details_label,
              subtitle: ce_hours_subtitle(complete),
              href: registration_ce_path(registration.slug),
-             target: nil, trailing_icon: "fa-solid fa-arrow-right")
+             target: nil, trailing_icon: "fa-solid fa-arrow-right",
+             chip: ce_hours_chip(complete))
   end
 
   def ce_hours_subtitle(complete)
     return "Continuing education — requirements & how to request" unless registration.ce_credit_requested?
     return "Add your CE hours and license number" unless complete
-    "#{registration.ce_hours_requested} hours · #{MoneyFormatter.dollars_from_cents(registration.ce_amount_owed_cents)} due"
+    "#{registration.ce_hours_requested} hours"
+  end
+
+  # Amount owed, shown as an amber chip on the card — matching the ticket's
+  # "payment is due" chip. Only once the request is complete and money is owed.
+  def ce_hours_chip(complete)
+    return unless complete
+    amount = registration.ce_amount_owed_cents.to_i
+    return unless amount.positive?
+    "#{MoneyFormatter.dollars_from_cents(amount)} due"
   end
 
   # "Art supplies & what to bring" — the event's own details page.

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -93,7 +93,8 @@ class MagicTicketCallouts
              title: "Scholarship",
              subtitle: awarded ? "Your award — amount, funder, and tasks" : "Your scholarship request status",
              href: registration_scholarship_path(registration.slug),
-             target: nil, trailing_icon: "fa-solid fa-arrow-right")
+             target: nil, trailing_icon: "fa-solid fa-arrow-right",
+             chip: awarded ? MoneyFormatter.dollars_from_cents(registration.scholarships.sum(:amount_cents)) : nil)
   end
 
   # CE hours: an action card prompting the registrant to request credit until

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -12,6 +12,7 @@
 <% target = local_assigns.fetch(:target) { callout.try(:target) } %>
 <% trailing = local_assigns.fetch(:trailing_icon) { callout.try(:trailing_icon) }.presence ||
               (callout.action? ? "fa-solid fa-arrow-right" : "fa-solid fa-circle-info") %>
+<% chip = local_assigns.fetch(:chip) { callout.try(:chip) } %>
 <% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
 <% card_body = capture do %>
   <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
@@ -22,6 +23,10 @@
       <p class="text-sm <%= theme[:subtitle] %>"><%= callout.subtitle %></p>
     <% end %>
   </div>
+
+  <% if chip.present? %>
+    <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800 shrink-0"><%= chip %></span>
+  <% end %>
 
   <i class="<%= trailing %> <%= theme[:icon] %> shrink-0"></i>
 <% end %>

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -12,21 +12,23 @@
 <% target = local_assigns.fetch(:target) { callout.try(:target) } %>
 <% trailing = local_assigns.fetch(:trailing_icon) { callout.try(:trailing_icon) }.presence ||
               (callout.action? ? "fa-solid fa-arrow-right" : "fa-solid fa-circle-info") %>
-<% chip = local_assigns.fetch(:chip) { callout.try(:chip) } %>
+<% badge = callout.try(:badge) %>
+<% badge_classes = callout.try(:badge_classes).presence || "bg-amber-100 text-amber-800" %>
 <% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
 <% card_body = capture do %>
   <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
 
   <div class="flex-1 min-w-0 text-left">
     <p class="font-semibold <%= theme[:title] %>"><%= callout.title %></p>
-    <% if callout.subtitle.present? %>
-      <p class="text-sm <%= theme[:subtitle] %>"><%= callout.subtitle %></p>
+    <% if badge.present? || callout.subtitle.present? %>
+      <p class="text-sm <%= theme[:subtitle] %> flex items-center gap-1.5 flex-wrap">
+        <% if badge.present? %>
+          <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold <%= badge_classes %>"><%= badge %></span>
+        <% end %>
+        <%= callout.subtitle %>
+      </p>
     <% end %>
   </div>
-
-  <% if chip.present? %>
-    <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800 shrink-0"><%= chip %></span>
-  <% end %>
 
   <i class="<%= trailing %> <%= theme[:icon] %> shrink-0"></i>
 <% end %>

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -13,7 +13,7 @@
 <% trailing = local_assigns.fetch(:trailing_icon) { callout.try(:trailing_icon) }.presence ||
               (callout.action? ? "fa-solid fa-arrow-right" : "fa-solid fa-circle-info") %>
 <% badge = callout.try(:badge) %>
-<% badge_classes = callout.try(:badge_classes).presence || "bg-amber-100 text-amber-800" %>
+<% badge_classes = callout.try(:badge_classes).presence || "bg-amber-100 text-amber-800 border border-amber-300" %>
 <% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
 <% card_body = capture do %>
   <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -17,23 +17,21 @@
 
     <!-- Ticket Body -->
     <div class="bg-gray-50 px-6 py-6 space-y-5">
-      <!-- Event Image + Title -->
-      <div class="text-center space-y-4">
-        <div class="inline-block rounded-lg overflow-hidden border border-gray-200 shadow-sm">
-          <%= render "assets/display_image",
-                       resource: event_registration.event,
-                       width: 48, height: 32,
-                       variant: :index,
-                       link: event_path(event_registration.event, reg: event_registration.slug),
-                       file: event_registration.event.decorate.display_image %>
-        </div>
+      <!-- Event thumbnail + title -->
+      <div class="flex items-center justify-center gap-4">
+        <%= render "assets/display_image",
+                     resource: event_registration.event,
+                     width: 18, height: 18,
+                     variant: :index,
+                     link: event_path(event_registration.event, reg: event_registration.slug),
+                     file: event_registration.event.decorate.display_image %>
 
-        <div>
+        <div class="min-w-0 text-left">
           <% if event_registration.event.respond_to?(:pre_title) && event_registration.event.pre_title.present? %>
-            <p class="text-base font-semibold text-gray-700 mb-1" style="font-family: 'Telefon Bold', sans-serif"><%= event_registration.event.pre_title %></p>
+            <p class="text-sm font-semibold text-gray-700 mb-0.5" style="font-family: 'Telefon Bold', sans-serif"><%= event_registration.event.pre_title %></p>
           <% end %>
 
-          <h2 class="text-3xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
+          <h2 class="text-2xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
         </div>
       </div>
 

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -32,6 +32,20 @@
           <% end %>
 
           <h2 class="text-2xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
+
+          <p class="text-sm font-semibold text-blue-900 mt-0.5" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
+
+          <%
+            venue = if event_registration.event.autoshow_videoconference_label && event_registration.event.videoconference_label.present?
+              event_registration.event.videoconference_label
+            else
+              event_registration.event.location&.name
+            end
+            summary = [ event_registration.event.decorate.labelled_cost.presence, ("Location: #{venue}" if venue.present?) ].compact
+          %>
+          <% if summary.any? %>
+            <p class="text-sm text-gray-600 mt-0.5"><%= summary.join(" · ") %></p>
+          <% end %>
         </div>
       </div>
 
@@ -55,56 +69,35 @@
         </p>
       </div>
 
-      <!-- Event Details -->
-      <div class="text-center space-y-2">
-        <div class="text-xl font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.times(display_day: true, display_date: true, styled: true) %></div>
+      <!-- Live "Join on …" link, shown only near event time (date/cost/venue now sit under the title) -->
+      <% if event_registration.event.autoshow_videoconference_link && event_registration.event.videoconference_url.present? && event_registration.joinable? %>
+        <div class="text-center">
+          <%= render "events/videoconference_link", event: event_registration.event.decorate, joinable: event_registration.joinable? %>
+        </div>
+      <% end %>
 
-        <% if event_registration.event.decorate.labelled_cost.present? %>
-          <div class="text-lg font-bold text-purple-900 uppercase" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.labelled_cost %></div>
-        <% end %>
-
-        <% if event_registration.event.location.present? %>
-          <div class="text-base text-gray-700"><%= event_registration.event.location.name %></div>
-        <% end %>
-
-        <% if event_registration.event.autoshow_videoconference_label && event_registration.event.videoconference_label.present? %>
-          <div class="text-base text-gray-700"><%= event_registration.event.videoconference_label %></div>
-        <% end %>
-
-        <%= render "events/videoconference_link", event: event_registration.event.decorate, joinable: event_registration.joinable? %>
-      </div>
-
-      <% if event_registration.event.cost_cents.to_i > 0 && event_registration.status != "cancelled" %>
-        <% if event_registration.remaining_cost <= 0 || @checkout_payment_status == "paid" %>
-          <div class="text-center mt-2"><span class="inline-flex items-center gap-1 rounded-full text-sm font-medium border px-3 py-1 bg-green-50 text-green-700 border-green-200"> Paid </span></div>
-        <% else %>
-          <% due_cents = event_registration.remaining_cost %>
-          <div class="text-center mt-2">
-            <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800"><%= dollars_from_cents(due_cents) %> payment is due</span>
-
-            <% if event_registration.intends_to_pay? %>
-              <div class="mt-2">
-                <span class="inline-flex items-center gap-1 rounded-full text-sm font-medium border px-3 py-1 bg-blue-50 text-blue-700 border-blue-200">
-                  <i class="fa-solid fa-circle-check"></i> Access granted — payment pending
-                </span>
-              </div>
-            <% end %>
-
-            <div class="mt-3">
-              <% if preview %>
-                <button type="button" disabled
-                        class="btn px-6 py-2 text-sm uppercase font-telefon text-white opacity-60 cursor-not-allowed"
-                        style="background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);">Pay with Credit Card</button>
-              <% else %>
-                <%= button_to "Pay with Credit Card",
-                              registration_pay_path(event_registration.slug),
-                              data: { turbo: false },
-                              class: "btn px-6 py-2 text-sm uppercase font-telefon text-white hover:bg-white",
-                              style: "background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);" %>
-              <% end %>
+      <% if event_registration.event.cost_cents.to_i > 0 && event_registration.status != "cancelled" && event_registration.remaining_cost > 0 && @checkout_payment_status != "paid" %>
+        <div class="text-center mt-2 space-y-3">
+          <% if event_registration.intends_to_pay? %>
+            <div>
+              <span class="inline-flex items-center gap-1.5 rounded-full text-sm font-medium border px-3 py-1 bg-blue-50 text-blue-700 border-blue-200">
+                <i class="fa-solid fa-circle-check"></i> Access granted · payment to follow
+              </span>
             </div>
+          <% end %>
+
+          <div>
+            <% if preview %>
+              <button type="button" disabled
+                      class="btn btn-accent px-6 py-2 text-sm uppercase font-telefon opacity-60 cursor-not-allowed">Pay with Credit Card</button>
+            <% else %>
+              <%= button_to "Pay with Credit Card",
+                            registration_pay_path(event_registration.slug),
+                            data: { turbo: false },
+                            class: "btn btn-accent px-6 py-2 text-sm uppercase font-telefon" %>
+            <% end %>
           </div>
-        <% end %>
+        </div>
       <% end %>
 
       <!-- Magic callouts: code-defined cards the app controls (event details, CE

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -25,19 +25,19 @@
             <%= button_to button_text,
                           event_registrant_registration_path(event_id: event),
                           data: { turbo: !event.object.cost_cents.to_i.positive? },
-                          class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
-                          style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+                          class: "btn btn-accent px-10 py-2 text-2xl uppercase",
+                          style: "font-family: 'Telefon Bold', sans-serif;" %>
           <% else %>
             <%= link_to button_text,
                         new_event_public_registration_path(event),
-                        class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
-                        style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+                        class: "btn btn-accent px-10 py-2 text-2xl uppercase",
+                        style: "font-family: 'Telefon Bold', sans-serif;" %>
           <% end %>
         <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
           <%= link_to button_text,
                       new_event_public_registration_path(event),
-                      class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-register-btn",
-                      style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(170, 46, 0); border: 3px solid rgb(170, 46, 0);" %>
+                      class: "btn btn-accent px-10 py-2 text-2xl uppercase",
+                      style: "font-family: 'Telefon Bold', sans-serif;" %>
         <% end %>
       <% else %>
         <span class="text-2xl font-bold text-blue-400 italic">Registration closed</span>

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -21,7 +21,9 @@
   <div class="mt-5 flex items-end justify-end border-t border-gray-200 pt-4">
     <div class="text-right">
       <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount due</p>
-      <p class="mt-1 text-2xl font-semibold tabular-nums <%= @event_registration.remaining_cost.positive? ? "text-amber-700" : "text-green-700" %>"><%= dollars_from_cents(@event_registration.remaining_cost) %></p>
+      <p class="mt-1">
+        <span class="inline-flex items-center rounded-full px-3 py-1 text-2xl font-semibold tabular-nums <%= @event_registration.remaining_cost.positive? ? "bg-amber-200 text-amber-900" : "bg-green-100 text-green-800" %>"><%= dollars_from_cents(@event_registration.remaining_cost) %></span>
+      </p>
     </div>
   </div>
 
@@ -30,17 +32,31 @@
       <%= button_to "Pay with Credit Card",
                     registration_pay_path(@event_registration.slug),
                     data: { turbo: false },
-                    class: "btn px-6 py-2 text-sm uppercase font-telefon text-white hover:bg-white",
-                    style: "background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);" %>
+                    class: "btn btn-accent px-6 py-2 text-sm uppercase font-telefon" %>
     </div>
 
-    <div class="mt-6 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 leading-relaxed space-y-2">
-      <p class="font-semibold text-gray-900">Paying by check?</p>
-      <p>Write the check out to <strong>A Window Between Worlds</strong> and mail it to:</p>
-      <p class="font-medium text-gray-900">1210 Fernside Dr.<br>La Cañada, CA 91011</p>
-      <p>Please send us an email letting us know the date the check will be mailed. If that date changes, please let us know.</p>
-      <p><strong>Note:</strong> AWBW had an address change in recent years. Please be sure your accounting department has this current address — mail sent to the old address will not be received.</p>
-      <p>Payment is due no later than 5:00 PM PT on April 9th. We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
-    </div>
+    <%= link_to registration_invoice_path(@event_registration.slug), target: "_blank", rel: "noopener",
+                  class: "mt-10 flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
+      <i class="fa-solid fa-file-invoice-dollar text-gray-400 text-xl shrink-0"></i>
+
+      <div class="flex-1 min-w-0 text-left">
+        <p class="font-semibold text-gray-900">View invoice</p>
+        <p class="text-sm text-gray-500">Itemized invoice for this registration</p>
+      </div>
+
+      <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
+    <% end %>
+
+    <details class="mt-6">
+      <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-700">Prefer to pay by check?</summary>
+
+      <div class="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 leading-relaxed space-y-2">
+        <p>Write the check out to <strong>A Window Between Worlds</strong> and mail it to:</p>
+        <p class="font-medium text-gray-900">1210 Fernside Dr.<br>La Cañada, CA 91011</p>
+        <p>Please send us an email letting us know the date the check will be mailed. If that date changes, please let us know.</p>
+        <p><strong>Note:</strong> AWBW had an address change in recent years. Please be sure your accounting department has this current address — mail sent to the old address will not be received.</p>
+        <p>Payment is due no later than 5:00 PM PT on April 9th. We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
+      </div>
+    </details>
   <% end %>
 <% end %>

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -22,7 +22,7 @@
     <div class="text-right">
       <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount due</p>
       <p class="mt-1">
-        <span class="inline-flex items-center rounded-full px-3 py-1 text-2xl font-semibold tabular-nums <%= @event_registration.remaining_cost.positive? ? "bg-amber-200 text-amber-900" : "bg-green-100 text-green-800" %>"><%= dollars_from_cents(@event_registration.remaining_cost) %></span>
+        <span class="inline-flex items-center rounded-full px-3 py-1 text-2xl font-semibold tabular-nums <%= @event_registration.remaining_cost.positive? ? "bg-amber-200 text-amber-900" : "bg-blue-100 text-blue-800" %>"><%= dollars_from_cents(@event_registration.remaining_cost) %></span>
       </p>
     </div>
   </div>

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -124,6 +124,11 @@ RSpec.describe EventDecorator do
       event = build(:event, cost_cents: 2505).decorate
       expect(event.labelled_cost).to eq("Cost: $25.05")
     end
+
+    it "adds a thousands separator for large amounts" do
+      event = build(:event, cost_cents: 150_000).decorate
+      expect(event.labelled_cost).to eq("Cost: $1,500")
+    end
   end
 
   describe "#calendar_links" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("Payment history")
       expect(response.body).to include("Amount due")
       expect(response.body).to include("Pay with Credit Card")
-      expect(response.body).to include("Paying by check?")
+      expect(response.body).to include("View invoice")
+      expect(response.body).to include("Prefer to pay by check?")
       expect(response.body).to include("A Window Between Worlds")
     end
 
@@ -157,7 +158,7 @@ RSpec.describe "Events::Registrations", type: :request do
       create(:allocation, allocatable: registration, amount: event.cost_cents)
       get registration_payment_path(registration.slug)
       expect(response.body).not_to include("Pay with Credit Card")
-      expect(response.body).not_to include("Paying by check?")
+      expect(response.body).not_to include("Prefer to pay by check?")
     end
   end
 

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -79,7 +79,13 @@ RSpec.describe MagicTicketCallouts do
       registration.update!(ce_hours_requested: 6, ce_license_number: "LIC123")
       complete = card(registration, event.ce_hours_details_label)
       expect(complete.theme).to eq(DomainTheme.swatch("teal"))
-      expect(complete.subtitle).to eq("6 hours · $150 due")
+      expect(complete.subtitle).to eq("6 hours")
+      expect(complete.chip).to eq("$150 due")
+    end
+
+    it "carries no CE chip until hours, license, and a positive amount are on file" do
+      registration.update!(ce_credit_requested: true, ce_hours_requested: nil, ce_license_number: nil)
+      expect(card(registration, event.ce_hours_details_label).chip).to be_nil
     end
 
     it "shows the scholarship card only when requested" do

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe MagicTicketCallouts do
       due = card(registration, "Make your payment")
       expect(due.theme).to eq(DomainTheme.swatch("orange"))
       expect(due.badge).to end_with("due")
+      expect(due.badge_classes).to be_nil
       expect(due.trailing_icon).to eq("fa-solid fa-arrow-right")
 
       create(:allocation, source: create(:payment), allocatable: registration, amount: event.cost_cents)
       paid = card(registration, "Payment")
       expect(paid.theme).to eq(DomainTheme.swatch("blue"))
       expect(paid.badge).to eq("Paid")
+      expect(paid.badge_classes).to include("blue")
       expect(paid.trailing_icon).to eq("fa-solid fa-arrow-right")
     end
 
@@ -72,22 +74,28 @@ RSpec.describe MagicTicketCallouts do
       expect(card_titles(registration)).to include(event.ce_hours_details_label)
     end
 
-    it "themes the CE card teal and reflects requested-vs-complete in the subtitle" do
+    it "shows an amber 'what's needed' CE badge until complete, then a teal amount due" do
       registration.update!(ce_credit_requested: true, ce_hours_requested: nil, ce_license_number: nil)
-      incomplete = card(registration, event.ce_hours_details_label)
-      expect(incomplete.theme).to eq(DomainTheme.swatch("teal"))
-      expect(incomplete.subtitle).to eq("Add your CE hours and license number")
+      both = card(registration, event.ce_hours_details_label)
+      expect(both.theme).to eq(DomainTheme.swatch("teal"))
+      expect(both.subtitle).to eq("Continuing education credit")
+      expect(both.badge).to eq("Hours & license number needed")
+      expect(both.badge_classes).to be_nil
+
+      registration.update!(ce_hours_requested: 6, ce_license_number: nil)
+      license = card(registration, event.ce_hours_details_label)
+      expect(license.subtitle).to eq("6 hours")
+      expect(license.badge).to eq("$150 · License number needed")
+      expect(license.badge_classes).to be_nil
+
+      registration.update!(ce_hours_requested: nil, ce_license_number: "LIC123")
+      expect(card(registration, event.ce_hours_details_label).badge).to eq("Hours needed")
 
       registration.update!(ce_hours_requested: 6, ce_license_number: "LIC123")
       complete = card(registration, event.ce_hours_details_label)
-      expect(complete.theme).to eq(DomainTheme.swatch("teal"))
       expect(complete.subtitle).to eq("6 hours")
       expect(complete.badge).to eq("$150 due")
-    end
-
-    it "carries no CE chip until hours, license, and a positive amount are on file" do
-      registration.update!(ce_credit_requested: true, ce_hours_requested: nil, ce_license_number: nil)
-      expect(card(registration, event.ce_hours_details_label).badge).to be_nil
+      expect(complete.badge_classes).to include("teal")
     end
 
     it "shows the scholarship card only when requested, without an amount chip until awarded" do
@@ -98,11 +106,22 @@ RSpec.describe MagicTicketCallouts do
       expect(scholarship_card.badge).to be_nil
     end
 
-    it "shows the awarded scholarship amount as a chip once awarded" do
+    it "flags an awarded scholarship with outstanding tasks in an amber chip" do
       registration.update!(scholarship_requested: true)
-      scholarship = create(:scholarship, amount_cents: 25_000)
+      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: false)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
-      expect(card(registration, "Scholarship").badge).to eq("$250")
+      scholarship_card = card(registration, "Scholarship")
+      expect(scholarship_card.badge).to eq("$250 · Tasks outstanding")
+      expect(scholarship_card.badge_classes).to be_nil
+    end
+
+    it "shows a fuchsia amount chip once scholarship tasks are complete" do
+      registration.update!(scholarship_requested: true)
+      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: true)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
+      scholarship_card = card(registration, "Scholarship")
+      expect(scholarship_card.badge).to eq("$250")
+      expect(scholarship_card.badge_classes).to include("fuchsia")
     end
 
     it "places payment first and FAQ last in the full ordering" do

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MagicTicketCallouts do
   describe "#cards" do
     it "shows the always-present cards for a bare paid-cost registration" do
       expect(card_titles(registration)).to eq([
-        "Payment", "Forms", "Handouts", "Frequently asked questions", "Facilitator Portal access"
+        "Make your payment", "Forms", "Handouts", "Frequently asked questions", "Facilitator Portal access"
       ])
     end
 
@@ -25,13 +25,15 @@ RSpec.describe MagicTicketCallouts do
     end
 
     it "makes the payment card an action card while a balance is due, reference once paid" do
-      due = card(registration, "Payment")
+      due = card(registration, "Make your payment")
       expect(due.theme).to eq(DomainTheme.swatch("orange"))
+      expect(due.badge).to end_with("due")
       expect(due.trailing_icon).to eq("fa-solid fa-arrow-right")
 
       create(:allocation, source: create(:payment), allocatable: registration, amount: event.cost_cents)
       paid = card(registration, "Payment")
       expect(paid.theme).to eq(DomainTheme.swatch("blue"))
+      expect(paid.badge).to eq("Paid")
       expect(paid.trailing_icon).to eq("fa-solid fa-arrow-right")
     end
 
@@ -80,12 +82,12 @@ RSpec.describe MagicTicketCallouts do
       complete = card(registration, event.ce_hours_details_label)
       expect(complete.theme).to eq(DomainTheme.swatch("teal"))
       expect(complete.subtitle).to eq("6 hours")
-      expect(complete.chip).to eq("$150 due")
+      expect(complete.badge).to eq("$150 due")
     end
 
     it "carries no CE chip until hours, license, and a positive amount are on file" do
       registration.update!(ce_credit_requested: true, ce_hours_requested: nil, ce_license_number: nil)
-      expect(card(registration, event.ce_hours_details_label).chip).to be_nil
+      expect(card(registration, event.ce_hours_details_label).badge).to be_nil
     end
 
     it "shows the scholarship card only when requested, without an amount chip until awarded" do
@@ -93,14 +95,14 @@ RSpec.describe MagicTicketCallouts do
       registration.update!(scholarship_requested: true)
       scholarship_card = card(registration, "Scholarship")
       expect(scholarship_card.subtitle).to eq("Your scholarship request status")
-      expect(scholarship_card.chip).to be_nil
+      expect(scholarship_card.badge).to be_nil
     end
 
     it "shows the awarded scholarship amount as a chip once awarded" do
       registration.update!(scholarship_requested: true)
       scholarship = create(:scholarship, amount_cents: 25_000)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
-      expect(card(registration, "Scholarship").chip).to eq("$250")
+      expect(card(registration, "Scholarship").badge).to eq("$250")
     end
 
     it "places payment first and FAQ last in the full ordering" do
@@ -109,7 +111,7 @@ RSpec.describe MagicTicketCallouts do
                     start_date: 3.days.ago, end_date: 2.days.ago)
       registration.update!(status: "attended", scholarship_requested: true, ce_credit_requested: true)
       expect(card_titles(registration)).to eq([
-        "Payment",
+        "Make your payment",
         "Certificate of completion",
         "Scholarship",
         event.ce_hours_details_label,

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -88,10 +88,19 @@ RSpec.describe MagicTicketCallouts do
       expect(card(registration, event.ce_hours_details_label).chip).to be_nil
     end
 
-    it "shows the scholarship card only when requested" do
+    it "shows the scholarship card only when requested, without an amount chip until awarded" do
       expect(card_titles(registration)).not_to include("Scholarship")
       registration.update!(scholarship_requested: true)
-      expect(card(registration, "Scholarship").subtitle).to eq("Your scholarship request status")
+      scholarship_card = card(registration, "Scholarship")
+      expect(scholarship_card.subtitle).to eq("Your scholarship request status")
+      expect(scholarship_card.chip).to be_nil
+    end
+
+    it "shows the awarded scholarship amount as a chip once awarded" do
+      registration.update!(scholarship_requested: true)
+      scholarship = create(:scholarship, amount_cents: 25_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
+      expect(card(registration, "Scholarship").chip).to eq("$250")
     end
 
     it "places payment first and FAQ last in the full ordering" do

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -49,11 +49,12 @@ RSpec.describe "Event registration show page", type: :system do
   end
 
   describe "payment due" do
-    it "shows the payment-due badge and pay button for an active registration with a balance" do
+    it "shows the payment card with the amount due and a pay button for an active registration with a balance" do
       sign_in(user)
       visit registration_ticket_path(registration.slug)
 
-      expect(page).to have_text("payment is due")
+      expect(page).to have_text("Make your payment")
+      expect(page).to have_text("due")
       expect(page).to have_button("Pay with Credit Card")
     end
   end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Tightens the registration ticket so registrants can scan the essentials and act, and consolidates payment/CE/scholarship status into the cards instead of one-off pills.
- Reclaims vertical space (the old centered banner image ate a full row) and gives the `MagicTicketCallouts` cards more prominence.

### How did you approach the change?

**Header**
- Event image → a small thumbnail inline with the title; title nudged to `text-2xl`.
- Date/times and `Cost · Location` moved up under the title as a compact three-line header (one-line date via the non-styled `times`); dropped the old centered Event Details block.
- `labelled_cost` now formats through `MoneyFormatter.dollars_from_cents`, so amounts carry a thousands separator (`$1,500`).

**Status chips (one `badge` / `badge_classes` on `MagicTicketCallouts::Card`, rendered in the subtitle row)**
- Each chip is themed to read against its own card, with amber reserved for "action needed", and carries a matching darker border:
  - **Payment** — `Make your payment` + amber `$X due` while due; `Payment` + blue `Paid` once settled.
  - **CE** — teal `$X due` once hours + license are on file; otherwise amber, naming what's missing: `$250 · License number needed`, `Hours needed`, or `Hours & license number needed` (amount prefixed when the hours/fee are known).
  - **Scholarship** — fuchsia award amount once tasks are met; amber `$X · Tasks outstanding` while tasks remain.
- All colour shades come from the existing `@source inline` Tailwind safelist (no rebuild needed).

**Payment page** (`events/callouts/payment.html.erb`)
- Added a **View invoice** card; tucked the pay-by-check details into a collapsed disclosure (keeping the grey card); chipped the amount-due total.

**Buttons**
- Fixed the brand-red pay/register buttons' hover: new `.btn-accent` variant carries its own border/bg so invert-on-hover works without an inline style overriding it. Applied on the ticket, the payment page, and the event-show register buttons.

### Testing

- `magic_ticket_callouts`, `event_registration_show` (system), `events/registrations` (request), and `event_decorator` specs all pass; Rubocop clean.

### Note

- Collaboration across parallel workspaces: the CE and scholarship amount chips landed separately and were unified onto the single `badge` mechanism here.
- **Open question:** the CE `Hours needed` badge can't show an amount (the fee derives from the hours, which are what's missing), so it has no `$` prefix — unlike `$250 · License number needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)