### PR TITLE
Add a scholarship agreement recipients accept before it shows as awarded

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -64,6 +64,23 @@ module Events
       @form_responses_available = @event.registration_form&.form_submissions&.exists?(person: @event_registration.registrant)
     end
 
+    # Records the recipient agreeing, from their scholarship page, to complete the
+    # scholarship's tasks. Only "Yes" signs it; the model stamps agreement_signed_at.
+    def sign_agreement
+      scholarship = @event_registration.scholarships.first
+      unless scholarship
+        redirect_to registration_scholarship_path(@event_registration.slug)
+        return
+      end
+
+      if params[:agreement] == "yes"
+        scholarship.update!(agreement_signed: true) unless scholarship.agreement_signed?
+        redirect_to registration_scholarship_path(@event_registration.slug), notice: "Thanks — your agreement has been recorded."
+      else
+        redirect_to registration_scholarship_path(@event_registration.slug), alert: "Please select Yes to agree to complete the tasks."
+      end
+    end
+
     # CE hours status: hours, amount owed, and license number.
     def ce
       case params[:checkout]

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -65,7 +65,8 @@ module Events
     end
 
     # Records the recipient agreeing, from their scholarship page, to complete the
-    # scholarship's tasks. Only "Yes" signs it; the model stamps agreement_signed_at.
+    # scholarship's tasks. The Agree button submits agreement=yes, which stamps
+    # agreement_signed_at via the model.
     def sign_agreement
       scholarship = @event_registration.scholarships.first
       unless scholarship
@@ -77,7 +78,7 @@ module Events
         scholarship.update!(agreement_signed: true) unless scholarship.agreement_signed?
         redirect_to registration_scholarship_path(@event_registration.slug), notice: "Thanks — your agreement has been recorded."
       else
-        redirect_to registration_scholarship_path(@event_registration.slug), alert: "Please select Yes to agree to complete the tasks."
+        redirect_to registration_scholarship_path(@event_registration.slug), alert: "Something went wrong recording your agreement. Please try again."
       end
     end
 

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -207,7 +207,7 @@ class ScholarshipsController < ApplicationController
 
   def scholarship_params
     params.require(:scholarship).permit(
-      :amount_dollars, :amount_cents, :tasks_completed, :grant_id, :recipient_id,
+      :amount_dollars, :amount_cents, :tasks_completed, :agreement_signed, :grant_id, :recipient_id,
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id, :_destroy ]
     )

--- a/app/decorators/scholarship_decorator.rb
+++ b/app/decorators/scholarship_decorator.rb
@@ -52,4 +52,8 @@ class ScholarshipDecorator < ApplicationDecorator
   def tasks_completed?
     object.tasks_completed?
   end
+
+  def agreement_signed?
+    object.agreement_signed?
+  end
 end

