### PR TITLE
Link ticket callouts to resources; show docs in a registrant resource page

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -54,15 +54,25 @@ module Events
     end
 
     # Handouts page: callout-card links to the training worksheet/handout
-    # resources, in display order, each opening in a new tab.
+    # resources, in display order, each opening its own registrant resource page
+    # (PDF preview + download, with a back-to-ticket eyebrow).
     def handouts
       by_title = Resource.where(title: HANDOUT_RESOURCE_TITLES).index_by(&:title)
       @handout_cards = HANDOUT_RESOURCE_TITLES.filter_map do |title|
         resource = by_title[title]
         next unless resource
         resource_card(icon: "fa-solid fa-file-pdf", title: resource.title,
-                      subtitle: "Open this training resource", href: resource_path(resource))
+                      subtitle: "Open this training resource",
+                      href: registration_resource_path(@event_registration.slug, resource), target: nil)
       end
+    end
+
+    # Registrant-facing page for a single Resource, shown in the shared callout
+    # chrome: the PDF first-page preview and a download button. Reached from the
+    # handouts/forms callouts so a registrant views a document without leaving the
+    # ticket context.
+    def resource
+      @resource = Resource.find(params[:resource_id]).decorate
     end
 
     # Facilitator Portal access info, with a link to the home screen.
@@ -107,15 +117,17 @@ module Events
       if letter
         cards << resource_card(icon: "fa-solid fa-file-arrow-down", title: "Letter to supervisors",
                                subtitle: "Share to request release time",
-                               href: resource_download_path(letter), trailing_icon: "fa-solid fa-download")
+                               href: registration_resource_path(@event_registration.slug, letter), target: nil)
       end
       cards
     end
 
-    # A blue, new-tab callout card linking to an external/resource document.
-    def resource_card(icon:, title:, subtitle:, href:, trailing_icon: "fa-solid fa-arrow-right")
+    # A blue callout card linking to a document. External/static links open in a
+    # new tab (target: "_blank"); registrant resource pages stay in-tab so the
+    # back-to-ticket eyebrow works (pass target: nil).
+    def resource_card(icon:, title:, subtitle:, href:, target: "_blank", trailing_icon: "fa-solid fa-arrow-right")
       MagicTicketCallouts::Card.new(icon_class: icon, color: "blue", title: title, subtitle: subtitle,
-                                    href: href, target: "_blank", trailing_icon: trailing_icon)
+                                    href: href, target: target, trailing_icon: trailing_icon)
     end
   end
 end

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -4,13 +4,13 @@ class RegistrationTicketCalloutsController < ApplicationController
 
   # Public detail page for a single registration ticket callout, linked from the
   # call-out on the registration ticket (mirrors the events#details / #ce_hours
-  # pages). When the callout has no description there is nothing to read, so fall
-  # back to the event page.
+  # pages). With no description and no linked resource there is nothing to show,
+  # so fall back to the event page.
   def show
     @callout = @event.registration_ticket_callouts.find(params[:id])
     authorize! @callout, to: :show?
 
-    if @callout.description.blank?
+    if @callout.description.blank? && @callout.resource.nil?
       redirect_to event_path(@event, reg: params[:reg].presence)
       return
     end

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -13,6 +13,11 @@ class RegistrationTicketCallout < ApplicationRecord
 
   belongs_to :event
 
+  # Optionally links the callout to a Resource. When present, the callout's
+  # detail page renders the resource's display (PDF first-page preview, etc.)
+  # and a download button beneath the callout's own title/subtitle/content.
+  belongs_to :resource, optional: true
+
   # Per-event ordering, drag-reordered after save via the shared `sortable`
   # Stimulus controller (a per-row PUT to #update). The gem reflows the other
   # callouts' positions on each move, exactly like Category. It assigns position

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -144,7 +144,7 @@ class EventPolicy < ApplicationPolicy
                   sector_ids: [],
                   primary_asset_attributes: [ :id, :file, :_destroy ],
                   gallery_assets_attributes: [ :id, :file, :_destroy ],
-                  registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :payment_access_gated, :_destroy ]
+                  registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :payment_access_gated, :resource_id, :_destroy ]
         ]
 
     permitted.prepend(:ga4_snippet, :gtm_head_snippet, :gtm_body_snippet) if admin?

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -68,6 +68,14 @@
             class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
     </div>
 
