### PR TITLE
Limit bulk-payment allocation dropdown to unpaid registrants

### DIFF
--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -174,9 +174,10 @@
             <%= form_tag allocate_bulk_payment_event_path(@event),
                          class: "flex items-center gap-2" do %>
               <%= hidden_field_tag :payment_id, payment.id %>
+              <% unpaid_registrations = event_registrations.reject { |r| allocated_by_registration.fetch(r.id, 0) >= event_cost_cents } %>
               <div class="w-64 shrink-0">
                 <%= select_tag :event_registration_id,
-                     options_from_collection_for_select(event_registrations, :id, ->(r) { "#{r.registrant.name} — #{r.registrant.email}" }),
+                     options_from_collection_for_select(unpaid_registrations, :id, ->(r) { "#{r.registrant.name} — #{r.registrant.email}" }),
                      prompt: "Select registrant...",
                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring focus:ring-blue-200 focus:border-blue-500" %>
               </div>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1645,6 +1645,25 @@ RSpec.describe "Events", type: :request do
       expect(response.body).to include("text-gray-500 whitespace-nowrap\">Paid<")
       expect(response.body).not_to include("$0.00")
     end
+
+    it "lists only registrants who are not yet fully paid in the new-allocation dropdown" do
+      # The dropdown only renders when the payment still has an unallocated balance.
+      create(:payment, person: payer, form_submission: submission,
+             amount_cents: 5000, amount_cents_remaining: 5000)
+      unpaid = create(:person, first_name: "Owes", last_name: "Money", email: "owes.money@example.com")
+      create(:event_registration, event: event, registrant: unpaid, status: "registered")
+      paid = create(:person, first_name: "All", last_name: "Square", email: "all.square@example.com")
+      paid_registration = create(:event_registration, event: event, registrant: paid, status: "registered")
+      # Fully cover the $25 registration fee so this registrant drops off the list.
+      create(:allocation, source: create(:payment, amount_cents: 2500, amount_cents_remaining: 2500),
+             allocatable: paid_registration, amount: 2500)
+
+      get bulk_payments_event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Owes Money — owes.money@example.com")
+      expect(response.body).not_to include("All Square — all.square@example.com")
+    end
   end
 
   describe "POST /events/:id/allocate_bulk_payment" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the event bulk-payments dashboard, the "New allocation" registrant dropdown listed every active registrant, including those already fully paid.
- Admins allocating a payment had to scan past settled attendees to find who still owes; this hides registrants whose allocations already cover the event cost so only unpaid registrants remain.

### How did you approach the change?
- Filtered the dropdown options to registrants whose allocated total is below `event_cost_cents`, reusing the `allocated_by_registration` data and "paid in full" logic already in the card (no extra query).
- Filtered the dropdown collection specifically rather than the shared `event_registrations` list, since that collection also drives attendee matching elsewhere in the card.

### UI Testing Checklist
- [ ] Open an event's bulk-payments page with a payment that has remaining balance and confirm fully-paid registrants no longer appear in the "New allocation" dropdown.

### Anything else to add?
- Added a request spec (red-green verified) asserting a fully-covered registrant is excluded while an unpaid one is listed.