### PR TITLE
WAIT: Add "All age groups" diagram to event background page

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -444,6 +444,39 @@ class EventDashboard
       .transform_values { |rows| rows.map(&:first).uniq }
   end
 
+  # Every age group tagged on registrants (primary + additional AgeRange profile
+  # tags), backing the "All age groups" chart. The "Primary age group" chart
+  # instead reads from the registration "primary_age_group" answers (#age_groups).
+  def all_age_groups
+    @all_age_groups ||= Category.age_ranges
+      .where(id: all_age_group_counts.keys)
+      .ordered_by_position_and_name
+  end
+
+  # Distinct registrant count per age-group category, from profile AgeRange tags.
+  # Keyed by Category id, so it pairs with all_age_groups for the view.
+  def all_age_group_counts
+    @all_age_group_counts ||= age_range_items
+      .distinct
+      .group(:category_id)
+      .count(:categorizable_id)
+  end
+
+  # Registrant ids tagged with at least one age group.
+  def all_age_group_registrant_ids
+    @all_age_group_registrant_ids ||= age_range_items.distinct.pluck(:categorizable_id)
+  end
+
+  # Registrant ids per age-group category, keyed by Category id — the people
+  # behind each row, for drilling into the matching registrant list.
+  def all_age_group_registrant_ids_by_category
+    @all_age_group_registrant_ids_by_category ||= age_range_items
+      .distinct
+      .pluck(:category_id, :categorizable_id)
+      .group_by(&:first)
+      .transform_values { |rows| rows.map(&:last).uniq }
+  end
+
   # US states only — international registrants' regions (e.g. provinces) are
   # excluded so the States breakdown reflects domestic residents.
   def states
@@ -804,6 +837,15 @@ class EventDashboard
 
   def registrant_life_experience_ids
     @registrant_life_experience_ids ||= life_experience_items.distinct.pluck(:category_id)
