### PR TITLE
Match seeded reg/scholarship forms to the real AWBW training form

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -212,8 +212,8 @@ module ApplicationHelper
   # values for these is mirrored by FormField#allowed_answer_values.
   def dynamic_form_field_options(field)
     case field.field_identifier
-    when *FormField::SERVICE_AREA_FIELD_IDENTIFIERS
-      field.service_area_sectors.map { |sector| [ sector.name, sector.id.to_s, sector.description ] }
+    when *FormField::SECTOR_FIELD_IDENTIFIERS
+      field.sector_options.map { |sector| [ sector.name, sector.id.to_s, sector.description ] }
     when *FormField::DYNAMIC_FIELD_CATEGORY_TYPES.keys
       field.dynamic_categories.map { |category| [ category.name, category.id.to_s, category.description ] }
     end
@@ -236,7 +236,7 @@ module ApplicationHelper
   # editor badge: a sentence-case label and a link to the filtered admin list
   # that manages those options. Returns nil for fields with stored options.
   def form_field_option_source(field)
-    if field.field_identifier.in?(FormField::SERVICE_AREA_FIELD_IDENTIFIERS)
+    if field.field_identifier.in?(FormField::SECTOR_FIELD_IDENTIFIERS)
       { label: "Sectors", path: sectors_path }
     elsif (type_name = FormField::DYNAMIC_FIELD_CATEGORY_TYPES[field.field_identifier])
       type = CategoryType.find_by(name: type_name)

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -141,7 +141,7 @@ module EventHelper
             .join(", ").presence || submitted_answer
     }
     case field&.field_identifier
-    when "primary_service_area", "primary_service_area_single"
+    when *FormField::SECTOR_FIELD_IDENTIFIERS
       resolve.call(Sector)
     when "primary_age_group", "additional_age_group"
       resolve.call(Category)

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -15,15 +15,20 @@ class FormField < ApplicationRecord
   # "required" flag is meaningless for them (nothing to fill in).
   NON_INPUT_ANSWER_TYPES = %w[no_user_input group_header].freeze
 
+  # Multi-select "additional sectors" field identifiers. The current "sector"
+  # name and the legacy "service area" name are both accepted so existing form
+  # data keeps resolving.
+  ADDITIONAL_SECTOR_FIELD_IDENTIFIERS = %w[primary_sector primary_service_area].freeze
+
+  # Single-select "primary sector" field identifiers (current + legacy). Unlike
+  # the multi-select "additional" field, these omit the catch-all "Other" sector
+  # — a respondent's primary sector must be a concrete sector.
+  PRIMARY_SECTOR_FIELD_IDENTIFIERS = %w[primary_sector_single primary_service_area_single].freeze
+
   # Field identifiers whose selectable options are sourced dynamically from
   # Sector records rather than the field's own stored answer options. The
   # submitted value for these is a Sector id (as a string).
-  SERVICE_AREA_FIELD_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
-
-  # The single-select "primary" service-area field. Unlike the multi-select
-  # "additional" field, it omits the catch-all "Other" sector — a respondent's
-  # primary service area must be a concrete sector.
-  PRIMARY_SERVICE_AREA_FIELD_IDENTIFIER = "primary_service_area_single"
+  SECTOR_FIELD_IDENTIFIERS = (ADDITIONAL_SECTOR_FIELD_IDENTIFIERS + PRIMARY_SECTOR_FIELD_IDENTIFIERS).freeze
 
   # Field identifiers whose selectable options are sourced dynamically from a
   # CategoryType's published categories. The submitted value is a Category id
@@ -291,7 +296,7 @@ class FormField < ApplicationRecord
   # True when this field's selectable options come from Sector/Category data
   # rather than its own stored answer options. Dynamic fields never offer "Other".
   def dynamic_options?
-    field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS) ||
+    field_identifier.in?(SECTOR_FIELD_IDENTIFIERS) ||
       DYNAMIC_FIELD_CATEGORY_TYPES.key?(field_identifier)
   end
 
@@ -302,8 +307,8 @@ class FormField < ApplicationRecord
   def allowed_answer_values
     return unless selectable?
 
-    values = if field_identifier.in?(SERVICE_AREA_FIELD_IDENTIFIERS)
-      service_area_sectors.pluck(:id).map(&:to_s)
+    values = if field_identifier.in?(SECTOR_FIELD_IDENTIFIERS)
+      sector_options.pluck(:id).map(&:to_s)
     elsif DYNAMIC_FIELD_CATEGORY_TYPES.key?(field_identifier)
       dynamic_categories.pluck(:id).map(&:to_s)
     else
@@ -313,13 +318,13 @@ class FormField < ApplicationRecord
     values.to_set
   end
 
-  # The published Sector records a service-area field offers, in name order. The
+  # The published Sector records a sector-backed field offers, in name order. The
   # single-select "primary" field omits the catch-all "Other" sector; the
   # multi-select "additional" field includes it. Source of truth shared by the
   # public form's rendering and submission validation.
-  def service_area_sectors
+  def sector_options
     scope = Sector.published.order(:name)
-    field_identifier == PRIMARY_SERVICE_AREA_FIELD_IDENTIFIER ? scope.excluding_other : scope
+    field_identifier.in?(PRIMARY_SECTOR_FIELD_IDENTIFIERS) ? scope.excluding_other : scope
   end
 
   # The published Category records a category-backed dynamic field offers, in

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -228,16 +228,14 @@ class Person < ApplicationRecord
     }
   end
 
-  # Field identifiers whose "Other" free text maps onto the profile's sectors.
-  OTHER_SERVICE_AREA_IDENTIFIERS = %w[primary_service_area primary_service_area_single].freeze
   # Field identifiers whose "Other" free text maps onto the category-backed
   # profile fields shown on the edit page.
   OTHER_WORKSHOP_SETTING_IDENTIFIERS = %w[primary_age_group additional_age_group].freeze
 
-  # Free-text "Other" service areas the person typed on registration forms.
+  # Free-text "Other" sectors the person typed on registration forms.
   # They can't be Sector records, so they're surfaced beside the sector tags.
   def other_service_area_responses
-    other_form_responses(OTHER_SERVICE_AREA_IDENTIFIERS)
+    other_form_responses(FormField::SECTOR_FIELD_IDENTIFIERS)
   end
 
   # Free-text "Other" workshop settings (category-backed fields) from forms.

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -43,8 +43,13 @@ class EventDashboard
 
   # Professional-info answers shown in each recipient's header. The view falls
   # back to the person's profile (sectors / age-range tags) when these aren't on
-  # file as form answers.
-  HEADER_ANSWER_IDENTIFIERS = %w[primary_service_area primary_age_group].freeze
+  # file as form answers. Sector answers are normalized under the "sector" key
+  # (see #header_answers_by_applicant) so the view reads one key regardless of
+  # which sector field identifier the answer was stored under.
+  HEADER_ANSWER_IDENTIFIERS = (FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS + %w[primary_age_group]).freeze
+
+  # The key sector answers are filed under in the per-applicant header hash.
+  HEADER_SECTOR_KEY = "sector".freeze
 
   # Active registrants who requested a scholarship for this event, as Person
   # records sorted by display name. Sectors, age-range tags, and affiliations are
@@ -70,12 +75,20 @@ class EventDashboard
       .transform_values { |answers| dedupe_answers(answers) }
   end
 
-  # primary_service_area / primary_age_group answers for the recipients page
-  # header, keyed by Person id then by field identifier (one answer each). Same
-  # cross-submission gathering as scholarship_answers_by_applicant.
+  # Sector / primary_age_group answers for the recipients page header, keyed by
+  # Person id then by header key (one answer each). Sector answers (whichever
+  # sector field identifier they used) are filed under HEADER_SECTOR_KEY so the
+  # view reads a single, stable key. Same cross-submission gathering as
+  # scholarship_answers_by_applicant.
   def header_answers_by_applicant
     @header_answers_by_applicant ||= applicant_answers_for(HEADER_ANSWER_IDENTIFIERS)
