### PR TITLE
Add scholarship edit link to recipients page; show status by default

### DIFF
--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -151,10 +151,17 @@ class ScholarshipsController < ApplicationController
 
     if @allocatable.respond_to?(:event)
       return edit_event_registration_path(@allocatable) if params[:return_to] == "registration"
+      return recipients_return_path(@allocatable.event) if params[:return_to] == "recipients"
       return registrants_event_path(@allocatable.event)
     end
 
     edit_scholarship_path(@scholarship)
+  end
+
+  # Return to the recipients roster, scrolling back to the participant card the
+  # Edit link was opened from (its slug rides along in the participant param).
+  def recipients_return_path(event)
+    recipients_event_path(event, anchor: ("participant-#{params[:participant]}" if params[:participant].present?))
   end
 
   # After destroying, leave the scholarship entirely: back to the grant when that
@@ -163,7 +170,10 @@ class ScholarshipsController < ApplicationController
     return grant_return_path(grant) if grant_context?(grant)
 
     event = @allocatable.try(:event)
-    return registrants_event_path(event) if event
+    if event
+      return recipients_return_path(event) if params[:return_to] == "recipients"
+      return registrants_event_path(event)
+    end
     return grant_path(grant) if grant
 
     root_path

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -176,6 +176,14 @@
                   </span>
                 <% end %>
                 <%= render "scholarships/tasks_status", scholarship: scholarship %>
+                <% if allowed_to?(:edit?, scholarship) %>
+                  <%= link_to edit_scholarship_path(scholarship, return_to: "recipients", participant: participant_slug),
+                              class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                              target: "_blank", rel: "noopener" do %>
+                    Edit
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+                  <% end %>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -27,20 +27,21 @@
   </div>
 
   <% if @dashboard.scholarship_applicants.any? %>
-    <div data-controller="expandable-cards scholarship-status-toggle">
+    <div data-controller="expandable-cards scholarship-status-toggle"
+         data-scholarship-status-toggle-shown-value="true">
       <%# Controls — show/hide scholarship status for all recipients, and expand/collapse all %>
       <div class="flex flex-wrap items-center justify-between gap-3 mb-4 print:hidden">
         <%# Show / hide each recipient's awarded amount + tasks-completed status %>
-        <button type="button" role="switch" aria-checked="false"
+        <button type="button" role="switch" aria-checked="true"
                 data-action="scholarship-status-toggle#toggle"
                 data-scholarship-status-toggle-target="switch"
                 class="group inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800">
-          <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-gray-300 transition-colors"
+          <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-fuchsia-600 transition-colors"
                 data-scholarship-status-toggle-target="track">
-            <span class="inline-block h-4 w-4 translate-x-0.5 transform rounded-full bg-white shadow transition-transform"
+            <span class="inline-block h-4 w-4 translate-x-[1.125rem] transform rounded-full bg-white shadow transition-transform"
                   data-scholarship-status-toggle-target="knob"></span>
           </span>
-          <span data-scholarship-status-toggle-target="label">Show scholarship status</span>
+          <span data-scholarship-status-toggle-target="label">Hide scholarship status</span>
         </button>
         <%# Expand / collapse all %>
         <button type="button" data-action="expandable-cards#toggleAll"
@@ -161,7 +162,7 @@
               stays visible regardless of the card's expand/collapse state. %>
           <% scholarship = @dashboard.scholarship_by_recipient[person.id] %>
           <% if scholarship %>
-            <div class="hidden px-5 py-3 border-b <%= DomainTheme.border_class_for(:scholarships) %> bg-gray-50"
+            <div class="px-5 py-3 border-b <%= DomainTheme.border_class_for(:scholarships) %> bg-gray-50"
                  data-scholarship-status-toggle-target="status">
               <div class="flex flex-wrap items-center gap-3">
                 <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Scholarship</span>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -242,6 +242,8 @@
 <%# ---- Footer actions ---- %>
 <% cancel_path = if grant_nav
      params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)
+   elsif @allocatable.respond_to?(:event) && params[:return_to] == "recipients"
+     recipients_event_path(@allocatable.event, anchor: ("participant-#{params[:participant]}" if params[:participant].present?))
    elsif @allocatable.respond_to?(:event)
      params[:return_to] == "registration" ? edit_event_registration_path(@allocatable) : registrants_event_path(@allocatable.event)
    elsif grant.present?
@@ -253,7 +255,7 @@
   <% if f.object.persisted? %>
     <%# turbo: true re-enables Turbo for this link since the surrounding form sets
         turbo: false — turbo_method: :delete needs Turbo to issue the DELETE. %>
-    <%= link_to scholarship_path(f.object, return_to: params[:return_to].presence),
+    <%= link_to scholarship_path(f.object, return_to: params[:return_to].presence, participant: params[:participant].presence),
                 class: "btn btn-danger-outline",
                 data: { turbo: true, turbo_method: :delete, turbo_confirm: "Remove this scholarship?" } do %>
       <i class="fa-solid fa-trash-can"></i>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -14,6 +14,10 @@
       <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
+    <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "recipients" %>
+      <%= link_to recipients_event_path(@allocatable.event, anchor: ("participant-#{params[:participant]}" if params[:participant].present?)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
+      <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
       <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
@@ -43,7 +47,7 @@
   <%# turbo: false matches the other cocoon/nested-attributes admin forms (registration,
       workshops). A plain full-page submit avoids the Turbo + nested-fields double/stale
       resubmission that surfaced as a save committing yet the request returning 422. %>
