### PR TITLE
Add a paid-in-full receipt for event registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This codebase (Rails 8.1)
 | `app/views/` | ERB templates | ~504 files |
 | `app/decorators/` | Draper decorators for view logic | ~38 files |
 | `app/policies/` | ActionPolicy authorization rules | ~49 files |
-| `app/presenters/` | Presentation objects | 3 files |
+| `app/presenters/` | Presentation objects | 4 files |
 | `app/helpers/` | View helpers | ~24 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -62,8 +62,9 @@ module Events
     def ce
     end
 
-    # Forms page: callout-card links to the W-9 and letter-to-supervisors
-    # resource pages (when seeded) and the invoice, each returning to forms.
+    # Forms page: callout-card links to the W-9 (when seeded) and, for paid
+    # events, the invoice and the paid-in-full receipt (once settled), each
+    # returning to forms.
     def forms
       @form_cards = build_form_cards
     end
@@ -113,9 +114,9 @@ module Events
       @event = @event_registration.event
     end
 
-    # Builds the callout-card links shown on the forms page. The W-9 opens in
-    # its own resource page (preview + download) when seeded; the invoice is
-    # always available.
+    # Builds the callout-card links shown on the forms page. The W-9 opens in its
+    # own resource page (preview + download) when seeded; the invoice and the
+    # paid-in-full receipt (once settled) show for paid events. Each returns to forms.
     def build_form_cards
       cards = []
       w9 = Resource.find_by(title: "W-9")
@@ -124,9 +125,16 @@ module Events
                                subtitle: "AWBW's W-9 tax form for your records",
                                href: registration_resource_path(@event_registration.slug, w9, return_to: "forms"), target: nil)
       end
-      cards << resource_card(icon: "fa-solid fa-file-invoice-dollar", title: "View invoice",
-                             subtitle: "Itemized invoice for this registration",
-                             href: registration_invoice_path(@event_registration.slug, return_to: "forms"))
+      if @event_registration.invoice_available?
+        cards << resource_card(icon: "fa-solid fa-file-invoice-dollar", title: "View invoice",
+                               subtitle: "Itemized invoice for this registration",
+                               href: registration_invoice_path(@event_registration.slug, return_to: "forms"))
+      end
+      if @event_registration.receipt_available?
+        cards << resource_card(icon: "fa-solid fa-receipt", title: "View receipt",
+                               subtitle: "Paid-in-full receipt for this registration",
+                               href: registration_receipt_path(@event_registration.slug, return_to: "forms"))
+      end
       cards
     end
 

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -3,7 +3,7 @@ module Events
     before_action :authenticate_user!, only: [ :create, :destroy ]
     before_action :set_event, only: [ :create, :destroy ]
     before_action :set_registrant, only: [ :create, :destroy ]
-    before_action :set_event_registration, only: [ :show, :invoice, :resend_confirmation, :cancel, :reactivate, :pay ]
+    before_action :set_event_registration, only: [ :show, :invoice, :receipt, :resend_confirmation, :cancel, :reactivate, :pay ]
 
     def show
       authorize! @event_registration, to: :show_public?
@@ -24,8 +24,28 @@ module Events
 
     def invoice
       authorize! @event_registration, to: :show_public?
+
+      unless @event_registration.invoice_available?
+        redirect_to registration_ticket_path(@event_registration.slug),
+                    alert: "There's no invoice for a free event."
+        return
+      end
+
       @event = @event_registration.event
       @invoice = EventInvoice.from_registration(@event_registration)
+    end
+
+    def receipt
+      authorize! @event_registration, to: :show_public?
+
+      unless @event_registration.receipt_available?
+        redirect_to registration_ticket_path(@event_registration.slug),
+                    alert: "A receipt is available once your balance is paid in full."
+        return
+      end
+
+      @event = @event_registration.event
+      @receipt = EventReceipt.from_registration(@event_registration)
     end
 
     def resend_confirmation

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -309,6 +309,17 @@ class EventRegistration < ApplicationRecord
     event.end_date.present? && event.end_date.past? && attended? && scholarship_tasks_met?
   end
 
