### PR TITLE
Keep affiliation primary contact on one line at full width

### DIFF
--- a/app/views/organizations/_affiliation_fields.html.erb
+++ b/app/views/organizations/_affiliation_fields.html.erb
@@ -5,11 +5,11 @@
          style="border-left: 4px solid <%= f.object.facilitator? ? '#e879f9' : '#d1d5db' %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
-      <div style="width: 350px; min-width: 350px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
+      <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
         <% if f.object.persisted? && f.object.person.present? %>
           <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
           <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
-          <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
+          <%= person_profile_button(f.object.person, truncate_at: 25, subtitle: (f.object.person.preferred_email if show_email)) %>
           <%= f.hidden_field :person_id %>
         <% else %>
           <%= f.input :person_id,

--- a/app/views/people/_affiliation_fields.html.erb
+++ b/app/views/people/_affiliation_fields.html.erb
@@ -4,10 +4,10 @@
     <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-end mb-4 rounded-lg border p-3 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : 'bg-white border-gray-200' %>"
          style="border-left: 4px solid <%= f.object.facilitator? ? '#e879f9' : '#d1d5db' %>"
          data-inactive-toggle-target="row">
-      <div style="width: 350px; min-width: 350px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
+      <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
         <% if f.object.persisted? && f.object.organization.present? %>
           <label class="block text-sm font-medium text-gray-700 mb-1">Organization</label>
-          <%= organization_profile_button(f.object.organization, truncate_at: 30) %>
+          <%= organization_profile_button(f.object.organization, truncate_at: 25) %>
           <%= f.hidden_field :organization_id %>
         <% else %>
           <%= f.input :organization_id,


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the person/organization affiliation forms, the **Primary contact** checkbox was wrapping onto its own line even at full width, breaking the intended single-row layout.

### How did you approach the change?
- The #1486 revert widened the Person/Organization profile column from `280px` to `350px`, which consumed enough horizontal space to push **Primary contact** past the wrap point.
- Restored the column to `280px` (and matched `truncate_at: 25`) in both `organizations/_affiliation_fields` and `people/_affiliation_fields`.
- The row still uses `flex flex-wrap`, so fields continue to wrap on narrow viewports — they just fit on one line again at full width.

### UI Testing Checklist
- [ ] Edit an organization with affiliations — Person, Title, Start, End, Primary contact all sit on one line at full width.
- [ ] Edit a person with affiliations — same single-row layout.
- [ ] Shrink the browser window — fields wrap gracefully.

### Anything else to add?
- Display-only CSS change; no logic or schema impact.