### PR TITLE
Require all PRs to start in draft mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,7 +242,8 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 ## PRs
 
-- **Push to a draft PR early** — push commits and create a draft PR (`gh pr create --draft`) as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
+- **Always create PRs as drafts** — every PR starts in draft (`gh pr create --draft`), no exceptions. Never open a PR ready for review; only `gh pr ready` promotes it once work is complete.
+- **Push to a draft PR early** — create the draft PR as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,8 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 ## PRs
 
-- **Push to a draft PR early** — push commits and create a draft PR (`gh pr create --draft`) as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
+- **Always create PRs as drafts** — every PR starts in draft (`gh pr create --draft`), no exceptions. Never open a PR ready for review; only `gh pr ready` promotes it once work is complete.
+- **Push to a draft PR early** — create the draft PR as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure


### PR DESCRIPTION
👀 Skim

### What is the goal of this PR and why is this important?
Makes "always draft" an explicit, no-exceptions rule in both AI instruction files so agents never open a PR ready for review — promotion happens only via `gh pr ready` once work is complete.

### How did you approach the change?
Added a firm bullet to the PRs section of `CLAUDE.md` and the synced `.github/copilot-instructions.md`, above the existing "push early" guidance.

### Anything else to add?
Docs/conventions only — no code or behavior changes.