### PR TITLE
WAIT: Transfer a registrant to another event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~78 files |
-| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~28 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~29 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 15 concerns |
 
@@ -197,6 +197,7 @@ end
 
 - `EventRegistrationServices::ProcessConfirmation` — Registration confirmation flow
 - `EventRegistrationServices::PublicRegistration` — Public registration handling
+- `EventRegistrationServices::Transfer` — Moves a registrant to another event: creates a new registration linked via `transferred_from` and marks the original "transferred"
 - `ReminderRecipientFilter` — Decides which event registrations stay checked on the bulk reminder page given the admin's filters (matches in memory, returns matching ids)
 - `MagicTicketCallouts` — Code-defined ("magic") ticket callout cards (payment, certificate, scholarship, CE hours, art supplies, forms, handouts, portal, videoconference, FAQ), each with its own visibility rule; rendered through the same `_callout_card` partial as admin-configured `RegistrationTicketCallout`s. Their public show pages live under `app/views/events/callouts/` and are served by `Events::CalloutsController` (slug-authorized, no login)
 

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -270,6 +270,36 @@ class EventRegistrationsController < ApplicationController
     redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} unlinked from this registration."
   end
 
+  def transfer
+    @event_registration = EventRegistration.includes(:event, :registrant).find(params[:id])
+    authorize! @event_registration, to: :transfer?
+    # Pick a published event the registrant isn't already on (and not the current
+    # one) — the uniqueness index forbids registering the same person twice.
+    registered_event_ids = @event_registration.registrant.event_registrations.pluck(:event_id)
+    @events = Event.where(published: true)
+                   .where.not(id: registered_event_ids)
+                   .order(start_date: :desc)
+  end
+
+  def create_transfer
+    @event_registration = EventRegistration.includes(:event, :registrant).find(params[:id])
+    authorize! @event_registration, to: :create_transfer?
+
+    result = EventRegistrationServices::Transfer.call(
+      source: @event_registration,
+      target_event_id: params[:target_event_id],
+      current_user: current_user
+    )
+
+    if result.success?
+      redirect_to edit_event_registration_path(result.registration, return_to: params[:return_to].presence),
+                  notice: "#{@event_registration.registrant.full_name} transferred to #{result.registration.event.title}."
+    else
+      redirect_to transfer_event_registration_path(@event_registration, return_to: params[:return_to].presence),
+                  alert: result.error
+    end
+  end
+
   def destroy
     authorize! @event_registration
     event = @event_registration.event

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -3,6 +3,13 @@ class EventRegistration < ApplicationRecord
 
   belongs_to :registrant, class_name: "Person"
   belongs_to :event
+  # A registration created by transferring this registrant from another event.
+  # `transferred_from` is the original (where the payment still lives);
+  # `transferred_to` is the new registration created on the destination event.
+  belongs_to :transferred_from, class_name: "EventRegistration", optional: true,
+    inverse_of: :transferred_to
+  has_one :transferred_to, class_name: "EventRegistration",
+    foreign_key: :transferred_from_id, dependent: :nullify, inverse_of: :transferred_from
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :event_registration_organizations, dependent: :destroy
   has_many :notifications, as: :noticeable, dependent: :destroy
@@ -23,7 +30,11 @@ class EventRegistration < ApplicationRecord
   after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance ].freeze
-  INACTIVE_STATUSES = %w[ cancelled no_show ].freeze
+  # "transferred" marks a registration whose registrant was moved to another
+  # event via the Transfer action. It's inactive so transferred registrants drop
+  # out of active rosters; the matching new registration links back via
+  # `transferred_from`.
+  INACTIVE_STATUSES = %w[ cancelled no_show transferred ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
 
   # Manual onboarding checklist steps shown on the event's Onboarding tab. Each is
@@ -138,11 +149,13 @@ class EventRegistration < ApplicationRecord
       ), 0)
     SQL
   }
+  scope :transferred, -> { where.not(transferred_from_id: nil) }
   scope :payment_status, ->(value) {
     case value
     when "paid" then paid_in_full
     when "unpaid" then not_paid_in_full
     when "intends_to_pay" then where(intends_to_pay: true)
+    when "previous_registration" then transferred
     else all
     end
   }
@@ -215,12 +228,20 @@ class EventRegistration < ApplicationRecord
   # surfaces (rosters, CSV exports, dashboard metrics) must keep using `paid?` /
   # `paid_in_full?` so they still reflect the real balance owed.
   def payment_access_granted?
