### PR TITLE
HOLD: Confirm registrants with a "You're registered!" banner

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -69,7 +69,7 @@ module Events
           checkout_session = create_stripe_checkout_session(registration, result.form_submission)
           redirect_to checkout_session.url, allow_other_host: true, status: :see_other
         else
-          redirect_to registration_ticket_path(registration.slug),
+          redirect_to registration_ticket_path(registration.slug, registered: true),
                       notice: "You have been successfully registered!"
         end
       else

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -20,6 +20,8 @@ module Events
       when "cancelled"
         flash.now[:alert] = "Payment was cancelled. You are registered for this event but payment may still be due."
       end
+
+      @just_registered = params[:registered].present? || params[:checkout] == "success"
     end
 
     def invoice

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -10,4 +10,15 @@
   <% end %>
   </div>
 </div>
+<% if @just_registered %>
+  <div class="max-w-2xl mx-auto px-4 pt-3">
+    <div class="flex items-center gap-4 rounded-2xl border border-green-200 bg-green-50 px-5 py-4 text-green-800 shadow-sm">
+      <i class="fa-solid fa-circle-check text-3xl text-green-600"></i>
+      <div>
+        <p class="text-xl font-bold leading-tight">You're registered!</p>
+        <p class="text-sm text-green-700">A confirmation has been emailed to you. Your ticket is below — save this page for your records.</p>
+      </div>
+    </div>
+  </div>
+<% end %>
 <%= render "event_registrations/ticket", event_registration: @event_registration %>

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -81,6 +81,23 @@ RSpec.describe "Events::Registrations", type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "just-registered banner" do
+      it "shows a 'You're registered!' banner when arriving from a fresh registration" do
+        get registration_ticket_path(registration.slug, registered: true)
+        expect(response.body).to include("You're registered!")
+      end
+
+      it "shows the banner after a successful Stripe checkout" do
+        get registration_ticket_path(registration.slug, checkout: "success")
+        expect(response.body).to include("You're registered!")
+      end
+
+      it "omits the banner on a plain ticket view" do
+        get registration_ticket_path(registration.slug)
+        expect(response.body).not_to include("You're registered!")
+      end
+    end
   end
 
   describe "GET /registration/:slug/invoice" do


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- After a successful public event registration, the registrant landed on the ticket page with no explicit "you're in" confirmation beyond the transient flash toast.

### How did you approach the change?
- The success redirect carries a `registered` flag to the ticket page.
- `registrations#show` sets `@just_registered` for that flag **or** a successful Stripe `checkout=success` return, and the ticket view renders a green "You're registered!" banner above the ticket.
- The banner is not shown on plain return visits to an existing ticket URL. The existing "You have been successfully registered!" flash toast is unchanged.

### UI Testing Checklist
- [ ] Register on a free event → land on the ticket page with a "You're registered!" banner.
- [ ] Pay by card and complete Stripe checkout → ticket page shows the banner.
- [ ] Re-open an existing ticket URL directly → no banner.

### Anything else to add?
- Split out of #1760 to keep the success banner reviewable on its own.
- Specs cover the banner showing for `registered`/`checkout=success` but not on plain ticket views.