### PR TITLE
Drive recipients shout-outs from an admin flag and per-person text

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -263,11 +263,13 @@ class EventRegistrationsController < ApplicationController
     params.require(:event_registration).permit(
       :event_id, :registrant_id, :status,
       :scholarship_requested,
+      :shoutout,
       :intends_to_pay,
       :ce_credit_requested,
       :ce_hours_requested,
       :ce_license_number,
       organization_ids: [],
+      registrant_attributes: [ :id, :shoutout_text ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]
     )

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -380,7 +380,7 @@ class PeopleController < ApplicationController
       :date_of_birth,
       :license_number,
       :license_type,
-      :bio, :notes,
+      :bio, :shoutout_text, :notes,
       :display_name_preference,
       :pronouns,
       :profile_show_name_preference,

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -13,6 +13,9 @@ class EventRegistration < ApplicationRecord
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
   accepts_nested_attributes_for :notifications, reject_if: proc { |attrs| attrs["email_subject"].blank? }
+  # Lets the registration edit form edit the registrant's shout-out text (which
+  # lives on the Person) inline, alongside the registration's own shout-out flag.
+  accepts_nested_attributes_for :registrant
 
   before_create :generate_slug
   after_create :snapshot_registrant_organizations

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -80,18 +80,25 @@ class EventDashboard
   # registration) paired with the shout-out text from their profile and their
   # affiliated organization (if any), for the recognition block on the
   # recipients page.
-  Shoutout = Struct.new(:recipient, :organization, :text, keyword_init: true)
+  Shoutout = Struct.new(:recipient, :organization, :text, :sector, :age_group, keyword_init: true)
 
   # Shout outs for the recipients page: each active registrant the admin flagged
   # for a shout-out who also has shout-out text on their profile, paired with that
-  # text and their first active affiliated organization (if any). Flagged
-  # registrants with blank shout-out text are omitted; the organization is optional.
+  # text, their first active affiliated organization (if any), and their primary
+  # sector / age group (from their profile) for the parenthetical after their name.
+  # Flagged registrants with blank shout-out text are omitted; org/sector/age are optional.
   def shoutouts
     @shoutouts ||= shoutout_registrants.filter_map do |person|
       text = person.shoutout_text.to_s.strip.presence
       next unless text
       organization = person.affiliations.reject(&:inactive?).filter_map(&:organization).first
-      Shoutout.new(recipient: person, organization: organization, text: text)
+      Shoutout.new(
+        recipient: person,
+        organization: organization,
+        text: text,
+        sector: primary_sector_name_for(person),
+        age_group: age_group_text_for(person)
+      )
     end
   end
 
@@ -652,13 +659,26 @@ class EventDashboard
     @shoutout_registrant_ids ||= active_registrations.where(shoutout: true).pluck(:registrant_id)
   end
 
-  # People who opted into a shout-out, sorted by display name, with affiliations
-  # and organizations preloaded for the shout-out block.
+  # People who opted into a shout-out, sorted by display name, with affiliations,
+  # organizations, sectors, and age-range categories preloaded for the shout-out
+  # block (org link + the primary sector / age-group parenthetical).
   def shoutout_registrants
     @shoutout_registrants ||= Person
       .where(id: shoutout_registrant_ids)
-      .includes(affiliations: :organization)
+      .includes({ affiliations: :organization }, { sectorable_items: :sector }, { categories: :category_type })
       .sort_by(&:name)
+  end
+
+  # The person's primary service area: the sector they marked primary, falling
+  # back to their first sector alphabetically. Nil when they have none.
+  def primary_sector_name_for(person)
+    person.sectorable_items_primary_first.first&.sector&.name
+  end
+
+  # The person's age group(s) served, from their AgeRange profile tags, ", "-joined.
+  # Nil when they have none.
+  def age_group_text_for(person)
+    person.categories.select { |category| category.category_type&.name == "AgeRange" }.map(&:name).join(", ").presence
   end
 
   # Ids of every form submission the applicants made for this event's forms —

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -76,23 +76,22 @@ class EventDashboard
       .transform_values { |answers| answers.index_by { |answer| answer.form_field&.field_identifier } }
   end
 
-  # A scholarship "shout out": a recipient paired with their affiliated
-  # organization and that organization's bio, for the recognition block on the
+  # A "shout out": a registrant the admin opted in (shoutout on their
+  # registration) paired with the shout-out text from their profile and their
+  # affiliated organization (if any), for the recognition block on the
   # recipients page.