-    paid? || intends_to_pay?
+    paid? || intends_to_pay? || transferred?
+  end
+
+  # True when this registration was created by transferring the registrant from
+  # an earlier event, so its fee is considered covered by that prior payment.
+  def transferred?
+    transferred_from_id.present?
   end
 
   # Human-readable payment status for rosters and CSV exports. Assumes the event
-  # has a cost — callers show nothing for free events.
+  # has a cost — callers show nothing for free events. A transferred registration
+  # reports "Previous registration" since the fee was paid on the original event.
   def payment_status_label
+    return "Previous registration" if transferred?
     return "Paid" if paid_in_full?
     return "Intends to pay" if intends_to_pay?
     "Due"
@@ -335,6 +356,7 @@ class EventRegistration < ApplicationRecord
     when "incomplete_attendance" then "Incomplete attendance"
     when "cancelled" then "Cancelled"
     when "no_show" then "No show"
+    when "transferred" then "Transferred"
     else status.humanize
     end
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -149,13 +149,13 @@ class EventRegistration < ApplicationRecord
       ), 0)
     SQL
   }
-  scope :transferred, -> { where.not(transferred_from_id: nil) }
+  scope :paid_via_previous_registration, -> { where.not(transferred_from_id: nil) }
   scope :payment_status, ->(value) {
     case value
     when "paid" then paid_in_full
     when "unpaid" then not_paid_in_full
     when "intends_to_pay" then where(intends_to_pay: true)
-    when "previous_registration" then transferred
+    when "previous_registration" then paid_via_previous_registration
     else all
     end
   }
@@ -228,20 +228,30 @@ class EventRegistration < ApplicationRecord
   # surfaces (rosters, CSV exports, dashboard metrics) must keep using `paid?` /
   # `paid_in_full?` so they still reflect the real balance owed.
   def payment_access_granted?
-    paid? || intends_to_pay? || transferred?
+    # A registrant transferred OUT to another event isn't attending this one, so
+    # they get no access here even though the original payment still lives on it.
+    return false if transferred_out?
+    paid? || intends_to_pay?
+  end
+
+  # True when this registration's registrant was transferred to a different
+  # event (its inactive attendance status). It's the event they're NOT attending.
+  def transferred_out?
+    status == "transferred"
   end
 
   # True when this registration was created by transferring the registrant from
-  # an earlier event, so its fee is considered covered by that prior payment.
-  def transferred?
+  # an earlier event, so its fee is covered by that prior payment. This is the
+  # event they ARE attending; its payment status reads "Previous reg".
+  def paid_via_previous_registration?
     transferred_from_id.present?
   end
 
   # Human-readable payment status for rosters and CSV exports. Assumes the event
-  # has a cost — callers show nothing for free events. A transferred registration
-  # reports "Previous registration" since the fee was paid on the original event.
+  # has a cost — callers show nothing for free events. A registration created by
+  # a transfer reports "Previous reg" since the fee was paid on the original event.
   def payment_status_label
-    return "Previous registration" if transferred?
+    return "Previous reg" if paid_via_previous_registration?
     return "Paid" if paid_in_full?
     return "Intends to pay" if intends_to_pay?
     "Due"

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -18,6 +18,8 @@ class EventRegistrationPolicy < ApplicationPolicy
   # Editing the onboarding matrix is an admin management action; event owners
   # (the event's creator) manage their own events' onboarding too.
   def update_onboarding? = admin? || event_owner?
+  def transfer? = admin?
+  def create_transfer? = admin?
 
 
   relation_scope do |relation|

