### PR TITLE
Reorganize the registration org-linking popup

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -155,19 +155,23 @@ class EventRegistrationsController < ApplicationController
     # whether each linked org is also an active/inactive affiliation (removing a
     # link here leaves the affiliation untouched).
     @affiliations_by_org = @person.affiliations.group_by(&:organization_id)
-    @submitted_org_name = find_submitted_agency_name(@event_registration)
-    # Whether an org with the submitted name already exists — if so, there's
-    # nothing to create (the admin links the existing one), so the "Create org
-    # & link" button is hidden.
-    @submitted_org_exists = @submitted_org_name.present? &&
-      Organization.where("LOWER(name) = ?", @submitted_org_name.strip.downcase).exists?
-    # The job title/position the registrant typed on the form, to compare against
-    # the title on any existing affiliation for a linked org.
-    @submitted_position = find_submitted_answer(@event_registration, "agency_position")
-    # The registrant's submission of the event's registration form, so we can link
-    # out to the public-facing form view.
-    reg_form = @event_registration.event.registration_form
-    @form_submission = reg_form && @person.form_submissions.find_by(form: reg_form)
+    # Every registration-form submission and the org/title the registrant entered
+    # on each. Normally there's one, but a registrant can have more (legacy or
+    # duplicate data), so we surface them all rather than silently picking one.
+    @submitted_entries = registration_submission_entries(@event_registration)
+    @form_submission = @submitted_entries.first&.fetch(:submission)
+    # The "primary" submitted org/title — the first submission that named an org
+    # (else the first submission) — drives the suggested-match and comparison logic.
+    primary = @submitted_entries.find { |entry| entry[:org_name].present? } || @submitted_entries.first
+    @submitted_org_name = primary && primary[:org_name]
+    @submitted_position = primary && primary[:position]
+    # Each distinct submitted org name that isn't already in the database gets its
+    # own "Create and link" row, so every typed-but-missing org can be resolved.
+    submitted_names = @submitted_entries.filter_map { |entry| entry[:org_name].presence&.strip }.uniq { |name| name.downcase }
+    existing_names = submitted_names.any? ?
+      Organization.where("LOWER(name) IN (?)", submitted_names.map(&:downcase)).pluck(Arel.sql("LOWER(name)")).map(&:to_s).to_set :
+      Set.new
+    @creatable_org_names = submitted_names.reject { |name| existing_names.include?(name.downcase) }
     @potential_matches = if @submitted_org_name.present?
       Organization.remote_search(@submitted_org_name).where.not(id: @linked_organizations.ids).limit(10)
     else
@@ -193,9 +197,13 @@ class EventRegistrationsController < ApplicationController
     @event_registration = EventRegistration.find(params[:id])
     authorize! @event_registration, to: :create_organization?
     @person = @event_registration.registrant
-    # Build the org from the name the registrant typed on the form, so the button
-    # can't be used to create an arbitrary org — it only resolves the pending name.
-    name = find_submitted_agency_name(@event_registration)
+    # Build the org from a name the registrant actually typed on the form, so the
+    # button can't be used to create an arbitrary org — it only resolves a pending
+    # submitted name. A specific name is passed when there are several submissions;
+    # otherwise default to the first submitted name.
+    submitted_names = submitted_agency_names(@event_registration)
+    requested = params[:organization_name].presence
+    name = requested ? submitted_names.find { |submitted| submitted.casecmp?(requested) } : submitted_names.first
     if name.blank?
       redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), alert: "No submitted organization name to create from."
       return
@@ -314,6 +322,40 @@ class EventRegistrationsController < ApplicationController
         ]
       end
     end
+  end
+
+  # Each registration-form submission with the org name and position the registrant
+  # entered on it: [{ submission:, org_name:, position: }], oldest first.
+  def registration_submission_entries(registration)
+    form = registration.event.registration_form
+    return [] unless form
+
+    field_ids = form.form_fields
+      .where(field_identifier: %w[agency_name agency_position])
+      .pluck(:field_identifier, :id).to_h
+    name_field_id = field_ids["agency_name"]
+    position_field_id = field_ids["agency_position"]
+
+    registration.registrant.form_submissions
+      .where(form: form)
+      .order(:created_at)
+      .includes(:form_answers)
+      .map do |submission|
+        answers = submission.form_answers.index_by(&:form_field_id)
+        {
+          submission: submission,
+          org_name: name_field_id && answers[name_field_id]&.submitted_answer,
+          position: position_field_id && answers[position_field_id]&.submitted_answer
+        }
+      end
+  end
+
+  # Distinct, non-blank org names the registrant typed across their registration-form
+  # submissions (case-insensitive dedupe, first spelling wins).
+  def submitted_agency_names(registration)
+    registration_submission_entries(registration)
+      .filter_map { |entry| entry[:org_name].presence&.strip }
+      .uniq { |name| name.downcase }
   end
 
   def find_submitted_agency_name(registration)

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -336,7 +336,7 @@ class EventRegistrationsController < ApplicationController
     name_field_id = field_ids["agency_name"]
     position_field_id = field_ids["agency_position"]
 
-    registration.registrant.form_submissions
+    entries = registration.registrant.form_submissions
       .where(form: form)
       .order(:created_at)
       .includes(:form_answers)
@@ -348,6 +348,15 @@ class EventRegistrationsController < ApplicationController
           position: position_field_id && answers[position_field_id]&.submitted_answer
         }
       end
+
+    # Attach the matching DB org (if any) for each submitted name, so the view can
+    # show its city/state next to the answer. Batched to avoid a query per entry.
+    names = entries.filter_map { |entry| entry[:org_name].presence&.strip&.downcase }.uniq
+    orgs_by_name = names.any? ?
+      Organization.where("LOWER(name) IN (?)", names).index_by { |org| org.name.to_s.downcase } :
+      {}
+    entries.each { |entry| entry[:organization] = entry[:org_name].present? ? orgs_by_name[entry[:org_name].strip.downcase] : nil }
+    entries
   end
 
   # Distinct, non-blank org names the registrant typed across their registration-form

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -103,7 +103,15 @@ module Events
         return
       end
 
-      @form_submission = @form.form_submissions.find_by(person: person)
+      # A specific submission can be requested by id (a registrant may have more
+      # than one); scope it to this form and person so the id can't reach another
+      # person's submission. Otherwise show their first submission for the form.
+      submissions = @form.form_submissions.where(person: person)
+      @form_submission = if params[:form_submission_id].present?
+        submissions.find_by(id: params[:form_submission_id])
+      else
+        submissions.first
+      end
       unless @form_submission
         redirect_to event_path(@event), alert: "No registration form submission found."
         return

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,5 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false)
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {})
     if inactive
       bg = "bg-gray-100"
       hover_bg = "hover:bg-gray-200"