-  Shoutout = Struct.new(:recipient, :organization, :bio, keyword_init: true)
+  Shoutout = Struct.new(:recipient, :organization, :text, keyword_init: true)
 
-  # Shout outs for the recipients page: each scholarship recipient whose
-  # affiliated organization has a bio on file, paired with that organization and
-  # its description. Affiliations and organizations are already preloaded on
-  # scholarship_applicants. Recipients without an affiliated org, or whose org
-  # has no bio, are omitted.
-  def scholarship_shoutouts
-    @scholarship_shoutouts ||= scholarship_applicants.filter_map do |person|
+  # Shout outs for the recipients page: each active registrant the admin flagged
+  # for a shout-out who also has shout-out text on their profile, paired with that
+  # text and their first active affiliated organization (if any). Flagged
+  # registrants with blank shout-out text are omitted; the organization is optional.
+  def shoutouts
+    @shoutouts ||= shoutout_registrants.filter_map do |person|
+      text = person.shoutout_text.to_s.strip.presence
+      next unless text
       organization = person.affiliations.reject(&:inactive?).filter_map(&:organization).first
-      next unless organization
-      bio = organization.description.to_s.strip.presence
-      next unless bio
-      Shoutout.new(recipient: person, organization: organization, bio: bio)
+      Shoutout.new(recipient: person, organization: organization, text: text)
     end
   end
 
@@ -645,6 +644,21 @@ class EventDashboard
 
   def scholarship_applicant_ids
     @scholarship_applicant_ids ||= active_registrations.where(scholarship_requested: true).pluck(:registrant_id)
+  end
+
+  # Registrant (Person) ids behind active registrations that opted into a
+  # shout-out — the candidates for the recipients page shout-out block.
+  def shoutout_registrant_ids
+    @shoutout_registrant_ids ||= active_registrations.where(shoutout: true).pluck(:registrant_id)
+  end
+
+  # People who opted into a shout-out, sorted by display name, with affiliations
+  # and organizations preloaded for the shout-out block.
+  def shoutout_registrants
+    @shoutout_registrants ||= Person
+      .where(id: shoutout_registrant_ids)
+      .includes(affiliations: :organization)
+      .sort_by(&:name)
   end
 
   # Ids of every form submission the applicants made for this event's forms —

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -276,44 +276,6 @@
         </section>
       </div>
 
-      <%# ---- Shout out — admin opts this registrant into the recipients page
-          shout-out block and edits the text shown there. That text lives on the
-          registrant's profile (Person#shoutout_text); editing it here updates
-          their profile via nested attributes. ---- %>
-      <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
-            <i class="fa-solid fa-bullhorn"></i>
-          </span>
-          <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
-        </div>
-
-        <div class="space-y-3 p-4">
-          <label class="flex items-center gap-2.5 cursor-pointer">
-            <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
-            <input type="checkbox"
-                   name="event_registration[shoutout]"
-                   value="1"
-                   <%= "checked" if f.object.shoutout? %>
-                   class="sr-only peer">
-            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-emerald-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-300"></span>
-            <span class="text-sm font-medium text-gray-700">Feature on the recipients page</span>
-          </label>
-
-          <%= f.simple_fields_for :registrant do |rf| %>
-            <%= rf.input :shoutout_text,
-                  label: "Shout-out text",
-                  as: :text,
-                  input_html: {
-                    rows: 3,
-                    maxlength: 1650,
-                    class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
-                  },
-                  hint: "Shown beneath this registrant's name on the event's recipients page" %>
-          <% end %>
-        </div>
-      </section>
-
       <% if f.object.payment_unresolved? %>
         <div class="mt-3 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
           <i class="fa-solid fa-circle-exclamation"></i>
@@ -330,6 +292,47 @@
         </div>
       <% end %>
       <%= render "payment_history", event_registration: f.object %>