--- a/app/services/event_registration_services/transfer.rb
+++ b/app/services/event_registration_services/transfer.rb
@@ -1,0 +1,51 @@
+module EventRegistrationServices
+  # Moves a registrant from one event to another by creating a new registration
+  # on the destination event linked back to the original, and marking the
+  # original as "transferred". The payment/allocations stay on the original; the
+  # new registration shows a "Previous registration" payment status (fee covered
+  # by the prior payment), so nothing is owed on the destination event.
+  class Transfer
+    Result = Struct.new(:registration, :error, keyword_init: true) do
+      def success?
+        error.blank?
+      end
+    end
+
+    def self.call(source:, target_event_id:, current_user: nil)
+      new(source:, target_event_id:, current_user:).call
+    end
+
+    def initialize(source:, target_event_id:, current_user: nil)
+      @source = source
+      @target_event_id = target_event_id
+      @current_user = current_user
+    end
+
+    def call
+      target_event = Event.find_by(id: @target_event_id)
+      return Result.new(error: "Choose an event to transfer to.") if target_event.nil?
+      return Result.new(error: "Choose a different event than the current one.") if target_event.id == @source.event_id
+
+      if EventRegistration.exists?(registrant_id: @source.registrant_id, event_id: target_event.id)
+        return Result.new(error: "#{@source.registrant.full_name} is already registered for #{target_event.title}.")
+      end
+
+      new_registration = nil
+      ApplicationRecord.transaction do
+        new_registration = EventRegistration.create!(
+          registrant: @source.registrant,
+          event: target_event,
+          status: "registered",
+          transferred_from: @source
+        )
+        @source.update!(status: "transferred")
+      end
+
+      Result.new(registration: new_registration)
+    rescue ActiveRecord::RecordInvalid => e
+      Result.new(error: e.record.errors.full_messages.to_sentence)
+    rescue ActiveRecord::RecordNotUnique
+      Result.new(error: "#{@source.registrant.full_name} is already registered for that event.")
+    end
+  end
+end

--- a/app/services/event_registration_services/transfer.rb
+++ b/app/services/event_registration_services/transfer.rb
@@ -2,7 +2,7 @@ module EventRegistrationServices
   # Moves a registrant from one event to another by creating a new registration
   # on the destination event linked back to the original, and marking the
   # original as "transferred". The payment/allocations stay on the original; the
-  # new registration shows a "Previous registration" payment status (fee covered
+  # new registration shows a "Previous reg" payment status (fee covered
   # by the prior payment), so nothing is owed on the destination event.
   class Transfer
     Result = Struct.new(:registration, :error, keyword_init: true) do

--- a/app/views/event_registrations/_attendance_status_badge.html.erb
+++ b/app/views/event_registrations/_attendance_status_badge.html.erb
@@ -4,14 +4,16 @@
     "attended"                => "bg-green-50 text-green-700 border-green-200",
     "incomplete_attendance"   => "bg-amber-50 text-amber-700 border-amber-200",
     "cancelled"               => "bg-gray-50 text-gray-500 border-gray-200",
-    "no_show"                 => "bg-red-50 text-red-700 border-red-200"
+    "no_show"                 => "bg-red-50 text-red-700 border-red-200",
+    "transferred"             => "bg-indigo-50 text-indigo-700 border-indigo-200"
   }
   status_icons = {
     "registered"              => "fa-clipboard-list",
     "attended"                => "fa-circle-check",
     "incomplete_attendance"   => "fa-clock",
     "cancelled"               => "fa-ban",
-    "no_show"                 => "fa-circle-xmark"
+    "no_show"                 => "fa-circle-xmark",
+    "transferred"             => "fa-right-left"
   }
   current_style = status_styles[registration.status] || "bg-gray-50 text-gray-500 border-gray-200"
   current_icon  = status_icons[registration.status] || "fa-question"

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -17,14 +17,16 @@
            "attended"              => "text-green-600",
            "incomplete_attendance" => "text-amber-600",
            "cancelled"             => "text-gray-500",
-           "no_show"               => "text-red-600"
+           "no_show"               => "text-red-600",
+           "transferred"           => "text-indigo-600"
          } %>
       <% status_icons = {
            "registered"            => "fa-clipboard-list",
            "attended"              => "fa-circle-check",
            "incomplete_attendance" => "fa-clock",
            "cancelled"             => "fa-ban",
-           "no_show"               => "fa-circle-xmark"
+           "no_show"               => "fa-circle-xmark",
+           "transferred"           => "fa-right-left"
          } %>
       <% current_icon_color = status_icon_colors[f.object.status] || "text-gray-500" %>
       <% current_icon = status_icons[f.object.status] || "fa-question" %>
@@ -438,6 +440,14 @@
                     data: { turbo: true, turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } do %>
           <i class="fa-solid fa-trash-can"></i>
           Delete
+        <% end %>
+      <% end %>
+
+      <% if f.object.persisted? && allowed_to?(:transfer?, f.object) %>
+        <%= link_to transfer_event_registration_path(f.object, return_to: params[:return_to].presence),
+                    class: "btn btn-secondary-outline" do %>
+          <i class="fa-solid fa-right-left"></i>
+          Transfer
         <% end %>
       <% end %>
 

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -21,7 +21,7 @@
   </div>
 
   <div class="p-4">
