### PR TITLE
Add an admin sample-ticket preview for events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show, :staff, :details, :ce_hours ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview dashboard background registrants details ce_hours staff edit_staff update_staff recipients bulk_payments preview_reminder confirm_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
+  before_action :set_event, only: %i[ show edit update destroy preview dashboard sample_ticket background registrants details ce_hours staff edit_staff update_staff recipients bulk_payments preview_reminder confirm_reminder send_reminder copy_registration_form allocate_bulk_payment create_bulk_payment ]
 
   def index
     authorize!
@@ -40,6 +40,33 @@ class EventsController < ApplicationController
     authorize! @event
     @event = @event.decorate
     @dashboard = EventDashboard.new(@event)
+  end
+
+  # Admin preview of the registration ticket. Builds an in-memory sample
+  # registration — never saved — with every registrant-chosen option turned on,
+  # so admins can see what their event's ticket looks like with all sections
+  # present. The ticket partial renders in `preview: true` mode, which disables
+  # the state-changing buttons (pay, resend, cancel) and renders the callout
+  # cards non-navigating. A sentinel slug lets the callout route helpers build
+  # without raising, since the sample isn't persisted.
+  def sample_ticket
+    authorize! @event, to: :dashboard?
+
+    registrant = Person.new(first_name: "Sample", last_name: "Registrant")
+    @event_registration = @event.event_registrations.new(
+      registrant: registrant,
+      slug: "sample",
+      status: "registered",
+      intends_to_pay: true,
+      w9_requested: true,
+      invoice_requested: true,
+      scholarship_requested: true,
+      shoutout: true,
+      ce_credit_requested: true,
+      ce_hours_requested: 6,
+      ce_license_number: "SAMPLE-12345",
+      created_at: Time.current
+    )
   end
 
   def background

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -3,14 +3,17 @@
     locals: callout (responds to #theme, #display_icon_class, #title, #subtitle).
             href / target / trailing_icon may be passed explicitly (admin callouts
             compute href from a route) or read off the callout when it carries them
-            (MagicTicketCallouts::Card). %>
+            (MagicTicketCallouts::Card).
+            linked (default true): when false the card renders as a non-navigating
+            div — the sample-ticket preview has no real per-registration pages. %>
 <% theme = callout.theme %>
+<% linked = local_assigns.fetch(:linked, true) %>
 <% href = local_assigns.fetch(:href) { callout.href } %>
 <% target = local_assigns.fetch(:target) { callout.try(:target) } %>
 <% trailing = local_assigns.fetch(:trailing_icon) { callout.try(:trailing_icon) }.presence ||
               (callout.action? ? "fa-solid fa-arrow-right" : "fa-solid fa-circle-info") %>
-<%= link_to href, target: target, rel: (target.present? ? "noopener" : nil),
-              class: "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" do %>
+<% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
+<% card_body = capture do %>
   <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
 
   <div class="flex-1 min-w-0 text-left">
@@ -21,4 +24,9 @@
   </div>
 
   <i class="<%= trailing %> <%= theme[:icon] %> shrink-0"></i>
+<% end %>
+<% if linked %>
+  <%= link_to href, target: target, rel: (target.present? ? "noopener" : nil), class: card_class do %><%= card_body %><% end %>
+<% else %>
+  <div class="<%= card_class %>"><%= card_body %></div>
 <% end %>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -1,3 +1,4 @@
+<% preview = local_assigns.fetch(:preview, false) %>
 <div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
   <!-- Ticket Container -->
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
@@ -48,7 +49,7 @@
         <p class="text-gray-500 uppercase tracking-wide text-xs">Registrant</p>
 
         <p class="font-medium text-gray-900 text-lg">
-          <% if user_signed_in? %>
+          <% if user_signed_in? && !preview %>
             <%= link_to event_registration.registrant.full_name, person_path(event_registration.registrant), class: "text-blue-700 hover:text-blue-900 underline" %>
           <% else %>
             <%= event_registration.registrant.full_name %>
@@ -92,20 +93,27 @@
             <% end %>
 
             <div class="mt-3">
-              <%= button_to "Pay with Credit Card",
-                            registration_pay_path(event_registration.slug),
-                            data: { turbo: false },
-                            class: "btn px-6 py-2 text-sm uppercase font-telefon text-white hover:bg-white",
-                            style: "background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);" %>
+              <% if preview %>
+                <button type="button" disabled
+                        class="btn px-6 py-2 text-sm uppercase font-telefon text-white opacity-60 cursor-not-allowed"
+                        style="background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);">Pay with Credit Card</button>
+              <% else %>
+                <%= button_to "Pay with Credit Card",
+                              registration_pay_path(event_registration.slug),
+                              data: { turbo: false },
+                              class: "btn px-6 py-2 text-sm uppercase font-telefon text-white hover:bg-white",
+                              style: "background-color: rgb(170, 46, 0); border: 2px solid rgb(170, 46, 0);" %>
+              <% end %>
             </div>
           </div>
         <% end %>
       <% end %>
 
       <!-- Magic callouts: code-defined cards the app controls (event details, CE
-           hours, requested W-9/invoice). Each knows its own visibility rule. -->
+           hours, requested W-9/invoice). Each knows its own visibility rule. In
+           preview the cards render non-navigating (the sample has no real page). -->
       <% MagicTicketCallouts.new(event_registration).cards.each do |card| %>
