### PR TITLE
Add taggings presence filter to sectors index

### DIFF
--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -8,6 +8,7 @@ class SectorsController < ApplicationController
     base_scope = authorized_scope(Sector.all)
     filtered = base_scope.filter_scope(params)
     @sectors = filtered.order(:name).paginate(page: params[:page], per_page: per_page)
+    @taggings_counts = SectorableItem.where(sector_id: @sectors.map(&:id)).group(:sector_id).count
 
     @count_display = filtered.count == base_scope.count ? base_scope.count : "#{filtered.count}/#{base_scope.count}"
   end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -70,6 +70,13 @@ class Sector < ApplicationRecord
   end
   scope :excluding_other, -> { where.not(name: OTHER_SECTOR_NAME) }
   scope :has_taggings, -> { joins(:sectorable_items).distinct }
+  scope :taggings_presence, ->(value) do
+    case value
+    when "with" then has_taggings
+    when "without" then where.missing(:sectorable_items)
+    else all
+    end
+  end
   scope :has_published_taggings, -> {
     subqueries = Tag::TAGGABLE_META.map do |_key, data|
       klass = data[:klass]
@@ -89,6 +96,7 @@ class Sector < ApplicationRecord
     filtered = filtered.sector_ids(params[:sector_ids]) if params[:sector_ids].present?
     filtered = filtered.published if params[:published] == "true"
     filtered = filtered.where(published: false) if params[:published] == "false"
+    filtered = filtered.taggings_presence(params[:has_taggings])
     filtered
   end
 

--- a/app/views/sectors/_search_boxes.html.erb
+++ b/app/views/sectors/_search_boxes.html.erb
@@ -28,6 +28,18 @@
                    onchange: "this.form.requestSubmit()" %>
     </div>
 
+    <!-- Taggings -->
+    <div>
+      <%= f.label :has_taggings, "Taggings",
+                  class: "block text-sm font-medium text-gray-700" %>
+
+      <%= f.select :has_taggings,
+                   options_for_select([["All", ""], ["With taggings", "with"], ["Without taggings", "without"]], params[:has_taggings]),
+                   {},
+                   class: "mt-1 block w-full rounded-md border border-gray-300 p-2",
+                   onchange: "this.form.requestSubmit()" %>
+    </div>
+
     <!-- Clear -->
     <div>
       <%= link_to "Clear filters",

--- a/app/views/sectors/index.html.erb
+++ b/app/views/sectors/index.html.erb
@@ -70,7 +70,7 @@
                       <%= link_to "Edit",
                                   edit_sector_path(sector),
                                   class: "btn btn-secondary-outline whitespace-nowrap" %>
-                      <%= link_to "Taggings",
+                      <%= link_to "Taggings (#{@taggings_counts[sector.id].to_i})",
                                   taggings_path(sector_names_all: sector.name),
                                   class: "btn btn-secondary-outline whitespace-nowrap" %>
                     </td>

--- a/spec/models/sector_spec.rb
+++ b/spec/models/sector_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Sector, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe ".taggings_presence" do
+    let!(:tagged) { create(:sector) }
+    let!(:untagged) { create(:sector) }
+
+    before { create(:sectorable_item, sector: tagged) }
+
+    it "returns only sectors with taggings for \"with\"" do
+      expect(Sector.taggings_presence("with")).to contain_exactly(tagged)
+    end
+
+    it "returns only sectors without taggings for \"without\"" do
+      expect(Sector.taggings_presence("without")).to contain_exactly(untagged)
+    end
+
+    it "returns all sectors for a blank value" do
+      expect(Sector.taggings_presence("")).to contain_exactly(tagged, untagged)
+    end
+  end
 end

--- a/spec/views/sectors/index.html.erb_spec.rb
+++ b/spec/views/sectors/index.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "sectors/index", type: :view do
       create(:category, :published, name: "Sector One"),
       create(:category, name: "Sector Two")
     ])
+    assign(:taggings_counts, {})
     allow(view).to receive(:current_user).and_return(admin)
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins managing sectors need to spot orphaned sectors (no taggings) and tagged ones quickly. The sectors index now has a **Taggings** filter (All / With taggings / Without taggings) next to the existing name and published filters, and each row's **Taggings** button shows that sector's taggings count.

### How did you approach the change?
- Added a `taggings_presence` scope on `Sector` (`with` reuses `has_taggings`; `without` uses `where.missing(:sectorable_items)`) and chained it into `filter_scope` via `params[:has_taggings]`.
- Added the filter select to the index `_search_boxes` partial (matching the existing auto-submitting pattern), surfaced the per-sector count on the Taggings button via a single grouped query in the controller to avoid an N+1, and added model specs for the new scope.

### UI Testing Checklist
- [ ] On the sectors index, the **Taggings** filter shows With/Without taggings and filters the list correctly.
- [ ] **Clear filters** resets the Taggings filter along with the others.
- [ ] Each row's **Taggings** button shows the correct count, e.g. `Taggings (3)`.

### Anything else to add?
- The `without` case needs an anti-join, so it can't reuse the join-based `has_taggings` scope directly.