-    <% if event_registration.transferred? %>
+    <% if event_registration.paid_via_previous_registration? %>
       <% source = event_registration.transferred_from %>
       <div class="mb-4 flex items-start gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs text-indigo-700">
         <i class="fa-solid fa-right-left mt-0.5"></i>
@@ -45,7 +45,7 @@
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount allocated</dt>
           <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(paid_cents) %></dd>
         </div>
-        <% amount_due = due_cents > 0 && !event_registration.transferred? %>
+        <% amount_due = due_cents > 0 && !event_registration.paid_via_previous_registration? %>
         <div class="rounded-lg border px-4 py-3 <%= amount_due ? "border-amber-300 bg-amber-50" : "border-gray-300 bg-gray-50" %>">
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount due</dt>
           <dd class="mt-1 flex items-center gap-1.5 text-sm font-semibold tabular-nums <%= amount_due ? "text-amber-700" : "text-gray-500" %>">

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -21,6 +21,20 @@
   </div>
 
   <div class="p-4">
+    <% if event_registration.transferred? %>
+      <% source = event_registration.transferred_from %>
+      <div class="mb-4 flex items-start gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs text-indigo-700">
+        <i class="fa-solid fa-right-left mt-0.5"></i>
+        <span>
+          Covered by a previous registration — nothing owed here. The payment lives on
+          <% if source %>
+            <%= link_to source.event.title, edit_event_registration_path(source), class: "font-semibold underline", data: { turbo_frame: "_top" } %>.
+          <% else %>
+            the original event.
+          <% end %>
+        </span>
+      </div>
+    <% end %>
     <% if cost_cents > 0 %>
       <dl class="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div class="rounded-lg border border-gray-300 bg-gray-50 px-4 py-3">
@@ -31,7 +45,7 @@
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount allocated</dt>
           <dd class="mt-1 text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(paid_cents) %></dd>
         </div>
-        <% amount_due = due_cents > 0 %>
+        <% amount_due = due_cents > 0 && !event_registration.transferred? %>
         <div class="rounded-lg border px-4 py-3 <%= amount_due ? "border-amber-300 bg-amber-50" : "border-gray-300 bg-gray-50" %>">
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount due</dt>
           <dd class="mt-1 flex items-center gap-1.5 text-sm font-semibold tabular-nums <%= amount_due ? "text-amber-700" : "text-gray-500" %>">

--- a/app/views/event_registrations/transfer.html.erb
+++ b/app/views/event_registrations/transfer.html.erb
@@ -1,0 +1,56 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+  <%# Back to the registration we're transferring from. %>
+  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+    <%= link_to edit_event_registration_path(@event_registration, return_to: params[:return_to].presence), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Edit registration
+    <% end %>
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+
+  <%= render "shared/event_page_header",
+             title: "Transfer registrant",
+             icon: "fa-solid fa-right-left",
+             color: :event_registrations,
+             event: @event_registration.event,
+             event_url: dashboard_event_path(@event_registration.event) %>
+
+  <div class="mt-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+    <p class="text-sm text-gray-600">
+      Move <span class="font-semibold text-gray-900"><%= @event_registration.registrant.full_name %></span>
+      to another event. Their current registration on
+      <span class="font-semibold text-gray-900"><%= @event_registration.event.title %></span>
+      will be marked <span class="font-medium">Transferred</span> (its payment history stays put), and a new
+      registration is created on the event you pick — shown as paid via this
+      <span class="font-medium">previous registration</span>, so nothing is owed there.
+    </p>
+
+    <% if @events.any? %>
+      <%= form_with url: create_transfer_event_registration_path(@event_registration), method: :post, data: { turbo: false }, class: "mt-5 space-y-4" do |f| %>
+        <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
+
+        <div>
+          <label for="target_event_id" class="mb-1 block text-sm font-medium text-gray-700">Transfer to event</label>
+          <%= select_tag :target_event_id,
+                options_from_collection_for_select(@events, :id, :time_title),
+                include_blank: "Select an event…",
+                required: true,
+                id: "target_event_id",
+                class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+        </div>
+
+        <div class="flex items-center gap-3 border-t border-gray-200 pt-4">
+          <div class="ml-auto flex items-center gap-3">
+            <%= link_to "Cancel", edit_event_registration_path(@event_registration, return_to: params[:return_to].presence), class: "btn btn-secondary-outline" %>
+            <%= f.submit "Transfer registrant", class: "btn btn-primary" %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+        No other published events are available to transfer this registrant to.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -198,10 +198,13 @@
                   <% paid_cents = registration.allocations_sum %>
                   <% due_cents = @event.cost_cents - paid_cents %>
                   <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= due_cents %>">
