### PR TITLE
Consolidate built-in & custom ticket call-outs in one editor

### DIFF
--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -15,6 +15,35 @@ class MagicTicketCallouts
     def theme = DomainTheme.swatch(color)
   end
 
+  # A registration-free description of one built-in card, for the event editor's
+  # callouts section. `key` is :ce_hours / :event_details for the two whose text
+  # admins edit; nil for the cards the app fully controls (shown greyed out).
+  # `subtitle` mirrors the card's ticket subtitle; `visibility` describes when the
+  # app shows it (rendered next to the "Built in" chip in the editor); `note` is an
+  # optional extra hint on where the card's content comes from.
+  EditorCard = Data.define(:key, :icon_class, :color, :title, :subtitle, :visibility, :note) do
+    def theme = DomainTheme.swatch(color)
+    def editable? = key.present?
+  end
+
+  # Every built-in card in the order it appears on a ticket, for the editor to
+  # preview the full ticket context. Keep in sync with #cards: add a card method,
+  # add it here.
+  def self.editor_cards(event)
+    [
+      EditorCard.new(nil, "fa-solid fa-credit-card", "orange", "Payment", "Your balance and payment history", "When the event has a cost", nil),
+      EditorCard.new(nil, "fa-solid fa-certificate", "green", "Certificate of completion", "View and download your certificate", "Once the certificate is unlocked", nil),
+      EditorCard.new(nil, "fa-solid fa-award", "fuchsia", "Scholarship", "Your scholarship request and award", "When the registrant requested a scholarship", nil),
+      EditorCard.new(:ce_hours, "fa-solid fa-graduation-cap", "teal", event.ce_hours_details_label, "Continuing education — requirements & how to request", "When a registrant requests CE credit", nil),
+      EditorCard.new(:event_details, "fa-solid fa-palette", "blue", event.event_details_label, "Important info for this event — please read", "When the content below is filled in", nil),
+      EditorCard.new(nil, "fa-solid fa-video", "blue", "Videoconference", "Join link and how to add it to your calendar", "When the event has a videoconference link", "Details come from this event's videoconference settings."),
+      EditorCard.new(nil, "fa-solid fa-file-lines", "blue", "Forms", "W-9, invoice, and letter to supervisors", "Always shown", "Items link to their relevant resources."),
+      EditorCard.new(nil, "fa-solid fa-folder-open", "blue", "Handouts", "Worksheets and resources for the training", "Always shown", "Items link to their relevant resources."),
+      EditorCard.new(nil, "fa-solid fa-circle-question", "blue", "Frequently asked questions", "Common questions about the 2-day training", "Always shown", nil),
+      EditorCard.new(nil, "fa-solid fa-right-to-bracket", "gray", "Facilitator Portal access", "Sign in once the training is complete", "Always shown", nil)
+    ]
+  end
+
   def initialize(event_registration)
     @registration = event_registration
     @event = event_registration.event

--- a/app/views/events/_builtin_callout_card.html.erb
+++ b/app/views/events/_builtin_callout_card.html.erb
@@ -1,0 +1,28 @@
+<%# An editable built-in registration-ticket callout (CE hours, art supplies),
+    rendered inside the event form's callouts section and tinted in the colour the
+    card uses on the ticket. locals: f (event form builder), card
+    (MagicTicketCallouts::EditorCard), label_field/content_field (event attribute
+    symbols), title_placeholder, content_help, content_placeholder. %>
+<% theme = card.theme %>
+<div class="registration-ticket-callout-fields flex items-start gap-3 rounded-lg border <%= theme[:border] %> <%= theme[:bg] %> p-3 shadow-sm">
+  <i class="<%= card.icon_class %> <%= theme[:icon] %> w-6 shrink-0 text-center text-xl pt-1.5" aria-hidden="true"></i>
+  <div class="flex-1 min-w-0 space-y-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="inline-flex items-center rounded-full bg-white px-2 py-0.5 text-xs font-medium <%= theme[:subtitle] %>">Built in</span>
+      <span class="text-xs <%= theme[:subtitle] %>"><%= card.visibility %></span>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div>
+        <%= f.label label_field, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <%= f.text_area label_field, rows: 2, placeholder: title_placeholder,
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+      </div>
+      <div>
+        <%= f.label content_field, "Callout page text", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+        <p class="text-xs text-gray-500 mb-1"><%= content_help %></p>
+        <%= f.text_area content_field, rows: 3, placeholder: content_placeholder,
+              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -426,82 +426,11 @@
       </div>
     </div>
 
