### PR TITLE
Link an affiliation to one of its organization's addresses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (72) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (73) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -262,6 +262,7 @@ end
 
 ### Stimulus Controllers
 
+- `address_select` — Compact numbered picker linking an affiliation to an org address
 - `affiliation_dates` — Recalculate affiliation date ranges
 - `anchor_highlight` — Highlight anchored elements
 - `asset_picker` — Asset selection UI

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -239,6 +239,7 @@ class OrganizationsController < ApplicationController
         :title,
         :start_date,
         :end_date,
+        :organization_address_id,
         :_destroy
       ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -473,6 +473,7 @@ class PeopleController < ApplicationController
         :primary_contact,
         :start_date,
         :end_date,
+        :organization_address_id,
         :_destroy
       ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -152,7 +152,7 @@ class PeopleController < ApplicationController
       { avatar_attachment: :blob },
       { comments: [ :created_by, :updated_by ] },
       { sectorable_items: :sector },
-      affiliations: { organization: :logo_attachment }
+      affiliations: { organization: [ :logo_attachment, :addresses ] }
     ).find(params[:id]).decorate
     authorize! @person
     set_form_variables

--- a/app/frontend/javascript/controllers/address_select_controller.js
+++ b/app/frontend/javascript/controllers/address_select_controller.js
@@ -1,0 +1,65 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Compact numbered address picker for the affiliation editor row. The trigger
+// button shows only the selected address's number (or a dash); the panel lists
+// each address with its full one-line text. Selecting an option writes the
+// address id into a hidden field so it saves as the affiliation's
+// organization_address_id.
+//
+// Connects to data-controller="address-select"
+export default class extends Controller {
+  static targets = ["panel", "input", "label"];
+
+  connect() {
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
+    this.handleEscapeKey = this.handleEscapeKey.bind(this);
+  }
+
+  disconnect() {
+    this.removeGlobalListeners();
+  }
+
+  toggle() {
+    if (this.panelTarget.classList.contains("hidden")) {
+      this.open();
+    } else {
+      this.close();
+    }
+  }
+
+  open() {
+    this.panelTarget.classList.remove("hidden");
+    // Defer so the click that opened the panel doesn't immediately close it.
+    setTimeout(() => this.addGlobalListeners(), 0);
+  }
+
+  close() {
+    this.panelTarget.classList.add("hidden");
+    this.removeGlobalListeners();
+  }
+
+  select(event) {
+    const option = event.currentTarget;
+    this.inputTarget.value = option.dataset.value;
+    this.labelTarget.textContent = option.dataset.number;
+    this.close();
+  }
+
+  handleOutsideClick(event) {
+    if (!this.element.contains(event.target)) this.close();
+  }
+
+  handleEscapeKey(event) {
+    if (event.key === "Escape") this.close();
+  }
+
+  addGlobalListeners() {
+    document.addEventListener("click", this.handleOutsideClick);
+    document.addEventListener("keydown", this.handleEscapeKey);
+  }
+
+  removeGlobalListeners() {
+    document.removeEventListener("click", this.handleOutsideClick);
+    document.removeEventListener("keydown", this.handleEscapeKey);
+  }
+}

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -1,5 +1,8 @@
 import { application } from "./application"
 
+import AddressSelectController from "./address_select_controller"
+application.register("address-select", AddressSelectController)
+
 import AffiliationDatesController from "./affiliation_dates_controller"
 application.register("affiliation-dates", AffiliationDatesController)
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,6 +4,9 @@ class Address < ApplicationRecord
   CONTACT_TYPES = [ nil, "work", "personal", "mailing", "unknown" ].freeze
 
   belongs_to :addressable, polymorphic: true, touch: true
+  # Affiliations that point to this address as their organization address. Nullify
+  # the link rather than block deletion when an org address is removed.
+  has_many :affiliations, foreign_key: :organization_address_id, dependent: :nullify, inverse_of: :organization_address
 
   validates :locality, presence: true
   validates :city, presence: true

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,9 +1,12 @@
 class Affiliation < ApplicationRecord
   belongs_to :organization
   belongs_to :person, touch: true