@@ -15,7 +15,7 @@ module PersonHelper
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")
 
-    link_to person_path(person),
+    link_to person_path(person, **path_params),
             data: { turbo_prefetch: false }.merge(data),
             title: hover_title,
             class: "group relative flex items-center gap-2

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -1,6 +1,6 @@
 <%# Renders affiliation-status pills for one org's affiliations. Shows nothing
     when the person has no affiliation for the org.
-    Locals: org, affiliations, submitted_org_name, submitted_position %>
+    Locals: org, affiliations, submitted_org_name, submitted_position, neutral (optional) %>
 <% if affiliations.any? %>
   <% badge = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-2.5 py-0.5" %>
   <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
@@ -11,8 +11,18 @@
     <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
     <% affiliations.each do |a| %>
       <% a_active = active.call(a) %>
-      <% color = a_active ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
-      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")}#{" — inactive" unless a_active}" %>
+      <% color = a_active && !local_assigns[:neutral] ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
+      <% start_month = a.start_date&.strftime("%B %Y") %>
+      <% end_month = a.end_date&.strftime("%B %Y") %>
+      <% duration =
+           if start_month && end_month
+             " from #{start_month} - #{end_month}"
+           elsif end_month
+             " until #{end_month}"
+           elsif start_month
+             " starting #{start_month}"
+           end %>
+      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")}#{duration}#{" — inactive" unless a_active}" %>
       <% title_attr = a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : nil %>
       <span class="<%= badge %> <%= color %>" title="<%= title_attr %>"><%= label %></span>
     <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -94,7 +94,7 @@
           <% end %>
         </ul>
       <% else %>
-        <p class="text-gray-500 mb-4">No organizations are linked to this registration yet.</p>
+        <p class="text-gray-500 mb-4">No linked organizations.</p>
       <% end %>
 
       <%# Adding an org is part of managing the links, so it's nested in the same card. %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -1,157 +1,205 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-2xl mx-auto py-8 px-4">
+  <div class="mb-4">
+    <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
-    <div class="mb-6">
-      <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
-    </div>
-
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Organizations &amp; affiliations</h1>
-    <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
-
-    <%# === Linked organizations (registration–organization associations) === %>
-    <div class="flex items-center justify-between gap-3 mb-3">
-      <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration-linked organizations</h2>
+    <div class="flex items-start justify-between gap-3 mb-2">
+      <h1 class="text-2xl font-bold text-gray-900">Organizations &amp; affiliations</h1>
       <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
-                  class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700" do %>
-        View profile affiliations
+                  class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700 shrink-0 mt-1.5" do %>
+        View <%= @person.first_name.presence || @person.full_name %>'s affiliations
         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
       <% end %>
     </div>
-    <% if @linked_organizations.any? %>
-      <ul class="space-y-2 mb-6">
-        <% @linked_organizations.each do |org| %>
-          <li class="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg p-3">
-            <div class="min-w-0">
-              <p class="font-medium text-gray-800"><%= org.name %></p>
-              <% if org.city_state.present? %>
-                <p class="text-xs text-gray-500"><%= org.city_state %></p>
-              <% end %>
-              <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
-                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
-            </div>
-            <%# Intentional UX choice: Unlink only removes the org from this registration and keeps
-                the person's Affiliation. The confirm dialog spells out the distinction (Affiliations
-                are edited on the Person record). See EventRegistrationsController#unlink_organization. %>
-            <%= button_to "Unlink",
-                          unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
-                          method: :delete,
-                          form: { class: "shrink-0", data: { turbo_frame: "_top", turbo_confirm: "Unlink #{org.name} from this registration?\n\nThis only removes the organization from this registration — it will NOT delete any of #{@person.first_name.presence || @person.full_name}'s Affiliations with #{org.name}.\n\nTo change or remove any Affiliations, edit the Person record." } },
-                          class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
-          </li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="text-gray-500 mb-6">No organizations are linked to this registration yet.</p>
-    <% end %>
+    <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
 
-    <%# Adding an org is part of managing the links, so it's nested here. %>
-    <div class="border-t border-gray-100 pt-4 pl-4 mb-8">
-      <h3 class="text-sm font-semibold text-gray-700 mb-3">Add an organization</h3>
-
-      <% if @potential_matches.any? %>
-        <p class="text-xs text-gray-500 mb-2">Suggested matches for the submitted name:</p>
-        <div class="space-y-2 mb-4">
-          <% @potential_matches.each do |org| %>
-            <%= form_with url: select_organization_event_registration_path(@event_registration),
-                          method: :post,
-                          data: { turbo_frame: "_top" },
-                          class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
-              <%= hidden_field_tag :organization_id, org.id %>
-              <%= hidden_field_tag :return_to, params[:return_to] %>
-              <div>
-                <p class="font-medium text-gray-800"><%= org.name %></p>
-                <% if org.city_state.present? %>
-                  <p class="text-xs text-gray-500"><%= org.city_state %></p>
-                <% end %>
-              </div>
-              <%= submit_tag "Select", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
-
-      <%= form_with url: select_organization_event_registration_path(@event_registration),
-                    method: :post,
-                    data: { turbo_frame: "_top" },
-                    class: "flex items-stretch gap-2" do %>
-        <%= hidden_field_tag :return_to, params[:return_to] %>
-        <div class="flex-1 min-w-0">
-          <%= select_tag :organization_id,
-                         options_from_collection_for_select([], :id, :name),
-                         include_blank: true,
-                         class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                         data: { controller: "remote-select", remote_select_model_value: "organization" },
-                         prompt: "Type to search organizations…" %>
-        </div>
-        <%= submit_tag "Link organization",
-                       class: "shrink-0 rounded-md bg-blue-900 px-6 py-2 text-white font-semibold hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
-      <% end %>
-    </div>
-
-    <%# === Registration form submission (what the registrant typed). Collapsed by
-        default; expanded when the submitted org isn't in the DB (needs attention). === %>
+    <%# === Registration form submission (what the registrant typed). Shown first
+        as the source answer admins reconcile against; rendered grey/neutral. A
+        registrant can have more than one submission, so each is listed with its
+        own green link to that submission's public view. === %>
     <% form_show_params = @event_registration.slug.present? ? { reg: @event_registration.slug } : { person_id: @person.id } %>
-    <% submitted_org_unmatched = @submitted_org_name.present? && !@submitted_org_exists %>
-    <%# Expand unless the submitted org is resolved (matches an existing org), so it
-        opens both when nothing was submitted and when the name has no DB match. %>
-    <details class="mb-8"<%= " open" unless @submitted_org_exists %>>
+    <%# Each submitted org that isn't in the DB gets a "Create and link" row, the
+        expected next step — so those take the solid (primary) style and "Link
+        organization" is demoted to the outline style. %>
+    <% create_is_primary = @creatable_org_names.any? %>
+    <% btn_solid = "bg-blue-900 text-white hover:bg-blue-800" %>
+    <% btn_outline = "border border-blue-900 text-blue-900 hover:bg-blue-50" %>
+    <details class="mb-8" open>
       <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
       </summary>
