### PR TITLE
Create job + Facilitator affiliations on registration and org linking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~78 files |
-| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~27 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~28 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 15 concerns |
 
@@ -199,6 +199,10 @@ end
 - `EventRegistrationServices::PublicRegistration` — Public registration handling
 - `ReminderRecipientFilter` — Decides which event registrations stay checked on the bulk reminder page given the admin's filters (matches in memory, returns matching ids)
 - `MagicTicketCallouts` — Code-defined ("magic") ticket callout cards (payment, certificate, scholarship, CE hours, art supplies, forms, handouts, portal, videoconference, FAQ), each with its own visibility rule; rendered through the same `_callout_card` partial as admin-configured `RegistrationTicketCallout`s. Their public show pages live under `app/views/events/callouts/` and are served by `Events::CalloutsController` (slug-authorized, no login)
+
+### Affiliations
+
+- `AffiliationServices::CreateFromRegistration` — On registration / org linking, creates a "job affiliation" with the typed title (when present) plus a standing "Facilitator" affiliation, skipping the facilitator one only when the person already has an active affiliation titled exactly "Facilitator" with that org (so a job title like "Lead Facilitator" still gets its own Facilitator affiliation)
 
 ### Notifications
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ end
 
 ### Affiliations
 
-- `AffiliationServices::CreateFromRegistration` — On registration / org linking, creates a "job affiliation" with the typed title (when present) plus a standing "Facilitator" affiliation, skipping the facilitator one only when the person already has an active affiliation titled exactly "Facilitator" with that org (so a job title like "Lead Facilitator" still gets its own Facilitator affiliation)
+- `AffiliationServices::CreateFromRegistration` — On registration / org linking, creates a "job affiliation" with the typed title (when present) plus a standing "Facilitator" affiliation, in one transaction. Skips the facilitator one only when the person already has an active-or-pending affiliation titled exactly "Facilitator" with that org (a current one or one dated to a future training); an ended facilitator affiliation gets a fresh second one. Dedupe is by title + org + dates, so a job title like "Lead Facilitator" still gets its own Facilitator affiliation
 
 ### Notifications
 

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -212,7 +212,12 @@ class EventRegistrationsController < ApplicationController
     @person = @event_registration.registrant
     organization = Organization.find(params[:organization_id])
 
-    Affiliation.find_or_create_by!(person: @person, organization: organization)
+    AffiliationServices::CreateFromRegistration.call(
+      person: @person,
+      organization: organization,
+      job_title: submitted_position(@event_registration),
+      training_date: @event_registration.event.start_date
+    )
 
     @event_registration.event_registration_organizations
       .find_or_create_by!(organization: organization)
@@ -240,7 +245,12 @@ class EventRegistrationsController < ApplicationController
     existing = Organization.where("LOWER(name) = ?", name.strip.downcase).first
     organization = existing || Organization.create!(name: name.strip, organization_status: OrganizationStatus.find_by(name: "Active"))
 
-    Affiliation.find_or_create_by!(person: @person, organization: organization)
+    AffiliationServices::CreateFromRegistration.call(
+      person: @person,
+      organization: organization,
+      job_title: submitted_position(@event_registration),
+      training_date: @event_registration.event.start_date
+    )
     @event_registration.event_registration_organizations.find_or_create_by!(organization: organization)
 
     notice = existing ? "#{organization.name} linked." : "#{organization.name} created and linked."
@@ -408,22 +418,13 @@ class EventRegistrationsController < ApplicationController
       .uniq { |name| name.downcase }
   end
 
-  def find_submitted_agency_name(registration)
-    find_submitted_answer(registration, "agency_name")
-  end
-
-  def find_submitted_answer(registration, field_identifier)
-    form = registration.event.registration_form
-    return nil unless form
-
-    field = form.form_fields.find_by(field_identifier: field_identifier)
-    return nil unless field
-
-    FormAnswer
-      .joins(form_submission: :person)
-      .find_by(
-        form_submissions: { person_id: registration.registrant_id, form_id: form.id },
-        form_field_id: field.id
-      )&.submitted_answer
+  # The job title/position the registrant typed for their organization on the
+  # registration form. Uses the same "primary" submission as link_organization
+  # (the first submission that named an org, else the first), so the title applied
+  # when linking matches what the editor shows.
+  def submitted_position(registration)
+    entries = registration_submission_entries(registration)
+    primary = entries.find { |entry| entry[:org_name].present? } || entries.first
+    primary && primary[:position]
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -211,7 +211,7 @@ class PeopleController < ApplicationController
 
     if @person.save
       assign_associations(@person) if params.dig(:person, :category_ids)
-      redirect_to @person, notice: "Person was successfully updated."
+      redirect_to person_update_return_path, notice: "Person was successfully updated."
     else
       set_form_variables
       render :edit, status: :unprocessable_content
@@ -368,6 +368,17 @@ class PeopleController < ApplicationController
       name_match: exact,
       blocked: primary_email_match
     }
+  end
+
+  # Where to send the admin after a successful update. Defaults to the person's
+  # profile, but returns to the registration org-linking page when the edit was
+  # opened from one of its linked-org cards (preserving that page's own return_to).
+  def person_update_return_path
+    if params[:return_to] == "registration_link" && params[:event_registration_id].present?
+      link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence)
+    else
+      @person
+    end
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,4 +1,9 @@
 class Affiliation < ApplicationRecord
