### PR TITLE
Match facilitator affiliations exactly and case-sensitively

### DIFF
--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -67,11 +67,11 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   def facilitator_since_date
-    @facilitator_since_date ||= affiliations.where("title LIKE ?", "%Facilitator%").minimum(:start_date)
+    @facilitator_since_date ||= affiliations.facilitators.minimum(:start_date)
   end
 
   def facilitation_end_date
-    facilitator_affiliations = affiliations.where("title LIKE ?", "%Facilitator%")
+    facilitator_affiliations = affiliations.facilitators
     return nil if facilitator_affiliations.active.exists?
     facilitator_affiliations.maximum(:end_date)
   end

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -54,9 +54,11 @@ export default class extends Controller {
       ? new Date(Math.max(...affiliations.map(a => new Date(a.endDate))))
       : null
 
-    // Facilitator since/end — same logic filtered by title
+    // Facilitator since/end — same logic filtered by title. Mirror
+    // Affiliation#facilitator?: an exact, case-sensitive match on "Facilitator"
+    // (trimmed), so the live figure matches what the server will render.
     const facilitatorAffiliations = affiliations.filter(a =>
-      a.title.toLowerCase().includes("facilitator")
+      a.title.trim() === "Facilitator"
     )
     const facStartDates = facilitatorAffiliations.map(a => a.startDate).filter(Boolean)
     const facilitatorSince = facStartDates.length

--- a/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
@@ -62,7 +62,8 @@ export default class extends Controller {
       startDate,
       endDate,
       destroyed,
-      facilitator: title.toLowerCase().includes("facilitator"),
+      // Mirror Affiliation#facilitator?: exact, case-sensitive "Facilitator" (trimmed).
+      facilitator: title.trim() === "Facilitator",
     };
   }
 

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -10,7 +10,11 @@ class Affiliation < ApplicationRecord
       .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
   }
 
-  scope :facilitators, -> { where("title LIKE ?", "%facilitator%") }
+  # Only the exact, case-sensitive title "Facilitator" counts — variants like
+  # "Lead Facilitator" or "facilitator" are deliberately excluded. BINARY forces
+  # a case-sensitive comparison under MySQL's default case-insensitive collation;
+  # TRIM mirrors the in-memory #facilitator? strip so stray whitespace still matches.
+  scope :facilitators, -> { where("BINARY TRIM(title) = ?", "Facilitator") }
 
   before_validation :skip_if_duplicate
   before_save :set_inactive_from_dates
@@ -20,15 +24,11 @@ class Affiliation < ApplicationRecord
   after_destroy :sync_organization_affiliation_dates
 
   # Methods
+  # A facilitator affiliation is one whose title is *exactly* "Facilitator"
+  # (trimmed, case-sensitive). Variants like "Lead Facilitator" or "facilitator"
+  # are deliberately excluded. Mirrors the .facilitators scope so in-memory and
+  # SQL checks agree.
   def facilitator?
-    title.to_s.downcase.include?("facilitator")
-  end
-
-  # Stricter than #facilitator? / the .facilitators scope: the title is *exactly*
-  # "Facilitator" (trimmed, case-sensitive). Reserved for the editor-row highlight
-  # so variants like "Lead Facilitator" stay un-highlighted while still counting
-  # as facilitators everywhere else.
-  def exact_facilitator?
     title.to_s.strip == "Facilitator"
   end
 

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -6,14 +6,14 @@
 <% manage_subject = person_side ? Organization : Person %>
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
-  <% exact_facilitator = f.object.exact_facilitator? %>
-  <% active_bg = exact_facilitator ? "bg-purple-100 border-purple-300" : "bg-white border-gray-200" %>
+  <% facilitator = f.object.facilitator? %>
+  <% active_bg = facilitator ? "bg-purple-100 border-purple-300" : "bg-white border-gray-200" %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
   <div data-controller="inactive-toggle" class="relative mb-4">
     <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg"
-          style="background-color: <%= exact_facilitator ? '#a855f7' : '#d1d5db' %>"
+          style="background-color: <%= facilitator ? '#a855f7' : '#d1d5db' %>"
           data-inactive-toggle-target="accentBar"></span>
     <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border p-3 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PersonDecorator do
       beta = create(:organization, name: "Beta Org")
       alpha = create(:organization, name: "Alpha Org")
       create(:affiliation, person: person, organization: beta, title: "Facilitator")
-      create(:affiliation, person: person, organization: alpha, title: "Lead Facilitator")
+      create(:affiliation, person: person, organization: alpha, title: "Facilitator")
 
       expect(person.decorate.active_facilitator_organization_names).to eq([ "Alpha Org", "Beta Org" ])
     end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -14,43 +14,6 @@ RSpec.describe Affiliation do
     # it { should validate_presence_of(:person_id) } # we needed to not have this to support nested attrs
   end
 