+  # An invoice (and receipt) only make sense for a paid event — free events have
+  # nothing to bill or receipt.
+  def invoice_available?
+    event.cost_cents.to_i.positive?
+  end
+
+  # A paid-in-full receipt is available once a paid event carries no balance.
+  def receipt_available?
+    invoice_available? && remaining_cost.zero?
+  end
+
   # Cost source for the Registerable payment interface: the event's price.
   def cost_cents
     event.cost_cents

--- a/app/presenters/event_receipt.rb
+++ b/app/presenters/event_receipt.rb
@@ -1,0 +1,139 @@
+# Normalizes the data needed to render a paid-in-full receipt for a single
+# EventRegistration. Mirrors EventInvoice (same bill-to/attention/line-item
+# shape) but adds the allocation ledger that settled the balance and a summary
+# that always reconciles to $0 due — a receipt is only generated once the
+# registration is paid in full (see EventRegistration#receipt_available?).
+class EventReceipt
+  ISSUER_NAME = "A Window Between Worlds".freeze
+  ISSUER_ADDRESS_LINES = [ "1029 1/2 W 24th St", "Los Angeles, CA 90007" ].freeze
+  ISSUER_EMAIL = "info@awbw.org".freeze
+  THANK_YOU_NOTE = "Payment received in full — thank you. Please retain this receipt for your records.".freeze
+
+  # Friendly payment-method names for the ledger. Payment is an STI base whose
+  # polymorphic source_type is always "Payment"; the concrete subclass tells us
+  # how it was paid. Non-payment allocations (scholarships, discounts) fall back
+  # to their humanized type.
+  PAYMENT_METHOD_LABELS = {
+    "CashPayment" => "Cash",
+    "CheckPayment" => "Check",
+    "ExternalProcessorPayment" => "Credit card",
+    "FilemakerPayment" => "Payment"
+  }.freeze
+
+  LineItem = Struct.new(:date, :description, :quantity, :unit_price_cents, keyword_init: true) do
+    def amount_cents
+      unit_price_cents.to_i * quantity.to_i
+    end
+  end
+
+  Entry = Struct.new(:date, :method, :reference, :amount_cents, keyword_init: true)
+
+  attr_reader :event, :number, :date, :client_id,
+              :bill_to_name, :bill_to_address_lines, :bill_to_email,
+              :attention, :line_items, :entries, :amount_paid_cents, :balance_cents
+
+  # One registration → the event charge as a line item, every allocation that
+  # settled it as a ledger entry, and a balance that reconciles to zero. The
+  # snapshotted organization (if any) is the bill-to; otherwise bill the person.
+  def self.from_registration(registration)
+    event = registration.event
+    registrant = registration.registrant
+    organization = registration.organizations.first
+    addressable = organization || registrant
+    allocations = registration.allocations.includes(:source).order(:created_at)
+    amount_paid_cents = allocations.sum(&:amount)
+
+    new(
+      event: event,
+      number: "RCPT-#{registration.id}",
+      date: (allocations.last&.created_at || registration.created_at).to_date,
+      client_id: organization&.id || registrant.id,
+      bill_to_name: organization&.name.presence || registrant.full_name,
+      bill_to_address_lines: address_lines_for(addressable),
+      bill_to_email: organization&.email.presence || registrant.preferred_email,
+      attention: registrant.full_name,
+      line_items: [
+        LineItem.new(
+          date: registration.created_at.to_date,
+          description: event.title,
+          quantity: 1,
+          unit_price_cents: event.cost_cents.to_i
+        )
+      ],
+      entries: allocations.map { |allocation| entry_for(allocation) },
+      amount_paid_cents: amount_paid_cents,
+      balance_cents: [ event.cost_cents.to_i - amount_paid_cents, 0 ].max
+    )
+  end
+
+  def self.entry_for(allocation)
+    Entry.new(
+      date: allocation.created_at.to_date,
+      method: method_label(allocation),
+      reference: reference_for(allocation),
+      amount_cents: allocation.amount
+    )
+  end
+  private_class_method :entry_for
+
+  def self.method_label(allocation)
+    if allocation.source_type == Payment.polymorphic_name
+      PAYMENT_METHOD_LABELS[allocation.source&.class&.name] || "Payment"
+    else
+      allocation.source_type.underscore.humanize
+    end
+  end
+  private_class_method :method_label
+
+  # Check number, when the payment was a check — standard receipt detail so the
+  # payer can reconcile it against their own records.
+  def self.reference_for(allocation)
+    source = allocation.source
+    return unless source.is_a?(CheckPayment) && source.check_number.present?
+    "Check ##{source.check_number}"
+  end
+  private_class_method :reference_for
+
+  def initialize(event:, number:, date:, client_id:, bill_to_name:,
+                 bill_to_address_lines:, bill_to_email:, attention:, line_items:,
+                 entries:, amount_paid_cents:, balance_cents:)
+    @event = event
+    @number = number
+    @date = date
+    @client_id = client_id
+    @bill_to_name = bill_to_name
+    @bill_to_address_lines = bill_to_address_lines
+    @bill_to_email = bill_to_email
+    @attention = attention
+    @line_items = line_items
+    @entries = entries
+    @amount_paid_cents = amount_paid_cents
+    @balance_cents = balance_cents
+  end
+
+  def total_cents
+    line_items.sum(&:amount_cents)
+  end
+
+  def paid_in_full?
+    balance_cents.to_i.zero?
+  end
+
+  def issuer_name = ISSUER_NAME
+  def issuer_address_lines = ISSUER_ADDRESS_LINES
+  def issuer_email = ISSUER_EMAIL
+  def thank_you_note = THANK_YOU_NOTE
+
+  def self.address_lines_for(addressable)
+    return [] unless addressable.respond_to?(:addresses)
+
+    address = addressable.addresses.active.first
+    return [] unless address
+
+    city_line = [ address.city.presence,
+                  [ address.state.presence, address.zip_code.presence ].compact.join(" ").presence ]
+      .compact.join(", ")
+    [ address.street_address.presence, city_line.presence ].compact
+  end
+  private_class_method :address_lines_for
+end

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -45,7 +45,7 @@ class MagicTicketCallouts
       EditorCard.new(:ce_hours, "fa-solid fa-graduation-cap", "teal", event.ce_hours_details_label, "Continuing education — requirements & how to request", "When a registrant requests CE credit", nil),
       EditorCard.new(:event_details, "fa-solid fa-palette", "blue", event.event_details_label, "Important info for this event — please read", "When the content below is filled in", nil),
       EditorCard.new(nil, "fa-solid fa-video", "blue", "Videoconference", "Join link and how to add it to your calendar", "When the event has a videoconference link", "Details come from this event's videoconference settings."),
