### PR TITLE
Default sample ticket preview to a typical registrant, with options toggle

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -43,28 +43,31 @@ class EventsController < ApplicationController
   end
 
   # Admin preview of the registration ticket. Builds an in-memory sample
-  # registration — never saved — with every registrant-chosen option turned on,
-  # so admins can see what their event's ticket looks like with all sections
-  # present. The ticket partial renders in `preview: true` mode, which disables
-  # the state-changing buttons (pay, resend, cancel) and renders the callout
-  # cards non-navigating. A sentinel slug lets the callout route helpers build
-  # without raising, since the sample isn't persisted.
+  # registration — never saved. By default it models a typical registrant (no
+  # scholarship, no continuing education, no extra requests) so the preview is
+  # indicative of what most tickets look like. The "Show all options" toggle
+  # (?options=all) turns on every registrant-chosen option at once so admins can
+  # see every section present. The ticket partial renders in `preview: true`
+  # mode, which disables the state-changing buttons (pay, resend, cancel) and
+  # renders the callout cards non-navigating. A sentinel slug lets the callout
+  # route helpers build without raising, since the sample isn't persisted.
   def sample_ticket
     authorize! @event, to: :dashboard?
 
+    @show_all_options = params[:options] == "all"
     registrant = Person.new(first_name: "Sample", last_name: "Registrant")
     @event_registration = @event.event_registrations.new(
       registrant: registrant,
       slug: "sample",
       status: "registered",
       intends_to_pay: true,
-      w9_requested: true,
-      invoice_requested: true,
-      scholarship_requested: true,
-      shoutout: true,
-      ce_credit_requested: true,
-      ce_hours_requested: 6,
-      ce_license_number: "SAMPLE-12345",
+      w9_requested: @show_all_options,
+      invoice_requested: @show_all_options,
+      scholarship_requested: @show_all_options,
+      shoutout: @show_all_options,
+      ce_credit_requested: @show_all_options,
+      ce_hours_requested: @show_all_options ? 6 : nil,
+      ce_license_number: @show_all_options ? "SAMPLE-12345" : nil,
       created_at: Time.current
     )
   end

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -13,13 +13,37 @@
 <div class="max-w-2xl mx-auto px-4 pt-4">
   <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
 
+  <%# Preview box: the description on the left, the admin-only options toggle in
+      the top right. The toggle reloads this same preview with (or without)
+      ?options=all, preserving the origin so the eyebrow still points home. %>
   <div class="mt-4 flex items-start gap-3 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3">
     <i class="fa-solid fa-eye text-amber-500 text-xl shrink-0 mt-0.5"></i>
-    <div class="text-sm text-amber-800">
+    <div class="flex-1 min-w-0 text-sm text-amber-800">
       <p class="font-semibold text-amber-900">Sample ticket preview</p>
-      <p>This is an example registration with every option turned on, shown for
-        display purposes. Action buttons are disabled — no real registrant exists.</p>
+      <% if @show_all_options %>
+        <p>This is an example registration with every option turned on — including
+          scholarship and continuing education — shown for display purposes. Action
+          buttons are disabled — no real registrant exists.</p>
+      <% else %>
+        <p>This is an example registration for a typical registrant, shown for
+          display purposes. Use “Show all options” to preview every section,
+          including scholarship and continuing education. Action buttons are
+          disabled — no real registrant exists.</p>
+      <% end %>
     </div>
+
+    <% toggle_class = "admin-only shrink-0 inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 shadow-sm hover:border-amber-400 hover:bg-amber-50" %>
+    <% if @show_all_options %>
+      <%= link_to sample_ticket_event_path(@event, return_to: params[:return_to]), class: toggle_class do %>
+        <i class="fa-solid fa-user text-amber-500"></i>
+        Show typical ticket
+      <% end %>
+    <% else %>
+      <%= link_to sample_ticket_event_path(@event, options: "all", return_to: params[:return_to]), class: toggle_class do %>
+        <i class="fa-solid fa-list-check text-amber-500"></i>
+        Show all options
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Forms")
       end
 
+      it "models a typical registrant by default, hiding scholarship and CE" do
+        get sample_ticket_event_path(event)
+        expect(response.body).not_to include("Your scholarship request status")
+        expect(response.body).not_to include("CE hours")
+        expect(response.body).to include("Show all options")
+      end
+
+      it "turns on every option with ?options=all" do
+        get sample_ticket_event_path(event, options: "all")
+        expect(response.body).to include("Your scholarship request status")
+        expect(response.body).to include("CE hours")
+        expect(response.body).to include("Show typical ticket")
+      end
+
       it "does not create a registration" do
         expect { get sample_ticket_event_path(event) }
           .not_to change(EventRegistration, :count)


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The admin sample-ticket preview previously turned on every registrant option (scholarship, CE, W-9/invoice, shoutout), which isn't indicative of what most real tickets look like. This defaults the preview to a plain, typical registrant so admins see the common case, while still allowing a full "everything on" view on demand.

### How did you approach the change?
`EventsController#sample_ticket` now builds the in-memory sample with those options off by default and flips them all on when `?options=all` is passed; the dashboard and Form-actions-menu links keep pointing at the default. An admin-only toggle sits in the top-right of the preview box — "Show all options" reloads with `?options=all`, "Show typical ticket" returns to the default — preserving `return_to` so the eyebrow still points home, and the banner copy adapts to the active mode.

### UI Testing Checklist
- [ ] Sample ticket from the dashboard (and Form actions menu) shows a typical registrant — no scholarship or CE callout cards.
- [ ] "Show all options" reloads the preview with scholarship, CE, and other sections present; "Show typical ticket" toggles back.
- [ ] The eyebrow returns to the correct origin (Dashboard vs Registrants) in both modes.

### Anything else to add?
Stacked on #1793 (the original sample-ticket preview), which has since merged to main, so this targets main directly.
