### PR TITLE
HOLD-MAYBE NOT: Replace native confirm() with a styled in-page modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (73) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (74) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -278,6 +278,7 @@ end
 - `comment_edit_toggle` — Inline comment editing mode
 - `comment_required` — Require a comment body once a topic or body is filled in
 - `confirm_email` — Email confirmation UI
+- `confirm_modal` — Shared styled in-page confirmation modal (replaces native confirm(); wired to Turbo via setConfirmMethod)
 - `dirty_form` — Unsaved changes detection
 - `dismiss` — Dismissable elements
 - `dropdown` — Dropdown menus with keyboard/click-outside handling

--- a/app/frontend/javascript/application.js
+++ b/app/frontend/javascript/application.js
@@ -1,4 +1,4 @@
-import "@hotwired/turbo-rails";
+import { Turbo } from "@hotwired/turbo-rails";
 import "@rails/actiontext";
 import "rhino-editor";
 import "rhino-editor/exports/styles/trix.css";
@@ -12,3 +12,8 @@ ActiveStorage.start();
 import "./controllers";
 import "./rhino/extend-editor.js";
 import "./turbo-events";
+import { confirmModal } from "./confirm_modal";
+
+// Route Turbo's data-turbo-confirm prompts through the styled in-page modal
+// instead of the browser's native confirm() dialog.
+Turbo.setConfirmMethod((message) => confirmModal(message));

--- a/app/frontend/javascript/confirm_modal.js
+++ b/app/frontend/javascript/confirm_modal.js
@@ -1,0 +1,22 @@
+// Opens the shared, styled confirmation modal and resolves to the user's choice.
+//
+// Returns a Promise<boolean> so it can stand in for window.confirm() in async
+// flows and as Turbo's confirm method (see application.js). The request is
+// dispatched as a "confirm-modal:open" window event carrying the message,
+// options, and a resolve callback; the confirm-modal Stimulus controller
+// (rendered once in the layout) handles it and calls preventDefault.
+//
+// If the controller isn't on the page (e.g. an unusual layout) we fall back to
+// the browser's native confirm() so a missing modal never silently blocks an
+// action.
+export function confirmModal(message, options = {}) {
+  return new Promise((resolve) => {
+    const event = new CustomEvent("confirm-modal:open", {
+      detail: { message, options, resolve },
+      cancelable: true,
+    });
+
+    const handled = !window.dispatchEvent(event);
+    if (!handled) resolve(window.confirm(message));
+  });
+}

--- a/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { confirmModal } from "../confirm_modal";
 
 // Connects to data-controller="affiliation-facilitator-warning"
 //
