### PR TITLE
Open the draft PR at task start; label the review-depth tag REVIEW NEEDED

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -244,12 +244,13 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 - **Always create PRs as drafts** — every PR starts in draft (`gh pr create --draft`), no exceptions. Never open a PR ready for review; only `gh pr ready` promotes it once work is complete.
 - **Push to a draft PR early** — create the draft PR as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
+  - **In a new Conductor workspace, do this immediately** — as the first step of any task, make an initial commit on the workspace branch and open the draft PR right away (before the work is done), then keep pushing on every commit as you go. Don't wait until there's a finished change to show.
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
 - **Remove the `Closes …` line when there's no ticket** — it's a template placeholder. Keep it (with a real issue link) only when the PR closes a tracked ticket; otherwise drop the line entirely rather than leaving the placeholder.
 - **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
-- **Start the description with a review-depth tag** on its own single line, followed by a blank line, then the rest of the description. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+- **Start the description with a review-depth tag** on its own single line, prefixed with `REVIEW NEEDED: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `REVIEW NEEDED: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
   - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
   - **📖 Read** — light-logic: small, contained logic changes with low blast radius
   - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,12 +244,13 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 
 - **Always create PRs as drafts** — every PR starts in draft (`gh pr create --draft`), no exceptions. Never open a PR ready for review; only `gh pr ready` promotes it once work is complete.
 - **Push to a draft PR early** — create the draft PR as soon as work begins, rather than keeping changes in a local branch. Push on every commit.
+  - **In a new Conductor workspace, do this immediately** — as the first step of any task, make an initial commit on the workspace branch and open the draft PR right away (before the work is done), then keep pushing on every commit as you go. Don't wait until there's a finished change to show.
 - After completing work, **mark the PR ready** using `gh pr ready`
 - **Do not rename branches after creating a PR** — deleting the old remote branch auto-closes the PR on GitHub, and the head ref cannot be changed after creation
 - Use `docs/pull_request_template.md` for PR description structure
 - **Remove the `Closes …` line when there's no ticket** — it's a template placeholder. Keep it (with a real issue link) only when the PR closes a tracked ticket; otherwise drop the line entirely rather than leaving the placeholder.
 - **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
-- **Start the description with a review-depth tag** on its own single line, followed by a blank line, then the rest of the description. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+- **Start the description with a review-depth tag** on its own single line, prefixed with `REVIEW NEEDED: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `REVIEW NEEDED: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
   - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
   - **📖 Read** — light-logic: small, contained logic changes with low blast radius
   - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review


### PR DESCRIPTION
REVIEW NEEDED: 👀 Skim — view-only: docs only, no logic or data changes

Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
Two refinements to the AI instruction files so PRs get opened earlier and the review-depth tag is clearer.

### How did you approach the change?
- Added a sub-rule that, in a new Conductor workspace, the agent commits and opens the draft PR at the *start* of a task rather than waiting for finished work.
- Gave the review-depth tag a labeled format — `REVIEW NEEDED: <icon> <level> — <meaning>` — so the line reads as an instruction to the reviewer and always spells out what the level means instead of an icon and name alone.

### UI Testing Checklist
- [ ] N/A — documentation-only change to `CLAUDE.md` and `.github/copilot-instructions.md`.

### Anything else to add?
Both files are kept in sync per the project's own AI-files rule.