-                    <% is_paid = registration.paid_in_full? %>
-                    <% is_discounted = !is_paid && registration.discounted? %>
-                    <% is_partial = !is_discounted && registration.partially_paid? %>
-                    <% badge_classes = if is_paid
+                    <% is_transferred = registration.transferred? %>
+                    <% is_paid = !is_transferred && registration.paid_in_full? %>
+                    <% is_discounted = !is_transferred && !is_paid && registration.discounted? %>
+                    <% is_partial = !is_transferred && !is_discounted && registration.partially_paid? %>
+                    <% badge_classes = if is_transferred
+                         "bg-indigo-50 text-indigo-700 border-indigo-200"
+                       elsif is_paid
                          "bg-green-50 text-green-700 border-green-200"
                        elsif is_discounted
                          "bg-purple-50 text-purple-700 border-purple-200"
@@ -210,7 +213,9 @@
                        else
                          "bg-amber-50 text-amber-700 border-amber-200"
                        end %>
-                    <% badge_icon = if is_paid
+                    <% badge_icon = if is_transferred
+                         "fa-right-left"
+                       elsif is_paid
                          "fa-circle-check"
                        elsif is_discounted
                          "fa-tag"
@@ -232,7 +237,9 @@
 
                     <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), title: badge_title, class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} transition hover:opacity-80 hover:shadow-sm", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
-                      <% if is_paid %>
+                      <% if is_transferred %>
+                        <span>Previous registration</span>
+                      <% elsif is_paid %>
                         <span>Paid</span>
                       <% else %>
                         <span><%= dollars_from_cents(due_cents) %> due</span>
@@ -240,7 +247,7 @@
                       <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                     <% end %>
 
-                    <% if !is_paid && registration.intends_to_pay? %>
+                    <% if !is_transferred && !is_paid && registration.intends_to_pay? %>
                       <div class="mt-1 inline-flex items-center gap-1 whitespace-nowrap text-[0.65rem] font-medium text-blue-600">
                         <i class="fa-solid fa-hand-holding-dollar"></i>
                         <span>Intends to pay</span>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -198,7 +198,7 @@
                   <% paid_cents = registration.allocations_sum %>
                   <% due_cents = @event.cost_cents - paid_cents %>
                   <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= due_cents %>">
-                    <% is_transferred = registration.transferred? %>
+                    <% is_transferred = registration.paid_via_previous_registration? %>
                     <% is_paid = !is_transferred && registration.paid_in_full? %>
                     <% is_discounted = !is_transferred && !is_paid && registration.discounted? %>
                     <% is_partial = !is_transferred && !is_discounted && registration.partially_paid? %>
@@ -238,7 +238,7 @@
                     <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), title: badge_title, class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} transition hover:opacity-80 hover:shadow-sm", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
                       <% if is_transferred %>
-                        <span>Previous registration</span>
+                        <span>Previous reg</span>
                       <% elsif is_paid %>
                         <span>Paid</span>
                       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,8 @@ Rails.application.routes.draw do
       post :create_organization
       delete :unlink_organization
       patch :update_onboarding
+      get :transfer
+      post :create_transfer
     end
     resources :comments, only: [ :index, :create, :update ]
   end

--- a/db/migrate/20260619045051_add_transferred_from_to_event_registrations.rb
+++ b/db/migrate/20260619045051_add_transferred_from_to_event_registrations.rb
@@ -1,0 +1,18 @@
+class AddTransferredFromToEventRegistrations < ActiveRecord::Migration[8.1]
+  # Links a registration created by a "Transfer" to the original it was moved
+  # from, so the new event can show "Previous registration" and the old one can
+  # link forward to where the registrant went.
+  def up
+    add_reference :event_registrations, :transferred_from, null: true, index: true
+    unless foreign_key_exists?(:event_registrations, column: :transferred_from_id)
+      add_foreign_key :event_registrations, :event_registrations, column: :transferred_from_id
+    end
+  end
+
+  def down
+    if foreign_key_exists?(:event_registrations, column: :transferred_from_id)
+      remove_foreign_key :event_registrations, column: :transferred_from_id
+    end
+    remove_reference :event_registrations, :transferred_from, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -482,6 +482,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.boolean "shoutout", default: false, null: false
     t.string "slug"
     t.string "status", default: "registered", null: false
