### PR TITLE
WAIT: Show per-day add-to-calendar links for multi-day events

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -62,89 +62,27 @@ class EventDecorator < ApplicationDecorator
     length ? description&.truncate(length) : description
   end
 
+  # "Add to calendar" links. A multi-day event runs the same hours each day
+  # (e.g. Apr 21-23, 9 am-4:30 pm), so we emit a separate set of links per day —
+  # one calendar entry per day — rather than a single block that would span
+  # overnight. Each day's row is prefixed with its date.
   def calendar_links
-    start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
-    end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
-    title_encoded = ERB::Util.url_encode(object.title)
+    ranges = calendar_day_ranges
+    return calendar_links_for(ranges.first[:start], ranges.first[:end]) if ranges.one?
 
-    has_url      = object.videoconference_url.present?
-    has_location = object.location.present?
-    location_name = has_location ? object.location.name : nil
-
-    # If both: URL in location field, physical location in description
-    # If only URL: URL in location field
-    # If only location: location in location field
-    event_description = object.rhino_description.to_plain_text
-
-    if has_url && has_location
-      cal_location = object.videoconference_url
-      base_description = "#{location_name}\n\n#{event_description}"
-    elsif has_url
-      cal_location = object.videoconference_url
-      base_description = event_description
-    elsif has_location
-      cal_location = location_name
-      base_description = event_description
-    else
-      cal_location = nil
-      base_description = event_description
+    rows = ranges.map do |range|
+      day_label = h.content_tag(
+        :span,
+        "#{range[:start].in_time_zone(Time.zone).strftime('%b %-d')}:",
+        class: "text-xs font-semibold text-gray-500 mr-1 shrink-0"
+      )
+      h.content_tag(
+        :div,
+        h.safe_join([ day_label, calendar_links_for(range[:start], range[:end]) ], " "),
+        class: "flex flex-wrap gap-1 items-center justify-center w-full"
+      )
     end
