### PR TITLE
Count Unicode whitespace in form field min-words check

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -205,8 +205,13 @@ class FormField < ApplicationRecord
     field_identifier.in?(EMAIL_FIELD_IDENTIFIERS)
   end
 
+  # Counts whitespace-separated tokens. Uses the Unicode-aware [[:space:]] class
+  # rather than \S, which is ASCII-only — pasted answers (Word, Google Docs, web
+  # pages) routinely carry non-breaking (U+00A0) and other Unicode spaces that \S
+  # treats as word characters, collapsing a real answer into one "word" and
+  # wrongly tripping the minimum.
   def word_count(value)
-    value.to_s.scan(/\S+/).size
+    value.to_s.scan(/[^[:space:]]+/).size
   end
 
   # Returns a validation error string when a submitted value falls short of the

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe FormField do
       expect(field.min_words_error("  one\ntwo   three  ")).to be_nil
     end
 
+    it "treats non-breaking and other Unicode spaces as word separators" do
+      field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 5)
+      # These spaces sneak in when answers are pasted from Word, Google Docs, or
+      # a web page. Ruby's \S is ASCII-only, so with every separator a Unicode
+      # space a genuine five-word answer counts as one and is wrongly rejected.
+      # Written as \u escapes since the characters are invisible in source.
+      pasted = "this\u00A0answer\u202Fhas\u3000plenty words"
+      expect(field.min_words_error(pasted)).to be_nil
+    end
+
     it "returns an error when the value has too few words" do
       field = build(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 5)
       expect(field.min_words_error("only three words")).to eq("must be at least 5 words")


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Public registrants were getting **"must be at least N words"** errors on free-form fields *even when they had typed enough words*.
- The reported tell — *"it errors once, then goes through the second time"* — was the key clue: the validator is stateless, so identical text can't fail then pass. The text was actually *changing* between attempts.
- Root cause: `FormField#word_count` used `/\S+/`. **Ruby's `\S` is ASCII-only**, so Unicode spaces that ride along when text is pasted (non-breaking `U+00A0`, narrow no-break `U+202F`, ideographic `U+3000` — common from Word, Google Docs, and web pages) were counted as *word characters*. A real five-word pasted answer collapsed into **one** "word" and was wrongly rejected.
- Why retyping "fixed" it: editing in the plain `<textarea>` replaces the stray Unicode spaces with regular ASCII spaces, so the count came out right on the second try.

### How did you approach the change?

- Switched the word counter to the **Unicode-aware POSIX class** `[[:space:]]`: `value.to_s.scan(/[^[:space:]]+/).size`. Word boundaries now match what users actually see.
- TDD: added a failing model spec that feeds a five-word answer separated by `U+00A0`, `U+202F`, and `U+3000` and asserts no error, then made it pass. ASCII behavior is unchanged.

### UI Testing Checklist

- [ ] On a public registration form with a field that has a minimum word count, paste an answer copied from Google Docs/Word that meets the minimum → submits without a word-count error.

### Anything else to add?

- No migration or schema change; pure validation fix.
- Verified the existing `min_words` model, validator-service, and public-registration request specs all still pass (147 examples, 0 failures).