+    t.bigint "transferred_from_id"
     t.datetime "updated_at", null: false
     t.boolean "w9_requested", default: false, null: false
     t.index ["checkout_session_id"], name: "index_event_registrations_on_checkout_session_id"
@@ -490,6 +491,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.index ["registrant_id", "event_id"], name: "index_event_registrations_on_registrant_id_and_event_id", unique: true
     t.index ["registrant_id"], name: "index_event_registrations_on_registrant_id"
     t.index ["slug"], name: "index_event_registrations_on_slug", unique: true
+    t.index ["transferred_from_id"], name: "index_event_registrations_on_transferred_from_id"
   end
 
   create_table "event_staffs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1653,6 +1655,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
   add_foreign_key "event_registration_checklist_completions", "users", column: "completed_by_id"
   add_foreign_key "event_registration_organizations", "event_registrations"
   add_foreign_key "event_registration_organizations", "organizations"
+  add_foreign_key "event_registrations", "event_registrations", column: "transferred_from_id"
   add_foreign_key "event_registrations", "events"
   add_foreign_key "event_registrations", "people", column: "registrant_id"
   add_foreign_key "event_staffs", "events"

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -346,6 +346,54 @@ RSpec.describe EventRegistration, type: :model do
       create(:event_registration, event: event, registrant: create(:person))
       expect(EventRegistration.payment_status("intends_to_pay")).to contain_exactly(intends)
     end
+
+    it "filters to transferred registrations for 'previous_registration'" do
+      source = create(:event_registration, event: event, registrant: user.person)
+      transferred = create(:event_registration, event: create(:event), registrant: create(:person), transferred_from: source)
+      create(:event_registration, event: event, registrant: create(:person))
+      expect(EventRegistration.payment_status("previous_registration")).to contain_exactly(transferred)
+    end
+  end
+
+  describe "transfer" do
+    let(:source) { create(:event_registration) }
+    let(:transferred) { create(:event_registration, transferred_from: source) }
+
+    it "treats 'transferred' as an inactive status" do
+      expect(EventRegistration::INACTIVE_STATUSES).to include("transferred")
+      expect(EventRegistration::ACTIVE_STATUSES).not_to include("transferred")
+    end
+
+    it "labels the 'transferred' status" do
+      expect(create(:event_registration, status: "transferred").attendance_status_label).to eq("Transferred")
+    end
+
+    it "links transferred_to back from the source" do
+      expect(transferred.transferred_from).to eq(source)
+      expect(source.reload.transferred_to).to eq(transferred)
+    end
+
+    it "knows it was transferred" do
+      expect(transferred).to be_transferred
+      expect(source).not_to be_transferred
+    end
+
+    describe "#payment_status_label" do
+      it "is 'Previous registration' for a transferred registration" do
+        expect(transferred.payment_status_label).to eq("Previous registration")
+      end
+
+      it "falls back to the usual labels when not transferred" do
+        expect(source.payment_status_label).to eq("Due").or eq("Paid")
+      end
+    end
+
+    describe "#payment_access_granted?" do
+      it "is true for a transferred registration even with no allocations" do
+        reg = create(:event_registration, event: create(:event, cost_cents: 1099), transferred_from: source)
+        expect(reg.payment_access_granted?).to be true
+      end
+    end
   end
 
   describe "#paid_in_full?" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -373,25 +373,38 @@ RSpec.describe EventRegistration, type: :model do
       expect(source.reload.transferred_to).to eq(transferred)
     end
 
-    it "knows it was transferred" do
-      expect(transferred).to be_transferred
-      expect(source).not_to be_transferred
+    it "distinguishes the event being left from the one being attended" do
+      # The new registration is "paid via previous registration" (attending);
+      # the source becomes "transferred out" (not attending).
+      source.update!(status: "transferred")
+      expect(transferred).to be_paid_via_previous_registration
+      expect(transferred).not_to be_transferred_out
+      expect(source).to be_transferred_out
+      expect(source).not_to be_paid_via_previous_registration
     end
 
     describe "#payment_status_label" do
-      it "is 'Previous registration' for a transferred registration" do
-        expect(transferred.payment_status_label).to eq("Previous registration")
+      it "is 'Previous reg' for a registration created by a transfer" do
+        expect(transferred.payment_status_label).to eq("Previous reg")
       end
 
-      it "falls back to the usual labels when not transferred" do
+      it "falls back to the usual labels otherwise" do
         expect(source.payment_status_label).to eq("Due").or eq("Paid")
       end
     end
 
     describe "#payment_access_granted?" do