--- a/app/frontend/javascript/controllers/scholarship_preview_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_preview_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 // Live-previews the "Still owed" stat and the scholarship-amount allocation
 // as the user edits the amount — before saving.
 export default class extends Controller {
-  static targets = ["amount", "owed", "amountBox", "allocationStrip", "allocatedHint"]
+  static targets = ["amount", "owed", "amountBox"]
   static values = { eventCost: Number, otherAllocated: Number }
 
   connect() {
@@ -32,25 +32,9 @@ export default class extends Controller {
   }
 
   renderAllocation(allocatedCents) {
-    const allocated = allocatedCents > 0
-    const box = allocated ? "border-fuchsia-300 bg-fuchsia-50" : "border-gray-100 bg-gray-50"
-
-    if (this.hasAmountBoxTarget) {
-      this.amountBoxTarget.className = `rounded-lg border px-4 py-3 ${box}`
-    }
-
-    if (this.hasAllocationStripTarget) {
-      this.allocationStripTarget.className = `flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 ${box}`
-    }
-
-    if (this.hasAllocatedHintTarget) {
-      if (!allocated) {
-        this.allocatedHintTarget.innerHTML = `<span class="text-xs text-gray-500">$0 allocated to registration</span>`
-      } else {
-        const amount = this.formatDollars(allocatedCents)
-        this.allocatedHintTarget.innerHTML = `<span class="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-100 px-2 py-0.5 text-[0.65rem] font-medium text-fuchsia-700"><i class="fa-solid fa-circle-check text-[0.55rem]"></i>${amount} allocated to registration</span>`
-      }
-    }
+    if (!this.hasAmountBoxTarget) return
+    const box = allocatedCents > 0 ? "border-fuchsia-300 bg-fuchsia-50" : "border-gray-100 bg-gray-50"
+    this.amountBoxTarget.className = `rounded-lg border px-4 py-3 ${box}`
   }
 
   formatDollars(cents) {

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -353,6 +353,13 @@ class EventRegistration < ApplicationRecord
     scholarships.all?(&:tasks_completed?)
   end
 
+  # Display-only: a scholarship is only *shown* as awarded once the recipient has
+  # signed the agreement. The record and its allocation exist beforehand (the data
+  # is unchanged) — the award is just presented as pending acceptance until signed.
+  def scholarship_awarded?
+    scholarship? && scholarships.all?(&:agreement_signed?)
+  end
+
   def attended?
     status == "attended"
   end

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -12,6 +12,7 @@ class Scholarship < ApplicationRecord
   validate :recipient_must_match_allocation_registrant
   validate :within_grant_budget, if: :grant
 
+  before_save :stamp_agreement_signed_at, if: :will_save_change_to_agreement_signed?
   after_update :sync_allocation_amount, if: -> { saved_change_to_amount_cents? }
   after_create_commit :flag_event_registration_scholarship_requested
 
@@ -48,6 +49,14 @@ class Scholarship < ApplicationRecord
     if recipient != allocation.allocatable.registrant
       errors.add(:recipient, "must be the same person as the event registration's registrant")
     end
+  end
+
+  # Keep the signed-at timestamp in step with the flag however it's flipped — the
+  # admin toggle on the form or the recipient agreeing on their callout page.
+  # Stamp the moment it turns true (preserving an existing time), clear it when
+  # turned back off.
+  def stamp_agreement_signed_at
+    self.agreement_signed_at = agreement_signed? ? (agreement_signed_at || Time.current) : nil
   end
 
   def sync_allocation_amount

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -12,11 +12,23 @@ class Scholarship < ApplicationRecord
   validate :recipient_must_match_allocation_registrant
   validate :within_grant_budget, if: :grant
 
-  before_save :stamp_agreement_signed_at, if: :will_save_change_to_agreement_signed?
   after_update :sync_allocation_amount, if: -> { saved_change_to_amount_cents? }
   after_create_commit :flag_event_registration_scholarship_requested
 
   scope :completed, -> { where(tasks_completed: true) }
+  scope :agreement_signed, -> { where.not(agreement_signed_at: nil) }
+
+  # The agreement is signed when a signed-at timestamp is present — a single
+  # source of truth. `agreement_signed` reads/writes as a virtual boolean so the
+  # admin form checkbox and strong params keep working, stamping or clearing the
+  # timestamp accordingly (and preserving an existing time across re-saves).
+  def agreement_signed? = agreement_signed_at.present?
+  alias_method :agreement_signed, :agreement_signed?
+
+  def agreement_signed=(value)
+    signed = ActiveModel::Type::Boolean.new.cast(value)
+    self.agreement_signed_at = signed ? (agreement_signed_at || Time.current) : nil
+  end
 
   def amount_dollars
     amount_cents.to_d / 100 if amount_cents
@@ -49,14 +61,6 @@ class Scholarship < ApplicationRecord
     if recipient != allocation.allocatable.registrant
       errors.add(:recipient, "must be the same person as the event registration's registrant")
     end
-  end
-
-  # Keep the signed-at timestamp in step with the flag however it's flipped — the
-  # admin toggle on the form or the recipient agreeing on their callout page.
-  # Stamp the moment it turns true (preserving an existing time), clear it when
-  # turned back off.
-  def stamp_agreement_signed_at
-    self.agreement_signed_at = agreement_signed? ? (agreement_signed_at || Time.current) : nil
   end
 
   def sync_allocation_amount

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -149,18 +149,29 @@ class MagicTicketCallouts
   # met shows a fuchsia amount badge.
   def scholarship_status_card
     return unless registration.scholarship_requested?
-    awarded = registration.scholarship?
+    # Awarded is display-only: the scholarship record exists earlier, but the award
+    # is only shown as awarded once the recipient signs the agreement. Until then
+    # the card prompts them to accept.
+    awarded = registration.scholarship_awarded?
+    needs_agreement = registration.scholarship? && !awarded
     tasks_outstanding = awarded && !registration.scholarship_tasks_met?
+    action_needed = needs_agreement || tasks_outstanding
     Card.new(icon_class: "fa-solid fa-award",
-             # Amber while award tasks are outstanding (action needed), otherwise
-             # the scholarship colour.
-             color: tasks_outstanding ? "amber" : DomainTheme.color_for(:scholarships).to_s,
+             # Amber while an action is needed (accept the agreement, or complete
+             # tasks), otherwise the scholarship colour.
+             color: action_needed ? "amber" : DomainTheme.color_for(:scholarships).to_s,
              title: "Scholarship",
-             subtitle: awarded ? "Your award — amount, funder, and tasks" : "Your scholarship request status",
+             subtitle: scholarship_subtitle(awarded, needs_agreement),
              href: registration_scholarship_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
              badge: scholarship_badge(awarded, tasks_outstanding),
              badge_classes: tasks_outstanding ? nil : "bg-fuchsia-100 text-fuchsia-800 border border-fuchsia-300")
+  end
+
+  def scholarship_subtitle(awarded, needs_agreement)
+    return "Your award — amount, funder, and tasks" if awarded
+    return "Review and accept your scholarship agreement" if needs_agreement
+    "Your scholarship request status"
   end
 
   def scholarship_badge(awarded, tasks_outstanding)

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -62,6 +62,17 @@
               Tasks outstanding
             </span>
           <% end %>
+          <% if scholarship.agreement_signed? %>
+            <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+              <i class="fa-solid fa-file-signature"></i>
+              Agreement signed
+            </span>
+          <% else %>
+            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
+              <i class="fa-solid fa-file-signature"></i>
+              Agreement pending
+            </span>
+          <% end %>
         </div>
       </div>
     <% else %>

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -51,17 +51,7 @@
         <%# Pinned to the card's bottom so it lines up with the CE card's chip and
             the organizations card's "Connect organization" link. %>
         <div class="mt-auto flex flex-wrap items-center gap-1.5 pt-3">
-          <% if scholarship.tasks_completed? %>
-            <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
-              <i class="fa-solid fa-circle-check"></i>
-              Tasks completed
-            </span>
-          <% else %>
-            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
-              <i class="fa-solid fa-clock"></i>
-              Tasks outstanding
-            </span>
-          <% end %>
+          <%# Agreement first, then tasks — the recipient agrees before completing tasks. %>
           <% if scholarship.agreement_signed? %>
             <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
               <i class="fa-solid fa-file-signature"></i>
@@ -71,6 +61,17 @@
             <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
               <i class="fa-solid fa-file-signature"></i>
               Agreement pending
+            </span>
+          <% end %>
+          <% if scholarship.tasks_completed? %>
+            <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-2.5 py-0.5 text-xs font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+              <i class="fa-solid fa-circle-check"></i>
+              Tasks completed
+            </span>
+          <% else %>
+            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700">
+              <i class="fa-solid fa-clock"></i>
+              Tasks outstanding
             </span>
           <% end %>
         </div>

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -55,15 +55,26 @@
             <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount awarded</p>
             <p class="mt-1 text-3xl font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(@scholarship.amount_cents) %></p>
           </div>
-          <% if @scholarship.tasks_completed? %>
-            <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
-              <i class="fa-solid fa-circle-check"></i> Tasks completed
-            </span>
-          <% else %>
-            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
-              <i class="fa-solid fa-clock"></i> Tasks outstanding
-            </span>
-          <% end %>
+          <div class="flex flex-wrap items-center gap-2">
+            <% if @scholarship.tasks_completed? %>
+              <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+                <i class="fa-solid fa-circle-check"></i> Tasks completed
+              </span>
+            <% else %>
+              <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
+                <i class="fa-solid fa-clock"></i> Tasks outstanding
+              </span>
+            <% end %>
+            <% if @scholarship.agreement_signed? %>
+              <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+                <i class="fa-solid fa-file-signature"></i> Agreement signed
+              </span>
+            <% else %>
+              <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
+                <i class="fa-solid fa-file-signature"></i> Agreement needed
+              </span>
+            <% end %>
+          </div>
         </div>
 
         <% if grant %>

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -55,26 +55,15 @@
             <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount awarded</p>
             <p class="mt-1 text-3xl font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(@scholarship.amount_cents) %></p>
           </div>
-          <div class="flex flex-wrap items-center gap-2">
-            <% if @scholarship.tasks_completed? %>
-              <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
-                <i class="fa-solid fa-circle-check"></i> Tasks completed
-              </span>
-            <% else %>
-              <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
-                <i class="fa-solid fa-clock"></i> Tasks outstanding
-              </span>
-            <% end %>
-            <% if @scholarship.agreement_signed? %>
-              <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
-                <i class="fa-solid fa-file-signature"></i> Agreement signed
-              </span>
-            <% else %>
-              <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
-                <i class="fa-solid fa-file-signature"></i> Agreement needed
-              </span>
-            <% end %>
-          </div>
+          <% if @scholarship.tasks_completed? %>
+            <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+              <i class="fa-solid fa-circle-check"></i> Tasks completed
+            </span>
+          <% else %>
+            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
+              <i class="fa-solid fa-clock"></i> Tasks outstanding
+            </span>
+          <% end %>
         </div>
 
         <% if grant %>
@@ -108,13 +97,14 @@
           <% else %>
             <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Scholarship agreement</p>
             <p class="mt-1 text-sm text-gray-600">To accept this scholarship, please confirm that you agree to complete your scholarship tasks.</p>
-            <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "mt-3 flex flex-wrap items-end gap-3" do %>
-              <div>
-                <%= label_tag :agreement, "Do you agree to complete the tasks?", class: "block text-xs font-medium text-gray-600 mb-1" %>
-                <%= select_tag :agreement,
-                      options_for_select([ [ "Select…", "" ], [ "Yes", "yes" ] ]),
-                      class: "rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-fuchsia-500 focus:ring focus:ring-fuchsia-200 focus:outline-none" %>
-              </div>
+            <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "mt-3 space-y-3" do %>
+              <fieldset>
+                <legend class="block text-xs font-medium text-gray-600 mb-1.5">Do you agree to complete the tasks?</legend>
+                <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
+                  <input type="radio" name="agreement" value="yes" required class="text-blue-600 focus:ring-blue-500">
+                  Yes
+                </label>
+              </fieldset>
               <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-fuchsia-700">
                 <i class="fa-solid fa-file-signature"></i> Agree
               </button>

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -88,6 +88,39 @@
             <%= render "scholarships/grant_criteria_tasks", grant: %>
           </div>
         <% end %>
+
+        <%# Scholarship agreement: once awarded, the recipient confirms here that
+            they agree to complete their scholarship tasks. Signing stamps
+            agreement_signed_at; afterwards we show the confirmation and date. %>
+        <div class="border-t border-gray-100 pt-5">
+          <% if @scholarship.agreement_signed? %>
+            <div class="flex items-start gap-3">
+              <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
+                <i class="fa-solid fa-file-signature"></i>
+              </span>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Scholarship agreement signed</p>
+                <% if @scholarship.agreement_signed_at %>
+                  <p class="mt-1 text-sm text-gray-600">You agreed to complete your scholarship tasks on <%= @scholarship.agreement_signed_at.strftime("%B %-d, %Y") %>.</p>
+                <% end %>
+              </div>
+            </div>
+          <% else %>
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Scholarship agreement</p>
+            <p class="mt-1 text-sm text-gray-600">To accept this scholarship, please confirm that you agree to complete your scholarship tasks.</p>
+            <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "mt-3 flex flex-wrap items-end gap-3" do %>
+              <div>
+                <%= label_tag :agreement, "Do you agree to complete the tasks?", class: "block text-xs font-medium text-gray-600 mb-1" %>
+                <%= select_tag :agreement,
+                      options_for_select([ [ "Select…", "" ], [ "Yes", "yes" ] ]),
+                      class: "rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-fuchsia-500 focus:ring focus:ring-fuchsia-200 focus:outline-none" %>
+              </div>
+              <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-fuchsia-700">
+                <i class="fa-solid fa-file-signature"></i> Agree
+              </button>
+            <% end %>
+          <% end %>
+        </div>
       <% else %>
         <div class="flex items-start gap-3">
           <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -52,10 +52,17 @@
         <% grant = @scholarship.grant %>
         <div class="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Amount awarded</p>
+            <%# Shown as an offer until the recipient signs the agreement, then as
+                the confirmed award. The amount/allocation is unchanged either way. %>
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-400"><%= @scholarship.agreement_signed? ? "Amount awarded" : "Amount offered" %></p>
             <p class="mt-1 text-3xl font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(@scholarship.amount_cents) %></p>
           </div>
-          <% if @scholarship.tasks_completed? %>
+          <%# Status chip: pending until the agreement is signed, then the tasks state. %>
+          <% if !@scholarship.agreement_signed? %>
+            <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
+              <i class="fa-solid fa-file-signature"></i> Pending agreement
+            </span>
+          <% elsif @scholarship.tasks_completed? %>
             <span class="inline-flex items-center gap-1 rounded-full border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> <%= DomainTheme.bg_class_for(:scholarships, intensity: 50) %> px-3 py-1 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
               <i class="fa-solid fa-circle-check"></i> Tasks completed
             </span>
@@ -63,6 +70,24 @@
             <span class="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-sm font-medium text-amber-700">
               <i class="fa-solid fa-clock"></i> Tasks outstanding
             </span>
+          <% end %>
+        </div>
+
+        <%# Scholarship agreement — shown above the details so accepting comes first.
+            A single Agree button signs it; afterwards we confirm with the date. %>
+        <div class="border-t border-gray-100 pt-5">
+          <% if @scholarship.agreement_signed? %>
+            <p class="flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>">
+              <i class="fa-solid fa-circle-check"></i>
+              Agreement signed<% if @scholarship.agreement_signed_at %> · <%= @scholarship.agreement_signed_at.strftime("%B %-d, %Y") %><% end %>
+            </p>
+          <% else %>
+            <p class="text-sm text-gray-600">Agree to complete your scholarship tasks to accept this award.</p>
+            <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "mt-3" do %>
+              <button type="submit" name="agreement" value="yes" class="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-700">
+                <i class="fa-solid fa-check"></i> Agree
+              </button>
+            <% end %>
           <% end %>
         </div>
 
@@ -77,40 +102,6 @@
             <%= render "scholarships/grant_criteria_tasks", grant: %>
           </div>
         <% end %>
-
-        <%# Scholarship agreement: once awarded, the recipient confirms here that
-            they agree to complete their scholarship tasks. Signing stamps
-            agreement_signed_at; afterwards we show the confirmation and date. %>
-        <div class="border-t border-gray-100 pt-5">
-          <% if @scholarship.agreement_signed? %>
-            <div class="flex items-start gap-3">
-              <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">
-                <i class="fa-solid fa-file-signature"></i>
-              </span>
-              <div>
-                <p class="text-sm font-semibold text-gray-900">Scholarship agreement signed</p>
-                <% if @scholarship.agreement_signed_at %>
-                  <p class="mt-1 text-sm text-gray-600">You agreed to complete your scholarship tasks on <%= @scholarship.agreement_signed_at.strftime("%B %-d, %Y") %>.</p>
-                <% end %>
-              </div>
-            </div>
-          <% else %>
-            <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Scholarship agreement</p>
-            <p class="mt-1 text-sm text-gray-600">To accept this scholarship, please confirm that you agree to complete your scholarship tasks.</p>
-            <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "mt-3 space-y-3" do %>
-              <fieldset>
-                <legend class="block text-xs font-medium text-gray-600 mb-1.5">Do you agree to complete the tasks?</legend>
-                <label class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm text-gray-700 cursor-pointer transition hover:border-blue-400 hover:bg-blue-50 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-900 has-[:checked]:font-medium">
-                  <input type="radio" name="agreement" value="yes" required class="text-blue-600 focus:ring-blue-500">
-                  Yes
-                </label>
-              </fieldset>
-              <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-fuchsia-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-fuchsia-700">
-                <i class="fa-solid fa-file-signature"></i> Agree
-              </button>
-            <% end %>
-          <% end %>
-        </div>
       <% else %>
         <div class="flex items-start gap-3">
           <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>">

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -53,26 +53,11 @@
             </dd>
           </div>
         </dl>
-
-        <%# Tasks-completed toggle, styled to match the scholarship-agreement box
-            below. The amount box above already signals the allocation (fuchsia). %>
-        <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
-          <div>
-            <p class="text-xs font-medium text-gray-600">Tasks completed</p>
-            <p class="text-xs text-gray-400">Recipient has completed their scholarship tasks</p>
-          </div>
-          <label class="flex items-center gap-2.5 cursor-pointer">
-            <%= f.check_box :tasks_completed, class: "sr-only peer" %>
-            <span class="text-sm text-gray-400 peer-checked:hidden">Not yet</span>
-            <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Completed</span>
-            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
-          </label>
-        </div>
       </div>
     <% end %>
 
-    <%# With a registration, the amount + tasks-completed toggle live in the stat grid
-        above. Without one (grant-funded or standalone) they live here instead. %>
+    <%# With a registration, the amount lives in the stat grid above. Without one
+        (grant-funded or standalone) the recipient picker and amount live here. %>
     <% unless @allocatable.respond_to?(:event) %>
       <div class="flex flex-wrap items-start gap-x-10 gap-y-6">
         <% if grant_funded %>
@@ -94,22 +79,11 @@
             <%= f.number_field :amount_dollars, step: 0.01, min: 0, autocomplete: "off", class: "w-full rounded-lg border border-gray-300 pl-7 pr-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none", data: { "scholarship-preview-target": "amount", action: "input->scholarship-preview#update", lpignore: "true", "1p-ignore": "true", bwignore: "true", "form-type": "other" } %>
           </div>
         </div>
-
-        <div>
-          <%= f.label :tasks_completed, "Tasks completed", class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <label class="flex h-[2.625rem] items-center gap-2.5 cursor-pointer">
-            <%= f.check_box :tasks_completed, class: "sr-only peer" %>
-            <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
-            <span class="text-sm text-gray-400 peer-checked:hidden">Not yet</span>
-            <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Completed</span>
-          </label>
-        </div>
       </div>
     <% end %>
 
-    <%# Scholarship agreement: an informational toggle shown in either layout,
-        recording whether the recipient has signed their scholarship agreement.
-        It surfaces back to the recipient on their scholarship callout page. %>
+    <%# Scholarship agreement, then tasks — the recipient agrees first, then
+        completes the tasks. Both shown in either layout. %>
     <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
       <div>
         <p class="text-xs font-medium text-gray-600">Scholarship agreement</p>
@@ -119,6 +93,19 @@
         <%= f.check_box :agreement_signed, class: "sr-only peer" %>
         <span class="text-sm text-gray-400 peer-checked:hidden">Not signed</span>
         <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Signed</span>
+        <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
+      </label>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+      <div>
+        <p class="text-xs font-medium text-gray-600">Tasks completed</p>
+        <p class="text-xs text-gray-400">Recipient has completed their scholarship tasks</p>
+      </div>
+      <label class="flex items-center gap-2.5 cursor-pointer">
+        <%= f.check_box :tasks_completed, class: "sr-only peer" %>
+        <span class="text-sm text-gray-400 peer-checked:hidden">Not yet</span>
+        <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Completed</span>
         <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
       </label>
     </div>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -111,6 +111,22 @@
         </div>
       </div>
     <% end %>
+
+    <%# Scholarship agreement: an informational toggle shown in either layout,
+        recording whether the recipient has signed their scholarship agreement.
+        It surfaces back to the recipient on their scholarship callout page. %>
+    <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+      <div>
+        <p class="text-xs font-medium text-gray-600">Scholarship agreement</p>
+        <p class="text-xs text-gray-400">Signed agreement on file from the recipient</p>
+      </div>
+      <label class="flex items-center gap-2.5 cursor-pointer">
+        <%= f.check_box :agreement_signed, class: "sr-only peer" %>
+        <span class="text-sm text-gray-400 peer-checked:hidden">Not signed</span>
+        <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Signed</span>
+        <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
+      </label>
+    </div>
   </div>
 </section>
 

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -124,7 +124,7 @@
         <%= f.check_box :agreement_signed, class: "sr-only peer" %>
         <span class="text-sm text-gray-400 peer-checked:hidden">Not signed</span>
         <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Signed</span>
-        <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
+        <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
       </label>
     </div>
   </div>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -54,24 +54,19 @@
           </div>
         </dl>
 
-        <%# Allocation strip: shows the scholarship amount as allocated alongside
-            the informational "Tasks completed" toggle. %>
-        <div data-scholarship-preview-target="allocationStrip" class="flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 <%= allocated_cents > 0 ? "border-fuchsia-300 bg-fuchsia-50" : "border-gray-100 bg-gray-50" %>">
+        <%# Tasks-completed toggle, styled to match the scholarship-agreement box
+            below. The amount box above already signals the allocation (fuchsia). %>
+        <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+          <div>
+            <p class="text-xs font-medium text-gray-600">Tasks completed</p>
+            <p class="text-xs text-gray-400">Recipient has completed their scholarship tasks</p>
+          </div>
           <label class="flex items-center gap-2.5 cursor-pointer">
-            <span class="text-xs font-medium text-gray-600">Tasks completed</span>
             <%= f.check_box :tasks_completed, class: "sr-only peer" %>
+            <span class="text-sm text-gray-400 peer-checked:hidden">Not yet</span>
+            <span class="hidden text-sm font-medium text-fuchsia-700 peer-checked:inline">Completed</span>
             <span class="relative h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-fuchsia-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-fuchsia-300"></span>
           </label>
-          <div data-scholarship-preview-target="allocatedHint">
-            <% if allocated_cents > 0 %>
-              <span class="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-100 px-2 py-0.5 text-[0.65rem] font-medium text-fuchsia-700">
-                <i class="fa-solid fa-circle-check text-[0.55rem]"></i>
-                <%= dollars_from_cents(allocated_cents) %> allocated to registration
-              </span>
-            <% else %>
-              <span class="text-xs text-gray-500">$0 allocated to registration</span>
-            <% end %>
-          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -20,7 +20,12 @@
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500">Agreement signed</dt>
-      <dd class="mt-1 text-sm text-gray-900"><%= @scholarship.agreement_signed? ? "Yes" : "No" %></dd>
+      <dd class="mt-1 text-sm text-gray-900">
+        <%= @scholarship.agreement_signed? ? "Yes" : "No" %>
+        <% if @scholarship.agreement_signed_at %>
+          <span class="text-gray-500">· <%= @scholarship.agreement_signed_at.strftime("%B %d, %Y") %></span>
+        <% end %>
+      </dd>
     </div>
     <% if @scholarship.grant.present? %>
       <div>

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -18,6 +18,10 @@
       <dt class="text-sm font-medium text-gray-500">Tasks Completed</dt>
       <dd class="mt-1 text-sm text-gray-900"><%= @scholarship.tasks_completed? ? "Yes" : "No" %></dd>
     </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500">Agreement signed</dt>
+      <dd class="mt-1 text-sm text-gray-900"><%= @scholarship.agreement_signed? ? "Yes" : "No" %></dd>
+    </div>
     <% if @scholarship.grant.present? %>
       <div>
         <dt class="text-sm font-medium text-gray-500">Grant</dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   get "registration/:slug/invoice", to: "events/registrations#invoice", as: :registration_invoice
   get "registration/:slug/receipt", to: "events/registrations#receipt", as: :registration_receipt
   get "registration/:slug/scholarship", to: "events/callouts#scholarship", as: :registration_scholarship
+  post "registration/:slug/scholarship/agreement", to: "events/callouts#sign_agreement", as: :registration_scholarship_agreement
   get "registration/:slug/faq", to: "events/callouts#faq", as: :registration_faq
   get "registration/:slug/payment", to: "events/callouts#payment", as: :registration_payment
   get "registration/:slug/certificate", to: "events/callouts#certificate", as: :registration_certificate

--- a/db/migrate/20260619215907_add_agreement_signed_to_scholarships.rb
+++ b/db/migrate/20260619215907_add_agreement_signed_to_scholarships.rb
@@ -1,0 +1,9 @@
+class AddAgreementSignedToScholarships < ActiveRecord::Migration[8.1]
+  def up
+    add_column :scholarships, :agreement_signed, :boolean, default: false, null: false unless column_exists?(:scholarships, :agreement_signed)
+  end
+
+  def down
+    remove_column :scholarships, :agreement_signed, if_exists: true
+  end
+end

--- a/db/migrate/20260619221202_add_agreement_signed_at_to_scholarships.rb
+++ b/db/migrate/20260619221202_add_agreement_signed_at_to_scholarships.rb
@@ -1,0 +1,9 @@
+class AddAgreementSignedAtToScholarships < ActiveRecord::Migration[8.1]
+  def up
+    add_column :scholarships, :agreement_signed_at, :datetime unless column_exists?(:scholarships, :agreement_signed_at)
+  end
+
+  def down
+    remove_column :scholarships, :agreement_signed_at, if_exists: true
+  end
+end

--- a/db/migrate/20260714130312_drop_agreement_signed_from_scholarships.rb
+++ b/db/migrate/20260714130312_drop_agreement_signed_from_scholarships.rb
@@ -1,0 +1,14 @@
+class DropAgreementSignedFromScholarships < ActiveRecord::Migration[8.1]
+  # agreement_signed is redundant with agreement_signed_at (a nil timestamp means
+  # unsigned), so the boolean is dropped and inferred from the timestamp instead.
+  def up
+    remove_column :scholarships, :agreement_signed, if_exists: true
+  end
+
+  def down
+    unless column_exists?(:scholarships, :agreement_signed)
+      add_column :scholarships, :agreement_signed, :boolean, default: false, null: false
+      execute "UPDATE scholarships SET agreement_signed = TRUE WHERE agreement_signed_at IS NOT NULL"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -834,6 +834,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
     t.index ["windows_type_id"], name: "index_organizations_on_windows_type_id"
   end
 
+  create_table "other_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.string "normalized_text", null: false
+    t.bigint "person_id", null: false
+    t.bigint "promotable_id"
+    t.string "promotable_type"
+    t.bigint "source_form_answer_id"
+    t.string "status", default: "pending", null: false
+    t.string "text", null: false
+    t.datetime "updated_at", null: false
+    t.index ["person_id", "kind", "normalized_text"], name: "index_other_responses_on_person_kind_text", unique: true
+    t.index ["person_id"], name: "index_other_responses_on_person_id"
+    t.index ["promotable_type", "promotable_id"], name: "index_other_responses_on_promotable"
+    t.index ["source_form_answer_id"], name: "index_other_responses_on_source_form_answer_id"
+  end
+
   create_table "pay_charges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "amount", null: false
     t.integer "amount_refunded"
@@ -1189,6 +1206,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
   end
 
   create_table "scholarships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.boolean "agreement_signed", default: false, null: false
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false
     t.bigint "grant_id"
@@ -1738,6 +1756,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
   add_foreign_key "organizations", "locations"
   add_foreign_key "organizations", "organization_statuses"
   add_foreign_key "organizations", "windows_types"
+  add_foreign_key "other_responses", "form_answers", column: "source_form_answer_id"
+  add_foreign_key "other_responses", "people"
   add_foreign_key "pay_charges", "pay_customers", column: "customer_id"
   add_foreign_key "pay_charges", "pay_subscriptions", column: "subscription_id"
   add_foreign_key "pay_payment_methods", "pay_customers", column: "customer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_130312) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1206,7 +1206,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
   end
 
   create_table "scholarships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.boolean "agreement_signed", default: false, null: false
     t.datetime "agreement_signed_at"
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1207,6 +1207,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_113355) do
 
   create_table "scholarships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "agreement_signed", default: false, null: false
+    t.datetime "agreement_signed_at"
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false
     t.bigint "grant_id"

--- a/spec/decorators/scholarship_decorator_spec.rb
+++ b/spec/decorators/scholarship_decorator_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe ScholarshipDecorator, type: :decorator do
     expect(scholarship.recipient_name).to eq("Carmen Gomez")
   end
 
+  it "reflects the agreement_signed flag" do
+    expect(create(:scholarship, recipient: recipient, agreement_signed: false).decorate.agreement_signed?).to be(false)
+    expect(create(:scholarship, recipient: recipient, agreement_signed: true).decorate.agreement_signed?).to be(true)
+  end
+
   describe "program columns derived from the recipient's facilitator affiliation" do
     let(:org) { create(:organization, name: "Prevail") }
 

--- a/spec/factories/scholarships.rb
+++ b/spec/factories/scholarships.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     association :recipient, factory: :person
     amount_cents { 1000 }
     tasks_completed { false }
-    agreement_signed { false }
   end
 end

--- a/spec/factories/scholarships.rb
+++ b/spec/factories/scholarships.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     association :recipient, factory: :person
     amount_cents { 1000 }
     tasks_completed { false }
+    agreement_signed { false }
   end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -508,6 +508,26 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#scholarship_awarded?" do
+    it "is false with no scholarship" do
+      expect(create(:event_registration).scholarship_awarded?).to be false
+    end
+
+    it "is false while the scholarship exists but the agreement is unsigned" do
+      reg = create(:event_registration)
+      scholarship = create(:scholarship, amount_cents: 1099)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 1099)
+      expect(reg.scholarship_awarded?).to be false
+    end
+
+    it "is true once the agreement is signed" do
+      reg = create(:event_registration)
+      scholarship = create(:scholarship, amount_cents: 1099, agreement_signed: true)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 1099)
+      expect(reg.scholarship_awarded?).to be true
+    end
+  end
+
   describe "#joinable?" do
     let(:event) { create(:event, cost_cents: 1099, start_date: 1.hour.ago, end_date: 1.hour.from_now) }
     let(:user) { create(:user, :with_person) }

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -83,9 +83,17 @@ RSpec.describe Scholarship, type: :model do
     end
   end
 