-  describe '#facilitator?' do
-    it 'is true for any title containing "facilitator", case-insensitively' do
-      expect(build(:affiliation, title: "Facilitator").facilitator?).to be true
-      expect(build(:affiliation, title: "Lead Facilitator").facilitator?).to be true
-      expect(build(:affiliation, title: "co-facilitator").facilitator?).to be true
-    end
-
-    it 'is false for titles without the word' do
-      expect(build(:affiliation, title: "Board Member").facilitator?).to be false
-      expect(build(:affiliation, title: nil).facilitator?).to be false
-    end
-  end
-
-  describe '#exact_facilitator?' do
-    it 'is true only when the title is exactly "Facilitator"' do
-      expect(build(:affiliation, title: "Facilitator").exact_facilitator?).to be true
-    end
-
-    it 'ignores surrounding whitespace' do
-      expect(build(:affiliation, title: "  Facilitator ").exact_facilitator?).to be true
-    end
-
-    it 'is case-sensitive' do
-      expect(build(:affiliation, title: "facilitator").exact_facilitator?).to be false
-      expect(build(:affiliation, title: "FACILITATOR").exact_facilitator?).to be false
-    end
-
-    it 'is false for titles that merely contain the word' do
-      expect(build(:affiliation, title: "Lead Facilitator").exact_facilitator?).to be false
-      expect(build(:affiliation, title: "Facilitator in training").exact_facilitator?).to be false
-    end
-
-    it 'is false when the title is blank' do
-      expect(build(:affiliation, title: nil).exact_facilitator?).to be false
-    end
-  end
-
   describe '#active?' do
     it 'is true when not inactive and has no end date' do
       expect(build(:affiliation, inactive: false, end_date: nil).active?).to be true
@@ -95,6 +58,40 @@ RSpec.describe Affiliation do
       expect {
         described_class.active.joins(:organization).to_a
       }.not_to raise_error
+    end
+  end
+
+  describe '#facilitator?' do
+    it 'is true for the exact title "Facilitator"' do
+      expect(build(:affiliation, title: "Facilitator").facilitator?).to be true
+    end
+
+    it 'ignores surrounding whitespace' do
+      expect(build(:affiliation, title: "  Facilitator ").facilitator?).to be true
+    end
+
+    it 'is false for title variants like "Lead Facilitator"' do
+      expect(build(:affiliation, title: "Lead Facilitator").facilitator?).to be false
+    end
+
+    it 'is case-sensitive' do
+      expect(build(:affiliation, title: "facilitator").facilitator?).to be false
+      expect(build(:affiliation, title: "FACILITATOR").facilitator?).to be false
+    end
+
+    it 'is false when the title is blank' do
+      expect(build(:affiliation, title: nil).facilitator?).to be false
+    end
+  end
+
+  describe '.facilitators' do
+    let!(:exact) { create(:affiliation, title: "Facilitator") }
+    let!(:whitespace) { create(:affiliation, title: "  Facilitator ") }
+    let!(:variant) { create(:affiliation, title: "Lead Facilitator") }
+    let!(:lowercase) { create(:affiliation, title: "facilitator") }
+
+    it 'includes only the exact, case-sensitive title "Facilitator" (whitespace-trimmed)' do
+      expect(described_class.facilitators).to contain_exactly(exact, whitespace)
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Person, "scholarship index helpers" do
   describe "#program_organization" do
     it "returns the organization on the recipient's facilitator affiliation" do
       org = create(:organization, name: "Prevail")
-      create(:affiliation, person: person, organization: org, title: "Lead Facilitator")
+      create(:affiliation, person: person, organization: org, title: "Facilitator")
 
       expect(person.program_organization).to eq(org)
     end

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -66,11 +66,14 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     facilitator = find("[data-affiliation-dates-target='facilitatorSince']")
     expect(facilitator).to have_text("Mar 2020")
 
-    title_textareas = all("textarea[name*='affiliations_attributes'][name*='title']")
-    set_textarea_input(title_textareas.last, "Lead Facilitator")
+    # Renaming the only exact "Facilitator" to a variant drops it — facilitator
+    # matching is exact and case-sensitive, so "Lead Facilitator" no longer counts.
+    facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
+      f.find("textarea[name*='title']").value.strip == "Facilitator"
+    }
+    set_textarea_input(facilitator_row.find("textarea[name*='title']"), "Lead Facilitator")
 
-    # Both affiliations now have "Facilitator" in the title; earliest is still Mar 2020
-    expect(facilitator).to have_text("Mar 2020", wait: 5)
+    expect(facilitator).to have_text("—", wait: 5)
   end
 
   it "shows end date and icon when all affiliations are inactive" do


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: small, contained logic changes with low blast radius

### What is the goal of this PR and why is this important?
- Facilitator status, "facilitator since" dates, tenure badges, program status, the org-active determination, the editor card highlight, and the live JS figures all keyed off a fuzzy match (`LIKE '%facilitator%'` / case-insensitive `include?`), which counted variants like "Lead Facilitator" and "Co-Facilitator".
- Restrict every facilitator decision to the exact, case-sensitive title "Facilitator" (whitespace-trimmed) so a single canonical role governs them.

### How did you approach the change?
- Made `Affiliation#facilitator?` and the `.facilitators` scope exact (`BINARY TRIM(title) = "Facilitator"`; BINARY is needed for case sensitivity under MySQL's default collation). Every call site flows through one of them.
- The highlight rule (`exact_facilitator?`, previously the only exact matcher) and the business-logic rule now agree, so I collapsed them into one `#facilitator?` and dropped the redundant `exact_facilitator?`.
- Updated the two Stimulus controllers (`affiliation_dates`, `affiliation_facilitator_warning`) to mirror the same trimmed exact rule.

### Anything else to add?
- "Facilitator" is confirmed to be the only canonical affiliation title in use, so no data migration is needed.
- The cosmetic title-chip sort heuristics in a few view partials are intentionally left fuzzy — they only order display pills, not the facilitator-status determination.