### PR TITLE
Default ticket-callout icon to the arrow; move icon field after colour

### DIFF
--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -11,6 +11,11 @@ class RegistrationTicketCallout < ApplicationRecord
   DEFAULT_ICONS = { "action" => "fa-solid fa-arrow-right", "reference" => "fa-solid fa-circle-info" }.freeze
   DEFAULT_COLORS = { "action" => "orange", "reference" => "indigo" }.freeze
 
+  # New callouts start with the arrow icon pre-filled (the "action" default) so
+  # admins see a sensible value rather than an empty field. Loaded records keep
+  # their stored value; a blank one still falls back via #display_icon_class.
+  attribute :icon_class, :string, default: -> { DEFAULT_ICONS["action"] }
+
   belongs_to :event
 
   # Per-event ordering, drag-reordered after save via the shared `sortable`

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -45,18 +45,18 @@
               data: { callout_preview_target: "typeSelect", action: "callout-preview#update" } %>
       </div>
       <div>
-        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
-              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
-      </div>
-      <div>
         <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
         <%= f.select :color_class,
               DomainTheme::SWATCH_COLORS.map { |c| [ c.to_s.humanize, c ] },
               { include_blank: "Default (by type)" },
               class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
+      </div>
+      <div>
+        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
+              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
       </div>
     </div>
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
When admins add a registration-ticket callout, the **Icon** field rendered empty, giving no hint of a reasonable value. This pre-fills new callouts with the arrow icon and reorders the row so the most niche field (icon) comes last.

### How did you approach the change?
- Set an `attribute :icon_class` default of the "action" arrow (`fa-solid fa-arrow-right`) on `RegistrationTicketCallout`, so newly built callouts (including cocoon's "+ Add callout" template) start pre-filled. Loaded records keep their stored value, and a blank one still falls back via `#display_icon_class`, so existing callouts are unaffected.
- Reordered the callout fields row from Type → Icon → Colour to **Type → Colour → Icon**.

### Anything else to add?
The model spec still passes; its tests set `icon_class` explicitly so they're unaffected by the new default.