-      <div class="flex items-stretch gap-3">
-        <div class="flex-1 min-w-0 bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <% if @submitted_org_name.present? || @submitted_position.present? %>
-            <p class="text-sm text-gray-500 mb-2">
-              On the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>, <%= @person.first_name.presence || @person.full_name %> entered:
-            </p>
-            <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong></p>
-            <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
-          <% else %>
-            <p class="text-sm text-gray-500">
-              No organization was submitted on the <% if @form_submission %><%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %><% else %>registration form<% end %>.
-            </p>
-          <% end %>
-        </div>
-        <% if submitted_org_unmatched %>
-          <%# Creates an org from the typed name and links it in one step, for names with no existing match. %>
-          <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
-                        method: :post,
-                        form: { class: "shrink-0 self-center", data: { turbo_frame: "_top" } },
-                        class: "inline-flex items-center rounded-md border border-blue-900 px-5 py-2 text-blue-900 font-semibold hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
-            Create org &amp; link
-          <% end %>
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <% present_entries = @submitted_entries.select { |entry| entry[:org_name].present? || entry[:position].present? } %>
+        <% if present_entries.any? %>
+          <% multiple = present_entries.size > 1 %>
+          <ul class="space-y-3">
+            <% present_entries.each_with_index do |entry, i| %>
+              <li class="flex items-start gap-2">
+                <%# Same green form-submission icon used on the registrants list, linking
+                    to this specific submission's public view. %>
+                <%= link_to event_public_registration_path(@event_registration.event, **form_show_params, form_submission_id: entry[:submission].id, return_to: "link_organization", link_org_return_to: params[:return_to]),
+                            target: "_blank", rel: "noopener",
+                            class: "text-green-600 hover:text-green-800 mt-1 shrink-0",
+                            title: multiple ? "View submission ##{i + 1}" : "View form submission",
+                            data: { turbo_frame: "_top" } do %>
+                  <i class="fa-solid fa-file-lines"></i>
+                <% end %>
+                <div class="min-w-0">
+                  <p class="text-base text-gray-800">Organization: <strong><%= entry[:org_name].presence || "—" %></strong></p>
+                  <p class="text-base text-gray-800">Position / title: <strong><%= entry[:position].presence || "—" %></strong></p>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        <% elsif @form_submission %>
+          <p class="text-sm text-gray-500">
+            No organization was submitted on the <%= link_to "registration form submission", event_public_registration_path(@event_registration.event, **form_show_params, form_submission_id: @form_submission.id, return_to: "link_organization", link_org_return_to: params[:return_to]), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>.
+          </p>
+        <% else %>
+          <p class="text-sm text-gray-500">No registration form was submitted.</p>
         <% end %>
       </div>
     </details>
 
-    <%# === The person's affiliations to orgs NOT linked to this registration.
-        Collapsed by default; expanded when there are none (to show that state). === %>
-    <% linked_org_ids = @linked_organizations.map(&:id) %>
-    <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
-    <details<%= " open" if other_affiliations.empty? %>>
-      <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
-        <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
-        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
-      </summary>
-      <% if other_affiliations.any? %>
-        <ul class="space-y-2">
-          <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
-            <% org = affs.first.organization %>
-            <% next unless org %>
-            <li class="bg-gray-50 border border-gray-200 rounded-lg p-3">
-              <p class="font-medium text-gray-800"><%= org.name %></p>
-              <% if org.city_state.present? %>
-                <p class="text-xs text-gray-500"><%= org.city_state %></p>
-              <% end %>
-              <%= render "org_affiliation_pills", org: org, affiliations: affs,
-                                                  submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
+    <%# === Linked organizations (registration–organization associations). The
+        active, confirmed links — tinted with the domain-theme green swatch to
+        stand apart from the grey submission answer above and other affiliations
+        below. === %>
+    <% org_swatch = DomainTheme.swatch(:green) %>
+    <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Registration-linked organizations</h2>
+    <div class="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-8">
+      <% if @linked_organizations.any? %>
+        <ul class="space-y-2 mb-4">
+          <% @linked_organizations.each do |org| %>
+            <li class="flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3">
+              <div class="min-w-0">
+                <p class="font-medium text-gray-800"><%= org.name %></p>
+                <% if org.city_state.present? %>
+                  <p class="text-xs text-gray-500"><%= org.city_state %></p>
+                <% end %>
+                <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
+                                                    submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
+              </div>
+              <%# Intentional UX choice: Unlink only removes the org from this registration and keeps
+                  the person's Affiliation. The confirm dialog spells out the distinction (Affiliations
+                  are edited on the Person record). See EventRegistrationsController#unlink_organization. %>
+              <%= button_to "Unlink",
+                            unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
+                            method: :delete,
+                            form: { class: "shrink-0", data: { turbo_frame: "_top", turbo_confirm: "Unlink #{org.name} from this registration?\n\nThis only removes the organization from this registration — it will NOT delete any of #{@person.first_name.presence || @person.full_name}'s Affiliations with #{org.name}.\n\nTo change or remove any Affiliations, edit the Person record." } },
+                            class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
             </li>
           <% end %>
         </ul>
       <% else %>
-        <p class="text-gray-500">No other affiliations on record.</p>
+        <p class="text-gray-500 mb-4">No organizations are linked to this registration yet.</p>
       <% end %>