-  describe "agreement_signed_at stamping" do
+  describe "agreement_signed (virtual, backed by agreement_signed_at)" do
+    it "infers the flag from the timestamp" do
+      scholarship = create(:scholarship)
+      expect(scholarship.agreement_signed?).to be(false)
+
+      scholarship.update!(agreement_signed_at: Time.current)
+      expect(scholarship.agreement_signed?).to be(true)
+    end
+
     it "stamps the time when the agreement is first signed" do
-      scholarship = create(:scholarship, agreement_signed: false)
+      scholarship = create(:scholarship)
       expect(scholarship.agreement_signed_at).to be_nil
 
       scholarship.update!(agreement_signed: true)

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -82,4 +82,30 @@ RSpec.describe Scholarship, type: :model do
       expect { create(:scholarship, grant: create(:grant), recipient: person) }.not_to raise_error
     end
   end
+
+  describe "agreement_signed_at stamping" do
+    it "stamps the time when the agreement is first signed" do
+      scholarship = create(:scholarship, agreement_signed: false)
+      expect(scholarship.agreement_signed_at).to be_nil
+
+      scholarship.update!(agreement_signed: true)
+      expect(scholarship.agreement_signed_at).to be_present
+    end
+
+    it "clears the time when the agreement is unsigned" do
+      scholarship = create(:scholarship, agreement_signed: true)
+      expect(scholarship.agreement_signed_at).to be_present
+
+      scholarship.update!(agreement_signed: false)
+      expect(scholarship.agreement_signed_at).to be_nil
+    end
+
+    it "preserves the original time when re-saved while still signed" do
+      scholarship = create(:scholarship, agreement_signed: true)
+      original = scholarship.agreement_signed_at
+      scholarship.update!(amount_cents: 2_000)
+
+      expect(scholarship.reload.agreement_signed_at).to be_within(1.second).of(original)
+    end
+  end
 end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -293,6 +293,20 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).not_to include("reverted payments still count")
       end
 