-    <%# ---- BEFORE YOU ATTEND (ticket call-out + details page) ---- %>
-    <div class="ticket-details-section" data-controller="dropdown">
-      <button
-        type="button"
-        id="ticket_details_button"
-        class="
-          flex items-center justify-between cursor-pointer w-full
-          bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
-        data-action="dropdown#toggle"
-        data-dropdown-payload-param='[{"ticket_details":"hidden"}, {"ticket_details_arrow":"rotate-180"}, {"ticket_details_button":"rounded-md rounded-t-md"}]'>
-        Before you attend
-        <i id="ticket_details_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
-      </button>
-
-      <div id="ticket_details" class="hidden border border-gray-300 p-4 rounded-b-md">
-        <p class="text-sm text-gray-500 mb-4">Extra info shown on the registration ticket as a prominent call-out linking to its own details page — for materials, supplies, what to bring, and policies (the kind of thing that used to live in a long confirmation email).</p>
-
-        <div class="form-group">
-          <%= f.label :event_details_label, "Details section label", class: "block font-medium mb-1 text-gray-700" %>
-          <%= f.text_field :event_details_label,
-                       placeholder: "Before you attend",
-                       class: "w-full rounded border-gray-300 shadow-sm px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500" %>
-          <p class="text-gray-500 text-sm mt-1">Heading for the details call-out on the ticket and the details page (e.g. "Before you attend", "Art supplies &amp; materials").</p>
-        </div>
-
-        <div class="form-group mt-6">
-          <%= f.label :event_details, "Details content", class: "block font-medium mb-1 text-gray-700" %>
-          <p class="text-xs text-gray-500 mb-1">
-            Materials, supplies, what to bring, and policies — shown on its own page linked prominently from the ticket. Leave blank to hide it entirely. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.
-          </p>
-          <%= f.text_area :event_details, rows: 8,
-                placeholder: "e.g. <h3>Workshop 1</h3><ul><li>Clear glass stones</li></ul>",
-                class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
-        </div>
-      </div>
-    </div>
-
-    <%# ---- CE HOURS (ticket call-out + details page) ---- %>
-    <div class="ce-hours-section" data-controller="dropdown">
-      <button
-        type="button"
-        id="ce_hours_button"
-        class="
-          flex items-center justify-between cursor-pointer w-full
-          bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
-        data-action="dropdown#toggle"
-        data-dropdown-payload-param='[{"ce_hours_details":"hidden"}, {"ce_hours_arrow":"rotate-180"}, {"ce_hours_button":"rounded-md rounded-t-md"}]'>
-        CE hours
-        <i id="ce_hours_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
-      </button>
-
-      <div id="ce_hours_details" class="hidden border border-gray-300 p-4 rounded-b-md">
-        <p class="text-sm text-gray-500 mb-4">Continuing education info shown on the registration ticket as a prominent call-out linking to its own details page — CAMFT approval, license-number and payment requirements, sign-in rules, and the post-training evaluation (the kind of thing that used to live in a long CE confirmation email).</p>
-
-        <div class="form-group">
-          <%= f.label :ce_hours_details_label, "CE hours section label", class: "block font-medium mb-1 text-gray-700" %>
-          <%= f.text_field :ce_hours_details_label,
-                       placeholder: "CE hours",
-                       class: "w-full rounded border-gray-300 shadow-sm px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500" %>
-          <p class="text-gray-500 text-sm mt-1">Heading for the CE hours call-out on the ticket and the details page (e.g. "CE hours", "Continuing education").</p>
-        </div>
-
-        <div class="form-group mt-6">
-          <%= f.label :ce_hours_details, "CE hours content", class: "block font-medium mb-1 text-gray-700" %>
-          <p class="text-xs text-gray-500 mb-1">
-            CE requirements, payment, sign-in rules, and the post-training evaluation — shown on its own page linked prominently from the ticket. Leave blank to hide it entirely. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.
-          </p>
-          <%= f.text_area :ce_hours_details, rows: 8,
-                placeholder: "e.g. <p>AWBW is approved by CAMFT…</p><h3>Before the training</h3><ul><li>Email your license number</li></ul>",
-                class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
-        </div>
-      </div>
-    </div>
-
-    <%# ---- REGISTRATION TICKET CALLOUTS (custom ticket call-outs, drag to reorder) ---- %>
-    <div class="registration-ticket-callouts-section" data-controller="dropdown">
+    <%# ---- REGISTRATION TICKET CALLOUTS (built-in + custom ticket call-outs) ---- %>
+    <%# ?expand=callouts (from the ticket's "Edit event" link) auto-opens this
+        section via a dropdown expand target; scroll-mt keeps the anchor clear of
+        any sticky chrome. %>
+    <div id="registration_ticket_callouts" class="registration-ticket-callouts-section scroll-mt-24" data-controller="dropdown">
       <button
         type="button"
         id="registration_ticket_callouts_button"