+  # Which of the organization's addresses this person is affiliated with (optional).
+  belongs_to :organization_address, class_name: "Address", optional: true
 
   # Validations
   validates_presence_of :organization_id
+  validate :organization_address_belongs_to_organization
 
   scope :active, -> {
     where(inactive: false)
@@ -44,6 +47,16 @@ class Affiliation < ApplicationRecord
   end
 
   private
+
+  # The linked address must be one of this affiliation's organization's own
+  # addresses — not a stray address or another org's / person's address.
+  def organization_address_belongs_to_organization
+    return if organization_address.blank?
+
+    valid = organization_address.addressable_type == "Organization" &&
+            organization_address.addressable_id == organization_id
+    errors.add(:organization_address_id, "must be an address of this organization") unless valid
+  end
 
   def skip_if_duplicate
     scope = Affiliation.where(

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,5 +1,5 @@
 class Affiliation < ApplicationRecord
-  belongs_to :organization
+  belongs_to :organization, inverse_of: :affiliations
   belongs_to :person, touch: true
   # Which of the organization's addresses this person is affiliated with (optional).
   belongs_to :organization_address, class_name: "Address", optional: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,7 +6,7 @@ class Organization < ApplicationRecord
   belongs_to :windows_type, optional: true
   has_many :addresses, as: :addressable, dependent: :destroy
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :affiliations, dependent: :restrict_with_error
+  has_many :affiliations, dependent: :restrict_with_error, inverse_of: :organization
   has_many :event_registration_organizations, dependent: :restrict_with_error
   has_many :event_registrations, through: :event_registration_organizations
   has_many :people, through: :affiliations

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -1,13 +1,17 @@
 <%# Compact numbered picker linking an affiliation to one of its organization's
     addresses. The trigger button is only wide enough for a double-digit number;
     the panel that opens shows each address's full one-line text. Numbers mirror
-    the org address editor's "Address #N" (1-based, in association order); only
-    active addresses are offered. When the org has none, renders an equal-width
-    spacer so the following fields stay aligned across rows. %>
+    the org address editor's "Address #N" (1-based, in association order).
+    Active addresses are offered; an inactive address is offered only when it's
+    the one already linked, shown with an [INACTIVE] marker so the selection
+    stays visible. When there's nothing to show, renders an equal-width spacer so
+    the following fields stay aligned across rows. %>
 <% org = f.object.organization %>
-<% numbered = org ? org.addresses.each_with_index.filter_map { |address, i| [ i + 1, address ] unless address.inactive? } : [] %>
-<% if numbered.any? %>
-  <% selected = numbered.find { |_number, address| address.id == f.object.organization_address_id } %>
+<% all_numbered = org ? org.addresses.each_with_index.map { |address, i| [ i + 1, address ] } : [] %>
+<% selected_id = f.object.organization_address_id %>
+<% selected = all_numbered.find { |_number, address| address.id == selected_id } %>
+<% options = all_numbered.select { |_number, address| !address.inactive? || address.id == selected_id } %>
+<% if options.any? %>
   <div class="w-full sm:w-16" data-controller="address-select">
     <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>
     <div class="relative">
@@ -26,14 +30,14 @@
                 data-value=""
                 data-number="—"
                 data-action="address-select#select">— None</button>
-        <% numbered.each do |number, address| %>
+        <% options.each do |number, address| %>
           <button type="button"
                   class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-800 hover:bg-gray-100"
                   data-value="<%= address.id %>"
                   data-number="<%= number %>"
                   data-action="address-select#select">
             <span class="w-5 shrink-0 font-semibold text-gray-500"><%= number %></span>
-            <span><%= address.name %></span>
+            <span><% if address.inactive? %><span class="font-semibold text-gray-400">[INACTIVE]</span> <% end %><%= address.name %></span>
           </button>
         <% end %>
       </div>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -1,16 +1,14 @@
 <%# Compact numbered picker linking an affiliation to one of its organization's
     addresses. The trigger button is only wide enough for a double-digit number;
     the panel that opens shows each address's full one-line text. Numbers mirror
-    the org address editor's "Address #N" (1-based, in association order).
-    Active addresses are offered; an inactive address is offered only when it's
-    the one already linked, shown with an [INACTIVE] marker so the selection
-    stays visible. When there's nothing to show, renders an equal-width spacer so
-    the following fields stay aligned across rows. %>
+    the org address editor's "Address #N" (1-based, in association order). All
+    addresses are selectable; inactive ones are shown with an [INACTIVE] marker.
+    When the org has no addresses, renders an equal-width spacer so the following
+    fields stay aligned across rows. %>
 <% org = f.object.organization %>
-<% all_numbered = org ? org.addresses.each_with_index.map { |address, i| [ i + 1, address ] } : [] %>
+<% options = org ? org.addresses.each_with_index.map { |address, i| [ i + 1, address ] } : [] %>
 <% selected_id = f.object.organization_address_id %>
-<% selected = all_numbered.find { |_number, address| address.id == selected_id } %>
-<% options = all_numbered.select { |_number, address| !address.inactive? || address.id == selected_id } %>
+<% selected = options.find { |_number, address| address.id == selected_id } %>
 <% if options.any? %>
   <div class="w-full sm:w-16" data-controller="address-select">
     <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -4,7 +4,7 @@
     the org address editor's "Address #N" (1-based, in association order); only
     active addresses are offered. Renders nothing when the org has none. %>
 <% org = f.object.organization %>
-<% numbered = org ? org.addresses.each_with_index.filter_map { |address, i| [ i + 1, address ] if address.active? } : [] %>
+<% numbered = org ? org.addresses.each_with_index.filter_map { |address, i| [ i + 1, address ] unless address.inactive? } : [] %>
 <% if numbered.any? %>
   <% selected = numbered.find { |_number, address| address.id == f.object.organization_address_id } %>
   <div class="w-full sm:w-auto" data-controller="address-select">

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -11,7 +11,7 @@
     <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-white px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
         <span data-address-select-target="label"><%= selected&.first || "—" %></span>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -2,12 +2,13 @@
     addresses. The trigger button is only wide enough for a double-digit number;
     the panel that opens shows each address's full one-line text. Numbers mirror
     the org address editor's "Address #N" (1-based, in association order); only
-    active addresses are offered. Renders nothing when the org has none. %>
+    active addresses are offered. When the org has none, renders an equal-width
+    spacer so the following fields stay aligned across rows. %>
 <% org = f.object.organization %>
 <% numbered = org ? org.addresses.each_with_index.filter_map { |address, i| [ i + 1, address ] unless address.inactive? } : [] %>
 <% if numbered.any? %>
   <% selected = numbered.find { |_number, address| address.id == f.object.organization_address_id } %>
-  <div class="w-full sm:w-auto" data-controller="address-select">
+  <div class="w-full sm:w-16" data-controller="address-select">
     <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>
     <div class="relative">
       <button type="button"
@@ -38,4 +39,8 @@
       </div>
     </div>
   </div>
+<% else %>
+  <%# No addresses to pick from: hold the column's width so the Start/End/etc.
+      fields stay vertically aligned with rows that do have an address picker. %>
+  <div class="hidden sm:block sm:w-16"></div>
 <% end %>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -1,0 +1,41 @@
+<%# Compact numbered picker linking an affiliation to one of its organization's
+    addresses. The trigger button is only wide enough for a double-digit number;
+    the panel that opens shows each address's full one-line text. Numbers mirror
+    the org address editor's "Address #N" (1-based, in association order); only
+    active addresses are offered. Renders nothing when the org has none. %>
+<% org = f.object.organization %>
+<% numbered = org ? org.addresses.each_with_index.filter_map { |address, i| [ i + 1, address ] if address.active? } : [] %>
+<% if numbered.any? %>
+  <% selected = numbered.find { |_number, address| address.id == f.object.organization_address_id } %>
+  <div class="w-full sm:w-auto" data-controller="address-select">
+    <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>
+    <div class="relative">
+      <button type="button"
+              class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-white px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              data-address-select-target="button"
+              data-action="address-select#toggle">
+        <span data-address-select-target="label"><%= selected&.first || "—" %></span>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400"></i>
+      </button>
+      <%= f.hidden_field :organization_address_id, data: { address_select_target: "input" } %>
+      <div class="hidden absolute z-20 mt-1 max-h-60 w-72 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+           data-address-select-target="panel">
+        <button type="button"
+                class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-500 hover:bg-gray-100"
+                data-value=""
+                data-number="—"
+                data-action="address-select#select">— None</button>
+        <% numbered.each do |number, address| %>
+          <button type="button"
+                  class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-800 hover:bg-gray-100"
+                  data-value="<%= address.id %>"
+                  data-number="<%= number %>"
+                  data-action="address-select#select">
+            <span class="w-5 shrink-0 font-semibold text-gray-500"><%= number %></span>
+            <span><%= address.name %></span>
+          </button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -45,7 +45,7 @@
         <% end %>
       </div>
 
-      <div class="w-full sm:w-auto" style="min-width: 200px;">
+      <div class="w-full sm:w-auto" style="width: 150px; min-width: 150px;">
         <%= f.input :title,
                     as: :text,
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -60,6 +60,8 @@
                     } %>
       </div>
 
+      <%= render "affiliations/address_picker", f: f %>
+
       <div class="w-full sm:w-auto">
         <%= f.input :start_date,
                     as: :string,

--- a/db/migrate/20260621213947_add_organization_address_to_affiliations.rb
+++ b/db/migrate/20260621213947_add_organization_address_to_affiliations.rb
@@ -1,0 +1,13 @@
+class AddOrganizationAddressToAffiliations < ActiveRecord::Migration[8.1]
+  def up
+    add_column :affiliations, :organization_address_id, :bigint
+    add_index :affiliations, :organization_address_id
+    add_foreign_key :affiliations, :addresses, column: :organization_address_id, on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :affiliations, column: :organization_address_id if foreign_key_exists?(:affiliations, column: :organization_address_id)
+    remove_index :affiliations, :organization_address_id if index_exists?(:affiliations, :organization_address_id)
+    remove_column :affiliations, :organization_address_id if column_exists?(:affiliations, :organization_address_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_104933) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_104933) do
     t.date "end_date"
     t.string "filemaker_code"
     t.boolean "inactive", default: false, null: false
