### PR TITLE
Auto-scroll the registration error band into view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (73) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (74) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 

--- a/app/frontend/javascript/controllers/form_errors_controller.js
+++ b/app/frontend/javascript/controllers/form_errors_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// When the form re-renders with validation errors, scroll the error flash band
+// into view so the registrant immediately sees what needs fixing. Attached to
+// the band itself, so it only connects when an error message is present.
+export default class extends Controller {
+  connect() {
+    this.element.scrollIntoView({ behavior: "smooth", block: "center" })
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -84,6 +84,9 @@ application.register("file-preview", FilePreviewController)
 import FieldOptionsController from "./field_options_controller"
 application.register("field-options", FieldOptionsController)
 
+import FormErrorsController from "./form_errors_controller"
+application.register("form-errors", FormErrorsController)
+
 import FormFieldsSortableController from "./form_fields_sortable_controller"
 application.register("form-fields-sortable", FormFieldsSortableController)
 

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -85,8 +85,10 @@
       <% end %>
       <%= render "forms/header", form: @form, event: @event %>
 
+      <%# The error flash band carries the form-errors controller so it scrolls
+          itself into view on connect after a failed submit. %>
       <% if flash[:alert] %>
-        <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">
+        <div role="alert" class="scroll-mt-24 flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6" data-controller="form-errors">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
           <span><%= flash[:alert] %></span>
         </div>

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -69,6 +69,34 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "POST create error presentation" do
+    it "wires the error flash band to auto-scroll into view on failure" do
+      post_registration("too few")
+
+      expect(response).to have_http_status(:unprocessable_content)
+      # The form-errors Stimulus controller rides on the error flash band so it
+      # scrolls itself into view on connect.
+      expect(response.body).to match(/role="alert"[^>]*data-controller="form-errors"/)
+    end
+
+    it "shows no error band on a successful submission" do
+      first = create(:form_field, form: form, field_identifier: "first_name", name: "First name", required: false)
+      last = create(:form_field, form: form, field_identifier: "last_name", name: "Last name", required: false)
+      email = create(:form_field, form: form, field_identifier: "primary_email", name: "Email", required: false)
+
+      post event_public_registration_path(event),
+           params: { public_registration: { form_fields: {
+             essay_field.id.to_s => "this answer has plenty of words",
+             first.id.to_s => "Pat",
+             last.id.to_s => "Lee",
+             email.id.to_s => "pat@example.com"
+           } } }
+
+      expect(response).to have_http_status(:redirect)
+      expect(response.body).not_to include('data-controller="form-errors"')
+    end
+  end
+
   describe "POST create with a maximum character count" do
     let!(:bio_field) do
       create(:form_field, form: form, answer_type: :free_form_input_one_line,


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- A failed public event registration already renders a top-of-form error flash band (added in #1758), but after submitting from the bottom of a long form it lands off-screen — the registrant sees nothing change and assumes the page hung.

### How did you approach the change?
- Attach a small `form-errors` Stimulus controller to the **existing** error flash band so it scrolls itself into view on connect. It's on the band element, so it only connects when an alert is actually present.
- Works on both submit paths — Turbo (free events) and full-page (paid events).
- No new band: an earlier version of this PR added its own summary band, but #1758 landed the same generic band on `main` in the meantime, so this now just adds the scroll behaviour to that band (no duplication).

### UI Testing Checklist
- [ ] On a long registration form, submit with a required field missing → the page scrolls up to the red error band.
- [ ] Submit a valid registration → no band, normal success flow.

### Anything else to add?
- Bumped the Stimulus controller count in `AGENTS.md`.
- The success "You're registered!" banner (#1764) and over-length-answer handling (#1763, already merged) were split out of this branch earlier.