### PR TITLE
Link registration affiliations to the org's address (+ country, backfill)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,11 @@ end
 
 ### Affiliations
 
-- `AffiliationServices::CreateFromRegistration` — On registration / org linking, creates a "job affiliation" with the typed title (when present) plus a standing "Facilitator" affiliation, in one transaction. Skips the facilitator one only when the person already has an active-or-pending affiliation titled exactly "Facilitator" with that org (a current one or one dated to a future training); an ended facilitator affiliation gets a fresh second one. Dedupe is by title + org + dates, so a job title like "Lead Facilitator" still gets its own Facilitator affiliation
+- `AffiliationServices::CreateFromRegistration` — On registration / org linking, creates a "job affiliation" with the typed title (when present) plus a standing "Facilitator" affiliation, in one transaction. Skips the facilitator one only when the person already has an active-or-pending affiliation titled exactly "Facilitator" with that org (a current one or one dated to a future training); an ended facilitator affiliation gets a fresh second one. Dedupe is by title + org + dates, so a job title like "Lead Facilitator" still gets its own Facilitator affiliation. Accepts an optional `organization_address:` and sets it on every affiliation it creates (the registrant's typed agency address, upserted onto the org); when an affiliation already exists and is skipped, it backfills that address onto the existing one only if it has none (an admin-set address is never overwritten)
+
+### Organizations
+
+- `OrganizationServices::UpsertAddress` — Find-or-create an organization's "work" address from a registrant's submitted agency fields (street/city/state/zip/country). Updates the matching city/state address in place, else adds a new one; never demotes the org's existing primary (a registrant's address becomes primary only when the org has none yet). Returns nil when no city is given. Shared by `PublicRegistration` and the admin org-linking actions so both build the org address identically before linking the affiliation to it
 
 ### Notifications
 

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -215,12 +215,7 @@ class EventRegistrationsController < ApplicationController
     @person = @event_registration.registrant
     organization = Organization.find(params[:organization_id])
 
-    AffiliationServices::CreateFromRegistration.call(
-      person: @person,
-      organization: organization,
-      job_title: submitted_position(@event_registration),
-      training_date: @event_registration.event.start_date
-    )
+    link_affiliations_for(@event_registration, organization)
 
     @event_registration.event_registration_organizations
       .find_or_create_by!(organization: organization)
@@ -248,12 +243,7 @@ class EventRegistrationsController < ApplicationController
     existing = Organization.where("LOWER(name) = ?", name.strip.downcase).first
     organization = existing || Organization.create!(name: name.strip, organization_status: OrganizationStatus.find_by(name: "Active"))
 
-    AffiliationServices::CreateFromRegistration.call(
-      person: @person,
-      organization: organization,
-      job_title: submitted_position(@event_registration),
-      training_date: @event_registration.event.start_date
-    )
+    link_affiliations_for(@event_registration, organization)
     @event_registration.event_registration_organizations.find_or_create_by!(organization: organization)
 
     notice = existing ? "#{organization.name} linked." : "#{organization.name} created and linked."
@@ -386,10 +376,8 @@ class EventRegistrationsController < ApplicationController
     return [] unless form
 
     field_ids = form.form_fields
-      .where(field_identifier: %w[agency_name agency_position])
+      .where(field_identifier: %w[agency_name agency_position agency_street agency_city agency_state agency_zip agency_country])
       .pluck(:field_identifier, :id).to_h
-    name_field_id = field_ids["agency_name"]
-    position_field_id = field_ids["agency_position"]
 
     entries = registration.registrant.form_submissions
       .where(form: form)
@@ -397,10 +385,18 @@ class EventRegistrationsController < ApplicationController
       .includes(:form_answers)
       .map do |submission|
         answers = submission.form_answers.index_by(&:form_field_id)