+    t.bigint "organization_address_id"
     t.integer "organization_agency_id"
     t.integer "organization_id", null: false
     t.bigint "person_id", null: false
@@ -118,6 +119,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_104933) do
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
+    t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_agency_id"], name: "index_affiliations_on_organization_agency_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
     t.index ["person_id"], name: "index_affiliations_on_person_id"
@@ -1617,6 +1619,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_104933) do
   add_foreign_key "action_text_mentions", "action_text_rich_texts"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "affiliations", "addresses", column: "organization_address_id", on_delete: :nullify
   add_foreign_key "affiliations", "organizations"
   add_foreign_key "affiliations", "organizations", column: "organization_agency_id"
   add_foreign_key "affiliations", "people"

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Affiliation do
   describe 'associations' do
     it { should belong_to(:organization) }
     it { should belong_to(:person) }
+    it { should belong_to(:organization_address).class_name("Address").optional }
   end
 
   describe 'validations' do
@@ -12,6 +13,40 @@ RSpec.describe Affiliation do
     end
     it { should validate_presence_of(:organization_id) }
     # it { should validate_presence_of(:person_id) } # we needed to not have this to support nested attrs
+  end
+
+  describe '#organization_address' do
+    let(:organization) { create(:organization) }
+    let(:address) { create(:address, addressable: organization) }
+
+    it 'is valid when the address belongs to the same organization' do
+      affiliation = build(:affiliation, organization: organization, organization_address: address)
+      expect(affiliation).to be_valid
+    end
+
+    it 'is valid when no address is linked' do
+      affiliation = build(:affiliation, organization: organization, organization_address: nil)
+      expect(affiliation).to be_valid
+    end
+
+    it 'is invalid when the address belongs to a different organization' do
+      other_address = create(:address, addressable: create(:organization))
+      affiliation = build(:affiliation, organization: organization, organization_address: other_address)
+      expect(affiliation).not_to be_valid
+      expect(affiliation.errors[:organization_address_id]).to be_present
+    end
+
+    it "is invalid when the address belongs to a person" do
+      person_address = create(:address, addressable: create(:person))
+      affiliation = build(:affiliation, organization: organization, organization_address: person_address)
+      expect(affiliation).not_to be_valid
+    end
+
+    it 'is nullified when its linked address is destroyed' do
+      affiliation = create(:affiliation, organization: organization, organization_address: address)
+      address.destroy
+      expect(affiliation.reload.organization_address_id).to be_nil
+    end
   end
 
   describe '#active?' do

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -248,6 +248,25 @@ RSpec.describe "/organizations", type: :request do
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
+
+    context "linking an affiliation to an organization address" do
+      it "saves the chosen organization_address_id on the affiliation" do
+        organization = Organization.create!(valid_attributes)
+        address = create(:address, addressable: organization)
+        person = create(:person)
+        affiliation = create(:affiliation, organization: organization, person: person)
+
+        patch organization_url(organization), params: {
+          organization: {
+            affiliations_attributes: {
+              "0" => { id: affiliation.id, person_id: person.id, organization_address_id: address.id }
+            }
+          }
+        }
+
+        expect(affiliation.reload.organization_address_id).to eq(address.id)
+      end
+    end
   end
 
   describe "sector saving" do

