### PR TITLE
Split transfer attendance status into transferred_in and transferred_out

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -21,8 +21,8 @@ class EventRegistration < ApplicationRecord
   after_create :snapshot_registrant_organizations
   after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
-  ACTIVE_STATUSES = %w[ registered attended incomplete_attendance ].freeze
-  INACTIVE_STATUSES = %w[ cancelled no_show transferring ].freeze
+  ACTIVE_STATUSES = %w[ registered attended incomplete_attendance transferred_in ].freeze
+  INACTIVE_STATUSES = %w[ cancelled no_show transferred_out ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
 
   # Default price the registrant owes per requested continuing-education hour.
@@ -292,7 +292,8 @@ class EventRegistration < ApplicationRecord
     when "incomplete_attendance" then "Incomplete attendance"
     when "cancelled" then "Cancelled"
     when "no_show" then "No show"
-    when "transferring" then "Transferring"
+    when "transferred_in" then "Transferred in"
+    when "transferred_out" then "Transferred out"
     else status.humanize
     end
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -22,7 +22,7 @@ class EventRegistration < ApplicationRecord
   after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance ].freeze
-  INACTIVE_STATUSES = %w[ cancelled no_show ].freeze
+  INACTIVE_STATUSES = %w[ cancelled no_show transferring ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
 
   # Default price the registrant owes per requested continuing-education hour.
@@ -292,6 +292,7 @@ class EventRegistration < ApplicationRecord
     when "incomplete_attendance" then "Incomplete attendance"
     when "cancelled" then "Cancelled"
     when "no_show" then "No show"
+    when "transferring" then "Transferring"
     else status.humanize
     end
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -170,11 +170,14 @@ class EventPolicy < ApplicationPolicy
     if authenticated?
       relation
         .joins(
-          "LEFT OUTER JOIN event_registrations
-             ON event_registrations.event_id = events.id
-             AND event_registrations.status IN ('registered', 'attended', 'incomplete_attendance')
-           LEFT OUTER JOIN people
-             ON people.id = event_registrations.registrant_id"
+          ActiveRecord::Base.sanitize_sql_array([
+            "LEFT OUTER JOIN event_registrations
+               ON event_registrations.event_id = events.id
+               AND event_registrations.status IN (?)
+             LEFT OUTER JOIN people
+               ON people.id = event_registrations.registrant_id",
+            EventRegistration::ACTIVE_STATUSES
+          ])
         )
         .published
         .where(

--- a/app/views/event_registrations/_attendance_status_badge.html.erb
+++ b/app/views/event_registrations/_attendance_status_badge.html.erb
@@ -4,14 +4,16 @@
     "attended"                => "bg-green-50 text-green-700 border-green-200",
     "incomplete_attendance"   => "bg-amber-50 text-amber-700 border-amber-200",
     "cancelled"               => "bg-gray-50 text-gray-500 border-gray-200",
-    "no_show"                 => "bg-red-50 text-red-700 border-red-200"
+    "no_show"                 => "bg-red-50 text-red-700 border-red-200",
+    "transferring"            => "bg-purple-50 text-purple-700 border-purple-200"
   }
   status_icons = {
     "registered"              => "fa-clipboard-list",
     "attended"                => "fa-circle-check",
     "incomplete_attendance"   => "fa-clock",
     "cancelled"               => "fa-ban",
-    "no_show"                 => "fa-circle-xmark"
+    "no_show"                 => "fa-circle-xmark",
+    "transferring"            => "fa-right-left"
   }
   current_style = status_styles[registration.status] || "bg-gray-50 text-gray-500 border-gray-200"
   current_icon  = status_icons[registration.status] || "fa-question"

--- a/app/views/event_registrations/_attendance_status_badge.html.erb
+++ b/app/views/event_registrations/_attendance_status_badge.html.erb
@@ -5,7 +5,8 @@
     "incomplete_attendance"   => "bg-amber-50 text-amber-700 border-amber-200",
     "cancelled"               => "bg-gray-50 text-gray-500 border-gray-200",
     "no_show"                 => "bg-red-50 text-red-700 border-red-200",
-    "transferring"            => "bg-purple-50 text-purple-700 border-purple-200"
+    "transferred_in"          => "bg-teal-50 text-teal-700 border-teal-200",
+    "transferred_out"         => "bg-purple-50 text-purple-700 border-purple-200"
   }
   status_icons = {
     "registered"              => "fa-clipboard-list",
@@ -13,7 +14,8 @@
     "incomplete_attendance"   => "fa-clock",
     "cancelled"               => "fa-ban",
     "no_show"                 => "fa-circle-xmark",
-    "transferring"            => "fa-right-left"
+    "transferred_in"          => "fa-right-to-bracket",
+    "transferred_out"         => "fa-right-from-bracket"
   }
   current_style = status_styles[registration.status] || "bg-gray-50 text-gray-500 border-gray-200"
   current_icon  = status_icons[registration.status] || "fa-question"

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -18,7 +18,8 @@
            "incomplete_attendance" => "text-amber-600",
            "cancelled"             => "text-gray-500",
            "no_show"               => "text-red-600",