+        answer = ->(identifier) { (id = field_ids[identifier]) && answers[id]&.submitted_answer }
         {
           submission: submission,
-          org_name: name_field_id && answers[name_field_id]&.submitted_answer,
-          position: position_field_id && answers[position_field_id]&.submitted_answer
+          org_name: answer.call("agency_name"),
+          position: answer.call("agency_position"),
+          address: {
+            street_address: answer.call("agency_street"),
+            city: answer.call("agency_city"),
+            state: answer.call("agency_state"),
+            zip_code: answer.call("agency_zip"),
+            country: answer.call("agency_country")
+          }
         }
       end
 
@@ -430,5 +426,31 @@ class EventRegistrationsController < ApplicationController
     entries = registration_submission_entries(registration)
     primary = entries.find { |entry| entry[:org_name].present? } || entries.first
     primary && primary[:position]
+  end
+
+  # The org address fields the registrant typed on the same "primary" submission
+  # used for the org name/position, as attrs for OrganizationServices::UpsertAddress.
+  def submitted_agency_address(registration)
+    entries = registration_submission_entries(registration)
+    primary = entries.find { |entry| entry[:org_name].present? } || entries.first
+    primary && primary[:address] || {}
+  end
+
+  # Upsert the linked org's work address from the registrant's submission and
+  # create the job + facilitator affiliations linked to it. Shared by the
+  # select-existing and create-new org-linking actions.
+  def link_affiliations_for(registration, organization)
+    organization_address = OrganizationServices::UpsertAddress.call(
+      organization: organization,
+      **submitted_agency_address(registration)
+    )
+
+    AffiliationServices::CreateFromRegistration.call(
+      person: registration.registrant,
+      organization: organization,
+      job_title: submitted_position(registration),
+      training_date: registration.event.start_date,
+      organization_address: organization_address
+    )
   end
 end

--- a/app/services/affiliation_services/create_from_registration.rb
+++ b/app/services/affiliation_services/create_from_registration.rb
@@ -22,15 +22,16 @@ module AffiliationServices
   # (they may have been with the org for years before this training), and dating it
   # to registration would misrepresent that.
   class CreateFromRegistration
-    def self.call(person:, organization:, job_title: nil, training_date: nil)
-      new(person:, organization:, job_title:, training_date:).call
+    def self.call(person:, organization:, job_title: nil, training_date: nil, organization_address: nil)
+      new(person:, organization:, job_title:, training_date:, organization_address:).call
     end
 
-    def initialize(person:, organization:, job_title: nil, training_date: nil)
+    def initialize(person:, organization:, job_title: nil, training_date: nil, organization_address: nil)
       @person = person
       @organization = organization
       @job_title = job_title.presence&.strip
       @training_date = training_date
+      @organization_address = organization_address
     end
 
     def call
@@ -44,27 +45,48 @@ module AffiliationServices
 
     def create_job_affiliation
       return unless @job_title
-      return if active_or_pending_affiliation_with_title?(@job_title)
+
+      existing = active_or_pending_affiliations_with_title(@job_title)
+      return backfill_address(existing) if existing.exists?
 
       create_affiliation(@job_title, start_date: nil)
     end
 
     def create_facilitator_affiliation
-      return if active_or_pending_facilitator_affiliation?
+      existing = active_or_pending_facilitator_affiliations
+      return backfill_address(existing) if existing.exists?
 
       create_affiliation(Affiliation::FACILITATOR_TITLE, start_date: facilitator_start_date)
     end
 
+    # When we'd otherwise skip creating an affiliation because an active-or-pending
+    # one already exists, still link this registration's organization address onto
+    # any of those affiliations that don't have one yet. We only fill the blank —
+    # an address an admin set deliberately (via the affiliation address picker) is
+    # left untouched. No-op when this registration carried no organization address.
+    def backfill_address(affiliations)
+      return unless @organization_address
+
+      affiliations.where(organization_address_id: nil).find_each do |affiliation|
+        affiliation.update!(organization_address: @organization_address)
+      end
+    end
+
     def create_affiliation(title, start_date:)
