### PR TITLE
Recolor domain themes so events isn't blue next to the sky banner

### DIFF
--- a/app/views/home/_video_recordings.html.erb
+++ b/app/views/home/_video_recordings.html.erb
@@ -1,6 +1,6 @@
 <% title ||= "Video Gallery" %>
 
-<section class="py-10 bg-teal-50">
+<section class="py-10 <%= DomainTheme.bg_class_for(:video_recordings) %>">
   <div class="max-w-6xl mx-auto px-4">
     <%= render "home/home_section_header",
                title: title,

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -8,8 +8,8 @@ module DomainTheme
     resources:                :violet,
     community_news:           :orange,
     stories:                  :fuchsia,
-    events:                   :blue,
-    people:                   :sky,
+    events:                   :teal,
+    people:                   :cyan,
     organizations:            :emerald,
     quotes:                   :slate,
     grants:                   :green,
@@ -21,12 +21,12 @@ module DomainTheme
 
     forms:                    :purple,
     faqs:                     :pink,
-    video_recordings:         :cyan,
+    video_recordings:         :sky,
 
     workshop_ideas:           :indigo,
     workshop_variation_ideas: :purple,
     story_ideas:              :fuchsia,
-    event_registrations:      :blue,
+    event_registrations:      :teal,
 
     banners:                  :yellow,
     users:                    :rose,

--- a/spec/lib/domain_theme_spec.rb
+++ b/spec/lib/domain_theme_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DomainTheme do
 
     it "supports intensity overrides" do
       expect(DomainTheme.bg_class_for(:events, intensity: 100))
-        .to eq("bg-blue-100")
+        .to eq("bg-teal-100")
     end
 
     it "supports hover classes for 100's" do


### PR DESCRIPTION
REVIEW NEEDED: 📖 Read — light-logic: small, contained logic changes with low blast radius

### What is the goal of this PR and why is this important?
Blue events sat too close to the sky-toned welcome banner and shared blue with `admin_only`. This recolors the `DomainTheme` palette so each hue carries a clearer meaning.

### How did you approach the change?
In `lib/domain_theme.rb`: events→teal, people→cyan, video recordings→sky (freeing cyan for people), and event registrations→teal to stay paired with events. Also routed the home video-gallery section through `DomainTheme.bg_class_for(:video_recordings)` instead of a hardcoded `bg-teal-50`, so the map remains the single source of truth.

### Anything else to add?
Open question for review: `event_registrations` is currently teal to match its parent event — slate was considered to give the registrant flow its own identity, but that dilutes slate's quiet-metadata role. Left as teal.