### PR TITLE
Persist scholarship-form answers on public registration

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -59,7 +59,9 @@ module Events
         form: @form,
         form_params: registration_params,
         scholarship_requested: @scholarship,
-        person: current_user&.person
+        person: current_user&.person,
+        scholarship_form: @scholarship_form,
+        scholarship_params: scholarship_params
       )
 
       if result.success?
@@ -173,28 +175,6 @@ module Events
       end
 
       [ registration, scholarship ]
-    end
-
-    def create_or_update_scholarship_submission(person, scholarship_params)
-      scholarship_form = @event.scholarship_form
-      return unless scholarship_form
-
-      submission = FormSubmission.find_or_create_by!(
-        person: person, form: scholarship_form, role: "scholarship"
-      ) do |record|
-        record.event = @event
-      end
-
-      scholarship_params.each do |field_id, raw_value|
-        field = scholarship_form.form_fields.find_by(id: field_id)
-        next unless field
-        next if field.group_header?
-
-        text = raw_value.is_a?(Array) ? raw_value.reject(&:blank?).join(", ") : raw_value.to_s
-
-        record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
-      end
     end
 
     def visible_form_fields

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -15,16 +15,21 @@ module EventRegistrationServices
     ADDITIONAL_FORMS_INVOICE = "Invoice".freeze
     ADDITIONAL_FORMS_W9 = "W-9".freeze
 
-    def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil)
-      new(event:, form:, form_params:, scholarship_requested:, person:).call
+    def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil,
+                  scholarship_form: nil, scholarship_params: {})
+      new(event:, form:, form_params:, scholarship_requested:, person:,
+          scholarship_form:, scholarship_params:).call
     end
 
-    def initialize(event:, form:, form_params:, scholarship_requested: false, person: nil)
+    def initialize(event:, form:, form_params:, scholarship_requested: false, person: nil,
+                   scholarship_form: nil, scholarship_params: {})
       @event = event
       @form = form
       @form_params = form_params
       @scholarship_requested = scholarship_requested
       @person = person
+      @scholarship_form = scholarship_form
+      @scholarship_params = scholarship_params || {}
       @errors = []
     end
 
@@ -52,11 +57,13 @@ module EventRegistrationServices
             send_notifications(existing)
           end
           submission = update_form_submission(person)
+          save_scholarship_submission(person)
           return Result.new(success?: true, event_registration: existing, form_submission: submission, errors: [])
         end
 
         event_registration = create_event_registration(person)
         submission = create_form_submission(person)
+        save_scholarship_submission(person)
 
         send_notifications(event_registration)
 
@@ -324,6 +331,34 @@ module EventRegistrationServices
         field = @form.form_fields.find_by(id: field_id)
         next unless field
         next if field.group_header? || field.field_identifier == "confirm_email"
+
+        text = if raw_value.is_a?(Array)
+          raw_value.reject(&:blank?).join(", ")
+        else
+          raw_value.to_s
+        end
+
+        record = submission.form_answers.find_or_initialize_by(form_field: field)
+        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+      end
+    end
+
+    # Persist the answers to the separate scholarship form (when one is asked and a
+    # scholarship was requested) as its own role: "scholarship" submission tied to
+    # the event, mirroring how the registration submission is saved above.
+    def save_scholarship_submission(person)
+      return unless @scholarship_requested && @scholarship_form && @scholarship_params.present?
+
+      submission = FormSubmission.find_or_create_by!(
+        person: person, form: @scholarship_form, role: "scholarship"
+      ) do |record|
+        record.event = @event
+      end
+
+      @scholarship_params.each do |field_id, raw_value|
+        field = @scholarship_form.form_fields.find_by(id: field_id)
+        next unless field
+        next if field.group_header?
 
         text = if raw_value.is_a?(Array)
           raw_value.reject(&:blank?).join(", ")

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -98,6 +98,24 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).not_to include("must be at least 8 words")
     end
+
+    context "when the registrant is signed in" do
+      let(:user) { create(:user, :with_person) }
+
+      before { sign_in user }
+
+      it "persists the scholarship answers as a scholarship-role submission" do
+        expect {
+          post_with_scholarship("this scholarship answer clearly has more than eight words total")
+        }.to change { FormSubmission.where(role: "scholarship").count }.by(1)
+
+        submission = FormSubmission.where(role: "scholarship").last
+        expect(submission.person).to eq(user.person)
+        expect(submission.event).to eq(event)
+        expect(submission.form_answers.find_by(form_field: scholarship_essay).submitted_answer)
+          .to eq("this scholarship answer clearly has more than eight words total")
+      end
+    end
   end
 
   describe "POST create with credit card payment" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -322,4 +322,46 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(answer.submitted_answer).to eq("Healing, Other: poetry therapy")
     end
   end
+
+  describe "separate scholarship form submission" do
+    let(:scholarship_form) do
+      f = create(:form, role: "scholarship")
+      event.event_forms.create!(form: f, role: "scholarship")
+      f
+    end
+    let!(:scholarship_field) do
+      create(:form_field, form: scholarship_form, answer_type: :free_form_input_paragraph,
+             name: "Describe your need", required: false)
+    end
+
+    it "persists the scholarship answers as a scholarship-role submission tied to the event" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Sky", last_name: "Need", email: "sky@example.com"),
+        scholarship_requested: true,
+        scholarship_form: scholarship_form,
+        scholarship_params: { scholarship_field.id.to_s => "Our training budget was cut this year." }
+      )
+
+      expect(result.success?).to be true
+      person = result.event_registration.registrant
+      submission = FormSubmission.find_by(person: person, form: scholarship_form, role: "scholarship")
+      expect(submission).to be_present
+      expect(submission.event).to eq(event)
+      expect(submission.form_answers.find_by(form_field: scholarship_field).submitted_answer)
+        .to eq("Our training budget was cut this year.")
+    end
+
+    it "does not create a scholarship submission when no scholarship was requested" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Plain", last_name: "Reg", email: "plain@example.com")
+      )
+
+      person = result.event_registration.registrant
+      expect(FormSubmission.where(person: person, role: "scholarship")).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
When a registrant filled out the separate scholarship form, their answers were validated but never saved — the application was silently dropped on submit. This makes scholarship applications actually persist.

### How did you approach the change?
Moved scholarship persistence into the `PublicRegistration` service so it runs in the same transaction as the registration, creating a `role: "scholarship"` `FormSubmission` tied to the event, and removed the dead controller method that was meant to do this but was never wired up.

### UI Testing Checklist
- [ ] Submitting a registration with the scholarship form filled in creates a scholarship submission with the answers
- [ ] A plain registration (no scholarship requested) creates no scholarship submission

### Anything else to add?
Part of splitting a combined branch into focused PRs; surfacing the saved answers to users/admins follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