-      .transform_values { |answers| answers.index_by { |answer| answer.form_field&.field_identifier } }
+      .transform_values { |answers| answers.index_by { |answer| header_answer_key(answer.form_field&.field_identifier) } }
+  end
+
+  # Normalizes a header answer's field identifier to its lookup key: every sector
+  # field collapses to HEADER_SECTOR_KEY; other identifiers pass through.
+  def header_answer_key(identifier)
+    identifier.in?(FormField::SECTOR_FIELD_IDENTIFIERS) ? HEADER_SECTOR_KEY : identifier
   end
 
   # A "shout out": a registrant the admin opted in (shoutout on their
@@ -365,7 +378,7 @@ class EventDashboard
 
   # Registrant ids per primary sector, for the chart's per-row drill-in links.
   def primary_sector_registrant_ids_by_sector
-    @primary_sector_registrant_ids_by_sector ||= primary_service_area_rows
+    @primary_sector_registrant_ids_by_sector ||= primary_sector_rows
       .group_by(&:last)
       .transform_values { |rows| rows.map(&:first).uniq }
   end
@@ -834,7 +847,7 @@ class EventDashboard
   # Distinct sector ids registrants named as their primary sector, limited
   # to sectors actually represented among registrants.
   def primary_sector_ids
-    @primary_sector_ids ||= primary_service_area_rows.map(&:last).uniq & registrant_sector_ids
+    @primary_sector_ids ||= primary_sector_rows.map(&:last).uniq & registrant_sector_ids
   end
 
   # Distinct sectors a registrant has as a tag without having named that sector as
@@ -842,7 +855,7 @@ class EventDashboard
   # primary for one registrant and additional for another.
   def additional_sector_ids
     @additional_sector_ids ||= begin
-      primary_pairs = primary_service_area_rows.to_set
+      primary_pairs = primary_sector_rows.to_set
       registrant_sector_pairs.reject { |pair| primary_pairs.include?(pair) }.map(&:last).uniq
     end
   end
@@ -856,10 +869,10 @@ class EventDashboard
   end
 
   # [ person_id, sector_id ] pairs from registrants' primary sector answers.
-  # Read from the single-select dropdown ("primary_service_area_single"); the
-  # checkbox "primary_service_area" field collects the Additional sectors.
-  def primary_service_area_rows
-    field = registration_form_field("primary_service_area_single")
+  # Read from the single-select dropdown (PRIMARY_SECTOR_FIELD_IDENTIFIERS); the
+  # multi-select checkbox field collects the Additional sectors.
+  def primary_sector_rows
+    field = registration_form_field(FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS)
     return [] unless field
 
     FormAnswer

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -273,8 +273,7 @@ module EventRegistrationServices
     end
 
     def assign_tags(person, organization)
-      sector_ids = collect_ids_from_checkboxes("primary_service_area_single") +
-                   collect_ids_from_checkboxes("primary_service_area")
+      sector_ids = FormField::SECTOR_FIELD_IDENTIFIERS.flat_map { |id| collect_ids_from_checkboxes(id) }
       primary_age_ids = collect_ids_from_checkboxes("primary_age_group")
       additional_age_ids = collect_ids_from_checkboxes("additional_age_group")
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -44,14 +44,14 @@ class FormBuilderService
     person_identifier: %w[first_name last_name primary_email confirm_email],
     person_contact_info: %w[
       primary_email_type nickname pronouns secondary_email secondary_email_type
-      mailing_street mailing_address_type mailing_city mailing_state mailing_zip
-      phone phone_type agency_name agency_position agency_street agency_city
-      agency_state agency_zip agency_type agency_website
+      mailing_street mailing_address_type mailing_city mailing_state mailing_zip mailing_country
+      phone phone_type agency_name agency_position agency_website agency_type
+      agency_street agency_city agency_state agency_zip agency_country
     ],
     person_background: %w[racial_ethnic_identity],
-    professional_info: %w[primary_service_area_single primary_service_area primary_age_group additional_age_group],
+    professional_info: %w[primary_sector_single primary_sector primary_age_group additional_age_group],
     marketing: %w[referral_source training_motivation interested_in_more],
-    scholarship: %w[scholarship_eligibility impact_description implementation_plan additional_comments],
+    scholarship: %w[scholarship_eligibility scholarship_contribution impact_description implementation_plan additional_comments],
     payment: %w[payment_method],
     consent: %w[communication_consent],
     post_event_feedback: %w[event_rating most_valuable improvement_suggestions],
@@ -65,7 +65,7 @@ class FormBuilderService
     person_background: [ "Background Information" ],
     professional_info: [ "Professional Information" ],
     marketing: [ "Marketing" ],
-    scholarship: [ "Scholarship Application" ],
+    scholarship: [ "Scholarship Application", "Your goals", "Anything else?" ],
     payment: [ "Payment Information" ],
     consent: [ "Consent" ],
     post_event_feedback: [ "Post-Event Feedback" ],
@@ -80,20 +80,21 @@ class FormBuilderService
     person_identifier: [ "First Name", "Last Name", "Email", "Confirm Email" ],
     person_contact_info: [
       "Primary Email Type", "Preferred Nickname", "Pronouns", "Secondary Email", "Secondary Email Type",
-      "Street Address", "Address Type", "City", "State / Province", "Zip / Postal Code",
-      "Phone", "Phone Type", "Organization Name", "Position / Title",
+      "Street Address", "Address Type", "City", "State / Province", "Zip / Postal Code", "Country",
+      "Phone", "Phone Type", "Organization Name", "Position / Title", "Organization Website", "Organization Type",
       "Organization Street Address", "Organization City", "Organization State / Province", "Organization Zip / Postal Code",
-      "Organization Type", "Organization Website"
+      "Organization Country"
     ],
-    person_background: [ "Racial / Ethnic Identity" ],
+    person_background: [ "How would you best describe yourself?" ],
     professional_info: [ "Primary sector", "Additional sectors", "Primary Age Group(s) Served", "Additional Age Group(s) Served" ],
     marketing: [
-      "How did you hear about this training?",
-      "What motivates you to attend this training?",
+      "How did you hear about this AWBW training?",
+      "What motivated you to sign up for AWBW's Facilitator Training?",
       "Are you interested in learning more about upcoming trainings or resources?"
     ],
     scholarship: [
-      "I / my agency cannot afford the full training cost and need a scholarship to attend.",
+      "I and/or my organization cannot afford the full training cost and need a scholarship to attend.",
+      "How much are you (and/or your organization) able to pay for this training?",
       "How will what you gain from this training directly impact the people you serve?",
       "Please describe one way in which you plan to use art workshops and how you envision it will help.",
       "Anything else you'd like to share with us?"
@@ -387,6 +388,8 @@ class FormBuilderService
                          key: "mailing_state", group: "person_contact_info", required: true, width: :third)
     position = add_field(form, position, "Zip / Postal Code", :free_form_input_one_line,
                          key: "mailing_zip", group: "person_contact_info", required: true, width: :third)
+    position = add_field(form, position, "Country", :free_form_input_one_line,
+                         key: "mailing_country", group: "person_contact_info", required: false)
 
     position = add_field(form, position, "Phone", :free_form_input_one_line,
                          key: "phone", group: "person_contact_info", required: true, width: :half)
@@ -399,6 +402,14 @@ class FormBuilderService
                          key: "agency_name", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Position / Title", :free_form_input_one_line,
                          key: "agency_position", group: "person_contact_info", required: false, width: :half)
+    position = add_field(form, position, "Organization Website", :free_form_input_one_line,
+                         key: "agency_website", group: "person_contact_info", required: false)
+    position = add_field(form, position, "Organization Type", :single_select_radio,
+                         key: "agency_type", group: "person_contact_info", required: false,
+                         options: [
+                           "501c3/nonprofit", "For-profit", "Government agency",
+                           "Other (please specify below)"
+                         ])
     position = add_field(form, position, "Organization Street Address", :free_form_input_one_line,
                          key: "agency_street", group: "person_contact_info", required: false)
     position = add_field(form, position, "Organization City", :free_form_input_one_line,
@@ -407,23 +418,26 @@ class FormBuilderService
                          key: "agency_state", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Organization Zip / Postal Code", :free_form_input_one_line,
                          key: "agency_zip", group: "person_contact_info", required: false, width: :third)