+
+      <%# ---- Shout out — admin opts this registrant into the recipients page
+          shout-out block and edits the text shown there. The text lives on the
+          registrant's profile (Person#shoutout_text); editing it here updates
+          their profile via nested attributes. ---- %>
+      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
+            <i class="fa-solid fa-bullhorn"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
+        </div>
+
+        <div class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
+          <label class="flex shrink-0 items-center gap-2.5 cursor-pointer">
+            <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
+            <input type="checkbox"
+                   name="event_registration[shoutout]"
+                   value="1"
+                   <%= "checked" if f.object.shoutout? %>
+                   class="sr-only peer">
+            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-emerald-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-300"></span>
+            <span class="text-sm font-medium text-gray-700">Feature on the recipients page</span>
+          </label>
+
+          <div class="flex-1">
+            <%= f.simple_fields_for :registrant do |rf| %>
+              <%= rf.input :shoutout_text,
+                    label: "Shout-out text",
+                    label_html: { class: "sr-only" },
+                    as: :string,
+                    placeholder: "Shown beneath their name on the recipients page",
+                    wrapper_html: { class: "mb-0" },
+                    input_html: {
+                      maxlength: 1650,
+                      class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
+                    } %>
+            <% end %>
+          </div>
+        </div>
+      </section>
 
       <% if allowed_to?(:index?, with: NotificationPolicy) %>
         <%= render "notifications", f: f %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -276,6 +276,44 @@
         </section>
       </div>
 
+      <%# ---- Shout out — admin opts this registrant into the recipients page
+          shout-out block and edits the text shown there. That text lives on the
+          registrant's profile (Person#shoutout_text); editing it here updates
+          their profile via nested attributes. ---- %>
+      <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
+            <i class="fa-solid fa-bullhorn"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
+        </div>
+
+        <div class="space-y-3 p-4">
+          <label class="flex items-center gap-2.5 cursor-pointer">
+            <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
+            <input type="checkbox"
+                   name="event_registration[shoutout]"
+                   value="1"
+                   <%= "checked" if f.object.shoutout? %>
+                   class="sr-only peer">
+            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-emerald-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-300"></span>
+            <span class="text-sm font-medium text-gray-700">Feature on the recipients page</span>
+          </label>
+
+          <%= f.simple_fields_for :registrant do |rf| %>
+            <%= rf.input :shoutout_text,
+                  label: "Shout-out text",
+                  as: :text,
+                  input_html: {
+                    rows: 3,
+                    maxlength: 1650,
+                    class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
+                  },
+                  hint: "Shown beneath this registrant's name on the event's recipients page" %>
+          <% end %>
+        </div>
+      </section>
+
       <% if f.object.payment_unresolved? %>
         <div class="mt-3 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
           <i class="fa-solid fa-circle-exclamation"></i>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -293,47 +293,6 @@
       <% end %>
       <%= render "payment_history", event_registration: f.object %>
 
-      <%# ---- Shout out — admin opts this registrant into the recipients page
-          shout-out block and edits the text shown there. The text lives on the
-          registrant's profile (Person#shoutout_text); editing it here updates
-          their profile via nested attributes. ---- %>
-      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
-            <i class="fa-solid fa-bullhorn"></i>
-          </span>
-          <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
-        </div>
-
-        <div class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
-          <label class="flex shrink-0 items-center gap-2.5 cursor-pointer">
-            <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
-            <input type="checkbox"
-                   name="event_registration[shoutout]"
-                   value="1"
-                   <%= "checked" if f.object.shoutout? %>
-                   class="sr-only peer">
-            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-emerald-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-300"></span>
-            <span class="text-sm font-medium text-gray-700">Feature on the recipients page</span>
-          </label>
-
-          <div class="flex-1">
-            <%= f.simple_fields_for :registrant do |rf| %>
-              <%= rf.input :shoutout_text,
-                    label: "Shout-out text",
-                    label_html: { class: "sr-only" },
-                    as: :string,
-                    placeholder: "Shown beneath their name on the recipients page",
-                    wrapper_html: { class: "mb-0" },
-                    input_html: {
-                      maxlength: 1650,
-                      class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
-                    } %>
-            <% end %>
-          </div>
-        </div>
-      </section>
-
       <% if allowed_to?(:index?, with: NotificationPolicy) %>
         <%= render "notifications", f: f %>
       <% end %>
@@ -380,6 +339,47 @@
               <span data-comment-edit-toggle-target="editLabel">Edit comments</span>
               <span data-comment-edit-toggle-target="viewLabel" style="display:none">Done editing</span>
             </button>