+
+      <%# Adding an org is part of managing the links, so it's nested in the same card. %>
+      <div class="border-t border-gray-200 pt-4">
+        <h3 class="text-sm font-semibold text-gray-700 mb-3">Add an organization</h3>
+
+        <% if @creatable_org_names.any? %>
+          <%# Each org the registrant typed that we don't have gets its own create+link
+              row. The reason sits on its own full-width line so it never truncates;
+              the names truncate safely inside their boxes. Fixed-width buttons keep
+              the boxes aligned with the search row below. %>
+          <p class="text-sm text-gray-600 mb-2">
+            <%= @creatable_org_names.size > 1 ? "These organizations the registrant entered aren't in the database yet. Create each in the database and link it in one step:" : "The registrant entered this organization on their form, but it's not in the database yet. Create the organization in the database and link it in one step:" %>
+          </p>
+          <% @creatable_org_names.each do |creatable_name| %>
+            <div class="flex items-stretch gap-2 mb-2">
+              <div class="flex-1 min-w-0 flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800">
+                <span class="truncate"><%= creatable_name %></span>
+              </div>
+              <%= button_to create_organization_event_registration_path(@event_registration, return_to: params[:return_to]),
+                            method: :post,
+                            params: { organization_name: creatable_name },
+                            form: { class: "shrink-0", data: { turbo_frame: "_top" } },
+                            class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{btn_solid} focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
+                Create and link
+              <% end %>
+            </div>
+          <% end %>
+          <p class="text-sm text-gray-600 mb-2 mt-4">Or, add an existing organization instead:</p>
+        <% end %>
+
+        <% if @potential_matches.any? %>
+          <p class="text-xs text-gray-500 mb-2">Suggested matches for the submitted name:</p>
+          <div class="space-y-2 mb-4">
+            <% @potential_matches.each do |org| %>
+              <%= form_with url: select_organization_event_registration_path(@event_registration),
+                            method: :post,
+                            data: { turbo_frame: "_top" },
+                            class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
+                <%= hidden_field_tag :organization_id, org.id %>
+                <%= hidden_field_tag :return_to, params[:return_to] %>
+                <div>
+                  <p class="font-medium text-gray-800"><%= org.name %></p>
+                  <% if org.city_state.present? %>
+                    <p class="text-xs text-gray-500"><%= org.city_state %></p>
+                  <% end %>
+                </div>
+                <%= submit_tag "Link again", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%= form_with url: select_organization_event_registration_path(@event_registration),
+                      method: :post,
+                      data: { turbo_frame: "_top" },
+                      class: "flex items-stretch gap-2" do %>
+          <%= hidden_field_tag :return_to, params[:return_to] %>
+          <div class="flex-1 min-w-0">
+            <%= select_tag :organization_id,
+                           options_from_collection_for_select([], :id, :name),
+                           include_blank: true,
+                           class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                           data: { controller: "remote-select", remote_select_model_value: "organization" },
+                           prompt: "Type to search organizations…" %>
+          </div>
+          <%= submit_tag "Link organization",
+                         class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{create_is_primary ? btn_outline : btn_solid} focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+        <% end %>
+      </div>
+    </div>
+
+    <%# === The person's affiliations to orgs NOT linked to this registration.
+        Always expanded so admins see the full affiliation history at a glance;
+        rendered grey/neutral. === %>
+    <% linked_org_ids = @linked_organizations.map(&:id) %>
+    <% other_affiliations = @affiliations_by_org.reject { |org_id, _| linked_org_ids.include?(org_id) } %>
+    <details open>
+      <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
+        <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
+      </summary>
+      <div class="bg-gray-50 border border-gray-200 rounded-xl p-4">
+        <% if other_affiliations.any? %>
+          <ul class="list-disc list-inside space-y-2 text-gray-800 marker:text-gray-400">
+            <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
+              <% org = affs.first.organization %>
+              <% next unless org %>
+              <li>
+                <span class="font-medium"><%= org.name %></span>
+                <% if org.city_state.present? %>
+                  <span class="text-xs text-gray-500">· <%= org.city_state %></span>
+                <% end %>
+                <div class="pl-6">
+                  <%= render "org_affiliation_pills", org: org, affiliations: affs,
+                                                      submitted_org_name: @submitted_org_name, submitted_position: @submitted_position,
+                                                      neutral: true %>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-gray-500">No other affiliations on record.</p>
+        <% end %>
+      </div>
     </details>
   </div>
 </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -47,7 +47,7 @@
                   <i class="fa-solid fa-file-lines"></i>
                 <% end %>
                 <div class="min-w-0">
-                  <p class="text-base text-gray-800">Organization: <strong><%= entry[:org_name].presence || "—" %></strong></p>
+                  <p class="text-base text-gray-800">Organization: <strong><%= entry[:org_name].presence || "—" %></strong><% if entry[:organization]&.city_state.present? %> <span class="text-sm text-gray-500">· <%= entry[:organization].city_state %></span><% end %></p>
                   <p class="text-base text-gray-800">Position / title: <strong><%= entry[:position].presence || "—" %></strong></p>
                 </div>
               </li>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -75,10 +75,7 @@
           <% @linked_organizations.each do |org| %>
             <li class="flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3">
               <div class="min-w-0">
-                <p class="font-medium text-gray-800"><%= org.name %></p>
-                <% if org.city_state.present? %>
-                  <p class="text-xs text-gray-500"><%= org.city_state %></p>
-                <% end %>
+                <p class="font-medium text-gray-800"><%= org.name %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
                                                     submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
               </div>
@@ -136,11 +133,8 @@
                             class: "flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg p-3" do %>
                 <%= hidden_field_tag :organization_id, org.id %>
                 <%= hidden_field_tag :return_to, params[:return_to] %>
-                <div>
-                  <p class="font-medium text-gray-800"><%= org.name %></p>
-                  <% if org.city_state.present? %>
-                    <p class="text-xs text-gray-500"><%= org.city_state %></p>
-                  <% end %>
+                <div class="min-w-0">
+                  <p class="font-medium text-gray-800"><%= org.name %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 </div>
                 <%= submit_tag "Link organization", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
               <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -171,7 +171,12 @@
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
       </summary>
-      <div class="bg-gray-50 border border-gray-200 rounded-xl p-4">
+      <%# The whole card links to the person's affiliations on their profile (same
+          destination as the header jump link) — these are managed there, not here. %>
+      <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
+                  title: "Edit affiliations on #{@person.first_name.presence || @person.full_name}'s profile",
+                  class: "group relative block bg-gray-50 border border-gray-200 rounded-xl p-4 hover:bg-gray-100 transition-colors" do %>
+        <i class="fa-solid fa-arrow-up-right-from-square absolute top-3 right-3 text-[0.6rem] text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"></i>
         <% if other_affiliations.any? %>
           <ul class="list-disc list-inside space-y-2 text-gray-800 marker:text-gray-400">
             <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>
@@ -193,7 +198,7 @@
         <% else %>
           <p class="text-gray-500">No other affiliations on record.</p>
         <% end %>
-      </div>
+      <% end %>
     </details>
   </div>
 </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -142,7 +142,7 @@
                     <p class="text-xs text-gray-500"><%= org.city_state %></p>
                   <% end %>
                 </div>
-                <%= submit_tag "Link again", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+                <%= submit_tag "Link organization", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
               <% end %>
             <% end %>
           </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -113,19 +113,6 @@
                       <i class="fa-solid fa-triangle-exclamation text-amber-500" title="Multiple registrants share this email address — this may cause login conflicts"></i>
                     <% end %>
                   </div>
-
-                  <%# Organizations where this person is an active facilitator —
-                      distinct from the registration's linked orgs (next column). %>
-                  <% facilitator_orgs = person.decorate.active_facilitator_organization_names %>
-                  <% if facilitator_orgs.any? %>
-                    <div class="mt-1 flex flex-wrap gap-1">
-                      <% facilitator_orgs.each do |org_name| %>
-                        <span class="inline-flex items-center gap-1 rounded-full text-xs font-medium border px-2 py-0.5 bg-purple-50 text-purple-700 border-purple-200" title="Active facilitator at <%= org_name %>">
-                          <i class="fa-solid fa-chalkboard-user text-[0.6rem]"></i><%= org_name %>
-                        </span>
-                      <% end %>
-                    </div>
-                  <% end %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -86,7 +86,7 @@
 
                   <div class="flex items-center gap-1">
                     <div class="w-52 min-w-0">