-    position = add_field(form, position, "Organization Type", :single_select_radio,
-                         key: "agency_type", group: "person_contact_info", required: false,
-                         options: [
-                           "501c3/nonprofit", "For-profit", "Government agency",
-                           "Other (please specify below)"
-                         ])
-    position = add_field(form, position, "Organization Website", :free_form_input_one_line,
-                         key: "agency_website", group: "person_contact_info", required: false)
+    position = add_field(form, position, "Organization Country", :free_form_input_one_line,
+                         key: "agency_country", group: "person_contact_info", required: false)
     position
   end
+
+  # Self-identified race/ethnicity options, mirroring the AWBW facilitator
+  # training form. Stored under the long-standing racial_ethnic_identity
+  # identifier so existing reporting keeps resolving.
+  RACIAL_ETHNIC_IDENTITY_OPTIONS = [
+    "Alaskan Native", "American Indian or Native American", "Asian",
+    "Black or African American", "Latinx", "Middle Eastern", "Multi-racial",
+    "Native Hawaiian or other Pacific Islander", "White"
+  ].freeze
 
   def build_person_background_fields(form, position)
     position = add_header(form, position, "Background Information", group: "background")
 
-    position = add_field(form, position, "Racial / Ethnic Identity", :free_form_input_one_line,
+    position = add_field(form, position, "How would you best describe yourself?", :single_select_radio,
                          key: "racial_ethnic_identity", group: "background", required: false,
-                         subtitle: "This information helps us understand the diversity of our community.")
+                         options: RACIAL_ETHNIC_IDENTITY_OPTIONS)
     position
   end
 
@@ -431,27 +445,53 @@ class FormBuilderService
     position = add_header(form, position, "Professional Information", group: "professional")
 
     position = add_field(form, position, "Primary sector", :single_select_dropdown,
-                         key: "primary_service_area_single", group: "professional", required: false,
+                         key: "primary_sector_single", group: "professional", required: false,
                          subtitle: "Select the option that best represents those you primarily intend to serve through the art workshops")
     position = add_field(form, position, "Additional sectors", :multi_select_checkbox,
-                         key: "primary_service_area", group: "professional", required: false,
+                         key: "primary_sector", group: "professional", required: false,
                          subtitle: "Select all options that represent who you intend to serve through the art workshops (check all that apply)")
-    position = add_field(form, position, "Primary Age Group(s) Served", :multi_select_checkbox,
+    position = add_field(form, position, "Primary Age Group(s) Served", :single_select_dropdown,
                          key: "primary_age_group", group: "professional", required: false,
-                         subtitle: "Select all age groups you primarily serve.")
+                         subtitle: "Select the age group you primarily intend to serve through the art workshops")
     position = add_field(form, position, "Additional Age Group(s) Served", :multi_select_checkbox,
                          key: "additional_age_group", group: "professional", required: false,
-                         subtitle: "Select all that apply. These represent the other age groups you serve.")
+                         subtitle: "Select all additional age groups you may serve through the art workshops (check all that apply)")
     position
   end
+
+  # Ways a registrant may have heard about the training. Several options reveal a
+  # free-text "please specify" box (see FormField::SPECIFY_OPTION_PLACEHOLDERS).
+  REFERRAL_SOURCE_OPTIONS = [
+    "Online Search", "Social Media", "Presentation",
+    "Work(ed) at an agency that has/had an AWBW program", "Word of Mouth",
+    "Foundation/Funder", "Email from AWBW", "Other"
+  ].freeze
+
+  # What motivated a registrant to sign up, mirroring the AWBW facilitator
+  # training form. Multi-select; the trailing "Other" reveals a free-text box.
+  TRAINING_MOTIVATION_OPTIONS = [
+    "Use art to offer accessible and effective client programming (strength-based, low-barrier, research-informed)",
+    "Deepen understanding of trauma-informed and intersectional practices",
+    "Address staff burnout through art",
+    "Support staff wellness through art",
+    "Connect with and learn from a community of art facilitators",
+    "Use art for team building and organizational culture change",
+    "Use art to support advocacy, awareness, and/or fundraising",
+    "Earn certification as an AWBW Facilitator for personal/professional development",
+    "Earn Continuing Education (CE) hours and expand knowledge about integrating art into clinical work",
+    "Other"
+  ].freeze
 
   def build_marketing_fields(form, position)
     position = add_header(form, position, "Marketing", group: "marketing")
 
-    position = add_field(form, position, "How did you hear about this training?", :free_form_input_paragraph,
-                         key: "referral_source", group: "marketing", required: false)
-    position = add_field(form, position, "What motivates you to attend this training?", :free_form_input_paragraph,
-                         key: "training_motivation", group: "marketing", required: false)
+    position = add_field(form, position, "How did you hear about this AWBW training?", :single_select_radio,
+                         key: "referral_source", group: "marketing", required: false,
+                         options: REFERRAL_SOURCE_OPTIONS)
+    position = add_field(form, position, "What motivated you to sign up for AWBW's Facilitator Training?",
+                         :multi_select_checkbox,
+                         key: "training_motivation", group: "marketing", required: false,
+                         options: TRAINING_MOTIVATION_OPTIONS)
     position = add_field(form, position, "Are you interested in learning more about upcoming trainings or resources?",
                          :single_select_radio,
                          key: "interested_in_more", group: "marketing", required: true,
@@ -463,10 +503,16 @@ class FormBuilderService
     position = add_header(form, position, "Scholarship Application", group: "scholarship")
 
     position = add_field(form, position,
-                         "I / my agency cannot afford the full training cost and need a scholarship to attend.",
-                         :multi_select_checkbox,
+                         "I and/or my organization cannot afford the full training cost and need a scholarship to attend.",
+                         :single_select_radio,
                          key: "scholarship_eligibility", group: "scholarship", required: true,
-                         options: [ "Yes" ])
+                         options: %w[Yes No])
+    position = add_field(form, position,
+                         "How much are you (and/or your organization) able to pay for this training?",
+                         :free_form_input_one_line,
+                         key: "scholarship_contribution", group: "scholarship", required: false)
+
+    position = add_header(form, position, "Your goals", group: "scholarship")
     position = add_field(form, position,
                          "How will what you gain from this training directly impact the people you serve?",
                          :free_form_input_paragraph,
@@ -477,6 +523,8 @@ class FormBuilderService
                          :free_form_input_paragraph,
                          key: "implementation_plan", group: "scholarship", required: true,
                          subtitle: "Please describe in 3-5+ sentences.")
+
+    position = add_header(form, position, "Anything else?", group: "scholarship")
     position = add_field(form, position, "Anything else you'd like to share with us?", :free_form_input_paragraph,
                          key: "additional_comments", group: "scholarship", required: false)
     position

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -74,7 +74,7 @@
               <%= "required" if field.required %>><%= value %></textarea>
 
   <% when "single_select_radio" %>
-    <%# Dynamic fields (e.g. primary_service_area) source options from Sector/Category
+    <%# Dynamic fields (e.g. primary_sector) source options from Sector/Category
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
@@ -110,7 +110,7 @@
     <% end %>
 
   <% when "single_select_dropdown" %>
-    <%# Dynamic fields (e.g. primary_service_area_single) source options from
+    <%# Dynamic fields (e.g. primary_sector_single) source options from
         Sector/Category data; everything else uses the field's own stored options. %>
     <%# Dropdowns have no free-text input, so the "Other" option is omitted here.
         Named specify options keep meaning as a bare choice, so they stay. %>
@@ -133,7 +133,7 @@
   <% when "multi_select_checkbox" %>
     <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
     <% selected_values = Array(value) %>
-    <%# Dynamic fields (e.g. primary_service_area) source options from Sector/Category
+    <%# Dynamic fields (e.g. primary_sector) source options from Sector/Category
         data; everything else uses the field's own stored answer options. Sector and
         Category options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -56,7 +56,7 @@
         <% participant_slug = @dashboard.registration_slug_by_registrant[person.id] %>
         <% answers = (answers_by_applicant[person.id] || []).reject { |a| a.form_field&.field_identifier == "scholarship_eligibility" } %>
         <% header = header_answers[person.id] || {} %>
-        <% service_area_answer = header["primary_service_area"] %>
+        <% service_area_answer = header[EventDashboard::HEADER_SECTOR_KEY] %>
         <% age_group_answer = header["primary_age_group"] %>
         <%# Prefer the registrant's form answers; fall back to their profile data. %>
         <% service_area_text = resolve_answer_text(service_area_answer&.form_field, service_area_answer&.submitted_answer).presence || person.sectors.map(&:name).join(", ").presence %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -5,9 +5,14 @@
 
 puts "Creating standalone registration forms…"
 unless Form.standalone.exists?(name: "Training Registration Form")
