### PR TITLE
WAIT-MAYBE NOT: Hide ticket credit-card button when paying by check

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -227,6 +227,12 @@ class EventRegistration < ApplicationRecord
     "Due"
   end
 
+  # True when the registrant opted to pay by mailed check. The digital ticket
+  # reads this to hide the "Pay with Credit Card" button.
+  def pays_by_check?
+    payment_method == FormBuilderService::PAYMENT_METHOD_CHECK
+  end
+
   def scholarship?
     scholarships.exists?
   end

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -86,17 +86,21 @@
             </div>
           <% end %>
 
-          <div>
-            <% if preview %>
-              <button type="button" disabled
-                      class="btn btn-accent px-6 py-2 text-sm uppercase font-telefon opacity-60 cursor-not-allowed">Pay with Credit Card</button>
-            <% else %>
-              <%= button_to "Pay with Credit Card",
-                            registration_pay_path(event_registration.slug),
-                            data: { turbo: false },
-                            class: "btn btn-accent px-6 py-2 text-sm uppercase font-telefon" %>
-            <% end %>
-          </div>
+          <% if event_registration.pays_by_check? %>
+            <div class="text-sm text-gray-600">Pay by mailed check, as selected during registration.</div>
+          <% else %>
+            <div>
+              <% if preview %>
+                <button type="button" disabled
+                        class="btn btn-accent px-6 py-2 text-sm uppercase font-telefon opacity-60 cursor-not-allowed">Pay with Credit Card</button>
+              <% else %>
+                <%= button_to "Pay with Credit Card",
+                              registration_pay_path(event_registration.slug),
+                              data: { turbo: false },
+                              class: "btn btn-accent px-6 py-2 text-sm uppercase font-telefon" %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       <% end %>
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -209,6 +209,23 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#pays_by_check?" do
+    it "returns true when the payment method is Check" do
+      reg = build(:event_registration, payment_method: FormBuilderService::PAYMENT_METHOD_CHECK)
+      expect(reg).to be_pays_by_check
+    end
+
+    it "returns false for a credit-card method" do
+      reg = build(:event_registration, payment_method: FormBuilderService::PAYMENT_METHOD_PAY_NOW)
+      expect(reg).not_to be_pays_by_check
+    end
+
+    it "returns false when no payment method is set" do
+      reg = build(:event_registration, payment_method: nil)
+      expect(reg).not_to be_pays_by_check
+    end
+  end
+
   describe "#scholarship_tasks_met?" do
     it "returns true when no scholarship exists" do
       reg = create(:event_registration)

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe "Event registration show page", type: :system do
       expect(page).to have_text("due")
       expect(page).to have_button("Pay with Credit Card")
     end
+
+    it "hides the pay button when the registrant chose to pay by check" do
+      registration.update!(payment_method: "Check")
+
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      # The balance callout still shows (a check payer still owes), but the
+      # credit-card action button is replaced by the mailed-check note.
+      expect(page).to have_text("Make your payment")
+      expect(page).to have_no_button("Pay with Credit Card")
+      expect(page).to have_text("Pay by mailed check")
+    end
   end
 
   describe "before-you-attend call-out" do


### PR DESCRIPTION
> ⛓️ **Stacked on #1761** — base is `maebeale/hide-cc-button-check-payment` (the `payment_method` column). Review/merge that first; this PR will retarget to `main` once it lands.

### What is the goal of this PR and why is this important?
- A registrant who chose **"Check"** intends to mail payment, so the digital ticket's **"Pay with Credit Card"** button is misleading.
- This hides that button for check payers and shows a "Pay by mailed check" note instead, while keeping the amount-due badge.

### How did you approach the change?
- Added `EventRegistration#pays_by_check?` (`payment_method == FormBuilderService::PAYMENT_METHOD_CHECK`) as the single seam the ticket gates on.
- Updated the ticket view to branch on it; covered with a model spec and a ticket system spec.

### UI Testing Checklist
- [ ] Ticket for a paid registration whose method is **Check** → shows "payment is due" + "Pay by mailed check", **no** credit-card button.
- [ ] Ticket for a card method (or no method) → still shows the **Pay with Credit Card** button.

### Anything else to add?
- Depends on the `payment_method` column from #1761; nothing here is user-editable (that lives in the base PR).