--- a/spec/requests/people_affiliation_address_spec.rb
+++ b/spec/requests/people_affiliation_address_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "People affiliation address picker", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "GET /people/:id/edit" do
+    it "renders the affiliation editor when the org has an address" do
+      person = create(:person)
+      organization = create(:organization)
+      create(:address, addressable: organization)
+      create(:affiliation, person: person, organization: organization)
+
+      get edit_person_path(person)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Address")
+    end
+  end
+end

--- a/spec/requests/people_affiliation_address_spec.rb
+++ b/spec/requests/people_affiliation_address_spec.rb
@@ -17,5 +17,17 @@ RSpec.describe "People affiliation address picker", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Address")
     end
+
+    it "still lists a linked address that is inactive, marked [INACTIVE]" do
+      person = create(:person)
+      organization = create(:organization)
+      address = create(:address, addressable: organization, inactive: true, street_address: "123 Sesame Street")
+      create(:affiliation, person: person, organization: organization, organization_address: address)
+
+      get edit_person_path(person)
+
+      expect(response.body).to include("[INACTIVE]")
+      expect(response.body).to include("123 Sesame Street")
+    end
   end
 end


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: new optional FK + nested-attr param + a small Stimulus dropdown

### What is the goal of this PR and why is this important?
Organizations can have several addresses. This lets an editor record *which* address a person's affiliation is tied to, rather than leaving it ambiguous.