+  # Sections are built in this order (not the canonical SECTIONS order) so the
+  # seeded form reads top-to-bottom like the real AWBW Facilitator Training form:
+  # Your Information → Mailing Address → Your Organization → Participant
+  # Information → About You → Payment → Consent. The CE and "Additional forms"
+  # magic questions are appended below and slotted into place by reorder.
   FormBuilderService.new(
     name: "Training Registration Form",
-    sections: %i[person_identifier professional_info payment],
+    sections: %i[person_identifier person_contact_info professional_info person_background marketing payment consent],
     role: "registration"
   ).call
 end
@@ -87,25 +92,42 @@ if scholarship_form.header.blank?
   HTML
 end
 
-# Ensure the professional section (Primary Age Group(s) Served, Primary Service
-# Area, etc.) exists even on a registration form seeded before it was added — the
-# event Background charts aggregate answers to those questions.
-if registration_form.form_fields.where(field_identifier: "primary_age_group").none?
-  FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
-end
+# The two "Your goals" essays carry a 250-word minimum on the real form. Set it
+# on the seeded scholarship form so the public form shows the "Minimum of 250
+# words" hint and enforces it on submit. Idempotent: only sets when not already set.
+scholarship_form.form_fields
+  .where(field_identifier: %w[impact_description implementation_plan], min_words: [ nil, 0 ])
+  .update_all(min_words: 250)
 
-# Ensure the person/organization section (Organization Name, Position / Title) exists
-# so registrants can record the org + title they typed on the form — the registrants
-# page compares that typed org name against the registration's linked orgs.
-if registration_form.form_fields.where(field_identifier: "agency_name").none?
-  FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :person_contact_info ])
+# Rename the generic section headers FormBuilderService creates to the AWBW
+# Facilitator Training wording, and add the subtitles shown on the real form.
+# Idempotent: each rename only matches the default name, so a re-seed (or an admin
+# edit) is left alone.
+rename_registration_header = ->(from, to, subtitle: nil) do
+  header = registration_form.form_fields.find_by(answer_type: :group_header, name: from)
+  header&.update!(name: to, subtitle: subtitle)
 end
+rename_registration_header.call("Contact Information", "Your Information")
+rename_registration_header.call("Mailing Address", "Primary Mailing Address",
+                                subtitle: "For mailing raffle prizes, incentives, and important announcements")
+rename_registration_header.call("Organization Information", "Your Organization",
+                                subtitle: "If your organization has a website, please put your organization name as it appears on the website. " \
+                                          "If you're not associated with an organization, please provide a name for your art program.")
+rename_registration_header.call("Professional Information", "Participant Information")
+rename_registration_header.call("Background Information", "About You")
+
+# The real form folds the "How did you hear" / "What motivated you" questions in
+# under the "About You" heading, with no separate Marketing header and no
+# "interested in learning more?" question. Drop both so the seeded form matches.
+registration_form.form_fields.where(answer_type: :group_header, name: "Marketing").destroy_all
+registration_form.form_fields.where(field_identifier: "interested_in_more").destroy_all
 
 # The CE-interest "magic question": a single Yes/No whose answer drives the
 # resulting registration's ce_credit_requested flag (see
 # EventRegistrationServices::PublicRegistration). Seeded straight onto the form
 # with its own section so the form builder's add/remove-section logic leaves it
-# alone, and carrying the well-known field_identifier the service keys off.
+# alone, and carrying the well-known field_identifier the service keys off. A
+# follow-on license-number question mirrors the real form's CE block.
 ce_identifier = EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER
 if registration_form.form_fields.where(field_identifier: ce_identifier).none?
   next_position = (registration_form.form_fields.maximum(:position) || 0) + 1
