### PR TITLE
Rescue concurrent duplicate event registration inserts

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -66,15 +66,14 @@ class EventRegistrationsController < ApplicationController
         }
       end
     else
-      respond_to do |format|
-        format.html {
-          case params[:return_to]
-          when "registrants" then redirect_to registrants_event_path(@event_registration.event), alert: @event_registration.errors.full_messages.to_sentence
-          else redirect_to event_registrations_path, alert: @event_registration.errors.full_messages.to_sentence
-          end
-        }
-      end
+      redirect_after_failed_create(@event_registration.errors.full_messages.to_sentence)
     end
+  rescue ActiveRecord::RecordNotUnique
+    # The uniqueness validation isn't atomic with the insert, so a concurrent
+    # request or double-submit can slip past it and hit the DB unique index on
+    # (registrant_id, event_id). Treat it the same as a duplicate validation
+    # failure instead of surfacing a 500.
+    redirect_after_failed_create("This person is already registered for this event.")
   end
 
   def update
@@ -253,6 +252,13 @@ class EventRegistrationsController < ApplicationController
   end
 
   private
+
+  def redirect_after_failed_create(alert)
+    case params[:return_to]
+    when "registrants" then redirect_to registrants_event_path(@event_registration.event), alert: alert
+    else redirect_to event_registrations_path, alert: alert
+    end
+  end
 
   def set_event_registration
     @event_registration = EventRegistration.includes({ registrant: [ :user, { affiliations: :organization } ] }, { event: [ :location, :event_forms ] }, :organizations, comments: [ :created_by, :updated_by ]).find(params[:id])

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -118,6 +118,23 @@ RSpec.describe "EventRegistrations", type: :request do
         registration = EventRegistration.last
         expect(response).to redirect_to(confirm_event_registration_path(registration, return_to: "registrants"))
       end
+
+      it "handles a concurrent duplicate insert without raising" do
+        # Simulate the race where two requests both pass the uniqueness
+        # validation before either inserts, so the DB unique index rejects the
+        # second insert. The controller must rescue this and not 500.
+        allow_any_instance_of(EventRegistration).to receive(:save).and_raise(
+          ActiveRecord::RecordNotUnique.new("Duplicate entry")
+        )
+
+        expect {
+          post event_registrations_path,
+               params: { return_to: "registrants", event_registration: { event_id: event.id, registrant_id: regular_user.person.id } }
+        }.not_to change(EventRegistration, :count)
+
+        expect(response).to redirect_to(registrants_event_path(event))
+        expect(flash[:alert]).to be_present
+      end
     end
 
     describe "GET /event_registrations/:id/confirm" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Fixes a production 500 (`ActiveRecord::RecordNotUnique`) when creating an event registration that collides with an existing one on `(registrant_id, event_id)`.
- The model's `uniqueness` validation runs as a separate `SELECT` before the `INSERT`, so a double-submit or two concurrent requests can both pass validation and have the second insert violate the DB unique index.

### How did you approach the change?
- Wrapped `EventRegistrationsController#create` in a `rescue ActiveRecord::RecordNotUnique` that treats the lost race exactly like a duplicate validation failure, redirecting back with a clear alert instead of surfacing a 500.
- Extracted the failure redirect into a `redirect_after_failed_create` helper so the validation and race paths share one `return_to`-aware redirect, and added a request spec that forces the race and asserts a graceful redirect.

### UI Testing Checklist
- [ ] Attempt to register the same person for the same event twice (or double-click submit) and confirm you see an alert instead of an error page.

### Anything else to add?
- No schema change; the existing unique index is what now gets handled gracefully at the controller layer.