+  # Standing title given to the "facilitator affiliation" we create on registration
+  # and org linking. Matches the `facilitators` scope / `facilitator?` predicate
+  # (both treat exactly "Facilitator" as canonical).
+  FACILITATOR_TITLE = "Facilitator".freeze
+
   belongs_to :organization, inverse_of: :affiliations
   belongs_to :person, touch: true
   # Which of the organization's addresses this person is affiliated with (optional).

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -13,10 +13,15 @@ class Affiliation < ApplicationRecord
   validates_presence_of :organization_id
   validate :organization_address_belongs_to_organization
 
-  scope :active, -> {
+  # Not flagged inactive and not past its end date. Includes affiliations whose
+  # start_date is still in the future (e.g. a Facilitator affiliation dated to an
+  # upcoming training's month) — they are "pending" but counted here.
+  scope :active_or_pending, -> {
     where(inactive: false)
       .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
   }
+
+  scope :active, -> { active_or_pending }
 
   # Only the exact, case-sensitive title "Facilitator" counts — variants like
   # "Lead Facilitator" or "facilitator" are deliberately excluded. BINARY forces

--- a/app/services/affiliation_services/create_from_registration.rb
+++ b/app/services/affiliation_services/create_from_registration.rb
@@ -1,0 +1,72 @@
+module AffiliationServices
+  # Creates the affiliations we want whenever a person registers for an event or
+  # an admin links an organization to their registration:
+  #
+  #   1. a "job affiliation" with the title the person typed on their form, when
+  #      one was provided, and
+  #   2. a standing "facilitator affiliation" titled "Facilitator".
+  #
+  # The facilitator affiliation is skipped only when the person already has an
+  # active affiliation titled exactly "Facilitator" with the organization. Because
+  # the job affiliation is created first, a job title of exactly "Facilitator"
+  # satisfies that check, so we don't add a redundant duplicate. A facilitator-ish
+  # job title that isn't exactly "Facilitator" (e.g. "Lead Facilitator") still gets
+  # its own standing "Facilitator" affiliation alongside it.
+  #
+  # Start dates: the facilitator affiliation begins on the first day of the
+  # training's month (that's when they become a facilitator). The job affiliation
+  # is left without a start date — we don't know when the person began that role
+  # (they may have been with the org for years before this training), and dating it
+  # to registration would misrepresent that.
+  class CreateFromRegistration
+    def self.call(person:, organization:, job_title: nil, training_date: nil)
+      new(person:, organization:, job_title:, training_date:).call
+    end
+
+    def initialize(person:, organization:, job_title: nil, training_date: nil)
+      @person = person
+      @organization = organization
+      @job_title = job_title.presence&.strip
+      @training_date = training_date
+    end
+
+    def call
+      create_job_affiliation
+      create_facilitator_affiliation
+    end
+
+    private
+
+    def create_job_affiliation
+      return unless @job_title
+      return if active_affiliation_with_title?(@job_title)
+
+      create_affiliation(@job_title, start_date: nil)
+    end
+
+    def create_facilitator_affiliation
+      return if active_facilitator_affiliation?
+
+      create_affiliation(Affiliation::FACILITATOR_TITLE, start_date: facilitator_start_date)
+    end
+
+    def create_affiliation(title, start_date:)
+      @person.affiliations.create!(organization: @organization, title: title, start_date: start_date)
+    end
+
+    def facilitator_start_date
+      (@training_date || Date.current).to_date.beginning_of_month
+    end
+
+    def active_affiliation_with_title?(title)
+      @person.affiliations.active.where(organization: @organization, title: title).exists?
+    end
+
+    # Uses the model's canonical `facilitators` scope (exactly "Facilitator",
+    # trimmed and case-sensitive) so this agrees with #facilitator? and the rest of
+    # the app on what counts as a facilitator affiliation.
+    def active_facilitator_affiliation?
+      @person.affiliations.active.facilitators.where(organization: @organization).exists?
+    end
+  end
+end

--- a/app/services/affiliation_services/create_from_registration.rb
+++ b/app/services/affiliation_services/create_from_registration.rb
@@ -7,11 +7,14 @@ module AffiliationServices
   #   2. a standing "facilitator affiliation" titled "Facilitator".
   #
   # The facilitator affiliation is skipped only when the person already has an
-  # active affiliation titled exactly "Facilitator" with the organization. Because
-  # the job affiliation is created first, a job title of exactly "Facilitator"
-  # satisfies that check, so we don't add a redundant duplicate. A facilitator-ish
-  # job title that isn't exactly "Facilitator" (e.g. "Lead Facilitator") still gets
-  # its own standing "Facilitator" affiliation alongside it.
+  # active-or-pending affiliation titled exactly "Facilitator" with the
+  # organization (a current one, or one dated to a future training that hasn't
+  # started yet). An ended facilitator affiliation does NOT block a new one — a
+  # returning facilitator gets a second affiliation with the new start date.
+  # Because the job affiliation is created first, a job title of exactly
+  # "Facilitator" satisfies that check, so we don't add a redundant duplicate. A
+  # facilitator-ish job title that isn't exactly "Facilitator" (e.g. "Lead
+  # Facilitator") still gets its own standing "Facilitator" affiliation alongside it.
   #
   # Start dates: the facilitator affiliation begins on the first day of the
   # training's month (that's when they become a facilitator). The job affiliation
@@ -31,21 +34,23 @@ module AffiliationServices
     end
 
     def call
-      create_job_affiliation
-      create_facilitator_affiliation
+      ActiveRecord::Base.transaction do
+        create_job_affiliation
+        create_facilitator_affiliation
+      end
     end
 
     private
 
     def create_job_affiliation
       return unless @job_title
-      return if active_affiliation_with_title?(@job_title)
+      return if active_or_pending_affiliation_with_title?(@job_title)
 
       create_affiliation(@job_title, start_date: nil)
     end
 
     def create_facilitator_affiliation
-      return if active_facilitator_affiliation?
+      return if active_or_pending_facilitator_affiliation?
 
       create_affiliation(Affiliation::FACILITATOR_TITLE, start_date: facilitator_start_date)
     end
@@ -58,15 +63,17 @@ module AffiliationServices
       (@training_date || Date.current).to_date.beginning_of_month
     end
 
-    def active_affiliation_with_title?(title)
-      @person.affiliations.active.where(organization: @organization, title: title).exists?
+    def active_or_pending_affiliation_with_title?(title)
+      @person.affiliations.active_or_pending.where(organization: @organization, title: title).exists?
     end
 
     # Uses the model's canonical `facilitators` scope (exactly "Facilitator",
     # trimmed and case-sensitive) so this agrees with #facilitator? and the rest of
-    # the app on what counts as a facilitator affiliation.
-    def active_facilitator_affiliation?
-      @person.affiliations.active.facilitators.where(organization: @organization).exists?
+    # the app on what counts as a facilitator affiliation. Counts pending
+    # (future-dated) facilitator affiliations too, so registering for a second
+    # upcoming training doesn't mint a duplicate.
+    def active_or_pending_facilitator_affiliation?
+      @person.affiliations.active_or_pending.facilitators.where(organization: @organization).exists?
     end
   end
 end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -15,6 +15,14 @@ module EventRegistrationServices
     ADDITIONAL_FORMS_INVOICE = "Invoice".freeze
     ADDITIONAL_FORMS_W9 = "W-9".freeze
 
+    # Well-known field_identifiers for the registrant's organization name and
+    # position on the registration form. We name them in organization terms here
+    # as we move the vocabulary away from "agency"; the stored identifiers are
+    # still "agency_*" pending a form-field rename. Kept here so the service,
+    # controller, and specs agree on a single source.
+    ORGANIZATION_NAME_IDENTIFIER = "agency_name".freeze
+    ORGANIZATION_POSITION_IDENTIFIER = "agency_position".freeze
+
     def self.call(event:, form:, form_params:, scholarship_requested: false, person: nil,
                   scholarship_form: nil, scholarship_params: {})
       new(event:, form:, form_params:, scholarship_requested:, person:,
@@ -40,7 +48,7 @@ module EventRegistrationServices
         create_mailing_address(person) if field_value("mailing_city").present?
         create_phone_contact(person) if field_value("phone").present?
 
-        organization = find_organization if field_value("agency_name").present?
+        organization = find_organization if field_value(ORGANIZATION_NAME_IDENTIFIER).present?
         create_affiliation(person, organization) if organization
         create_agency_address(organization) if organization && field_value("agency_city").present?
 
@@ -198,20 +206,19 @@ module EventRegistrationServices
     end
 
     def find_organization
-      name = field_value("agency_name")&.strip
+      name = field_value(ORGANIZATION_NAME_IDENTIFIER)&.strip
       return nil if name.blank?
 
       Organization.find_by(name: name)
     end
 
     def create_affiliation(person, organization)
-      Affiliation.find_or_create_by!(
+      AffiliationServices::CreateFromRegistration.call(
         person: person,
-        organization: organization
-      ) do |aff|
-        aff.title = field_value("agency_position")
-        aff.start_date = Date.current
-      end
+        organization: organization,
+        job_title: field_value(ORGANIZATION_POSITION_IDENTIFIER),
+        training_date: @event.start_date
+      )
     end
 
     def create_agency_address(organization)

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -14,15 +14,17 @@
       <% color = a_active && !local_assigns[:neutral] ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
       <% start_month = a.start_date&.strftime("%B %Y") %>
       <% end_month = a.end_date&.strftime("%B %Y") %>
-      <% duration =
+      <% dates =
            if start_month && end_month
-             " from #{start_month} - #{end_month}"
+             "#{start_month} – #{end_month}"
            elsif end_month
-             " until #{end_month}"
+             "until #{end_month}"
            elsif start_month
-             " starting #{start_month}"
+             "since #{start_month}"
+           else
+             "no dates"
            end %>
-      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")}#{duration}#{" — inactive" unless a_active}" %>
+      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")} (#{dates})#{" — inactive" unless a_active}" %>
       <% title_attr = a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : nil %>
       <span class="<%= badge %> <%= color %>" title="<%= title_attr %>"><%= label %></span>
     <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -83,7 +83,6 @@
             <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">
               <div class="min-w-0">
                 <p class="font-medium text-gray-800"><%= link_to org.name, edit_person_path(@person, anchor: "affiliations"),
-                            target: "_blank", rel: "noopener",
                             title: "Edit #{@person.first_name.presence || @person.full_name}'s affiliations",
                             class: "after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none",
                             data: { turbo_frame: "_top" } %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -77,14 +77,14 @@
       <% if @linked_organizations.any? %>
         <ul class="space-y-2 mb-4">
           <% @linked_organizations.each do |org| %>
-            <%# The whole card links to the person's affiliations section (where these
-                are managed) via a stretched link on the org name; the Unlink button is
-                lifted above the overlay with relative z-10 so it stays clickable. %>
+            <%# The whole card links to the person's edit-affiliations section (where
+                these are managed) via a stretched link on the org name; the Unlink
+                button is lifted above the overlay with relative z-10 so it stays clickable. %>
             <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">
               <div class="min-w-0">
