### PR TITLE
Add videoconference passcode and meeting-room details to events

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -5,6 +5,27 @@ class EventDecorator < ApplicationDecorator
     URI.parse(videoconference_url).host&.split(".")&.[](-2)&.capitalize rescue "video call"
   end
 
+  # The meeting room pulled out of the join URL so registrants can dial in
+  # manually: the numeric ID for Zoom (".../j/1234567890") or the meeting code
+  # for Google Meet ("meet.google.com/abc-defg-hij"). Returns a { label:, value: }
+  # hash, or nil when the URL is blank or the platform isn't recognized.
+  def videoconference_room
+    return if videoconference_url.blank?
+
+    uri = URI.parse(videoconference_url)
+    host = uri.host.to_s.downcase
+
+    if host.end_with?("zoom.us")
+      id = uri.path[%r{/(?:j|wc/join|wc)/(\d+)}, 1]
+      id && { label: "Meeting ID", value: format_zoom_meeting_id(id) }
+    elsif host == "meet.google.com"
+      code = uri.path.delete_prefix("/").presence
+      code && { label: "Meeting code", value: code }
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def display_image
     return primary_asset.file if primary_asset&.file&.attached?
 
@@ -57,17 +78,21 @@ class EventDecorator < ApplicationDecorator
 
     if has_url && has_location
       cal_location = object.videoconference_url
-      description  = "#{location_name}\n\n#{event_description}"
+      base_description = "#{location_name}\n\n#{event_description}"
     elsif has_url
       cal_location = object.videoconference_url
-      description  = event_description
+      base_description = event_description
     elsif has_location
       cal_location = location_name
-      description  = event_description
+      base_description = event_description
     else
       cal_location = nil
-      description  = event_description
+      base_description = event_description
     end
+
+    # Carry the join link, meeting ID/code, and passcode into the calendar entry
+    # so registrants have everything they need to connect straight from the event.
+    description = [ videoconference_calendar_details, base_description ].compact_blank.join("\n\n")
 
     desc_encoded     = ERB::Util.url_encode(description)
     location_encoded = ERB::Util.url_encode(cal_location.to_s)
@@ -295,6 +320,30 @@ class EventDecorator < ApplicationDecorator
   end
 
   private
+
+  # The videoconference connection block (join link, meeting ID/code, passcode)
+  # as plain text for embedding in calendar entries. Nil when there's no link.
+  def videoconference_calendar_details
+    return if videoconference_url.blank?
+
+    lines = [ "Join on #{videoconference_domain}: #{videoconference_url}" ]
+    if (room = videoconference_room)
+      lines << "#{room[:label]}: #{room[:value]}"
+    end
+    lines << "Passcode: #{videoconference_passcode}" if videoconference_passcode.present?
+    lines.join("\n")
+  end
+
+  # Group Zoom meeting-ID digits the way Zoom's own UI does so they're easy to
+  # read aloud/type (e.g. "88285411273" → "882 8541 1273"). Unknown lengths are
+  # returned unchanged.
+  def format_zoom_meeting_id(id)
+    case id.length
+    when 11 then id.sub(/\A(\d{3})(\d{4})(\d{4})\z/, '\1 \2 \3')
+    when 10 then id.sub(/\A(\d{3})(\d{3})(\d{4})\z/, '\1 \2 \3')
+    else id
+    end
+  end
 
   def header_image
     return unless object.rhino_header.body.present?

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -108,6 +108,7 @@ class EventPolicy < ApplicationPolicy
                   :pre_title,
                   :videoconference_url,
                   :videoconference_label,
+                  :videoconference_passcode,
                   :rhino_header,
                   :rhino_description,
                   :event_details,

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -40,6 +40,13 @@
       <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
         <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= @event.decorate.videoconference_domain %></a>
       </p>
+      <% vc_room = @event.decorate.videoconference_room %>
+      <% if vc_room %>
+        <p style="font-size: 14px; color: #6b7280; margin: 0 0 4px;"><%= vc_room[:label] %>: <%= vc_room[:value] %></p>
+      <% end %>
+      <% if @event.videoconference_passcode.present? %>
+        <p style="font-size: 14px; color: #6b7280; margin: 0 0 8px;">Passcode: <%= @event.videoconference_passcode %></p>
+      <% end %>
     <% end %>
 
     <% if @event.registration_close_date %>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -14,7 +14,10 @@ Location: <%= @event.location.name %>
 
 <% if @event.videoconference_url.present? %>
 Videoconference URL: <%= @event.videoconference_url %>
-<% end %>
+<% vc_room = @event.decorate.videoconference_room %>
+<% if vc_room %><%= vc_room[:label] %>: <%= vc_room[:value] %>
+<% end %><% if @event.videoconference_passcode.present? %>Passcode: <%= @event.videoconference_passcode %>
+<% end %><% end %>
 
 <% if @event.labelled_cost.present? %>
   <%= @event.labelled_cost %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -190,6 +190,13 @@
                         placeholder: "Virtual event",
                         class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                       } %>