+  end
+
+  # CategorizableItem rows tying registrants to AgeRange categories (primary +
+  # additional age-group tags) — the source for the "All age groups" breakdown.
+  def age_range_items
+    CategorizableItem
+      .joins(category: :category_type)
+      .where(categorizable_type: "Person", categorizable_id: registrant_ids)
+      .where(category_types: { name: "AgeRange" })
   end
 
   # CategorizableItem rows tying registrants to WorkshopEnvironment (workshop

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -3,6 +3,7 @@
 <% primary_sector_data = @dashboard.primary_sectors.map { |s| [ s.name, @dashboard.primary_sector_counts.fetch(s.id, 0) ] }.sort_by { |_, count| -count } %>
 <% sector_data = @dashboard.sectors.map { |s| [ s.name, @dashboard.sector_counts.fetch(s.id, 0) ] }.sort_by { |_, count| -count } %>
 <% age_group_data = @dashboard.age_groups.map { |c| [ c.name, @dashboard.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
+<% all_age_group_data = @dashboard.all_age_groups.map { |c| [ c.name, @dashboard.all_age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% state_data = @dashboard.state_counts.sort_by { |_, count| -count } %>
 <% country_data = @dashboard.country_counts.sort_by { |_, count| -count } %>
 <% school_district_data = @dashboard.school_district_counts.sort_by { |_, count| -count } %>
@@ -199,6 +200,7 @@
   <% primary_sector_paths = @dashboard.primary_sectors.to_h { |s| [ s.name, registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids_by_sector.fetch(s.id, []).join("-")) ] } %>
   <% sector_paths = @dashboard.sectors.to_h { |s| [ s.name, registrants_event_path(@event, sector: s.id) ] } %>
   <% age_group_paths = @dashboard.age_groups.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.age_group_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
+  <% all_age_group_paths = @dashboard.all_age_groups.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.all_age_group_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% state_paths = @dashboard.states.index_with { |state| registrants_event_path(@event, state: state) } %>
   <% country_paths = @dashboard.country_registrant_ids_by_country.transform_values { |ids| registrants_event_path(@event, registrant_ids: ids.join("-")) } %>
   <% school_district_paths = @dashboard.school_district_registrant_ids_by_district.transform_values { |ids| registrants_event_path(@event, registrant_ids: ids.join("-")) } %>
@@ -214,17 +216,17 @@
     <% end %>
     <%# States and countries use the addresses theme color (slate) for their map ramps. %>
     <% addresses_color = "#475569" %>
-    <%# Age group and Countries are both short; stack them in one column so the pair
-        fits within the height of the taller Primary sector pie card. %>
-    <div class="flex flex-col gap-6">
-      <%# Primary age group comes from the registration "ages served" answers;
-          always show the card (with a no-data box when empty). %>
-      <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
-                                   empty_message: "No age group responses from registration answers yet.", row_paths: age_group_paths %>
-      <% if country_data.any? %>
-        <%= render "breakdown_card", title: "Countries", data: country_data, chart: :world_map, palette: palette, map_color: addresses_color, row_paths: country_paths %>
-      <% end %>
-    </div>
+    <%# Primary age group comes from the registration "ages served" answers; All
+        age groups comes from registrants' AgeRange profile tags (primary +
+        additional), mirroring the Primary sector / All sectors pair. Always show
+        both cards (with a no-data box when empty). %>
+    <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
+                                 empty_message: "No age group responses from registration answers yet.", row_paths: age_group_paths %>
+    <%= render "breakdown_card", title: "All age groups", data: all_age_group_data, chart: :pie, palette: palette,
+                                 empty_message: "No age groups tagged on registrants yet.", row_paths: all_age_group_paths %>
+    <% if country_data.any? %>
+      <%= render "breakdown_card", title: "Countries", data: country_data, chart: :world_map, palette: palette, map_color: addresses_color, row_paths: country_paths %>
+    <% end %>
     <% if state_data.any? %>
       <%= render "breakdown_card", title: "States", data: state_data, chart: :map, palette: palette, map_color: addresses_color, row_paths: state_paths %>
     <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1278,6 +1278,24 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("100.0%")
       end
 
+      it "shows an all age groups breakdown from registrants' AgeRange profile tags" do
+        age_range = create(:category_type, name: "AgeRange")
+        teens = create(:category, name: "Teens", category_type: age_range)
+        create(:categorizable_item, category: teens, categorizable: person)
+
+        get background_event_path(event)
+
+        expect(response.body).to include("All age groups")
+        expect(response.body).to include("Teens")
+      end
+
+      it "shows a no-data box for all age groups when registrants have no AgeRange tags" do
+        get background_event_path(event)
+
+        expect(response.body).to include("All age groups")
+        expect(response.body).to include("No age groups tagged on registrants yet.")
+      end
+
       it "shows a life experiences breakdown from registrants' StoryPopulation tags" do
         story_population = create(:category_type, name: "StoryPopulation")
         experience = create(:category, name: "Veterans", category_type: story_population)

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe EventDashboard do
       create(:categorizable_item, category: setting2, categorizable: person2)
       create(:categorizable_item, category: setting_excluded, categorizable: cancelled_person)
 
+      # Age groups (AgeRange categories) tagged on registrant profiles, backing the
+      # "All age groups" breakdown; the excluded one belongs to the cancelled person.
+      create(:categorizable_item, category: age_group1, categorizable: person1)
+      create(:categorizable_item, category: age_group1, categorizable: person2)
+      create(:categorizable_item, category: age_group2, categorizable: person2)
+      create(:categorizable_item, category: age_group_excluded, categorizable: cancelled_person)
+
       # Primary age group(s) served, captured as "primary_age_group" answers on
       # each registrant's registration submission (", "-joined AgeRange ids).
       # person1 → Adults; person2 → Adults + Teens; cancelled → Children (ignored).
@@ -325,6 +332,26 @@ RSpec.describe EventDashboard do
 
       it "maps each age group to its registrant ids" do
         map = dashboard.age_group_registrant_ids_by_category
+        expect(map[age_group1.id]).to contain_exactly(person1.id, person2.id)
+        expect(map[age_group2.id]).to contain_exactly(person2.id)
+      end
+    end
+
+    describe "all age groups (from profile tags)" do
+      it "returns unique AgeRange categories tagged across active registrants" do
+        expect(dashboard.all_age_groups).to contain_exactly(age_group1, age_group2)
+      end
+
+      it "counts distinct registrants per tagged age group" do
+        expect(dashboard.all_age_group_counts).to eq(age_group1.id => 2, age_group2.id => 1)
+      end
+
+      it "returns the registrant ids tagged with an age group" do
+        expect(dashboard.all_age_group_registrant_ids).to contain_exactly(person1.id, person2.id)
+      end
+
+      it "maps each tagged age group to its registrant ids" do
+        map = dashboard.all_age_group_registrant_ids_by_category
         expect(map[age_group1.id]).to contain_exactly(person1.id, person2.id)
         expect(map[age_group2.id]).to contain_exactly(person2.id)
       end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The event background page ("Get to know the registrants") paired **Primary sector** and **All sectors** diagrams, but only showed a single **Primary age group** chart — so there was no way to see the full spread of age groups served across registrants.
- This adds an **All age groups** diagram so both taxonomies (sectors and age groups) read consistently with a primary + all pairing.

### How did you approach the change?

- Added `all_age_groups` / `all_age_group_counts` / `all_age_group_registrant_ids` / `all_age_group_registrant_ids_by_category` to `EventDashboard`, backed by a private `age_range_items` helper (CategorizableItem joined to the `AgeRange` category type, scoped to registrants) — mirroring the existing `life_experience_items` / `settings_items` pattern.
- **Data sources mirror the sectors pair:** Primary age group reads from the registration `primary_age_group` answers; All age groups reads from registrants' AgeRange **profile tags** (primary + additional) — exactly the two distinct sources used by Primary sector / All sectors.
- Rendered the new "All age groups" pie card next to "Primary age group" with a no-data fallback; each row drills into the registrant list filtered to the people behind it. Moved Countries to its own grid cell.

### UI Testing Checklist

- [ ] On an event with registrants tagged with AgeRange profile categories, the **All age groups** pie renders with correct counts/percentages
- [ ] Each age-group row drills into the registrant list filtered to those people
- [ ] With no AgeRange tags, the card shows "No age groups tagged on registrants yet."

### Anything else to add?

- ⚠️ **HOLD** — opened on hold; do not merge yet.
- Open question: "All age groups" sources from profile AgeRange tags (parallel to All sectors). If it should instead aggregate the registration answers (primary + additional answers rather than profile tags), the data source is a one-line swap.
- Tests: `event_dashboard_spec` (95 examples) and the background request specs (19 examples) pass; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