-      EditorCard.new(nil, "fa-solid fa-file-lines", "blue", "Forms", "W-9 and invoice", "Always shown", "Items link to their relevant resources."),
+      EditorCard.new(nil, "fa-solid fa-file-lines", "blue", "Forms", "W-9, invoice, and receipt", "Always shown", "Items link to their relevant resources."),
       EditorCard.new(nil, "fa-solid fa-folder-open", "blue", "Handouts", "Worksheets and resources for the training", "Always shown", "Items link to their relevant resources."),
       EditorCard.new(nil, "fa-solid fa-circle-question", "blue", "Frequently asked questions", "Common questions about the 2-day training", "Always shown", nil)
     ]
@@ -181,12 +181,12 @@ class MagicTicketCallouts
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
 
-  # Always-present. Its page links to the W-9 (when requested) and invoice
-  # (when requested).
+  # Always-present. Its page links to the W-9, the invoice, and the paid-in-full
+  # receipt (once settled).
   def forms_card
     Card.new(icon_class: "fa-solid fa-file-lines", color: "blue",
              title: "Forms",
-             subtitle: "W-9 and invoice",
+             subtitle: "W-9, invoice, and receipt",
              href: registration_forms_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -35,18 +35,6 @@
                     class: "btn btn-accent px-6 py-2 text-sm uppercase font-telefon" %>
     </div>
 
-    <%= link_to registration_invoice_path(@event_registration.slug, return_to: "payment"), target: "_blank", rel: "noopener",
-                  class: "mt-10 flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
-      <i class="fa-solid fa-file-invoice-dollar text-gray-400 text-xl shrink-0"></i>
-
-      <div class="flex-1 min-w-0 text-left">
-        <p class="font-semibold text-gray-900">View invoice</p>
-        <p class="text-sm text-gray-500">Itemized invoice for this registration</p>
-      </div>
-
-      <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
-    <% end %>
-
     <details class="mt-6">
       <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-700">Prefer to pay by check?</summary>
 
@@ -58,5 +46,33 @@
         <p>Payment is due no later than 5:00 PM PT on April 9th. We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
       </div>
     </details>
+  <% end %>
+
+  <%# Documents for paid events, available regardless of balance: the invoice
+      always, and the paid-in-full receipt once there's no balance due. %>
+  <% if @event_registration.invoice_available? %>
+    <div class="mt-10 space-y-3">
+      <%= link_to registration_invoice_path(@event_registration.slug, return_to: "payment"), target: "_blank", rel: "noopener",
+                    class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
+        <i class="fa-solid fa-file-invoice-dollar text-gray-400 text-xl shrink-0"></i>
+        <div class="flex-1 min-w-0 text-left">
+          <p class="font-semibold text-gray-900">View invoice</p>
+          <p class="text-sm text-gray-500">Itemized invoice for this registration</p>
+        </div>
+        <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
+      <% end %>
+
+      <% if @event_registration.receipt_available? %>
+        <%= link_to registration_receipt_path(@event_registration.slug, return_to: "payment"), target: "_blank", rel: "noopener",
+                      class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
+          <i class="fa-solid fa-receipt text-gray-400 text-xl shrink-0"></i>
+          <div class="flex-1 min-w-0 text-left">
+            <p class="font-semibold text-gray-900">View receipt</p>
+            <p class="text-sm text-gray-500">Paid-in-full receipt for this registration</p>
+          </div>
+          <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
+        <% end %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/events/invoices/_invoice.html.erb
+++ b/app/views/events/invoices/_invoice.html.erb
@@ -18,7 +18,7 @@
   <%# Bill-to %>
   <div class="space-y-1">
     <p class="text-sm font-bold">Invoice To:</p>
-    <div class="rounded-2xl border border-gray-300 px-4 py-3 text-sm leading-relaxed">
+    <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm leading-relaxed">
       <p class="font-medium"><%= invoice.bill_to_name %></p>
       <% invoice.bill_to_address_lines.each do |line| %>
         <p><%= line %></p>
@@ -32,13 +32,13 @@
   <%# Attention %>
   <div class="space-y-1 mt-5">
     <p class="text-sm font-bold">Attention:</p>
-    <div class="rounded-2xl border border-gray-300 px-4 py-3 text-sm">
+    <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm">
       <%= invoice.attention.presence || "—" %>
     </div>
   </div>
 
   <%# Meta row: number / date / reference / client id %>
-  <div class="mt-6 rounded-2xl border border-gray-300 grid grid-cols-2 sm:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200 text-center">
+  <div class="mt-6 rounded-lg border border-gray-300 grid grid-cols-2 sm:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200 text-center">
     <% [
          [ "Invoice Number", invoice.number ],
          [ "Invoice Date", invoice.date&.strftime("%-d %b, %Y") ],

--- a/app/views/events/receipts/_receipt.html.erb
+++ b/app/views/events/receipts/_receipt.html.erb
@@ -1,0 +1,141 @@
+<%# Renders one EventReceipt as a printable document. Mirrors the invoice layout
+    but adds the payment ledger and a balance summary that reconciles to $0.
+    `receipt` is an EventReceipt. %>
+<article class="mx-auto max-w-3xl bg-white text-gray-800 px-8 py-10 print:px-0 print:py-0 print:max-w-none">
+  <%# Header: issuer details (left) + brand logo (right) %>
+  <header class="flex items-start justify-between gap-6">
+    <address class="not-italic text-sm leading-snug">
+      <p class="font-medium"><%= receipt.issuer_name %></p>
+      <% receipt.issuer_address_lines.each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+      <p><%= receipt.issuer_email %></p>
+    </address>
+    <%= image_tag "logo-with-tagline.png", alt: receipt.issuer_name, class: "h-16 w-auto shrink-0" %>
+  </header>
+
+  <div class="my-8 flex flex-col items-center gap-3">
+    <h1 class="text-center text-3xl font-semibold tracking-wide">RECEIPT</h1>
+    <span class="inline-flex items-center gap-1.5 rounded-full border border-green-600 bg-green-50 px-3 py-1 text-sm font-semibold uppercase tracking-wide text-green-700">
+      <i class="fa-solid fa-circle-check"></i> Paid in full
+    </span>
+  </div>
+
+  <%# Received from %>
+  <div class="space-y-1">
+    <p class="text-sm font-bold">Received From:</p>
+    <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm leading-relaxed">
+      <p class="font-medium"><%= receipt.bill_to_name %></p>
+      <% receipt.bill_to_address_lines.each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+      <% if receipt.bill_to_email.present? %>
+        <p class="text-gray-500"><%= receipt.bill_to_email %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Attention %>
+  <div class="space-y-1 mt-5">
+    <p class="text-sm font-bold">Attention:</p>
+    <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm">
+      <%= receipt.attention.presence || "—" %>
+    </div>
+  </div>
+
+  <%# Meta row: number / date / client id %>
+  <div class="mt-6 rounded-lg border border-gray-300 grid grid-cols-3 divide-x divide-gray-200 text-center">
+    <% [
+         [ "Receipt Number", receipt.number ],
+         [ "Date Paid", receipt.date&.strftime("%-d %b, %Y") ],
+         [ "Client ID", receipt.client_id ]
+       ].each do |label, value| %>
+      <div class="px-3 py-3">
+        <p class="text-xs font-bold text-gray-600"><%= label %></p>
+        <p class="text-sm mt-1"><%= value.presence || " " %></p>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Charges %>
+  <table class="w-full mt-8 text-sm">
+    <thead>
+      <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
+        <th class="text-left py-2 pr-3">Date</th>
+        <th class="text-left py-2 pr-3">Description</th>
+        <th class="text-right py-2 px-3 whitespace-nowrap">Quantity/Units</th>
+        <th class="text-right py-2 px-3 whitespace-nowrap">Unit Price</th>
+        <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% receipt.line_items.each do |item| %>
+        <tr class="border-b border-gray-100">
+          <td class="py-2 pr-3 whitespace-nowrap align-top"><%= item.date&.strftime("%m/%d/%y") %></td>
+          <td class="py-2 pr-3 align-top"><%= item.description %></td>
+          <td class="py-2 px-3 text-right tabular-nums align-top"><%= item.quantity %></td>
+          <td class="py-2 px-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.unit_price_cents) %></td>
+          <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.amount_cents) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%# Payment ledger: every allocation that settled the balance %>
+  <div class="mt-8">
+    <p class="text-xs font-bold text-gray-700 uppercase tracking-wide mb-2">Payments &amp; credits</p>
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
+          <th class="text-left py-2 pr-3">Date</th>
+          <th class="text-left py-2 pr-3">Method</th>
+          <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if receipt.entries.any? %>
+          <% receipt.entries.each do |entry| %>
+            <tr class="border-b border-gray-100">
+              <td class="py-2 pr-3 whitespace-nowrap align-top"><%= entry.date&.strftime("%m/%d/%y") %></td>
+              <td class="py-2 pr-3 align-top">
+                <%= entry.method %>
+                <% if entry.reference.present? %>
+                  <span class="text-xs text-gray-500">· <%= entry.reference %></span>
+                <% end %>
+              </td>
+              <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(entry.amount_cents) %></td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr class="border-b border-gray-100">
+            <td colspan="3" class="py-2 text-gray-500">No payments recorded.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <%# Summary: total charged, amount paid, balance due (always $0) %>
+  <div class="mt-8 flex justify-end">
+    <dl class="w-full max-w-xs text-sm">
+      <div class="flex items-center justify-between py-1">
+        <dt class="text-gray-600">Total charged</dt>
+        <dd class="tabular-nums"><%= dollars_from_cents(receipt.total_cents) %></dd>
+      </div>
+      <div class="flex items-center justify-between py-1">
+        <dt class="text-gray-600">Amount paid</dt>
+        <dd class="tabular-nums"><%= dollars_from_cents(receipt.amount_paid_cents) %></dd>
+      </div>
+      <div class="mt-1 flex items-center justify-between border-t border-gray-300 pt-2 font-bold">
+        <dt>Balance due</dt>
+        <dd>
+          <span class="inline-block rounded-md border border-green-500 bg-green-50 px-3 py-1 text-green-700 tabular-nums whitespace-nowrap"><%= dollars_from_cents(receipt.balance_cents) %></span>
+        </dd>
+      </div>
+    </dl>
+  </div>
+
+  <footer class="mt-12 text-sm">
+    <p><%= receipt.thank_you_note %></p>
+  </footer>
+</article>

--- a/app/views/events/registrations/receipt.html.erb
+++ b/app/views/events/registrations/receipt.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:page_bg_class, "public") %>
+<% content_for(:page_title, "Receipt — #{@event.title}") %>
+<%# Eyebrow returns to the callout the registrant came from (forms/payment),
+    falling back to the forms page when reached directly. %>
+<% back_path, back_label = case params[:return_to]
+   when "payment"
+     [ registration_payment_path(@event_registration.slug), "Back to payment" ]
+   else
+     [ registration_forms_path(@event_registration.slug), "Back to forms" ]
+   end %>
+<%= render "events/invoices/actions", back_path: back_path, back_label: back_label %>
+<div class="px-4 sm:px-8 py-6 print:p-0">
+  <%= render "events/receipts/receipt", receipt: @receipt %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   post "bulk_payment/:slug/resend_confirmation", to: "events/bulk_payments#resend_confirmation", as: :bulk_payment_resend_confirmation
   get "registration/:slug", to: "events/registrations#show", as: :registration_ticket
   get "registration/:slug/invoice", to: "events/registrations#invoice", as: :registration_invoice