+      it "shows the scholarship agreement status on the scholarship card" do
+        scholarship = Scholarship.new(recipient: existing_registration.registrant, amount_cents: 1_000)
+        scholarship.build_allocation(allocatable: existing_registration, amount: 1_000)
+        scholarship.save!
+
+        get edit_event_registration_path(existing_registration)
+        expect(response.body).to include("Agreement pending")
+
+        scholarship.update!(agreement_signed: true)
+        get edit_event_registration_path(existing_registration)
+        expect(response.body).to include("Agreement signed")
+        expect(response.body).not_to include("Agreement pending")
+      end
+
       it "hides Delete and explains why for a registration with payment records" do
         payment = create(:payment, person: regular_user.person, amount_cents: 1000, amount_cents_remaining: nil)
         create(:allocation, source: payment, allocatable: existing_registration, amount: 1000)

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -171,25 +171,10 @@ RSpec.describe "Events::Callouts", type: :request do
     let(:scholarship)  { create(:scholarship, recipient: registration.registrant, amount_cents: 5_000) }
     let!(:allocation)  { create(:allocation, source: scholarship, allocatable: registration, amount: 5_000) }
 
-    it "shows the agreement as needed until it is signed" do
-      get registration_scholarship_path(registration.slug)
-
-      expect(response).to have_http_status(:success)
-      expect(response.body).to include("Agreement needed")
-      expect(response.body).not_to include("Agreement signed")
-    end
-
-    it "shows the agreement as signed once the flag is set" do
-      scholarship.update!(agreement_signed: true)
-      get registration_scholarship_path(registration.slug)
-
-      expect(response.body).to include("Agreement signed")
-      expect(response.body).not_to include("Agreement needed")
-    end
-
     it "renders the agree form while the agreement is unsigned" do
       get registration_scholarship_path(registration.slug)
 