-                <p class="font-medium text-gray-800"><%= link_to org.name, person_path(@person, anchor: "affiliations"),
+                <p class="font-medium text-gray-800"><%= link_to org.name, edit_person_path(@person, anchor: "affiliations"),
                             target: "_blank", rel: "noopener",
-                            title: "View #{@person.first_name.presence || @person.full_name}'s affiliations",
+                            title: "Edit #{@person.first_name.presence || @person.full_name}'s affiliations",
                             class: "after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none",
                             data: { turbo_frame: "_top" } %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -77,9 +77,16 @@
       <% if @linked_organizations.any? %>
         <ul class="space-y-2 mb-4">
           <% @linked_organizations.each do |org| %>
-            <li class="flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3">
+            <%# The whole card links to the person's affiliations section (where these
+                are managed) via a stretched link on the org name; the Unlink button is
+                lifted above the overlay with relative z-10 so it stays clickable. %>
+            <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">
               <div class="min-w-0">
-                <p class="font-medium text-gray-800"><%= org.name %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
+                <p class="font-medium text-gray-800"><%= link_to org.name, person_path(@person, anchor: "affiliations"),
+                            target: "_blank", rel: "noopener",
+                            title: "View #{@person.first_name.presence || @person.full_name}'s affiliations",
+                            class: "after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none",
+                            data: { turbo_frame: "_top" } %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 <%= render "org_affiliation_pills", org: org, affiliations: (@affiliations_by_org[org.id] || []),
                                                     submitted_org_name: @submitted_org_name, submitted_position: @submitted_position %>
               </div>
