### PR TITLE
Lock payment-method answer options from casual edits

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -40,6 +40,12 @@ class FormField < ApplicationRecord
   ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER = "additional_age_group"
   AGE_GROUP_FIELD_IDENTIFIERS = [ PRIMARY_AGE_GROUP_FIELD_IDENTIFIER, ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER ].freeze
 
+  # The payment-method field. Its answer options ("Credit card (now)", etc.) are
+  # wired to Stripe charge logic in the controllers, so they must not be edited
+  # casually from the form builder — the editor shows them read-only unless the
+  # admin override is present.
+  PAYMENT_METHOD_FIELD_IDENTIFIER = "payment_method"
+
   # The generic free-text option label that lets a respondent supply their own
   # value; a chosen "Other" answer is stored as "Other" or "Other: <text>".
   OTHER_OPTION_PREFIX = "Other"
@@ -161,6 +167,13 @@ class FormField < ApplicationRecord
 
   def selectable?
     answer_type.in?(SELECTABLE_ANSWER_TYPES)
+  end
+
+  # True for fields whose answer options are tied to backend logic (currently the
+  # payment-method field's Stripe wiring) and so should be shown read-only in the
+  # form builder rather than freely edited.
+  def fixed_options?
+    field_identifier == PAYMENT_METHOD_FIELD_IDENTIFIER
   end
 
   def html_id

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -151,12 +151,27 @@
         </div>
 
         <% unless option_source %>
+          <% options_locked = field.fixed_options? && params[:admin] != "true" %>
           <div class="hidden space-y-2 pl-1 border-t border-gray-100 pt-3" data-answer-options-target="list">
-            <%= f.fields_for :form_field_answer_options do |opt| %>
-              <%= render "form_field_answer_option_fields", f: opt %>
+            <% if options_locked %>
+              <%# Payment-method options drive Stripe charge logic, so they're shown
+                  read-only here. Append ?admin=true to the URL to edit them. %>
+              <% field.form_field_answer_options.each do |option| %>
+                <div class="flex items-center gap-2 text-sm text-gray-600">
+                  <i class="fa-solid fa-circle text-gray-300 text-[5px] shrink-0"></i>
+                  <span><%= option.option_name %></span>
+                </div>
+              <% end %>
+              <p class="text-xs text-gray-400 italic">
+                These options aren't editable here — they're tied to system logic and must stay in sync with it.
+              </p>
+            <% else %>
+              <%= f.fields_for :form_field_answer_options do |opt| %>
+                <%= render "form_field_answer_option_fields", f: opt %>
+              <% end %>
+              <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
+                    class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
             <% end %>
-            <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
-                  class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
           </div>
         <% end %>
       </div>

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -454,6 +454,20 @@ RSpec.describe FormField do
     end
   end
 
+  describe "#fixed_options?" do
+    let(:form) { create(:form) }
+
+    it "returns true for the payment-method field" do
+      field = build(:form_field, form: form, field_identifier: "payment_method")
+      expect(field.fixed_options?).to be true
+    end
+
+    it "returns false for an ordinary field" do
+      field = build(:form_field, form: form, field_identifier: "how_did_you_hear")
+      expect(field.fixed_options?).to be false
+    end
+  end
+
   describe "#html_input_type" do
     let(:form) { create(:form) }
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -165,6 +165,33 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("+ Add option")
     end
 
+    it "shows payment-method options read-only (no editable inputs) without the admin override" do
+      form = FormBuilderService.new(name: "Test", sections: %i[payment]).call
+      payment_field = form.form_fields.find_by(field_identifier: "payment_method")
+      expect(payment_field).to be_present
+
+      get edit_form_path(form)
+
+      # The options are still shown...
+      FormBuilderService::PAYMENT_METHOD_OPTIONS.each do |option|
+        expect(response.body).to include(option)
+      end
+      # ...but not as editable inputs, and they can't be added/removed.
+      expect(response.body).not_to match(/payment_method.{0,600}\[option_name\]/m)
+      expect(response.body).not_to match(/payment_method.{0,600}\+ Add option/m)
+      # A note explains why they're locked.
+      expect(response.body).to include("tied to system logic")
+    end
+
+    it "renders payment-method options as editable inputs with ?admin=true" do
+      form = FormBuilderService.new(name: "Test", sections: %i[payment]).call
+
+      get edit_form_path(form, admin: "true")
+
+      expect(response.body).to include("[option_name]")
+      expect(response.body).to include("+ Add option")
+    end
+
     it "shows an option-source badge linking to the managed list for dynamic fields" do
       type = CategoryType.create!(name: "AgeRange", published: true)
       form = create(:form, :standalone)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The payment-method field's answer options (`Credit card (now)`, `Credit card (later)`, `Check`) are wired to Stripe charge logic in the registration controllers — the `Credit card (now)` option triggers an immediate charge.
- Editing, renaming, or removing these options from the form builder can silently break payments without any warning.
- This makes those options **read-only in the form editor** so they can't be changed casually, while still showing them so admins can see what's configured.

### How did you approach the change?

- Added `FormField#fixed_options?` (true for the `payment_method` field) and a `PAYMENT_METHOD_FIELD_IDENTIFIER` constant.
- In the form-builder "Answer options" panel, when a field has fixed options and `?admin=true` is **not** present, the options render as static read-only text with a short note explaining they're tied to system logic.
- Appending `?admin=true` to the form-editor URL restores the normal editable inputs and the "+ Add option" link for the rare case the options genuinely need to change.
- Read-only mode simply omits the nested-attribute inputs, so on save the existing options are left untouched (Rails nested attributes only modify records present in params) — they can't be accidentally wiped.

### UI Testing Checklist

- [ ] Open the form editor for a form with a payment-method field; expand "Answer options" — the three options show as read-only text with the explanatory note, no inputs or "+ Add option".
- [ ] Add `?admin=true` to the URL and reload — the options are now editable inputs with "+ Add option".
- [ ] Other multiple-choice fields remain fully editable in both cases.

### Anything else to add?

- This is UI-level gating. The `update` action still permits `form_field_answer_options_attributes`, so a hand-crafted POST could technically still submit them. Happy to add server-side enforcement if we want it locked down harder (that would also require carrying `admin=true` through the form submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)