### How did you approach the change?
- New optional `affiliations.organization_address_id` FK → `addresses` (`on_delete: :nullify`); migration is reversible.
- `Affiliation belongs_to :organization_address` (optional) with a validation that the address actually belongs to the affiliation's organization. `Address has_many :affiliations` with `dependent: :nullify`.
- Permitted `organization_address_id` in both the organizations and people affiliations nested params (the editor row is shared).
- UI: a compact numbered picker in the shared affiliation editor row — the trigger is only wide enough for a double-digit number, the panel shows each address's full one-line text. Numbers mirror the org address editor's "Address #N".
- New `address-select` Stimulus controller (open/close, outside-click + escape, writes the id to a hidden field).

### Editor-row layout & behavior tweaks
- Narrowed the Title field so the new Address column fits and Remove stays inline.
- Grey-filled the picker trigger (`bg-gray-100`) so it reads like the other optional fields.
- When an org has no addresses, the column renders an equal-width spacer so Start/End/Primary stay vertically aligned across rows.
- All addresses are selectable; inactive ones are shown with an `[INACTIVE]` marker and keep their number.

### Performance
- Preload each org's addresses on the person edit form, and add `inverse_of` between `Organization`/`Affiliation` so the org edit form reuses the already-loaded organization — removes the per-row address queries (N+1).

### Anything else to add?
- Numbering reflects each address's real position so it matches the address section.