@@ -509,13 +438,52 @@
           flex items-center justify-between cursor-pointer w-full
           bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
         data-action="dropdown#toggle"
+        <%== 'data-dropdown-target="expand"' if params[:expand] == "callouts" %>
         data-dropdown-payload-param='[{"registration_ticket_callouts_panel":"hidden"}, {"registration_ticket_callouts_arrow":"rotate-180"}, {"registration_ticket_callouts_button":"rounded-md rounded-t-md"}]'>
         Registration ticket callouts
         <i id="registration_ticket_callouts_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
       </button>
 
       <div id="registration_ticket_callouts_panel" class="hidden border border-gray-300 p-4 rounded-b-md">
-        <p class="text-sm text-gray-500 mb-4">Custom call-outs shown on the registration ticket — each links to its own page. Use them for actions (forms to download, balances to pay) or reference reading (parking, policies, what to bring). New callouts save in the order shown; drag the handle to reorder saved callouts.</p>
+        <p class="text-sm text-gray-500 mb-4">Call-outs shown on the registration ticket — each links to its own page. The built-in cards below are managed by the app, which decides when each appears; a few (shown in colour, with fields) let you edit their text here, while the rest (greyed out) are preview-only. Below them, add your own call-outs for actions (forms to download, balances to pay) or reference reading (parking, policies, what to bring). New custom callouts save in the order shown; drag the handle to reorder saved callouts.</p>
+
+        <%# Built-in cards, shown above custom callouts in the order they appear on
+            the ticket. The two editable ones (CE hours, art supplies) carry their
+            ticket colour and editable text; the rest are greyed-out previews of
+            cards the app controls, so the full ticket context is visible here. %>
+        <div class="space-y-3 mb-3">
+          <% MagicTicketCallouts.editor_cards(@event).each do |card| %>
+            <% case card.key %>
+            <% when :ce_hours %>
+              <%= render "events/builtin_callout_card", f: f, card: card,
+                    label_field: :ce_hours_details_label, content_field: :ce_hours_details,
+                    title_placeholder: "CE hours",
+                    content_help: "CE requirements, payment, sign-in rules, and the post-training evaluation — shown on its own page linked from the ticket. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.",
+                    content_placeholder: "e.g. <p>AWBW is approved by CAMFT…</p><h3>Before the training</h3><ul><li>Email your license number</li></ul>" %>
+            <% when :event_details %>
+              <%= render "events/builtin_callout_card", f: f, card: card,
+                    label_field: :event_details_label, content_field: :event_details,
+                    title_placeholder: "Before you attend",
+                    content_help: "Materials, supplies, what to bring, and policies — shown on its own page linked from the ticket. Leave blank to hide it entirely. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks.",
+                    content_placeholder: "e.g. <h3>Workshop 1</h3><ul><li>Clear glass stones</li></ul>" %>
+            <% else %>
+              <div class="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 opacity-70">
+                <i class="<%= card.icon_class %> <%= card.theme[:icon] %> w-6 shrink-0 text-center text-xl pt-0.5" aria-hidden="true"></i>
+                <div class="flex-1 min-w-0">
+                  <div class="flex flex-wrap items-center gap-2 mb-0.5">
+                    <span class="inline-flex items-center rounded-full bg-gray-200 px-2 py-0.5 text-xs font-medium text-gray-500">Built in</span>
+                    <span class="text-xs text-gray-400"><%= card.visibility %></span>
+                  </div>
+                  <p class="font-semibold text-gray-500"><%= card.title %></p>
+                  <p class="text-sm text-gray-400"><%= card.subtitle %></p>
+                  <% if card.note.present? %>
+                    <p class="text-xs text-gray-400 italic mt-0.5"><%= card.note %></p>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
 
         <div id="registration_ticket_callouts_list" class="space-y-3"
              data-controller="sortable"

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -14,69 +14,75 @@
   <% end %>
 
   <div class="flex-1 min-w-0 space-y-3">