-      @person.affiliations.create!(organization: @organization, title: title, start_date: start_date)
+      @person.affiliations.create!(
+        organization: @organization,
+        title: title,
+        start_date: start_date,
+        organization_address: @organization_address
+      )
     end
 
     def facilitator_start_date
       (@training_date || Date.current).to_date.beginning_of_month
     end
 
-    def active_or_pending_affiliation_with_title?(title)
-      @person.affiliations.active_or_pending.where(organization: @organization, title: title).exists?
+    def active_or_pending_affiliations_with_title(title)
+      @person.affiliations.active_or_pending.where(organization: @organization, title: title)
     end
 
     # Uses the model's canonical `facilitators` scope (exactly "Facilitator",
@@ -72,8 +94,8 @@ module AffiliationServices
     # the app on what counts as a facilitator affiliation. Counts pending
     # (future-dated) facilitator affiliations too, so registering for a second
     # upcoming training doesn't mint a duplicate.
-    def active_or_pending_facilitator_affiliation?
-      @person.affiliations.active_or_pending.facilitators.where(organization: @organization).exists?
+    def active_or_pending_facilitator_affiliations
+      @person.affiliations.active_or_pending.facilitators.where(organization: @organization)
     end
   end
 end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -52,9 +52,9 @@ module EventRegistrationServices
 
         organization = find_organization if field_value(ORGANIZATION_NAME_IDENTIFIER).present?
         if organization
-          create_affiliation(person, organization)
           sync_organization_profile(organization)
-          create_agency_address(organization) if field_value("agency_city").present?
+          agency_address = create_agency_address(organization)
+          create_affiliation(person, organization, agency_address)
         end
 
         assign_tags(person, organization)
@@ -302,49 +302,24 @@ module EventRegistrationServices
         .find_or_create_by!(organization: organization)
     end
 
-    def create_affiliation(person, organization)
+    def create_affiliation(person, organization, organization_address = nil)
       AffiliationServices::CreateFromRegistration.call(
         person: person,
         organization: organization,
         job_title: field_value(ORGANIZATION_POSITION_IDENTIFIER),
-        training_date: @event.start_date
+        training_date: @event.start_date,
+        organization_address: organization_address
       )
     end
 
     def create_agency_address(organization)