+      expect(response).to have_http_status(:success)
       expect(response.body).to include("Do you agree to complete the tasks?")
       expect(response.body).to match(/name="agreement"/)
     end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -186,5 +186,47 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).to include("Agreement signed")
       expect(response.body).not_to include("Agreement needed")
     end
+
+    it "renders the agree form while the agreement is unsigned" do
+      get registration_scholarship_path(registration.slug)
+
+      expect(response.body).to include("Do you agree to complete the tasks?")
+      expect(response.body).to match(/name="agreement"/)
+    end
+
+    it "shows the signed date once the agreement is signed" do
+      scholarship.update!(agreement_signed: true)
+      get registration_scholarship_path(registration.slug)
+
+      expect(response.body).to include("You agreed to complete your scholarship tasks on")
+      expect(response.body).not_to include("Do you agree to complete the tasks?")
+    end
+  end
+
+  describe "POST /registration/:slug/scholarship/agreement" do
+    it "signs the agreement and stamps the time when Yes is selected" do
+      expect(scholarship.agreement_signed?).to be(false)
+
+      post registration_scholarship_agreement_path(registration.slug), params: { agreement: "yes" }
+
+      expect(response).to redirect_to(registration_scholarship_path(registration.slug))
+      expect(scholarship.reload.agreement_signed?).to be(true)
+      expect(scholarship.agreement_signed_at).to be_present
+    end
+
+    it "does not sign the agreement when Yes is not selected" do
+      post registration_scholarship_agreement_path(registration.slug), params: { agreement: "" }
+
+      expect(response).to redirect_to(registration_scholarship_path(registration.slug))
+      expect(scholarship.reload.agreement_signed?).to be(false)
+    end
+
+    it "redirects to the scholarship page when there is no awarded scholarship" do
+      other = create(:event_registration, event: event, scholarship_requested: true)
+
+      post registration_scholarship_agreement_path(other.slug), params: { agreement: "yes" }
+
+      expect(response).to redirect_to(registration_scholarship_path(other.slug))
+    end
   end
 end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -164,4 +164,27 @@ RSpec.describe "Events::Callouts", type: :request do
       end
     end
   end
