### PR TITLE
Spell out bulk payment attendees on the event invoice

### DIFF
--- a/app/presenters/event_invoice.rb
+++ b/app/presenters/event_invoice.rb
@@ -8,9 +8,13 @@ class EventInvoice
   ISSUER_EMAIL = "info@awbw.org".freeze
   PAYABLE_TO_NOTE = "Please make checks payable to A Window Between Worlds".freeze
 
-  LineItem = Struct.new(:date, :description, :quantity, :unit_price_cents, keyword_init: true) do
+  LineItem = Struct.new(:date, :description, :quantity, :unit_price_cents, :details, keyword_init: true) do
     def amount_cents
       unit_price_cents.to_i * quantity.to_i
+    end
+
+    def details
+      self[:details] || []
     end
   end
 
@@ -94,11 +98,25 @@ class EventInvoice
           date: submission.created_at.to_date,
           description: event&.title,
           quantity: quantity,
-          unit_price_cents: event&.cost_cents.to_i
+          unit_price_cents: event&.cost_cents.to_i,
+          details: attendee_detail_lines(submission)
         )
       ]
     )
   end
+
+  # One "First Last — email" line per attendee the payer entered on the bulk
+  # payment form, so the invoice spells out who the payment covers. Either field
+  # may be blank, so each line falls back to whichever part is present.
+  def self.attendee_detail_lines(submission)
+    submission.bulk_payment_attendees.filter_map do |attendee|
+      name = [ attendee["first_name"], attendee["last_name"] ]
+        .map { |part| part.to_s.strip.presence }.compact.join(" ")
+      email = attendee["email"].to_s.strip.presence
+      [ name.presence, email ].compact.join(" — ").presence
+    end
+  end
+  private_class_method :attendee_detail_lines
 
   def initialize(event:, number:, date:, client_id:, bill_to_name:,
                  bill_to_address_lines:, bill_to_email:, attention:, line_items:,

--- a/app/views/events/invoices/_invoice.html.erb
+++ b/app/views/events/invoices/_invoice.html.erb
@@ -67,7 +67,16 @@
       <% invoice.line_items.each do |item| %>
         <tr class="border-b border-gray-100">
           <td class="py-2 pr-3 whitespace-nowrap align-top"><%= item.date&.strftime("%m/%d/%y") %></td>
-          <td class="py-2 pr-3 align-top"><%= item.description %></td>
+          <td class="py-2 pr-3 align-top">
+            <%= item.description %>
+            <% if item.details.any? %>
+              <ul class="mt-1 text-xs text-gray-500 leading-relaxed">
+                <% item.details.each do |detail| %>
+                  <li><%= detail %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
           <td class="py-2 px-3 text-right tabular-nums align-top"><%= item.quantity %></td>
           <td class="py-2 px-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.unit_price_cents) %></td>
           <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.amount_cents) %></td>

--- a/spec/presenters/event_invoice_spec.rb
+++ b/spec/presenters/event_invoice_spec.rb
@@ -88,5 +88,32 @@ RSpec.describe EventInvoice do
       expect(item.unit_price_cents).to eq(150_000)
       expect(invoice.total_cents).to eq(1_200_000)
     end
+
+    context "with attendee names and emails submitted" do
+      before do
+        attendees = [
+          { first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" },
+          { first_name: "Grace", last_name: "Hopper", email: "grace@example.com" }
+        ]
+        add_answer("bulk_payment_attendees", attendees.to_json)
+      end
+
+      it "lists each attendee's name and email under the line item" do
+        invoice = described_class.from_bulk_payment(submission)
+
+        item = invoice.line_items.first
+        expect(item.description).to eq("AWBW 2-Day Art Facilitator Training")
+        expect(item.details).to eq([
+          "Ada Lovelace — ada@example.com",
+          "Grace Hopper — grace@example.com"
+        ])
+      end
+    end
+
+    it "leaves attendee details empty when none were submitted" do
+      invoice = described_class.from_bulk_payment(submission)
+
+      expect(invoice.line_items.first.details).to eq([])
+    end
   end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- A bulk payment covers many attendees, but the generated invoice only showed the event title and a quantity — leaving no record of *who* the payment was for.
- This itemizes the bill so AWBW and the payer can see exactly which people a bulk payment covers.

### How did you approach the change?
- `EventInvoice.from_bulk_payment` now builds one `First Last — email` detail line per attendee from the names/emails the payer already entered on the bulk payment form (`bulk_payment_attendees`), via a new `details` field on the `LineItem` struct.
- The invoice partial renders those detail lines as a small gray list beneath the line item description; quantity and totals are unchanged.
- Each line gracefully falls back when a name or email part is blank, and details stay empty when no attendees were submitted (covered by new presenter specs).

### UI Testing Checklist
- [ ] Open a bulk-payment invoice (`B-…`) for a submission with attendee names/emails and confirm each attendee shows as a `Name — email` line under the event title.
- [ ] Confirm a bulk-payment invoice with no attendee detail still renders cleanly (just the event title).
- [ ] Confirm per-registration invoices (`R-…`) are unaffected.

### Anything else to add?
- No schema or form changes — attendee names/emails were already captured; this only surfaces them on the invoice.