+    <div class="pl-9 pr-9">
+      <%= f.label :resource_id, "Linked resource", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+      <p class="text-xs text-gray-500 mb-1">Optional. Shows the resource below the content on the call-out's page (PDF first-page preview, etc.), with a download button when the resource has a downloadable file.</p>
+      <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
+            { include_blank: "None" },
+            class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+    </div>
+
     <div class="flex items-center justify-between pl-9 pr-9">
       <label class="flex items-center gap-2 text-sm text-gray-600">
         <%= f.check_box :payment_access_gated, class: "rounded border-gray-300 text-purple-600" %>

--- a/app/views/events/callouts/_callout_page.html.erb
+++ b/app/views/events/callouts/_callout_page.html.erb
@@ -1,9 +1,11 @@
 <%# Shared chrome for registrant callout show pages: back-to-ticket eyebrow +
     branded header, with the body supplied as a block via render(layout:). Callers
-    set their own page_bg_class / page_title and pass a `title` local. Uses
-    @event_registration and @event. %>
+    set their own page_bg_class / page_title and pass a `title` local. Uses @event.
+    The eyebrow defaults to the registrant's ticket (uses @event_registration);
+    callers without a registration can override it with a `back_path` local. %>
+<% back_path = local_assigns.fetch(:back_path) { registration_ticket_path(@event_registration.slug) } %>
 <div class="max-w-3xl mx-auto px-4 pt-4">
-  <%= link_to registration_ticket_path(@event_registration.slug),
+  <%= link_to back_path,
               class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
   <% end %>

--- a/app/views/events/callouts/_callout_page.html.erb
+++ b/app/views/events/callouts/_callout_page.html.erb
@@ -2,14 +2,17 @@
     branded header, with the body supplied as a block via render(layout:). Callers
     set their own page_bg_class / page_title and pass a `title` local. Uses @event.
     The eyebrow defaults to the registrant's ticket (uses @event_registration);
-    callers without a registration can override it with a `back_path` local. %>
+    callers without a registration can override it with a `back_path` local, or
+    pass `back_path: nil` to drop the eyebrow. %>
 <% back_path = local_assigns.fetch(:back_path) { registration_ticket_path(@event_registration.slug) } %>
-<div class="max-w-3xl mx-auto px-4 pt-4">
-  <%= link_to back_path,
-              class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
-    <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
-  <% end %>
-</div>
+<% if back_path %>
+  <div class="max-w-3xl mx-auto px-4 pt-4">
+    <%= link_to back_path,
+                class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
+    <% end %>
+  </div>
+<% end %>
 
 <div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -1,0 +1,16 @@
+<%# Renders a resource inside a callout page: a top-right download button (when a
+    downloadable file is attached) plus the resource display (PDF first-page preview
+    etc., via the same pipeline as resources/show). `resource` is a decorated
+    Resource. Shared by the registrant resource viewer and admin callouts that link
+    a resource. %>
+<% if resource.downloadable_asset&.file&.attached? %>
+  <div class="flex justify-end mb-4">
+    <%= link_to resource_download_path(resource), download: true, class: "btn btn-utility" do %>
+      Download <i class="fa-solid fa-download"></i>
+    <% end %>
+  </div>
+<% end %>
+
+<%= render "assets/display_assets",
+           resource: resource, file: resource.display_image,
+           variant: :hero, link: true %>

--- a/app/views/events/callouts/resource.html.erb
+++ b/app/views/events/callouts/resource.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:page_bg_class, "public") %>
+<% content_for(:page_title, "#{@resource.title} — #{@event.title}") %>
+<%= render layout: "events/callouts/callout_page", locals: { title: @resource.title } do %>
+  <%= render "events/callouts/resource_body", resource: @resource %>
+<% end %>

--- a/app/views/events/registrations/invoice.html.erb
+++ b/app/views/events/registrations/invoice.html.erb
@@ -2,7 +2,7 @@
 <% content_for(:page_title, "Invoice — #{@event.title}") %>
 <%= render "events/invoices/actions",
       back_path: registration_ticket_path(@event_registration.slug),
-      back_label: "Back to registration" %>
+      back_label: "Back to ticket" %>
 <div class="px-4 sm:px-8 py-6 print:p-0">
   <%= render "events/invoices/invoice", invoice: @invoice %>
 </div>

