### PR TITLE
Add ai/review skill for workspace-diff code review

### DIFF
--- a/.claude/skills/ai-review/SKILL.md
+++ b/.claude/skills/ai-review/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: ai-review
+description: >
+  Review a proposed code change as a reviewer would. Get the workspace diff,
+  flag only bugs the original author would fix, post concise inline
+  comments, then give a Recap + Risks + Outstanding decisions summary.
+  Invoked by ai/review.
+allowed-tools:
+  - Bash
+  - Read
+  - mcp__conductor__GetWorkspaceDiff
+  - mcp__conductor__DiffComment
+---
+
+# ai-review
+
+You are acting as a reviewer for a proposed code change made by another engineer.
+
+Below are some default guidelines for determining whether the original author would appreciate the issue being flagged.
+
+These are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.
+Those guidelines should be considered to override these general instructions.
+
+Here are the general guidelines for determining whether something is a bug and should be flagged.
+
+It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
+The bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).
+Fixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn't need very detailed comments and input validation in a repository of one-off scripts in personal projects)
+The bug was introduced in the commit (pre-existing bugs should not be flagged).
+The author of the original PR would likely fix the issue if they were made aware of it.
+The bug does not rely on unstated assumptions about the codebase or author's intent.
+It is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.
+The bug is clearly not just an intentional change by the original author.
+When flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment — defer to any subsequent guidelines that you encounter.
+
+The comment should be clear about why the issue is a bug.
+The comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.
+The comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.
+The comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.
+The comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+The comment's tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+The comment should be written such that the original author can immediately grasp the idea without close reading.
+The comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like "Great job …", "Thanks for …".
+Below are some more detailed guidelines that you should apply to this specific review.
+
+## How many findings to return
+
+Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
+
+## Guidelines
+
+Ignore trivial style unless it obscures meaning or violates documented standards.
+Prefix each inline comment with a severity tag so the author can triage: **`blocker:`** (must fix before merge — correctness, security, data loss), **`should-fix:`** (a real problem worth addressing), or **`nit:`** (minor/optional). This mirrors the repo's `🤖 PR, suggested 👤 review level:` depth tags.
+Use one comment per distinct issue (or a multi-line range if necessary).
+Use ```suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block).
+In every ```suggestion block, preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).
+Do NOT introduce or remove outer indentation levels unless that is the actual fix.
+The comments will be presented in the code review as inline comments. You should avoid providing unnecessary location details in the comment body. Always keep the line range as short as possible for interpreting the issue. Avoid ranges longer than 5–10 lines; instead, choose the most suitable subrange that pinpoints the problem.
+
+## Getting the diff
+
+Use the `mcp__conductor__GetWorkspaceDiff` tool to review the workspace diff. Start with `stat: true` to understand the files that changed, then request specific files as needed.
+
+### Fallback: if you don't have access to the workspace diff tool
+
+If you don't have access to the `mcp__conductor__GetWorkspaceDiff` tool, use the following git commands to get the diff:
+
+```bash
+# Get the merge base between this branch and the target
+MERGE_BASE=$(git merge-base origin/main HEAD)
+
+# Get the committed diff against the merge base
+git diff $MERGE_BASE HEAD
+
+# Get any uncommitted changes (staged and unstaged)
+git diff HEAD
+```
+
+Review the combination of both outputs: the first shows all committed changes on this branch relative to the target, and the second shows any uncommitted work in progress.
+
+No need to mention in your report whether or not you used one of the fallback strategies; it's usually irrelevant.
+
+## Understand the intent first
+
+Before judging the code, work out what the change is *trying* to do. Read the PR description and commit messages (`git log --format='%B' origin/main..HEAD`, and `gh pr view --json title,body` if a PR exists). Then check the diff actually delivers that intent — a change that's internally clean but doesn't do what it claims is the most important thing to flag.
+
+Also watch for **scope creep**: unrelated changes bundled into the same diff (a drive-by refactor inside a bugfix, an unrelated file touched, a dependency bump mixed with a feature). Call these out — they make review and rollback harder even when each change is individually fine.
+
+## Check against project conventions
+
+This repo documents its conventions in `CLAUDE.md` and `AGENTS.md` (and mirrors `CLAUDE.md` to `.github/copilot-instructions.md`). Read the relevant parts and flag violations the author would want to fix. Common ones in this codebase:
+
+- **Money** — display via `dollars_from_cents` / `MoneyFormatter`, never `number_to_currency` or `format("%.2f", …)`; store and compute in integer cents.
+- **New full-page views** — set `content_for(:page_bg_class, "…")` matching the action's policy, and register the view in `spec/views/page_bg_class_alignment_spec.rb`'s `EXPECTED_MAPPINGS`.
+- **Cross-page links** — pass `return_to` (and any state/anchor needed) so the destination's eyebrow returns to the right origin; keep controller redirects and the view eyebrow in agreement.
+- **Casing** — sentence case for UI labels/headings (`.underscore.humanize`, not `.titleize`).
+- **Rails idioms** — `after_commit` for side effects (not `after_save`); guard/early-return over nested conditionals; `presence` over blank checks; service objects/POROs over concerns; avoid `update_all` unless intended.
+- **Migrations** — real second-level UTC timestamp (not round/sequential numbers); reversible with explicit `up`/`down` and idempotent guards (`if_exists:`, `*_exists?`).
+- **Style** — rubocop-rails-omakase (double quotes, spaces inside `[ ]`/`{ }`, no trailing commas, modern hash syntax, `%w[]`/`%i[]`). Don't nitpick style an autoformatter would catch unless it's clearly wrong or the rule is documented.
+- **Stimulus/JS** — prefer reusing/adapting an existing controller over a near-duplicate; targets/values/actions/classes APIs over `querySelector`/manual listeners; Tailwind utilities over custom CSS; clean up listeners/timers in `disconnect()`.
+
+## Related-files completeness
+
+Use the "Related Files" table in `CLAUDE.md`. When the diff changes one side, check whether its companions were updated and flag missing ones:
+
+- **Model** → decorator, policy, factory, model spec.
+- **Controller** → policy, request spec, routing spec, views.
+- **View** → system spec, Stimulus controller (if interactive).
+- **Service / decorator / mailer** → matching spec (and mailer preview for new/removed mailers).
+- **New/removed model, concern, service, gem, Stimulus controller, mailer, or rake task** → `AGENTS.md` updated.
+- **`CLAUDE.md` changed** → `.github/copilot-instructions.md` kept in sync.
+
+## Test discipline
+
+Behavior changes should come with tests. Flag a diff that changes logic or fixes a bug without an accompanying spec (this repo's rule: bug fixes require a failing test first). Distinguish "no tests at all" (worth flagging) from "tests exist but miss an edge case" (note under Outstanding decisions).
+
+## Verify each finding before posting
+
+For every candidate finding, read the surrounding **unchanged** code — not just the diff hunk — to confirm it's real. Diff-only context is the main source of false positives: a "missing" guard or method may exist just outside the hunk, a "broken" caller may be handled elsewhere. If you can't substantiate a finding by pointing at the provably-affected code, drop it or downgrade it to an Outstanding decision phrased as a question. A wrong confident comment costs the author more than a missed nit.
+
+## What not to comment on
+
+Skip generated, vendored, or mechanical files unless the change to them is clearly wrong: lockfiles (`Gemfile.lock`, `package-lock.json`), `db/schema.rb`, snapshots/fixtures, `vendor/`, build output, and other autogenerated artifacts. Don't flag pre-existing issues the diff didn't introduce, and don't re-flag anything an existing review comment already covers (check existing comments first).
+
+## Output format
+
+Post inline comments for each issue using `mcp__conductor__DiffComment`:
+
+IMPORTANT: Only post ONE comment per unique issue.
+
+Write out a list of issues found, along with the location of the comment. For example:
+
+### **#1 Empty input causes crash**
+blocker: If the input field is empty when page loads, the app will crash.
+
+File: src/client/frontends/desktop/ui/Input.tsx
+
+#2 Dead code
+nit: The getUserData function is now unused. It should be deleted.
+
+File: src/client/frontends/desktop/core/UserData.ts
+
+## Summary
+
+After posting the inline comments, end your reply with a written summary (in the chat, not as a diff comment) in three parts, modeled on the `ai/recap` format:
+
+1. **Recap** — a short prose paragraph or a few bullets describing what the change does: the intent of the diff, the main files/areas touched, and your overall read on it. Keep it tight; the reader can see the diff.
+2. **Risks** — a bulleted list explicitly calling out anything that could bite later, even if it didn't meet the bar for an inline comment. Cover, where applicable:
+   - **Security** (Rails-specific) — missing/incorrect Pundit authorization (action not scoped to the current user, wrong policy, `authorize` omitted); mass-assignment via permissive strong params; SQL injection through string interpolation in `where`/`order` (use `Arel.sql` / bind params); `html_safe`/`raw`/`render inline:` on user input; secrets or credentials in code; CSRF/`skip_before_action` bypasses; unscoped finders that leak other tenants' records.
+   - **Brittleness** — fragile assumptions, missing nil/empty handling, race conditions, ordering dependence, untested edge cases, things likely to break on refactor or with real-world data.
+   - **Data & migrations** — irreversible or unguarded migrations, backfills, `update_all`, destructive operations.
+   - **Performance** — N+1 queries, unbounded loops/loads, missing indexes.
+   - **Blast radius** — shared code, public APIs, or behavior other parts of the codebase provably depend on.
+
+   Each risk is one bullet: what it is, the condition under which it matters, and its severity. If there are none in a category, omit it. If there are no risks at all, say so explicitly:
+
+   ```
+   - No notable risks
+     - Change is contained and low-impact
+   ```
+
+   Risks here are broader than the inline-comment bar: an inline comment must be a discrete bug the author would fix, but a risk can be a heads-up worth stating even when it's an accepted trade-off or doesn't warrant a code change.
+3. **Outstanding decisions** — a bulleted list of things the author needs to resolve or that you couldn't settle from the diff alone (the review analog of `ai/recap`'s "Unresolved"): open questions, ambiguous intent, choices that look deliberate but you're unsure about, missing tests you'd want before merge, or trade-offs the author should consciously sign off on. Each bullet states the question and why it matters; phrase it so the author can answer it directly. Keep these distinct from Risks — a risk is a warning, a decision is a question awaiting an answer. If there's nothing open, say so:
+
+   ```
+   - Nothing outstanding
+     - No open questions; change reads as complete
+   ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,7 +250,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - Use `docs/pull_request_template.md` for PR description structure
 - **Remove the `Closes …` line when there's no ticket** — it's a template placeholder. Keep it (with a real issue link) only when the PR closes a tracked ticket; otherwise drop the line entirely rather than leaving the placeholder.
 - **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
-- **Start the description with a review-depth tag** on its own single line, prefixed with `REVIEW NEEDED: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `REVIEW NEEDED: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+- **Start the description with a review-depth tag** on its own single line, prefixed with `🤖 PR, suggested 👤 review level: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `🤖 PR, suggested 👤 review level: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
   - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
   - **📖 Read** — light-logic: small, contained logic changes with low blast radius
   - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review
@@ -308,6 +308,7 @@ See `ai/` directory for executable scripts:
 | Command | What it does |
 |---|---|
 | `ai/recap` | Session recap: accomplishments + unresolved items (see above) |
+| `ai/review` | Code review: agent reviews the workspace diff, posts inline comments, and gives a Recap + Risks + Outstanding decisions summary (runs the `ai-review` skill) |
 | `ai/test [args]` | Run RSpec |
 | `ai/lint` | Rubocop on all files |
 | `ai/lint --fix` | Auto-fix lint issues |
@@ -318,4 +319,4 @@ See `ai/` directory for executable scripts:
 | `ai/seed` | Load the full dev sample dataset (`db:seed:dev`) into the workspace DB |
 | `ai/security` | Security scan: Brakeman + bundler-audit (mirrors CI) |
 
-> **"ai <name>" means the `ai/` script of that name** (e.g. "ai test" → `ai/test`, "ai security" → `ai/security`) — shell scripts in `ai/`, not slash-command skills. If a referenced `ai/<name>` script doesn't exist, ask what's intended rather than substituting a similarly named skill. (`ai/recap` is special — it triggers the agent **Session recap** behavior above, not a real script's output; never confuse it with the `/audit` design skill or the `ai/security` scan.)
+> **"ai <name>" means the `ai/` script of that name** (e.g. "ai test" → `ai/test`, "ai security" → `ai/security`) — shell scripts in `ai/`, not slash-command skills. If a referenced `ai/<name>` script doesn't exist, ask what's intended rather than substituting a similarly named skill. Two are special — they print a trigger word, and the agent does the work directly rather than producing script output: (1) **"ai recap"** triggers the **Session recap** behavior above; never confuse it with the `/audit` design skill or the `ai/security` scan. (2) **"ai review"** (`ai/review`) triggers the **`ai-review` skill** — review the current workspace diff, post one inline comment per qualifying bug, then give a Recap + Risks + Outstanding decisions summary; it is not the `/audit` skill or the `/code-review` / `/review` skills.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ Follow the [Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introducti
 - Use `docs/pull_request_template.md` for PR description structure
 - **Remove the `Closes …` line when there's no ticket** — it's a template placeholder. Keep it (with a real issue link) only when the PR closes a tracked ticket; otherwise drop the line entirely rather than leaving the placeholder.
 - **Keep descriptions as short as possible** — a few terse bullets, not paragraphs. Cut anything a reviewer can see from the diff; only keep what explains *why*.
-- **Start the description with a review-depth tag** on its own single line, prefixed with `REVIEW NEEDED: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `REVIEW NEEDED: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
+- **Start the description with a review-depth tag** on its own single line, prefixed with `🤖 PR, suggested 👤 review level: `, followed by a blank line, then the rest of the description. The tag is the prefix, the icon, the level name, and the short note on what that level means — e.g. `🤖 PR, suggested 👤 review level: 👀 Skim — view-only: markup/copy/styling, no logic or data changes`. Always spell out the meaning inline; never post the icon and name alone. The tag tells the reviewer how closely to look (depth of review, not how risky/good the change is):
   - **👀 Skim** — view-only: markup/copy/styling, no logic or data changes
   - **📖 Read** — light-logic: small, contained logic changes with low blast radius
   - **🔬 Inspect** — big change: substantive logic, migrations that rename or transform data (backfills), or wide-reaching changes that warrant careful review
@@ -317,6 +317,7 @@ See `ai/` directory for executable scripts:
 | Command | What it does |
 |---|---|
 | `ai/recap` | Session recap: accomplishments + unresolved items (see above) |
+| `ai/review` | Code review: agent reviews the workspace diff, posts inline comments, and gives a Recap + Risks + Outstanding decisions summary (runs the `ai-review` skill) |
 | `ai/test [args]` | Run RSpec |
 | `ai/lint` | Rubocop on all files |
 | `ai/lint --fix` | Auto-fix lint issues |
@@ -327,4 +328,4 @@ See `ai/` directory for executable scripts:
 | `ai/seed` | Load the full dev sample dataset (`db:seed:dev`) into the workspace DB |
 | `ai/security` | Security scan: Brakeman + bundler-audit (mirrors CI) |
 
-> **"ai <name>" means the `ai/` script of that name** (e.g. "ai test" → `ai/test`, "ai security" → `ai/security`) — shell scripts in `ai/`, not slash-command skills. If a referenced `ai/<name>` script doesn't exist, ask what's intended rather than substituting a similarly named skill. (`ai/recap` is special — it triggers the agent **Session recap** behavior above, not a real script's output; never confuse it with the `/audit` design skill or the `ai/security` scan.)
+> **"ai <name>" means the `ai/` script of that name** (e.g. "ai test" → `ai/test`, "ai security" → `ai/security`) — shell scripts in `ai/`, not slash-command skills. If a referenced `ai/<name>` script doesn't exist, ask what's intended rather than substituting a similarly named skill. Two are special — they print a trigger word, and the agent does the work directly rather than producing script output: (1) **"ai recap"** triggers the **Session recap** behavior above; never confuse it with the `/audit` design skill or the `ai/security` scan. (2) **"ai review"** (`ai/review`) triggers the **`ai-review` skill** — review the current workspace diff, post one inline comment per qualifying bug, then give a Recap + Risks + Outstanding decisions summary; it is not the `/audit` skill or the `/code-review` / `/review` skills.

--- a/ai/README.md
+++ b/ai/README.md
@@ -5,6 +5,7 @@ Quick-reference scripts for common development tasks. Designed for AI agents and
 | Command | What it does |
 |---|---|
 | `ai/recap` | Session recap: accomplishments + unresolved items (agent behavior; see below) |
+| `ai/review` | Code review: agent reviews the workspace diff, posts inline comments, and gives a Recap + Risks + Outstanding decisions summary (agent behavior; see below) |
 | `ai/test [args]` | Run RSpec tests (`ai/test spec/models/user_spec.rb:42`) |
 | `ai/lint` | Rubocop on all files |
 | `ai/lint --fix` | Auto-fix lint issues |
@@ -20,4 +21,5 @@ All scripts pass through extra arguments, so `ai/test --fail-fast` works as expe
 Only the commands listed above exist. "ai <name>" refers to one of these `ai/` scripts — not a slash-command skill. Two phrases are special:
 
 - **"ai security"** runs `ai/security` (the security scan above).
+- **"ai review"** (or `ai/review`, which just prints a trigger) tells the agent to run the `ai-review` skill (`.claude/skills/ai-review/SKILL.md`): review the current workspace diff against the review guidelines, post one concise inline comment per qualifying bug, then give a written **Recap + Risks + Outstanding decisions** summary (modeled on `ai recap`). It is never the `/audit` design skill or `ai/security`.
 - **"ai recap"** (or `ai/recap`, which just prints the trigger word) tells the agent to review the conversation and report two parts: **Recap** (what was accomplished) and **Unresolved** (dropped threads, unanswered questions, unfinished tasks, and disagreements from either side). The agent performs it directly per `CLAUDE.md`. It is never the `/audit` design/accessibility skill.

--- a/ai/review
+++ b/ai/review
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Code review: triggers the AI to review the current workspace diff against the
+# review guidelines and post concise inline comments for each qualifying bug.
+# This script just prints the trigger; the agent runs the `ai-review` skill
+# (.claude/skills/ai-review/SKILL.md), which holds the full guidelines.
+echo "Run the ai-review skill."


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — AI instruction/docs + a one-line trigger script, no app logic or data changes

### What is the goal of this PR and why is this important?
- Adds an **`ai review`** trigger that mirrors the existing `ai recap` pattern, so reviewing the current workspace diff follows the same documented convention instead of ad-hoc prompting.

### How did you approach the change?
- New `.claude/skills/ai-review/SKILL.md` holds the review guidelines (flag only real bugs, post one concise inline comment per finding, end with Recap + Risks + Outstanding decisions).
- New `ai/review` script just prints the trigger word; the agent runs the skill.
- Registered the command in `CLAUDE.md`, `.github/copilot-instructions.md` (kept in sync), and `ai/README.md`.
- Also refreshed the PR review-depth tag to `🤖 PR, suggested 👤 review level:` (uses literal 👤 so it renders inside code spans and on GitHub).

### Anything else to add?
- Docs/tooling only — no Ruby, migrations, or runtime behavior touched.