+          </div>
+        </div>
+      </section>
+
+      <%# ---- Shout out — admin opts this registrant into the recipients page
+          shout-out block and edits the text shown there. The text lives on the
+          registrant's profile (Person#shoutout_text); editing it here updates
+          their profile via nested attributes. ---- %>
+      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
+            <i class="fa-solid fa-bullhorn"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
+        </div>
+
+        <div class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
+          <label class="flex shrink-0 items-center gap-2.5 cursor-pointer">
+            <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
+            <input type="checkbox"
+                   name="event_registration[shoutout]"
+                   value="1"
+                   <%= "checked" if f.object.shoutout? %>
+                   class="sr-only peer">
+            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-emerald-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-emerald-300"></span>
+            <span class="text-sm font-medium text-gray-700">Feature on the recipients page</span>
+          </label>
+
+          <div class="flex-1">
+            <%= f.simple_fields_for :registrant do |rf| %>
+              <%= rf.input :shoutout_text,
+                    label: "Shout-out text",
+                    label_html: { class: "sr-only" },
+                    as: :string,
+                    placeholder: "Shown beneath their name on the recipients page",
+                    wrapper_html: { class: "mb-0" },
+                    input_html: {
+                      maxlength: 1650,
+                      class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
+                    } %>
+            <% end %>
           </div>
         </div>
       </section>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -193,23 +193,28 @@
     </div>
   <% end %>
 
-  <%# ---- Shout outs: recipients' organizations and their bios ---- %>
-  <% if @dashboard.scholarship_shoutouts.any? %>
+  <%# ---- Shout outs: registrants who opted in, with their shout-out text ---- %>
+  <% if @dashboard.shoutouts.any? %>
     <div class="mt-10 break-inside-avoid">
       <h2 class="text-xl font-bold mb-4 flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
         <i class="fa-solid fa-bullhorn"></i>
-        Shout out scholarship programs
+        Shout outs
       </h2>
       <div class="bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm divide-y divide-gray-100">
-        <% @dashboard.scholarship_shoutouts.each do |shoutout| %>
+        <% @dashboard.shoutouts.each do |shoutout| %>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 px-5 py-4 break-inside-avoid">
             <div class="sm:col-span-1">
-              <%= link_to shoutout.organization.name, organization_path(shoutout.organization),
+              <%= link_to shoutout.recipient.name, person_path(shoutout.recipient),
                           class: "text-sm font-semibold #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:#{DomainTheme.text_class_for(:scholarships)} hover:underline" %>
+              <% if shoutout.organization %>
+                <div class="text-xs text-gray-500 mt-0.5">
+                  <%= link_to shoutout.organization.name, organization_path(shoutout.organization),
+                              class: "hover:text-gray-700 hover:underline" %>
+                </div>
+              <% end %>
             </div>
             <div class="sm:col-span-2 text-sm text-gray-700">
-              <span class="font-semibold text-gray-900"><%= shoutout.recipient.name %></span>
-              — <%= shoutout.bio %>
+              <%= shoutout.text %>
             </div>
           </div>
         <% end %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -202,19 +202,28 @@
       </h2>
       <div class="bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm divide-y divide-gray-100">
         <% @dashboard.shoutouts.each do |shoutout| %>
+          <% org_link_class = "text-sm font-semibold #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:#{DomainTheme.text_class_for(:scholarships)} hover:underline" %>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 px-5 py-4 break-inside-avoid">
+            <%# Organization on the left, linked to its website when it has one,
+                otherwise to its profile page. %>
             <div class="sm:col-span-1">
-              <%= link_to shoutout.recipient.name, person_path(shoutout.recipient),
-                          class: "text-sm font-semibold #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:#{DomainTheme.text_class_for(:scholarships)} hover:underline" %>
-              <% if shoutout.organization %>
-                <div class="text-xs text-gray-500 mt-0.5">
-                  <%= link_to shoutout.organization.name, organization_path(shoutout.organization),
-                              class: "hover:text-gray-700 hover:underline" %>
-                </div>
+              <% if (organization = shoutout.organization) %>
+                <% website = organization.website_url.presence && (URI.parse(organization.website_url).to_s rescue nil) %>
+                <% if website %>
+                  <%= link_to organization.name, website, target: "_blank", rel: "noopener noreferrer", class: org_link_class %>
+                <% else %>
+                  <%= link_to organization.name, organization_path(organization), class: org_link_class %>
+                <% end %>
               <% end %>
             </div>
+            <%# Recipient name on the right, bold and linked to their profile, with
+                their primary sector and age group in parens, then their shout-out text. %>
             <div class="sm:col-span-2 text-sm text-gray-700">