@@ -89,7 +96,7 @@
               <%= button_to "Unlink",
                             unlink_organization_event_registration_path(@event_registration, organization_id: org.id, return_to: params[:return_to]),
                             method: :delete,
-                            form: { class: "shrink-0", data: { turbo_frame: "_top", turbo_confirm: "Unlink #{org.name} from this registration?\n\nThis only removes the organization from this registration — it will NOT delete any of #{@person.first_name.presence || @person.full_name}'s Affiliations with #{org.name}.\n\nTo change or remove any Affiliations, edit the Person record." } },
+                            form: { class: "relative z-10 shrink-0", data: { turbo_frame: "_top", turbo_confirm: "Unlink #{org.name} from this registration?\n\nThis only removes the organization from this registration — it will NOT delete any of #{@person.first_name.presence || @person.full_name}'s Affiliations with #{org.name}.\n\nTo change or remove any Affiliations, edit the Person record." } },
                             class: "inline-flex items-center rounded-full border border-transparent px-3 py-0.5 text-sm text-gray-500 underline transition hover:bg-red-50 hover:text-red-700 hover:border-red-200 hover:no-underline cursor-pointer" %>
             </li>
           <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -82,7 +82,7 @@
                 button is lifted above the overlay with relative z-10 so it stays clickable. %>
             <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">
               <div class="min-w-0">
-                <p class="font-medium text-gray-800"><%= link_to org.name, edit_person_path(@person, anchor: "affiliations"),
+                <p class="font-medium text-gray-800"><%= link_to org.name, edit_person_path(@person, anchor: "affiliations", return_to: "registration_link", event_registration_id: @event_registration.id, link_org_return_to: params[:return_to].presence),
                             title: "Edit #{@person.first_name.presence || @person.full_name}'s affiliations",
                             class: "after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none",
                             data: { turbo_frame: "_top" } %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -1,4 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<%# Every jump to the person's affiliations editor (header link, linked-org cards,
+    other-affiliations card) shares this path so a save returns here — carrying the
+    origin and this page's own return_to. %>
+<% edit_affiliations_path = edit_person_path(@person, anchor: "affiliations", return_to: "registration_link", event_registration_id: @event_registration.id, link_org_return_to: params[:return_to].presence) %>
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="mb-4">
     <% if params[:return_to] == "onboarding" %>
@@ -10,10 +14,9 @@
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
     <div class="flex items-start justify-between gap-3 mb-2">
       <h1 class="text-2xl font-bold text-gray-900">Organizations &amp; affiliations</h1>
-      <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
+      <%= link_to edit_affiliations_path, data: { turbo_frame: "_top" },
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700 shrink-0 mt-1.5" do %>
-        View <%= @person.first_name.presence || @person.full_name %>'s affiliations
-        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+        Edit <%= @person.first_name.presence || @person.full_name %>'s affiliations
       <% end %>
     </div>
     <p class="text-gray-600 mb-6">Registrant: <strong><%= @person.full_name %></strong></p>