--- a/app/views/registration_ticket_callouts/show.html.erb
+++ b/app/views/registration_ticket_callouts/show.html.erb
@@ -1,37 +1,33 @@
 <% content_for(:page_bg_class, "public") %>
-
+<% content_for(:page_title, "#{@callout.title} — #{@event.title}") %>
 <% reg_slug = params[:reg].presence %>
 <% back_path = reg_slug ? registration_ticket_path(reg_slug) : event_path(@event) %>
-<% back_label = reg_slug ? "Back to ticket" : "Back to event" %>
-<div class="max-w-3xl mx-auto px-4 pt-4">
-  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
-    <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
-  <% end %>
-</div>
-
-<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
-      <div class="flex items-center gap-5">
-        <div class="shrink-0">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
-        </div>
-        <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight"><%= @callout.title %></h1>
-          <p class="text-sm text-blue-200"><%= @event.title %></p>
-        </div>
-      </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
-    </div>
-
-    <div class="px-6 sm:px-8 py-7">
-      <% if @callout.subtitle.present? %>
-        <p class="text-base text-gray-500 mb-4"><%= @callout.subtitle %></p>
+<% resource = @callout.resource&.decorate %>
+<% downloadable = resource if resource&.downloadable_asset&.file&.attached? %>
+<%= render layout: "events/callouts/callout_page", locals: { title: @callout.title, back_path: back_path } do %>
+  <% if downloadable %>
+    <div class="flex justify-end mb-4">
+      <%= link_to resource_download_path(downloadable), download: true, class: "btn btn-utility" do %>
+        Download <i class="fa-solid fa-download"></i>
       <% end %>
-
-      <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
-        <%= form_label_html(@callout.description) %>
-      </div>
     </div>
-  </div>
-</div>
+  <% end %>
+
+  <% if @callout.subtitle.present? %>
+    <p class="text-base text-gray-500 mb-4"><%= @callout.subtitle %></p>
+  <% end %>
+
+  <% if @callout.description.present? %>
+    <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
+      <%= form_label_html(@callout.description) %>
+    </div>
+  <% end %>
+
+  <% if resource %>
+    <div class="mt-6">
+      <%= render "assets/display_assets",
+                 resource: resource, file: resource.display_image,
+                 variant: :hero, link: true %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/registration_ticket_callouts/show.html.erb
+++ b/app/views/registration_ticket_callouts/show.html.erb
@@ -1,18 +1,9 @@
 <% content_for(:page_bg_class, "public") %>
 <% content_for(:page_title, "#{@callout.title} — #{@event.title}") %>
 <% reg_slug = params[:reg].presence %>
-<% back_path = reg_slug ? registration_ticket_path(reg_slug) : event_path(@event) %>
+<% back_path = reg_slug ? registration_ticket_path(reg_slug) : nil %>
 <% resource = @callout.resource&.decorate %>
-<% downloadable = resource if resource&.downloadable_asset&.file&.attached? %>
 <%= render layout: "events/callouts/callout_page", locals: { title: @callout.title, back_path: back_path } do %>
-  <% if downloadable %>
-    <div class="flex justify-end mb-4">
-      <%= link_to resource_download_path(downloadable), download: true, class: "btn btn-utility" do %>
-        Download <i class="fa-solid fa-download"></i>
-      <% end %>
-    </div>
-  <% end %>
-
   <% if @callout.subtitle.present? %>
     <p class="text-base text-gray-500 mb-4"><%= @callout.subtitle %></p>
   <% end %>
@@ -25,9 +16,7 @@
 
   <% if resource %>
     <div class="mt-6">
-      <%= render "assets/display_assets",
-                 resource: resource, file: resource.display_image,
-                 variant: :hero, link: true %>
+      <%= render "events/callouts/resource_body", resource: resource %>
     </div>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
   get "registration/:slug/ce", to: "events/callouts#ce", as: :registration_ce
   get "registration/:slug/forms", to: "events/callouts#forms", as: :registration_forms
   get "registration/:slug/handouts", to: "events/callouts#handouts", as: :registration_handouts
+  get "registration/:slug/resource/:resource_id", to: "events/callouts#resource", as: :registration_resource
   get "registration/:slug/portal", to: "events/callouts#portal", as: :registration_portal
   get "registration/:slug/videoconference", to: "events/callouts#videoconference", as: :registration_videoconference
   post "registration/:slug/resend_confirmation", to: "events/registrations#resend_confirmation", as: :registration_resend_confirmation