-              <%= shoutout.text %>
+              <%= link_to shoutout.recipient.name, person_path(shoutout.recipient),
+                          class: "font-semibold text-gray-900 hover:underline" %>
+              <% meta = [ shoutout.sector, shoutout.age_group ].compact_blank %>
+              <% if meta.any? %><span class="text-gray-500">(<%= meta.join(", ") %>)</span><% end %>
+              — <%= shoutout.text %>
             </div>
           </div>
         <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -289,6 +289,17 @@
               },
               hint: "Maximum 250 characters" %>
 
+  <%= f.input :shoutout_text,
+              label: "Shout-out",
+              as: :text,
+              input_html: {
+                rows: 2,
+                maxlength: 1650,
+                class: "w-full rounded-md border-gray-300 shadow-sm
+                    focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+              },
+              hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+
   <div class="flex flex-col lg:flex-row gap-6 items-start">
     <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">
       <div class="flex flex-col sm:flex-row gap-6 items-start">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -279,26 +279,31 @@
   </div>
 
   <!-- PERSON FIELDS -->
-  <%= f.input :bio,
-              as: :text,
-              input_html: {
-                rows: 2,
-                maxlength: 1650,
-                class: "w-full rounded-md border-gray-300 shadow-sm
-                    focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-              },
-              hint: "Maximum 250 characters" %>
+  <%# Bio and Shout-out share one row, each half width. %>
+  <div class="flex flex-col sm:flex-row gap-6 items-start">
+    <%= f.input :bio,
+                wrapper_html: { class: "w-full sm:w-1/2" },
+                as: :text,
+                input_html: {
+                  rows: 2,
+                  maxlength: 1650,
+                  class: "w-full rounded-md border-gray-300 shadow-sm
+                      focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                },
+                hint: "Maximum 250 characters" %>
 
-  <%= f.input :shoutout_text,
-              label: "Shout-out",
-              as: :text,
-              input_html: {
-                rows: 2,
-                maxlength: 1650,
-                class: "w-full rounded-md border-gray-300 shadow-sm
-                    focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-              },
-              hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+    <%= f.input :shoutout_text,
+                label: "Shout-out",
+                wrapper_html: { class: "w-full sm:w-1/2" },
+                as: :text,
+                input_html: {
+                  rows: 2,
+                  maxlength: 1650,
+                  class: "w-full rounded-md border-gray-300 shadow-sm
+                      focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                },
+                hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+  </div>
 
   <div class="flex flex-col lg:flex-row gap-6 items-start">
     <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">

--- a/db/migrate/20260618182728_add_shoutout_to_event_registrations.rb
+++ b/db/migrate/20260618182728_add_shoutout_to_event_registrations.rb
@@ -1,0 +1,10 @@
+class AddShoutoutToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:event_registrations, :shoutout)
+    add_column :event_registrations, :shoutout, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :event_registrations, :shoutout, if_exists: true
+  end
+end

--- a/db/migrate/20260618182729_add_shoutout_text_to_people.rb
+++ b/db/migrate/20260618182729_add_shoutout_text_to_people.rb
@@ -1,0 +1,10 @@
+class AddShoutoutTextToPeople < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:people, :shoutout_text)
+    add_column :people, :shoutout_text, :text
+  end
+
+  def down
+    remove_column :people, :shoutout_text, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_18_160031) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_182729) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -458,6 +458,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_160031) do
     t.boolean "payment_unresolved"
     t.bigint "registrant_id", null: false
     t.boolean "scholarship_requested", default: false, null: false
+    t.boolean "shoutout", default: false, null: false
     t.string "slug"
     t.string "status", default: "registered", null: false
     t.datetime "updated_at", null: false
@@ -957,6 +958,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_18_160031) do
     t.boolean "profile_show_workshop_variations", default: true, null: false
     t.boolean "profile_show_workshops", default: true, null: false
     t.string "pronouns"
+    t.text "shoutout_text"
     t.string "twitter_url"
     t.datetime "updated_at", null: false
     t.integer "updated_by_id"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1136,31 +1136,27 @@ if facilitator_training
   end
 end
 
