### PR TITLE
WAIT: Match interstitial duplicates on legal first name too

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -293,16 +293,26 @@ class PeopleController < ApplicationController
       normalized_last = NicknameMap.normalize(last_name)
       normalized_first = NicknameMap.normalize(first_name)
 
+      # Match the typed first name (and its nickname variants) against either the
+      # stored first_name or legal_first_name, so a returning registrant whose legal
+      # name lives in legal_first_name (nickname in first_name) is still surfaced when
+      # they type their legal name. Mirrors the registration matcher in
+      # EventRegistrationServices::PublicRegistration#find_matching_person.
       name_matches = Person.includes(:user)
                            .where("REPLACE(REPLACE(LOWER(last_name), '.', ''), ' ', '') = ?", normalized_last)
-                           .where("REPLACE(REPLACE(LOWER(first_name), '.', ''), ' ', '') IN (?)", first_variants)
+                           .where(
+                             "REPLACE(REPLACE(LOWER(first_name), '.', ''), ' ', '') IN (:names) " \
+                             "OR REPLACE(REPLACE(LOWER(COALESCE(legal_first_name, '')), '.', ''), ' ', '') IN (:names)",
+                             names: first_variants
+                           )
                            .limit(10)
 
       name_matches.each do |person|
         next if duplicate_ids.include?(person.id)
 
         duplicate_ids.add(person.id)
-        exact_name = NicknameMap.normalize(person.first_name) == normalized_first
+        exact_name = NicknameMap.normalize(person.first_name) == normalized_first ||
+          NicknameMap.normalize(person.legal_first_name) == normalized_first
         duplicates << format_duplicate(person, exact: exact_name, entered_email: email)
       end
     end

--- a/spec/requests/people_check_duplicates_spec.rb
+++ b/spec/requests/people_check_duplicates_spec.rb
@@ -63,6 +63,39 @@ RSpec.describe "/people/check_duplicates", type: :request do
       end
     end
 
+    # --- Legal first name matching ---
+
+    context "when the entered first name matches a stored legal first name" do
+      before do
+        create(:person, first_name: "Sunny", legal_first_name: "Yuki", last_name: "Tanaka")
+      end
+
+      it "matches a returning registrant who types their legal name" do
+        get check_duplicates_people_path, params: { first_name: "Yuki", last_name: "Tanaka", email: "" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Sunny Tanaka")
+        expect(response.body).to include("name match")
+      end
+
+      it "matches the legal name through period normalization" do
+        create(:person, first_name: "Beanie", legal_first_name: "J.J.", last_name: "Park")
+
+        get check_duplicates_people_path, params: { first_name: "JJ", last_name: "Park", email: "" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Beanie Park")
+        expect(response.body).to include("name match")
+      end
+
+      it "does not match when neither first nor legal name matches" do
+        get check_duplicates_people_path, params: { first_name: "Kenji", last_name: "Tanaka", email: "" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Sunny Tanaka")
+      end
+    end
+
     # --- Period and space normalization ---
 
     context "when names contain periods or extra spaces" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained change to the duplicate-person name query

### What is the goal of this PR and why is this important?
The new-person duplicate interstitial matched the typed first name (and its nickname variants) only against the stored `first_name` column. A returning registrant whose legal name lives in `legal_first_name` (nickname in `first_name`) who types their legal name slipped past the name check — the exact duplicate the interstitial exists to surface.

This is the follow-up to the registration-side fix (`PublicRegistration#find_matching_person`), ported the other direction: high-recall instead of swapping in the conservative matcher.

### How did you approach the change?
- Match the first-name variants against **either** `first_name` **or** `legal_first_name` (period/space normalized, mirroring the existing column normalization).
- Count a legal-name hit as an exact name match so the "name match" badge and sort order behave like a first-name hit.
- Failing test first (red/green): added a "Legal first name matching" context to the request spec.

### Anything else to add?
Kept the interstitial's own normalization (strip `.`/spaces, nickname variants) rather than the registration matcher's plain `LOWER` — fully aligning the two normalizations is a separate, larger change and isn't needed to close this duplicate.