### PR TITLE
Match returning registrants across a nickname/legal first-name swap

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -129,10 +129,7 @@ module EventRegistrationServices
       email = field_value("primary_email")&.strip&.downcase
       email_type = field_value("primary_email_type")&.downcase
 
-      person = Person.find_by(
-        "LOWER(first_name) = ? AND LOWER(last_name) = ? AND LOWER(email) = ?",
-        first_name&.downcase, last_name&.downcase, email&.downcase
-      )
+      person = find_matching_person(last_name: last_name, email: email)
       return person if person
 
       Person.create!(
@@ -145,6 +142,28 @@ module EventRegistrationServices
         email_2: field_value("secondary_email")&.strip,
         email_2_type: field_value("secondary_email_type")&.downcase,
       )
+    end
+
+    # Find the existing registrant this submission belongs to, tolerating a
+    # first-name / nickname swap. We match on email + last name (both strong,
+    # stable identifiers) and accept either the typed first name or the nickname
+    # against either the stored first_name or legal_first_name. Without this, a
+    # returning registrant who types their legal name when we stored their
+    # nickname (or vice versa) slips past the match and registers as a duplicate
+    # Person. Anonymous (incognito) registrations rely on this; logged-in ones
+    # already arrive with @person set and never reach here.
+    def find_matching_person(last_name:, email:)
+      return if email.blank? || last_name.blank?
+
+      first_names = [ field_value("first_name"), field_value("nickname") ]
+        .filter_map { |value| value&.strip.presence&.downcase }
+        .uniq
+      return if first_names.empty?
+
+      Person
+        .where("LOWER(last_name) = ? AND LOWER(email) = ?", last_name.downcase, email.downcase)
+        .where("LOWER(first_name) IN (:names) OR LOWER(COALESCE(legal_first_name, '')) IN (:names)", names: first_names)
+        .first
     end
 
     def create_mailing_address(person)

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -51,6 +51,46 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "matching an existing registrant by name" do
+    it "matches a person stored under a nickname when the registrant types their legal first name" do
+      existing = create(:person, first_name: "Bob", legal_first_name: "Robert",
+                                 last_name: "Smith", email: "bob@example.com")
+
+      params = base_form_params(first_name: "Robert", last_name: "Smith", email: "bob@example.com")
+
+      expect {
+        described_class.call(event: event, form: form, form_params: params)
+      }.not_to change(Person, :count)
+
+      expect(EventRegistration.last.registrant).to eq(existing)
+    end
+
+    it "matches a person stored under a legal name when the registrant types their nickname" do
+      existing = create(:person, first_name: "Robert", legal_first_name: nil,
+                                 last_name: "Smith", email: "bob@example.com")
+
+      params = base_form_params(first_name: "Robert", last_name: "Smith", email: "bob@example.com").merge(
+        field_id("nickname") => "Bob"
+      )
+
+      expect {
+        described_class.call(event: event, form: form, form_params: params)
+      }.not_to change(Person, :count)
+
+      expect(EventRegistration.last.registrant).to eq(existing)
+    end
+
+    it "still creates a new person when the email matches but it is a different name" do
+      create(:person, first_name: "Bob", last_name: "Smith", email: "shared@example.com")
+
+      params = base_form_params(first_name: "Dana", last_name: "Jones", email: "shared@example.com")
+
+      expect {
+        described_class.call(event: event, form: form, form_params: params)
+      }.to change(Person, :count).by(1)
+    end
+  end
+
   describe "an answer longer than its database column" do
     # `city` (like the other mapped person/address columns) is a varchar(255).
     # A longer answer must surface as a form error, not an ActiveRecord::ValueTooLong


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — small, contained change to one matching method, covered by specs

Stop incognito registrations from creating duplicate people when the registrant's first name and nickname swap places.

## Why
Anonymous registrations match an existing `Person` by exact `first_name + last_name + email`. The registrant's "first name" is the **nickname** when they give one (`resolve_names`), so a returning person who types their legal first name where we stored their nickname — or the reverse — slips past the match and registers as a **duplicate Person**. Logged-in registrations are unaffected (they arrive with the person already resolved).

## What
`find_matching_person` now matches on **email + last name** (strong, stable identifiers) and accepts **either** the typed first name **or** the nickname against **either** the stored `first_name` **or** `legal_first_name`.

This only *widens* the previous match — every registrant that matched before still matches — so there's no risk of a returning person newly being treated as new. The last-name + email gate keeps it from merging genuinely different people who happen to share an email.

## Tests
- Matches a nickname-stored person who types their legal name, and the reverse.
- Still creates a new person when the email matches but it's a different name (guard against over-merging).