-    <div class="flex items-center gap-3">
-      <i class="w-6 shrink-0 text-center text-xl" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
+    <%# Two columns that collapse to one as the viewport narrows: the call-out's
+        identity (title + presentation) on the left, its page content on the right. %>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <%# LEFT: title, subtitle, and presentation (type, colour, icon) %>
+      <div class="flex items-start gap-3 min-w-0">
+        <i class="w-6 shrink-0 text-center text-xl pt-6" data-callout-preview-target="leadingIcon" aria-hidden="true"></i>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3 flex-1 min-w-0">
+        <div class="flex-1 min-w-0 space-y-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <%= f.label :title, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+              <%= f.text_field :title, required: true, placeholder: "e.g. Parking & directions",
+                    class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+            </div>
+            <div>
+              <%= f.label :subtitle, "Subtitle", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+              <%= f.text_field :subtitle, placeholder: "Short line shown under the title on the ticket",
+                    class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <%= f.label :callout_type, "Type", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+              <%= f.select :callout_type,
+                    RegistrationTicketCallout::CALLOUT_TYPES.map { |t| [ t.humanize, t ] },
+                    {},
+                    class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                    data: { callout_preview_target: "typeSelect", action: "callout-preview#update" } %>
+            </div>
+            <div>
+              <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+              <%= f.select :color_class,
+                    DomainTheme::SWATCH_COLORS.map { |c| [ c.to_s.humanize, c ] },
+                    { include_blank: "Default (by type)" },
+                    class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                    data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
+            </div>
+            <div>
+              <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+              <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
+                    class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
+                    data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <%# RIGHT: the call-out's own page — its text and an optional linked resource %>
+      <div class="min-w-0 space-y-3">
         <div>
-          <%= f.label :title, "Title", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-          <%= f.text_field :title, required: true, placeholder: "e.g. Parking & directions",
+          <%= f.label :description, "Callout page text", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+          <p class="text-xs text-gray-500 mb-1">Shown on its own page. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
+          <%= f.text_area :description, rows: 4,
+                placeholder: "e.g. <p>Enter through the north lot…</p>",
+                class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
+        </div>
+
+        <div>
+          <%= f.label :resource_id, "Linked resource", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+          <p class="text-xs text-gray-500 mb-1">Optional. Shows the resource below the content on the call-out's page (PDF first-page preview, etc.), with a download button when the resource has a downloadable file.</p>
+          <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
+                { include_blank: "None" },
                 class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         </div>
-        <div>
-          <%= f.label :subtitle, "Subtitle", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-          <%= f.text_field :subtitle, placeholder: "Short line shown under the title on the ticket",
-                class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-        </div>
-      </div>
-
-      <div class="w-6 shrink-0 text-center text-gray-300" data-callout-preview-target="arrow" aria-hidden="true" title="Links to its own page on the ticket">
-        <i class="fa-solid fa-arrow-right"></i>
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 pl-9 pr-9">
-      <div>
-        <%= f.label :callout_type, "Type", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.select :callout_type,
-              RegistrationTicketCallout::CALLOUT_TYPES.map { |t| [ t.humanize, t ] },
-              {},
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
-              data: { callout_preview_target: "typeSelect", action: "callout-preview#update" } %>
-      </div>
-      <div>
-        <%= f.label :color_class, "Colour", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.select :color_class,
-              DomainTheme::SWATCH_COLORS.map { |c| [ c.to_s.humanize, c ] },
-              { include_blank: "Default (by type)" },
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
-              data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
-      </div>
-      <div>
-        <%= f.label :icon_class, "Icon", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-        <%= f.text_field :icon_class, placeholder: "fa-solid fa-car",
-              class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono",
-              data: { callout_preview_target: "iconInput", action: "callout-preview#update" } %>
-      </div>
-    </div>
-
-    <div class="pl-9 pr-9">
-      <%= f.label :description, "Content", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-      <p class="text-xs text-gray-500 mb-1">Shown on its own page. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Leave blank to keep the call-out from linking anywhere.</p>
-      <%= f.text_area :description, rows: 4,
-            placeholder: "e.g. <p>Enter through the north lot…</p>",
-            class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm font-mono" %>
-    </div>
-
-    <div class="pl-9 pr-9">
-      <%= f.label :resource_id, "Linked resource", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-      <p class="text-xs text-gray-500 mb-1">Optional. Shows the resource below the content on the call-out's page (PDF first-page preview, etc.), with a download button when the resource has a downloadable file.</p>
-      <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
-            { include_blank: "None" },
-            class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-    </div>
-
-    <div class="flex items-center justify-between pl-9 pr-9">
+    <div class="flex flex-wrap items-center justify-between gap-2">
       <label class="flex items-center gap-2 text-sm text-gray-600">
         <%= f.check_box :payment_access_gated, class: "rounded border-gray-300 text-purple-600" %>
         Only show once payment is made or committed

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -4,10 +4,13 @@
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
   <% end %>
   <div class="ml-auto flex gap-2">