-                      <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
+                      <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }) %>
                     </div>
 
                     <% if event_form_ids.any? && (submissions = form_submissions[person.id]) %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -8,6 +8,14 @@
     <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
     <% end %>
+    <%# Came here from the admin org-linking popup (opens in a new tab, so the
+        browser back button is useless); carry its own return_to so its
+        "Back to registrants" eyebrow still resolves. %>
+    <% if reg && params[:return_to] == "link_organization" && allowed_to?(:index?, EventRegistration) %>
+      <%= link_to link_organization_event_registration_path(reg, return_to: params[:link_org_return_to].presence), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Back to linked organizations
+      <% end %>
+    <% end %>
     <% if reg && allowed_to?(:index?, EventRegistration) %>
       <%= link_to "Registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,4 +1,13 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-authsearchable") %>
+<%# Returned from a registrant's profile link on the event registrants page. Shown
+    above the profile topper; needs event_id since the profile isn't event-scoped. %>
+<% if params[:return_to] == "registrants" && params[:event_id].present? %>
+  <div class="mb-3">
+    <%= link_to registrants_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Back to registrants
+    <% end %>
+  </div>
+<% end %>
 <div class="admin-or-owner <%#= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow overflow-hidden">
   <!-- Person header banner -->
   <div class="<%= DomainTheme.bg_class_for(:people, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:people, intensity: 300) %> px-8 py-3">

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -94,6 +94,13 @@ if registration_form.form_fields.where(field_identifier: "primary_age_group").no
   FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
 end
 
+# Ensure the person/organization section (Organization Name, Position / Title) exists
+# so registrants can record the org + title they typed on the form — the registrants
+# page compares that typed org name against the registration's linked orgs.
+if registration_form.form_fields.where(field_identifier: "agency_name").none?
+  FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :person_contact_info ])
+end
+
 # The CE-interest "magic question": a single Yes/No whose answer drives the
 # resulting registration's ce_credit_requested flag (see
 # EventRegistrationServices::PublicRegistration). Seeded straight onto the form
@@ -928,6 +935,10 @@ form_submissions.each do |data|
 
   # Fill in required text fields with sample data
   data[:form].form_fields.where(answer_type: [ :free_form_input_one_line, :free_form_input_paragraph ]).each do |field|
+    # Organization Name + Position / Title are seeded later with org-matching values
+    # (record_organization_answers), so leave them blank here.
+    next if %w[agency_name agency_position].include?(field.field_identifier)
+
     sample_text = case field.field_identifier
     when "first_name" then data[:person].first_name
     when "last_name" then data[:person].last_name
@@ -1029,6 +1040,58 @@ record_professional_answers = ->(submission, i) do
   end
 end
 
+# Real orgs (minus the AWBW house org) to link registrations against and match on,
+# plus a spread of plausible job titles for the "Position / Title" answer.
+org_answer_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
+job_titles = [ "Facilitator", "Program Director", "Counselor", "Art Therapist",
+               "Case Manager", "Volunteer Coordinator", "Executive Director", "Social Worker" ]
+# Plausible, domain-appropriate org names that intentionally do NOT match any seeded
+# org, so a registrant typing one produces a realistic "Pending" mismatch chip.
+unmatched_org_names = [ "Riverside Healing Arts Collective", "Westview Community Healing",
+                        "Lakeside Survivor Support Network", "Cedar Grove Family Services",
+                        "Harbor Light Crisis Center", "Meadowbrook Wellness Coalition" ]
+
+# Give a registrant's submission the "Organization Name" + "Position / Title" answers
+# the registrants page reads: link a real org to the registration and submit a name
+# that USUALLY matches it, but every 4th enriched registrant types a different
+# organization so the "Pending" mismatch chip has visible volume. The mismatch counter
+# only advances when an org answer is actually written (registrants with submissions are
+# sparse), so the ~1-in-4 ratio holds regardless of how many registrants are skipped.
+# Idempotent: skips an already-answered field and reuses an existing linked org.
+org_answer_index = 0
+record_organization_answers = ->(registration, submission, i) do
+  person = registration.registrant
+  form = submission.form
+
+  position_field = form.form_fields.find_by(field_identifier: "agency_position")
+  if position_field && submission.form_answers.where(form_field: position_field).none?
+    submission.form_answers.create!(form_field: position_field,
+                                    submitted_answer: job_titles[i % job_titles.size],
+                                    question_name_when_answered: position_field.name)
+  end
+
+  agency_field = form.form_fields.find_by(field_identifier: "agency_name")
+  next unless agency_field && org_answer_orgs.any?
+  next if submission.form_answers.where(form_field: agency_field).any?
+
+  linked_org = registration.organizations.first
+  unless linked_org
+    linked_org = org_answer_orgs[i % org_answer_orgs.size]
+    Affiliation.find_or_create_by!(person: person, organization: linked_org) do |aff|
+      aff.title = job_titles[i % job_titles.size]
+      aff.start_date = Date.current
+    end
+    registration.event_registration_organizations.find_or_create_by!(organization: linked_org)
+  end
+
+  mismatch = org_answer_index % 4 == 3
+  typed_name = mismatch ? unmatched_org_names[org_answer_index / 4 % unmatched_org_names.size] : linked_org.name
+  org_answer_index += 1
+  submission.form_answers.create!(form_field: agency_field,
+                                  submitted_answer: typed_name,
+                                  question_name_when_answered: agency_field.name)
+end
+
 # Give the flagship cohort registration submissions so its Background charts have
 # volume (named scenarios above are unchanged; the cohort are generic fill-ins).
 if facilitator_training && (reg_form = facilitator_training.registration_form)
@@ -1053,6 +1116,7 @@ end
     next unless submission
 
     record_professional_answers.call(submission, i)
+    record_organization_answers.call(registration, submission, i)
   end
 end
 

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1218,6 +1218,10 @@ if facilitator_training && registration_form
   # Real, existing orgs to link against / match on (skip the AWBW house org).
   demo_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
   matched_org = demo_orgs.first
+  # A partial of the matched org's name (its words minus the first) shares words
+  # with it but isn't an exact match — drives the fuzzy "Suggested matches" list
+  # (case 9). Nil when the org name is a single word (no partial to take).
+  fuzzy_agency = matched_org&.name.to_s.split.length.to_i > 1 ? matched_org.name.split.drop(1).join(" ") : nil
 
   link_org = ->(registration, organization) do
     Affiliation.find_or_create_by!(person: registration.registrant, organization: organization) do |aff|