--- a/db/migrate/20260618202115_add_resource_to_registration_ticket_callouts.rb
+++ b/db/migrate/20260618202115_add_resource_to_registration_ticket_callouts.rb
@@ -1,0 +1,14 @@
+class AddResourceToRegistrationTicketCallouts < ActiveRecord::Migration[8.1]
+  def up
+    # resources.id is a legacy `int` (not bigint), so the FK column must match.
+    add_reference :registration_ticket_callouts, :resource, type: :integer, null: true, index: true
+    add_foreign_key :registration_ticket_callouts, :resources, on_delete: :nullify
+  end
+
+  def down
+    if foreign_key_exists?(:registration_ticket_callouts, :resources)
+      remove_foreign_key :registration_ticket_callouts, :resources
+    end
+    remove_reference :registration_ticket_callouts, :resource, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1027,11 +1027,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_120508) do
     t.string "icon_class"
     t.boolean "payment_access_gated", default: false, null: false
     t.integer "position", null: false
+    t.integer "resource_id"
     t.string "subtitle"
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["event_id", "position"], name: "index_registration_ticket_callouts_on_event_id_and_position"
     t.index ["event_id"], name: "index_registration_ticket_callouts_on_event_id"
+    t.index ["resource_id"], name: "index_registration_ticket_callouts_on_resource_id"
   end
 
   create_table "report_form_field_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1663,6 +1665,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_120508) do
   add_foreign_key "quotable_item_quotes", "quotes"
   add_foreign_key "quotes", "workshops"
   add_foreign_key "registration_ticket_callouts", "events"
+  add_foreign_key "registration_ticket_callouts", "resources", on_delete: :nullify
   add_foreign_key "report_form_field_answers", "answer_options"
   add_foreign_key "report_form_field_answers", "form_fields"
   add_foreign_key "report_form_field_answers", "reports"

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Registration ticket callouts", type: :request do
       expect(response.body).to include("Use the north lot.")
     end
 
-    it "redirects to the event when the callout has no description" do
+    it "redirects to the event when the callout has no description or resource" do
       callout = create(:registration_ticket_callout, event:, description: "")
 
       get event_registration_ticket_callout_path(event, callout)
@@ -35,12 +35,56 @@ RSpec.describe "Registration ticket callouts", type: :request do
       expect(response.body).to include("Parking")
     end
 
+    it "renders a resource-linked callout even when it has no description" do
+      resource = create(:resource)
+      create(:downloadable_asset, owner: resource)
+      callout = create(:registration_ticket_callout, event:, description: "", resource:)
+
+      get event_registration_ticket_callout_path(event, callout)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(resource_download_path(resource))
+    end
+
     it "does not find a callout belonging to a different event" do
       other_callout = create(:registration_ticket_callout, description: "<p>Hi.</p>")
 
       get event_registration_ticket_callout_path(event, other_callout)
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    context "when linked to a resource with a downloadable file" do
+      let(:resource) { create(:resource) }
+      let(:callout) do
+        create(:registration_ticket_callout, event:, title: "Workbook",
+          description: "<p>Read this first.</p>", resource:)
+      end
+
+      before { create(:downloadable_asset, owner: resource) }
+
+      it "renders the callout content above the resource display and a download button" do
+        get event_registration_ticket_callout_path(event, callout)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Read this first.")
+        expect(response.body).to include(resource_download_path(resource))
+      end
+    end
+
+    context "when linked to a resource without a downloadable file" do
+      let(:resource) { create(:resource) }
+      let(:callout) do
+        create(:registration_ticket_callout, event:,
+          description: "<p>Read this first.</p>", resource:)
+      end
+
+      it "does not render a download button" do
+        get event_registration_ticket_callout_path(event, callout)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(resource_download_path(resource))
+      end
     end
   end
 
@@ -64,6 +108,24 @@ RSpec.describe "Registration ticket callouts", type: :request do
       ordered = event.registration_ticket_callouts.reload.ordered
       expect(ordered.map(&:title)).to eq(%w[First Second Third])
       expect(ordered.map(&:position)).to eq([ 1, 2, 3 ])