+  get "registration/:slug/receipt", to: "events/registrations#receipt", as: :registration_receipt
   get "registration/:slug/scholarship", to: "events/callouts#scholarship", as: :registration_scholarship
   get "registration/:slug/faq", to: "events/callouts#faq", as: :registration_faq
   get "registration/:slug/payment", to: "events/callouts#payment", as: :registration_payment

--- a/spec/presenters/event_receipt_spec.rb
+++ b/spec/presenters/event_receipt_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe EventReceipt do
+  describe ".from_registration" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+    let(:registrant) { create(:person, first_name: "Helena", last_name: "Lopez") }
+    let(:registration) { create(:event_registration, event: event, registrant: registrant) }
+
+    it "reconciles the event charge against its payments to a zero balance" do
+      payment = create(:payment, type: "CashPayment", amount_cents: 150_000)
+      create(:allocation, source: payment, allocatable: registration, amount: 150_000)
+
+      receipt = described_class.from_registration(registration)
+
+      expect(receipt.attention).to eq("Helena Lopez")
+      expect(receipt.bill_to_name).to eq("Helena Lopez")
+      expect(receipt.total_cents).to eq(150_000)
+      expect(receipt.amount_paid_cents).to eq(150_000)
+      expect(receipt.balance_cents).to eq(0)
+      expect(receipt).to be_paid_in_full
+
+      item = receipt.line_items.first
+      expect(item.description).to eq("AWBW 2-Day Art Facilitator Training")
+      expect(item.amount_cents).to eq(150_000)
+
+      entry = receipt.entries.first
+      expect(receipt.entries.size).to eq(1)
+      expect(entry.method).to eq("Cash")
+      expect(entry.amount_cents).to eq(150_000)
+    end
+
+    it "labels a check payment with its check number" do
+      payment = create(:payment, type: "CheckPayment", amount_cents: 150_000, check_number: "4821")
+      create(:allocation, source: payment, allocatable: registration, amount: 150_000)
+
+      receipt = described_class.from_registration(registration)
+      entry = receipt.entries.first
+
+      expect(entry.method).to eq("Check")
+      expect(entry.reference).to eq("Check #4821")
+    end
+
+    it "lists multiple allocations as separate ledger entries in order" do
+      cash = create(:payment, type: "CashPayment", amount_cents: 50_000)
+      check = create(:payment, type: "CheckPayment", amount_cents: 100_000, check_number: "12")
+      create(:allocation, source: cash, allocatable: registration, amount: 50_000)
+      create(:allocation, source: check, allocatable: registration, amount: 100_000)
+
+      receipt = described_class.from_registration(registration)
+
+      expect(receipt.entries.map(&:method)).to eq([ "Cash", "Check" ])
+      expect(receipt.entries.map(&:amount_cents)).to eq([ 50_000, 100_000 ])
+      expect(receipt.amount_paid_cents).to eq(150_000)
+      expect(receipt.balance_cents).to eq(0)
+    end
+
+    context "with a snapshotted organization" do
+      let(:organization) { create(:organization, name: "A Greater Hope") }
+
+      before do
+        create(:event_registration_organization, event_registration: registration, organization: organization)
+        create(:address, addressable: organization, street_address: "PO Box 1477", city: "Victorville", state: "CA", zip_code: "92393")
+        payment = create(:payment, type: "CashPayment", amount_cents: 150_000)
+        create(:allocation, source: payment, allocatable: registration, amount: 150_000)
+      end
+
+      it "addresses the receipt to the organization but keeps the registrant as attention" do
+        receipt = described_class.from_registration(registration)
+
+        expect(receipt.bill_to_name).to eq("A Greater Hope")
+        expect(receipt.attention).to eq("Helena Lopez")
+        expect(receipt.bill_to_address_lines).to eq([ "PO Box 1477", "Victorville, CA 92393" ])
+        expect(receipt.client_id).to eq(organization.id)
+      end
+    end
+  end
+end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Events::Registrations", type: :request do
       it "renders the consolidated magic callout cards" do
         get registration_ticket_path(registration.slug)
         expect(response.body).to include("view your balance")
