### PR TITLE
Warn before unlinking an org from a registration

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -217,10 +217,12 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration, to: :unlink_organization?
     organization = Organization.find(params[:organization_id])
 
-    # Removes only the registration-scoped link; the person's global affiliation is left intact.
+    # Intentional UX choice: "Unlink" only removes the org from this registration and
+    # deliberately leaves the person's global Affiliation intact. Affiliations are managed
+    # on the Person record, not here — the Unlink button's confirm dialog warns about this.
     @event_registration.event_registration_organizations.where(organization_id: organization.id).destroy_all
 
-    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} removed from this registration."
+    redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), notice: "#{organization.name} unlinked from this registration."
   end
 
   def destroy

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -30,10 +30,13 @@
                                                   submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
                                                   event_registration: @event_registration %>
             </div>
-            <%= button_to "Remove",
+            <%# Intentional UX choice: Unlink only removes the org from this registration and keeps
+                the person's Affiliation. The confirm dialog spells out the distinction (Affiliations
+                are edited on the Person record). See EventRegistrationsController#unlink_organization. %>
+            <%= button_to "Unlink",
                           unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
                           method: :delete,
-                          form: { class: "shrink-0", data: { turbo_frame: "_top" } },
+                          form: { class: "shrink-0", data: { turbo_frame: "_top", turbo_confirm: "Unlink #{org.name} from this registration?\n\nThis only removes the organization from this registration — it will NOT delete any of #{@person.first_name.presence || @person.full_name}'s Affiliations with #{org.name}.\n\nTo change or remove any Affiliations, edit the Person record." } },
                           class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
           </li>
         <% end %>

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -397,6 +397,15 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).to include("#{edit_person_path(regular_user.person)}#affiliations")
         end
 
+        it "warns on Unlink that it removes the org but keeps the affiliation" do
+          get link_organization_event_registration_path(existing_registration)
+
+          confirm = Nokogiri::HTML(response.body).css("form[data-turbo-confirm]").map { |f| f["data-turbo-confirm"] }.join
+          expect(confirm).to include("will NOT delete")
+          expect(confirm).to include("Affiliation")
+          expect(confirm).to include("edit the Person record")
+        end
+
         it "lists affiliations for non-linked orgs under the registrant's other affiliations" do
           other_org = create(:organization, name: "Unlinked Org Co")
           create(:affiliation, person: regular_user.person, organization: other_org, title: "Board Member")


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The "Remove" control on a registration's *Organizations & affiliations* page only severs the registration↔organization link; it intentionally leaves the person's global Affiliations alone (those are managed on the Person record).
- That distinction wasn't visible, so an admin could reasonably expect it to delete the affiliation too.

### How did you approach the change?
- Renamed the button "Remove" → "Unlink" so it reads as removing a link, not deleting a record.
- Added a Turbo confirm dialog spelling out that unlinking does NOT delete any of the person's Affiliations, and that affiliations are edited on the Person record.
- Documented the intentional UX choice in the view and the `unlink_organization` controller action, and added a request spec asserting the warning is present (existing spec already covers that unlinking preserves the affiliation).

### UI Testing Checklist
- [ ] On a registration with a linked org, click **Unlink** and confirm the dialog explains affiliations are kept.
- [ ] Confirm unlinking removes the org from the registration but the person's Affiliation still appears on their Person record.

### Anything else to add?
- Uses the app's native Turbo confirm convention (no custom modal). The flash notice now reads "… unlinked from this registration."