-      it "is true for a transferred registration even with no allocations" do
+      it "is denied for a registration whose registrant was transferred out, even when paid" do
+        event = create(:event, cost_cents: 1099)
+        reg = create(:event_registration, event: event, status: "transferred")
+        payment = create(:payment, person: reg.registrant, amount_cents: 1099, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: reg, amount: 1099)
+        expect(reg.payment_access_granted?).to be false
+      end
+
+      it "is not granted by the transfer alone on the attended event (no allocations)" do
         reg = create(:event_registration, event: create(:event, cost_cents: 1099), transferred_from: source)
-        expect(reg.payment_access_granted?).to be true
+        expect(reg.payment_access_granted?).to be false
       end
     end
   end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -330,6 +330,44 @@ RSpec.describe "EventRegistrations", type: :request do
       end
     end
 
+    describe "GET /event_registrations/:id/transfer" do
+      it "renders the transfer form excluding the current and already-registered events" do
+        available = create(:event, title: "Available destination", published: true)
+        already_on = create(:event, title: "Already registered", published: true)
+        create(:event_registration, event: already_on, registrant: regular_user.person)
+
+        get transfer_event_registration_path(existing_registration)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(available.title)
+        expect(response.body).not_to include(already_on.title)
+      end
+    end
+
+    describe "POST /event_registrations/:id/create_transfer" do
+      let!(:target) { create(:event, title: "Destination event", published: true) }
+
+      it "transfers the registrant to the chosen event" do
+        expect {
+          post create_transfer_event_registration_path(existing_registration), params: { target_event_id: target.id }
+        }.to change(EventRegistration, :count).by(1)
+
+        existing_registration.reload
+        expect(existing_registration.status).to eq("transferred")
+        new_registration = existing_registration.transferred_to
+        expect(new_registration.event).to eq(target)
+        expect(response).to redirect_to(edit_event_registration_path(new_registration))
+      end
+
+      it "redirects back with an alert when the target is invalid" do
+        post create_transfer_event_registration_path(existing_registration), params: { target_event_id: existing_registration.event_id }
+
+        expect(response).to redirect_to(transfer_event_registration_path(existing_registration))
+        expect(flash[:alert]).to match(/different event/i)
+        expect(existing_registration.reload.status).to eq("registered")
+      end
+    end
+
     describe "organization linking" do
       let(:organization) { create(:organization, name: "Helping Hands") }
 
@@ -843,6 +881,16 @@ RSpec.describe "EventRegistrations", type: :request do
               params: { event_registration: { event_id: new_event.id } }
 
         expect(existing_registration.reload.event_id).to eq(original_event_id)
+      end
+    end
+
+    describe "POST /event_registrations/:id/create_transfer" do
+      it "is not authorized for a regular user" do
+        target = create(:event, published: true)
+        expect {
+          post create_transfer_event_registration_path(existing_registration), params: { target_event_id: target.id }
+        }.not_to change(EventRegistration, :count)
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/spec/services/event_registration_services/transfer_spec.rb
+++ b/spec/services/event_registration_services/transfer_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe EventRegistrationServices::Transfer do
+  let(:registrant) { create(:person) }
+  let(:source_event) { create(:event, title: "Spring workshop") }
+  let(:target_event) { create(:event, title: "Summer workshop") }
+  let(:source) { create(:event_registration, event: source_event, registrant: registrant, status: "registered") }
+
+  describe ".call" do
+    it "creates a new registration on the target event linked to the source" do
+      result = described_class.call(source: source, target_event_id: target_event.id)
+
+      expect(result).to be_success
+      new_registration = result.registration
+      expect(new_registration.event).to eq(target_event)
+      expect(new_registration.registrant).to eq(registrant)
+      expect(new_registration.status).to eq("registered")
+      expect(new_registration.transferred_from).to eq(source)
+    end
+
+    it "marks the source registration as transferred" do
+      described_class.call(source: source, target_event_id: target_event.id)
+      expect(source.reload.status).to eq("transferred")
+    end
+
+    it "leaves the source's payment/allocations untouched" do
+      payment = create(:payment, person: registrant, amount_cents: 1000, amount_cents_remaining: nil)
+      allocation = create(:allocation, source: payment, allocatable: source, amount: 1000)
+
+      described_class.call(source: source, target_event_id: target_event.id)
+
+      expect(allocation.reload.allocatable).to eq(source)
+      expect(source.reload.allocations_sum).to eq(1000)
+    end
+
+    it "fails when no target event is chosen" do
+      result = described_class.call(source: source, target_event_id: nil)
+      expect(result).not_to be_success
+      expect(result.error).to match(/choose an event/i)
+    end
+
+    it "fails when the target is the same as the source event" do
+      result = described_class.call(source: source, target_event_id: source_event.id)
+      expect(result).not_to be_success
+      expect(result.error).to match(/different event/i)
+    end
+
+    it "fails when the registrant is already registered for the target event" do
+      create(:event_registration, event: target_event, registrant: registrant)
+      result = described_class.call(source: source, target_event_id: target_event.id)
+      expect(result).not_to be_success
+      expect(result.error).to match(/already registered/i)
+    end
+
+    it "does not mark the source transferred when creation fails" do
+      create(:event_registration, event: target_event, registrant: registrant)
+      described_class.call(source: source, target_event_id: target_event.id)
+      expect(source.reload.status).to eq("registered")
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     # ─── admin-only confirm/interstitial ───
     "app/views/event_registrations/confirm.html.erb"     => "admin-only bg-blue-100",
     "app/views/event_registrations/link_organization.html.erb" => "admin-only bg-blue-100",