+
+  describe "GET /registration/:slug/scholarship" do
+    let(:event)        { create(:event, cost_cents: 10_000) }
+    let(:registration) { create(:event_registration, event: event, scholarship_requested: true) }
+    let(:scholarship)  { create(:scholarship, recipient: registration.registrant, amount_cents: 5_000) }
+    let!(:allocation)  { create(:allocation, source: scholarship, allocatable: registration, amount: 5_000) }
+
+    it "shows the agreement as needed until it is signed" do
+      get registration_scholarship_path(registration.slug)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Agreement needed")
+      expect(response.body).not_to include("Agreement signed")
+    end
+
+    it "shows the agreement as signed once the flag is set" do
+      scholarship.update!(agreement_signed: true)
+      get registration_scholarship_path(registration.slug)
+
+      expect(response.body).to include("Agreement signed")
+      expect(response.body).not_to include("Agreement needed")
+    end
+  end
 end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -173,25 +173,27 @@ RSpec.describe "Events::Callouts", type: :request do
     let!(:allocation)  { create(:allocation, source: scholarship, allocatable: registration, amount: 5_000) }
 
     describe "GET /registration/:slug/scholarship" do
-      it "renders the agree form while the agreement is unsigned" do
+      it "shows the amount as offered with an Agree button while unsigned" do
         get registration_scholarship_path(registration.slug)
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include("Do you agree to complete the tasks?")
-        expect(response.body).to match(/name="agreement"/)
+        expect(response.body).to include("Amount offered")
+        expect(response.body).to include("Pending agreement")
+        expect(response.body).to match(/name="agreement" value="yes"/)
       end
 
