### PR TITLE
WAIT: Point incidental sector field-identifier references at the canonical names

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -100,7 +100,7 @@ class FormField < ApplicationRecord
   # Keeps an over-long name as a friendly validation error instead of a
   # database ValueTooLong exception (the column is text, this is the UX cap).
   validates :name, length: { maximum: 1000 }
-  # A field_identifier wires a field to backend logic (Stripe, service areas,
+  # A field_identifier wires a field to backend logic (Stripe, sectors,
   # email checks, etc.), so the same identifier must not appear twice on one form
   # or that logic would target an ambiguous field. Ordinary fields carry no
   # identifier, so blanks are exempt — any number of them may coexist.

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -151,7 +151,7 @@
         </div>
 
         <% if params[:admin] == "true" %>
-          <%# Field identifiers tie a field to backend logic (Stripe, service areas, email, etc.),
+          <%# Field identifiers tie a field to backend logic (Stripe, sectors, email, etc.),
               so they're only editable with ?admin=true on the URL. %>
           <label class="flex items-center justify-end gap-2 text-xs text-gray-500">
             <span class="shrink-0 font-medium">Field identifier</span>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -454,19 +454,19 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#dynamic_form_field_options" do
     let(:form) { create(:form) }
 
-    it "omits the Other sector for the primary service-area dropdown" do
+    it "omits the Other sector for the primary sector dropdown" do
       create(:sector, :published, name: "Domestic Violence")
       create(:sector, :published, name: "Other")
-      field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
+      field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_sector_single")
 
       labels = helper.dynamic_form_field_options(field).map(&:first)
       expect(labels).to include("Domestic Violence")
       expect(labels).not_to include("Other")
     end
 
-    it "includes the Other sector for the additional service-areas field" do
+    it "includes the Other sector for the additional sectors field" do
       create(:sector, :published, name: "Other")
-      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_service_area")
+      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_sectors")
 
       labels = helper.dynamic_form_field_options(field).map(&:first)
       expect(labels).to include("Other")
@@ -475,7 +475,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "carries each sector's description as the third tuple element" do
       create(:sector, :published, name: "Domestic Violence", description: "DV services")
       create(:sector, :published, name: "Mental Health", description: nil)
-      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_service_area")
+      field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_sectors")
 
       descriptions = helper.dynamic_form_field_options(field).to_h { |name, _id, desc| [ name, desc ] }
       expect(descriptions["Domestic Violence"]).to eq("DV services")

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -416,8 +416,8 @@ RSpec.describe FormField do
     end
 
     context "with dynamically-sourced options" do
-      it "accepts a published Sector id and rejects others for a service-area field" do
-        field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
+      it "accepts a published Sector id and rejects others for a sector field" do
+        field = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_sector_single")
         offered = create(:sector, :published)
         unpublished = create(:sector, :unpublished)
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -425,8 +425,8 @@ RSpec.describe Person, type: :model do
           .to contain_exactly("Toddlers")
       end
 
-      it "does not pull from the service area fields" do
-        answer("primary_service_area", "Other: Equine therapy")
+      it "does not pull from the sector fields" do
+        answer("additional_sectors", "Other: Equine therapy")
 
         expect(person.other_workshop_setting_responses).to be_empty
       end

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -354,14 +354,14 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
 
     it "renders a dynamic-option field switched to single choice as radio buttons" do
-      # primary_service_area sources its options dynamically from Sector
+      # additional_sectors sources its options dynamically from Sector
       # (it stores no answer options of its own). When such a field is changed
       # from checkbox to single-choice radio, the public form must still render
       # the dynamic options — otherwise the question shows up blank.
       sector_a = create(:sector, :published, name: "Healthcare")
       sector_b = create(:sector, :published, name: "Education")
       create(:form_field, form: form, answer_type: :single_select_radio,
-             field_identifier: "primary_service_area", name: "Primary sector",
+             field_identifier: "additional_sectors", name: "Additional sectors",
              required: false)
 
       get new_event_public_registration_path(event)
@@ -375,7 +375,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     it "still renders a dynamic-option field as checkboxes" do
       create(:sector, :published, name: "Healthcare")
       create(:form_field, form: form, answer_type: :multi_select_checkbox,
-             field_identifier: "primary_service_area", name: "Primary sector",
+             field_identifier: "additional_sectors", name: "Additional sectors",
              required: false)
 
       get new_event_public_registration_path(event)

--- a/spec/requests/people_other_responses_spec.rb
+++ b/spec/requests/people_other_responses_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Person Other form responses", type: :request do
   before { sign_in admin }
 
   describe "profile page" do
-    it "shows the Other service area as a free-text chip, not the primary sector" do
+    it "shows the Other sector as a free-text chip, not the primary sector" do
       person.update!(profile_show_sectors: true)
-      answer("primary_service_area", "Other: Equine therapy")
+      answer("additional_sectors", "Other: Equine therapy")
 
       get person_path(person)
 
@@ -29,8 +29,8 @@ RSpec.describe "Person Other form responses", type: :request do
   end
 
   describe "edit page" do
-    it "shows the Other service area in the sectors section" do
-      answer("primary_service_area_single", "Other: Music therapy")
+    it "shows the Other sector in the sectors section" do
+      answer("primary_sector_single", "Other: Music therapy")
 
       get edit_person_path(person)
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe EventDashboard do
         # single-select dropdown. Both also carry sector1 as a tag, so sector1 is
         # primary for person1 AND an additional sector for person2 — the counts
         # overlap (don't partition).
-        service_field = create(:form_field, form: registration_form, field_identifier: "primary_service_area_single",
+        service_field = create(:form_field, form: registration_form, field_identifier: "primary_sector_single",
                                             answer_type: :single_select_dropdown)
         create(:form_answer, form_field: service_field, submitted_answer: sector1.id.to_s,
                              form_submission: FormSubmission.find_by!(person: person1, form: registration_form))
@@ -246,7 +246,7 @@ RSpec.describe EventDashboard do
                              form_submission: FormSubmission.find_by!(person: person2, form: registration_form))
       end
 
-      it "counts distinct sectors named as a primary service area" do
+      it "counts distinct sectors named as a primary sector" do
         expect(dashboard.primary_sector_count).to eq(2)
       end
 


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: spec fixtures and comment copy, no logic or data changes

### What is the goal of this PR and why is this important?
- #1834 made `additional_sectors` / `primary_sector_single` the canonical sector field identifiers, keeping the legacy `primary_sector` / `primary_service_area` names accepted via `FormField`'s `*_SECTOR_FIELD_IDENTIFIERS` constants.
- App code and seeds already moved to the canonical names; this cleans up the last incidental stragglers so nothing outside the legacy constants still reads as "service area".

### How did you approach the change?
- Repointed spec fixtures that just needed *a* sector field at the canonical identifiers, and fixed two stale "service areas" comments.
- Left the deliberate backward-compat tests (form_field_spec's parameterized legacy schemes, person_spec's `#other_sector_responses` block, event_dashboard_spec's legacy-resolution case) on the legacy names on purpose — they exist to prove the legacy entries in the constants still resolve.

### Anything else to add?
- No production logic or data changes (no migration). RuboCop clean; the affected specs (376 examples) pass.