### PR TITLE
Accept bare domains for organization website URLs

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -38,8 +38,6 @@ class Organization < ApplicationRecord
   validates :name, presence: true
   validates :organization_status_id, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true
-  validates :website_url, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must be a valid web address" }, allow_blank: true
-  before_validation :normalize_website_url
   validate :affiliation_dates_locked, if: -> { affiliations.any? && !Current.user&.super_user? }
 
   # Nested attributes
@@ -243,16 +241,19 @@ class Organization < ApplicationRecord
 
   remote_searchable_by :name
 
-  private
-
-  # Lets users enter a bare domain (e.g. "awbw.org") by defaulting to https://
-  # when no scheme is present, so the value passes URL validation and renders as
-  # a working link.
-  def normalize_website_url
+  # Returns the website as a clickable, scheme-qualified URL — prepending
+  # https:// to a bare domain like "awbw.org" — or nil when the value is blank or
+  # not a usable web address. Drives the external links on the org profile and
+  # recipients pages without forcing users to type a scheme.
+  def website_link_url
     return if website_url.blank?
-    stripped = website_url.strip
-    self.website_url = stripped.match?(/\Ahttps?:\/\//i) ? stripped : "https://#{stripped}"
+    candidate = website_url.strip
+    candidate = "https://#{candidate}" unless candidate.match?(/\Ahttps?:\/\//i)
+    uri = URI.parse(candidate) rescue nil
+    candidate if uri.is_a?(URI::HTTP) && uri.host.present?
   end
+
+  private
 
   # Union of the org's own age groups and its affiliated people's, deduped. The
   # affiliated people (with their taggings) are loaded once and memoized so the

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -38,7 +38,8 @@ class Organization < ApplicationRecord
   validates :name, presence: true
   validates :organization_status_id, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true
-  validates :website_url, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must start with http:// or https://" }, allow_blank: true
+  validates :website_url, format: { with: /\Ahttps?:\/\/\S+\z/i, message: "must be a valid web address" }, allow_blank: true
+  before_validation :normalize_website_url
   validate :affiliation_dates_locked, if: -> { affiliations.any? && !Current.user&.super_user? }
 
   # Nested attributes
@@ -243,6 +244,15 @@ class Organization < ApplicationRecord
   remote_searchable_by :name
 
   private
+
+  # Lets users enter a bare domain (e.g. "awbw.org") by defaulting to https://
+  # when no scheme is present, so the value passes URL validation and renders as
+  # a working link.
+  def normalize_website_url
+    return if website_url.blank?
+    stripped = website_url.strip
+    self.website_url = stripped.match?(/\Ahttps?:\/\//i) ? stripped : "https://#{stripped}"
+  end
 
   # Union of the org's own age groups and its affiliated people's, deduped. The
   # affiliated people (with their taggings) are loaded once and memoized so the

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -220,7 +220,7 @@
                 otherwise to its profile page. %>
             <div class="sm:col-span-1">
               <% if (organization = shoutout.organization) %>
-                <% website = organization.website_url.presence && (URI.parse(organization.website_url).to_s rescue nil) %>
+                <% website = organization.website_link_url %>
                 <% if website %>
                   <%= link_to organization.name, website, target: "_blank", rel: "noopener noreferrer", class: org_link_class %>
                 <% else %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -142,7 +142,7 @@
       <%= f.input :website_url,
                   label: "Website URL #{website_warning}".html_safe,
                   as: :string,
-                  hint: "e.g. awbw.org, and we'll add https://".html_safe,
+                  hint: "Invalid URLs won't show as a clickable link".html_safe,
                   wrapper_html: { id: "website-url-field" },
                   input_html: {
                     class: "rounded-md #{"bg-red-200" if website_warning.present? } border-gray-300

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -142,7 +142,7 @@
       <%= f.input :website_url,
                   label: "Website URL #{website_warning}".html_safe,
                   as: :string,
-                  hint: "Invalid URLs won't show as a clickable link".html_safe,
+                  hint: "Invalid URLs won't be clickable in Portal".html_safe,
                   wrapper_html: { id: "website-url-field" },
                   input_html: {
                     class: "rounded-md #{"bg-red-200" if website_warning.present? } border-gray-300

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -142,7 +142,7 @@
       <%= f.input :website_url,
                   label: "Website URL #{website_warning}".html_safe,
                   as: :string,
-                  hint: "Enter full URL: https:// or http://".html_safe,
+                  hint: "e.g. awbw.org, and we'll add https://".html_safe,
                   wrapper_html: { id: "website-url-field" },
                   input_html: {
                     class: "rounded-md #{"bg-red-200" if website_warning.present? } border-gray-300

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -82,7 +82,7 @@
             <% end %>
           <% end %>
           <% if @organization.profile_show_website? && @organization.website_url.present? %>
-            <% safe_url = URI.parse(@organization.website_url).to_s rescue nil %>
+            <% safe_url = @organization.website_link_url %>
             <% if safe_url.present? %>
               <span class="text-gray-600">
                 🌎 <%= link_to @organization.website_url, safe_url,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -238,7 +238,42 @@
         79
       ],
       "note": "Admin-only reminder confirmation. Same as preview_reminder: the raw value is the server-rendered email HTML; the embedded custom message is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "081b76f4d760b6f2879493fdde335a57dfc310ba0adfb28d5abe40d5f983189f",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/organizations/show.html.erb",
+      "line": 88,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_url, Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_link_url, :target => \"_blank\", :rel => \"noopener noreferrer\", :class => \"text-blue-600 hover:underline\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "OrganizationsController",
+          "method": "show",
+          "line": 74,
+          "file": "app/controllers/organizations_controller.rb",
+          "rendered": {
+            "name": "organizations/show",
+            "file": "app/views/organizations/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "organizations/show"
+      },
+      "user_input": "Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_link_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Organization#website_link_url only ever returns an http(s):// URL (it requires a URI::HTTP with a host), so the href can't carry a javascript: or data: scheme."
     }
   ],
-  "brakeman_version": "8.0.4"
+  "brakeman_version": "8.0.4",
+  "updated": "2026-06-19 10:05:46 -0400"
 }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe Organization do
     it { should allow_value("").for(:email) }
     it { should allow_value(nil).for(:email) }
     it { should_not allow_value("not-an-email").for(:email).with_message("must be a valid email address") }
+
+    it { should allow_value("https://awbw.org").for(:website_url) }
+    it { should allow_value("http://awbw.org").for(:website_url) }
+    it { should allow_value("awbw.org").for(:website_url) }
+    it { should allow_value("www.awbw.org").for(:website_url) }
+    it { should allow_value("").for(:website_url) }
+    it { should allow_value(nil).for(:website_url) }
+    it { should_not allow_value("not a url").for(:website_url) }
+
+    it "prepends https:// to a website without a scheme" do
+      org = build(:organization, website_url: "awbw.org")
+      org.valid?
+      expect(org.website_url).to eq("https://awbw.org")
+    end
+
+    it "leaves a website with a scheme unchanged" do
+      org = build(:organization, website_url: "http://awbw.org")
+      org.valid?
+      expect(org.website_url).to eq("http://awbw.org")
+    end
   end
 
   it 'is valid with valid attributes' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -23,24 +23,37 @@ RSpec.describe Organization do
     it { should allow_value(nil).for(:email) }
     it { should_not allow_value("not-an-email").for(:email).with_message("must be a valid email address") }
 
-    it { should allow_value("https://awbw.org").for(:website_url) }
-    it { should allow_value("http://awbw.org").for(:website_url) }
-    it { should allow_value("awbw.org").for(:website_url) }
-    it { should allow_value("www.awbw.org").for(:website_url) }
-    it { should allow_value("").for(:website_url) }
-    it { should allow_value(nil).for(:website_url) }
-    it { should_not allow_value("not a url").for(:website_url) }
-
-    it "prepends https:// to a website without a scheme" do
+    it "stores the website_url verbatim without requiring a scheme" do
       org = build(:organization, website_url: "awbw.org")
       org.valid?
-      expect(org.website_url).to eq("https://awbw.org")
+      expect(org.errors[:website_url]).to be_empty
+      expect(org.website_url).to eq("awbw.org")
+    end
+  end
+
+  describe "#website_link_url" do
+    it "prepends https:// to a bare domain" do
+      org = build(:organization, website_url: "awbw.org")
+      expect(org.website_link_url).to eq("https://awbw.org")
     end
 
-    it "leaves a website with a scheme unchanged" do
+    it "leaves an existing scheme unchanged" do
       org = build(:organization, website_url: "http://awbw.org")
-      org.valid?
-      expect(org.website_url).to eq("http://awbw.org")
+      expect(org.website_link_url).to eq("http://awbw.org")
+    end
+
+    it "trims surrounding whitespace" do
+      org = build(:organization, website_url: "  awbw.org  ")
+      expect(org.website_link_url).to eq("https://awbw.org")
+    end
+
+    it "is nil when blank" do
+      expect(build(:organization, website_url: "").website_link_url).to be_nil
+      expect(build(:organization, website_url: nil).website_link_url).to be_nil
+    end
+
+    it "is nil when the value can't form a usable web address" do
+      expect(build(:organization, website_url: "not a url").website_link_url).to be_nil
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The organization Website URL field rejected anything without an explicit `http://`/`https://` scheme, so users who naturally typed `awbw.org` hit a validation error.
- This removes that friction: users can save whatever they type, and the clickable links still work.

### How did you approach the change?
- Dropped the `website_url` format validation on `Organization` so the value is stored verbatim.
- Added `Organization#website_link_url`, which prepends `https://` to a bare domain and returns `nil` for input that can't form a usable web address (requires a `URI::HTTP` with a host).
- The org profile and recipients pages now build their external links via that method, so a bare `awbw.org` links out correctly while genuine junk falls back (profile link / "Bad URL" notice).

### UI Testing Checklist
- [ ] Edit an organization, enter `awbw.org` in Website URL, save — it persists as typed and the profile page shows a working external link to `https://awbw.org`.
- [ ] An org with `awbw.org` on the event recipients page links out to the site; an org with junk text falls back to its profile page.

### Anything else to add?
- New model specs cover `website_link_url` (bare domain, existing scheme, whitespace, blank, unusable input). A weak-confidence Brakeman `LinkToHref` warning is suppressed in `config/brakeman.ignore` because the method can only ever return an `http(s)://` URL.