### PR TITLE
Preserve non-US address state so editing doesn't blank it

### DIFF
--- a/app/helpers/geography_helper.rb
+++ b/app/helpers/geography_helper.rb
@@ -54,4 +54,15 @@ module GeographyHelper
       [ "Wyoming", "WY" ]
     ]
   end
+
+  # State dropdown options that always include the address's current value, even
+  # when it isn't a US state (e.g. an international province like "ON" or
+  # "England"). Without this the US-only list can't match such a value, so the
+  # select renders blank and saving wipes the state — tripping the presence
+  # validation on an otherwise-untouched address.
+  def state_select_options(current = nil)
+    return us_states if current.blank? || us_states.any? { |_name, abbr| abbr == current }
+
+    us_states + [ [ current, current ] ]
+  end
 end

--- a/app/views/addresses/_address_fields.html.erb
+++ b/app/views/addresses/_address_fields.html.erb
@@ -91,8 +91,10 @@
 
     <%= f.input :state,
                 as: :select,
-                collection: us_states,
+                collection: state_select_options(f.object.state),
+                selected: f.object.state,
                 input_html: {
+                  value: f.object.state,
                   class: "rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                 } %>
     <%= f.input :zip_code,

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -97,7 +97,12 @@
 
     <%= f.input :state,
                 label: "State",
+                as: :select,
+                collection: state_select_options(f.object.state),
+                include_blank: true,
+                selected: f.object.state,
                 input_html: {
+                  value: f.object.state,
                   class: "rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                 } %>
     <%= f.input :zip_code,

--- a/spec/helpers/geography_helper_spec.rb
+++ b/spec/helpers/geography_helper_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe GeographyHelper, type: :helper do
+  describe "#state_select_options" do
+    it "returns the US states unchanged for a known abbreviation" do
+      expect(helper.state_select_options("CA")).to eq(helper.us_states)
+    end
+
+    it "returns the US states unchanged when no value is given" do
+      expect(helper.state_select_options).to eq(helper.us_states)
+      expect(helper.state_select_options("")).to eq(helper.us_states)
+    end
+
+    it "appends a non-US value so an international state stays selectable" do
+      options = helper.state_select_options("ON")
+
+      expect(options).to include([ "ON", "ON" ])
+      expect(options.last).to eq([ "ON", "ON" ])
+    end
+
+    it "does not duplicate a value that is already a known state" do
+      expect(helper.state_select_options("NY").count { |_name, abbr| abbr == "NY" }).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Editing a person or organization whose address holds an international province (e.g. `"ON"`, `"England"`) and saving an unrelated change failed with *"Addresses state can't be blank"*.
- The state field is a US-only dropdown, so it couldn't match those values, rendered blank, and resubmitted an empty state — tripping the address presence validation on an otherwise-untouched record. These non-US states are intentional (the world/Countries map needs them and they must not be US abbreviations).

### How did you approach the change?
- Added `GeographyHelper#state_select_options`, which returns the US states plus the address's current value when it isn't a known US state, so any existing value stays selectable, selected, and survives a save.
- Used it in the person and organization address partials, and switched the organization address state field from a free-text input to the same dropdown people already had.

### Anything else to add?
- Added helper specs covering known, blank, and non-US state values.