-        <%= render "event_registrations/callout_card", callout: card %>
+        <%= render "event_registrations/callout_card", callout: card, linked: !preview %>
       <% end %>
 
       <!-- Custom ticket callouts (admin-configured: actions & reference reading) -->
@@ -114,7 +122,8 @@
         <% next if callout.payment_access_gated && !payment_access %>
         <%= render "event_registrations/callout_card",
                    callout: callout,
-                   href: event_registration_ticket_callout_path(event_registration.event, callout, reg: event_registration.slug) %>
+                   href: event_registration_ticket_callout_path(event_registration.event, callout, reg: event_registration.slug),
+                   linked: !preview %>
       <% end %>
 
       <!-- Divider -->
@@ -146,14 +155,19 @@
                           class: "text-sm text-gray-500 hover:text-blue-600 underline" %>
           <% end %>
 
-          <%= button_to "Resend confirmation email",
-                          registration_resend_confirmation_path(event_registration.slug),
-                          class: "text-sm text-gray-500 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+          <% if preview %>
+            <button type="button" disabled class="text-sm text-gray-400 underline bg-transparent border-0 cursor-not-allowed p-0">Resend confirmation email</button>
+            <button type="button" disabled class="text-sm text-gray-400 underline bg-transparent border-0 cursor-not-allowed p-0">Cancel registration</button>
+          <% else %>
+            <%= button_to "Resend confirmation email",
+                            registration_resend_confirmation_path(event_registration.slug),
+                            class: "text-sm text-gray-500 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %>
 
-          <%= button_to "Cancel registration",
-                          registration_cancel_path(event_registration.slug),
-                          data: { turbo_confirm: "Are you sure you want to cancel your registration?" },
-                          class: "text-sm text-gray-500 hover:text-red-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+            <%= button_to "Cancel registration",
+                            registration_cancel_path(event_registration.slug),
+                            data: { turbo_confirm: "Are you sure you want to cancel your registration?" },
+                            class: "text-sm text-gray-500 hover:text-red-600 underline bg-transparent border-0 cursor-pointer p-0" %>
+          <% end %>
         </div>
 
         <!-- Add to calendar (secondary utility, kept at the bottom) -->

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -27,5 +27,7 @@
     <% else %>
       <%= link_to "Enable forms", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
+    <div class="my-1 border-t border-gray-100"></div>
+    <%= link_to "Sample ticket", sample_ticket_event_path(@event, return_to: "registrants"), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
   </div>
 </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -55,6 +55,14 @@
         <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
       <% end %>
     <% end %>