+    "app/views/event_registrations/transfer.html.erb"    => "admin-only bg-blue-100",
     "app/views/users/confirm_email_change.html.erb"      => "admin-only bg-blue-100",
     "app/views/users/confirm_email_manual.html.erb"      => "admin-only bg-blue-100"
   }.freeze


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins sometimes need to move a registrant from one event to another (e.g. a reschedule) **without making them pay again**.
- Until now there was no supported way to do this — the only options were deleting the registration or manually re-registering, both of which lose history and misrepresent the payment.

### How did you approach the change?

- **New "Transfer" action** on the registration edit page. The admin picks a destination event (the picker excludes the current event and any the registrant is already on, since the unique `[registrant, event]` index forbids duplicates).
- Transferring **creates a new registration** on the destination, linked back to the original via a new `transferred_from_id` FK, and **marks the original "Transferred"** — a new *inactive* attendance status, so transferred registrants drop out of active rosters. The original keeps its payment history intact.
- **New "Previous reg" payment status** on the destination registration: because the fee was already collected on the original event, the new one shows nothing owed.
  - Deliberately **not** modeled as a 100% `Discount` — a discount means revenue was *forgiven*, which would corrupt discount/revenue reporting and can't record *why* it's $0. The real payment stays where it was paid; the destination only *displays* that it's covered (`payment_status_label`, the roster badge, and a banner on the payment card link back to the source event).
- **Two concepts kept distinct** (one predicate each, so they can't be conflated):
  - `transferred_out?` — the *attendance status* of the event the registrant is **leaving**. It is inactive and grants **no** access to that event's paid content, even though the original payment still lives on it (`payment_access_granted?` denies it).
  - `paid_via_previous_registration?` — the *payment status* ("Previous reg") of the event the registrant **is attending**. It's a display only and does not by itself unlock content access.
- Logic lives in `EventRegistrationServices::Transfer` (transactional: create new + mark old, all-or-nothing). Admin-only via `EventRegistrationPolicy#transfer?`/`#create_transfer?`.

### Naming

- Action/button: **Transfer** (avoided "Reallocate" — collides with the payment *Allocation* concept — and "Credit" — implies an account balance).
- Original (left) registration status: **Transferred** (inactive).
- Destination (attended) payment status: **Previous reg**.

### UI Testing Checklist

- [ ] Edit a registration → **Transfer** → pick a destination event → registrant appears on the new event; original shows **Transferred** and is hidden from the active roster.
- [ ] Destination registration's payment shows **Previous reg** (no amount due) on the roster, the edit page, and CSV export; payment card links back to the source event.
- [ ] Transfer picker omits the current event and events the registrant is already registered for; transferring to an already-registered event is rejected with an alert.
- [ ] Original registration's payment history is unchanged after transfer.

### Anything else to add?

- **Access note:** a "Previous reg" registration is a payment *display*, not an access grant — it doesn't auto-unlock the attended event's join links/materials. If a transferred registrant needs that access, an admin can toggle **Intends to pay** on the destination registration. Happy to wire "Previous reg" into the access seam instead if that's preferred.
- Tests: service spec (`EventRegistrationServices::Transfer`), model spec (status/labels/scope/access), and request specs (GET form, POST happy path + invalid target + non-admin not authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)