@@ -82,7 +85,7 @@
                 button is lifted above the overlay with relative z-10 so it stays clickable. %>
             <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">
               <div class="min-w-0">
-                <p class="font-medium text-gray-800"><%= link_to org.name, edit_person_path(@person, anchor: "affiliations", return_to: "registration_link", event_registration_id: @event_registration.id, link_org_return_to: params[:return_to].presence),
+                <p class="font-medium text-gray-800"><%= link_to org.name, edit_affiliations_path,
                             title: "Edit #{@person.first_name.presence || @person.full_name}'s affiliations",
                             class: "after:absolute after:inset-0 hover:underline focus-visible:underline focus:outline-none",
                             data: { turbo_frame: "_top" } %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
@@ -181,12 +184,11 @@
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500"><%= @person.first_name.presence || @person.full_name %>'s other affiliations</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
       </summary>
-      <%# The whole card links to the person's affiliations on their profile (same
-          destination as the header jump link) — these are managed there, not here. %>
-      <%= link_to edit_person_path(@person, anchor: "affiliations"), target: "_blank", rel: "noopener",
+      <%# The whole card links to the person's affiliations editor (same destination
+          as the header jump link) — these are managed there, not here. %>
+      <%= link_to edit_affiliations_path, data: { turbo_frame: "_top" },
                   title: "Edit affiliations on #{@person.first_name.presence || @person.full_name}'s profile",
                   class: "group relative block bg-gray-50 border border-gray-200 rounded-xl p-4 hover:bg-gray-100 transition-colors" do %>
-        <i class="fa-solid fa-arrow-up-right-from-square absolute top-3 right-3 text-[0.6rem] text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"></i>
         <% if other_affiliations.any? %>
           <ul class="list-disc list-inside space-y-2 text-gray-800 marker:text-gray-400">
             <% other_affiliations.values.sort_by { |affs| affs.first.organization&.name.to_s.downcase }.each do |affs| %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -8,6 +8,14 @@
   <% user_id = @user&.id || @person&.user&.id %>
   <%= hidden_field_tag :user_id, user_id if user_id %>
 
+  <%# Carry the origin context through the save so #update can return the admin
+      to where they came from (e.g. the registration org-linking page). %>
+  <% if params[:return_to] == "registration_link" && params[:event_registration_id].present? %>
+    <%= hidden_field_tag :return_to, "registration_link" %>
+    <%= hidden_field_tag :event_registration_id, params[:event_registration_id] %>
+    <%= hidden_field_tag :link_org_return_to, params[:link_org_return_to] if params[:link_org_return_to].present? %>
+  <% end %>
+
   <div class="flex flex-col md:flex-row gap-8 items-start">
     <div class="w-full md:w-3/4">
       <div class="space-y-6">

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -7,6 +7,12 @@
                 <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
               <% end %>
             </div>
+          <% elsif params[:return_to] == "registration_link" && params[:event_registration_id].present? %>
+            <div class="mb-2">
+              <%= link_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+                <i class="fa-solid fa-arrow-left text-xs"></i> Organization linking
+              <% end %>
+            </div>
           <% end %>
           <div class="flex flex-wrap justify-end gap-2 mb-4">
             <% unless @person.user %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1063,8 +1063,11 @@ record_organization_answers = ->(registration, submission, i) do
   person = registration.registrant
   form = submission.form
 
+  # A title on most submissions, but leave roughly one in five blank so dev data
+  # exercises both registration/linking outcomes: a job + Facilitator affiliation
+  # when a title was given, and a Facilitator-only affiliation when it wasn't.
   position_field = form.form_fields.find_by(field_identifier: "agency_position")
-  if position_field && submission.form_answers.where(form_field: position_field).none?
+  if position_field && i % 5 != 4 && submission.form_answers.where(form_field: position_field).none?
     submission.form_answers.create!(form_field: position_field,
                                     submitted_answer: job_titles[i % job_titles.size],
                                     question_name_when_answered: position_field.name)

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -365,29 +365,29 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).to include("No other affiliations on record")
         end
 
-        it "shows the affiliation pill inline on the linked org" do
+        it "shows the affiliation pill inline on the linked org, noting it has no dates" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Counselor")
-          expect(response.body).not_to include("Counselor — inactive")
+          expect(response.body).to include("Counselor (no dates)")
+          expect(response.body).not_to include("Counselor (no dates) — inactive")
         end
 
-        it "appends the affiliation's start date as 'starting Month YYYY' when there is no end date" do
+        it "shows the start date as '(since Month YYYY)' when there is no end date" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor", start_date: Date.new(2024, 3, 1))
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Counselor starting March 2024")
+          expect(response.body).to include("Counselor (since March 2024)")
         end
 
-        it "shows the date range when the affiliation has an end date" do
+        it "shows the date range in parens when the affiliation has an end date" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor", start_date: Date.new(2024, 3, 1), end_date: Date.new(2025, 6, 1))
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("Counselor from March 2024 - June 2025")
+          expect(response.body).to include("Counselor (March 2024 – June 2025)")
         end
 
         it "renders a non-facilitator affiliation title as a non-editable pill" do
@@ -435,7 +435,7 @@ RSpec.describe "EventRegistrations", type: :request do
           get link_organization_event_registration_path(existing_registration)
 
           expect(response.body).to include("Facilitator")