+    <% if allowed_to?(:edit?, @event_registration.event) %>
+      <%= link_to "Edit event", edit_event_path(@event_registration.event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% end %>
+    <% if allowed_to?(:index?, EventRegistration) %>
+      <%= link_to "Registration", edit_event_registration_path(@event_registration), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% end %>
     <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% if allowed_to?(:index?, EventRegistration) %>
-    <%= link_to "Registration", edit_event_registration_path(@event_registration), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-  <% end %>
   </div>
 </div>
 <%= render "event_registrations/ticket", event_registration: @event_registration %>

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -10,8 +10,14 @@
   <% back_label = "← Dashboard" %>
   <% back_path = dashboard_event_path(@event) %>
 <% end %>
-<div class="max-w-2xl mx-auto px-4 pt-4">
-  <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+<div class="max-w-2xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
+  <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <div class="ml-auto flex gap-2">
+    <%= link_to "Edit event", edit_event_path(@event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  </div>
+</div>
+<div class="max-w-2xl mx-auto px-4">
 
   <%# Preview box: the description on the left, the admin-only options toggle in
       the top right. The toggle reloads this same preview with (or without)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -211,18 +211,26 @@ RSpec.describe "Events", type: :request do
       expect(response.body).not_to include("Preview bulk payment page")
     end
 
-    it "renders the 'Before you attend' toggle with the details fields" do
+    it "renders the built-in 'Before you attend' card fields within the callouts section" do
       get edit_event_path(event)
+      expect(response.body).to include("Registration ticket callouts")
       expect(response.body).to include("Before you attend")
       expect(response.body).to include("event[event_details_label]")
       expect(response.body).to include("event[event_details]")
     end
 
-    it "renders the 'CE hours' toggle with the details fields" do
+    it "renders the built-in 'CE hours' card fields within the callouts section" do
       get edit_event_path(event)
+      expect(response.body).to include("Registration ticket callouts")
       expect(response.body).to include("CE hours")
       expect(response.body).to include("event[ce_hours_details_label]")
       expect(response.body).to include("event[ce_hours_details]")
+    end
+
+    it "previews the app-controlled built-in callouts (greyed, non-editable)" do
+      get edit_event_path(event)
+      expect(response.body).to include("Facilitator Portal access")
+      expect(response.body).to include("Frequently asked questions")
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- The CE-hours and "Before you attend" ticket call-outs were edited via **separate top-level accordions** on the event form, disconnected from the **Registration ticket callouts** section those fields actually drive.
- This moves them into that section so admins manage **all** ticket call-outs in one place, with the built-in cards previewed in the same order and colour they appear on the registrant's ticket.

### How did you approach the change?

- **One editor for all call-outs.** Removed the standalone "Before you attend" / "CE hours" accordions; the Registration ticket callouts section now lists every built-in (magic) card in ticket order, above the custom call-outs.
- **Editable built-ins.** CE hours and art supplies render tinted in their real ticket colour, each with editable **Title** and **Callout page text** fields (side-by-side).
- **Previewed built-ins.** The app-controlled cards (Payment, Certificate, Scholarship, Videoconference, Forms, Handouts, FAQ, Portal) render greyed-out as previews — icon in its ticket colour, ticket subtitle, a "when shown" note beside a **Built in** chip, and a hint on where their content comes from (videoconference settings; forms/handouts link to their resources).
- **Deep link from the ticket.** Added an **Edit event** link to both the real registration ticket and the admin sample preview; it opens the event form with the callouts section auto-expanded and scrolled into view. Reordered the ticket's top-right links to **Edit event → Registration → Home** (Home now far right).
- New `MagicTicketCallouts.editor_cards(event)` catalog keeps the editor preview in sync with the cards rendered on the ticket.

### Anything else to add?

- The greyed previews are a static catalog of what *can* appear, with each card's visibility rule shown as a note — they don't evaluate the specific event's state.
- Built-in card field names are unchanged (just relocated), so no controller/param changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)