### PR TITLE
Show "Events attended" on org profiles (was unimplemented "Events hosted")

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -36,6 +36,15 @@ class OrganizationsController < ApplicationController
 
   def show
     authorize! @organization
+
+    if turbo_frame_request? && params[:section] == "events"
+      events = Event.where(id: @organization.event_registrations.active.select(:event_id))
+                    .includes(:primary_asset)
+                    .order(start_date: :desc)
+                    .paginate(page: params[:page], per_page: 9)
+      return render partial: "organizations/sections/events", locals: { organization: @organization, events: events }
+    end
+
     track_view(@organization)
 
     workshop_logs = WorkshopLog.where(organization_id: @organization.id)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -54,7 +54,7 @@ class PeopleController < ApplicationController
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }
       when "events"
-        @event_registrations = @person.event_registrations.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
+        @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/events", locals: { person: @person, event_registrations: @event_registrations }
       when "workshop_ideas"
         @workshop_ideas = @person.user&.workshop_ideas_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []

--- a/app/views/organizations/sections/_events.html.erb
+++ b/app/views/organizations/sections/_events.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag "organization_events_section" do %>
+  <% if events.any? %>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+      <% events.each do |event| %>
+        <% decorated = event.decorate %>
+        <%= render "people/show_card",
+                   bookmarkable: event,
+                   record_title: "#{decorated.title}<br>" +
+                     "<span class='text-xs text-gray-500'>TIME: " +
+                     "#{decorated.times}<span>",
+                   record: decorated, title_font_size: "text-sm" %>
+      <% end %>
+    </div>
+    <div class="mt-6 flex justify-center">
+      <%= tailwind_paginate events, params: { section: "events" } %>
+    </div>
+  <% else %>
+    <p class="text-gray-500 italic">No events recorded.</p>
+  <% end %>
+<% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -218,22 +218,17 @@
           <%# end %>
         </div>
       <% end %>
-      <!-- Events registered -->
+      <!-- Events attended -->
     <% if @organization.profile_show_events_registered? %>
       <div class="mt-10">
         <h2 class="text-lg font-semibold text-gray-800 mb-2">
-          Events hosted
+          Events attended
         </h2>
-        <%# if Event.all.any? %>
-        <%# Event.all.each do |event| %>
-          <%# event_name = "#{event.title} - #{event.start_date.strftime("%b %Y") rescue nil}" %>
-          <%#= link_to event_name, event_path(event), class: "btn btn-secondary-outline" %>
-          <%# end %>
-          <%# else %>
-          <p class="text-gray-500 italic">No events recorded.</p>
-          <%# end %>
-        </div>
-      <% end %>
+        <%= turbo_frame_tag "organization_events_section", src: organization_path(@organization, section: "events"), loading: :lazy do %>
+          <p class="text-gray-500 italic">Loading events...</p>
+        <% end %>
+      </div>
+    <% end %>
     <hr class="my-8 border-gray-200">
     <% if allowed_to?(:show_workshop_logs?, @organization) %>
         <div class="organization-only <%= DomainTheme.bg_class_for(:user_only) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -231,11 +231,11 @@
             Participation history
           </h2>
         </div>
-        <!-- Events registered -->
+        <!-- Events attended -->
         <div class="section-content px-3 sm:px-4 py-4 sm:py-6 space-y-8 sm:space-y-10">
           <% if @person.profile_show_events_registered? %>
             <div class="p-3">
-              <h2 class="text-lg font-semibold text-gray-800 mb-3">Events registered</h2>
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Events attended</h2>
               <%= turbo_frame_tag "person_events_section", src: person_path(@person, section: "events"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading events...</p>
               <% end %>

--- a/spec/requests/organizations_events_section_spec.rb
+++ b/spec/requests/organizations_events_section_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Organization profile events-attended section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:organization) { create(:organization) }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_events_section
+    get organization_path(organization, section: "events"),
+        headers: { "Turbo-Frame" => "organization_events_section" }
+  end
+
+  # A registration snapshots the registrant's active org affiliations on create,
+  # which is what links the event to the organization profile.
+  def register(event:, status: "registered")
+    person = create(:person)
+    create(:affiliation, organization: organization, person: person)
+    create(:event_registration, registrant: person, event: event, status: status)
+  end
+
+  it "shows events members are actively registered for" do
+    event = create(:event, title: "Trauma-Informed Art Day")
+    register(event: event)
+
+    get_events_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Trauma-Informed Art Day")
+  end
+
+  it "excludes cancelled and no-show registrations" do
+    cancelled = create(:event, title: "Cancelled Workshop")
+    no_show = create(:event, title: "Missed Workshop")
+    register(event: cancelled, status: "cancelled")
+    register(event: no_show, status: "no_show")
+
+    get_events_section
+
+    expect(response.body).not_to include("Cancelled Workshop")
+    expect(response.body).not_to include("Missed Workshop")
+    expect(response.body).to include("No events recorded.")
+  end
+
+  it "lists each event once even when several members attended it" do
+    event = create(:event, title: "Shared Event")
+    register(event: event)
+    register(event: event)
+
+    get_events_section
+
+    expect(response.body.scan("Shared Event").size).to eq(1)
+  end
+
+  it "renders the section heading and lazy frame on the profile page" do
+    get organization_path(organization)
+
+    expect(response.body).to include("Events attended")
+    expect(response.body).to include("organization_events_section")
+  end
+end


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: new read-only profile section + a status filter on an existing one

The org profile's "Events hosted" section was an unimplemented stub, and the label was wrong — there's no org→event hosting relationship in the data model, only the events the org's affiliated members registered for.

- Rename the org section to **Events attended** and populate it from the org's active event registrations (`event_registration_organizations`), deduped to distinct events. Lazy-loads via a Turbo frame and reuses the person profile's card grid.
- Match the **person** profile: rename its heading "Events registered" → "Events attended", and scope both profiles to `EventRegistration.active`, so cancelled / no-show registrations drop off ("show until inactive").

🤖 Generated with [Claude Code](https://claude.com/claude-code)