-  <%= simple_form_for @scholarship, url: scholarship_path(@scholarship, return_to: params[:return_to].presence), html: { class: "space-y-6" }, data: { turbo: false, controller: "submit-once", "submit-once-submitting-text-value": "Saving…" } do |f| %>
+  <%= simple_form_for @scholarship, url: scholarship_path(@scholarship, return_to: params[:return_to].presence, participant: params[:participant].presence), html: { class: "space-y-6" }, data: { turbo: false, controller: "submit-once", "submit-once-submitting-text-value": "Saving…" } do |f| %>
     <%= render "form", f: f %>
   <% end %>
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1186,6 +1186,17 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Tasks completed")
       end
 
+      it "links each scholarship to its edit page, returning to this recipients page" do
+        event.update!(cost_cents: 50_000)
+        registration = event.event_registrations.find_by(registrant: applicant)
+        scholarship = create(:scholarship, recipient: applicant, amount_cents: 50_000, tasks_completed: true)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 50_000)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include(CGI.escapeHTML(edit_scholarship_path(scholarship, return_to: "recipients", participant: registration.slug)))
+      end
+
       it "names the funding donor when the scholarship is drawn from a grant" do
         registration = event.event_registrations.find_by(registrant: applicant)
         org = create(:organization, name: "Joyful Heart Foundation")

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1165,12 +1165,13 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include('data-expandable-card-target="body"')
       end
 
-      it "renders a page-wide toggle to show/hide scholarship status" do
+      it "renders a page-wide toggle to show/hide scholarship status, shown by default" do
         get recipients_event_path(event)
 
         expect(response.body).to include('data-controller="expandable-cards scholarship-status-toggle"')
         expect(response.body).to include('data-action="scholarship-status-toggle#toggle"')
-        expect(response.body).to include("Show scholarship status")
+        expect(response.body).to include('data-scholarship-status-toggle-shown-value="true"')
+        expect(response.body).to include("Hide scholarship status")
       end
 
       it "shows each recipient's awarded amount and completed tasks status" do

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 
+  describe "PATCH /scholarships/:id from the recipients page Edit link" do
+    it "returns to the recipients page, scrolled to the participant card" do
+      patch scholarship_path(scholarship, return_to: "recipients", participant: registration.slug),
+            params: { scholarship: { amount_dollars: "40" } }
+
+      expect(response).to redirect_to(recipients_event_path(event, anchor: "participant-#{registration.slug}"))
+    end
+  end
+
   describe "POST /scholarships from the registration Add link" do
     it "returns to the event registration edit page on create (symmetric with View)" do
       expect {
@@ -136,6 +145,12 @@ RSpec.describe "Scholarships", type: :request do
       get edit_scholarship_path(scholarship, return_to: "registration")
 
       expect(response.body).to include("href=\"#{edit_event_registration_path(registration)}\"")
+    end
+
+    it "links the edit page back to the recipients page when return_to=recipients" do
+      get edit_scholarship_path(scholarship, return_to: "recipients", participant: registration.slug)
+
+      expect(response.body).to include("href=\"#{recipients_event_path(event, anchor: "participant-#{registration.slug}")}\"")
     end
   end
 
@@ -179,6 +194,12 @@ RSpec.describe "Scholarships", type: :request do
 
       expect(response).to redirect_to(registrants_event_path(event))
       expect(flash[:notice]).to eq("Scholarship removed.")
+    end
+
+    it "returns to the recipients page when deleted from there" do
+      delete scholarship_path(scholarship, return_to: "recipients", participant: registration.slug)
+
+      expect(response).to redirect_to(recipients_event_path(event, anchor: "participant-#{registration.slug}"))
     end
   end
 


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- Admins reviewing the **Scholarship recipients** roster had no way to jump straight to a scholarship to adjust it — they had to leave the page and find the registrant on the registrants roster. This adds an **Edit** link to each scholarship row.
- Admins almost always want to see awarded amounts and task status while reviewing, so the page-wide scholarship-status toggle now defaults to **shown** instead of requiring a click every visit.

### How did you approach the change?
- Added an admin-gated **Edit** link in each recipient's scholarship status section, opening the scholarship edit page in a new tab (matching the existing registration-card Edit link).
- Taught the scholarship edit flow about the new `return_to=recipients` origin: the back-link eyebrow and the post-save/destroy redirects return to the recipients page, carrying the `participant` slug so the page scrolls back to the originating card.
- Defaulted the `scholarship-status-toggle` Stimulus controller to the shown state, with the server-rendered toggle markup (label, switch, status sections) matching so there's no flash on load.

### UI Testing Checklist
- [ ] On an event's **Scholarship recipients** page, scholarship status (awarded amount + task status) is visible by default and the toggle reads "Hide scholarship status".
- [ ] Each awarded scholarship row shows an **Edit** link; clicking it opens the scholarship edit page (new tab) with a "← Recipients" back link.
- [ ] Saving or deleting the scholarship returns to the recipients page, scrolled to that recipient's card.
- [ ] The Edit link is not shown to non-admins.

### Anything else to add?
- Request specs cover the link rendering, the save/delete/back-link redirects for the new `recipients` origin, and the toggle defaulting to shown.