+          <%= f.input :videoconference_passcode,
+                      label: "Videoconference passcode",
+                      hint: "Shown alongside the join link. The meeting ID/code is read from the URL automatically.",
+                      input_html: {
+                        placeholder: "e.g. 123456",
+                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                      } %>
         </div>
 
         <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">

--- a/app/views/events/_videoconference_connection.html.erb
+++ b/app/views/events/_videoconference_connection.html.erb
@@ -1,0 +1,14 @@
+<%# Meeting room ID/code (parsed from the join URL) and passcode for the event.
+    Render only where the join link itself is revealed. `event` must be a
+    decorated Event. %>
+<% room = event.videoconference_room %>
+<% if room || event.videoconference_passcode.present? %>
+  <div class="mt-2 space-y-0.5 text-sm text-gray-600">
+    <% if room %>
+      <div><span class="font-medium text-gray-700"><%= room[:label] %>:</span> <%= room[:value] %></div>
+    <% end %>
+    <% if event.videoconference_passcode.present? %>
+      <div><span class="font-medium text-gray-700">Passcode:</span> <%= event.videoconference_passcode %></div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/events/_videoconference_link.html.erb
+++ b/app/views/events/_videoconference_link.html.erb
@@ -8,6 +8,7 @@
     <% end %>
     <% if show_link %>
       <%= link_to "Join on #{event.videoconference_domain}", safe_url(event.videoconference_url), target: "_blank", rel: "noopener noreferrer", class: "underline" %>
+      <%= render "events/videoconference_connection", event: event %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -10,6 +10,7 @@
           <i class="fa-solid fa-video"></i> Join on <%= @event.videoconference_domain %>
         <% end %>
         <p class="mt-2 text-xs text-gray-500 break-all"><%= @event.videoconference_url %></p>
+        <%= render "events/videoconference_connection", event: @event %>
       </div>
     <% end %>
 

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
@@ -47,6 +47,13 @@
     <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
       <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= @event.decorate.videoconference_domain %></a>
     </p>
+    <% vc_room = @event.decorate.videoconference_room %>
+    <% if vc_room %>
+      <p style="font-size: 14px; color: #6b7280; margin: 0 0 4px;"><%= vc_room[:label] %>: <%= vc_room[:value] %></p>
+    <% end %>
+    <% if @event.videoconference_passcode.present? %>
+      <p style="font-size: 14px; color: #6b7280; margin: 0 0 8px;">Passcode: <%= @event.videoconference_passcode %></p>
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
@@ -26,7 +26,10 @@ Event date
 <% if @event.videoconference_url.present? %>
   Videoconference URL
   <%= @event.videoconference_url %>
-<% end %>
+<% vc_room = @event.decorate.videoconference_room %>
+<% if vc_room %>  <%= vc_room[:label] %>: <%= vc_room[:value] %>
+<% end %><% if @event.videoconference_passcode.present? %>  Passcode: <%= @event.videoconference_passcode %>
+<% end %><% end %>
 
 <% if @event.labelled_cost.present? %>
   Cost

