### PR TITLE
Fix UrlGenerationError on slugless bulk payment submissions

### DIFF
--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -62,7 +62,10 @@ module Events
     def show
       authorize! :bulk_payment, to: :show?
 
-      @submission = FormSubmission.bulk_payment.find_by!(slug: params[:reg], event_id: @event.id)
+      # where.not(slug: nil) guards against a blank reg matching a legacy
+      # slugless bulk payment, which would then crash building its ticket link.
+      @submission = FormSubmission.bulk_payment.where.not(slug: nil)
+                                  .find_by!(slug: params[:reg], event_id: @event.id)
       @event = @event.decorate
     end
 

--- a/app/controllers/events/bulk_payments_controller.rb
+++ b/app/controllers/events/bulk_payments_controller.rb
@@ -56,16 +56,21 @@ module Events
       end
     end
 
-    # Public view of the submitted bulk payment form, reached by the payer (the
-    # "View submission" link in their confirmation email and on the ticket) and by
-    # admins from the dashboard. Backs to the ticket. Mirrors PublicRegistrations#show.
+    # View of the submitted bulk payment form, rendering the same partial either
+    # way. Mirrors PublicRegistrations#show: the payer reaches it publicly by slug
+    # (?reg=), while admins (e.g. from the dashboard, including legacy submissions
+    # with no slug) reach it by id (?submission_id=).
     def show
-      authorize! :bulk_payment, to: :show?
+      if params[:reg].present?
+        authorize! :bulk_payment, to: :show?
+        # where.not(slug: nil) keeps a blank reg from matching a slugless record.
+        @submission = FormSubmission.bulk_payment.where.not(slug: nil)
+                                    .find_by!(slug: params[:reg], event_id: @event.id)
+      else
+        @submission = FormSubmission.bulk_payment.find_by!(id: params[:submission_id], event_id: @event.id)
+        authorize! @submission, to: :show?
+      end
 
-      # where.not(slug: nil) guards against a blank reg matching a legacy
-      # slugless bulk payment, which would then crash building its ticket link.
-      @submission = FormSubmission.bulk_payment.where.not(slug: nil)
-                                  .find_by!(slug: params[:reg], event_id: @event.id)
       @event = @event.decorate
     end
 

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -35,7 +35,10 @@
     </span>
     <span class="text-sm text-gray-500 whitespace-nowrap"><%= submission.created_at.strftime("%b %-d, %Y") %></span>
     <div class="flex items-center gap-2">
-      <%= link_to event_bulk_payment_path(@event, reg: submission.slug, return_to: "bulk_payments", expand: submission.id),
+      <%# Payer slug when present; otherwise the admin-only id fallback so legacy
+          slugless submissions are still viewable from the dashboard. %>
+      <% submission_show_params = submission.slug.present? ? { reg: submission.slug } : { submission_id: submission.id } %>
+      <%= link_to event_bulk_payment_path(@event, **submission_show_params, return_to: "bulk_payments", expand: submission.id),
                   title: "View form submission",
                   class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
         <i class="fa-solid fa-file-lines text-xs"></i> Submission

--- a/app/views/events/bulk_payments/show.html.erb
+++ b/app/views/events/bulk_payments/show.html.erb
@@ -1,11 +1,15 @@
 <% content_for(:page_bg_class, "public") %>
 <div class="max-w-3xl mx-auto px-4 pt-4">
-  <%# Primary back link is always the payer's ticket. Admins arriving from the
-      bulk payments dashboard (return_to=bulk_payments) also get a second link
-      back there, with their originating row re-expanded. %>
+  <%# Primary back link is the payer's ticket, available only for slug-based
+      submissions. Admins arriving from the bulk payments dashboard
+      (return_to=bulk_payments) also get a link back there, with their
+      originating row re-expanded — and it's the only eyebrow for legacy
+      slugless submissions, which have no public ticket. %>
   <div class="flex flex-col items-start gap-1">
-    <%= link_to bulk_payment_ticket_path(@submission.slug, return_to: params[:return_to], expand: params[:expand]), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
+    <% if @submission.slug.present? %>
+      <%= link_to bulk_payment_ticket_path(@submission.slug, return_to: params[:return_to], expand: params[:expand]), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
+      <% end %>
     <% end %>
     <% if params[:return_to] == "bulk_payments" %>
       <%= link_to bulk_payments_return_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -195,6 +195,14 @@ RSpec.describe "Events::BulkPayments", type: :request do
 
         expect(response).to have_http_status(:not_found)
       end
+
+      it "404s for a blank reg, even when a slugless bulk payment exists" do
+        submission.update_columns(slug: nil)
+
+        get event_bulk_payment_path(event)
+
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     context "as an admin arriving from the dashboard" do

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -203,6 +203,26 @@ RSpec.describe "Events::BulkPayments", type: :request do
 
         expect(response).to have_http_status(:not_found)
       end
+
+      it "does not let a signed-out viewer reach a submission by id" do
+        get event_bulk_payment_path(event, submission_id: submission.id)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as an admin viewing a slugless submission by id" do
+      before { submission.update_columns(slug: nil) }
+
+      it "renders the same submission partial without a ticket back link" do
+        get event_bulk_payment_path(event, submission_id: submission.id, return_to: "bulk_payments")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Bulk payment submission")
+        expect(response.body).to include("Northside Shelter")
+        expect(response.body).not_to include("Back to ticket")
+        expect(response.body).to include("Back to bulk payments")
+      end
     end
 
     context "as an admin arriving from the dashboard" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Fixes a production `ActionController::UrlGenerationError` (`No route matches … slug: nil`) when viewing a bulk payment submission, and restores admin access to legacy submissions that have no slug (created before the `before_create :generate_slug` callback).

### How did you approach the change?
- `BulkPaymentsController#show` now mirrors `PublicRegistrations#show`: payers reach it publicly by slug (`?reg=`), while admins reach it by id (`?submission_id=`) — both render the same `form_submissions/submission` partial.
- The slug branch scopes with `where.not(slug: nil)` so a blank `reg` 404s instead of matching a slugless record and crashing; the id branch is gated by `FormSubmissionPolicy#show?` (admin only).
- The bulk-payments dashboard card links by slug when present, otherwise by `submission_id`; the view shows the "Back to ticket" eyebrow only when a slug exists.
- Added request specs covering the blank-reg 404, the admin id view of a slugless submission, and that signed-out viewers cannot reach a submission by id.

### Anything else to add?
- No schema or data migration; legacy slugless submissions stay as-is and are simply viewable again by admins.
