### PR TITLE
Rename event-edit accordion label to "Form settings"

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -246,7 +246,7 @@
           data-action="dropdown#toggle"
           data-reveal-section-target="toggle"
           data-dropdown-payload-param='[{"registration_form_section":"hidden"}, {"registration_form_arrow":"rotate-180"}, {"registration_form_button":"rounded-t-md rounded-md"}]'>
-          Registration Form
+          Form settings
           <i id="registration_form_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300 rotate-180"></i>
         </button>
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The accordion toggle on the event edit page read "Registration Form", which conflated the section header with the registration-form selection field inside it.
- Renaming it to "Form settings" better describes the broader registration configuration the section reveals.

### How did you approach the change?
- Updated the toggle button label in `app/views/events/_form.html.erb`; the inner "Registration form" select label is unchanged since it labels the form-selection input itself.

### UI Testing Checklist
- [ ] Open an event's edit page as an admin and confirm the accordion toggle reads "Form settings".
- [ ] Confirm the accordion still expands/collapses and the inner "Registration form" field is unaffected.

### Anything else to add?
- Text-only change; no logic, IDs, or Stimulus targets were altered.