+
+    <%# Admin-only preview of the registration ticket with every option enabled. %>
+    <%= link_to sample_ticket_event_path(@event), target: "_blank", rel: "noopener noreferrer",
+          class: "#{link_base} border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50" do %>
+      <i class="fa-solid fa-ticket text-gray-500"></i>
+      Sample ticket
+      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
+    <% end %>
   </div>
 
   <%# Money cards (paid events only) — shown first %>

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<%# Eyebrow returns the admin to wherever they opened the preview from. The
+    Form actions menu lives on the registrants page; the dashboard has its own
+    quick link. Default to the dashboard when the origin is absent/unknown. %>
+<% case params[:return_to]
+   when "registrants" %>
+  <% back_label = "← Registrants" %>
+  <% back_path = registrants_event_path(@event) %>
+<% else %>
+  <% back_label = "← Dashboard" %>
+  <% back_path = dashboard_event_path(@event) %>
+<% end %>
+<div class="max-w-2xl mx-auto px-4 pt-4">
+  <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+
+  <div class="mt-4 flex items-start gap-3 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3">
+    <i class="fa-solid fa-eye text-amber-500 text-xl shrink-0 mt-0.5"></i>
+    <div class="text-sm text-amber-800">
+      <p class="font-semibold text-amber-900">Sample ticket preview</p>
+      <p>This is an example registration with every option turned on, shown for
+        display purposes. Action buttons are disabled — no real registrant exists.</p>
+    </div>
+  </div>
+</div>
+
+<%= render "event_registrations/ticket", event_registration: @event_registration, preview: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
   resources :events do
     member do
       get :dashboard
+      get :sample_ticket
       get :background
       get :registrants
       get :details

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -94,6 +94,36 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "GET /sample_ticket" do
+    context "as admin" do
+      before { sign_in admin }
+
+      it "renders a preview ticket for an unsaved sample registration" do
+        create(:registration_ticket_callout, event: event)
+        get sample_ticket_event_path(event)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Sample ticket preview")
+        expect(response.body).to include("Sample Registrant")
+        # Magic callout cards render (always-present "Forms" card) without raising
+        # on the unsaved sample's sentinel slug.
+        expect(response.body).to include("Forms")
+      end
+
+      it "does not create a registration" do
+        expect { get sample_ticket_event_path(event) }
+          .not_to change(EventRegistration, :count)
+      end
+    end
+
+    context "as non-admin" do
+      it "redirects" do
+        sign_in user
+        get sample_ticket_event_path(event)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
   describe "GET /details" do
     let(:event) { create(:event, :published, :publicly_visible) }
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/categories/index.html.erb"              => "admin-only bg-blue-100",
     "app/views/category_types/index.html.erb"          => "admin-only bg-blue-100",
     "app/views/events/dashboard.html.erb"              => "admin-only bg-blue-100",
+    "app/views/events/sample_ticket.html.erb"          => "admin-only bg-blue-100",
     "app/views/events/bulk_payments.html.erb"          => "admin-only bg-blue-100",
     "app/views/events/background.html.erb"             => "admin-only bg-blue-100",
     "app/views/events/edit_staff.html.erb"             => "admin-only bg-white",


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Admins had no way to preview a registration ticket without creating a throwaway registration. This adds a **Sample ticket** preview — a non-persisted example registration with every registrant-chosen option enabled — so admins can see exactly what registrants will see (magic callouts, payment states, manage actions) for their event.

### How did you approach the change?
- New admin-only `events#sample_ticket` action (gated by `dashboard?`) builds an in-memory `EventRegistration` with all flags on, a fake "Sample Registrant", and a sentinel slug so the callout route helpers generate without raising — nothing is saved.
- The shared `_ticket` partial gained a `preview` flag that disables the state-changing buttons (pay, resend, cancel); `_callout_card` gained a `linked` flag so the magic/admin callout cards render non-navigating in the preview.
- Linked from the dashboard quick links and the **Form actions** menu (the latter passing `return_to: "registrants"` so the eyebrow returns correctly); registered the new view's `page_bg_class` and added request specs covering admin render, non-admin redirect, and that no registration is created.

### UI Testing Checklist
- [ ] Dashboard → "Sample ticket" opens the preview in a new tab; eyebrow returns to Dashboard
- [ ] Registrants → Form actions → "Sample ticket" opens the preview; eyebrow returns to Registrants
- [ ] Preview shows all sections including the magic callout cards
- [ ] Pay / resend / cancel buttons are visibly disabled; callout cards are non-navigating
- [ ] Non-admin cannot reach the preview

### Anything else to add?
Rebased onto `main` to pick up the new `MagicTicketCallouts` system, so the preview renders the current callout cards. The preview reflects the event's real configuration plus all registrant options, so payment sections only appear when the event actually has a cost. Replaces #1779.