### PR TITLE
Redirect to event dashboard after editing an event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -433,7 +433,7 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if success
-        format.html { redirect_to @event, notice: "Event was successfully updated." }
+        format.html { redirect_to dashboard_event_path(@event), notice: "Event was successfully updated." }
         format.json { render :show, status: :ok, location: @event }
       else
         set_form_variables

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -359,6 +359,11 @@ RSpec.describe "Events", type: :request do
         expect(event.reload.title).to eq("Updated")
       end
 
+      it "redirects to the event dashboard" do
+        patch event_path(event), params: update_params
+        expect(response).to redirect_to(dashboard_event_path(event))
+      end
+
       it "persists the show-details-on-registration toggle" do
         event.update!(autoshow_registration_details: false)
         patch event_path(event), params: { event: { autoshow_registration_details: "1" } }


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: small, contained logic changes with low blast radius

### What is the goal of this PR and why is this important?
After editing an event, the user was dropped on the event show page even though the edit page's eyebrow says "← Dashboard". This lands them back on the dashboard where they came from.

### How did you approach the change?
Changed the `update` success redirect in `EventsController` from the show page to `dashboard_event_path`, and added a request spec asserting the dashboard redirect.

### Anything else to add?
The events edit/update flow doesn't carry a `return_to` param today, so there's no alternate destination to honor — the dashboard is the single sensible landing spot.
