### PR TITLE
Show the scholarship application on the view-submission page

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -109,6 +109,9 @@ module Events
 
       @form_fields = visible_form_fields
       @responses = @form_submission.form_answers.index_by(&:form_field_id)
+
+      load_scholarship_submission(person)
+
       @event = @event.decorate
     end
 
@@ -156,6 +159,23 @@ module Events
 
     def registration_form
       @event.registration_form
+    end
+
+    # Surface the separate scholarship-form application (its own role: "scholarship"
+    # submission) on the view-submission page when the registrant filled it out.
+    # Only set when answers are actually on file so the view renders nothing for
+    # plain registrations.
+    def load_scholarship_submission(person)
+      scholarship_form = @event.scholarship_form
+      return unless scholarship_form
+
+      submission = scholarship_form.form_submissions.find_by(person: person, role: "scholarship")
+      return unless submission&.form_answers&.exists?
+
+      @scholarship_submission = submission
+      @scholarship_form = scholarship_form
+      @scholarship_fields = scholarship_form.form_fields.reorder(position: :asc)
+      @scholarship_responses = submission.form_answers.index_by(&:form_field_id)
     end
 
     def scholarship_mode?

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -66,4 +66,56 @@
       </div>
     </div>
   </div>
+
+  <%# ---- SCHOLARSHIP APPLICATION CARD — only when the registrant filled out the
+      separate scholarship form (its own role: "scholarship" submission). ---- %>
+  <% if @scholarship_submission %>
+    <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8">
+
+      <%# Card Header %>
+      <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+        <div class="flex items-center gap-3">
+          <i class="fa-solid fa-hand-holding-heart text-accent text-xl"></i>
+          <div class="flex-1">
+            <h2 class="text-xl font-semibold tracking-wide leading-tight">Scholarship application</h2>
+            <p class="text-sm text-blue-200"><%= @scholarship_form.display_name %></p>
+          </div>
+        </div>
+        <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+      </div>
+
+      <%# Card Body %>
+      <div class="px-6 sm:px-8 py-7">
+        <%= render "forms/header", form: @scholarship_form, event: @event %>
+
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+          <% @scholarship_fields.each do |field| %>
+            <% next if field.name.to_s.strip.casecmp?(@scholarship_form.display_name.to_s.strip) %>
+
+            <% if field.group_header? %>
+              <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
+                <h3 class="rich-label flex items-center gap-2.5 text-lg font-semibold text-gray-800">
+                  <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
+                </h3>
+              </div>
+            <% else %>
+              <% response = @scholarship_responses[field.id] %>
+              <div class="<%= field.grid_span_class %> py-2">
+                <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
+                <dd class="mt-1 text-sm text-gray-900 whitespace-pre-line">
+                  <%= display_response_text(field, response) %>
+                </dd>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="pt-4 border-t border-gray-200 mt-4">
+          <p class="text-xs text-gray-500">
+            Submitted on <%= @scholarship_submission.created_at.strftime("%B %d, %Y at %l:%M %P") %>
+          </p>
+        </div>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -501,5 +501,34 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("Why do you want to attend?")
       expect(response.body).not_to include("Reworded after submission")
     end
+
+    context "when the registrant filled out a separate scholarship form" do
+      let(:scholarship_form) { create(:form, role: "scholarship") }
+      let!(:scholarship_field) do
+        create(:form_field, form: scholarship_form, answer_type: :free_form_input_paragraph,
+               name: "Why do you need a scholarship?", required: false)
+      end
+
+      before do
+        EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+        submission = FormSubmission.create!(person: person, form: scholarship_form, event: event, role: "scholarship")
+        submission.form_answers.create!(form_field: scholarship_field,
+                                        submitted_answer: "Our agency training budget was cut.")
+      end
+
+      it "shows the scholarship application answers alongside the registration responses" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Why do you need a scholarship?")
+        expect(response.body).to include("Our agency training budget was cut.")
+      end
+    end
+
+    it "does not render a scholarship section when there is no scholarship submission" do
+      get event_public_registration_path(event, person_id: person.id)
+
+      expect(response.body).not_to include("Scholarship application")
+    end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
A registrant who filled out the separate scholarship form had no way to review those answers — the "View your form responses" page only showed the registration-form responses.

### How did you approach the change?
The `show` action now loads the registrant's `role: "scholarship"` submission, and the page renders its answers as a second "Scholarship application" card, shown only when such a submission with answers exists (so plain registrations are unchanged).

### UI Testing Checklist
- [ ] A registrant with a scholarship submission sees a "Scholarship application" card with their answers on the view-submission page
- [ ] A registrant without a scholarship submission sees no scholarship section

### Anything else to add?
Depends on the scholarship-saving PR for real data; this PR renders whatever scholarship submission exists. Part of splitting a combined branch into focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
