### PR TITLE
Show multi-day events as a date range with a single daily time

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -182,15 +182,6 @@ class EventDecorator < ApplicationDecorator
       t
     end
 
-    parts_for = lambda do |d, prefix: nil|
-      parts = []
-      parts << wrap.call(prefix, muted) if prefix
-      parts << "#{day.call(d)}, " if display_day
-      parts << "#{date.call(d)} @ " if display_date
-      parts << format_time.call(d)
-      h.safe_join(parts)
-    end
-
     tz_display = wrap.call(" #{tz_abbr}", muted)
 
     # --------------------------------------------------
@@ -224,20 +215,26 @@ class EventDecorator < ApplicationDecorator
     end
 
     # --------------------------------------------------
-    # DIFFERENT DAY → two lines
+    # DIFFERENT DAY → date range + per-day time range
+    # The event runs the same hours each day, so we show the date span and a
+    # single start-end time (e.g. "Mon-Wed, Apr 21-23 @ 9 am - 4:30 pm PST")
+    # rather than a continuous range that would imply an overnight event.
     # --------------------------------------------------
     if s.to_date != e.to_date
-      if inline
-        return h.safe_join(
-          [ parts_for.call(s), h.safe_join([ parts_for.call(e), tz_display ]) ],
-          " - "
-        )
+      date_part = if s.month == e.month && s.year == e.year
+        "#{date.call(s)}-#{e.strftime('%-d')}"
+      elsif s.year == e.year
+        "#{date.call(s)} - #{date.call(e)}"
       else
-        return h.safe_join(
-          [ parts_for.call(s), h.safe_join([ parts_for.call(e), tz_display ]) ],
-          h.tag.br
-        )
+        "#{s.strftime('%b %-d, %Y')} - #{e.strftime('%b %-d, %Y')}"
       end
+
+      parts = []
+      parts << "#{day.call(s)}-#{day.call(e)}, " if display_day
+      parts << "#{date_part} @ " if display_date
+      parts << "#{format_time.call(s)} - #{format_time.call(e)}"
+      parts << tz_display
+      return h.safe_join(parts)
     end
 
     # --------------------------------------------------

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -168,4 +168,18 @@ RSpec.describe EventDecorator do
       expect(apple["href"]).to include("Passcode: secret123")
     end
   end
+
+  describe "#times" do
+    it "shows a multi-day event as a date range with a single daily time range" do
+      event = build(:event, start_date: Time.zone.local(2026, 4, 21, 9), end_date: Time.zone.local(2026, 4, 23, 16, 30)).decorate
+      tz = Time.zone.local(2026, 4, 21, 9).strftime("%Z")
+      expect(event.times(display_day: true, display_date: true)).to eq("Tue-Thu, Apr 21-23 @ 9 am - 4:30 pm #{tz}")
+    end
+
+    it "shows a cross-month multi-day event with both months" do
+      event = build(:event, start_date: Time.zone.local(2026, 4, 30, 9), end_date: Time.zone.local(2026, 5, 2, 16, 30)).decorate
+      tz = Time.zone.local(2026, 4, 30, 9).strftime("%Z")
+      expect(event.times(display_day: true, display_date: true)).to eq("Thu-Sat, Apr 30 - May 2 @ 9 am - 4:30 pm #{tz}")
+    end
+  end
 end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Multi-day events run the same hours each day, but `EventDecorator#times` rendered them as a two-line continuous span ("start day @ start time" / "end day @ end time"), which reads like an overnight event.
- Show the dates as a range with a single start-end time so the schedule reflects how the event actually runs.

### How did you approach the change?

- Reworked the non-styled multi-day path of `EventDecorator#times` to render `Tue-Thu, Apr 21-23 @ 9 am - 4:30 pm PST` (cross-month ranges show both months, e.g. `Apr 30 - May 2`).
- This matches the styled show-page variant, which already collapsed to a date + time range.
- Removed the now-unused `parts_for` lambda.

This affects the non-styled `times(...)` callers: confirmation/cancellation emails, FYI notifications, bulk-payment emails, event cards, the shared event header, the registrations and allocations lists, and the registration form.

### UI Testing Checklist
- [ ] Confirmation/cancellation emails show the date-range + daily time for a multi-day event
- [ ] Event cards / listings show the new range format
- [ ] Single-day events are unchanged

### Anything else to add?

- Added decorator specs for the same-month and cross-month multi-day range formats.
- Split out from #1790 (per-day calendar links), which keeps the `calendar_links` change separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)