### PR TITLE
Move payment status detail into chip tooltips

### DIFF
--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -136,7 +136,7 @@
                       attention; a name matching a linked org is already resolved. %>
                   <% needs_linking = submitted_org_name.present? && linked_org_names.exclude?(submitted_org_name.downcase) %>
                   <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
-                  <% pill_classes = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 hover:opacity-80" %>
+                  <% pill_classes = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
                   <div class="flex flex-wrap gap-1.5">
                     <% linked_orgs.each do |org| %>
                       <%= link_to editor_path,
@@ -171,7 +171,7 @@
                   <% if (s = registration.scholarships.first) %>
                     <% if s.tasks_completed? %>
                       <%= link_to edit_scholarship_path(s, return_to: "registrants"),
-                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-green-50 text-green-700 border-green-200 hover:opacity-80",
+                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-green-50 text-green-700 border-green-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Completed</span>
@@ -179,7 +179,7 @@
                       <% end %>
                     <% else %>
                       <%= link_to edit_scholarship_path(s, return_to: "registrants"),
-                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-blue-50 text-blue-700 border-blue-200 hover:opacity-80",
+                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-blue-50 text-blue-700 border-blue-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Recipient</span>
@@ -189,7 +189,7 @@
                   <% else %>
                     <% if registration.scholarship_requested? %>
                       <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
-                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80",
+                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-amber-50 text-amber-700 border-amber-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Requested</span>
@@ -197,7 +197,7 @@
                       <% end %>
                     <% else %>
                       <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
-                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-gray-50 text-gray-400 border-gray-200 hover:opacity-80",
+                                  class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-gray-50 text-gray-400 border-gray-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fas fa-graduation-cap"></i>
                         <span>Create</span>
@@ -232,21 +232,21 @@
                        else
                          "fa-circle-exclamation"
                        end %>
+                    <% badge_title = if is_paid
+                         "Paid in full"
+                       elsif is_discounted
+                         "Discounted · #{dollars_from_cents(due_cents)} due"
+                       elsif is_partial
+                         "Partial payment · #{dollars_from_cents(due_cents)} due"
+                       else
+                         "#{dollars_from_cents(due_cents)} due"
+                       end %>
+                    <% badge_title = "#{badge_title} · Intends to pay" if !is_paid && registration.intends_to_pay? %>
 
-                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} hover:opacity-80", data: { turbo_frame: "_top" } do %>
+                    <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), title: badge_title, class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} transition hover:opacity-80 hover:shadow-sm", data: { turbo_frame: "_top" } do %>
                       <i class="fas <%= badge_icon %>"></i>
                       <% if is_paid %>
                         <span>Paid</span>
-                      <% elsif is_discounted %>
-                        <span class="flex flex-col leading-tight text-left">
-                          <span>Discounted</span>
-                          <span><%= dollars_from_cents(due_cents) %> due</span>
-                        </span>
-                      <% elsif is_partial %>
-                        <span class="flex flex-col leading-tight text-left">
-                          <span>Partial payment</span>
-                          <span><%= dollars_from_cents(due_cents) %> due</span>
-                        </span>
                       <% else %>
                         <span><%= dollars_from_cents(due_cents) %> due</span>
                       <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -683,7 +683,8 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-circle-half-stroke")
-        expect(response.body).to include("Partial payment")
+        expect(response.body).to include("Partial payment · $6 due")
+        expect(response.body).not_to include(">Partial payment<")
         expect(response.body).to include("$6 due")
       end
 
@@ -715,7 +716,8 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response.body).to include("fa-tag")
-        expect(response.body).to include(">Discounted<")
+        expect(response.body).to include("Discounted · $6 due")
+        expect(response.body).not_to include(">Discounted<")
         expect(response.body).to include("$6 due")
       end
 


### PR DESCRIPTION
👀 Skim

### What is the goal of this PR and why is this important?
- The registrants payment chips spelled out "Partial payment"/"Discounted" on a second line, crowding the Payment column. This declutters them while keeping the detail accessible.

### How did you approach the change?
- Collapsed the payment chips to a status icon + amount due, moving the full status (and "Intends to pay") into the chip's hover tooltip.
- Unified the hover treatment (`transition hover:opacity-80 hover:shadow-sm`) across all chips in the row.

### Anything else to add?
- View-only; no logic or data changes. The seed data that exercises the Organization "Pending" chip moved to #1804.
