### PR TITLE
Add editable payment method to event registrations

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -330,6 +330,7 @@ class EventRegistrationsController < ApplicationController
       :scholarship_requested,
       :shoutout,
       :intends_to_pay,
+      :payment_method,
       :ce_credit_requested,
       :ce_hours_requested,
       :ce_license_number,

--- a/app/frontend/javascript/controllers/icon_select_controller.js
+++ b/app/frontend/javascript/controllers/icon_select_controller.js
@@ -1,29 +1,30 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="attendance-status"
-// Swaps the colored icon inside the status select as the dropdown changes. The
-// select looks like an ordinary form field (not the roster's autosaving chip),
-// so an "Unsaved" hint is shown until the form is saved.
+// Connects to data-controller="icon-select"
+// Swaps the colored icon inside a select as the dropdown changes, driven by
+// colors/icons maps keyed on the option value. Used by the registration-status
+// and payment-method selects. The select looks like an ordinary form field (not
+// the roster's autosaving chip), so an "Unsaved" hint is shown until saved.
 export default class extends Controller {
   static targets = ["select", "icon", "dirty"]
   static values = { colors: Object, icons: Object, initial: String }
 
   update() {
-    const status = this.selectTarget.value
+    const value = this.selectTarget.value
 
     if (this.hasIconTarget) {
       const allColors = Object.values(this.colorsValue).flatMap((c) => c.split(" "))
       const allIcons = Object.values(this.iconsValue).flatMap((c) => c.split(" "))
       this.iconTarget.classList.remove(...allColors, ...allIcons)
-      if (this.iconsValue[status]) this.iconTarget.classList.add(...this.iconsValue[status].split(" "))
-      if (this.colorsValue[status]) this.iconTarget.classList.add(...this.colorsValue[status].split(" "))
+      if (this.iconsValue[value]) this.iconTarget.classList.add(...this.iconsValue[value].split(" "))
+      if (this.colorsValue[value]) this.iconTarget.classList.add(...this.colorsValue[value].split(" "))
     }
 
-    // The status only persists on form save, so flag it as unsaved while it
+    // The value only persists on form save, so flag it as unsaved while it
     // differs from the value the page loaded with. Toggle both display classes
     // so "hidden" and "inline-flex" are never set at once (they'd fight in CSS).
     if (this.hasDirtyTarget) {
-      const clean = status === this.initialValue
+      const clean = value === this.initialValue
       this.dirtyTarget.classList.toggle("hidden", clean)
       this.dirtyTarget.classList.toggle("inline-flex", !clean)
     }

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -18,8 +18,8 @@ application.register("anchor-highlight", AnchorHighlightController)
 import AnswerOptionsController from "./answer_options_controller"
 application.register("answer-options", AnswerOptionsController)
 
-import AttendanceStatusController from "./attendance_status_controller"
-application.register("attendance-status", AttendanceStatusController)
+import IconSelectController from "./icon_select_controller"
+application.register("icon-select", IconSelectController)
 
 import AssetPickerController from "./asset_picker_controller"
 application.register("asset-picker", AssetPickerController)

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -49,6 +49,7 @@ class EventRegistration < ApplicationRecord
   validates :status, inclusion: { in: ATTENDANCE_STATUSES }, allow_nil: false
   validates :slug, uniqueness: true, allow_nil: true
   validates :ce_hours_requested, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :payment_method, inclusion: { in: FormBuilderService::PAYMENT_METHOD_OPTIONS }, allow_blank: true
 
   # Scopes
   scope :registrant_name, ->(registrant_name) { joins(:registrant).where(

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -60,6 +60,7 @@ module EventRegistrationServices
           existing.update!(ce_credit_requested: true, ce_hours_requested: ce_hours_requested) if ce_credit_requested?
           existing.update!(w9_requested: true) if w9_requested?
           existing.update!(invoice_requested: true) if invoice_requested?
+          existing.update!(payment_method: payment_method) if payment_method.present?
           if existing.status == "cancelled"
             existing.update!(status: "registered")
             send_notifications(existing)
@@ -311,7 +312,8 @@ module EventRegistrationServices
         ce_credit_requested: ce_credit_requested?,
         ce_hours_requested: ce_hours_requested,
         w9_requested: w9_requested?,
-        invoice_requested: invoice_requested?
+        invoice_requested: invoice_requested?,
+        payment_method: payment_method
       )
     end
 
@@ -348,6 +350,14 @@ module EventRegistrationServices
 
     def invoice_requested?
       additional_forms_selections.any? { |value| value.casecmp?(ADDITIONAL_FORMS_INVOICE) }
+    end
+
+    # The payment method the registrant chose (one of
+    # FormBuilderService::PAYMENT_METHOD_OPTIONS), persisted on the registration
+    # so admins can see/change it and the ticket can hide the credit-card button
+    # for check payers. nil when the form omits the question.
+    def payment_method
+      field_value("payment_method").presence
     end
 
     def create_form_submission(person)

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -3,7 +3,10 @@ class FormBuilderService
   # charge, so controllers match against PAYMENT_METHOD_PAY_NOW rather than
   # repeating its label. Keep this the single source of truth for the label.
   PAYMENT_METHOD_PAY_NOW = "Credit card (now)".freeze
-  PAYMENT_METHOD_OPTIONS = [ PAYMENT_METHOD_PAY_NOW, "Credit card (later)", "Check" ].freeze
+  # The "Check" option means the registrant intends to mail a check. Kept here
+  # as the single source of truth for the label.
+  PAYMENT_METHOD_CHECK = "Check".freeze
+  PAYMENT_METHOD_OPTIONS = [ PAYMENT_METHOD_PAY_NOW, "Credit card (later)", PAYMENT_METHOD_CHECK ].freeze
 
   SECTIONS = {
     person_identifier: { label: "Person identifier", method: :build_person_identifier_fields },

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -74,13 +74,13 @@
           <% end %>
 
           <div class="sm:w-64"
-               data-controller="attendance-status"
-               data-attendance-status-colors-value="<%= status_icon_colors.to_json %>"
-               data-attendance-status-icons-value="<%= status_icons.to_json %>"
-               data-attendance-status-initial-value="<%= f.object.status %>">
+               data-controller="icon-select"
+               data-icon-select-colors-value="<%= status_icon_colors.to_json %>"
+               data-icon-select-icons-value="<%= status_icons.to_json %>"
+               data-icon-select-initial-value="<%= f.object.status %>">
             <div class="mb-1 flex items-center justify-between gap-2">
               <span class="text-xs font-medium text-gray-400">Registration status</span>
-              <span data-attendance-status-target="dirty"
+              <span data-icon-select-target="dirty"
                     class="hidden items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[0.65rem] font-medium text-amber-700"
                     title="Save the form to apply this change">
                 <i class="fa-solid fa-pen text-[0.55rem]"></i>
@@ -89,12 +89,12 @@
             </div>
 
             <div class="relative">
-              <i data-attendance-status-target="icon" class="fas <%= current_icon %> <%= current_icon_color %> pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm"></i>
+              <i data-icon-select-target="icon" class="fas <%= current_icon %> <%= current_icon_color %> pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm"></i>
               <%= f.select :status,
                     EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
                     { selected: f.object.status },
                     class: "w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none cursor-pointer",
-                    data: { "attendance-status-target": "select", action: "attendance-status#update" },
+                    data: { "icon-select-target": "select", action: "icon-select#update" },
                     "aria-label": "Registration status" %>
             </div>
           </div>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -46,22 +46,73 @@
         </div>
       </dl>
 
-      <%# Intends to pay — grants ticket/material access while the balance above is
-          still owed, for registrants who've committed to paying after the deadline.
-          Does not change the amount due or mark the registration as paid. %>
-      <label class="mt-4 flex items-start gap-2.5 border-t border-gray-100 pt-4 cursor-pointer">
-        <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
-        <input type="checkbox"
-               name="event_registration[intends_to_pay]"
-               value="1"
-               <%= "checked" if event_registration.intends_to_pay %>
-               class="sr-only peer">
-        <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
-        <span>
-          <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
-          <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
-        </span>
-      </label>
+      <%# Two columns: "Intends to pay" toggle on the left, the editable payment
+          method dropdown on the right. %>
+      <% payment_method_icons = {
+           ""                     => "fa-circle-question",
+           "Credit card (now)"    => "fa-credit-card",
+           "Credit card (later)"  => "fa-credit-card",
+           "Check"                => "fa-money-check-dollar"
+         } %>
+      <% payment_method_colors = {
+           ""                     => "text-gray-400",
+           "Credit card (now)"    => "text-blue-600",
+           "Credit card (later)"  => "text-indigo-600",
+           "Check"                => "text-green-600"
+         } %>
+      <% current_method = event_registration.payment_method.to_s %>
+      <% current_method_icon = payment_method_icons[current_method] || "fa-circle-question" %>
+      <% current_method_color = payment_method_colors[current_method] || "text-gray-400" %>
+      <% payment_method_options = [ [ "Not specified", "" ] ].concat(FormBuilderService::PAYMENT_METHOD_OPTIONS.map { |option| [ option, option ] }) %>
+      <div class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <%# Intends to pay — grants ticket/material access while the balance above
+            is still owed, for registrants who've committed to paying after the
+            deadline. Does not change the amount due or mark the registration as paid. %>
+        <label class="flex items-start gap-2.5 cursor-pointer">
+          <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
+          <input type="checkbox"
+                 name="event_registration[intends_to_pay]"
+                 value="1"
+                 <%= "checked" if event_registration.intends_to_pay %>
+                 class="sr-only peer">
+          <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
+          <span>
+            <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
+            <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
+          </span>
+        </label>
+
+        <%# Payment method — the registrant's choice from the registration form,
+            editable here via an icon dropdown mirroring the registration-status
+            select. %>
+        <div data-controller="icon-select"
+             data-icon-select-colors-value="<%= payment_method_colors.to_json %>"
+             data-icon-select-icons-value="<%= payment_method_icons.to_json %>"
+             data-icon-select-initial-value="<%= current_method %>">
+          <div class="mb-1 flex items-center justify-between gap-2">
+            <span class="text-sm font-medium text-gray-700">Payment method</span>
+            <span data-icon-select-target="dirty"
+                  class="hidden items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[0.65rem] font-medium text-amber-700"
+                  title="Save the form to apply this change">
+              <i class="fa-solid fa-pen text-[0.55rem]"></i>
+              Unsaved
+            </span>
+          </div>
+
+          <div class="relative">
+            <i data-icon-select-target="icon" class="fas <%= current_method_icon %> <%= current_method_color %> pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm"></i>
+            <select name="event_registration[payment_method]"
+                    class="w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none cursor-pointer"
+                    data-icon-select-target="select"
+                    data-action="icon-select#update"
+                    aria-label="Payment method">
+              <% payment_method_options.each do |option_label, option_value| %>
+                <option value="<%= option_value %>" <%= "selected" if current_method == option_value %>><%= option_label %></option>
+              <% end %>
+            </select>
+          </div>
+        </div>
+      </div>
     <% else %>
       <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-0.5 text-xs font-medium text-gray-500">
         <i class="fa-solid fa-gift"></i>

--- a/db/migrate/20260618235407_add_payment_method_to_event_registrations.rb
+++ b/db/migrate/20260618235407_add_payment_method_to_event_registrations.rb
@@ -1,0 +1,9 @@
+class AddPaymentMethodToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    add_column :event_registrations, :payment_method, :string
+  end
+
+  def down
+    remove_column :event_registrations, :payment_method, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -476,6 +476,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.text "fee_note"
     t.boolean "intends_to_pay", default: false, null: false
     t.boolean "invoice_requested", default: false, null: false
+    t.string "payment_method"
     t.boolean "payment_unresolved"
     t.bigint "registrant_id", null: false
     t.boolean "scholarship_requested", default: false, null: false

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -224,6 +224,15 @@ RSpec.describe "EventRegistrations", type: :request do
       end
     end
 
+    describe "GET /event_registrations/:id/edit" do
+      it "renders the editable payment-method control" do
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include("Payment method")
+        expect(response.body).to include('name="event_registration[payment_method]"')
+      end
+    end
+
     describe "PATCH /event_registrations/:id" do
       it "can update registration" do
         patch event_registration_path(existing_registration),
@@ -249,6 +258,22 @@ RSpec.describe "EventRegistrations", type: :request do
         existing_registration.reload
         expect(existing_registration.ce_hours_requested).to eq(5)
         expect(existing_registration.ce_license_number).to eq("LIC-987")
+      end
+
+      it "updates the payment method" do
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { payment_method: "Check" } }
+
+        expect(existing_registration.reload.payment_method).to eq("Check")
+      end
+
+      it "clears the payment method when set to not specified" do
+        existing_registration.update!(payment_method: "Check")
+
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { payment_method: "" } }
+
+        expect(existing_registration.reload.payment_method).to be_blank
       end
 
       it "sets the shout-out flag and stores the shout-out text on the registrant" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -341,6 +341,34 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "payment method" do
+    def register_with_payment_method(method, first_name: "Pam", last_name: "Beesly", email: "pam@example.com")
+      params = base_form_params(first_name: first_name, last_name: last_name, email: email)
+      params = params.merge(field_id("payment_method") => method) unless method.nil?
+      described_class.call(event: event, form: form, form_params: params)
+    end
+
+    it "stores the chosen payment method on the registration" do
+      registration = register_with_payment_method(FormBuilderService::PAYMENT_METHOD_CHECK).event_registration
+      expect(registration.payment_method).to eq(FormBuilderService::PAYMENT_METHOD_CHECK)
+    end
+
+    it "stores a credit-card choice" do
+      registration = register_with_payment_method(FormBuilderService::PAYMENT_METHOD_PAY_NOW).event_registration
+      expect(registration.payment_method).to eq(FormBuilderService::PAYMENT_METHOD_PAY_NOW)
+    end
+
+    it "updates the payment method on an existing registration that re-registers" do
+      person = create(:person, first_name: "Pam", last_name: "Beesly", email: "pam@example.com")
+      existing = create(:event_registration, event: event, registrant: person,
+                                             payment_method: FormBuilderService::PAYMENT_METHOD_CHECK)
+
+      register_with_payment_method("Credit card (later)")
+
+      expect(existing.reload.payment_method).to eq("Credit card (later)")
+    end
+  end
+
   describe "re-registration after cancellation" do
     let(:person) { create(:person, first_name: "Jane", last_name: "Doe", email: "jane@example.com") }
     let!(:cancelled_registration) do

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "Event registration edit page", type: :system do
       sign_in(admin)
       visit edit_event_registration_path(registration)
 
-      badge = "[data-attendance-status-target='dirty']"
+      badge = "[data-icon-select-target='dirty']"
       expect(page).to have_no_css(badge, visible: true)
 
       find("select[name='event_registration[status]']")


### PR DESCRIPTION
> 📦 First of two PRs. This one adds the `payment_method` data + admin editing. The ticket-facing behavior for check payers is in the stacked follow-up **#1762**.

### What is the goal of this PR and why is this important?
- Admins need to **see and change** a registrant's payment method (currently it only exists as a registration form answer, not on the registration record).
- This stores the choice on the registration and makes it editable, as groundwork for tailoring the ticket to check payers (#1762).

### How did you approach the change?
- Added a `payment_method` string column to `event_registrations`, populated from the registration form's `payment_method` answer (create and re-registration paths) — same options as the bulk payment form (`FormBuilderService::PAYMENT_METHOD_OPTIONS`), guarded by a light inclusion validation.
- Added an editable **icon dropdown** in the registration edit page's payments box (styled like the registration-status select, icon swaps per choice), laid out in two columns beside "Intends to pay", and permitted the param.
- Renamed the `attendance-status` Stimulus controller to `icon-select` since it now drives both the status and payment-method selects.

### UI Testing Checklist
- [ ] On a registration's edit page, change **Payment method** in the dropdown → icon updates, "Unsaved" hint shows, and saving persists the choice.
- [ ] Set it back to **Not specified** → clears the stored value.

### Anything else to add?
- No ticket/registrant-facing change here — that's #1762, which gates the credit-card button on `payment_method == "Check"`.