-          expect(response.body).not_to include("Facilitator — inactive")
+          expect(response.body).not_to include("Facilitator (no dates) — inactive")
         end
 
         it "shows a facilitator affiliation as inactive once it has ended" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -374,10 +374,12 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("Counselor (no dates) — inactive")
         end
 
-        it "links the linked-org card to the person's edit-affiliations section" do
+        it "links the linked-org card to the person's edit-affiliations section, returning here on save" do
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("href=\"#{edit_person_path(regular_user.person, anchor: "affiliations")}\"")
+          expect(response.body).to include(edit_person_path(regular_user.person))
+          expect(response.body).to include("return_to=registration_link")
+          expect(response.body).to include("event_registration_id=#{existing_registration.id}")
         end
 
         it "shows the start date as '(since Month YYYY)' when there is no end date" do
@@ -405,13 +407,15 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include('name="affiliation[title]"')
         end
 
-        it "links to the registrant's profile affiliations anchor using their name" do
+        it "links to the registrant's edit-affiliations section using their name, returning here on save" do
           person = regular_user.person
 
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("View #{person.first_name.presence || person.full_name}'s affiliations")
-          expect(response.body).to include("#{edit_person_path(person)}#affiliations")
+          expect(response.body).to include("Edit #{person.first_name.presence || person.full_name}'s affiliations")
+          expect(response.body).to include(edit_person_path(person))
+          expect(response.body).to include("#affiliations")
+          expect(response.body).to include("return_to=registration_link")
         end
 
         it "warns on Unlink that it removes the org but keeps the affiliation" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -602,6 +602,28 @@ RSpec.describe "EventRegistrations", type: :request do
 
           expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
         end
+
+        it "creates a job affiliation and a facilitator affiliation from the submitted position" do
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: EventRegistrationServices::PublicRegistration::ORGANIZATION_POSITION_IDENTIFIER)
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Counselor")
+
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
+            .to contain_exactly("Counselor", "Facilitator")
+        end
+
+        it "creates a facilitator affiliation even when no position was submitted" do
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
+            .to contain_exactly("Facilitator")
+        end
       end
 
       describe "POST /event_registrations/:id/create_organization" do
@@ -619,6 +641,23 @@ RSpec.describe "EventRegistrations", type: :request do
 
           expect(existing_registration.organizations.pluck(:name)).to include("Brand New Org")
           expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+        end
+
+        it "creates a job affiliation and a facilitator affiliation for the new org from the submitted position" do
+          create(:organization_status, name: "Active")
+          reg_form = create(:form, name: "Reg form")
+          name_field = create(:form_field, form: reg_form, field_identifier: EventRegistrationServices::PublicRegistration::ORGANIZATION_NAME_IDENTIFIER)
+          position_field = create(:form_field, form: reg_form, field_identifier: EventRegistrationServices::PublicRegistration::ORGANIZATION_POSITION_IDENTIFIER)
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: name_field, submitted_answer: "Brand New Org")
+          create(:form_answer, form_submission: submission, form_field: position_field, submitted_answer: "Counselor")
+
+          post create_organization_event_registration_path(existing_registration)
+
+          organization = Organization.find_by(name: "Brand New Org")
+          expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
+            .to contain_exactly("Counselor", "Facilitator")
         end
 
         it "links an existing org instead of creating a duplicate" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -374,6 +374,12 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("Counselor (no dates) — inactive")
         end
 
+        it "links the linked-org card to the person's affiliations section" do
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("href=\"#{person_path(regular_user.person, anchor: "affiliations")}\"")
+        end
+
         it "shows the start date as '(since Month YYYY)' when there is no end date" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor", start_date: Date.new(2024, 3, 1))
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -374,10 +374,10 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("Counselor (no dates) — inactive")
         end
 
-        it "links the linked-org card to the person's affiliations section" do
+        it "links the linked-org card to the person's edit-affiliations section" do
           get link_organization_event_registration_path(existing_registration)
 
-          expect(response.body).to include("href=\"#{person_path(regular_user.person, anchor: "affiliations")}\"")
+          expect(response.body).to include("href=\"#{edit_person_path(regular_user.person, anchor: "affiliations")}\"")
         end
 
         it "shows the start date as '(since Month YYYY)' when there is no end date" do

--- a/spec/requests/people_registration_link_return_spec.rb
+++ b/spec/requests/people_registration_link_return_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Person edit return to registration org-linking", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event) }
+  let(:person) { create(:person) }
+  let(:event_registration) { create(:event_registration, event: event, registrant: person) }
+
+  before { sign_in admin }
+
+  it "shows an Organization linking eyebrow when arriving from the linking page" do
+    get edit_person_path(person, return_to: "registration_link", event_registration_id: event_registration.id)
+
+    expect(response.body).to include("Organization linking")
+    expect(response.body).to include(link_organization_event_registration_path(event_registration))
+  end
+
+  it "returns to the linking page after a successful update" do
+    patch person_path(person), params: {
+      person: { first_name: "Updated" },
+      return_to: "registration_link",
+      event_registration_id: event_registration.id
+    }
+
+    expect(response).to redirect_to(link_organization_event_registration_path(event_registration))
+  end
+
+  it "preserves the linking page's own return_to on the way back" do
+    patch person_path(person), params: {
+      person: { first_name: "Updated" },
+      return_to: "registration_link",
+      event_registration_id: event_registration.id,
+      link_org_return_to: "registrants"
+    }
+
+    expect(response).to redirect_to(link_organization_event_registration_path(event_registration, return_to: "registrants"))
+  end
+
+  it "redirects to the profile for a normal edit with no origin context" do
+    patch person_path(person), params: { person: { first_name: "Updated" } }
+
+    expect(response).to redirect_to(person_path(person))
+  end
+end