@@ -1256,6 +1260,9 @@ if facilitator_training && registration_form
     { last: "7 None nothing typed" },
     { last: "8 Pending matches existing org", agency: matched_org&.name }
   ]
+  # Case 9: a partial of an existing org's name — not an exact match, so it shows
+  # BOTH a "Create and link" row and the existing org under fuzzy "Suggested matches".
+  scenarios << { last: "9 Fuzzy match suggestions", agency: fuzzy_agency } if fuzzy_agency.present?
 
   scenarios.each_with_index do |scenario, i|
     person = Person.create!(
@@ -1269,6 +1276,24 @@ if facilitator_training && registration_form
 
     Array(scenario[:orgs]).each { |org| link_org.call(registration, org) }
     submit_agency_name.call(registration, scenario[:agency]) if scenario.key?(:agency)
+  end
+
+  # Demo 10: a registrant with more than one registration-form submission, each
+  # naming a different org we don't have — exercises the per-submission "View
+  # submission #N" links and one "Create and link" row per distinct submitted org.
+  if agency_field
+    demo_multi = Person.create!(
+      email: "orgchip.demo.10@seed.example.com",
+      first_name: "Org Demo",
+      last_name: "10 Multiple submissions"
+    )
+    EventRegistration.find_or_create_by!(event: facilitator_training, registrant: demo_multi) do |reg|
+      reg.status = "registered"
+    end
+    [ "Greenfield Survivor Services", "Harbor Light Counseling" ].each do |org_name|
+      submission = FormSubmission.create!(person: demo_multi, form: registration_form, event: facilitator_training)
+      submission.form_answers.create!(form_field: agency_field, submitted_answer: org_name, question_name_when_answered: agency_field.name)
+    end
   end
 
   # --- Affiliation-status demo: two affiliations per org (a real job title plus the

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1214,6 +1214,7 @@ if facilitator_training && registration_form
     )
   end
   agency_field = registration_form.form_fields.find_by(field_identifier: "agency_name")
+  agency_position_field = registration_form.form_fields.find_by(field_identifier: "agency_position")
 
   # Real, existing orgs to link against / match on (skip the AWBW house org).
   demo_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
@@ -1234,7 +1235,11 @@ if facilitator_training && registration_form
     "Riverside Trauma Recovery",
     "Riverside Youth Outreach",
     "Riverside Wellness Collective"
-  ].each { |org_name| Organization.find_or_create_by!(name: org_name) { |o| o.organization_status = active_status } }
+  ].each do |org_name|
+    org = Organization.find_or_create_by!(name: org_name) { |o| o.organization_status = active_status }
+    # Give each a location so the fuzzy "Suggested matches" list shows city/state.
+    org.addresses.create!(street_address: "100 Demo Way", city: "Riverside", locality: "Riverside", state: "CA", zip_code: "92501", primary: true) if org.addresses.none?
+  end
 
   link_org = ->(registration, organization) do
     Affiliation.find_or_create_by!(person: registration.registrant, organization: organization) do |aff|
@@ -1263,19 +1268,22 @@ if facilitator_training && registration_form
   # Case 8 is the stale edge case: a typed name that matches an existing org but was
   # never linked (e.g. the org was created after the person registered) — it reads as
   # "Pending", and the editor offers that org as a one-click match to select.
+  # Numbers are zero-padded so the registrants list (sorted by name) shows them in
+  # order 01..11 rather than 1, 10, 11, 2, 3…
   scenarios = [
-    { last: "1 Linked one org",       orgs: demo_orgs.first(1) },
-    { last: "2 Linked three orgs",    orgs: demo_orgs.first(3) },
-    { last: "3 Pending no match",     agency: "Riverside Healing Arts Collective" },
-    { last: "4 Matched name auto-linked", orgs: demo_orgs.first(1), agency: matched_org&.name },
-    { last: "5 Mixed linked + pending", orgs: demo_orgs.first(1), agency: "Westview Community Healing" },
-    { last: "6 None blank typed",     agency: "" },
-    { last: "7 None nothing typed" },
-    { last: "8 Pending matches existing org", agency: matched_org&.name }
+    { last: "01 Linked one org",       orgs: demo_orgs.first(1) },
+    { last: "02 Linked three orgs",    orgs: demo_orgs.first(3) },
+    { last: "03 Pending no match",     agency: "Riverside Healing Arts Collective" },
+    { last: "04 Matched name auto-linked", orgs: demo_orgs.first(1), agency: matched_org&.name },
+    { last: "05 Mixed linked + pending", orgs: demo_orgs.first(1), agency: "Westview Community Healing" },
+    { last: "06 None blank typed",     agency: "" },
+    { last: "07 None nothing typed" },
+    { last: "08 Pending matches existing org", agency: matched_org&.name }
   ]
   # Case 9: a single word shared by several orgs — not an exact match, so it shows
   # a "Create and link" row plus a handful of orgs under fuzzy "Suggested matches".