-      new_city = field_value("agency_city")&.strip
-      new_state = field_value("agency_state")&.strip
-
-      existing = organization.addresses.find_by(
-        "LOWER(city) = ? AND LOWER(COALESCE(state, '')) = ?",
-        new_city&.downcase, new_state&.downcase.to_s
-      )
-
-      # Unlike a person's mailing address, an organization accumulates work
-      # addresses from every registrant, so we never demote its existing primary:
-      # a registrant's address becomes primary only when the org has none yet.
-      make_primary = organization.addresses.active.where(primary: true).none?
-
-      if existing
-        existing.update!(
-          street_address: field_value("agency_street"),
-          zip_code: field_value("agency_zip"),
-          primary: existing.primary? || make_primary,
-          inactive: false
-        )
-        apply_value(existing, :country, field_value("agency_country"))
-        return existing
-      end
-
-      organization.addresses.create!(
+      OrganizationServices::UpsertAddress.call(
+        organization: organization,
         street_address: field_value("agency_street"),
-        city: new_city,
-        state: new_state,
+        city: field_value("agency_city"),
+        state: field_value("agency_state"),
         zip_code: field_value("agency_zip"),
-        country: field_value("agency_country")&.strip,
-        locality: "Unknown",
-        address_type: "work",
-        primary: make_primary
+        country: field_value("agency_country")
       )
     end
 

--- a/app/services/organization_services/upsert_address.rb
+++ b/app/services/organization_services/upsert_address.rb
@@ -1,0 +1,61 @@
+module OrganizationServices
+  # Find-or-create an organization's work address from a registrant's submitted
+  # agency address fields. When the org already has an address in the same
+  # city/state, update it in place; otherwise add a new "work" address.
+  #
+  # Unlike a person's mailing address, an organization accumulates work addresses
+  # from every registrant, so we never demote its existing primary: a registrant's
+  # address becomes primary only when the org has none yet.
+  #
+  # Shared by the public registration flow and the admin org-linking actions so
+  # both build the org address identically. Returns the Address, or nil when no
+  # city was given (we key addresses on city, so a blank city means there is
+  # nothing to save).
+  class UpsertAddress
+    def self.call(organization:, city: nil, state: nil, street_address: nil, zip_code: nil, country: nil)
+      new(organization:, city:, state:, street_address:, zip_code:, country:).call
+    end
+
+    def initialize(organization:, city: nil, state: nil, street_address: nil, zip_code: nil, country: nil)
+      @organization = organization
+      @city = city&.strip
+      @state = state&.strip
+      @street_address = street_address
+      @zip_code = zip_code
+      @country = country&.strip
+    end
+
+    def call
+      return if @city.blank?
+
+      existing = @organization.addresses.find_by(
+        "LOWER(city) = ? AND LOWER(COALESCE(state, '')) = ?",
+        @city.downcase, @state&.downcase.to_s
+      )
+
+      make_primary = @organization.addresses.active.where(primary: true).none?
+
+      if existing
+        existing.update!(
+          street_address: @street_address,
+          zip_code: @zip_code,
+          primary: existing.primary? || make_primary,
+          inactive: false
+        )
+        existing.update!(country: @country) if @country.present?
+        return existing
+      end
+
+      @organization.addresses.create!(
+        street_address: @street_address,
+        city: @city,
+        state: @state,
+        zip_code: @zip_code,
+        country: @country,
+        locality: "Unknown",
+        address_type: "work",
+        primary: make_primary
+      )
+    end
+  end
+end

--- a/app/services/organization_services/upsert_address.rb
+++ b/app/services/organization_services/upsert_address.rb
@@ -19,10 +19,10 @@ module OrganizationServices
     def initialize(organization:, city: nil, state: nil, street_address: nil, zip_code: nil, country: nil)
       @organization = organization
       @city = city&.strip
-      @state = state&.strip
+      @state = state&.strip.presence
       @street_address = street_address
       @zip_code = zip_code
-      @country = country&.strip
+      @country = country&.strip.presence
     end
 
     def call

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -729,6 +729,25 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
             .to contain_exactly("Facilitator")
         end
+
+        it "builds the org address from the submission and links the affiliations to it" do
+          reg_form = create(:form, name: "Reg form")
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          { "agency_street" => "1 Main St", "agency_city" => "Austin", "agency_state" => "TX", "agency_zip" => "78701", "agency_country" => "USA" }.each do |identifier, value|
+            field = create(:form_field, form: reg_form, field_identifier: identifier)
+            create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+          end
+
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          address = organization.addresses.find_by(city: "Austin")
+          expect(address).to be_present
+          expect(address.country).to eq("USA")
+          expect(regular_user.person.affiliations.where(organization: organization).map(&:organization_address))
+            .to all(eq(address))
+        end
       end
 
       describe "POST /event_registrations/:id/create_organization" do
@@ -763,6 +782,27 @@ RSpec.describe "EventRegistrations", type: :request do
           organization = Organization.find_by(name: "Brand New Org")
           expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
             .to contain_exactly("Counselor", "Facilitator")
+        end
+
+        it "builds the new org's address from the submission and links the affiliations to it" do
+          create(:organization_status, name: "Active")
+          reg_form = create(:form, name: "Reg form")
+          name_field = create(:form_field, form: reg_form, field_identifier: EventRegistrationServices::PublicRegistration::ORGANIZATION_NAME_IDENTIFIER)
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: name_field, submitted_answer: "Brand New Org")
+          { "agency_street" => "1 Main St", "agency_city" => "Austin", "agency_state" => "TX", "agency_zip" => "78701" }.each do |identifier, value|
+            field = create(:form_field, form: reg_form, field_identifier: identifier)
+            create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
+          end
+
+          post create_organization_event_registration_path(existing_registration)
+
+          organization = Organization.find_by(name: "Brand New Org")
+          address = organization.addresses.find_by(city: "Austin")
+          expect(address).to be_present
+          expect(regular_user.person.affiliations.where(organization: organization).map(&:organization_address))
+            .to all(eq(address))
         end
 
         it "links an existing org instead of creating a duplicate" do