@@ -119,7 +141,7 @@ if registration_form.form_fields.where(field_identifier: ce_identifier).none?
     visibility: :always_ask
   )
   ce_field = registration_form.form_fields.create!(
-    name: "Might you be seeking continuing education (CE) hours for attending this training?",
+    name: "Do you plan to use Continuing Education (CE) hours for this course?",
     answer_type: :single_select_radio,
     status: :active,
     position: next_position + 1,
@@ -134,6 +156,17 @@ if registration_form.form_fields.where(field_identifier: ce_identifier).none?
     ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
     ce_field.form_field_answer_options.create!(answer_option: ao)
   end
+  registration_form.form_fields.create!(
+    name: "If seeking CE hours, what is your LMFT, LCSW, LPCC or LEP license number?",
+    answer_type: :free_form_input_one_line,
+    status: :active,
+    position: next_position + 2,
+    required: false,
+    field_identifier: "ce_license_number",
+    section: "continuing_education",
+    visibility: :always_ask,
+    width: :full
+  )
 end
 
 # The "Additional forms" question: a multi-select whose checked options drive the
@@ -142,7 +175,8 @@ end
 # flags to surface the matching downloads. Seeded onto its own section, like the
 # CE question above, so the form builder's add/remove-section logic leaves it
 # alone, and carrying the well-known field_identifier the service keys off. The
-# answer-option names must match the service's ADDITIONAL_FORMS_* constants.
+# W-9/Invoice option names must match the service's ADDITIONAL_FORMS_* constants;
+# "No forms needed" is an inert opt-out the service ignores.
 additional_forms_identifier = EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_IDENTIFIER
 if registration_form.form_fields.where(field_identifier: additional_forms_identifier).none?
   next_position = (registration_form.form_fields.maximum(:position) || 0) + 1
@@ -168,13 +202,26 @@ if registration_form.form_fields.where(field_identifier: additional_forms_identi
     subtitle: "If selected, these will be available on your digital registration ticket."
   )
   [
+    EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_W9,
     EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_INVOICE,
-    EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_W9
+    "No forms needed"
   ].each_with_index do |opt, idx|
     ao = AnswerOption.find_or_create_by!(name: opt) { |a| a.position = idx }
     additional_forms_field.form_field_answer_options.create!(answer_option: ao)
   end
 end
+
+# Renumber the form's fields so the appended CE block sits between "About You" and
+# "Payment Information", and "Additional forms" sits between payment and consent —
+# the order the real form uses. Idempotent: re-running lands on the same order.
+registration_section_order = %w[
+  person_identifier person_contact_info professional background marketing
+  continuing_education payment additional_forms consent
+]
+registration_section_rank = registration_section_order.each_with_index.to_h
+registration_form.form_fields.reorder(:position).to_a.each_with_index
+  .sort_by { |field, index| [ registration_section_rank.fetch(field.section, registration_section_rank.size), index ] }
+  .each_with_index { |(field, _index), position| field.update_column(:position, position + 1) }
 
 # Each entry: [title, form_type, cost_cents, scholarship?, visibility, span_days]
 # form_type: :long, :short, or :none. span_days (optional) makes a multi-day event.
@@ -951,7 +998,6 @@ form_submissions.each do |data|
     when "agency_organization_name" then Faker::Company.name
     when "position_title" then "Facilitator"
     when "agency_website" then "https://example.org"
-    when "racial_ethnic_identity" then "Prefer not to say"
     when "secondary_email" then data[:person].email_2
     when "preferred_nickname" then data[:person].first_name
     when "pronouns" then [ "she/her", "he/him", "they/them" ].sample
@@ -977,13 +1023,13 @@ puts "Giving Amy a free-text \"Other\" answer on her Facilitator Training submis
 # who picked the "Other" option (folded into "Other: <text>") on a sector-backed
 # field (Additional sectors). The free-text value can't be a Sector record, so it
 # only surfaces via Person#other_service_area_responses.
-# Seeded before the professional-answer enrichment below so the primary_service_area
+# Seeded before the professional-answer enrichment below so the primary_sector
 # value survives its "skip if already answered" guard. Idempotent.
 if facilitator_training && amy_person
   amy_submission = FormSubmission.find_by(person: amy_person, form: facilitator_training.registration_form)
   if amy_submission
     {
-      "primary_service_area" => "Other: Equine-assisted therapy"
+      "primary_sector" => "Other: Equine-assisted therapy"
     }.each do |identifier, value|
       field = amy_submission.form.form_fields.find_by(field_identifier: identifier)
       next unless field
@@ -1012,15 +1058,16 @@ record_professional_answers = ->(submission, i) do
   person = submission.person
   form = submission.form
 
+  # Primary age group is a single-select dropdown, so store one AgeRange category id.
   age_field = form.form_fields.find_by(field_identifier: "primary_age_group")
-  ages = pick_categories.call(age_range_categories, i, 2)
-  if age_field && ages.present? && submission.form_answers.where(form_field: age_field).none?
+  age = age_range_categories[i % age_range_categories.size] if age_range_categories.any?
+  if age_field && age && submission.form_answers.where(form_field: age_field).none?
     submission.form_answers.create!(form_field: age_field,
-                                    submitted_answer: ages.map(&:id).join(", "),
+                                    submitted_answer: age.id.to_s,
                                     question_name_when_answered: age_field.name)
   end
 
-  service_field = form.form_fields.find_by(field_identifier: "primary_service_area")
+  service_field = form.form_fields.find_by(field_identifier: "primary_sector")
   sectors = service_area_sectors.empty? ? [] : [ service_area_sectors[i % service_area_sectors.size], service_area_sectors[(i + 4) % service_area_sectors.size] ].uniq
   if service_field && sectors.present? && submission.form_answers.where(form_field: service_field).none?
     submission.form_answers.create!(form_field: service_field,

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -164,8 +164,9 @@ scholarship_answer_sets = [
     "additional_comments" =>
       "Thank you for considering my application. A scholarship is the only way my small agency can send me to this training right now, " \
       "and the ripple effect on the survivors we serve would be immediate.",
+    "scholarship_contribution" => "Our agency can contribute about $250 toward the cost.",
     "service_area" => "Sexual Assault",
-    "age_group" => "18+",
+    "age_group" => "Adults (18+)",
     "title" => "Prevention, Education, and Outreach Specialist"
   },
   {
@@ -180,6 +181,7 @@ scholarship_answer_sets = [
       "I envision the shared making and witnessing reducing isolation and helping members feel they aren't alone in their experience.",
     "additional_comments" =>
       "I've wanted formal facilitation training for years but our continuing-education budget was cut. This scholarship would change that.",
+    "scholarship_contribution" => "I could personally cover roughly $150.",
     "service_area" => "Mental Health",
     "age_group" => "Mixed-age groups",
     "title" => "Behavioral Health Clinician"
@@ -196,8 +198,9 @@ scholarship_answer_sets = [
       "I envision it giving teens a consistent place to process their week and build confidence through finishing something that's theirs.",
     "additional_comments" =>
       "Our program serves families at no cost, so outside funding for my training is what makes this possible. Thank you.",
-    "service_area" => "Child Abuse",
-    "age_group" => "6-12",
+    "scholarship_contribution" => "Unfortunately we can't contribute anything at this time.",
+    "service_area" => "Child Abuse/Neglect",
+    "age_group" => "Children (0-12)",
     "title" => "Youth Program Coordinator"
   },
   {
@@ -212,8 +215,9 @@ scholarship_answer_sets = [
       "I envision it strengthening the group's sense of community and giving members a tangible reminder of how far they've come.",
     "additional_comments" =>
       "I'm so grateful for this opportunity. Investing in me is investing in everyone I'll go on to support.",
+    "scholarship_contribution" => "I'm able to pay up to $100 out of pocket.",
     "service_area" => "Domestic Violence",
-    "age_group" => "18+",
+    "age_group" => "Adults (18+)",
     "title" => "Peer Support Specialist"
   }
 ]
@@ -230,10 +234,10 @@ scholarship_fields = scholarship_form ? scholarship_form.form_fields.where.not(a
 # answers — the recipients page reads those first, then falls back to the
 # person's profile (sectors / age-range tags).
 registration_form = Form.standalone.find_by(role: "registration")
-if registration_form && registration_form.form_fields.where(field_identifier: "primary_service_area").none?
+if registration_form && registration_form.form_fields.where(field_identifier: "primary_sector").none?
   FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
 end
-service_area_field = registration_form&.form_fields&.find_by(field_identifier: "primary_service_area")
+service_area_field = registration_form&.form_fields&.find_by(field_identifier: "primary_sector")
 age_group_field = registration_form&.form_fields&.find_by(field_identifier: "primary_age_group")
 
 # Existing dev organizations (excluding AWBW itself) to affiliate recipients

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -403,13 +403,20 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error("999999")).to eq("has an invalid selection")
       end
 
-      it "rejects the Other sector for the primary service-area field but accepts it for additional" do
-        other = create(:sector, :published, name: "Other")
-        primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_service_area_single")
-        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_service_area")
+      # Both the current "sector" identifiers and the legacy "service area"
+      # identifiers must behave identically so existing form data keeps resolving.
+      {
+        "sector" => %w[primary_sector_single primary_sector],
+        "service area (legacy)" => %w[primary_service_area_single primary_service_area]
+      }.each do |scheme, (primary_id, additional_id)|
+        it "rejects the Other sector for the primary #{scheme} field but accepts it for additional" do
+          other = create(:sector, :published, name: "Other")
+          primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: primary_id)
+          additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: additional_id)
 
-        expect(primary.answer_inclusion_error(other.id.to_s)).to eq("has an invalid selection")
-        expect(additional.answer_inclusion_error([ other.id.to_s ])).to be_nil
+          expect(primary.answer_inclusion_error(other.id.to_s)).to eq("has an invalid selection")
+          expect(additional.answer_inclusion_error([ other.id.to_s ])).to be_nil
+        end
       end
 
       it "accepts a published Category id from the backing type for a category field" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -456,14 +456,16 @@ RSpec.describe EventDashboard do
       expect(dashboard.scholarship_answers_by_applicant[embedded_applicant.id].size).to eq(1)
     end
 
-    it "gathers header (service area / age group) answers keyed by applicant and identifier" do
+    it "gathers header (sector / age group) answers keyed by applicant, sector answers under the normalized sector key" do
+      # Use a legacy "service area" identifier to confirm it still resolves under
+      # the normalized sector key alongside the current "sector" identifiers.
       service_field = create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_service_area")
       reg_submission = FormSubmission.find_by(person: embedded_applicant, form: registration_form)
       create(:form_answer, form_submission: reg_submission, form_field: service_field, submitted_answer: "5")
 
       header = dashboard.header_answers_by_applicant
 
-      expect(header[embedded_applicant.id]["primary_service_area"].submitted_answer).to eq("5")
+      expect(header[embedded_applicant.id][EventDashboard::HEADER_SECTOR_KEY].submitted_answer).to eq("5")
       expect(header).not_to have_key(non_applicant.id)
     end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -121,16 +121,16 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
-  describe "primary service area tagging" do
+  describe "primary sector tagging" do
     let!(:primary_sector) { create(:sector, name: "Healthcare") }
     let!(:other_sector) { create(:sector, name: "Education") }
 
-    it "tags the selected primary service area sectors as primary on the person" do
+    it "tags the selected primary sector as primary on the person" do
       result = described_class.call(
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+          field_id("primary_sector") => [ primary_sector.id.to_s ]
         )
       )
 
@@ -148,7 +148,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_service_area") => [ primary_sector.id.to_s ]
+          field_id("primary_sector") => [ primary_sector.id.to_s ]
         )
       )
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe FormBuilderService do
         expect(keys).to include("nickname", "pronouns", "phone", "mailing_city", "agency_name")
       end
 