-  scenarios << { last: "9 Fuzzy match suggestions", agency: fuzzy_match_word }
+  # Includes a job title so the submission detail shows a position too.
+  scenarios << { last: "09 Fuzzy match suggestions", agency: fuzzy_match_word, position: "Lead Facilitator" }
 
   scenarios.each_with_index do |scenario, i|
     person = Person.create!(
@@ -1289,6 +1297,11 @@ if facilitator_training && registration_form
 
     Array(scenario[:orgs]).each { |org| link_org.call(registration, org) }
     submit_agency_name.call(registration, scenario[:agency]) if scenario.key?(:agency)
+    if scenario[:position].present? && agency_position_field
+      submission = FormSubmission.find_or_create_by!(person: person, form: registration_form)
+      answer = submission.form_answers.find_or_initialize_by(form_field: agency_position_field)
+      answer.update!(submitted_answer: scenario[:position], question_name_when_answered: agency_position_field.name)
+    end
   end
 
   # Demo 10: a registrant with more than one registration-form submission, each

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1296,6 +1296,26 @@ if facilitator_training && registration_form
     end
   end
 
+  # Demo 11: fuzzy matching AND multiple submissions together — two submissions,
+  # each naming a partial of a different existing org. Exercises multiple "View
+  # submission #N" links, a "Create and link" row per partial, and the fuzzy
+  # "Suggested matches" list (driven by the first/primary submission).
+  fuzzy_agency_2 = demo_orgs[1]&.name.to_s.split.length.to_i > 1 ? demo_orgs[1].name.split.drop(1).join(" ") : nil
+  if agency_field && fuzzy_agency.present? && fuzzy_agency_2.present?
+    demo_fuzzy_multi = Person.create!(
+      email: "orgchip.demo.11@seed.example.com",
+      first_name: "Org Demo",
+      last_name: "11 Fuzzy + multiple submissions"
+    )
+    EventRegistration.find_or_create_by!(event: facilitator_training, registrant: demo_fuzzy_multi) do |reg|
+      reg.status = "registered"
+    end
+    [ fuzzy_agency, fuzzy_agency_2 ].each do |org_name|
+      submission = FormSubmission.create!(person: demo_fuzzy_multi, form: registration_form, event: facilitator_training)
+      submission.form_answers.create!(form_field: agency_field, submitted_answer: org_name, question_name_when_answered: agency_field.name)
+    end
+  end
+
   # --- Affiliation-status demo: two affiliations per org (a real job title plus the
   # Facilitator role that gates AWBW-active), plus the position typed on the form, so
   # the org-link editor's affiliation pills can be seen across their states. ---

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1219,9 +1219,22 @@ if facilitator_training && registration_form
   demo_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
   matched_org = demo_orgs.first
   # A partial of the matched org's name (its words minus the first) shares words
-  # with it but isn't an exact match — drives the fuzzy "Suggested matches" list
-  # (case 9). Nil when the org name is a single word (no partial to take).
+  # with it but isn't an exact match — drives a fuzzy "Suggested matches" hit
+  # (case 11). Nil when the org name is a single word (no partial to take).
   fuzzy_agency = matched_org&.name.to_s.split.length.to_i > 1 ? matched_org.name.split.drop(1).join(" ") : nil
+
+  # Several orgs that share a word ("Riverside"), so typing just that word surfaces
+  # a handful of fuzzy "Suggested matches" at once (case 9). find_or_create so
+  # re-seeding doesn't pile up duplicates.
+  active_status = OrganizationStatus.find_by(name: "Active")
+  fuzzy_match_word = "Riverside"
+  [
+    "Riverside Counseling Center",
+    "Riverside Family Services",
+    "Riverside Trauma Recovery",
+    "Riverside Youth Outreach",
+    "Riverside Wellness Collective"
+  ].each { |org_name| Organization.find_or_create_by!(name: org_name) { |o| o.organization_status = active_status } }
 
   link_org = ->(registration, organization) do
     Affiliation.find_or_create_by!(person: registration.registrant, organization: organization) do |aff|
@@ -1260,9 +1273,9 @@ if facilitator_training && registration_form
     { last: "7 None nothing typed" },
     { last: "8 Pending matches existing org", agency: matched_org&.name }
   ]
-  # Case 9: a partial of an existing org's name — not an exact match, so it shows
-  # BOTH a "Create and link" row and the existing org under fuzzy "Suggested matches".
-  scenarios << { last: "9 Fuzzy match suggestions", agency: fuzzy_agency } if fuzzy_agency.present?
+  # Case 9: a single word shared by several orgs — not an exact match, so it shows
+  # a "Create and link" row plus a handful of orgs under fuzzy "Suggested matches".
+  scenarios << { last: "9 Fuzzy match suggestions", agency: fuzzy_match_word }
 
   scenarios.each_with_index do |scenario, i|
     person = Person.create!(

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -374,6 +374,22 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("Counselor — inactive")
         end
 
+        it "appends the affiliation's start date as 'starting Month YYYY' when there is no end date" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor", start_date: Date.new(2024, 3, 1))
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Counselor starting March 2024")
+        end
+
+        it "shows the date range when the affiliation has an end date" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor", start_date: Date.new(2024, 3, 1), end_date: Date.new(2025, 6, 1))
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Counselor from March 2024 - June 2025")
+        end
+
         it "renders a non-facilitator affiliation title as a non-editable pill" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
 
@@ -383,11 +399,13 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include('name="affiliation[title]"')
         end
 
-        it "links 'View profile affiliations' to the registrant profile affiliations anchor" do
+        it "links to the registrant's profile affiliations anchor using their name" do
+          person = regular_user.person
+
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("View profile affiliations")
-          expect(response.body).to include("#{edit_person_path(regular_user.person)}#affiliations")
+          expect(response.body).to include("View #{person.first_name.presence || person.full_name}'s affiliations")
+          expect(response.body).to include("#{edit_person_path(person)}#affiliations")
         end
 
         it "warns on Unlink that it removes the org but keeps the affiliation" do
@@ -459,12 +477,63 @@ RSpec.describe "EventRegistrations", type: :request do
         end
 
         it "links the registration form submission to the public form view" do
-          submit_form(org_name: "Typed Agency")
+          submission = submit_form(org_name: "Typed Agency")
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("registration form submission")
-          expect(response.body).to include(event_public_registration_path(event, reg: existing_registration.slug))
+          expect(response.body).to include(event_public_registration_path(event))
+          expect(response.body).to include("reg=#{existing_registration.slug}")
+          expect(response.body).to include("form_submission_id=#{submission.id}")
+        end
+
+        it "lists each registration-form submission with its own view link" do
+          reg_form = Form.find_by(name: "Reg form") || create(:form, name: "Reg form")
+          create(:event_form, :registration, event: event, form: reg_form) unless event.registration_form
+          field = reg_form.form_fields.find_by(field_identifier: "agency_name") ||
+            create(:form_field, form: reg_form, field_identifier: "agency_name")
+          sub1 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub1, form_field: field, submitted_answer: "First Org")
+          sub2 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub2, form_field: field, submitted_answer: "Second Org")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("First Org")
+          expect(response.body).to include("Second Org")
+          expect(response.body).to include("form_submission_id=#{sub1.id}")
+          expect(response.body).to include("form_submission_id=#{sub2.id}")
+        end
+
+        it "shows a Create and link row for each distinct submitted org not in the database" do
+          reg_form = Form.find_by(name: "Reg form") || create(:form, name: "Reg form")
+          create(:event_form, :registration, event: event, form: reg_form) unless event.registration_form
+          field = reg_form.form_fields.find_by(field_identifier: "agency_name") ||
+            create(:form_field, form: reg_form, field_identifier: "agency_name")
+          sub1 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub1, form_field: field, submitted_answer: "Alpha Agency")
+          sub2 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub2, form_field: field, submitted_answer: "Beta Agency")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Alpha Agency")
+          expect(response.body).to include("Beta Agency")
+          expect(response.body.scan(%r{name="organization_name"}).size).to eq(2)
+        end
+
+        it "says no registration form was submitted when the person has no submission" do
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("No registration form was submitted")
+        end
+
+        it "says no organization was submitted when the form was submitted without one" do
+          submit_form
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("No organization was submitted on the")
+          expect(response.body).not_to include("No registration form was submitted")
         end
 
         it "shows 'Create org & link' when the submitted org has no existing match" do
@@ -499,12 +568,12 @@ RSpec.describe "EventRegistrations", type: :request do
             expect(details_open?(response.body, "Registration form submission")).to be true
           end
 
