### PR TITLE
Show grantor name on event registration scholarship card

### DIFF
--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -40,6 +40,18 @@
           <% end %>
         </div>
 
+        <% if scholarship.grant&.funder_name.present? %>
+          <p class="text-xs text-gray-500">
+            Funded by
+            <% if scholarship.grant.donor %>
+              <%= link_to scholarship.grant.funder_name, polymorphic_path(scholarship.grant.donor),
+                          class: "font-medium text-gray-700 hover:underline" %>
+            <% else %>
+              <span class="font-medium text-gray-700"><%= scholarship.grant.funder_name %></span>
+            <% end %>
+          </p>
+        <% end %>
+
         <div class="flex flex-wrap items-center gap-1.5">
           <% if scholarship.tasks_completed? %>
             <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -106,6 +106,47 @@ RSpec.describe "Event registration edit page", type: :system do
         expect(page).to have_no_css("span", text: "Tasks completed")
       end
     end
+
+    it "links the grant's organization funder to its profile" do
+      organization = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, donor: organization)
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, grant: grant)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Scholarship") do
+        expect(page).to have_text("Funded by")
+        expect(page).to have_link("Acme Foundation", href: organization_path(organization))
+      end
+    end
+
+    it "links the grant's person funder to its profile" do
+      funder = create(:person, first_name: "Dana", last_name: "Donor")
+      grant = create(:grant, :donated_by_person, donor: funder)
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, grant: grant)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Scholarship") do
+        expect(page).to have_link(funder.full_name, href: person_path(funder))
+      end
+    end
+
+    it "omits the funder line when the scholarship has no grant" do
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Scholarship") do
+        expect(page).to have_no_text("Funded by")
+      end
+    end
   end
 
   describe "shout out box" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The scholarship card on the event registration page showed the amount and task status, but gave no indication of **which grant funded the scholarship**.
- Awarders reviewing a registration couldn't see the funder at a glance, nor jump to the funder's profile.

### How did you approach the change?

- Added a "Funded by *{grantor}*" line beneath the scholarship amount in `app/views/event_registrations/_scholarship.html.erb` (visible on the registration **edit** page, `/event_registrations/:id/edit`).
- The grantor is the scholarship's `grant` → polymorphic `donor`; the name uses the existing `Grant#funder_name` accessor (resolves a `Person#full_name` or `Organization#name`), matching the grant picker's display.
- The name links to the donor's profile via `polymorphic_path(donor)`, routing to `person_path`/`organization_path` automatically. Falls back to plain text when the grant has no donor.
- The line only renders when the scholarship has a grant with a funder.

### Testing

- Added system specs in `spec/system/event_registration_edit_spec.rb`:
  - Organization funder links to `organization_path`.
  - Person funder links to `person_path`.
  - No "Funded by" line when the scholarship has no grant.

### Anything else to add?

- Display-only change; no model, controller, or migration changes.