-      it "shows the signed date once the agreement is signed" do
+      it "shows the award as signed with the date once the agreement is signed" do
         scholarship.update!(agreement_signed: true)
         get registration_scholarship_path(registration.slug)
 
-        expect(response.body).to include("You agreed to complete your scholarship tasks on")
-        expect(response.body).not_to include("Do you agree to complete the tasks?")
+        expect(response.body).to include("Amount awarded")
+        expect(response.body).to include("Agreement signed")
+        expect(response.body).not_to include("Pending agreement")
       end
     end
 
     describe "POST /registration/:slug/scholarship/agreement" do
-      it "signs the agreement and stamps the time when Yes is selected" do
+      it "signs the agreement and stamps the time when Agree is submitted" do
         expect(scholarship.agreement_signed?).to be(false)
 
         post registration_scholarship_agreement_path(registration.slug), params: { agreement: "yes" }
@@ -201,7 +203,7 @@ RSpec.describe "Events::Callouts", type: :request do
         expect(scholarship.agreement_signed_at).to be_present
       end
 
-      it "does not sign the agreement when Yes is not selected" do
+      it "does not sign the agreement without an affirmative submission" do
         post registration_scholarship_agreement_path(registration.slug), params: { agreement: "" }
 
         expect(response).to redirect_to(registration_scholarship_path(registration.slug))

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -165,53 +165,56 @@ RSpec.describe "Events::Callouts", type: :request do
     end
   end
 
-  describe "GET /registration/:slug/scholarship" do
+  # Shared setup for the scholarship callout page and its agree action.
+  context "scholarship agreement" do
     let(:event)        { create(:event, cost_cents: 10_000) }
     let(:registration) { create(:event_registration, event: event, scholarship_requested: true) }
     let(:scholarship)  { create(:scholarship, recipient: registration.registrant, amount_cents: 5_000) }
     let!(:allocation)  { create(:allocation, source: scholarship, allocatable: registration, amount: 5_000) }
 
-    it "renders the agree form while the agreement is unsigned" do
-      get registration_scholarship_path(registration.slug)
+    describe "GET /registration/:slug/scholarship" do
+      it "renders the agree form while the agreement is unsigned" do
+        get registration_scholarship_path(registration.slug)
 
-      expect(response).to have_http_status(:success)
-      expect(response.body).to include("Do you agree to complete the tasks?")
-      expect(response.body).to match(/name="agreement"/)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Do you agree to complete the tasks?")
+        expect(response.body).to match(/name="agreement"/)
+      end
+
+      it "shows the signed date once the agreement is signed" do
+        scholarship.update!(agreement_signed: true)
+        get registration_scholarship_path(registration.slug)
+
+        expect(response.body).to include("You agreed to complete your scholarship tasks on")
+        expect(response.body).not_to include("Do you agree to complete the tasks?")
+      end
     end
 
-    it "shows the signed date once the agreement is signed" do
-      scholarship.update!(agreement_signed: true)
-      get registration_scholarship_path(registration.slug)
+    describe "POST /registration/:slug/scholarship/agreement" do
+      it "signs the agreement and stamps the time when Yes is selected" do
+        expect(scholarship.agreement_signed?).to be(false)
 
-      expect(response.body).to include("You agreed to complete your scholarship tasks on")
-      expect(response.body).not_to include("Do you agree to complete the tasks?")
-    end
-  end
+        post registration_scholarship_agreement_path(registration.slug), params: { agreement: "yes" }
 
-  describe "POST /registration/:slug/scholarship/agreement" do
-    it "signs the agreement and stamps the time when Yes is selected" do
-      expect(scholarship.agreement_signed?).to be(false)
+        expect(response).to redirect_to(registration_scholarship_path(registration.slug))
+        expect(scholarship.reload.agreement_signed?).to be(true)
+        expect(scholarship.agreement_signed_at).to be_present
+      end
 
-      post registration_scholarship_agreement_path(registration.slug), params: { agreement: "yes" }
+      it "does not sign the agreement when Yes is not selected" do
+        post registration_scholarship_agreement_path(registration.slug), params: { agreement: "" }
 
-      expect(response).to redirect_to(registration_scholarship_path(registration.slug))
-      expect(scholarship.reload.agreement_signed?).to be(true)
-      expect(scholarship.agreement_signed_at).to be_present
-    end
+        expect(response).to redirect_to(registration_scholarship_path(registration.slug))
+        expect(scholarship.reload.agreement_signed?).to be(false)
+      end
 
