### PR TITLE
AI FILES: Guide shorter PR descriptions with a review-depth tag

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -246,6 +246,11 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
+- **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
+- **Start the description with a review-depth tag** on its own single line, followed by a blank line, then the rest of the description. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+  - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
+  - **📖 Read** — light-logic: small, contained logic changes with low blast radius
+  - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review
 - Use bullet points, not paragraphs, when filling out each section
 - Description must explain why the change was made, not just what
 - Include screenshots for UI changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,11 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
+- **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
+- **Start the description with a review-depth tag** on its own single line, followed by a blank line, then the rest of the description. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+  - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
+  - **📖 Read** — light-logic: small, contained logic changes with low blast radius
+  - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review
 - Use bullet points, not paragraphs, when filling out each section
 - Description must explain why the change was made, not just what
 - Include screenshots for UI changes


### PR DESCRIPTION
👀 Skim

### What is the goal of this PR and why is this important?
- Reviewers need a fast signal for how closely to read a PR, and our descriptions had drifted toward long prose.

### How did you approach the change?
- Added a "keep descriptions short" rule to the AI instruction files.
- Introduced a review-depth tag convention (👀 Skim / 📖 Read / 🔬 Inspect) for the first line of every PR description.
- Kept `CLAUDE.md` and `.github/copilot-instructions.md` in sync.

### Anything else to add?
- Docs-only change to AI instruction files; no code or behavior affected.