--- a/db/migrate/20260621104933_add_videoconference_passcode_to_events.rb
+++ b/db/migrate/20260621104933_add_videoconference_passcode_to_events.rb
@@ -1,0 +1,9 @@
+class AddVideoconferencePasscodeToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :videoconference_passcode, :string unless column_exists?(:events, :videoconference_passcode)
+  end
+
+  def down
+    remove_column :events, :videoconference_passcode if column_exists?(:events, :videoconference_passcode)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_120508) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_104933) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -528,6 +528,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_120508) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.string "videoconference_label", default: "Virtual event"
+    t.string "videoconference_passcode"
     t.string "videoconference_url"
     t.index ["created_by_id"], name: "index_events_on_created_by_id"
     t.index ["facilitator_training"], name: "index_events_on_facilitator_training"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -252,8 +252,9 @@ end
 # so the seeded data demonstrates those grey parentheticals on its registration
 # page. force-set on re-seed, mirroring the date/cost refresh above.
 Event.find_by(title: "AWBW Facilitator Training")&.update!(
-  videoconference_url: "https://awbw-org.zoom.us/j/0000000000",
+  videoconference_url: "https://awbw-org.zoom.us/j/88285411273",
   videoconference_label: "Zoom",
+  videoconference_passcode: "awbwmarch",
   autoshow_registration_details: true,
   hint_dates: "must attend both days",
   hint_times: "both days",

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -23,6 +23,38 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#videoconference_room" do
+    it "pulls the Zoom meeting ID from the join URL and groups the digits" do
+      event = build(:event, videoconference_url: "https://awbw-org.zoom.us/j/88285411273").decorate
+      expect(event.videoconference_room).to eq({ label: "Meeting ID", value: "882 8541 1273" })
+    end
+
+    it "ignores a Zoom pwd query param" do
+      event = build(:event, videoconference_url: "https://us02web.zoom.us/j/1234567890?pwd=abc123").decorate
+      expect(event.videoconference_room).to eq({ label: "Meeting ID", value: "123 456 7890" })
+    end
+
+    it "pulls the meeting code from a Google Meet URL" do
+      event = build(:event, videoconference_url: "https://meet.google.com/abc-defg-hij").decorate
+      expect(event.videoconference_room).to eq({ label: "Meeting code", value: "abc-defg-hij" })
+    end
+
+    it "returns nil for an unrecognized platform" do
+      event = build(:event, videoconference_url: "https://example.com/room/42").decorate
+      expect(event.videoconference_room).to be_nil
+    end
+
+    it "returns nil when there is no URL" do
+      event = build(:event, videoconference_url: nil).decorate
+      expect(event.videoconference_room).to be_nil
+    end
+
+    it "returns nil for an invalid URL" do
+      event = build(:event, videoconference_url: "not a url").decorate
+      expect(event.videoconference_room).to be_nil
+    end
+  end
+
   describe "#multi_day?" do
     it "is true when start and end fall on different days" do
       event = build(:event, start_date: Time.zone.local(2026, 7, 23, 9), end_date: Time.zone.local(2026, 7, 24, 16)).decorate
@@ -120,6 +152,20 @@ RSpec.describe EventDecorator do
 
       yahoo = links.find { |a| a.text == "Yahoo" }
       expect(yahoo["href"]).to include("desc=#{desc_encoded}")
+    end
+
+    it "embeds the join link, meeting ID, and passcode in the calendar description" do
+      event = create(:event,
+                      videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                      videoconference_passcode: "secret123")
+      decorated = event.decorate
+
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      apple = doc.css("a").find { |a| a.text == "Apple" }
+
+      expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
+      expect(apple["href"]).to include("Meeting ID: 882 8541 1273")
+      expect(apple["href"]).to include("Passcode: secret123")
     end
   end
 end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -252,14 +252,22 @@ RSpec.describe "Events::Registrations", type: :request do
   end
 
   describe "GET /registration/:slug/videoconference" do
-    let(:event) { create(:event, videoconference_url: "https://awbw.zoom.us/j/123", videoconference_label: "Zoom") }
+    let(:event) { create(:event, videoconference_url: "https://awbw.zoom.us/j/88285411273", videoconference_label: "Zoom", videoconference_passcode: "secret123") }
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
     it "shows the join link and add-to-calendar options" do
       get registration_videoconference_path(registration.slug)
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("https://awbw.zoom.us/j/123")
+      expect(response.body).to include("https://awbw.zoom.us/j/88285411273")
       expect(response.body).to include("Add to your calendar")
+    end
+
+    it "shows the meeting ID parsed from the URL and the passcode" do
+      get registration_videoconference_path(registration.slug)
+      expect(response.body).to include("Meeting ID")
+      expect(response.body).to include("882 8541 1273")
+      expect(response.body).to include("Passcode")
+      expect(response.body).to include("secret123")
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
Registrants joining a virtual event need the meeting ID and passcode — not just a join link — so they can dial in manually, recover from an expired link, or rejoin from a calendar reminder. We previously stored only the URL, so this adds a passcode field and surfaces the full connection details everywhere the link appears.

### How did you approach the change?
- Added a `videoconference_passcode` column (migration + admin form field + permitted param) and a decorator that parses the meeting ID (Zoom, grouped like Zoom's UI) or meeting code (Google Meet) out of the join URL.
- Surfaced the meeting ID/code + passcode wherever the link is already revealed — the registration ticket, event show page, confirmation/FYI emails, and the videoconference callout page — via a shared `_videoconference_connection` partial, keeping them behind the same join-link visibility gating so they never leak on public cards or previews.
- Embedded the join link, meeting ID/code, and passcode into the add-to-calendar links (Google/Apple/Outlook/Office 365/Yahoo) so the details travel into the registrant's calendar, and added decorator + request specs covering URL parsing and display.

### UI Testing Checklist
- [ ] Admin event form saves a videoconference passcode
- [ ] Registration ticket and event page show the meeting ID/code + passcode only when the join link is revealed
- [ ] Videoconference callout page shows the meeting ID/code + passcode
- [ ] Confirmation and FYI emails (HTML + text) include the meeting ID/code + passcode
- [ ] Add-to-calendar links carry the join link, meeting ID/code, and passcode in the event description

### Anything else to add?
Meeting ID grouping mirrors Zoom's display (e.g. `882 8541 1273`); unrecognized platforms simply omit the room line. The `?pwd=` URL param is ignored in favor of the explicit passcode field.