@@ -13,6 +14,7 @@ import { Controller } from "@hotwired/stimulus";
 // change is detected the user must confirm or the submission is cancelled.
 export default class extends Controller {
   connect() {
+    this.confirmed = false;
     this.snapshots = this.captureSnapshots();
     this.handleSubmit = (event) => this.guardSubmit(event);
     // Capture phase so this runs before other submit listeners (e.g. dirty-form).
@@ -24,7 +26,17 @@ export default class extends Controller {
   }
 
   guardSubmit(event) {
+    // The modal resolved true on a prior pass — let this re-submission through.
+    if (this.confirmed) {
+      this.confirmed = false;
+      return;
+    }
+
     if (!this.facilitatorChangePresent()) return;
+
+    // The modal is async, so stop this submission and re-submit only if confirmed.
+    event.preventDefault();
+    event.stopImmediatePropagation();
 
     const message =
       "You're adding, removing, or editing a facilitator affiliation. " +
@@ -32,10 +44,13 @@ export default class extends Controller {
       "from facilitator affiliations and their start and end dates.\n\n" +
       "Are you sure you want to save this change?";
 
-    if (!window.confirm(message)) {
-      event.preventDefault();
-      event.stopImmediatePropagation();
-    }
+    const submitter = event.submitter;
+    confirmModal(message).then((confirmed) => {
+      if (!confirmed) return;
+
+      this.confirmed = true;
+      this.element.requestSubmit(submitter);
+    });
   }
 
   rows() {

--- a/app/frontend/javascript/controllers/confirm_modal_controller.js
+++ b/app/frontend/javascript/controllers/confirm_modal_controller.js
@@ -1,0 +1,67 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="confirm-modal"
+//
+// Shared, single-instance confirmation modal that replaces the browser's native
+// confirm() dialog. Rendered once in the layout (shared/_confirm_modal). Other
+// code opens it by calling confirmModal(message) (see confirm_modal.js), which
+// dispatches a "confirm-modal:open" window event carrying the message and a
+// resolve callback. Turbo's data-turbo-confirm is routed here via
+// Turbo.setConfirmMethod in application.js.
+//
+// The element is a full-screen overlay; the dialog target is the card inside it.
+export default class extends Controller {
+  static targets = ["dialog", "message", "confirm", "cancel"];
+
+  connect() {
+    this.resolve = null;
+  }
+
+  open(event) {
+    event.preventDefault();
+
+    const { message, options = {}, resolve } = event.detail;
+    this.resolve = resolve;
+
+    this.messageTarget.textContent = message || "Are you sure?";
+    this.confirmTarget.textContent = options.confirmLabel || "Confirm";
+    this.cancelTarget.textContent = options.cancelLabel || "Cancel";
+
+    this.element.classList.remove("hidden");
+    this.confirmTarget.focus();
+  }
+
+  confirm() {
+    this.finish(true);
+  }
+
+  cancel() {
+    this.finish(false);
+  }
+
+  backdropClick(event) {
+    if (event.target === this.element) this.cancel();
+  }
+
+  keydown(event) {
+    // Enter is handled natively by the focused Confirm button.
+    if (event.key !== "Escape") return;
+
+    event.preventDefault();
+    this.cancel();
+  }
+
+  finish(result) {
+    if (this.element.classList.contains("hidden")) return;
+
+    this.element.classList.add("hidden");
+    const resolve = this.resolve;
+    this.resolve = null;
+    if (resolve) resolve(result);
+  }
+
+  disconnect() {
+    // Resolve any pending request so a navigated-away modal never hangs a promise.
+    this.finish(false);
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -45,6 +45,9 @@ application.register("collection", CollectionController)
 import ConfirmEmailController from "./confirm_email_controller"
 application.register("confirm-email", ConfirmEmailController)
 
+import ConfirmModalController from "./confirm_modal_controller"
+application.register("confirm-modal", ConfirmModalController)
+
 import ColumnToggleController from "./column_toggle_controller"
 application.register("column-toggle", ColumnToggleController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,5 +59,6 @@
 
     <div class="site-footer print:hidden <%= 'mt-12' unless controller_name == 'home' %>"><%= render "shared/footer" %></div>
     <%= render "shared/footer_nav" %>
+    <%= render "shared/confirm_modal" %>
   </body>
 </html>

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -1,0 +1,30 @@
+<%# Shared, single-instance confirmation modal that replaces the browser's native
+    confirm() dialog. Rendered once in the layout. Opened via confirmModal() (see
+    confirm_modal.js); Turbo's data-turbo-confirm is routed here in application.js. %>
+<div data-controller="confirm-modal"
+     data-action="confirm-modal:open@window->confirm-modal#open click->confirm-modal#backdropClick keydown->confirm-modal#keydown"
+     class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4 print:hidden"
+     role="presentation">
+  <div data-confirm-modal-target="dialog"
+       class="w-full max-w-md rounded-lg bg-white shadow-xl"
+       role="alertdialog"
+       aria-modal="true"
+       aria-labelledby="confirm-modal-message"
+       tabindex="-1">
+    <div class="p-6">
+      <p data-confirm-modal-target="message"
+         id="confirm-modal-message"
+         class="whitespace-pre-line text-gray-800"></p>
+    </div>
+    <div class="flex justify-end gap-3 border-t border-gray-200 px-6 py-4">
+      <button type="button"
+              data-confirm-modal-target="cancel"
+              data-action="confirm-modal#cancel"
+              class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">Cancel</button>
+      <button type="button"
+              data-confirm-modal-target="confirm"
+              data-action="confirm-modal#confirm"
+              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">Confirm</button>
+    </div>
+  </div>
+</div>

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe "EventRegistrations", type: :request do
 
         get event_registrations_path(organization_id: organization.id)
         expect(response).to have_http_status(:success)
-        expect(response.body).to include(matching_reg.registrant.first_name)
-        expect(response.body).not_to include(existing_registration.registrant.first_name)
+        # Assert on each row's dom_id rather than the registrant's (Faker-random,
+        # possibly 2-char) first name, which can collide with unrelated page markup.
+        expect(response.body).to include(ActionView::RecordIdentifier.dom_id(matching_reg))
+        expect(response.body).not_to include(ActionView::RecordIdentifier.dom_id(existing_registration))
       end
 
       it "exports CSV with headers and data only (no captions)" do

--- a/spec/support/system_helpers/asset_upload_helpers.rb
+++ b/spec/support/system_helpers/asset_upload_helpers.rb
@@ -13,14 +13,13 @@ module AssetUploadHelpers
       end
 
     within("turbo-frame#assets") do
-      asset_container = find("div[id^='#{div_prefix}']")
-
-      accept_confirm("Delete this asset?") do
-        asset_container
-          .find("form.button_to button[type='submit']", visible: :all)
-          .click
-      end
+      find("div[id^='#{div_prefix}']")
+        .find("form.button_to button[type='submit']", visible: :all)
+        .click
     end
+
+    # The confirm modal renders at the end of <body>, outside the turbo frame.
+    accept_confirm_modal("Delete this asset?")
 
     expect(page).to have_no_selector("div[id^='#{div_prefix}']")
     expect(page).to have_selector("#asset_upload_form")

--- a/spec/support/system_helpers/confirm_modal_helpers.rb
+++ b/spec/support/system_helpers/confirm_modal_helpers.rb
@@ -1,0 +1,32 @@
+module ConfirmModalHelpers
+  # Drop-in replacements for Capybara's accept_confirm / dismiss_confirm now that
+  # confirmations render in the styled in-page modal (shared/_confirm_modal)
+  # instead of the browser's native confirm() dialog.
+  #
+  # Pass a block that triggers the confirmation (the modal opens after it runs),
+  # or call with no block if the triggering action already happened. An optional
+  # text argument (String or Regexp) asserts the modal's message.
+  #
+  # Call these at the top level, not nested inside another `within` block, so the
+  # modal — rendered at the end of <body> — is in scope.
+  def accept_confirm_modal(text = nil)
+    yield if block_given?
+    within_confirm_modal(text) { click_button "Confirm" }
+  end
+
+  def dismiss_confirm_modal(text = nil)
+    yield if block_given?
+    within_confirm_modal(text) { click_button "Cancel" }
+  end
+
+  def within_confirm_modal(text)
+    within "[data-controller='confirm-modal']" do
+      expect(page).to have_text(text) if text
+      yield
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include ConfirmModalHelpers, type: :system
+end

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe "Event registration edit page", type: :system do
       sign_in(admin)
       visit edit_event_registration_path(registration)
 
-      accept_confirm("Are you sure you want to delete?") do
+      accept_confirm_modal("Are you sure you want to delete?") do
         click_on "Delete"
       end
 

--- a/spec/system/organization_facilitator_warning_spec.rb
+++ b/spec/system/organization_facilitator_warning_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Facilitator affiliation change warning", type: :system do
     start_input = row_for("Facilitator").find("input[name*='start_date']")
     set_date_input(start_input, "2017-02-01")
 
-    accept_confirm(/status with AWBW/) do
+    accept_confirm_modal(/status with AWBW/) do
       find("[type='submit']").click
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Facilitator affiliation change warning", type: :system do
     start_input = row_for("Facilitator").find("input[name*='start_date']")
     set_date_input(start_input, "2017-02-01")
 
-    dismiss_confirm(/status with AWBW/) do
+    dismiss_confirm_modal(/status with AWBW/) do
       find("[type='submit']").click
     end
 
@@ -65,7 +65,7 @@ RSpec.describe "Facilitator affiliation change warning", type: :system do
 
     row_for("Facilitator").find("a", text: "Remove").click
 
-    accept_confirm(/status with AWBW/) do
+    accept_confirm_modal(/status with AWBW/) do
       find("[type='submit']").click
     end
 


### PR DESCRIPTION
📖 Read

Replaces the browser's native `confirm()` dialog with a styled in-page modal.

**Why:** native confirms are unstyled and visually inconsistent with the app.

**How it works:**
- All 41 `data-turbo-confirm` prompts are routed through the modal via `Turbo.setConfirmMethod` — no per-call view changes needed.
- A shared `confirmModal(message)` helper (returns a `Promise<boolean>`) lets JS controllers use the same modal. The facilitator-warning controller now uses it (was `window.confirm`).
- Modal is a single instance rendered once in the layout; supports Esc/backdrop to cancel, falls back to native `confirm()` if absent.

**Specs:** native `confirm()` can't be driven by Capybara's `accept_confirm`/`dismiss_confirm` anymore, so added `accept_confirm_modal`/`dismiss_confirm_modal` helpers and updated the affected specs.

**Not converted:** `dirty_form_controller`'s `beforeunload`/`turbo:before-visit` guards stay native — those navigation events are synchronous and can't await an async modal (and `beforeunload` must use the browser's own prompt).
