### PR TITLE
Make registration ticket callout pages publicly readable

### DIFF
--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -7,8 +7,8 @@ class RegistrationTicketCalloutsController < ApplicationController
   # pages). When the callout has no description there is nothing to read, so fall
   # back to the event page.
   def show
-    authorize! @event, to: :show?
     @callout = @event.registration_ticket_callouts.find(params[:id])
+    authorize! @callout, to: :show?
 
     if @callout.description.blank?
       redirect_to event_path(@event, reg: params[:reg].presence)
@@ -22,8 +22,8 @@ class RegistrationTicketCalloutsController < ApplicationController
   # new 1-based position for a single moved callout; the positioning gem reflows
   # the rest. Only event managers can reorder (matches editing the event).
   def update
-    authorize! @event, to: :manage?
     @callout = @event.registration_ticket_callouts.find(params[:id])
+    authorize! @callout, to: :update?
 
     if @callout.update(callout_params)
       head :ok

--- a/app/policies/registration_ticket_callout_policy.rb
+++ b/app/policies/registration_ticket_callout_policy.rb
@@ -1,0 +1,14 @@
+class RegistrationTicketCalloutPolicy < ApplicationPolicy
+  # The callout detail page is public reading reached from the registration
+  # ticket. It must be viewable by anyone with the link — including registrants
+  # of ended or non-public events — so it does not mirror Event#show?. The
+  # callout id is scoped to its event, so there is nothing sensitive to gate.
+  def show?
+    true
+  end
+
+  # Drag-reorder persistence is editing the event, so it stays manager-only.
+  def update?
+    allowed_to?(:manage?, record.event)
+  end
+end

--- a/spec/policies/registration_ticket_callout_policy_spec.rb
+++ b/spec/policies/registration_ticket_callout_policy_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe RegistrationTicketCalloutPolicy, type: :policy do
+  let(:admin_user) { build_stubbed :user, :admin }
+  let(:regular_user) { build_stubbed :user }
+  let(:owner) { build_stubbed :user }
+  let(:event) { build_stubbed :event, :unpublished, created_by: owner }
+  let(:callout) { build_stubbed :registration_ticket_callout, event: event }
+
+  def policy_for(user:)
+    described_class.new(callout, user: user)
+  end
+
+  describe "#show?" do
+    it "is allowed for anyone, even on a non-public event" do
+      expect(policy_for(user: nil)).to be_allowed_to(:show?)
+      expect(policy_for(user: regular_user)).to be_allowed_to(:show?)
+      expect(policy_for(user: admin_user)).to be_allowed_to(:show?)
+    end
+  end
+
+  describe "#update?" do
+    it "is allowed only for the event's managers" do
+      expect(policy_for(user: admin_user)).to be_allowed_to(:update?)
+      expect(policy_for(user: owner)).to be_allowed_to(:update?)
+      expect(policy_for(user: regular_user)).not_to be_allowed_to(:update?)
+      expect(policy_for(user: nil)).not_to be_allowed_to(:update?)
+    end
+  end
+end

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe "Registration ticket callouts", type: :request do
       expect(response).to redirect_to(event_path(event))
     end
 
+    it "is publicly readable even when the event is not public" do
+      private_event = create(:event, :unpublished, :ended)
+      callout = create(:registration_ticket_callout, event: private_event,
+        title: "Parking", description: "<p>Use the north lot.</p>")
+
+      get event_registration_ticket_callout_path(private_event, callout)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Parking")
+    end
+
     it "does not find a callout belonging to a different event" do
       other_callout = create(:registration_ticket_callout, description: "<p>Hi.</p>")
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Callout detail pages are public reads reached from a registration ticket link
- They were authorized against `Event#show?`, which wrongly locked out registrants of unpublished or ended events — the very people who follow these links
- The callout id is already scoped to its event, so there is nothing sensitive to gate on read

### How did you approach the change?
- Added `RegistrationTicketCalloutPolicy` with `show?` open to everyone and `update?` (drag-reorder persistence) gated to event managers
- Pointed the controller's `show`/`update` actions at the callout policy instead of the event policy
- Covered both policy methods with a policy spec, and added a request spec asserting a callout on a non-public event is still publicly readable

### Anything else to add?
- Reorder persistence stays manager-only, matching event editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)