-puts "Adding shout-out bios to scholarship recipients' organizations…"
-# The recipients page "Shout out scholarship programs" section pairs each
-# scholarship recipient with their affiliated organization and that org's bio
-# (description). Seed orgs ship without a description, so the section renders
-# empty. Back-fill a realistic, hard-coded bio onto each scholarship recipient's
-# program — only when blank, so any real data is preserved. update_columns skips
-# validations/callbacks, which is fine for seed back-fill.
-shoutout_bios = [
-  "Provides trauma-informed art workshops and wraparound support to survivors of domestic violence and their children.",
-  "Offers emergency shelter, counseling, and economic-empowerment programs that help families rebuild after abuse.",
-  "Runs community-based healing circles and advocacy services for survivors across historically underserved neighborhoods.",
-  "Delivers culturally responsive crisis intervention, legal advocacy, and long-term recovery programming.",
-  "Supports survivors through safe housing, peer support, and creative-expression programming for all ages.",
-  "Champions prevention education and survivor-led programming to break cycles of violence in the community."
+puts "Featuring scholarship recipients with shout-outs…"
+# The recipients page "Shout outs" block features registrants the admin opted in
+# (EventRegistration#shoutout) whose profile carries shout-out text
+# (Person#shoutout_text). Seed people ship without either, so the block renders
+# empty. Opt in each scholarship recipient on the data-rich trainings and give
+# them realistic shout-out text — only filling blank text, so real data is
+# preserved. update_columns skips validations/callbacks, fine for seed back-fill.
+shoutout_texts = [
+  "Grateful for the chance to bring trauma-informed art workshops to the survivors and children we serve.",
+  "This training helps me give emergency-shelter families a creative way to begin rebuilding after abuse.",
+  "Proud to run community healing circles for survivors across our historically underserved neighborhoods.",
+  "Honored to deliver culturally responsive crisis intervention and long-term recovery programming.",
+  "Art has become our community's safest room — thank you for helping us hold that space for all ages.",
+  "Determined to keep survivor-led prevention work breaking cycles of violence where I live."
 ]
 
-recipient_orgs = [ facilitator_training, trauma_training ].compact
-  .flat_map { |evt| EventDashboard.new(evt).scholarship_applicants }
-  .uniq
-  .filter_map { |person| person.affiliations.reject(&:inactive?).filter_map(&:organization).first }
-  .uniq(&:id)
-
-recipient_orgs.each_with_index do |org, i|
-  next if org.description.present?
-  org.update_columns(description: shoutout_bios[i % shoutout_bios.size])
+[ facilitator_training, trauma_training ].compact.each do |evt|
+  EventDashboard.new(evt).scholarship_applicants.each_with_index do |person, i|
+    person.update_columns(shoutout_text: shoutout_texts[i % shoutout_texts.size]) if person.shoutout_text.blank?
+    evt.event_registrations.active.find_by(registrant: person)&.update_columns(shoutout: true)
+  end
 end
 
 puts "Recording school districts on registrant addresses…"

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -233,6 +233,17 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(existing_registration.ce_hours_requested).to eq(5)
         expect(existing_registration.ce_license_number).to eq("LIC-987")
       end
+
+      it "sets the shout-out flag and stores the shout-out text on the registrant" do
+        patch event_registration_path(existing_registration),
+              params: { event_registration: {
+                shoutout: "1",
+                registrant_attributes: { id: existing_registration.registrant_id, shoutout_text: "Grateful to bring art to survivors." }
+              } }
+
+        expect(existing_registration.reload.shoutout).to be(true)
+        expect(existing_registration.registrant.reload.shoutout_text).to eq("Grateful to bring art to survivors.")
+      end
     end
 
     describe "PATCH /event_registrations/:id scholarship handling" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1255,16 +1255,28 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Pat Plain")
       end
 
-      it "shouts out each recipient's organization with its linked profile and bio" do
-        org = create(:organization, name: "New Economics for Women", description: "Fights for economic justice for women.")
+      it "shouts out each opted-in registrant's text, linked profile, and organization" do
+        applicant.update!(shoutout_text: "Grateful to bring art to the survivors we serve.")
+        event.event_registrations.find_by(registrant: applicant).update!(shoutout: true)
+        org = create(:organization, name: "New Economics for Women")
         create(:affiliation, person: applicant, organization: org)
 
         get recipients_event_path(event)
 
-        expect(response.body).to include("Shout out scholarship programs")
+        expect(response.body).to include("Shout outs")
+        expect(response.body).to include("Tara Gallagher")
+        expect(response.body).to include(person_path(applicant))
         expect(response.body).to include("New Economics for Women")
         expect(response.body).to include(organization_path(org))
-        expect(response.body).to include("Fights for economic justice for women.")
+        expect(response.body).to include("Grateful to bring art to the survivors we serve.")
+      end
+
+      it "omits the shout-out block for registrants who did not opt in" do
+        applicant.update!(shoutout_text: "I have text but did not opt in.")
+
+        get recipients_event_path(event)
+
+        expect(response.body).not_to include("Shout outs")
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1255,20 +1255,43 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Pat Plain")
       end
 
-      it "shouts out each opted-in registrant's text, linked profile, and organization" do
+      it "shows the org linked to its website on the left and the bold recipient name linked to their profile on the right" do
         applicant.update!(shoutout_text: "Grateful to bring art to the survivors we serve.")
         event.event_registrations.find_by(registrant: applicant).update!(shoutout: true)
-        org = create(:organization, name: "New Economics for Women")
+        org = create(:organization, name: "New Economics for Women", website_url: "https://newecon.example.org")
         create(:affiliation, person: applicant, organization: org)
 
         get recipients_event_path(event)
 
         expect(response.body).to include("Shout outs")
+        expect(response.body).to include("New Economics for Women")
+        expect(response.body).to include("https://newecon.example.org")
         expect(response.body).to include("Tara Gallagher")
         expect(response.body).to include(person_path(applicant))
-        expect(response.body).to include("New Economics for Women")
-        expect(response.body).to include(organization_path(org))
         expect(response.body).to include("Grateful to bring art to the survivors we serve.")
+      end
+
+      it "links the org to its profile page when it has no website" do
+        applicant.update!(shoutout_text: "Art is how we heal.")
+        event.event_registrations.find_by(registrant: applicant).update!(shoutout: true)
+        org = create(:organization, name: "Quiet Org", website_url: nil)
+        create(:affiliation, person: applicant, organization: org)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include(organization_path(org))
+      end
+
+      it "shows the recipient's primary sector and age group in parentheses after their name" do
+        age_range = create(:category_type, name: "AgeRange")
+        applicant.sectorable_items.create!(sector: create(:sector, name: "Domestic Violence"), is_primary: true)
+        create(:categorizable_item, category: create(:category, name: "Teens", category_type: age_range), categorizable: applicant)
+        applicant.update!(shoutout_text: "Here to help.")
+        event.event_registrations.find_by(registrant: applicant).update!(shoutout: true)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include("(Domestic Violence, Teens)")
       end
 
       it "omits the shout-out block for registrants who did not opt in" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -468,25 +468,46 @@ RSpec.describe EventDashboard do
     end
 
     describe "shout outs" do
-      let(:org_with_bio) { create(:organization, name: "New Economics for Women", description: "Fights for economic justice for women.") }
-      let(:org_without_bio) { create(:organization, name: "Quiet Org", description: "") }
+      let(:org) { create(:organization, name: "New Economics for Women") }
 
-      it "pairs each recipient who has an affiliated org with a bio to that org and its description" do
-        create(:affiliation, person: embedded_applicant, organization: org_with_bio)
-
-        shoutout = dashboard.scholarship_shoutouts.find { |s| s.recipient == embedded_applicant }
-        expect(shoutout.organization).to eq(org_with_bio)
-        expect(shoutout.bio).to eq("Fights for economic justice for women.")
+      def opt_in(person, text:)
+        person.update!(shoutout_text: text)
+        EventRegistration.find_by(event: event, registrant: person).update!(shoutout: true)
       end
 
-      it "omits recipients with no affiliated organization" do
-        expect(dashboard.scholarship_shoutouts.map(&:recipient)).not_to include(separate_applicant)
+      it "pairs each opted-in registrant's shout-out text with their affiliated organization" do
+        opt_in(embedded_applicant, text: "Grateful to bring art to the survivors we serve.")
+        create(:affiliation, person: embedded_applicant, organization: org)
+
+        shoutout = dashboard.shoutouts.find { |s| s.recipient == embedded_applicant }
+        expect(shoutout.text).to eq("Grateful to bring art to the survivors we serve.")
+        expect(shoutout.organization).to eq(org)
       end
 
-      it "omits recipients whose organization has no bio on file" do
-        create(:affiliation, person: separate_applicant, organization: org_without_bio)
+      it "includes an opted-in registrant with no affiliated organization (org is optional)" do
+        opt_in(separate_applicant, text: "Art has been my way through.")
 
-        expect(dashboard.scholarship_shoutouts.map(&:recipient)).not_to include(separate_applicant)
+        shoutout = dashboard.shoutouts.find { |s| s.recipient == separate_applicant }
+        expect(shoutout.text).to eq("Art has been my way through.")
+        expect(shoutout.organization).to be_nil
+      end
+
+      it "is independent of scholarships — a non-scholarship registrant can opt in" do
+        opt_in(non_applicant, text: "Proud to support this work.")
+
+        expect(dashboard.shoutouts.map(&:recipient)).to include(non_applicant)
+      end
+
+      it "omits registrants who opted in but left their shout-out text blank" do
+        opt_in(embedded_applicant, text: "")
+
+        expect(dashboard.shoutouts.map(&:recipient)).not_to include(embedded_applicant)
+      end
+
+      it "omits registrants with shout-out text who did not opt in" do
+        separate_applicant.update!(shoutout_text: "I have text but did not opt in.")
+
+        expect(dashboard.shoutouts.map(&:recipient)).not_to include(separate_applicant)
       end
     end
   end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -484,6 +484,17 @@ RSpec.describe EventDashboard do
         expect(shoutout.organization).to eq(org)
       end
 
+      it "exposes the registrant's primary sector and age group" do
+        age_range = create(:category_type, name: "AgeRange")
+        embedded_applicant.sectorable_items.create!(sector: create(:sector, name: "Sexual Assault"), is_primary: true)
+        create(:categorizable_item, category: create(:category, name: "Teens", category_type: age_range), categorizable: embedded_applicant)
+        opt_in(embedded_applicant, text: "Here to help.")
+
+        shoutout = dashboard.shoutouts.find { |s| s.recipient == embedded_applicant }
+        expect(shoutout.sector).to eq("Sexual Assault")
+        expect(shoutout.age_group).to eq("Teens")
+      end
+
       it "includes an opted-in registrant with no affiliated organization (org is optional)" do
         opt_in(separate_applicant, text: "Art has been my way through.")
 

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -108,6 +108,24 @@ RSpec.describe "Event registration edit page", type: :system do
     end
   end
 
+  describe "shout out box" do
+    it "stores the shout-out text on the registrant and flags the registration when saved" do
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Shout out") do
+        fill_in "Shout-out text", with: "Grateful to bring art to the survivors we serve."
+        check "Feature on the recipients page", allow_label_click: true
+      end
+
+      click_on "Save changes"
+
+      expect(page).to have_current_path(registrants_event_path(event))
+      expect(registration.reload.shoutout).to be(true)
+      expect(registration.registrant.reload.shoutout_text).to eq("Grateful to bring art to the survivors we serve.")
+    end
+  end
+
   describe "registration status box" do
     it "flags the status as unsaved when changed until the form is saved" do
       sign_in(admin)


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
The recipients page "Shout outs" block was inferred from each scholarship recipient's affiliated organization description, so admins had no control over who was featured or what it said. This makes it an explicit admin decision so the recognition block shows the right people in their own words.

### How did you approach the change?
- Added an admin-set `shoutout` boolean to `event_registrations` and a `shoutout_text` field to `people` (paired beside Bio at half-width on the person form).
- Added a compact "Shout out" box at the bottom of the registration edit form (below comments): a toggle and a single-line text input side by side, with the text saved to the registrant's profile via `accepts_nested_attributes_for :registrant`.
- `EventDashboard#shoutouts` now lists admin-flagged active registrants who have shout-out text; the recipients page shows the organization on the left (linked to its website when present, else its profile page) and the bold recipient name on the right linked to their profile, with their primary sector and age group in parentheses.
- Updated the dev seeds to the new structure.

### UI Testing Checklist
- [ ] On a registration's edit page, the **Shout out** box sits at the bottom (below comments), with the toggle and single-line **Shout-out text** input side by side; saving stores the text on the registrant's profile.
- [ ] On the person edit form, **Bio** and **Shout-out** sit side by side, each half width.
- [ ] On `events/:id/recipients`, the **Shout outs** block lists each flagged registrant: org on the left (its website if it has one, else its profile), and the bold name on the right linked to their profile with `(primary sector, age group)` after it; registrants not flagged or with blank text are omitted.

### Anything else to add?
Naming note: the flag is `shoutout` (not `shoutout_requested`) because a shout-out is the admin's call, not a registrant request. The per-event `EventStaff#bio` is intentionally separate (its own column), so it isn't on the person form. Covered by request specs (nested storage on the person + recipients-page display, including the website/profile link fallback and the sector/age parenthetical) and a system spec driving the box end-to-end.