--- a/spec/services/affiliation_services/create_from_registration_spec.rb
+++ b/spec/services/affiliation_services/create_from_registration_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe AffiliationServices::CreateFromRegistration do
+  let(:person) { create(:person) }
+  let(:organization) { create(:organization) }
+
+  def titles
+    person.affiliations.where(organization: organization).pluck(:title)
+  end
+
+  it "creates a job affiliation and a facilitator affiliation when a title is given" do
+    described_class.call(person: person, organization: organization, job_title: "Counselor")
+
+    expect(titles).to contain_exactly("Counselor", "Facilitator")
+  end
+
+  it "creates only a facilitator affiliation when no title is given" do
+    described_class.call(person: person, organization: organization, job_title: nil)
+
+    expect(titles).to contain_exactly("Facilitator")
+  end
+
+  it "treats a blank title as no title" do
+    described_class.call(person: person, organization: organization, job_title: "   ")
+
+    expect(titles).to contain_exactly("Facilitator")
+  end
+
+  it "still adds a Facilitator affiliation alongside a facilitator-ish job title" do
+    described_class.call(person: person, organization: organization, job_title: "Lead Facilitator")
+
+    expect(titles).to contain_exactly("Lead Facilitator", "Facilitator")
+  end
+
+  it "does not add a duplicate when the job title is exactly Facilitator" do
+    described_class.call(person: person, organization: organization, job_title: "Facilitator")
+
+    expect(titles).to contain_exactly("Facilitator")
+  end
+
+  it "skips the facilitator affiliation when an active one already exists for the org" do
+    create(:affiliation, person: person, organization: organization, title: "Facilitator")
+
+    expect {
+      described_class.call(person: person, organization: organization, job_title: "Counselor")
+    }.to change { titles.sort }.from(%w[Facilitator]).to(%w[Counselor Facilitator])
+
+    expect(person.affiliations.facilitators.where(organization: organization).count).to eq(1)
+  end
+
+  it "adds a facilitator affiliation when the existing one for the org has ended" do
+    create(:affiliation, person: person, organization: organization,
+                         title: "Facilitator", end_date: 1.month.ago.to_date)
+
+    described_class.call(person: person, organization: organization, job_title: nil)
+
+    expect(person.affiliations.facilitators.where(organization: organization).count).to eq(2)
+  end
+
+  it "does not duplicate the job affiliation on a repeat call" do
+    described_class.call(person: person, organization: organization, job_title: "Counselor")
+    described_class.call(person: person, organization: organization, job_title: "Counselor")
+
+    expect(titles).to contain_exactly("Counselor", "Facilitator")
+  end
+
+  it "leaves the job affiliation without a start date" do
+    described_class.call(person: person, organization: organization, job_title: "Counselor")
+
+    job = person.affiliations.find_by(organization: organization, title: "Counselor")
+    expect(job.start_date).to be_nil
+  end
+
+  it "starts the facilitator affiliation on the first day of the training's month" do
+    described_class.call(person: person, organization: organization,
+                         job_title: "Counselor", training_date: Date.new(2026, 9, 17))
+
+    facilitator = person.affiliations.find_by(organization: organization, title: "Facilitator")
+    expect(facilitator.start_date).to eq(Date.new(2026, 9, 1))
+  end
+
+  it "falls back to the current month for the facilitator affiliation when no training date is given" do
+    described_class.call(person: person, organization: organization, job_title: nil)
+
+    facilitator = person.affiliations.find_by(organization: organization, title: "Facilitator")
+    expect(facilitator.start_date).to eq(Date.current.beginning_of_month)
+  end
+end

--- a/spec/services/affiliation_services/create_from_registration_spec.rb
+++ b/spec/services/affiliation_services/create_from_registration_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe AffiliationServices::CreateFromRegistration do
     expect(person.affiliations.facilitators.where(organization: organization).count).to eq(1)
   end
 
+  it "skips the facilitator affiliation when a pending (future-dated) one already exists for the org" do
+    create(:affiliation, person: person, organization: organization,
+                         title: "Facilitator", start_date: 2.months.from_now.to_date)
+
+    described_class.call(person: person, organization: organization, job_title: nil)
+
+    expect(person.affiliations.facilitators.where(organization: organization).count).to eq(1)
+  end
+
   it "adds a facilitator affiliation when the existing one for the org has ended" do
     create(:affiliation, person: person, organization: organization,
                          title: "Facilitator", end_date: 1.month.ago.to_date)
@@ -55,6 +64,15 @@ RSpec.describe AffiliationServices::CreateFromRegistration do
     described_class.call(person: person, organization: organization, job_title: nil)
 
     expect(person.affiliations.facilitators.where(organization: organization).count).to eq(2)