+    end
+
+    it "links a callout to a resource through nested attributes" do
+      resource = create(:resource)
+
+      patch event_path(event), params: {
+        event: {
+          title: event.title,
+          start_date: event.start_date,
+          end_date: event.end_date,
+          registration_ticket_callouts_attributes: {
+            "0" => { title: "Workbook", callout_type: "reference", resource_id: resource.id }
+          }
+        }
+      }
+
+      callout = event.registration_ticket_callouts.reload.find_by(title: "Workbook")
+      expect(callout.resource).to eq(resource)
     end
   end
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -209,26 +209,50 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include(registration_invoice_path(registration.slug))
     end
 
-    it "links to the letter-to-supervisors PDF below them when present" do
+    it "links to the letter-to-supervisors resource page below them when present" do
       letter = create(:resource, title: "Letter to Supervisors", kind: "Form")
       get registration_forms_path(registration.slug)
-      expect(response.body.index("/documents/awbw-w9.pdf")).to be < response.body.index(resource_download_path(letter))
+      expect(response.body.index("/documents/awbw-w9.pdf")).to be < response.body.index(registration_resource_path(registration.slug, letter))
     end
   end
 
   describe "GET /registration/:slug/handouts" do
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
-    it "links to seeded handout resources" do
+    it "links each handout to its registrant resource page" do
       handout = create(:resource, title: "AHA Moments", kind: "Handout")
       get registration_handouts_path(registration.slug)
       expect(response).to have_http_status(:success)
-      expect(response.body).to include(resource_path(handout))
+      expect(response.body).to include(registration_resource_path(registration.slug, handout))
     end
 
     it "shows a placeholder when no handouts are present" do
       get registration_handouts_path(registration.slug)
       expect(response.body).to include("Training handouts will be available here soon.")
+    end
+  end
+
+  describe "GET /registration/:slug/resource/:resource_id" do
+    let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+
+    it "renders the resource with a back-to-ticket link and a download button" do
+      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+      create(:downloadable_asset, owner: resource)
+
+      get registration_resource_path(registration.slug, resource)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("AHA Moments")
+      expect(response.body).to include(registration_ticket_path(registration.slug))
+      expect(response.body).to include(resource_download_path(resource))
+    end
+
+    it "is reachable by slug without logging in" do
+      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+
+      get registration_resource_path(registration.slug, resource)
+
+      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/callouts/ce.html.erb"               => "public",
     "app/views/events/callouts/forms.html.erb"            => "public",
     "app/views/events/callouts/handouts.html.erb"         => "public",
+    "app/views/events/callouts/resource.html.erb"         => "public",
     "app/views/events/callouts/portal.html.erb"           => "public",
     "app/views/events/callouts/videoconference.html.erb"  => "public",
     "app/views/events/details.html.erb"                   => "public",


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
Give registrants a consistent, in-context way to view a document from their ticket: admins can attach a Resource to a custom ticket callout, and the app's hard-coded handout/forms document links now open the same registrant resource page (PDF first-page preview + download) instead of dropping the registrant out to a resource's public page or a raw download.

### How did you approach the change?
- Added a nullable `resource_id` FK + `belongs_to :resource` on `RegistrationTicketCallout`, a "Linked resource" select in the callout fields (with `:resource_id` permitted), and rendered the resource on the callout's detail page.
- Added a slug-scoped resource viewer (`registration_resource`) that shows a Resource in the shared `events/callouts/_callout_page` chrome with a back-to-ticket eyebrow; the handouts cards and the forms "letter to supervisors" card now link to it (same tab). A shared `_resource_body` partial renders the preview + download identically on the viewer and the admin callout page.
- Callout back links always return to the ticket (the admin callout page drops its back-to-event fallback; the eyebrow is omitted when there's no registration slug), and the registrant invoice's back link was relabeled "Back to ticket".

### UI Testing Checklist
- [ ] Link a Resource (with a PDF) to a ticket callout and confirm its page shows the PDF preview + Download, in the same chrome as the other callout pages.
- [ ] From a ticket, open Handouts and the Forms "letter to supervisors" link and confirm each opens the resource page (preview + download) with a "Back to ticket" link, in the same tab.
- [ ] Confirm a callout with a linked resource but no content still renders.
- [ ] Confirm the registrant invoice page's back link reads "Back to ticket".

### Anything else to add?
The forms W-9 (a static PDF) and View invoice (already a registrant page) links are unchanged — only Resource-backed links route through the new viewer. The shared `_callout_page` back-link default is unchanged for the existing magic callout pages.