+      it "captures a mailing and organization country" do
+        keys = form.form_fields.pluck(:field_identifier).compact
+        expect(keys).to include("mailing_country", "agency_country")
+      end
+
+      it "asks for the organization website and type before its street address" do
+        positions = form.form_fields.where(
+          field_identifier: %w[agency_website agency_type agency_street]
+        ).pluck(:field_identifier, :position).to_h
+        expect(positions["agency_website"]).to be < positions["agency_street"]
+        expect(positions["agency_type"]).to be < positions["agency_street"]
+      end
+
       it "offers the agency type as the four organization classifications" do
         field = form.form_fields.find_by(field_identifier: "agency_type")
         expect(field.answer_options.pluck(:name)).to contain_exactly(
@@ -73,6 +86,13 @@ RSpec.describe FormBuilderService do
       it "creates scholarship fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include("scholarship_eligibility", "impact_description", "implementation_plan")
+      end
+
+      it "asks eligibility as Yes/No and captures what the applicant can contribute" do
+        eligibility = form.form_fields.find_by(field_identifier: "scholarship_eligibility")
+        expect(eligibility.answer_type).to eq("single_select_radio")
+        expect(eligibility.answer_options.pluck(:name)).to contain_exactly("Yes", "No")
+        expect(form.form_fields.pluck(:field_identifier)).to include("scholarship_contribution")
       end
     end
 
@@ -123,12 +143,30 @@ RSpec.describe FormBuilderService do
       let(:form) { described_class.new(name: "Test", sections: %i[professional_info]).call }
 
       it "asks for a single primary sector via a dropdown before the additional sectors checkboxes" do
-        primary = form.form_fields.find_by(field_identifier: "primary_service_area_single")
-        additional = form.form_fields.find_by(field_identifier: "primary_service_area")
+        primary = form.form_fields.find_by(field_identifier: "primary_sector_single")
+        additional = form.form_fields.find_by(field_identifier: "primary_sector")
 
         expect(primary).to have_attributes(name: "Primary sector", answer_type: "single_select_dropdown")
         expect(additional).to have_attributes(name: "Additional sectors", answer_type: "multi_select_checkbox")
         expect(primary.position).to be < additional.position
+      end
+
+      it "asks for a single primary age group via a dropdown alongside additional-age checkboxes" do
+        primary = form.form_fields.find_by(field_identifier: "primary_age_group")
+        additional = form.form_fields.find_by(field_identifier: "additional_age_group")
+
+        expect(primary.answer_type).to eq("single_select_dropdown")
+        expect(additional.answer_type).to eq("multi_select_checkbox")
+      end
+    end
+
+    context "person_background section" do
+      let(:form) { described_class.new(name: "Test", sections: %i[person_background]).call }
+
+      it "asks how respondents describe themselves as a single-select with options" do
+        field = form.form_fields.find_by(field_identifier: "racial_ethnic_identity")
+        expect(field.answer_type).to eq("single_select_radio")
+        expect(field.answer_options.pluck(:name)).to include("Multi-racial", "White")
       end
     end
 
@@ -138,6 +176,16 @@ RSpec.describe FormBuilderService do
       it "creates marketing fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include("referral_source", "training_motivation", "interested_in_more")
+      end
+
+      it "offers referral and motivation as selectable questions with options" do
+        referral = form.form_fields.find_by(field_identifier: "referral_source")
+        motivation = form.form_fields.find_by(field_identifier: "training_motivation")
+
+        expect(referral.answer_type).to eq("single_select_radio")
+        expect(referral.answer_options.pluck(:name)).to include("Online Search", "Word of Mouth")
+        expect(motivation.answer_type).to eq("multi_select_checkbox")
+        expect(motivation.answer_options.pluck(:name)).to include("Address staff burnout through art")
       end
     end
 
@@ -181,7 +229,7 @@ RSpec.describe FormBuilderService do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include(
           "first_name", "nickname", "racial_ethnic_identity",
-          "primary_service_area", "referral_source",
+          "primary_sector", "referral_source",
           "scholarship_eligibility", "payment_method", "communication_consent"
         )
       end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -1,0 +1,413 @@
+require "rails_helper"
+
+# Exercises the three public, seed-shaped forms end to end — registration, the
+# scholarship application appended to it, and bulk payment — each both while
+# logged out ("incognito") and while logged in, asserting every submitted answer
+# (and its registration / person side effects) is persisted. The forms are built
+# with FormBuilderService using the same sections + magic CE / "Additional forms"
+# questions the dev seeds attach, so the DOM matches what registrants really see.
+RSpec.describe "Public form submissions", type: :system do
+  let(:event) do
+    create(:event, :published, :publicly_visible,
+           title: "AWBW Facilitator Training",
+           cost_cents: 150_000,
+           start_date: 10.days.from_now.change(hour: 9),
+           end_date: 11.days.from_now.change(hour: 16),
+           registration_close_date: 5.days.from_now)
+  end
+
+  let(:registration_form) { build_registration_form }
+  let(:scholarship_form) do
+    FormBuilderService.new(name: "Scholarship Application", sections: %i[scholarship], role: "scholarship").call
+  end
+  let(:bulk_payment_form) do
+    FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
+  end
+
+  # Published Sectors + AgeRange categories so the dynamic sector / age fields
+  # render real, selectable options (they source from these records, not stored
+  # answer options).
+  let!(:age_type) { create(:category_type, name: "AgeRange", published: true) }
+  let!(:age_children) { create(:category, category_type: age_type, name: "Children (0-12)", published: true) }
+  let!(:age_teens) { create(:category, category_type: age_type, name: "Teens (13-17)", published: true) }
+  let!(:age_adults) { create(:category, category_type: age_type, name: "Adults (18+)", published: true) }
+  let!(:sector_education) { create(:sector, :published, name: "Education") }
+  let!(:sector_mental_health) { create(:sector, :published, name: "Mental Health") }
+  let!(:sector_dv) { create(:sector, :published, name: "Domestic Violence") }
+
+  let(:user) { create(:user) }
+  # A returning registrant whose name, email, primary address, and phone are on
+  # file — so the logged_out_only identity / mailing / phone fields are hidden when
+  # signed in, leaving the always-ask + answers-on-file questions to fill.
+  let(:logged_in_person) do
+    person = create(:person, user: user, first_name: "Dana", last_name: "Lee",
+                    email: "dana.lee@example.com", email_type: "personal")
+    person.addresses.create!(street_address: "1 A St", city: "Oakland", state: "CA",
+                             zip_code: "94601", locality: "Unknown", address_type: "personal", primary: true)
+    person.contact_methods.create!(kind: :phone, value: "555-000-1111", contact_type: "personal", primary: true)
+    person
+  end
+
+  before do
+    driven_by(:rack_test)
+    EventForm.create!(event: event, form: registration_form, role: "registration")
+    EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+    EventForm.create!(event: event, form: bulk_payment_form, role: "bulk_payment")
+  end
+
+  describe "registration form" do
+    it "incognito: persists every answer and its person / registration side effects" do
+      visit new_event_public_registration_path(event)
+
+      fill_full_registration
+
+      choose_pr_radio reg_field("ce_credit_interest"), "Yes"
+      choose_pr_radio reg_field("payment_method"), "Check"
+      check_pr_box reg_field("additional_forms"), "W-9"
+
+      click_button "Register"
+      expect(page).to have_content("successfully registered")
+
+      person = Person.find_by!(email: "robin.avery@example.com")
+      expect(person).to have_attributes(first_name: "Robin", last_name: "Avery", pronouns: "they/them",
+                                        email_2: "robin.alt@example.com")
+
+      registration = event.event_registrations.find_by!(registrant: person)
+      expect(registration).to have_attributes(scholarship_requested: false, ce_credit_requested: true,
+                                              w9_requested: true, invoice_requested: false)
+
+      answers = answers_by_identifier(registration_form.form_submissions.find_by!(person: person))
+      expect(answers).to include(
+        "first_name" => "Robin",
+        "last_name" => "Avery",
+        "primary_email" => "robin.avery@example.com",
+        "primary_email_type" => "Personal",
+        "pronouns" => "they/them",
+        "secondary_email" => "robin.alt@example.com",
+        "secondary_email_type" => "Work",
+        "mailing_street" => "123 Main St",
+        "mailing_address_type" => "Personal",
+        "mailing_city" => "Los Angeles",
+        "mailing_state" => "CA",
+        "mailing_zip" => "90001",
+        "mailing_country" => "United States",
+        "phone" => "555-123-4567",
+        "phone_type" => "Work",
+        "agency_name" => "Hope Center",
+        "agency_position" => "Art Therapist",
+        "agency_website" => "https://hope.example.org",
+        "agency_type" => "501c3/nonprofit",
+        "agency_country" => "United States",
+        "primary_sector_single" => sector_education.id.to_s,
+        "primary_sector" => sector_mental_health.id.to_s,
+        "primary_age_group" => age_adults.id.to_s,
+        "additional_age_group" => age_teens.id.to_s,
+        "racial_ethnic_identity" => "Multi-racial",
+        "referral_source" => "Online Search",
+        "training_motivation" => "Address staff burnout through art",
+        "ce_credit_interest" => "Yes",
+        "payment_method" => "Check",
+        "additional_forms" => "W-9",
+        "communication_consent" => "Yes"
+      )
+      # The service never stores the confirm_email answer (it only checks it matches).
+      expect(answers).not_to have_key("confirm_email")
+
+      address = person.addresses.find_by(primary: true)
+      expect(address).to have_attributes(city: "Los Angeles", state: "CA", zip_code: "90001")
+      expect(person.contact_methods.find_by(kind: :phone).value).to eq("555-123-4567")
+      expect(person.sectorable_items.map(&:sector)).to include(sector_education, sector_mental_health)
+      expect(person.primary_age_groups).to include(age_adults)
+      expect(person.additional_age_groups).to include(age_teens)
+    end
+
+    it "logged in: reuses the signed-in person, hides known fields, saves the rest" do
+      logged_in_person
+      sign_in user
+
+      visit new_event_public_registration_path(event)
+
+      # Known identity / mailing / phone questions are hidden for a returning person.
+      expect(page).not_to have_selector("##{pr_dom_id(reg_field('first_name'))}")
+      expect(page).not_to have_selector("##{pr_dom_id(reg_field('mailing_city'))}")
+
+      select_pr reg_field("primary_sector_single"), "Education"
+      check_pr_box reg_field("primary_sector"), sector_dv.id.to_s
+      select_pr reg_field("primary_age_group"), "Teens (13-17)"
+      choose_pr_radio reg_field("racial_ethnic_identity"), "Asian"
+      choose_pr_radio reg_field("referral_source"), "Social Media"
+      choose_pr_radio reg_field("payment_method"), "Check"
+      check_pr_box reg_field("communication_consent"), "Yes"
+
+      expect { click_button "Register" }.not_to change(Person, :count)
+      expect(page).to have_content("successfully registered")
+
+      registration = event.event_registrations.find_by!(registrant: logged_in_person)
+      expect(registration).to be_present
+
+      answers = answers_by_identifier(registration_form.form_submissions.find_by!(person: logged_in_person))
+      expect(answers).to include(
+        "primary_sector_single" => sector_education.id.to_s,
+        "primary_sector" => sector_dv.id.to_s,
+        "primary_age_group" => age_teens.id.to_s,
+        "racial_ethnic_identity" => "Asian",
+        "referral_source" => "Social Media",
+        "payment_method" => "Check",
+        "communication_consent" => "Yes"
+      )
+      logged_in_person.reload
+      expect(logged_in_person.primary_age_groups).to include(age_teens)
+      expect(logged_in_person.sectorable_items.map(&:sector)).to include(sector_education, sector_dv)
+    end
+  end
+
+  describe "scholarship application (scholarship_requested=true)" do
+    it "incognito: saves the registration and a separate scholarship submission" do
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      fill_full_registration
+      choose_pr_radio reg_field("payment_method"), "Check"
+
+      choose_pr_radio schol_field("scholarship_eligibility"), "Yes"
+      fill_pr_text schol_field("scholarship_contribution"), with: "Our agency can pay $200."
+      fill_pr_text schol_field("impact_description"), with: "Art gives the survivors I serve a safer way to process trauma."
+      fill_pr_text schol_field("implementation_plan"), with: "I'll run a weekly drop-in workshop at our advocacy center."
+      fill_pr_text schol_field("additional_comments"), with: "Thank you for considering my application."
+
+      click_button "Register"
+      expect(page).to have_content("successfully registered")
+
+      person = Person.find_by!(email: "robin.avery@example.com")
+      registration = event.event_registrations.find_by!(registrant: person)
+      expect(registration.scholarship_requested).to be(true)
+
+      scholarship_submission = scholarship_form.form_submissions.find_by!(person: person, role: "scholarship")
+      expect(answers_by_identifier(scholarship_submission)).to include(
+        "scholarship_eligibility" => "Yes",
+        "scholarship_contribution" => "Our agency can pay $200.",
+        "impact_description" => "Art gives the survivors I serve a safer way to process trauma.",
+        "implementation_plan" => "I'll run a weekly drop-in workshop at our advocacy center.",
+        "additional_comments" => "Thank you for considering my application."
+      )
+    end
+
+    it "logged in: flags the registration and saves the scholarship answers for the signed-in person" do
+      logged_in_person
+      sign_in user
+
+      visit new_event_public_registration_path(event, scholarship_requested: true)
+
+      choose_pr_radio reg_field("payment_method"), "Check"
+      check_pr_box reg_field("communication_consent"), "Yes"
+
+      choose_pr_radio schol_field("scholarship_eligibility"), "Yes"
+      fill_pr_text schol_field("impact_description"), with: "The clients I serve open up through making art."
+      fill_pr_text schol_field("implementation_plan"), with: "A six-week recovery group built around weekly art prompts."
+
+      click_button "Register"
+      expect(page).to have_content("successfully registered")
+
+      registration = event.event_registrations.find_by!(registrant: logged_in_person)
+      expect(registration.scholarship_requested).to be(true)
+
+      scholarship_submission = scholarship_form.form_submissions.find_by!(person: logged_in_person, role: "scholarship")
+      expect(answers_by_identifier(scholarship_submission)).to include(
+        "scholarship_eligibility" => "Yes",
+        "impact_description" => "The clients I serve open up through making art.",
+        "implementation_plan" => "A six-week recovery group built around weekly art prompts."
+      )
+    end
+  end
+
+  describe "bulk payment form" do
+    it "incognito: creates the payer and saves the bulk payment submission" do
+      visit new_event_bulk_payment_path(event)
+
+      fill_bp_text bp_field("payer_first_name"), with: "Pat"
+      fill_bp_text bp_field("payer_last_name"), with: "Morgan"
+      fill_bp_text bp_field("payer_email"), with: "pat.morgan@example.com"
+      fill_bp_text bp_field("payer_phone"), with: "555-987-6543"
+      fill_bp_text bp_field("payer_organization"), with: "Group Health"
+      fill_bp_text bp_field("number_of_attendees"), with: "3"
+      choose_bp_radio bp_field("payment_method"), "Check"
+
+      click_button "Submit"
+      expect(page).to have_content("bulk payment information has been submitted")
+
+      person = Person.find_by!(email: "pat.morgan@example.com")
+      expect(person).to have_attributes(first_name: "Pat", last_name: "Morgan")
+
+      submission = FormSubmission.bulk_payment.find_by!(person: person, event: event)
+      expect(answers_by_identifier(submission)).to include(
+        "payer_first_name" => "Pat",
+        "payer_last_name" => "Morgan",
+        "payer_email" => "pat.morgan@example.com",
+        "payer_phone" => "555-987-6543",
+        "payer_organization" => "Group Health",
+        "number_of_attendees" => "3",
+        "payment_method" => "Check"
+      )
+      expect(person.contact_methods.find_by(kind: :phone).value).to eq("555-987-6543")
+    end
+
+    it "logged in: hides the payer fields and bills the signed-in person" do
+      logged_in_person
+      sign_in user
+
+      visit new_event_bulk_payment_path(event)
+
+      expect(page).not_to have_selector("#bulk_payment_form_fields_#{bp_field('payer_first_name').id}")
+
+      fill_bp_text bp_field("number_of_attendees"), with: "2"
+      choose_bp_radio bp_field("payment_method"), "Check"
+
+      expect { click_button "Submit" }.not_to change(Person, :count)
+      expect(page).to have_content("bulk payment information has been submitted")
+
+      submission = FormSubmission.bulk_payment.find_by!(person: logged_in_person, event: event)
+      expect(answers_by_identifier(submission)).to include(
+        "number_of_attendees" => "2",
+        "payment_method" => "Check"
+      )
+    end
+  end
+
+  # ---- Form construction (mirrors the dev seeds) ----
+
+  # Builds the registration form the way db/seeds/dev/events_management.rb does:
+  # the full set of sections, minus the generic "interested in more?" question,
+  # plus the magic CE-interest and "Additional forms" questions whose answers
+  # drive the resulting registration's flags.
+  def build_registration_form
+    form = FormBuilderService.new(
+      name: "Training Registration Form",
+      sections: %i[person_identifier person_contact_info professional_info person_background marketing payment consent],
+      role: "registration"
+    ).call
+    form.form_fields.where(field_identifier: "interested_in_more").destroy_all
+
+    position = form.form_fields.maximum(:position).to_i
+    ce = form.form_fields.create!(
+      name: "Do you plan to use Continuing Education (CE) hours for this course?",
+      answer_type: :single_select_radio, status: :active, position: position += 1, required: false,
+      field_identifier: EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER,
+      section: "continuing_education", visibility: :always_ask
+    )
+    %w[Yes No].each do |name|
+      ce.form_field_answer_options.create!(answer_option: AnswerOption.find_or_create_by!(name: name))
+    end
+
+    additional_forms = form.form_fields.create!(
+      name: "Do you need either of the following?",
+      answer_type: :multi_select_checkbox, status: :active, position: position += 1, required: false,
+      field_identifier: EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_IDENTIFIER,
+      section: "additional_forms", visibility: :always_ask
+    )
+    [ EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_W9,
+      EventRegistrationServices::PublicRegistration::ADDITIONAL_FORMS_INVOICE,
+      "No forms needed" ].each do |name|
+      additional_forms.form_field_answer_options.create!(answer_option: AnswerOption.find_or_create_by!(name: name))
+    end
+
+    form
+  end
+
+  # ---- Field lookup ----
+
+  def reg_field(identifier)
+    registration_form.form_fields.find_by!(field_identifier: identifier)
+  end
+
+  def schol_field(identifier)
+    scholarship_form.form_fields.find_by!(field_identifier: identifier)
+  end
+
+  def bp_field(identifier)
+    bulk_payment_form.form_fields.find_by!(field_identifier: identifier)
+  end
+
+  def pr_dom_id(field)
+    "public_registration_form_fields_#{field.id}"
+  end
+
+  # ---- Form interaction (public_registration namespace; shared by the
+  # registration and appended scholarship fields) ----
+
+  def fill_pr_text(field, with:)
+    fill_in pr_dom_id(field), with: with
+  end
+
+  def select_pr(field, text)
+    select text, from: pr_dom_id(field)
+  end
+
+  # Radios/checkboxes carry no id, so target them by their submitted name + value.
+  def choose_pr_radio(field, value)
+    find("input[type='radio'][name='public_registration[form_fields][#{field.id}]'][value='#{value}']").set(true)
+  end
+
+  def check_pr_box(field, value)
+    find("input[type='checkbox'][name='public_registration[form_fields][#{field.id}][]'][value='#{value}']").set(true)
+  end
+
+  # ---- Form interaction (bulk_payment namespace) ----
+
+  def fill_bp_text(field, with:)
+    fill_in "bulk_payment_form_fields_#{field.id}", with: with
+  end
+
+  def choose_bp_radio(field, value)
+    find("input[type='radio'][name='bulk_payment[form_fields][#{field.id}]'][value='#{value}']").set(true)
+  end
+
+  # Fills every visible registration question for a logged-out registrant.
+  def fill_full_registration
+    fill_pr_text reg_field("first_name"), with: "Robin"
+    fill_pr_text reg_field("last_name"), with: "Avery"
+    fill_pr_text reg_field("primary_email"), with: "robin.avery@example.com"
+    fill_pr_text reg_field("confirm_email"), with: "robin.avery@example.com"
+    choose_pr_radio reg_field("primary_email_type"), "Personal"
+    fill_pr_text reg_field("pronouns"), with: "they/them"
+    fill_pr_text reg_field("secondary_email"), with: "robin.alt@example.com"
+    choose_pr_radio reg_field("secondary_email_type"), "Work"
+
+    fill_pr_text reg_field("mailing_street"), with: "123 Main St"
+    choose_pr_radio reg_field("mailing_address_type"), "Personal"
+    fill_pr_text reg_field("mailing_city"), with: "Los Angeles"
+    select_pr reg_field("mailing_state"), "California (CA)"
+    fill_pr_text reg_field("mailing_zip"), with: "90001"
+    fill_pr_text reg_field("mailing_country"), with: "United States"
+    fill_pr_text reg_field("phone"), with: "555-123-4567"
+    choose_pr_radio reg_field("phone_type"), "Work"
+
+    fill_pr_text reg_field("agency_name"), with: "Hope Center"
+    fill_pr_text reg_field("agency_position"), with: "Art Therapist"
+    fill_pr_text reg_field("agency_website"), with: "https://hope.example.org"
+    choose_pr_radio reg_field("agency_type"), "501c3/nonprofit"
+    fill_pr_text reg_field("agency_street"), with: "9 Center Ave"
+    fill_pr_text reg_field("agency_city"), with: "Pasadena"
+    select_pr reg_field("agency_state"), "California (CA)"
+    fill_pr_text reg_field("agency_zip"), with: "91101"
+    fill_pr_text reg_field("agency_country"), with: "United States"
+
+    select_pr reg_field("primary_sector_single"), "Education"
+    check_pr_box reg_field("primary_sector"), sector_mental_health.id.to_s
+    select_pr reg_field("primary_age_group"), "Adults (18+)"
+    check_pr_box reg_field("additional_age_group"), age_teens.id.to_s
+
+    choose_pr_radio reg_field("racial_ethnic_identity"), "Multi-racial"
+    choose_pr_radio reg_field("referral_source"), "Online Search"
+    check_pr_box reg_field("training_motivation"), "Address staff burnout through art"
+
+    check_pr_box reg_field("communication_consent"), "Yes"
+  end
+
+  # ---- Assertions ----
+
+  def answers_by_identifier(submission)
+    submission.form_answers.includes(:form_field).each_with_object({}) do |answer, hash|
+      identifier = answer.form_field.field_identifier
+      hash[identifier] = answer.submitted_answer if identifier.present?
+    end
+  end
+end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — field-identifier rename + substantive `FormBuilderService` changes and reshaped dev seeds, plus a new end-to-end spec

## ⚠️ Depends on #1831
The canonical Sector list + AgeRange categories were split into **#1831**, which should merge first. This branch's dev seeds reference the new age-group / sector names, so **rebase this PR onto main after #1831 lands** (the references resolve then). This branch's form-matching also depends on the field-identifier rename it carries, which is why it couldn't move into #1831.

## Why
The dev registration form built only a sparse subset of questions, so the seeded demo didn't resemble the live AWBW Facilitator Training form. This makes the seeded registration + scholarship forms mirror the real form, on top of the in-flight `service_area → sector` field-identifier rename.

## What
- **Field-identifier rename** (`service_area` → `sector`): `form_field.rb`, `public_registration.rb`, `event_dashboard.rb`, helpers, views, and their specs (accepts both old and new identifiers for backward compatibility).
- **`FormBuilderService`** (shared form builder):
  - Add mailing & organization **Country** fields; reorder the org block (website + type before street).
  - **Primary age group** is now a single-select dropdown (AgeRange-backed), mirroring Primary sector / Additional sectors.
  - Race, "how did you hear", and "what motivated you" become structured single/multi-select questions with options.
  - Scholarship: eligibility is **Yes/No**, add "what can you contribute", group essays under **Your goals** / **Anything else?**.
- **Dev seeds**: build the registration form with the full ordered section set, rename headers to AWBW wording, append the CE-interest + license-number and "Additional forms" (incl. "No forms needed") questions and slot them into place, set the 250-word scholarship-essay minimum, and update references to the new age-group / sector names (incl. fixing a pre-existing "Child Abuse" → "Child Abuse/Neglect" mismatch).
- **New system spec** `spec/system/public_registration_form_submission_spec.rb`: submits the registration, scholarship (`scholarship_requested=true`), and bulk-payment forms **both logged in and incognito**, asserting every answer (and its person/registration side effects) persists.

## Notes for reviewers
- Field-type/option changes are additive or keyed off `field_identifier`; the `SECTION_FIELD_NAMES` sync test guards the builder ↔ constant alignment.
- The Primary sector dropdown and Additional sectors checkboxes already draw from the same published `Sector` list (verified), so no field-identifier change was needed there.
- Kept Confirm Email / Nickname / Pronouns (standard product fields not pictured).