### PR TITLE
Point registration confirmation email at the ticket only

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -7,7 +7,6 @@ class EventMailer < ApplicationMailer
     @notification_type = "Event registration confirmation"
 
     @time_zone = @person.user&.time_zone || Time.zone.name
-    @event_url = event_url(@event, reg: @event_registration.slug)
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
     @organization_website  = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -60,12 +60,11 @@
 </div>
 
 <p>
-  Visit the event page for updates, directions, or calendar links:
+  Your ticket has everything you need — event details, calendar links, and options to manage your registration:
 </p>
 
 <p>
   <% if @event_registration.persisted? %>
     <a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a>
   <% end %>
-  <a href="<%= @event_url %>" class="button">View event</a>
 </p>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -28,9 +28,6 @@ Videoconference URL: <%= @event.videoconference_url %>
 View your ticket:
 <%= registration_ticket_url(@event_registration.slug) %>
 
-View the event page:
-<%= @event_url %>
-
 <% if @event.registration_close_date %>
   Registration closes on
   <% text_tz_abbr = @event.start_date.in_time_zone(@time_zone).strftime("%Z") %>

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe EventMailer, type: :mailer do
       expect(mail.body.encoded).to include(event_registration.registrant.full_name)
     end
 
+    it "links to the registrant's ticket" do
+      expect(mail.body.encoded).to include("/registration/#{event_registration.slug}")
+    end
+
+    it "offers only the ticket call to action, not a separate event link" do
+      body = mail.body.encoded
+
+      expect(body).to include("View ticket")
+      expect(body).not_to include("View event")
+    end
+
     context "when the event has a rhino_description" do
       let(:event) { create(:event, rhino_description: "Join us for an art healing workshop") }
       let(:event_registration) { create(:event_registration, event: event) }

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -41,14 +41,13 @@ class EventMailerPreview < ActionMailer::Preview
   end
 
   def sample_event_registration
-    # Try to reuse existing records to avoid duplication
+    # Try to reuse existing records to avoid duplication. Persist the registration
+    # so it has a slug and the confirmation email's "View ticket" link renders
+    # (the link is gated on a persisted registration).
     event = Event.first || create_event
     person = Person.first || create_person
 
-    EventRegistration.new(
-      event: event,
-      registrant: person
-    )
+    EventRegistration.find_or_create_by!(event: event, registrant: person)
   end
 
   def create_event


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The registration confirmation email should send registrants straight to their ticket, which already carries the event details, calendar links, and registration-management options — so the separate "View event" link was redundant noise.

### How did you approach the change?
Removed the "View event" link (and the now-unused `@event_url`) from both the HTML and text confirmation emails, leaving a single "View ticket" call to action. Also fixed the mailer preview, which built an unpersisted registration and therefore hid the ticket link entirely, by persisting the sample registration.

### UI Testing Checklist
- [ ] Confirmation email shows a single "View ticket" button linking to the registrant's ticket
- [ ] No "View event" link appears in the HTML or text email
- [ ] Mailer preview renders the ticket link

### Anything else to add?
Part of splitting a combined branch into focused PRs — scholarship-answer saving and the scholarship section on the view-submission page follow in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
