### PR TITLE
Turn over-length registration answers into form errors, not 500s

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -62,6 +62,8 @@ module EventRegistrationServices
 
         Result.new(success?: true, event_registration: event_registration, form_submission: submission, errors: [])
       end
+    rescue ActiveRecord::ValueTooLong => e
+      Result.new(success?: false, event_registration: nil, errors: [ too_long_message(e) ])
     rescue ActiveRecord::RecordInvalid => e
       Result.new(success?: false, event_registration: nil, errors: [ e.message ])
     rescue ActiveRecord::RecordNotUnique => e
@@ -74,6 +76,17 @@ module EventRegistrationServices
     end
 
     private
+
+    # Turn a database "Data too long for column 'city'" failure into a friendly,
+    # form-level message. We can't always map the column back to a single form
+    # field (both the mailing and agency address write `city`), so we name the
+    # column generically and ask the registrant to shorten that answer.
+    def too_long_message(error)
+      column = error.message[/column '([^']+)'/, 1]
+      return "One of your answers is too long. Please shorten it and try again." if column.blank?
+
+      "Your #{column.humanize.downcase} is too long. Please shorten it and try again."
+    end
 
     def field_value(key)
       field = @form.form_fields.find_by(field_identifier: key)

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -34,6 +34,41 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "POST create with an answer longer than its database column" do
+    # A real registration form maps answers onto person/address columns; `city`
+    # and friends are varchar(255). An over-length answer used to 500 with
+    # ActiveRecord::ValueTooLong — it should re-render the form with an error.
+    # These optional fields carry the identifiers the service maps to columns.
+    %w[first_name last_name primary_email mailing_street mailing_city mailing_state mailing_zip].each do |identifier|
+      let!("#{identifier}_field".to_sym) do
+        create(:form_field, form: form, field_identifier: identifier, name: identifier.humanize, required: false)
+      end
+    end
+
+    def fid(key)
+      form.form_fields.find_by!(field_identifier: key).id.to_s
+    end
+
+    it "re-renders the form with an error instead of raising" do
+      expect {
+        post event_public_registration_path(event),
+             params: { public_registration: { form_fields: {
+               essay_field.id.to_s => "this answer has plenty of words",
+               fid("first_name") => "Pat",
+               fid("last_name") => "Lee",
+               fid("primary_email") => "pat@example.com",
+               fid("mailing_street") => "1 Main St",
+               fid("mailing_city") => "a" * 256,
+               fid("mailing_state") => "CA",
+               fid("mailing_zip") => "90001"
+             } } }
+      }.not_to change(EventRegistration, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to match(/city is too long/i)
+    end
+  end
+
   describe "POST create with a maximum character count" do
     let!(:bio_field) do
       create(:form_field, form: form, answer_type: :free_form_input_one_line,

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -24,6 +24,36 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     }
   end
 
+  describe "an answer longer than its database column" do
+    # `city` (like the other mapped person/address columns) is a varchar(255).
+    # A longer answer must surface as a form error, not an ActiveRecord::ValueTooLong
+    # 500 that escapes the registration flow.
+    let(:params) do
+      base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+        field_id("mailing_street") => "1 Main St",
+        field_id("mailing_city") => "a" * 256,
+        field_id("mailing_state") => "CA",
+        field_id("mailing_zip") => "90001"
+      )
+    end
+
+    it "returns a failed result instead of raising" do
+      result = nil
+      expect {
+        result = described_class.call(event: event, form: form, form_params: params)
+      }.not_to raise_error
+
+      expect(result.success?).to be false
+      expect(result.errors.join).to match(/city.*too long/i)
+    end
+
+    it "does not create a registration" do
+      expect {
+        described_class.call(event: event, form: form, form_params: params)
+      }.not_to change(EventRegistration, :count)
+    end
+  end
+
   describe "primary service area tagging" do
     let!(:primary_sector) { create(:sector, name: "Healthcare") }
     let!(:other_sector) { create(:sector, name: "Education") }


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- A public registration answer longer than its mapped `varchar(255)` column (e.g. a long city) raised `ActiveRecord::ValueTooLong` mid-registration and surfaced as a **500**, with no way for the registrant to recover.
- `ValueTooLong` is a `StatementInvalid`, which the service's existing `RecordInvalid`/`RecordNotUnique` rescues don't catch — so it escaped the normal "re-render the form with an error" path.

### How did you approach the change?
- `EventRegistrationServices::PublicRegistration` now rescues `ActiveRecord::ValueTooLong` and returns a failed result with a friendly, column-named message (`"Your city is too long. Please shorten it and try again."`). The controller already re-renders the form with that error, so it flows through as an ordinary form validation error.
- The column can't always be mapped back to a single field (both the mailing and agency address write `city`), so the message names the **column** rather than guessing a field.

### UI Testing Checklist
- [ ] Submit the public registration form with an answer longer than its column (e.g. a 256-char city) → the form re-renders with "Your city is too long…", no 500, no registration created.

### Anything else to add?
- Split out of #1760 to keep the over-length fix reviewable on its own.
- Specs (failing-first): service returns a failed result instead of raising and creates no registration; request-level confirms the 422 form error end-to-end.