--- a/spec/services/affiliation_services/create_from_registration_spec.rb
+++ b/spec/services/affiliation_services/create_from_registration_spec.rb
@@ -82,6 +82,61 @@ RSpec.describe AffiliationServices::CreateFromRegistration do
     expect(titles).to contain_exactly("Counselor", "Facilitator")
   end
 
+  it "links every created affiliation to the given organization address" do
+    address = create(:address, addressable: organization)
+
+    described_class.call(person: person, organization: organization,
+                         job_title: "Counselor", organization_address: address)
+
+    linked = person.affiliations.where(organization: organization)
+    expect(linked.pluck(:title)).to contain_exactly("Counselor", "Facilitator")
+    expect(linked.map(&:organization_address)).to all(eq(address))
+  end
+
+  it "leaves the organization address nil when none is given" do
+    described_class.call(person: person, organization: organization, job_title: "Counselor")
+
+    expect(person.affiliations.where(organization: organization).map(&:organization_address)).to all(be_nil)
+  end
+
+  describe "backfilling the organization address onto an affiliation that already exists" do
+    let(:address) { create(:address, addressable: organization) }
+
+    it "links the address to an existing job affiliation that has none, instead of skipping it" do
+      job = create(:affiliation, person: person, organization: organization, title: "Counselor", organization_address: nil)
+
+      described_class.call(person: person, organization: organization,
+                           job_title: "Counselor", organization_address: address)
+
+      expect(job.reload.organization_address).to eq(address)
+    end
+
+    it "links the address to an existing facilitator affiliation that has none" do
+      facilitator = create(:affiliation, person: person, organization: organization, title: "Facilitator", organization_address: nil)
+
+      described_class.call(person: person, organization: organization, organization_address: address)
+
+      expect(facilitator.reload.organization_address).to eq(address)
+    end
+
+    it "does not overwrite an address the affiliation already has" do
+      other = create(:address, addressable: organization)
+      facilitator = create(:affiliation, person: person, organization: organization, title: "Facilitator", organization_address: other)
+
+      described_class.call(person: person, organization: organization, organization_address: address)
+
+      expect(facilitator.reload.organization_address).to eq(other)
+    end
+
+    it "leaves the existing affiliation's address nil when no address is given" do
+      facilitator = create(:affiliation, person: person, organization: organization, title: "Facilitator", organization_address: nil)
+
+      described_class.call(person: person, organization: organization)
+
+      expect(facilitator.reload.organization_address).to be_nil
+    end
+  end
+
   it "leaves the job affiliation without a start date" do
     described_class.call(person: person, organization: organization, job_title: "Counselor")
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -49,6 +49,33 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(person.affiliations.where(organization: organization).pluck(:title))
         .to contain_exactly("Facilitator")
     end