+  end
+
+  it "does not create a duplicate affiliation with the same title, org, and dates" do
+    described_class.call(person: person, organization: organization,
+                         job_title: "Counselor", training_date: Date.new(2026, 9, 17))
+    described_class.call(person: person, organization: organization,
+                         job_title: "Counselor", training_date: Date.new(2026, 9, 17))
+
+    expect(titles).to contain_exactly("Counselor", "Facilitator")
   end
 
   it "does not duplicate the job affiliation on a repeat call" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     }
   end
 
+  describe "affiliation creation" do
+    let!(:organization) { create(:organization, name: "Helping Hands") }
+
+    def register_with(position:)
+      params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
+        field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => "Helping Hands"
+      )
+      params[field_id(described_class::ORGANIZATION_POSITION_IDENTIFIER)] = position if position
+      described_class.call(event: event, form: form, form_params: params)
+      Person.find_by(email: "sam@example.com")
+    end
+
+    it "creates a job affiliation and a facilitator affiliation from the typed position" do
+      person = register_with(position: "Counselor")
+
+      expect(person.affiliations.where(organization: organization).pluck(:title))
+        .to contain_exactly("Counselor", "Facilitator")
+    end
+
+    it "creates only a facilitator affiliation when no position was typed" do
+      person = register_with(position: nil)
+
+      expect(person.affiliations.where(organization: organization).pluck(:title))
+        .to contain_exactly("Facilitator")
+    end
+  end
+
   describe "an answer longer than its database column" do
     # `city` (like the other mapped person/address columns) is a varchar(255).
     # A longer answer must surface as a form error, not an ActiveRecord::ValueTooLong


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: contained changes to affiliation creation/dedupe; one new model scope that `active` delegates to (no behavior change today)

### What is the goal of this PR and why is this important?

- When a person registers for an event — or an admin links an organization to their registration — we should automatically record their affiliation with that org, so the program roster reflects it without manual data entry.
- Each linking moment now creates up to **two** affiliations:
  - a **job affiliation** carrying the title the registrant typed on the form (only when they provided one), and
  - a standing **"Facilitator" affiliation**.

### How did you approach the change?

- Added `AffiliationServices::CreateFromRegistration`, a single PORO shared by every entry point so the behavior can't drift:
  - **Public registration** (`PublicRegistration`)
  - **Link existing org** (`EventRegistrationsController#select_organization`)
  - **Create & link org** (`EventRegistrationsController#create_organization`)
- **Facilitator de-dup:** the "Facilitator" affiliation is skipped only when an **active-or-pending** affiliation the model's `facilitators` scope considers canonical (exactly "Facilitator", trimmed, case-sensitive) already exists with that org — a current one **or** one dated to a future training that hasn't started yet. An **ended** Facilitator affiliation does not block a new one (a returning facilitator gets a fresh second affiliation). The job affiliation is created first, so a typed title of exactly "Facilitator" suppresses the duplicate — but a facilitator-ish title like "Lead Facilitator" still gets its own standing "Facilitator" alongside it.
- **`active_or_pending` scope:** added to `Affiliation` (not-inactive, not-ended; **includes** future-dated/pending affiliations). `active` now delegates to it, so existing behavior is unchanged — the scope just names the set the dedupe needs.
- **Atomicity:** the job and Facilitator creates run in **one transaction**, so a job affiliation is never left without its Facilitator (or vice versa).
- **Start dates:**
  - The **job** affiliation is left with **no start date** — we don't know when the person began that role (they may have been with the org for years before this training), and dating it to registration would misrepresent it.
  - The **Facilitator** affiliation starts on the **first day of the training's month** (falling back to the current month when an event has no start date).
- **Title source:** all three flows pull the job title from the registrant's position answer on the registration form, reusing the same "primary submission" the org-linking editor displays so the applied title matches what the editor shows.
- **Vocabulary:** new code refers to this as the *organization position*, not "agency". The legacy stored field identifiers (`agency_name` / `agency_position`) are localized behind organization-named constants on `PublicRegistration` pending a future form-field rename.
- **Dev seeds:** registration submissions now carry a job title most (~80%) of the time, leaving roughly one in five blank, so dev data exercises both the job + Facilitator and Facilitator-only outcomes.

### Anything else to add?

- New service spec (covers active/pending/ended dedupe, same title+org+dates no-dup, start-date rules) plus added coverage in the public-registration service spec and the event-registrations request spec.
- **Out of scope / follow-up PR:** treating organization status as derived from affiliations — reclassifying the ~20 `active` call sites between `active`/`active_or_pending`, tightening `active` to also require the start date to have arrived, and a symmetric org-status callback.
- **Rebased onto current `main`** (now includes #1815/#1814, which made facilitator matching exact + case-sensitive; #1818, which adds `organization_address` to affiliations; and #1788's Onboarding tab). Reconciliation notes for reviewers:
  - The service's facilitator de-dup now uses the model's `facilitators` scope, so it agrees with #1815's exact/case-sensitive definition instead of a looser `where(title:)`.
  - `Affiliation::FACILITATOR_TITLE` sits alongside #1818's new `organization_address` association; affiliations are created with no linked address (the new validation is a no-op when blank).
  - Controller auto-merged with #1788's `update_onboarding`; my org-linking actions and `submitted_position` (built on #1804's `registration_submission_entries`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