-    it "does not sign the agreement when Yes is not selected" do
-      post registration_scholarship_agreement_path(registration.slug), params: { agreement: "" }
+      it "redirects to the scholarship page when there is no awarded scholarship" do
+        other = create(:event_registration, event: event, scholarship_requested: true)
 
-      expect(response).to redirect_to(registration_scholarship_path(registration.slug))
-      expect(scholarship.reload.agreement_signed?).to be(false)
-    end
+        post registration_scholarship_agreement_path(other.slug), params: { agreement: "yes" }
 
-    it "redirects to the scholarship page when there is no awarded scholarship" do
-      other = create(:event_registration, event: event, scholarship_requested: true)
-
-      post registration_scholarship_agreement_path(other.slug), params: { agreement: "yes" }
-
-      expect(response).to redirect_to(registration_scholarship_path(other.slug))
+        expect(response).to redirect_to(registration_scholarship_path(other.slug))
+      end
     end
   end
 end

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe "Scholarships", type: :request do
       get edit_scholarship_path(scholarship)
 
       expect(response.body).to include("scholarship-preview")
-      expect(response.body).to include("scholarship-preview-target=\"amountBox\"")
-      # Tasks completed → the $50 amount is allocated to the registration.
-      expect(response.body).to include("$50 allocated to registration")
+      # A non-zero award tints the amount box fuchsia to signal the allocation.
+      expect(response.body).to match(/data-scholarship-preview-target="amountBox"[^>]*border-fuchsia-300 bg-fuchsia-50/)
       # Event cost $100 with $50 allocated leaves $50 owed.
       expect(response.body).to include("$50")
     end

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -159,6 +159,30 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 
+  describe "scholarship agreement toggle" do
+    it "renders the agreement toggle on the edit form" do
+      get edit_scholarship_path(scholarship)
+
+      expect(response.body).to include("Scholarship agreement")
+      expect(response.body).to match(/name="scholarship\[agreement_signed\]"/)
+    end
+
+    it "persists the agreement_signed flag through update" do
+      expect(scholarship.agreement_signed?).to be(false)
+
+      patch scholarship_path(scholarship), params: { scholarship: { agreement_signed: "1" } }
+
+      expect(scholarship.reload.agreement_signed?).to be(true)
+    end
+
+    it "shows the agreement status on the show page" do
+      scholarship.update!(agreement_signed: true)
+      get scholarship_path(scholarship)
+
+      expect(response.body).to include("Agreement signed")
+    end
+  end
+
   describe "POST /scholarships from the registration Add link" do
     it "returns to the event registration edit page on create (symmetric with View)" do
       expect {

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -108,9 +108,19 @@ RSpec.describe MagicTicketCallouts do
       expect(scholarship_card.theme).to eq(DomainTheme.swatch(DomainTheme.color_for(:scholarships)))
     end
 
+    it "prompts to accept the agreement, without an amount chip, until it is signed" do
+      registration.update!(scholarship_requested: true)
+      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: true, agreement_signed: false)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
+      scholarship_card = card(registration, "Scholarship")
+      expect(scholarship_card.subtitle).to eq("Review and accept your scholarship agreement")
+      expect(scholarship_card.badge).to be_nil
+      expect(scholarship_card.theme).to eq(DomainTheme.swatch("amber"))
+    end
+
     it "turns the scholarship card amber while award tasks are outstanding" do
       registration.update!(scholarship_requested: true)
-      scholarship = create(:scholarship, recipient: registration.registrant, tasks_completed: false)
+      scholarship = create(:scholarship, recipient: registration.registrant, tasks_completed: false, agreement_signed: true)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
 
       expect(card(registration, "Scholarship").theme).to eq(DomainTheme.swatch("amber"))
@@ -118,16 +128,16 @@ RSpec.describe MagicTicketCallouts do
 
     it "flags an awarded scholarship with outstanding tasks in an amber chip" do
       registration.update!(scholarship_requested: true)
-      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: false)
+      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: false, agreement_signed: true)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
       scholarship_card = card(registration, "Scholarship")
       expect(scholarship_card.badge).to eq("$250 · Tasks outstanding")
       expect(scholarship_card.badge_classes).to be_nil
     end
 
-    it "shows a fuchsia amount chip once scholarship tasks are complete" do
+    it "shows a fuchsia amount chip once the agreement is signed and tasks are complete" do
       registration.update!(scholarship_requested: true)
-      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: true)
+      scholarship = create(:scholarship, amount_cents: 25_000, tasks_completed: true, agreement_signed: true)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1000)
       scholarship_card = card(registration, "Scholarship")
       expect(scholarship_card.badge).to eq("$250")


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — new columns + a display-gating rule across recipient-facing surfaces

### What is the goal of this PR and why is this important?

- Scholarship recipients must **accept the terms** of their scholarship. Staff record/see it, recipients accept it themselves, and — per product — a scholarship is **not shown as awarded until the agreement is signed** (the underlying record and allocation are unchanged; only the display is gated).

### How did you approach the change?

**Data**
- One column: `agreement_signed_at` (datetime; nil = unsigned). `agreement_signed` is a **virtual** boolean that reads the timestamp and stamps/clears it on write — single source of truth, no sync callback.

**Accept before "awarded" (display only)**
- `EventRegistration#scholarship_awarded?` = scholarship present **and** agreement signed. Drives:
  - **Ticket callout card** — amber "Review and accept your scholarship agreement", no amount chip, until signed; then the award subtitle + amount.
  - **Scholarship page** — "Amount offered" + "Pending agreement" chip until signed; "Amount awarded" + tasks chip after.

**Recipient accepts**
- Scholarship page shows the agreement above the details with a single green **Agree** button; `POST events/callouts#sign_agreement` stamps it. Once signed: "Agreement signed · <date>".

**Staff**
- Editable toggle on the scholarship form (fuchsia fill); "Agreement signed: Yes · <date>" on the show page; "Agreement signed / pending" chip on the reg-edit scholarship card.

### UI Testing Checklist

- [ ] Recipient, unsigned: ticket card is amber "Review and accept…" with no amount; scholarship page shows "Amount offered" + "Pending agreement" + green Agree button.
- [ ] After clicking Agree: card shows the award + amount; page shows "Amount awarded", tasks chip, and "Agreement signed · <date>".
- [ ] Staff toggle flips the reg-edit chip and show-page status; the allocation/amount never changes.

### Anything else to add?

- Rebased across the CE cutover / callout consolidation; the toggle now uses main's CSS fuchsia fill.
- Gating is display-only by design — no change to allocation or what "exists".

🤖 Generated with [Claude Code](https://claude.com/claude-code)