-          it "collapses the form submission section when the submitted org already exists" do
+          it "keeps the form submission section expanded even when the submitted org already exists" do
             submit_form(org_name: organization.name)
 
             get link_organization_event_registration_path(existing_registration)
 
-            expect(details_open?(response.body, "Registration form submission")).to be false
+            expect(details_open?(response.body, "Registration form submission")).to be true
           end
 
           it "expands the other-affiliations section when there are none" do
@@ -513,12 +582,12 @@ RSpec.describe "EventRegistrations", type: :request do
             expect(details_open?(response.body, "other affiliations")).to be true
           end
 
-          it "collapses the other-affiliations section when the person has other affiliations" do
+          it "keeps the other-affiliations section expanded when the person has other affiliations" do
             create(:affiliation, person: regular_user.person, organization: create(:organization, name: "Unlinked Co"), title: "Member")
 
             get link_organization_event_registration_path(existing_registration)
 
-            expect(details_open?(response.body, "other affiliations")).to be false
+            expect(details_open?(response.body, "other affiliations")).to be true
           end
         end
       end
@@ -574,6 +643,37 @@ RSpec.describe "EventRegistrations", type: :request do
 
           expect(existing_registration.organizations).to be_empty
           expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+          expect(flash[:alert]).to be_present
+        end
+
+        it "creates the specific submitted org named in the request" do
+          create(:organization_status, name: "Active")
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          sub1 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub1, form_field: field, submitted_answer: "Alpha Agency")
+          sub2 = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: sub2, form_field: field, submitted_answer: "Beta Agency")
+
+          post create_organization_event_registration_path(existing_registration), params: { organization_name: "Beta Agency" }
+
+          expect(existing_registration.organizations.pluck(:name)).to include("Beta Agency")
+          expect(existing_registration.organizations.pluck(:name)).not_to include("Alpha Agency")
+        end
+
+        it "rejects creating an org name the registrant didn't submit" do
+          create(:organization_status, name: "Active")
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Alpha Agency")
+
+          expect {
+            post create_organization_event_registration_path(existing_registration), params: { organization_name: "Made Up Org" }
+          }.not_to change(Organization, :count)
+
           expect(flash[:alert]).to be_present
         end
       end

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -583,5 +583,26 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       expect(response.body).not_to include("Scholarship application")
     end
+
+    context "when reached from the admin org-linking popup" do
+      let(:admin) { create(:user, :admin) }
+      let!(:registration) { create(:event_registration, event: event, registrant: person) }
+
+      before { sign_in admin }
+
+      it "shows a back link to the org popup, carrying its own return_to" do
+        get event_public_registration_path(event, person_id: person.id,
+          return_to: "link_organization", link_org_return_to: "registrants")
+
+        expect(response.body).to include("Back to linked organizations")
+        expect(response.body).to include(link_organization_event_registration_path(registration, return_to: "registrants"))
+      end
+
+      it "omits the org-popup back link without the return_to marker" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response.body).not_to include("Back to linked organizations")
+      end
+    end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1915,24 +1915,14 @@ RSpec.describe "Events", type: :request do
 
     before { sign_in admin }
 
-    it "shows the registrant's active facilitator affiliation organization names" do
+    it "does not show the registrant's affiliation organization names (moved to the link-organization page)" do
       create(:affiliation, person: registration.registrant,
         organization: create(:organization, name: "Helping Hands Center"),
         title: "Facilitator")
 
       get registrants_event_path(event)
 
-      expect(response.body).to include("Helping Hands Center")
-    end
-
-    it "does not show organizations from non-facilitator affiliations" do
-      create(:affiliation, person: registration.registrant,
-        organization: create(:organization, name: "Board Only Org"),
-        title: "Board Member")
-
-      get registrants_event_path(event)
-
-      expect(response.body).not_to include("Board Only Org")
+      expect(response.body).not_to include("Helping Hands Center")
     end
   end
 end

--- a/spec/requests/people_registrants_eyebrow_spec.rb
+++ b/spec/requests/people_registrants_eyebrow_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Person profile back-to-registrants eyebrow", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event) }
+  let(:person) { create(:person) }
+
+  before { sign_in admin }
+
+  it "shows a Back to registrants link when arriving from the event registrants page" do
+    get person_path(person, return_to: "registrants", event_id: event.id)
+
+    expect(response.body).to include("Back to registrants")
+    expect(response.body).to include(registrants_event_path(event))
+  end
+
+  it "omits the link without the registrants return context" do
+    get person_path(person)
+
+    expect(response.body).not_to include("Back to registrants")
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Admins use the link-organization popup to reconcile the organization a registrant typed on their registration form against the orgs in the database. This reorganizes that screen so the source answer, the confirmed links, and the person's other affiliations are each clearly separated and actionable.

### How did you approach the change?
- Reordered the popup top→bottom: the registration-form submission answer first (grey), the registration-linked orgs in a green-tinted card (middle), and the person's other affiliations as a grey bulleted list (bottom).
- Surface **every** registration-form submission (a registrant can have more than one via public resubmission or future person-dedupe), each with its org/title and a green file-icon link to that specific submission's public view (`form_submission_id`, scoped to the form + person).
- Show one **"Create and link"** row (primary action) per distinct submitted org not yet in the database, validated server-side against what the registrant actually submitted; plus fuzzy suggested matches and an existing-org search.
- Distinguish "no form submitted" vs "form submitted without an org", show affiliation duration on chips ("starting June 2025" / "from March 2024 - June 2025"), move "View <name>'s affiliations" into the card header, and stop showing affiliations in purple on the registrants index.
- Add a **"Back to registrants"** eyebrow above the person profile when reached from the registrants list (carries `event_id`, since the profile isn't event-scoped).
- Seed: org-link demo registrants **9** (fuzzy partial-name suggestions) and **10** (multiple submissions) so the new states are visible in the dev data.

### UI Testing Checklist
- [ ] Open a registrant's organizations & affiliations popup from the registrants page.
- [ ] Submission answer shows at top; a registrant with multiple submissions (demo 10) gets one green "View submission #N" link per submission.
- [ ] "Create and link" shows (solid/primary) for each submitted org missing from the DB; "Link organization" is the outline/secondary action.
- [ ] Fuzzy partial-name matches appear under "Suggested matches" (demo 9); exact-but-unlinked match offers a one-click link (demo 8).
- [ ] Linked orgs show green chips with an Unlink button; other affiliations render as a grey bulleted list with neutral chips.
- [ ] Registrants index no longer shows purple facilitator pills; clicking a registrant's name shows a "Back to registrants" eyebrow on their profile.

### Anything else to add?
- Rebased onto current `main` and reconciled with its concurrent work on this feature — kept main's "Unlink" button + confirm dialog and its removal of inline affiliation title-editing, layering this PR's reorg on top.