+
+    it "links the created affiliations to the agency address built from the form" do
+      params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
+        field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => "Helping Hands",
+        field_id(described_class::ORGANIZATION_POSITION_IDENTIFIER) => "Counselor",
+        field_id("agency_street") => "1 Main St",
+        field_id("agency_city") => "Austin",
+        field_id("agency_state") => "TX",
+        field_id("agency_zip") => "78701",
+        field_id("agency_country") => "USA"
+      )
+      described_class.call(event: event, form: form, form_params: params)
+      person = Person.find_by(email: "sam@example.com")
+
+      address = organization.addresses.find_by(city: "Austin")
+      expect(address).to be_present
+      expect(address.country).to eq("USA")
+      linked = person.affiliations.where(organization: organization)
+      expect(linked.pluck(:title)).to contain_exactly("Counselor", "Facilitator")
+      expect(linked.map(&:organization_address)).to all(eq(address))
+    end
+
+    it "leaves the affiliations' organization address nil when no agency city was typed" do
+      person = register_with(position: "Counselor")
+
+      expect(person.affiliations.where(organization: organization).map(&:organization_address)).to all(be_nil)
+    end
   end
 
   describe "registration organizations" do

--- a/spec/services/organization_services/upsert_address_spec.rb
+++ b/spec/services/organization_services/upsert_address_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe OrganizationServices::UpsertAddress do
+  let(:organization) { create(:organization) }
+
+  it "creates a primary work address from the submitted fields" do
+    address = described_class.call(
+      organization: organization,
+      street_address: "1 Main St",
+      city: "Austin",
+      state: "TX",
+      zip_code: "78701",
+      country: "USA"
+    )
+
+    expect(address).to have_attributes(
+      addressable: organization,
+      street_address: "1 Main St",
+      city: "Austin",
+      state: "TX",
+      zip_code: "78701",
+      country: "USA",
+      address_type: "work",
+      primary: true
+    )
+  end
+
+  it "returns nil and creates nothing when no city is given" do
+    expect {
+      expect(described_class.call(organization: organization, street_address: "1 Main St")).to be_nil
+    }.not_to change { organization.addresses.count }
+  end
+
+  it "updates the matching city/state address in place instead of duplicating" do
+    existing = create(:address, addressable: organization, city: "Austin", state: "TX", primary: true)
+
+    result = described_class.call(
+      organization: organization,
+      street_address: "2 New Ave",
+      city: "austin",
+      state: "tx",
+      zip_code: "78702",
+      country: "Canada"
+    )
+
+    expect(result).to eq(existing)
+    expect(organization.addresses.count).to eq(1)
+    expect(existing.reload).to have_attributes(street_address: "2 New Ave", zip_code: "78702", country: "Canada", primary: true, inactive: false)
+  end
+
+  it "leaves the org's existing primary intact and adds the new-city address as non-primary" do
+    old_primary = create(:address, addressable: organization, city: "Dallas", state: "TX", primary: true)
+
+    described_class.call(organization: organization, street_address: "1 Main St", city: "Austin", state: "TX", zip_code: "78701")
+
+    expect(old_primary.reload).to have_attributes(primary: true, inactive: false)
+    expect(organization.addresses.find_by(city: "Austin")).to have_attributes(primary: false)
+  end
+end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — contained logic across three flows plus one new seed field; well covered by specs

Connect an affiliation to its org's address automatically (instead of only via the manual picker from #1818), and make sure the full agency address — including country — flows through.

## Why
A registrant types their agency address on the form (and an admin links/creates the org from that submission), but `affiliation.organization_address` was never set, and the typed **country** never reached the address at all.

## What
- **`OrganizationServices::UpsertAddress`** (new) — extracts the agency-address find-or-create/update out of `PublicRegistration` so registration and the admin org-linking actions build the org address identically (street/city/state/zip/**country**).
- **`CreateFromRegistration`** accepts `organization_address:` and sets it on every affiliation it creates; when an affiliation already exists and is skipped, it **backfills** the address onto it only if it has none (never overwrites an admin-set address).
- **Wired at all three entry points:** public registration, select-existing-org, create-new-org.
- **`agency_country`** added to the registration-form seed builder (prod already collects it; the seed was missing it) and threaded into the upsert so it lands on `addresses.country`.

## Tests
- New `UpsertAddress` spec (incl. country on create + update); affiliation-service backfill specs; public-registration + request specs asserting affiliations link to the built address and country is captured; form-builder seed spec for the new field.
