### PR TITLE
Group org address Primary and Inactive checkboxes in one column

### DIFF
--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -17,7 +17,7 @@
                   value: f.object.address_type,
                   class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
                 } %>
-    <div class="flex items-center">
+    <div class="flex items-center gap-6">
       <%= f.input :primary,
                   as: :boolean,
                   label: "Primary",
@@ -25,8 +25,6 @@
                     checked: f.object.new_record? || f.object.primary?,
                     class: "mr-2 rounded focus:ring-blue-500 text-blue-600"
                   } %>
-    </div>
-    <div class="flex items-center">
       <%= f.input :inactive,
                   as: :boolean,
                   label: "Inactive",


### PR DESCRIPTION
REVIEW LEVEL NEEDED: 👀 Skim — view-only: markup-only layout change, no logic or data changes

### What is the goal of this PR and why is this important?
- On the org address form, **Primary** and **Inactive** sat in separate grid columns with a wide gap between them. Group them into one column so the two checkboxes are adjacent.

### How did you approach the change?
- Wrapped both `f.input` checkboxes in a single flex container (`gap-6`) inside one grid cell. No field/column changes — `addresses.inactive` and `addresses.primary` are existing columns.

### Anything else to add?
- Split out of #1818 (affiliation ↔ org address) to keep that PR focused.