-        expect(response.body).to include("W-9 and invoice")
+        expect(response.body).to include("W-9, invoice, and receipt")
         expect(response.body).to include("Worksheets and resources for the training")
         expect(response.body).to include("Frequently asked questions")
       end
@@ -105,9 +105,67 @@ RSpec.describe "Events::Registrations", type: :request do
       end
     end
 
+    context "for a free event" do
+      let(:event) { create(:event, cost_cents: 0) }
+
+      it "redirects to the ticket (nothing to invoice)" do
+        get registration_invoice_path(registration.slug)
+        expect(response).to redirect_to(registration_ticket_path(registration.slug))
+      end
+    end
+
     context "with an invalid slug" do
       it "returns 404" do
         get registration_invoice_path("nonexistent-slug")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "GET /registration/:slug/receipt" do
+    let(:event) { create(:event, title: "AWBW 2-Day Art Facilitator Training", cost_cents: 150_000) }
+    let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+
+    context "when paid in full" do
+      before { create(:allocation, allocatable: registration, amount: 150_000) }
+
+      it "renders the receipt with a zero balance" do
+        get registration_receipt_path(registration.slug)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("RECEIPT")
+        expect(response.body).to include("Paid in full")
+        expect(response.body).to include("AWBW 2-Day Art Facilitator Training")
+        expect(response.body).to include("Balance due")
+      end
+
+      context "as a guest" do
+        before { sign_out user }
+
+        it "renders the receipt (slug is authorization)" do
+          get registration_receipt_path(registration.slug)
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
+
+    it "redirects to the ticket when a balance is still due" do
+      get registration_receipt_path(registration.slug)
+      expect(response).to redirect_to(registration_ticket_path(registration.slug))
+    end
+
+    context "for a free event" do
+      let(:event) { create(:event, cost_cents: 0) }
+
+      it "redirects to the ticket (nothing to receipt)" do
+        get registration_receipt_path(registration.slug)
+        expect(response).to redirect_to(registration_ticket_path(registration.slug))
+      end
+    end
+
+    context "with an invalid slug" do
+      it "returns 404" do
+        get registration_receipt_path("nonexistent-slug")
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -252,6 +310,20 @@ RSpec.describe "Events::Registrations", type: :request do
       get registration_forms_path(registration.slug)
       expect(response.body).to include(registration_resource_path(registration.slug, w9, return_to: "forms"))
       expect(response.body).not_to include("/documents/awbw-w9.pdf")
