### PR TITLE
Show submitted payment total in bulk payment confirmation email

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -25,6 +25,9 @@ class EventMailer < ApplicationMailer
     @event = form_submission.event&.decorate
     @answers = form_submission.answers_by_identifier
     @attendees = form_submission.bulk_payment_attendees
+    # Expected total (event cost × attendee count), shown even before a payment
+    # record lands. Mirrors the ticket page; omitted when there's no event/cost.
+    @total_cents = form_submission.event && form_submission.bulk_payment_amount_cents(form_submission.event)
 
     @notification_type = "Bulk payment confirmation"
 

--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -58,6 +58,12 @@
         <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payment_method"] %></td>
       </tr>
     <% end %>
+    <% if @total_cents.to_i > 0 %>
+      <tr>
+        <td style="padding: 12px 0 6px; border-top: 1px solid #e5e7eb; color: #374151; font-size: 16px; font-weight: 700;">Total</td>
+        <td style="padding: 12px 0 6px; border-top: 1px solid #e5e7eb; text-align: right; font-size: 16px; font-weight: 700; color: #166534;"><%= dollars_from_cents(@total_cents) %></td>
+      </tr>
+    <% end %>
   </table>
 
   <% if @attendees.any? %>

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -13,6 +13,7 @@ We've received your bulk payment submission<%= " for the following event" if @ev
 <% if @answers["payer_organization"].present? %>Organization: <%= @answers["payer_organization"] %>
 <% end %><% if @answers["number_of_attendees"].present? %>Number of attendees: <%= @answers["number_of_attendees"] %>
 <% end %><% if @answers["payment_method"].present? %>Payment method: <%= @answers["payment_method"] %>
+<% end %><% if @total_cents.to_i > 0 %>Total: <%= dollars_from_cents(@total_cents) %>
 <% end %>
 <% if @attendees.any? %>Attendees:
 <% @attendees.each do |attendee| %>- <%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %><%= " <#{attendee['email']}>" if attendee["email"].present? %>

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe EventMailer, type: :mailer do
       expect(body).to include("4")
       expect(body).to include("Check")
     end
+
+    it "includes the submitted payment total in the body" do
+      # Event cost (1099¢) × 4 attendees = $43.96
+      expect(mail.body.encoded).to include("$43.96")
+    end
   end
 
   describe "#event_registration_reminder" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The bulk payment confirmation email showed the per-event cost and attendee count separately, but never the total owed.
- Surfacing the computed total saves payers the math and matches the figure already shown on the bulk payment ticket page.

### How did you approach the change?
- `EventMailer#bulk_payment_confirmation` now sets `@total_cents` via `FormSubmission#bulk_payment_amount_cents` (event cost × attendee count), guarded for event-less submissions.
- Both the HTML and text templates render a **Total** row (using `dollars_from_cents`) only when the total is positive, so free or event-less submissions don't show a `$0` line.
- Added a mailer spec asserting the total appears in the body.

### UI Testing Checklist
- [ ] Open the EventMailer preview for `bulk_payment_confirmation` and confirm the **Total** row renders in both HTML and plain-text views.
- [ ] Confirm whole-dollar totals render without trailing `.00` and amounts with cents show two decimals.

### Anything else to add?
The total reflects the expected amount (event cost × attendee count), consistent with the ticket page, so it displays even before a payment record lands.