-           "transferring"          => "text-purple-600"
+           "transferred_in"        => "text-teal-600",
+           "transferred_out"       => "text-purple-600"
          } %>
       <% status_icons = {
            "registered"            => "fa-clipboard-list",
@@ -26,7 +27,8 @@
            "incomplete_attendance" => "fa-clock",
            "cancelled"             => "fa-ban",
            "no_show"               => "fa-circle-xmark",
-           "transferring"          => "fa-right-left"
+           "transferred_in"        => "fa-right-to-bracket",
+           "transferred_out"       => "fa-right-from-bracket"
          } %>
       <% current_icon_color = status_icon_colors[f.object.status] || "text-gray-500" %>
       <% current_icon = status_icons[f.object.status] || "fa-question" %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -17,14 +17,16 @@
            "attended"              => "text-green-600",
            "incomplete_attendance" => "text-amber-600",
            "cancelled"             => "text-gray-500",
-           "no_show"               => "text-red-600"
+           "no_show"               => "text-red-600",
+           "transferring"          => "text-purple-600"
          } %>
       <% status_icons = {
            "registered"            => "fa-clipboard-list",
            "attended"              => "fa-circle-check",
            "incomplete_attendance" => "fa-clock",
            "cancelled"             => "fa-ban",
-           "no_show"               => "fa-circle-xmark"
+           "no_show"               => "fa-circle-xmark",
+           "transferring"          => "fa-right-left"
          } %>
       <% current_icon_color = status_icon_colors[f.object.status] || "text-gray-500" %>
       <% current_icon = status_icons[f.object.status] || "fa-question" %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe EventRegistration, type: :model do
       reg = create(:event_registration, status: "no_show")
       expect(reg).not_to be_active
     end
+
+    it "returns false for transferring status" do
+      reg = create(:event_registration, status: "transferring")
+      expect(reg).not_to be_active
+    end
   end
 
   describe ".active" do
@@ -43,10 +48,11 @@ RSpec.describe EventRegistration, type: :model do
       active_reg = create(:event_registration, status: "registered")
       cancelled_reg = create(:event_registration, status: "cancelled")
       no_show_reg = create(:event_registration, status: "no_show")
+      transferring_reg = create(:event_registration, status: "transferring")
 
       results = EventRegistration.active
       expect(results).to include(active_reg)
-      expect(results).not_to include(cancelled_reg, no_show_reg)
+      expect(results).not_to include(cancelled_reg, no_show_reg, transferring_reg)
     end
   end
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -37,22 +37,28 @@ RSpec.describe EventRegistration, type: :model do
       expect(reg).not_to be_active
     end
 
-    it "returns false for transferring status" do
-      reg = create(:event_registration, status: "transferring")
+    it "returns false for transferred_out status" do
+      reg = create(:event_registration, status: "transferred_out")
       expect(reg).not_to be_active
+    end
+
+    it "returns true for transferred_in status" do
+      reg = create(:event_registration, status: "transferred_in")
+      expect(reg).to be_active
     end
   end
 
   describe ".active" do
     it "returns only registrations with active statuses" do
       active_reg = create(:event_registration, status: "registered")
+      transferred_in_reg = create(:event_registration, status: "transferred_in")
       cancelled_reg = create(:event_registration, status: "cancelled")
       no_show_reg = create(:event_registration, status: "no_show")
-      transferring_reg = create(:event_registration, status: "transferring")
+      transferred_out_reg = create(:event_registration, status: "transferred_out")
 
       results = EventRegistration.active
-      expect(results).to include(active_reg)
-      expect(results).not_to include(cancelled_reg, no_show_reg, transferring_reg)
+      expect(results).to include(active_reg, transferred_in_reg)
+      expect(results).not_to include(cancelled_reg, no_show_reg, transferred_out_reg)
     end
   end
 


### PR DESCRIPTION
> **WAIT** — not ready to merge; pending review of the open decisions below.

### What is the goal of this PR and why is this important?
- Adds two attendance statuses for event registrations so registrants moving between events are tracked distinctly instead of vanishing into a generic cancelled/no-show state.
- `transferred_in` is an **active** status (the person is attending this event); `transferred_out` is **inactive** (they've left for another event). These fall on opposite sides of the active/inactive line, so one combined status couldn't represent both.

### How did you approach the change?
- Added `transferred_in` to `ACTIVE_STATUSES` and `transferred_out` to `INACTIVE_STATUSES`, each with a human-readable label.
- Gave each a distinct badge/icon: teal `fa-right-to-bracket` for in, purple `fa-right-from-bracket` for out (badge partial + form status picker).
- Fixed `EventPolicy`'s authenticated event scope, which hardcoded the active statuses and would have hidden events from transferred-in registrants; it now derives the list from `ACTIVE_STATUSES`.
- Status filter dropdowns (`_registrants_search`, the form picker) are data-driven from `ATTENDANCE_STATUSES`, so they pick up the new values automatically — no hardcoded dropdown edits needed.

### UI Testing Checklist
- [ ] "Transferred in" shows a teal badge and counts toward active registrants/rosters.
- [ ] "Transferred out" shows a purple badge and is excluded from active counts.
- [ ] Both appear in the attendance-status filter dropdown and the per-registration status picker.

### Anything else to add?
- `status` is a string column validated by inclusion — no migration required.
- Open decision: whether to also surface *which* event a person transferred to/from (provenance), which would be a separate link/field rather than a status value.