+    end
+
+    it "omits the receipt link until the balance is paid in full" do
+      get registration_forms_path(registration.slug)
+      expect(response.body).not_to include(registration_receipt_path(registration.slug))
+    end
+
+    it "links to the receipt once paid in full, returning to forms" do
+      paid_event = create(:event, cost_cents: 150_000)
+      paid_registration = create(:event_registration, event: paid_event, registrant: user.person)
+      create(:allocation, allocatable: paid_registration, amount: 150_000)
+
+      get registration_forms_path(paid_registration.slug)
+      expect(response.body).to include(registration_receipt_path(paid_registration.slug, return_to: "forms"))
     end
   end
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/public_registrations/show.html.erb" => "public",
     "app/views/events/registrations/show.html.erb"        => "public",
     "app/views/events/registrations/invoice.html.erb"     => "public",
+    "app/views/events/registrations/receipt.html.erb"     => "public",
     "app/views/events/callouts/scholarship.html.erb"      => "public",
     "app/views/events/callouts/faq.html.erb"              => "public",
     "app/views/events/callouts/payment.html.erb"          => "public",


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: a new read-only receipt page modeled on the existing invoice, gated to paid-in-full registrations.

### What is the goal of this PR and why is this important?
- Gives registrants a printable **RECEIPT** (proof of payment) once their balance is settled, alongside the existing invoice.

### How did you approach the change?
- New `EventReceipt` presenter mirrors `EventInvoice` but adds the allocation ledger and a summary that reconciles to **$0 balance due**.
- New `receipt` action on `Events::RegistrationsController`, gated by `EventRegistration#receipt_available?` (paid event + zero balance).
- `EventRegistration#invoice_available?` gates the invoice too — **free events get neither** document.
- Reachable from the **Forms** callout (W-9, invoice, receipt) and the **Payment** page (invoice always, receipt once paid), so both are available even after the balance is paid. Reuses main's `return_to` eyebrow convention (forms/payment/ticket).
- Ledger labels payments by method (Cash / Check / Credit card), folding in the check number when present.
- Squared the invoice + receipt boxes (`rounded-2xl` → `rounded-lg`).

### Anything else to add?
- Rebased onto main after it independently landed the `return_to` invoice work and moved payment/allocation methods into the `Registerable` concern; receipt is layered on top of that structure.
- Receipt reachable by slug (same public auth as the invoice/ticket).