-
-    # Carry the join link, meeting ID/code, and passcode into the calendar entry
-    # so registrants have everything they need to connect straight from the event.
-    description = [ videoconference_calendar_details, base_description ].compact_blank.join("\n\n")
-
-    desc_encoded     = ERB::Util.url_encode(description)
-    location_encoded = ERB::Util.url_encode(cal_location.to_s)
-
-    google_link =
-      "https://calendar.google.com/calendar/render?action=TEMPLATE" \
-        "&text=#{title_encoded}&dates=#{start_time}/#{end_time}" \
-        "&details=#{desc_encoded}&location=#{location_encoded}"
-
-    apple_link =
-      "data:text/calendar;charset=utf8,BEGIN:VCALENDAR\n" \
-        "VERSION:2.0\n" \
-        "BEGIN:VEVENT\n" \
-        "SUMMARY:#{object.title}\n" \
-        "DTSTART:#{start_time}\n" \
-        "DTEND:#{end_time}\n" \
-        "DESCRIPTION:#{description}\n" \
-        "#{"LOCATION:#{cal_location}\n" if cal_location}" \
-        "END:VEVENT\n" \
-        "END:VCALENDAR"
-
-    outlook_link =
-      "https://outlook.live.com/owa/?rru=addevent" \
-        "&startdt=#{start_time}&enddt=#{end_time}" \
-        "&subject=#{title_encoded}&body=#{desc_encoded}&location=#{location_encoded}"
-
-    office365_link =
-      "https://outlook.office.com/owa/?rru=addevent" \
-        "&startdt=#{start_time}&enddt=#{end_time}" \
-        "&subject=#{title_encoded}&body=#{desc_encoded}&location=#{location_encoded}"
-
-    yahoo_link =
-      "https://calendar.yahoo.com/?v=60" \
-        "&title=#{title_encoded}&st=#{start_time}" \
-        "&et=#{end_time}&desc=#{desc_encoded}&in_loc=#{location_encoded}"
-
-    h.safe_join(
-      [
-        h.link_to("Google", google_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
-        h.content_tag(:span, "•", class: "text-gray-300"),
-        h.link_to("Apple", apple_link, class: "text-blue-600 hover:underline text-xs",
-                  target: "_blank",
-                  download: "#{object.title.parameterize}.ics"),
-        h.content_tag(:span, "•", class: "text-gray-300"),
-        h.link_to("Outlook", outlook_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
-        h.content_tag(:span, "•", class: "text-gray-300"),
-        h.link_to("Office 365", office365_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
-        h.content_tag(:span, "•", class: "text-gray-300"),
-        h.link_to("Yahoo", yahoo_link, class: "text-blue-600 hover:underline text-xs", target: "_blank")
-      ],
-      " "
-    )
+    h.safe_join(rows)
   end
 
   # True when the event spans more than one calendar day in the viewer's time
@@ -340,6 +278,109 @@ class EventDecorator < ApplicationDecorator
     when 10 then id.sub(/\A(\d{3})(\d{3})(\d{4})\z/, '\1 \2 \3')
     else id
     end
+  end
+
+  # One start/end pair per calendar day the event spans, each running the
+  # event's daily hours (start time-of-day to end time-of-day). A same-day event
+  # returns its actual start/end so single-day links are unchanged.
+  def calendar_day_ranges
+    s = object.start_date.in_time_zone(Time.zone)
+    e = (object.end_date || object.start_date).in_time_zone(Time.zone)
+    return [ { start: object.start_date, end: object.end_date || object.start_date } ] if s.to_date == e.to_date
+
+    (s.to_date..e.to_date).map do |day|
+      {
+        start: Time.zone.local(day.year, day.month, day.day, s.hour, s.min),
+        end:   Time.zone.local(day.year, day.month, day.day, e.hour, e.min)
+      }
+    end
+  end
+
+  # Builds the five provider links for a single start/end pair.
+  def calendar_links_for(start_date, end_date)
+    start_time    = start_date.utc.strftime("%Y%m%dT%H%M%SZ")
+    end_time      = end_date.utc.strftime("%Y%m%dT%H%M%SZ")
+    title_encoded = ERB::Util.url_encode(object.title)
+
+    has_url      = object.videoconference_url.present?
+    has_location = object.location.present?
+    location_name = has_location ? object.location.name : nil
+
+    # If both: URL in location field, physical location in description
+    # If only URL: URL in location field
+    # If only location: location in location field
+    event_description = object.rhino_description.to_plain_text
+
+    if has_url && has_location
+      cal_location = object.videoconference_url
+      base_description = "#{location_name}\n\n#{event_description}"
+    elsif has_url
+      cal_location = object.videoconference_url
+      base_description = event_description
+    elsif has_location
+      cal_location = location_name
+      base_description = event_description
+    else
+      cal_location = nil
+      base_description = event_description
+    end
+
+    # Carry the join link, meeting ID/code, and passcode into the calendar entry
+    # so registrants have everything they need to connect straight from the event.
+    description = [ videoconference_calendar_details, base_description ].compact_blank.join("\n\n")
+
+    desc_encoded     = ERB::Util.url_encode(description)
+    location_encoded = ERB::Util.url_encode(cal_location.to_s)
+
+    google_link =
+      "https://calendar.google.com/calendar/render?action=TEMPLATE" \
+        "&text=#{title_encoded}&dates=#{start_time}/#{end_time}" \
+        "&details=#{desc_encoded}&location=#{location_encoded}"
+
+    apple_link =
+      "data:text/calendar;charset=utf8,BEGIN:VCALENDAR\n" \
+        "VERSION:2.0\n" \
+        "BEGIN:VEVENT\n" \
+        "SUMMARY:#{object.title}\n" \
+        "DTSTART:#{start_time}\n" \
+        "DTEND:#{end_time}\n" \
+        "DESCRIPTION:#{description}\n" \
+        "#{"LOCATION:#{cal_location}\n" if cal_location}" \
+        "END:VEVENT\n" \
+        "END:VCALENDAR"
+
+    outlook_link =
+      "https://outlook.live.com/owa/?rru=addevent" \
+        "&startdt=#{start_time}&enddt=#{end_time}" \
+        "&subject=#{title_encoded}&body=#{desc_encoded}&location=#{location_encoded}"
+
+    office365_link =
+      "https://outlook.office.com/owa/?rru=addevent" \
+        "&startdt=#{start_time}&enddt=#{end_time}" \
+        "&subject=#{title_encoded}&body=#{desc_encoded}&location=#{location_encoded}"
+
+    yahoo_link =
+      "https://calendar.yahoo.com/?v=60" \
+        "&title=#{title_encoded}&st=#{start_time}" \
+        "&et=#{end_time}&desc=#{desc_encoded}&in_loc=#{location_encoded}"
+
+    ics_date = start_date.in_time_zone(Time.zone).strftime("%b-%-d").downcase
+    h.safe_join(
+      [
+        h.link_to("Google", google_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
+        h.content_tag(:span, "•", class: "text-gray-300"),
+        h.link_to("Apple", apple_link, class: "text-blue-600 hover:underline text-xs",
+                  target: "_blank",
+                  download: "#{object.title.parameterize}-#{ics_date}.ics"),
+        h.content_tag(:span, "•", class: "text-gray-300"),
+        h.link_to("Outlook", outlook_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
+        h.content_tag(:span, "•", class: "text-gray-300"),
+        h.link_to("Office 365", office365_link, class: "text-blue-600 hover:underline text-xs", target: "_blank"),
+        h.content_tag(:span, "•", class: "text-gray-300"),
+        h.link_to("Yahoo", yahoo_link, class: "text-blue-600 hover:underline text-xs", target: "_blank")
+      ],
+      " "
+    )
   end
 
   def header_image

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -62,7 +62,7 @@
       <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
         Add to Your Calendar
       </p>
-      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links %></div>
+      <div class="flex flex-wrap gap-1 items-center justify-center text-sm text-gray-700"><%= event.calendar_links %></div>
     </div>
   <% end %>
 <% end %>

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -167,6 +167,30 @@ RSpec.describe EventDecorator do
       expect(apple["href"]).to include("Meeting ID: 882 8541 1273")
       expect(apple["href"]).to include("Passcode: secret123")
     end
+
+    it "emits a single set of links for a same-day event" do
+      event = build(:event, start_date: Time.zone.local(2026, 4, 21, 9), end_date: Time.zone.local(2026, 4, 21, 16, 30))
+      doc = Nokogiri::HTML.fragment(event.decorate.calendar_links)
+
+      expect(doc.css("a").select { |a| a.text == "Google" }.size).to eq(1)
+    end
+
+    it "emits a separate set of links per day for a multi-day event, each running the daily hours" do
+      event = build(:event, start_date: Time.zone.local(2026, 4, 21, 9), end_date: Time.zone.local(2026, 4, 23, 16, 30))
+      doc = Nokogiri::HTML.fragment(event.decorate.calendar_links)
+
+      google_links = doc.css("a").select { |a| a.text == "Google" }
+      expect(google_links.size).to eq(3)
+
+      day_dates = google_links.map { |a| a["href"][/dates=([^&]+)/, 1] }
+      expect(day_dates).to eq([
+        "#{Time.zone.local(2026, 4, 21, 9).utc.strftime("%Y%m%dT%H%M%SZ")}/#{Time.zone.local(2026, 4, 21, 16, 30).utc.strftime("%Y%m%dT%H%M%SZ")}",
+        "#{Time.zone.local(2026, 4, 22, 9).utc.strftime("%Y%m%dT%H%M%SZ")}/#{Time.zone.local(2026, 4, 22, 16, 30).utc.strftime("%Y%m%dT%H%M%SZ")}",
+        "#{Time.zone.local(2026, 4, 23, 9).utc.strftime("%Y%m%dT%H%M%SZ")}/#{Time.zone.local(2026, 4, 23, 16, 30).utc.strftime("%Y%m%dT%H%M%SZ")}"
+      ])
+
+      expect(doc.text).to include("Apr 21:", "Apr 22:", "Apr 23:")
+    end
   end
 
   describe "#times" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Multi-day events run the same hours each day (e.g. Apr 21-23, 9 am-4:30 pm), but the add-to-calendar links generated a single calendar entry spanning the first day's start to the last day's end — which reads as one continuous overnight event.
- Emit a separate set of links per day instead, so each day is its own calendar entry running that day's hours.

### How did you approach the change?

**`EventDecorator#calendar_links`**
- Multi-day events now emit a separate set of links (Google · Apple · Outlook · Office 365 · Yahoo) **per day**, each prefixed with its date and running that day's hours.
- Same-day events are unchanged — one inline row.
- Extracted `calendar_links_for(start, end)` (builds the five provider links) and `calendar_day_ranges` (one start/end pair per calendar day).
- `.ics` download filenames now include the day so per-day downloads don't collide.

**View**
- `events/_registration_section.html.erb`: wrapper changed to `flex flex-wrap … justify-center` so per-day rows stack and center (matching the ticket). Each per-day row is centered within its width.

### UI Testing Checklist
- [ ] Registration ticket (`/registrations/:slug/ticket`) — per-day calendar links render centered for a multi-day event
- [ ] Event show page registration section — same
- [ ] Single-day event still shows one inline set of calendar links

### Anything else to add?

- Added decorator specs covering single-day vs. per-day link counts (with correct per-day date/time spans).
- The multi-day date-range **display** change (`EventDecorator#times`) is split out into #1791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)