### PR TITLE
Add CE status column and filter to registrants index

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,7 @@ When changing a model or controller, check whether these related files need upda
 - Avoid `update_all` unless explicitly intended
 - Prefer service objects under app/services/
 - Prefer POROs over concerns when possible
+- **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
 
 ## RuboCop (rubocop-rails-omakase)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ When changing a model or controller, check whether these related files need upda
 - Avoid `update_all` unless explicitly intended
 - Prefer service objects under app/services/
 - Prefer POROs over concerns when possible
+- **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
 
 ## RuboCop (rubocop-rails-omakase)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -87,6 +87,7 @@ class EventsController < ApplicationController
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
     scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?
     scope = scope.scholarship_status(params[:scholarship]) if params[:scholarship].present?
+    scope = scope.ce_status(params[:ce_status]) if params[:ce_status].present?
     scope = scope.registrant_ids(params[:registrant_ids]) if params[:registrant_ids].present?
     scope = scope.registrant_state(params[:state]) if params[:state].present?
     scope = scope.registrant_county(params[:county]) if params[:county].present?
@@ -105,6 +106,7 @@ class EventsController < ApplicationController
 
     @event_registrations = scope.order(Arel.sql("people.first_name, people.last_name"))
     @dashboard = EventDashboard.new(@event)
+    @offers_ce = @event.any_ce_credit_requests?
 
     emails = @event_registrations.map { |r| r.registrant.preferred_email&.downcase }.compact
     @duplicate_emails = emails.tally.select { |_, count| count > 1 }.keys.to_set
@@ -535,15 +537,17 @@ class EventsController < ApplicationController
   def event_registrations_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
+    include_ce = @event.any_ce_credit_requests?
     headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Intends to pay", "Payment total" ]
+    headers << "CE status" if include_ce
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
       @event_registrations.each do |registration|
-        csv_out << event_registration_csv_row(registration, cost_required)
+        csv_out << event_registration_csv_row(registration, cost_required, include_ce)
       end
     end
   end
 
-  def event_registration_csv_row(registration, cost_required)
+  def event_registration_csv_row(registration, cost_required, include_ce = false)
     person = registration.registrant
     orgs = person.affiliations
       .select { |a| !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) }
@@ -552,7 +556,7 @@ class EventsController < ApplicationController
     total_cents = registration.allocations_sum
     payment_total = total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
     payment_status = cost_required ? registration.payment_status_label : ""
-    [
+    row = [
       person.first_name,
       person.last_name,
       person.preferred_email.presence || "",
@@ -564,6 +568,8 @@ class EventsController < ApplicationController
       registration.intends_to_pay? ? "Yes" : "No",
       payment_total
     ]
+    row << registration.ce_status_label.to_s if include_ce
+    row
   end
 
   def onboarding_csv_string

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -90,6 +90,7 @@ class EventsController < ApplicationController
     scope = scope.ce_status(params[:ce_status]) if params[:ce_status].present?
     scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
     scope = scope.organization_status(params[:org_status], @event) if params[:org_status].present?
+    scope = scope.account_status(params[:account_status]) if params[:account_status].present?
     scope = scope.registrant_ids(params[:registrant_ids]) if params[:registrant_ids].present?
     scope = scope.registrant_state(params[:state]) if params[:state].present?
     scope = scope.registrant_county(params[:county]) if params[:county].present?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -82,12 +82,14 @@ class EventsController < ApplicationController
     authorize! @event, to: :registrants?
     @event = @event.decorate
     scope = @event.event_registrations
-      .includes(:comments, :organizations, registrant: [ :user, :contact_methods, { avatar_attachment: :blob }, { affiliations: :organization } ])
+      .includes(:comments, :organizations, { continuing_education_registrations: [ :professional_license, :allocations ] }, registrant: [ :user, :contact_methods, { avatar_attachment: :blob }, { affiliations: :organization } ])
       .joins(:registrant)
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
     scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?
     scope = scope.scholarship_status(params[:scholarship]) if params[:scholarship].present?
     scope = scope.ce_status(params[:ce_status]) if params[:ce_status].present?
+    scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
+    scope = scope.organization_status(params[:org_status], @event) if params[:org_status].present?
     scope = scope.registrant_ids(params[:registrant_ids]) if params[:registrant_ids].present?
     scope = scope.registrant_state(params[:state]) if params[:state].present?
     scope = scope.registrant_county(params[:county]) if params[:county].present?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -106,7 +106,7 @@ class EventsController < ApplicationController
 
     @event_registrations = scope.order(Arel.sql("people.first_name, people.last_name"))
     @dashboard = EventDashboard.new(@event)
-    @offers_ce = @event.any_ce_credit_requests?
+    @offers_ce = @event.offers_ce?
 
     emails = @event_registrations.map { |r| r.registrant.preferred_email&.downcase }.compact
     @duplicate_emails = emails.tally.select { |_, count| count > 1 }.keys.to_set
@@ -316,6 +316,7 @@ class EventsController < ApplicationController
   def preview_reminder
     authorize! @event
     @event = @event.decorate
+    @offers_ce = @event.offers_ce?
     @event_registrations = @event.event_registrations
       .includes(
         :event, :organizations, :comments,
@@ -537,7 +538,7 @@ class EventsController < ApplicationController
   def event_registrations_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
-    include_ce = @event.any_ce_credit_requests?
+    include_ce = @event.offers_ce?
     headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Intends to pay", "Payment total" ]
     headers << "CE status" if include_ce
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
@@ -575,12 +576,13 @@ class EventsController < ApplicationController
   def onboarding_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
+    include_ce = @event.offers_ce?
     day_count = @event.day_count
     headers = [ "First name", "Last name", "Email", "Organization", "Program type" ]
     headers += [ "Payment status", "Fees due", "Paid amount" ] if cost_required
     headers << "Fee note"
     headers += [ "Discounted amount", "Scholarship amount", "Scholarship grant", "Scholarship tasks completed" ]
-    headers += [ "CE requested", "CE hours", "CE amount", "CE license" ]
+    headers += [ "CE requested", "CE hours", "CE amount", "CE license" ] if include_ce
     headers += EventRegistration::CHECKLIST_STEPS.values
     headers += [ "Portal user status", "Portal access" ]
     headers += (1..day_count).map { |day| "Day #{day}" }
@@ -589,12 +591,12 @@ class EventsController < ApplicationController
 
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
       @event_registrations.each do |registration|
-        csv_out << onboarding_csv_row(registration, cost_required, day_count)
+        csv_out << onboarding_csv_row(registration, cost_required, day_count, include_ce)
       end
     end
   end
 
-  def onboarding_csv_row(registration, cost_required, day_count)
+  def onboarding_csv_row(registration, cost_required, day_count, include_ce = false)
     person = registration.registrant
     scholarship = registration.scholarships.first
     statuses = registration.program_statuses.map { |status| status.to_s.titleize }.join(", ")
@@ -617,11 +619,13 @@ class EventsController < ApplicationController
     row << (scholarship ? helpers.dollars_from_cents(scholarship.amount_cents) : "")
     row << (scholarship ? (scholarship.grant&.name.presence || "Unfunded") : "")
     row << onboarding_scholarship_tasks_csv(registration)
-    ce_hours = registration.ce_hours_requested.to_i
-    row << (registration.ce_credit_requested? ? "Yes" : "No")
-    row << (ce_hours.positive? ? ce_hours : "")
-    row << (registration.ce_amount_owed_cents.positive? ? helpers.dollars_from_cents(registration.ce_amount_owed_cents) : "")
-    row << registration.ce_license_number.to_s
+    if include_ce
+      ce_hours = registration.ce_hours_requested.to_i
+      row << (registration.ce_credit_requested? ? "Yes" : "No")
+      row << (ce_hours.positive? ? ce_hours : "")
+      row << (registration.ce_amount_owed_cents.positive? ? helpers.dollars_from_cents(registration.ce_amount_owed_cents) : "")
+      row << registration.ce_license_number.to_s
+    end
     EventRegistration::CHECKLIST_STEPS.each_key do |step|
       row << (registration.checklist_step_completed?(step) ? "Yes" : "No")
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -331,8 +331,11 @@ class EventsController < ApplicationController
 
     # Filters keep every registrant in the list and only flag who still matches,
     # so the recipient checkboxes pre-check the matched set rather than removing
-    # rows. See app/views/events/_reminder_recipients.html.erb.
-    recipient_filter = ReminderRecipientFilter.new(@event_registrations, params)
+    # rows. See app/views/events/_reminder_recipients.html.erb. The dropdown
+    # filters reuse the registrants-roster scopes (via the event), so both pages
+    # stay in sync; @dashboard supplies the state/county options.
+    @dashboard = EventDashboard.new(@event)
+    recipient_filter = ReminderRecipientFilter.new(@event_registrations, params, event: @event)
     @matched_ids = recipient_filter.matched_ids
     @filtering = recipient_filter.filtering?
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -106,7 +106,7 @@ class EventsController < ApplicationController
 
     @event_registrations = scope.order(Arel.sql("people.first_name, people.last_name"))
     @dashboard = EventDashboard.new(@event)
-    @offers_ce = @event.offers_ce?
+    @ce_eligible = @event.ce_eligible?
 
     emails = @event_registrations.map { |r| r.registrant.preferred_email&.downcase }.compact
     @duplicate_emails = emails.tally.select { |_, count| count > 1 }.keys.to_set
@@ -316,7 +316,7 @@ class EventsController < ApplicationController
   def preview_reminder
     authorize! @event
     @event = @event.decorate
-    @offers_ce = @event.offers_ce?
+    @ce_eligible = @event.ce_eligible?
     @event_registrations = @event.event_registrations
       .includes(
         :event, :organizations, :comments,
@@ -538,7 +538,7 @@ class EventsController < ApplicationController
   def event_registrations_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
-    include_ce = @event.offers_ce?
+    include_ce = @event.ce_eligible?
     headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Intends to pay", "Payment total" ]
     headers << "CE status" if include_ce
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
@@ -576,7 +576,7 @@ class EventsController < ApplicationController
   def onboarding_csv_string
     require "csv"
     cost_required = @event.cost_cents.to_i > 0
-    include_ce = @event.offers_ce?
+    include_ce = @event.ce_eligible?
     day_count = @event.day_count
     headers = [ "First name", "Last name", "Email", "Organization", "Program type" ]
     headers += [ "Payment status", "Fees due", "Paid amount" ] if cost_required

--- a/app/frontend/javascript/controllers/column_toggle_controller.js
+++ b/app/frontend/javascript/controllers/column_toggle_controller.js
@@ -1,23 +1,26 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="column-toggle"
-// Toggles visibility of table columns marked with a data attribute.
+// Each instance is a single slide switch that shows/hides the table columns
+// whose data-column-toggle-col value matches this switch's `group` value, so a
+// table can host several independent column toggles (e.g. "User confirmation",
+// "CE status"). Columns live outside the switch's element, under a shared
+// [data-column-toggle-root] ancestor.
 
 export default class extends Controller {
   static targets = ["toggle", "track", "knob"]
+  static values = { group: String }
 
   toggle() {
     const checked = this.toggleTarget.checked
-    this.element.querySelectorAll("[data-column-toggle-col]").forEach((el) => {
+    const root = this.element.closest("[data-column-toggle-root]") || document
+
+    root.querySelectorAll(`[data-column-toggle-col="${this.groupValue}"]`).forEach((el) => {
       el.classList.toggle("hidden", !checked)
     })
 
-    if (this.hasTrackTarget) {
-      this.trackTarget.classList.toggle("bg-gray-300", !checked)
-      this.trackTarget.classList.toggle("bg-blue-600", checked)
-    }
-    if (this.hasKnobTarget) {
-      this.knobTarget.style.transform = checked ? "translateX(16px)" : ""
-    }
+    this.trackTarget.classList.toggle("bg-gray-300", !checked)
+    this.trackTarget.classList.toggle("bg-blue-600", checked)
+    this.knobTarget.style.transform = checked ? "translateX(16px)" : ""
   }
 }

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -33,6 +33,7 @@
 
 @source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
 @source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
+@source inline("ring-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300,400,500}");
 @source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
 
 /* Per-field form layout widths (generated from FormField::WIDTH_GRID_SPANS, which

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,6 +12,19 @@ module EventsHelper
     onboarding_event_path(event_or_id, anchor: onboarding_row_id(registration_id), highlight: registration_id)
   end
 
+  # Stable anchor id for a registrant's row on the Registrants roster, so back
+  # links (e.g. from a viewed submission) can scroll to and highlight it.
+  def registrant_row_id(record_or_id)
+    id = record_or_id.respond_to?(:id) ? record_or_id.id : record_or_id
+    "registrant-row-#{id}"
+  end
+
+  # Path back to a specific registrant's row on the Registrants roster (scrolls
+  # to and highlights it). Accepts an Event or event id, and a registration id.
+  def registrants_event_row_path(event_or_id, registration_id)
+    registrants_event_path(event_or_id, anchor: registrant_row_id(registration_id), highlight: registration_id)
+  end
+
   # Ordered column descriptors for the event Onboarding matrix. The array index
   # is the table-sort column index, so the header row and every body row iterate
   # this same list — keeping header buttons and cell positions aligned no matter

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -39,7 +39,7 @@ module EventsHelper
     columns << { key: "scholarship_amount", label: "Scholarship amount", kind: :scholarship_amount, sortable: true, align: "center", toggle: "scholarship_amount" }
     columns << { key: "funder", label: "Scholarship grant", kind: :funder, sortable: true, align: "left", toggle: "funder" }
     columns << { key: "scholarship_tasks_completed", label: "Scholarship tasks done", kind: :scholarship_tasks, sortable: true, align: "center", toggle: "scholarship_tasks_completed" }
-    if event.offers_ce?
+    if event.ce_eligible?
       columns << { key: "ce_requested", label: "CE requested", kind: :ce_requested, sortable: true, align: "center", toggle: "ce_requested" }
       columns << { key: "ce_hours", label: "CE hours", kind: :ce_hours, sortable: true, align: "center", toggle: "ce_hours" }
       columns << { key: "ce_amount", label: "CE amount", kind: :ce_amount, sortable: true, align: "center", toggle: "ce_amount" }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -39,10 +39,12 @@ module EventsHelper
     columns << { key: "scholarship_amount", label: "Scholarship amount", kind: :scholarship_amount, sortable: true, align: "center", toggle: "scholarship_amount" }
     columns << { key: "funder", label: "Scholarship grant", kind: :funder, sortable: true, align: "left", toggle: "funder" }
     columns << { key: "scholarship_tasks_completed", label: "Scholarship tasks done", kind: :scholarship_tasks, sortable: true, align: "center", toggle: "scholarship_tasks_completed" }
-    columns << { key: "ce_requested", label: "CE requested", kind: :ce_requested, sortable: true, align: "center", toggle: "ce_requested" }
-    columns << { key: "ce_hours", label: "CE hours", kind: :ce_hours, sortable: true, align: "center", toggle: "ce_hours" }
-    columns << { key: "ce_amount", label: "CE amount", kind: :ce_amount, sortable: true, align: "center", toggle: "ce_amount" }
-    columns << { key: "ce_license", label: "License #", kind: :ce_license, sortable: true, align: "center", toggle: "ce_license" }
+    if event.offers_ce?
+      columns << { key: "ce_requested", label: "CE requested", kind: :ce_requested, sortable: true, align: "center", toggle: "ce_requested" }
+      columns << { key: "ce_hours", label: "CE hours", kind: :ce_hours, sortable: true, align: "center", toggle: "ce_hours" }
+      columns << { key: "ce_amount", label: "CE amount", kind: :ce_amount, sortable: true, align: "center", toggle: "ce_amount" }
+      columns << { key: "ce_license", label: "License #", kind: :ce_license, sortable: true, align: "center", toggle: "ce_license" }
+    end
     columns << { key: "fee_note", label: "Fee note", kind: :fee_note, sortable: false, align: "center", toggle: "fee_note" }
     columns << { key: "portal_invite", label: "Portal invite", kind: :portal_invite, sortable: true, align: "center", toggle: "portal_invite" }
     EventRegistration::CHECKLIST_STEPS.each do |step, label|

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,12 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {}, width_class: "w-full")
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {}, width_class: "w-full", compact: false)
+    # Compact mode shrinks the whole control (padding, avatar, type) for dense
+    # tables like the registrants roster where horizontal space is at a premium.
+    padding = compact ? "px-2 py-1" : "px-4 py-2"
+    avatar_size = compact ? "w-6 h-6" : "w-10 h-10"
+    initial_text_size = compact ? "text-xs" : "text-lg"
+    name_text_size = compact ? "text-xs" : ""
+
     if inactive
       bg = "bg-gray-100"
       hover_bg = "hover:bg-gray-200"
@@ -19,7 +26,7 @@ module PersonHelper
             data: { turbo_prefetch: false }.merge(data),
             title: hover_title,
             class: "group relative flex items-center gap-2
-                    #{width_class} px-4 py-2
+                    #{width_class} #{padding}
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
                     font-medium shadow-sm leading-none
@@ -29,11 +36,11 @@ module PersonHelper
       # --- Avatar ---
       avatar = if person.avatar.present?
         image_tag person.avatar.variant(:thumbnail),
-                  class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
+                  class: "#{avatar_size} rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
       else
         content_tag(:span, person.name.to_s.first.to_s.upcase,
-                    class: "w-10 h-10 rounded-full flex items-center justify-center
-                            bg-sky-200 text-sky-700 font-bold text-lg
+                    class: "#{avatar_size} rounded-full flex items-center justify-center
+                            bg-sky-200 text-sky-700 font-bold #{initial_text_size}
                             border border-sky-300 shadow-sm flex-shrink-0")
       end
 
@@ -43,7 +50,7 @@ module PersonHelper
       name = content_tag(
         :span,
         display_name,
-        class: "font-semibold #{text} truncate"
+        class: "font-semibold #{name_text_size} #{text} truncate"
       )
 
       subtitle_tag = if subtitle.present?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -107,6 +107,13 @@ class Event < ApplicationRecord
     forms.find_by(event_forms: { role: "registration" })
   end
 
+  # True when at least one registrant for this event requested CE credit. Drives
+  # the CE status column and filter on the registrants index — there's nothing
+  # to show or filter when no one has asked for CE.
+  def any_ce_credit_requests?
+    event_registrations.exists?(ce_credit_requested: true)
+  end
+
   # Whether a signed-in user should register in one click rather than being
   # routed to the registration form. True when no registration form is linked,
   # or when an admin has explicitly opted members out of the form. A linked form

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -107,11 +107,15 @@ class Event < ApplicationRecord
     forms.find_by(event_forms: { role: "registration" })
   end
 
-  # True when at least one registrant for this event requested CE credit. Drives
-  # the CE status column and filter on the registrants index — there's nothing
-  # to show or filter when no one has asked for CE.
-  def any_ce_credit_requests?
-    event_registrations.exists?(ce_credit_requested: true)
+  # True when this event's registration form includes the seeded CE-interest
+  # question — i.e. the event actually offers continuing-education credit. Gates
+  # every CE surface (registrants index, onboarding matrix, bulk reminders) and
+  # their CSV exports, so events that don't offer CE never show empty CE
+  # columns/filters even if a stray registration carries CE data.
+  def offers_ce?
+    registration_form&.form_fields&.exists?(
+      field_identifier: EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER
+    ) || false
   end
 
   # Whether a signed-in user should register in one click rather than being

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -107,17 +107,6 @@ class Event < ApplicationRecord
     forms.find_by(event_forms: { role: "registration" })
   end
 
-  # True when this event's registration form includes the seeded CE-interest
-  # question — i.e. the event actually offers continuing-education credit. Gates
-  # every CE surface (registrants index, onboarding matrix, bulk reminders) and
-  # their CSV exports, so events that don't offer CE never show empty CE
-  # columns/filters even if a stray registration carries CE data.
-  def offers_ce?
-    registration_form&.form_fields&.exists?(
-      field_identifier: EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER
-    ) || false
-  end
-
   # Whether a signed-in user should register in one click rather than being
   # routed to the registration form. True when no registration form is linked,
   # or when an admin has explicitly opted members out of the form. A linked form

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -160,6 +160,34 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
+  scope :comment_status, ->(value) {
+    commented = Comment.where(commentable_type: "EventRegistration").select(:commentable_id)
+    case value
+    when "none" then where.not(id: commented)
+    when "present" then where(id: commented)
+    when "flagged" then where(id: Comment.where(commentable_type: "EventRegistration", flagged: true).select(:commentable_id))
+    else all
+    end
+  }
+  # "linked" = at least one organization linked; "pending" = the registrant
+  # submitted an agency name on the event's registration form but nothing is
+  # linked yet (mirrors the Pending chip on the roster). Needs the event to
+  # resolve its registration form's agency_name field.
+  scope :organization_status, ->(value, event) {
+    linked = EventRegistrationOrganization.select(:event_registration_id)
+    case value
+    when "linked" then where(id: linked)
+    when "pending"
+      field = event.registration_form&.form_fields&.find_by(field_identifier: "agency_name")
+      next none unless field
+      submitted = FormAnswer.joins(:form_submission)
+        .where(form_field_id: field.id, form_submissions: { form_id: event.registration_form.id })
+        .where.not(submitted_answer: [ nil, "" ])
+        .select(Arel.sql("form_submissions.person_id"))
+      where(registrant_id: submitted).where.not(id: linked)
+    else all
+    end
+  }
   scope :keyword, ->(term) {
     return none if term.blank?
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -147,6 +147,19 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
+  # Mirrors ReminderRecipientFilter#matches_ce_status?. The "license"/"hours"
+  # sub-statuses only make sense for someone who requested CE credit, so they're
+  # gated on it. "paid" has no CE-specific payment record yet, so it falls back
+  # to the registrant being paid in full.
+  scope :ce_status, ->(value) {
+    case value
+    when "requested" then where(ce_credit_requested: true)
+    when "license_not_provided" then where(ce_credit_requested: true).where(ce_license_number: [ nil, "" ])
+    when "hours_not_provided" then where(ce_credit_requested: true).where("COALESCE(ce_hours_requested, 0) <= 0")
+    when "paid" then where(ce_credit_requested: true).merge(paid_in_full)
+    else all
+    end
+  }
   scope :keyword, ->(term) {
     return none if term.blank?
 
@@ -260,6 +273,17 @@ class EventRegistration < ApplicationRecord
   # True when the registrant has supplied a CE license number.
   def ce_license_provided?
     ce_license_number.present?
+  end
+
+  # A short label summarizing the registrant's CE credit standing, matching the
+  # ce_status filter buckets. Nil when CE credit was not requested, so callers
+  # can render a placeholder. "Incomplete" takes precedence over "Paid" because
+  # a missing license/hours is the actionable state regardless of payment.
+  def ce_status_label
+    return unless ce_credit_requested?
+    return "Incomplete" if !ce_license_provided? || ce_hours_requested.to_i <= 0
+    return "Paid" if paid_in_full?
+    "Requested"
   end
 
   # What the registrant owes for their requested CE hours, in cents, at the

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -169,6 +169,22 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
+  # Mirrors EventRegistration#account_status (none / has_access / invited /
+  # no_access) as a DB filter, joining the registrant's login account.
+  scope :account_status, ->(value) {
+    # Guard every subquery against NULL person_id (system/audit users) — a NULL in
+    # a NOT IN list makes the whole comparison return no rows.
+    with_user = User.where.not(person_id: nil).select(:person_id)
+    has_access = User.has_access.where.not(person_id: nil).select(:person_id)
+    invited = User.where.not(person_id: nil).where.not(welcome_instructions_sent_at: nil).select(:person_id)
+    case value
+    when "none" then where.not(registrant_id: with_user)
+    when "has_access" then where(registrant_id: has_access)
+    when "invited" then where(registrant_id: invited).where.not(registrant_id: has_access)
+    when "no_access" then where(registrant_id: with_user).where.not(registrant_id: has_access).where.not(registrant_id: invited)
+    else all
+    end
+  }
   # "linked" = at least one organization linked; "pending" = the registrant
   # submitted an agency name on the event's registration form but nothing is
   # linked yet (mirrors the Pending chip on the roster). Needs the event to

--- a/app/services/reminder_recipient_filter.rb
+++ b/app/services/reminder_recipient_filter.rb
@@ -6,18 +6,26 @@
 # like scholarships, grants, organizations, comments and the registrant's user
 # account without extra per-filter SQL.
 class ReminderRecipientFilter
-  FILTER_KEYS = %i[
-    name reg_org grantor comment email payment_status scholarship_status
-    account_status ce_status
+  # Free-text inputs matched in memory against the loaded registrations.
+  TEXT_KEYS = %i[ name reg_org grantor comment email ].freeze
+  # Dropdown filters shared with the registrants roster. They reuse the
+  # EventRegistration scopes (run once as a query) so both pages stay in sync —
+  # same param names, options, and semantics.
+  DROPDOWN_KEYS = %i[
+    attendance_status payment_status ce_status scholarship comment_status
+    org_status account_status state county
   ].freeze
+  FILTER_KEYS = (TEXT_KEYS + DROPDOWN_KEYS).freeze
 
-  def initialize(event_registrations, params)
+  def initialize(event_registrations, params, event: nil)
     @event_registrations = event_registrations
     @params = params
+    @event = event || event_registrations.first&.event
   end
 
   def matched_ids
-    @event_registrations.select { |reg| matches?(reg) }.map(&:id).to_set
+    text_matched = @event_registrations.select { |reg| matches_text?(reg) }.map(&:id).to_set
+    text_matched & dropdown_matched_ids
   end
 
   # True when at least one filter is narrowing the list. The view uses this to
@@ -29,16 +37,31 @@ class ReminderRecipientFilter
 
   private
 
-  def matches?(reg)
+  def matches_text?(reg)
     matches_name?(reg) &&
       matches_reg_org?(reg) &&
       matches_grantor?(reg) &&
       matches_comment?(reg) &&
-      matches_email?(reg) &&
-      matches_payment_status?(reg) &&
-      matches_scholarship_status?(reg) &&
-      matches_account_status?(reg) &&
-      matches_ce_status?(reg)
+      matches_email?(reg)
+  end
+
+  # Apply the registrants-roster scopes for whichever dropdowns are set, then
+  # return the matching ids. With no dropdown filter this is every registration,
+  # so the text-match set passes through unchanged.
+  def dropdown_matched_ids
+    return @event_registrations.map(&:id).to_set if @event.nil?
+
+    scope = @event.event_registrations
+    scope = scope.attendance_status(@params[:attendance_status]) if @params[:attendance_status].present?
+    scope = scope.payment_status(@params[:payment_status]) if @params[:payment_status].present?
+    scope = scope.ce_status(@params[:ce_status]) if @params[:ce_status].present?
+    scope = scope.scholarship_status(@params[:scholarship]) if @params[:scholarship].present?
+    scope = scope.comment_status(@params[:comment_status]) if @params[:comment_status].present?
+    scope = scope.organization_status(@params[:org_status], @event) if @params[:org_status].present?
+    scope = scope.account_status(@params[:account_status]) if @params[:account_status].present?
+    scope = scope.registrant_state(@params[:state]) if @params[:state].present?
+    scope = scope.registrant_county(@params[:county]) if @params[:county].present?
+    scope.pluck(:id).to_set
   end
 
   def matches_name?(reg)
@@ -81,46 +104,6 @@ class ReminderRecipientFilter
     person = reg.registrant
     [ person.preferred_email, person.email, person.email_2, person.user&.email ]
       .compact_blank.map(&:downcase)
-  end
-
-  def matches_payment_status?(reg)
-    case @params[:payment_status].presence
-    when "paid" then reg.paid_in_full?
-    when "unpaid" then reg.event.cost_cents.to_i > 0 && !reg.paid_in_full?
-    when "intends_to_pay" then reg.intends_to_pay?
-    when "paid_or_intends" then reg.payment_access_granted?
-    else true
-    end
-  end
-
-  def matches_scholarship_status?(reg)
-    case @params[:scholarship_status].presence
-    when "requested" then reg.scholarship_requested?
-    when "allocated" then reg.scholarships.any?
-    when "tasks_completed"
-      reg.scholarships.any? && reg.scholarships.all?(&:tasks_completed?)
-    else true
-    end
-  end
-
-  def matches_account_status?(reg)
-    status = @params[:account_status].presence
-    return true if status.blank?
-    reg.account_status == status
-  end
-
-  # CE sub-statuses (missing license / missing hours) only make sense for someone
-  # who actually requested CE credit, so they're gated on that. "paid" has no
-  # CE-specific payment record yet, so it falls back to the registrant being paid
-  # in full.
-  def matches_ce_status?(reg)
-    case @params[:ce_status].presence
-    when "requested" then reg.ce_credit_requested?
-    when "license_not_provided" then reg.ce_credit_requested? && !reg.ce_license_provided?
-    when "hours_not_provided" then reg.ce_credit_requested? && reg.ce_hours_requested.to_i <= 0
-    when "paid" then reg.ce_credit_requested? && reg.paid_in_full?
-    else true
-    end
   end
 
   # Text filters accept several values separated by "--" and match a registrant

--- a/app/views/allocations/index.html.erb
+++ b/app/views/allocations/index.html.erb
@@ -11,7 +11,7 @@
           <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "registrants" %>
-        <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "onboarding" %>
@@ -23,7 +23,7 @@
           <i class="fa-solid fa-arrow-left text-xs"></i> Registration
         <% end %>
       <% elsif @allocatable.respond_to?(:event) %>
-        <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% else %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -137,8 +137,8 @@
       <% active_orgs = f.object.registrant.affiliations.select { |a| !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) }.map(&:organization).compact.uniq.sort_by(&:name) %>
       <% connected_org_ids = f.object.organizations.map(&:id) %>
       <% addable_orgs = active_orgs.reject { |org| connected_org_ids.include?(org.id) } %>
-      <div class="grid grid-cols-1 gap-6 sm:grid-cols-4">
-        <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm sm:col-span-2">
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-3">
+        <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
           <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
             <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> <%= DomainTheme.text_class_for(:organizations, intensity: 600) %>">
               <i class="fa-solid fa-building"></i>
@@ -298,10 +298,10 @@
       <% end %>
 
       <%# ---- Comments ---- %>
-      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="comment-edit-toggle">
+      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm scroll-mt-24" id="comments-section" data-controller="comment-edit-toggle">
         <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:quotes, intensity: 100) %> <%= DomainTheme.text_class_for(:quotes, intensity: 600) %>">
-            <i class="fa-solid fa-comments"></i>
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:comments, intensity: 100) %> <%= DomainTheme.text_class_for(:comments, intensity: 600) %>">
+            <i class="fa-solid fa-message"></i>
           </span>
           <h2 class="text-sm font-semibold text-gray-700">Registration comments</h2>
           <%= link_to event_registration_comments_path(f.object),
@@ -372,11 +372,12 @@
               <%= rf.input :shoutout_text,
                     label: "Shout-out text",
                     label_html: { class: "sr-only" },
-                    as: :string,
+                    as: :text,
                     placeholder: "Shown beneath their name on the recipients page",
                     wrapper_html: { class: "mb-0" },
                     input_html: {
                       maxlength: 1650,
+                      rows: 3,
                       class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
                     } %>
             <% end %>
@@ -442,7 +443,7 @@
       <% end %>
 
       <% cancel_path = case params[:return_to]
-                       when "registrants" then registrants_event_path(event_registration.event)
+                       when "registrants" then registrants_event_row_path(event_registration.event, event_registration.id)
                        when "index" then event_registrations_path
                        when "preview_reminder" then preview_reminder_event_path(event_registration.event)
                        else allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -377,7 +377,7 @@
                     wrapper_html: { class: "mb-0" },
                     input_html: {
                       maxlength: 1650,
-                      rows: 3,
+                      rows: 1,
                       class: "w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-900 shadow-sm focus:border-emerald-500 focus:ring focus:ring-emerald-200 focus:outline-none"
                     } %>
             <% end %>

--- a/app/views/event_registrations/confirm.html.erb
+++ b/app/views/event_registrations/confirm.html.erb
@@ -84,7 +84,7 @@
       </label>
 
       <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
-        <% skip_path = @return_to == "registrants" ? registrants_event_path(@event_registration.event) : registration_ticket_path(@event_registration.slug) %>
+        <% skip_path = @return_to == "registrants" ? registrants_event_row_path(@event_registration.event, @event_registration.id) : registration_ticket_path(@event_registration.slug) %>
         <%= link_to "Skip", skip_path, class: "btn btn-secondary-outline" %>
         <button type="submit" class="btn btn-primary">Send selected</button>
       </div>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -19,7 +19,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% else %>
-      <%= link_to registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -8,7 +8,7 @@
     <% if params[:return_to] == "onboarding" %>
       <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <% else %>
-      <%= link_to "← Back to registrants", registrants_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <% end %>
   </div>
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">

--- a/app/views/events/_filter_select.html.erb
+++ b/app/views/events/_filter_select.html.erb
@@ -9,7 +9,7 @@
       blank        – include_blank placeholder label
       field_class  – Tailwind classes for the <select>
       wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
-<div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
+<div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-44") %>">
   <%= label_tag param, label, class: "block text-sm font-medium text-gray-700 mb-1" %>
   <%# Grey the text only while the include_blank placeholder (the first option) is
       selected, so a chosen value still reads in dark text. %>

--- a/app/views/events/_filter_select.html.erb
+++ b/app/views/events/_filter_select.html.erb
@@ -11,8 +11,10 @@
       wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
 <div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
   <%= label_tag param, label, class: "block text-sm font-medium text-gray-700 mb-1" %>
+  <%# Grey the text only while the include_blank placeholder (the first option) is
+      selected, so a chosen value still reads in dark text. %>
   <%= select_tag param,
                  options_for_select(options, selected),
                  include_blank: blank,
-                 class: field_class %>
+                 class: "#{field_class} has-[option:first-child:checked]:text-gray-400" %>
 </div>

--- a/app/views/events/_filter_select.html.erb
+++ b/app/views/events/_filter_select.html.erb
@@ -1,0 +1,18 @@
+<%# Shared labeled <select> used by the registrants roster filters and the bulk
+    reminder recipient filters, so the two stay visually identical. Only the
+    dropdowns are shared — each page keeps its own text inputs and decides which
+    selects (and options) to render. Locals:
+      param        – select name/id (Symbol)
+      label        – field label
+      options      – array passed to options_for_select
+      selected     – currently selected value
+      blank        – include_blank placeholder label
+      field_class  – Tailwind classes for the <select>
+      wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
+<div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
+  <%= label_tag param, label, class: "block text-sm font-medium text-gray-700 mb-1" %>
+  <%= select_tag param,
+                 options_for_select(options, selected),
+                 include_blank: blank,
+                 class: field_class %>
+</div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -177,7 +177,7 @@
               <% person = registration.registrant %>
 
               <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "hover:bg-gray-50" %>">
+              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "hover:bg-gray-50" %>">
                 <td class="px-4 py-2" data-sort-first="<%= person.first_name.to_s.downcase %>" data-sort-last="<%= person.last_name.to_s.downcase %>">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
@@ -281,11 +281,11 @@
                       <% ce_text = "No license #" %>
                       <% ce_title = "CE license number not provided" %>
                     <% elsif !cer.paid_in_full? %>
-                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_classes = "bg-blue-50 text-blue-700 border-blue-200" %>
                       <% ce_text = "Filed" %>
                       <% ce_title = "CE license filed — #{dollars_from_cents(cer.remaining_cost)} due" %>
                     <% else %>
-                      <% ce_classes = "bg-blue-50 text-blue-700 border-blue-200" %>
+                      <% ce_classes = "bg-green-50 text-green-700 border-green-200" %>
                       <% ce_text = "Recipient" %>
                       <% ce_title = "CE paid" %>
                     <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -177,7 +177,7 @@
               <% person = registration.registrant %>
 
               <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "hover:bg-gray-50" %>">
+              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "hover:bg-gray-50" %>">
                 <td class="px-4 py-2" data-sort-first="<%= person.first_name.to_s.downcase %>" data-sort-last="<%= person.last_name.to_s.downcase %>">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -40,8 +40,11 @@
     <% if @event_registrations.any? %>
       <div class="overflow-x-auto">
         <% payment_col = @event.cost_cents.to_i > 0 %>
-        <% date_index = payment_col ? 5 : 4 %>
-        <% attendance_index = payment_col ? 6 : 5 %>
+        <% ce_col = @offers_ce %>
+        <% extra_cols = (payment_col ? 1 : 0) + (ce_col ? 1 : 0) %>
+        <% ce_index = payment_col ? 4 : 3 %>
+        <% date_index = 4 + extra_cols %>
+        <% attendance_index = 5 + extra_cols %>
         <table class="w-full border-collapse border border-gray-200" data-controller="table-sort">
           <thead class="bg-gray-100">
             <tr>
@@ -62,6 +65,12 @@
               <% if payment_col %>
                 <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
                   <%= render "shared/sortable_header", label: "Payment", index: 3 %>
+                </th>
+              <% end %>
+
+              <% if ce_col %>
+                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                  <%= render "shared/sortable_header", label: "CE status", index: ce_index %>
                 </th>
               <% end %>
 
@@ -245,6 +254,31 @@
                         <i class="fa-solid fa-hand-holding-dollar"></i>
                         <span>Intends to pay</span>
                       </div>
+                    <% end %>
+                  </td>
+                <% end %>
+
+                <% if ce_col %>
+                  <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= registration.ce_credit_requested? ? 1 : 0 %>">
+                    <% if (ce_label = registration.ce_status_label) %>
+                      <% ce_badge_classes, ce_badge_icon = case ce_label
+                           when "Incomplete" then [ "bg-amber-50 text-amber-700 border-amber-200", "fa-circle-exclamation" ]
+                           when "Paid" then [ "bg-green-50 text-green-700 border-green-200", "fa-circle-check" ]
+                           else [ "bg-blue-50 text-blue-700 border-blue-200", "fa-certificate" ]
+                         end %>
+                      <% missing_parts = [] %>
+                      <% missing_parts << "license" unless registration.ce_license_provided? %>
+                      <% missing_parts << "hours" if registration.ce_hours_requested.to_i <= 0 %>
+                      <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
+                                  title: (missing_parts.any? ? "Missing #{missing_parts.to_sentence}" : "CE credit requested"),
+                                  class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{ce_badge_classes} hover:opacity-80",
+                                  data: { turbo_frame: "_top" } do %>
+                        <i class="fas <%= ce_badge_icon %>"></i>
+                        <span><%= ce_label %></span>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+                      <% end %>
+                    <% else %>
+                      <span class="text-gray-300" title="No CE credit requested">—</span>
                     <% end %>
                   </td>
                 <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -142,8 +142,8 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
-                    <div class="w-44 min-w-0">
-                      <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
+                    <div class="w-60 min-w-0">
+                      <%= person_profile_button(person, truncate_at: 30, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 
                     <% if event_form_ids.any? && (submissions = form_submissions[person.id]) %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -21,19 +21,39 @@
                  data-controller="column-toggle" data-column-toggle-group-value="ce">
             <span class="text-sm text-gray-500">CE status</span>
 
+            <%# On by default — the CE column shows unless the admin hides it. %>
             <input
               type="checkbox"
+              checked
               data-column-toggle-target="toggle"
               data-action="column-toggle#toggle"
               class="sr-only"
             >
 
             <span class="relative inline-block w-9 h-5">
-              <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
-              <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+              <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-blue-600 transition-colors"></span>
+              <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform" style="transform: translateX(16px)"></span>
             </span>
           </label>
         <% end %>
+
+        <%# Off by default — Attendance is hidden until the admin reveals it. %>
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+               data-controller="column-toggle" data-column-toggle-group-value="attendance">
+          <span class="text-sm text-gray-500">Attendance</span>
+
+          <input
+            type="checkbox"
+            data-column-toggle-target="toggle"
+            data-action="column-toggle#toggle"
+            class="sr-only"
+          >
+
+          <span class="relative inline-block w-9 h-5">
+            <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
+            <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+          </span>
+        </label>
 
         <label class="inline-flex items-center gap-2 cursor-pointer select-none"
                data-controller="column-toggle" data-column-toggle-group-value="confirmed">
@@ -64,9 +84,13 @@
         <% payment_col = @event.cost_cents.to_i > 0 %>
         <% ce_col = @ce_eligible %>
         <% extra_cols = (payment_col ? 1 : 0) + (ce_col ? 1 : 0) %>
-        <% ce_index = payment_col ? 4 : 3 %>
-        <% date_index = 4 + extra_cols %>
-        <% attendance_index = 5 + extra_cols %>
+        <%# Column order: Name, Organization, [CE status], Scholarship, [Payment],
+            Confirmed (hidden), Attendance, Edit, Date registered (far right). %>
+        <% ce_index = 2 %>
+        <% scholarship_index = ce_col ? 3 : 2 %>
+        <% payment_index = scholarship_index + 1 %>
+        <% attendance_index = 4 + extra_cols %>
+        <% date_index = 6 + extra_cols %>
         <table class="w-full border-collapse border border-gray-200" data-controller="table-sort">
           <thead class="bg-gray-100">
             <tr>
@@ -80,30 +104,31 @@
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none">
                 <%= render "shared/sortable_header", label: "Organization", index: 1 %>
               </th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
-                <%= render "shared/sortable_header", label: "Scholarship", index: 2 %>
-              </th>
-
-              <% if payment_col %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
-                  <%= render "shared/sortable_header", label: "Payment", index: 3 %>
-                </th>
-              <% end %>
 
               <% if ce_col %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 hidden" aria-sort="none" data-column-toggle-col="ce">
+                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none" data-column-toggle-col="ce">
                   <%= render "shared/sortable_header", label: "CE status", index: ce_index %>
                 </th>
               <% end %>
 
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col="confirmed">Confirmed</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
-                <%= render "shared/sortable_header", label: "Date registered", index: date_index %>
+                <%= render "shared/sortable_header", label: "Scholarship", index: scholarship_index %>
               </th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+
+              <% if payment_col %>
+                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                  <%= render "shared/sortable_header", label: "Payment", index: payment_index %>
+                </th>
+              <% end %>
+
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col="confirmed">Confirmed</th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 hidden" aria-sort="none" data-column-toggle-col="attendance">
                 <%= render "shared/sortable_header", label: "Attendance", index: attendance_index %>
               </th>
               <th class="px-4 py-2"></th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                <%= render "shared/sortable_header", label: "Date registered", index: date_index %>
+              </th>
             </tr>
           </thead>
 
@@ -111,23 +136,23 @@
             <% @event_registrations.each do |registration| %>
               <% person = registration.registrant %>
 
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <% highlighted = params[:highlight].to_s == registration.id.to_s %>
+              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-amber-50 ring-2 ring-inset ring-amber-300" : "hover:bg-gray-50" %>">
                 <td class="px-4 py-2" data-sort-first="<%= person.first_name.to_s.downcase %>" data-sort-last="<%= person.last_name.to_s.downcase %>">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
-                    <div class="w-52 min-w-0">
-                      <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }) %>
+                    <div class="w-44 min-w-0">
+                      <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 
                     <% if event_form_ids.any? && (submissions = form_submissions[person.id]) %>
                       <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
                       <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
                       <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
-                      <%= link_to event_public_registration_path(@event, **form_show_params),
+                      <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id),
                                   class: "text-green-600 hover:text-green-800",
                                   title: tooltip_parts.join("\n"),
-                                  target: "_blank",
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fa-solid fa-file-lines"></i>
                       <% end %>
@@ -185,13 +210,43 @@
                   </div>
                 </td>
 
+                <% if ce_col %>
+                  <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce">
+                    <% ce_label = registration.ce_status_label %>
+                    <% ce_missing = [] %>
+                    <% if ce_label %>
+                      <% ce_missing << "license" unless registration.ce_license_provided? %>
+                      <% ce_missing << "hours" if registration.ce_hours_requested.to_i <= 0 %>
+                    <% end %>
+                    <% ce_badge_classes = case ce_label
+                         when "Incomplete" then "bg-amber-50 text-amber-700 border-amber-200"
+                         when "Paid" then "bg-green-50 text-green-700 border-green-200"
+                         when "Requested" then "bg-blue-50 text-blue-700 border-blue-200"
+                         else "bg-gray-50 text-gray-400 border-gray-200"
+                       end %>
+                    <% ce_title = if ce_label.nil?
+                         "No CE credit requested"
+                       elsif ce_missing.any?
+                         "Missing #{ce_missing.to_sentence}"
+                       else
+                         "CE credit requested"
+                       end %>
+                    <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
+                                title: ce_title,
+                                class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{ce_badge_classes} transition hover:opacity-80 hover:shadow-sm",
+                                data: { turbo_frame: "_top" } do %>
+                      <span><%= ce_label || "Create" %></span>
+                      <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+                    <% end %>
+                  </td>
+                <% end %>
+
                 <td class="px-4 py-2 text-sm text-center">
                   <% if (s = registration.scholarships.first) %>
                     <% if s.tasks_completed? %>
                       <%= link_to edit_scholarship_path(s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-green-50 text-green-700 border-green-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
-                        <i class="fas fa-graduation-cap"></i>
                         <span>Completed</span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
@@ -199,7 +254,6 @@
                       <%= link_to edit_scholarship_path(s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-blue-50 text-blue-700 border-blue-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
-                        <i class="fas fa-graduation-cap"></i>
                         <span>Recipient</span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
@@ -209,7 +263,6 @@
                       <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-amber-50 text-amber-700 border-amber-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
-                        <i class="fas fa-graduation-cap"></i>
                         <span>Requested</span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
@@ -217,7 +270,6 @@
                       <%= link_to new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
                                   class: "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-5 py-0.5 bg-gray-50 text-gray-400 border-gray-200 transition hover:opacity-80 hover:shadow-sm",
                                   data: { turbo_frame: "_top" } do %>
-                        <i class="fas fa-graduation-cap"></i>
                         <span>Create</span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
@@ -241,15 +293,6 @@
                        else
                          "bg-amber-50 text-amber-700 border-amber-200"
                        end %>
-                    <% badge_icon = if is_paid
-                         "fa-circle-check"
-                       elsif is_discounted
-                         "fa-tag"
-                       elsif is_partial
-                         "fa-circle-half-stroke"
-                       else
-                         "fa-circle-exclamation"
-                       end %>
                     <% badge_title = if is_paid
                          "Paid in full"
                        elsif is_discounted
@@ -262,7 +305,6 @@
                     <% badge_title = "#{badge_title} · Intends to pay" if !is_paid && registration.intends_to_pay? %>
 
                     <%= link_to allocations_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"), title: badge_title, class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{badge_classes} transition hover:opacity-80 hover:shadow-sm", data: { turbo_frame: "_top" } do %>
-                      <i class="fas <%= badge_icon %>"></i>
                       <% if is_paid %>
                         <span>Paid</span>
                       <% else %>
@@ -280,31 +322,6 @@
                   </td>
                 <% end %>
 
-                <% if ce_col %>
-                  <td class="px-4 py-2 text-sm text-center hidden" data-column-toggle-col="ce" data-sort-value="<%= registration.ce_credit_requested? ? 1 : 0 %>">
-                    <% if (ce_label = registration.ce_status_label) %>
-                      <% ce_badge_classes, ce_badge_icon = case ce_label
-                           when "Incomplete" then [ "bg-amber-50 text-amber-700 border-amber-200", "fa-circle-exclamation" ]
-                           when "Paid" then [ "bg-green-50 text-green-700 border-green-200", "fa-circle-check" ]
-                           else [ "bg-blue-50 text-blue-700 border-blue-200", "fa-certificate" ]
-                         end %>
-                      <% missing_parts = [] %>
-                      <% missing_parts << "license" unless registration.ce_license_provided? %>
-                      <% missing_parts << "hours" if registration.ce_hours_requested.to_i <= 0 %>
-                      <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
-                                  title: (missing_parts.any? ? "Missing #{missing_parts.to_sentence}" : "CE credit requested"),
-                                  class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 #{ce_badge_classes} hover:opacity-80",
-                                  data: { turbo_frame: "_top" } do %>
-                        <i class="fas <%= ce_badge_icon %>"></i>
-                        <span><%= ce_label %></span>
-                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
-                      <% end %>
-                    <% else %>
-                      <span class="text-gray-300" title="No CE credit requested">—</span>
-                    <% end %>
-                  </td>
-                <% end %>
-
                 <td class="px-4 py-2 text-center align-top hidden" data-column-toggle-col="confirmed">
                   <% if person.user.present? %>
                     <%= render "users/confirmed_status", user: person.user, invite_params: {} %>
@@ -316,9 +333,9 @@
                   <% end %>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-nowrap text-center text-gray-600" data-sort-value="<%= registration.created_at.to_i %>" title="<%= registration.created_at.strftime("%B %-d, %Y at %l:%M %P") %>"><%= registration.created_at.strftime("%b %-d, %Y") %></td>
-                <td class="px-4 py-2 text-sm text-nowrap text-center" data-sort-value="<%= registration.status %>"><%= render "event_registrations/attendance_status_badge", registration: registration %></td>
+                <td class="px-4 py-2 text-sm text-nowrap text-center hidden" data-column-toggle-col="attendance" data-sort-value="<%= registration.status %>"><%= render "event_registrations/attendance_status_badge", registration: registration %></td>
                 <td class="px-4 py-2 text-right text-sm"><%= link_to "Edit", edit_event_registration_path(registration, return_to: "registrants"), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
+                <td class="px-4 py-2 text-sm text-nowrap text-center text-gray-600" data-sort-value="<%= registration.created_at.to_i %>" title="<%= registration.created_at.strftime("%B %-d, %Y at %l:%M %P") %>"><%= registration.created_at.strftime("%b %-d, %Y") %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :registrants_results do %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-controller="column-toggle">
+  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-column-toggle-root>
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <% current_filter = params[:attendance_status].present? ? nil : (params[:status_filter].presence || "active") %>
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Attendance filter">
@@ -15,21 +15,43 @@
         <% end %>
       </nav>
 
-      <label class="inline-flex items-center gap-2 cursor-pointer select-none">
-        <span class="text-sm text-gray-500">User confirmation</span>
+      <div class="flex items-center gap-4">
+        <% if @offers_ce %>
+          <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+                 data-controller="column-toggle" data-column-toggle-group-value="ce">
+            <span class="text-sm text-gray-500">CE status</span>
 
-        <input
-          type="checkbox"
-          data-column-toggle-target="toggle"
-          data-action="column-toggle#toggle"
-          class="sr-only"
-        >
+            <input
+              type="checkbox"
+              data-column-toggle-target="toggle"
+              data-action="column-toggle#toggle"
+              class="sr-only"
+            >
 
-        <span class="relative inline-block w-9 h-5">
-          <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
-          <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
-        </span>
-      </label>
+            <span class="relative inline-block w-9 h-5">
+              <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
+              <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+            </span>
+          </label>
+        <% end %>
+
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+               data-controller="column-toggle" data-column-toggle-group-value="confirmed">
+          <span class="text-sm text-gray-500">User confirmation</span>
+
+          <input
+            type="checkbox"
+            data-column-toggle-target="toggle"
+            data-action="column-toggle#toggle"
+            class="sr-only"
+          >
+
+          <span class="relative inline-block w-9 h-5">
+            <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
+            <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+          </span>
+        </label>
+      </div>
     </div>
 
     <% event_form_ids = @event.form_ids %>
@@ -69,12 +91,12 @@
               <% end %>
 
               <% if ce_col %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 hidden" aria-sort="none" data-column-toggle-col="ce">
                   <%= render "shared/sortable_header", label: "CE status", index: ce_index %>
                 </th>
               <% end %>
 
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col>Confirmed</th>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px] hidden" data-column-toggle-col="confirmed">Confirmed</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
                 <%= render "shared/sortable_header", label: "Date registered", index: date_index %>
               </th>
@@ -259,7 +281,7 @@
                 <% end %>
 
                 <% if ce_col %>
-                  <td class="px-4 py-2 text-sm text-center" data-sort-value="<%= registration.ce_credit_requested? ? 1 : 0 %>">
+                  <td class="px-4 py-2 text-sm text-center hidden" data-column-toggle-col="ce" data-sort-value="<%= registration.ce_credit_requested? ? 1 : 0 %>">
                     <% if (ce_label = registration.ce_status_label) %>
                       <% ce_badge_classes, ce_badge_icon = case ce_label
                            when "Incomplete" then [ "bg-amber-50 text-amber-700 border-amber-200", "fa-circle-exclamation" ]
@@ -283,7 +305,7 @@
                   </td>
                 <% end %>
 
-                <td class="px-4 py-2 text-center align-top hidden" data-column-toggle-col>
+                <td class="px-4 py-2 text-center align-top hidden" data-column-toggle-col="confirmed">
                   <% if person.user.present? %>
                     <%= render "users/confirmed_status", user: person.user, invite_params: {} %>
                   <% else %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -151,7 +151,7 @@
                       <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
                       <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
                       <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id),
-                                  class: "text-green-600 hover:text-green-800",
+                                  class: "text-blue-600 hover:text-blue-800",
                                   title: tooltip_parts.join("\n"),
                                   data: { turbo_frame: "_top" } do %>
                         <i class="fa-solid fa-file-lines"></i>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -1,4 +1,6 @@
 <%= turbo_frame_tag :registrants_results do %>
+  <%# Scholarship column shows by default only when the event charges a fee. %>
+  <% scholarship_on = @event.cost_cents.to_i > 0 %>
   <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-column-toggle-root>
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <% current_filter = params[:attendance_status].present? ? nil : (params[:status_filter].presence || "active") %>
@@ -16,10 +18,29 @@
       </nav>
 
       <div class="flex items-center gap-4">
+        <%# On by default — Organization shows unless the admin hides it. %>
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+               data-controller="column-toggle" data-column-toggle-group-value="organization">
+          <span class="text-sm text-gray-500">Organization</span>
+
+          <input
+            type="checkbox"
+            checked
+            data-column-toggle-target="toggle"
+            data-action="column-toggle#toggle"
+            class="sr-only"
+          >
+
+          <span class="relative inline-block w-9 h-5">
+            <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-blue-600 transition-colors"></span>
+            <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform" style="transform: translateX(16px)"></span>
+          </span>
+        </label>
+
         <% if @ce_eligible %>
           <label class="inline-flex items-center gap-2 cursor-pointer select-none"
                  data-controller="column-toggle" data-column-toggle-group-value="ce">
-            <span class="text-sm text-gray-500">CE status</span>
+            <span class="text-sm text-gray-500">CE</span>
 
             <%# On by default — the CE column shows unless the admin hides it. %>
             <input
@@ -36,6 +57,25 @@
             </span>
           </label>
         <% end %>
+
+        <%# On by default when the event charges a fee; always togglable. %>
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+               data-controller="column-toggle" data-column-toggle-group-value="scholarship">
+          <span class="text-sm text-gray-500">Scholarship</span>
+
+          <input
+            type="checkbox"
+            <%= "checked" if scholarship_on %>
+            data-column-toggle-target="toggle"
+            data-action="column-toggle#toggle"
+            class="sr-only"
+          >
+
+          <span class="relative inline-block w-9 h-5">
+            <span data-column-toggle-target="track" class="absolute inset-0 rounded-full <%= scholarship_on ? "bg-blue-600" : "bg-gray-300" %> transition-colors"></span>
+            <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform" style="transform: <%= scholarship_on ? "translateX(16px)" : "none" %>"></span>
+          </span>
+        </label>
 
         <%# Off by default — Attendance is hidden until the admin reveals it. %>
         <label class="inline-flex items-center gap-2 cursor-pointer select-none"
@@ -101,17 +141,17 @@
                   <%= render "shared/sortable_header", label: "Last", index: 0, key: "last" %>
                 </span>
               </th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none">
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none" data-column-toggle-col="organization">
                 <%= render "shared/sortable_header", label: "Organization", index: 1 %>
               </th>
 
               <% if ce_col %>
                 <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none" data-column-toggle-col="ce">
-                  <%= render "shared/sortable_header", label: "CE status", index: ce_index %>
+                  <%= render "shared/sortable_header", label: "CE", index: ce_index %>
                 </th>
               <% end %>
 
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 <%= "hidden" unless scholarship_on %>" aria-sort="none" data-column-toggle-col="scholarship">
                 <%= render "shared/sortable_header", label: "Scholarship", index: scholarship_index %>
               </th>
 
@@ -146,23 +186,27 @@
                       <%= person_profile_button(person, truncate_at: 30, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 
-                    <% if event_form_ids.any? && (submissions = form_submissions[person.id]) %>
-                      <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
-                      <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
-                      <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
-                      <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id),
-                                  class: "text-blue-600 hover:text-blue-800",
-                                  title: tooltip_parts.join("\n"),
-                                  data: { turbo_frame: "_top" } do %>
-                        <i class="fa-solid fa-file-lines"></i>
-                      <% end %>
-                    <% elsif event_form_ids.any? %>
-                      <i class="fa-regular fa-file-lines text-gray-300" title="No registration form submitted"></i>
+                    <% if event_form_ids.any? %>
+                      <%# Reserve a fixed slot so the comment/warning icons stay aligned
+                          across rows whether or not this registrant submitted a form. %>
+                      <span class="inline-flex w-4 justify-center">
+                        <% if (submissions = form_submissions[person.id]) %>
+                          <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
+                          <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
+                          <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
+                          <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id),
+                                      class: "text-blue-600 hover:text-blue-800",
+                                      title: tooltip_parts.join("\n"),
+                                      data: { turbo_frame: "_top" } do %>
+                            <i class="fa-regular fa-file-lines"></i>
+                          <% end %>
+                        <% end %>
+                      </span>
                     <% end %>
 
                     <% if registration.comments.any? %>
                       <% latest_comment = registration.comments.first %>
-                      <i class="fa-solid fa-message text-purple-400" title="<%= registration.comments.size %> comment<%= 's' if registration.comments.size != 1 %> — Latest (<%= latest_comment.created_at.strftime('%Y-%m-%d') %>): <%= latest_comment.body.truncate(100) %>"></i>
+                      <i class="fa-regular fa-message text-purple-400" title="<%= registration.comments.size %> comment<%= 's' if registration.comments.size != 1 %> — Latest (<%= latest_comment.created_at.strftime('%Y-%m-%d') %>): <%= latest_comment.body.truncate(100) %>"></i>
                     <% end %>
 
                     <% if @duplicate_emails&.include?(person.preferred_email&.downcase) %>
@@ -171,7 +215,7 @@
                   </div>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-gray-800">
+                <td class="px-4 py-2 text-sm text-gray-800" data-column-toggle-col="organization">
                   <% linked_orgs = registration.organizations %>
                   <% submitted_org_name = submitted_org_names[registration.registrant_id].to_s.strip %>
                   <%# A submitted org name needs admin attention only while nothing is linked
@@ -241,7 +285,7 @@
                   </td>
                 <% end %>
 
-                <td class="px-4 py-2 text-sm text-center">
+                <td class="px-4 py-2 text-sm text-center <%= "hidden" unless scholarship_on %>" data-column-toggle-col="scholarship">
                   <% if (s = registration.scholarships.first) %>
                     <% if s.tasks_completed? %>
                       <%= link_to edit_scholarship_path(s, return_to: "registrants"),

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -16,7 +16,7 @@
       </nav>
 
       <div class="flex items-center gap-4">
-        <% if @offers_ce %>
+        <% if @ce_eligible %>
           <label class="inline-flex items-center gap-2 cursor-pointer select-none"
                  data-controller="column-toggle" data-column-toggle-group-value="ce">
             <span class="text-sm text-gray-500">CE status</span>
@@ -62,7 +62,7 @@
     <% if @event_registrations.any? %>
       <div class="overflow-x-auto">
         <% payment_col = @event.cost_cents.to_i > 0 %>
-        <% ce_col = @offers_ce %>
+        <% ce_col = @ce_eligible %>
         <% extra_cols = (payment_col ? 1 : 0) + (ce_col ? 1 : 0) %>
         <% ce_index = payment_col ? 4 : 3 %>
         <% date_index = 4 + extra_cols %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -186,7 +186,7 @@
                                   title: org.name,
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
-                        <span><%= truncate(org.name, length: 40) %></span>
+                        <span><%= truncate(org.name, length: 52) %></span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -142,7 +142,7 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
-                    <div class="w-44 min-w-0">
+                    <div class="w-40 min-w-0">
                       <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -142,7 +142,7 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
-                    <div class="w-40 min-w-0">
+                    <div class="w-44 min-w-0">
                       <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 
@@ -179,14 +179,14 @@
                       submitted name is no longer treated as pending. %>
                   <% needs_linking = submitted_org_name.present? && linked_orgs.none? %>
                   <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
-                  <% pill_classes = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
+                  <% pill_classes = "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
                   <div class="flex flex-wrap gap-1.5">
                     <% linked_orgs.each do |org| %>
                       <%= link_to editor_path,
                                   title: org.name,
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
-                        <span><%= truncate(org.name, length: 52) %></span>
+                        <span><%= truncate(org.name, length: 31) %></span>
                         <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -256,30 +256,31 @@
 
                 <% if ce_col %>
                   <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce">
-                    <% ce_label = registration.ce_status_label %>
-                    <% ce_missing = [] %>
-                    <% if ce_label %>
-                      <% ce_missing << "license" unless registration.ce_license_provided? %>
-                      <% ce_missing << "hours" if registration.ce_hours_requested.to_i <= 0 %>
+                    <%# CE progression mirrors scholarship's colors: requested → orange,
+                        amount due once a license is on file → orange, paid → blue, and a
+                        gray "Create" affordance when CE wasn't requested. %>
+                    <% if !registration.ce_credit_requested? %>
+                      <% ce_classes = "bg-gray-50 text-gray-400 border-gray-200" %>
+                      <% ce_text = "Create" %>
+                      <% ce_title = "No CE credit requested" %>
+                    <% elsif registration.paid_in_full? %>
+                      <% ce_classes = "bg-blue-50 text-blue-700 border-blue-200" %>
+                      <% ce_text = "Recipient" %>
+                      <% ce_title = "CE paid" %>
+                    <% elsif registration.ce_license_provided? %>
+                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_text = "#{dollars_from_cents(registration.ce_amount_owed_cents)} due" %>
+                      <% ce_title = "CE amount due" %>
+                    <% else %>
+                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_text = "Requested" %>
+                      <% ce_title = "CE requested" %>
                     <% end %>
-                    <% ce_badge_classes = case ce_label
-                         when "Incomplete" then "bg-amber-50 text-amber-700 border-amber-200"
-                         when "Paid" then "bg-green-50 text-green-700 border-green-200"
-                         when "Requested" then "bg-blue-50 text-blue-700 border-blue-200"
-                         else "bg-gray-50 text-gray-400 border-gray-200"
-                       end %>
-                    <% ce_title = if ce_label.nil?
-                         "No CE credit requested"
-                       elsif ce_missing.any?
-                         "Missing #{ce_missing.to_sentence}"
-                       else
-                         "CE credit requested"
-                       end %>
                     <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
                                 title: ce_title,
-                                class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{ce_badge_classes} transition hover:opacity-80 hover:shadow-sm",
+                                class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-5 py-0.5 #{ce_classes} transition hover:opacity-80 hover:shadow-sm",
                                 data: { turbo_frame: "_top" } do %>
-                      <span><%= ce_label || "Create" %></span>
+                      <span><%= ce_text %></span>
                       <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                     <% end %>
                   </td>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -282,8 +282,8 @@
                       <% ce_title = "CE license number not provided" %>
                     <% elsif !cer.paid_in_full? %>
                       <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
-                      <% ce_text = "#{dollars_from_cents(cer.remaining_cost)} due" %>
-                      <% ce_title = "CE payment due" %>
+                      <% ce_text = "Filed" %>
+                      <% ce_title = "CE license filed — #{dollars_from_cents(cer.remaining_cost)} due" %>
                     <% else %>
                       <% ce_classes = "bg-blue-50 text-blue-700 border-blue-200" %>
                       <% ce_text = "Recipient" %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -177,7 +177,7 @@
               <% person = registration.registrant %>
 
               <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-amber-50 ring-2 ring-inset ring-amber-300" : "hover:bg-gray-50" %>">
+              <tr id="<%= registrant_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "hover:bg-gray-50" %>">
                 <td class="px-4 py-2" data-sort-first="<%= person.first_name.to_s.downcase %>" data-sort-last="<%= person.last_name.to_s.downcase %>">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
@@ -206,7 +206,15 @@
 
                     <% if registration.comments.any? %>
                       <% latest_comment = registration.comments.first %>
-                      <i class="fa-regular fa-message text-purple-400" title="<%= registration.comments.size %> comment<%= 's' if registration.comments.size != 1 %> — Latest (<%= latest_comment.created_at.strftime('%Y-%m-%d') %>): <%= latest_comment.body.truncate(100) %>"></i>
+                      <% any_flagged = registration.comments.any?(&:flagged?) %>
+                      <%# Flagged → orange filled (a warning); otherwise the comments theme lilac. %>
+                      <% comment_icon = any_flagged ? "fa-solid text-orange-500" : "fa-regular #{DomainTheme.text_class_for(:comments, intensity: 400)}" %>
+                      <%= link_to edit_event_registration_path(registration, return_to: "registrants", anchor: "comments-section"),
+                                  class: "hover:opacity-80",
+                                  title: "#{"Has flagged comments — " if any_flagged}#{registration.comments.size} comment#{"s" if registration.comments.size != 1} — Latest (#{latest_comment.created_at.strftime('%Y-%m-%d')}): #{latest_comment.body.truncate(100)}",
+                                  data: { turbo_frame: "_top" } do %>
+                        <i class="fa-message <%= comment_icon %>"></i>
+                      <% end %>
                     <% end %>
 
                     <% if @duplicate_emails&.include?(person.preferred_email&.downcase) %>
@@ -256,25 +264,30 @@
 
                 <% if ce_col %>
                   <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce">
-                    <%# CE progression mirrors scholarship's colors: requested → orange,
-                        amount due once a license is on file → orange, paid → blue, and a
-                        gray "Create" affordance when CE wasn't requested. %>
+                    <%# CE progression mirrors scholarship's colors. Until a CE registration
+                        record exists it's just "Requested"; once it does, walk through
+                        license → payment → paid. "Create" when CE wasn't requested. %>
+                    <% cer = registration.continuing_education_registrations.first %>
                     <% if !registration.ce_credit_requested? %>
                       <% ce_classes = "bg-gray-50 text-gray-400 border-gray-200" %>
                       <% ce_text = "Create" %>
                       <% ce_title = "No CE credit requested" %>
-                    <% elsif registration.paid_in_full? %>
+                    <% elsif cer.nil? %>
+                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_text = "Requested" %>
+                      <% ce_title = "CE requested — no registration record yet" %>
+                    <% elsif !cer.professional_license&.number_known? %>
+                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_text = "No license #" %>
+                      <% ce_title = "CE license number not provided" %>
+                    <% elsif !cer.paid_in_full? %>
+                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
+                      <% ce_text = "#{dollars_from_cents(cer.remaining_cost)} due" %>
+                      <% ce_title = "CE payment due" %>
+                    <% else %>
                       <% ce_classes = "bg-blue-50 text-blue-700 border-blue-200" %>
                       <% ce_text = "Recipient" %>
                       <% ce_title = "CE paid" %>
-                    <% elsif registration.ce_license_provided? %>
-                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
-                      <% ce_text = "#{dollars_from_cents(registration.ce_amount_owed_cents)} due" %>
-                      <% ce_title = "CE amount due" %>
-                    <% else %>
-                      <% ce_classes = "bg-amber-50 text-amber-700 border-amber-200" %>
-                      <% ce_text = "Requested" %>
-                      <% ce_title = "CE requested" %>
                     <% end %>
                     <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
                                 title: ce_title,

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: registrants_event_path(@event), method: :get,
   data: { controller: "collection", turbo_frame: "registrants_results" },
   autocomplete: "off",
-  class: "flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6" do %>
+  class: "flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6 bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
 
   <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
 
@@ -31,6 +31,20 @@
             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
   </div>
 
+  <% if @ce_eligible %>
+    <div class="w-full md:w-48">
+      <%= label_tag :ce_status, "CE status", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :ce_status,
+                     options_for_select(
+                       [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+                       params[:ce_status]
+                     ),
+                     include_blank: "Any CE status",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+    </div>
+  <% end %>
+
   <% if @event.cost_cents.to_i > 0 %>
     <div class="w-full md:w-48">
       <%= label_tag :payment_status, "Payment", class: "block text-sm font-medium text-gray-700 mb-1" %>
@@ -52,20 +66,6 @@
                        params[:scholarship]
                      ),
                      include_blank: "All registrants",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-    </div>
-  <% end %>
-
-  <% if @ce_eligible %>
-    <div class="w-full md:w-48">
-      <%= label_tag :ce_status, "CE status", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :ce_status,
-                     options_for_select(
-                       [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-                       params[:ce_status]
-                     ),
-                     include_blank: "Any CE status",
                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
               focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
     </div>

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -57,7 +57,7 @@
     </div>
   <% end %>
 
-  <% if @offers_ce %>
+  <% if @ce_eligible %>
     <div class="w-full md:w-48">
       <%= label_tag :ce_status, "CE status", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :ce_status,

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -57,6 +57,20 @@
     </div>
   <% end %>
 
+  <% if @offers_ce %>
+    <div class="w-full md:w-48">
+      <%= label_tag :ce_status, "CE status", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :ce_status,
+                     options_for_select(
+                       [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+                       params[:ce_status]
+                     ),
+                     include_blank: "Any CE status",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+    </div>
+  <% end %>
+
   <% if @dashboard.states.any? %>
     <div class="w-full md:w-48">
       <%= label_tag :state, "State", class: "block text-sm font-medium text-gray-700 mb-1" %>

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -1,104 +1,121 @@
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 <%= form_with url: registrants_event_path(@event), method: :get,
   data: { controller: "collection", turbo_frame: "registrants_results" },
   autocomplete: "off",
-  class: "flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6 bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
+  class: "mb-6 bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
 
   <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
 
-  <div class="w-full md:flex-1">
-    <%= label_tag :keyword, "Keyword", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <div class="relative">
-      <%= text_field_tag :keyword, params[:keyword],
-                         class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                         placeholder: "Name, email, phone, city, or organization" %>
-      <button type="submit"
-              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
-        <i class="fa fa-search"></i>
-      </button>
+  <%# Row 1: keyword + record-status filters, ordered to match the table columns
+      (CE, Scholarship, Payment). %>
+  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
+    <div class="w-full md:flex-1 md:min-w-[48rem]">
+      <%= label_tag :keyword, "Keyword", class: label_class %>
+      <div class="relative">
+        <%= text_field_tag :keyword, params[:keyword], class: field_class,
+                           placeholder: "Name, email, phone, city, or organization" %>
+        <button type="submit"
+                class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
+          <i class="fa fa-search"></i>
+        </button>
+      </div>
     </div>
+
+    <div class="w-full md:w-48">
+      <%= label_tag :attendance_status, "Attendance status", class: label_class %>
+      <%= select_tag :attendance_status,
+                     options_for_select(
+                       EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
+                       params[:attendance_status]
+                     ),
+                     include_blank: "All statuses", class: field_class %>
+    </div>
+
+    <% if @ce_eligible %>
+      <div class="w-full md:w-48">
+        <%= label_tag :ce_status, "CE status", class: label_class %>
+        <%= select_tag :ce_status,
+                       options_for_select(
+                         [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+                         params[:ce_status]
+                       ),
+                       include_blank: "Any CE status", class: field_class %>
+      </div>
+    <% end %>
+
+    <% if @event.cost_cents.to_i > 0 %>
+      <div class="w-full md:w-48">
+        <%= label_tag :scholarship, "Scholarship", class: label_class %>
+        <%= select_tag :scholarship,
+                       options_for_select(
+                         [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
+                         params[:scholarship]
+                       ),
+                       include_blank: "All registrants", class: field_class %>
+      </div>
+
+      <div class="w-full md:w-48">
+        <%= label_tag :payment_status, "Payment", class: label_class %>
+        <%= select_tag :payment_status,
+                       options_for_select(
+                         [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
+                         params[:payment_status]
+                       ),
+                       include_blank: "Any payment status", class: field_class %>
+      </div>
+    <% end %>
+
   </div>
 
-  <div class="w-full md:w-48">
-    <%= label_tag :attendance_status, "Attendance status", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= select_tag :attendance_status,
-                   options_for_select(
-                     EventRegistration::ATTENDANCE_STATUSES.map { |s| [EventRegistration.new(status: s).attendance_status_label, s] },
-                     params[:attendance_status]
-                   ),
-                   include_blank: "All statuses",
-                   class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-  </div>
-
-  <% if @ce_eligible %>
+  <%# Row 2: organization + comments + location filters, and the clear action. %>
+  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
     <div class="w-full md:w-48">
-      <%= label_tag :ce_status, "CE status", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :ce_status,
+      <%= label_tag :org_status, "Organization", class: label_class %>
+      <%= select_tag :org_status,
                      options_for_select(
-                       [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-                       params[:ce_status]
+                       [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
+                       params[:org_status]
                      ),
-                     include_blank: "Any CE status",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+                     include_blank: "All organizations", class: field_class %>
     </div>
-  <% end %>
 
-  <% if @event.cost_cents.to_i > 0 %>
     <div class="w-full md:w-48">
-      <%= label_tag :payment_status, "Payment", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :payment_status,
+      <%= label_tag :comment_status, "Comments", class: label_class %>
+      <%= select_tag :comment_status,
                      options_for_select(
-                       [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
-                       params[:payment_status]
+                       [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+                       params[:comment_status]
                      ),
-                     include_blank: "Any payment status",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+                     include_blank: "Any comments", class: field_class %>
     </div>
 
-    <div class="w-full md:w-48">
-      <%= label_tag :scholarship, "Scholarship", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :scholarship,
-                     options_for_select(
-                       [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
-                       params[:scholarship]
-                     ),
-                     include_blank: "All registrants",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-    </div>
-  <% end %>
+    <% if @dashboard.states.any? %>
+      <div class="w-full md:w-48">
+        <%= label_tag :state, "State", class: label_class %>
+        <%= select_tag :state,
+                       options_for_select(@dashboard.states, params[:state]),
+                       include_blank: "All states", class: field_class %>
+      </div>
+    <% end %>
 
-  <% if @dashboard.states.any? %>
-    <div class="w-full md:w-48">
-      <%= label_tag :state, "State", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :state,
-                     options_for_select(@dashboard.states, params[:state]),
-                     include_blank: "All states",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-    </div>
-  <% end %>
+    <% if @dashboard.counties.any? %>
+      <div class="w-full md:w-48">
+        <%= label_tag :county, "County", class: label_class %>
+        <%= select_tag :county,
+                       options_for_select(
+                         @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
+                         params[:county]
+                       ),
+                       include_blank: "All counties", class: field_class %>
+      </div>
+    <% end %>
 
-  <% if @dashboard.counties.any? %>
-    <div class="w-full md:w-48">
-      <%= label_tag :county, "County", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag :county,
-                     options_for_select(
-                       @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
-                       params[:county]
-                     ),
-                     include_blank: "All counties",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+    <div class="w-full md:w-auto md:ml-auto flex justify-end">
+      <%= link_to "Clear filters", registrants_event_path(@event),
+                  class: "btn btn-utility",
+                  data: { action: "collection#clearAndSubmit" } %>
     </div>
-  <% end %>
-
-  <div class="w-full md:w-auto flex justify-end">
-    <%= link_to "Clear filters", registrants_event_path(@event),
-                class: "btn btn-utility-outline",
-                data: { action: "collection#clearAndSubmit" } %>
   </div>
 <% end %>

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -55,9 +55,13 @@
           options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
           selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
 
+    <%= render "events/filter_select", param: :account_status, label: "User account",
+          options: [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+          selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+
     <% if @dashboard.states.any? %>
       <%= render "events/filter_select", param: :state, label: "State",
-            options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class %>
+            options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class, wrapper_class: "w-full md:w-32" %>
     <% end %>
 
     <% if @dashboard.counties.any? %>

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -8,11 +8,11 @@
 
   <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
 
-  <%# Row 1: keyword input + record-status filters, ordered to match the table
-      columns (CE, Scholarship, Payment). The dropdowns render via the shared
-      events/filter_select partial (also used by the reminder filters). %>
+  <%# Row 1: keyword input + record-status filters. Keyword flexes to fill the row;
+      the dropdowns render via the shared events/filter_select partial (also used
+      by the reminder filters). %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
-    <div class="w-full md:flex-1 md:min-w-[48rem]">
+    <div class="w-full md:flex-1 md:min-w-[16rem]">
       <%= label_tag :keyword, "Keyword", class: label_class %>
       <div class="relative">
         <%= text_field_tag :keyword, params[:keyword], class: field_class,
@@ -28,6 +28,12 @@
           options: EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
           selected: params[:attendance_status], blank: "All statuses", field_class: field_class %>
 
+    <% if @event.cost_cents.to_i > 0 %>
+      <%= render "events/filter_select", param: :payment_status, label: "Payment",
+            options: [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
+            selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
+    <% end %>
+
     <% if @ce_eligible %>
       <%= render "events/filter_select", param: :ce_status, label: "CE status",
             options: [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
@@ -38,10 +44,6 @@
       <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
             options: [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
             selected: params[:scholarship], blank: "All registrants", field_class: field_class %>
-
-      <%= render "events/filter_select", param: :payment_status, label: "Payment",
-            options: [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
-            selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
     <% end %>
   </div>
 

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -8,8 +8,9 @@
 
   <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
 
-  <%# Row 1: keyword + record-status filters, ordered to match the table columns
-      (CE, Scholarship, Payment). %>
+  <%# Row 1: keyword input + record-status filters, ordered to match the table
+      columns (CE, Scholarship, Payment). The dropdowns render via the shared
+      events/filter_select partial (also used by the reminder filters). %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
     <div class="w-full md:flex-1 md:min-w-[48rem]">
       <%= label_tag :keyword, "Keyword", class: label_class %>
@@ -23,93 +24,46 @@
       </div>
     </div>
 
-    <div class="w-full md:w-48">
-      <%= label_tag :attendance_status, "Attendance status", class: label_class %>
-      <%= select_tag :attendance_status,
-                     options_for_select(
-                       EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
-                       params[:attendance_status]
-                     ),
-                     include_blank: "All statuses", class: field_class %>
-    </div>
+    <%= render "events/filter_select", param: :attendance_status, label: "Attendance status",
+          options: EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
+          selected: params[:attendance_status], blank: "All statuses", field_class: field_class %>
 
     <% if @ce_eligible %>
-      <div class="w-full md:w-48">
-        <%= label_tag :ce_status, "CE status", class: label_class %>
-        <%= select_tag :ce_status,
-                       options_for_select(
-                         [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-                         params[:ce_status]
-                       ),
-                       include_blank: "Any CE status", class: field_class %>
-      </div>
+      <%= render "events/filter_select", param: :ce_status, label: "CE status",
+            options: [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+            selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
     <% end %>
 
     <% if @event.cost_cents.to_i > 0 %>
-      <div class="w-full md:w-48">
-        <%= label_tag :scholarship, "Scholarship", class: label_class %>
-        <%= select_tag :scholarship,
-                       options_for_select(
-                         [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
-                         params[:scholarship]
-                       ),
-                       include_blank: "All registrants", class: field_class %>
-      </div>
+      <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
+            options: [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
+            selected: params[:scholarship], blank: "All registrants", field_class: field_class %>
 
-      <div class="w-full md:w-48">
-        <%= label_tag :payment_status, "Payment", class: label_class %>
-        <%= select_tag :payment_status,
-                       options_for_select(
-                         [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
-                         params[:payment_status]
-                       ),
-                       include_blank: "Any payment status", class: field_class %>
-      </div>
+      <%= render "events/filter_select", param: :payment_status, label: "Payment",
+            options: [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
+            selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
     <% end %>
-
   </div>
 
   <%# Row 2: organization + comments + location filters, and the clear action. %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
-    <div class="w-full md:w-48">
-      <%= label_tag :org_status, "Organization", class: label_class %>
-      <%= select_tag :org_status,
-                     options_for_select(
-                       [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
-                       params[:org_status]
-                     ),
-                     include_blank: "All organizations", class: field_class %>
-    </div>
+    <%= render "events/filter_select", param: :org_status, label: "Organization",
+          options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
+          selected: params[:org_status], blank: "All organizations", field_class: field_class %>
 
-    <div class="w-full md:w-48">
-      <%= label_tag :comment_status, "Comments", class: label_class %>
-      <%= select_tag :comment_status,
-                     options_for_select(
-                       [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
-                       params[:comment_status]
-                     ),
-                     include_blank: "Any comments", class: field_class %>
-    </div>
+    <%= render "events/filter_select", param: :comment_status, label: "Comments",
+          options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+          selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
 
     <% if @dashboard.states.any? %>
-      <div class="w-full md:w-48">
-        <%= label_tag :state, "State", class: label_class %>
-        <%= select_tag :state,
-                       options_for_select(@dashboard.states, params[:state]),
-                       include_blank: "All states", class: field_class %>
-      </div>
+      <%= render "events/filter_select", param: :state, label: "State",
+            options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class %>
     <% end %>
 
     <% if @dashboard.counties.any? %>
-      <div class="w-full md:w-48">
-        <%= label_tag :county, "County", class: label_class %>
-        <%= select_tag :county,
-                       options_for_select(
-                         @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
-                         params[:county]
-                       ),
-                       include_blank: "All counties", class: field_class %>
-      </div>
+      <%= render "events/filter_select", param: :county, label: "County",
+            options: @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
+            selected: params[:county], blank: "All counties", field_class: field_class %>
     <% end %>
 
     <div class="w-full md:w-auto md:ml-auto flex justify-end">

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -12,7 +12,7 @@
       the dropdowns render via the shared events/filter_select partial (also used
       by the reminder filters). %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
-    <div class="w-full md:flex-1 md:min-w-[16rem]">
+    <div class="w-full md:flex-1 md:min-w-0">
       <%= label_tag :keyword, "Keyword", class: label_class %>
       <div class="relative">
         <%= text_field_tag :keyword, params[:keyword], class: field_class,

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -32,23 +32,56 @@
     </div>
   </div>
 
+  <%# Record-status filters — the same set (params/options) as the registrants
+      roster so the two stay in sync and filters can carry between the pages. %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
+    <%= render "events/filter_select", param: :attendance_status, label: "Attendance status",
+          options: EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
+          selected: params[:attendance_status], blank: "All statuses", field_class: field_class %>
+
     <% if @event.cost_cents.to_i > 0 %>
       <%= render "events/filter_select", param: :payment_status, label: "Payment",
-            options: [ [ "Paid", "paid" ], [ "Due", "unpaid" ], [ "Intends to pay", "intends_to_pay" ], [ "Paid + intends", "paid_or_intends" ] ],
+            options: [ [ "Due", "unpaid" ], [ "Paid", "paid" ], [ "Intends to pay", "intends_to_pay" ] ],
             selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
     <% end %>
-    <%= render "events/filter_select", param: :scholarship_status, label: "Scholarship",
-          options: [ [ "Requested", "requested" ], [ "Allocated", "allocated" ], [ "Tasks completed", "tasks_completed" ] ],
-          selected: params[:scholarship_status], blank: "Any scholarship status", field_class: field_class %>
+
     <% if @ce_eligible %>
-      <%= render "events/filter_select", param: :ce_status, label: "CE",
+      <%= render "events/filter_select", param: :ce_status, label: "CE status",
             options: [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
             selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
     <% end %>
+
+    <% if @event.cost_cents.to_i > 0 %>
+      <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
+            options: [ [ "All recipients", "yes" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
+            selected: params[:scholarship], blank: "All registrants", field_class: field_class %>
+    <% end %>
+  </div>
+
+  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
+    <%= render "events/filter_select", param: :org_status, label: "Organization",
+          options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
+          selected: params[:org_status], blank: "All organizations", field_class: field_class %>
+
+    <%= render "events/filter_select", param: :comment_status, label: "Comments",
+          options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+          selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
+
     <%= render "events/filter_select", param: :account_status, label: "User account",
           options: [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
           selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+
+    <% if @dashboard&.states&.any? %>
+      <%= render "events/filter_select", param: :state, label: "State",
+            options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class, wrapper_class: "w-full md:w-32" %>
+    <% end %>
+
+    <% if @dashboard&.counties&.any? %>
+      <%= render "events/filter_select", param: :county, label: "County",
+            options: @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
+            selected: params[:county], blank: "All counties", field_class: field_class %>
+    <% end %>
+
     <div class="w-full md:w-auto md:ml-auto flex justify-end">
       <%= link_to "Clear filters", preview_reminder_event_path(@event),
             class: "btn btn-utility",

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -36,45 +36,21 @@
 
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 items-end">
     <% if @event.cost_cents.to_i > 0 %>
-      <div>
-        <%= label_tag :payment_status, "Payment", class: label_class %>
-        <%= select_tag :payment_status,
-              options_for_select(
-                [ [ "Paid", "paid" ], [ "Due", "unpaid" ], [ "Intends to pay", "intends_to_pay" ], [ "Paid + intends", "paid_or_intends" ] ],
-                params[:payment_status]
-              ),
-              include_blank: "Any payment status", class: select_class %>
-      </div>
+      <%= render "events/filter_select", param: :payment_status, label: "Payment",
+            options: [ [ "Paid", "paid" ], [ "Due", "unpaid" ], [ "Intends to pay", "intends_to_pay" ], [ "Paid + intends", "paid_or_intends" ] ],
+            selected: params[:payment_status], blank: "Any payment status", field_class: select_class, wrapper_class: "" %>
     <% end %>
-    <div>
-      <%= label_tag :scholarship_status, "Scholarship", class: label_class %>
-      <%= select_tag :scholarship_status,
-            options_for_select(
-              [ [ "Requested", "requested" ], [ "Allocated", "allocated" ], [ "Tasks completed", "tasks_completed" ] ],
-              params[:scholarship_status]
-            ),
-            include_blank: "Any scholarship status", class: select_class %>
-    </div>
+    <%= render "events/filter_select", param: :scholarship_status, label: "Scholarship",
+          options: [ [ "Requested", "requested" ], [ "Allocated", "allocated" ], [ "Tasks completed", "tasks_completed" ] ],
+          selected: params[:scholarship_status], blank: "Any scholarship status", field_class: select_class, wrapper_class: "" %>
     <% if @ce_eligible %>
-      <div>
-        <%= label_tag :ce_status, "CE", class: label_class %>
-        <%= select_tag :ce_status,
-              options_for_select(
-                [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-                params[:ce_status]
-              ),
-              include_blank: "Any CE status", class: select_class %>
-      </div>
+      <%= render "events/filter_select", param: :ce_status, label: "CE",
+            options: [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+            selected: params[:ce_status], blank: "Any CE status", field_class: select_class, wrapper_class: "" %>
     <% end %>
-    <div>
-      <%= label_tag :account_status, "User account", class: label_class %>
-      <%= select_tag :account_status,
-            options_for_select(
-              [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
-              params[:account_status]
-            ),
-            include_blank: "Any account status", class: select_class %>
-    </div>
+    <%= render "events/filter_select", param: :account_status, label: "User account",
+          options: [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+          selected: params[:account_status], blank: "Any account status", field_class: select_class, wrapper_class: "" %>
     <div class="flex items-end">
       <%= link_to "Clear filters", preview_reminder_event_path(@event),
             class: "btn btn-utility-outline",

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -55,15 +55,17 @@
             ),
             include_blank: "Any scholarship status", class: select_class %>
     </div>
-    <div>
-      <%= label_tag :ce_status, "CE", class: label_class %>
-      <%= select_tag :ce_status,
-            options_for_select(
-              [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-              params[:ce_status]
-            ),
-            include_blank: "Any CE status", class: select_class %>
-    </div>
+    <% if @offers_ce %>
+      <div>
+        <%= label_tag :ce_status, "CE", class: label_class %>
+        <%= select_tag :ce_status,
+              options_for_select(
+                [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
+                params[:ce_status]
+              ),
+              include_blank: "Any CE status", class: select_class %>
+      </div>
+    <% end %>
     <div>
       <%= label_tag :account_status, "User account", class: label_class %>
       <%= select_tag :account_status,

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -3,57 +3,55 @@
     auto-submits into the reminder_recipients turbo frame via the collection
     controller, mirroring the workshops and registrants filters. %>
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-<%# Grey the dropdown text only while the include_blank placeholder (the first
-    option) is the one selected, so a chosen value still reads in dark text. %>
-<% select_class = "#{field_class} has-[option:first-child:checked]:text-gray-400" %>
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 <%= form_with url: preview_reminder_event_path(@event), method: :get,
   data: { controller: "collection", turbo_frame: "reminder_recipients" },
   autocomplete: "off",
   class: "bg-white border border-gray-200 rounded-xl shadow-sm p-4 mb-6" do %>
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-4 items-end">
-    <div>
+  <%# Inputs wrap in a flex row sized to match the shared filter dropdowns (w-48). %>
+  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-4">
+    <div class="w-full md:w-48">
       <%= label_tag :name, "Name", class: label_class %>
       <%= text_field_tag :name, params[:name], class: field_class, placeholder: "Registrant name" %>
     </div>
-    <div>
+    <div class="w-full md:w-48">
       <%= label_tag :reg_org, "Organization", class: label_class %>
       <%= text_field_tag :reg_org, params[:reg_org], class: field_class, placeholder: "Organization name" %>
     </div>
-    <div>
+    <div class="w-full md:w-48">
       <%= label_tag :grantor, "Grantor", class: label_class %>
       <%= text_field_tag :grantor, params[:grantor], class: field_class, placeholder: "Grantor name" %>
     </div>
-    <div>
+    <div class="w-full md:w-48">
       <%= label_tag :comment, "Comment", class: label_class %>
       <%= text_field_tag :comment, params[:comment], class: field_class, placeholder: "Comment text" %>
     </div>
-    <div>
+    <div class="w-full md:w-48">
       <%= label_tag :email, "Email", class: label_class %>
       <%= text_field_tag :email, params[:email], class: field_class, placeholder: "Email address" %>
     </div>
   </div>
 
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 items-end">
+  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
     <% if @event.cost_cents.to_i > 0 %>
       <%= render "events/filter_select", param: :payment_status, label: "Payment",
             options: [ [ "Paid", "paid" ], [ "Due", "unpaid" ], [ "Intends to pay", "intends_to_pay" ], [ "Paid + intends", "paid_or_intends" ] ],
-            selected: params[:payment_status], blank: "Any payment status", field_class: select_class, wrapper_class: "" %>
+            selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
     <% end %>
     <%= render "events/filter_select", param: :scholarship_status, label: "Scholarship",
           options: [ [ "Requested", "requested" ], [ "Allocated", "allocated" ], [ "Tasks completed", "tasks_completed" ] ],
-          selected: params[:scholarship_status], blank: "Any scholarship status", field_class: select_class, wrapper_class: "" %>
+          selected: params[:scholarship_status], blank: "Any scholarship status", field_class: field_class %>
     <% if @ce_eligible %>
       <%= render "events/filter_select", param: :ce_status, label: "CE",
             options: [ [ "Requested", "requested" ], [ "License not provided", "license_not_provided" ], [ "Hours not provided", "hours_not_provided" ], [ "Paid", "paid" ] ],
-            selected: params[:ce_status], blank: "Any CE status", field_class: select_class, wrapper_class: "" %>
+            selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
     <% end %>
     <%= render "events/filter_select", param: :account_status, label: "User account",
           options: [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
-          selected: params[:account_status], blank: "Any account status", field_class: select_class, wrapper_class: "" %>
-    <div class="flex items-end">
+          selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+    <div class="w-full md:w-auto md:ml-auto flex justify-end">
       <%= link_to "Clear filters", preview_reminder_event_path(@event),
-            class: "btn btn-utility-outline",
+            class: "btn btn-utility",
             data: { action: "collection#clearAndSubmit" } %>
     </div>
   </div>

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -55,7 +55,7 @@
             ),
             include_blank: "Any scholarship status", class: select_class %>
     </div>
-    <% if @offers_ce %>
+    <% if @ce_eligible %>
       <div>
         <%= label_tag :ce_status, "CE", class: label_class %>
         <%= select_tag :ce_status,

--- a/app/views/events/onboarding/_row.html.erb
+++ b/app/views/events/onboarding/_row.html.erb
@@ -8,13 +8,13 @@
 <% new_scholarship_link = new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "onboarding") %>
 <% align_class = { "left" => "text-left", "center" => "text-center", "right" => "text-right" } %>
 <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "hover:bg-gray-50" %>">
+<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "hover:bg-gray-50" %>">
   <% columns.each do |column| %>
     <% td_classes = [ "px-4 py-2 text-sm", align_class[column[:align]] ]
        if column[:sticky]
          # The row's inset ring is painted over by this sticky cell, so re-draw the
          # highlight border on the cell itself (same ring utility as the row).
-         td_classes << (highlighted ? "sticky left-0 bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "sticky left-0 bg-white")
+         td_classes << (highlighted ? "sticky left-0 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "sticky left-0 bg-white")
        end %>
     <% case column[:kind]
        when :first_name %>

--- a/app/views/events/onboarding/_row.html.erb
+++ b/app/views/events/onboarding/_row.html.erb
@@ -8,13 +8,13 @@
 <% new_scholarship_link = new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "onboarding") %>
 <% align_class = { "left" => "text-left", "center" => "text-center", "right" => "text-right" } %>
 <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "hover:bg-gray-50" %>">
+<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "hover:bg-gray-50" %>">
   <% columns.each do |column| %>
     <% td_classes = [ "px-4 py-2 text-sm", align_class[column[:align]] ]
        if column[:sticky]
          # The row's inset ring is painted over by this sticky cell, so re-draw the
          # highlight border on the cell itself (same ring utility as the row).
-         td_classes << (highlighted ? "sticky left-0 bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "sticky left-0 bg-white")
+         td_classes << (highlighted ? "sticky left-0 bg-yellow-50 ring-2 ring-inset ring-yellow-400" : "sticky left-0 bg-white")
        end %>
     <% case column[:kind]
        when :first_name %>

--- a/app/views/events/onboarding/_row.html.erb
+++ b/app/views/events/onboarding/_row.html.erb
@@ -8,13 +8,13 @@
 <% new_scholarship_link = new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "onboarding") %>
 <% align_class = { "left" => "text-left", "center" => "text-center", "right" => "text-right" } %>
 <% highlighted = params[:highlight].to_s == registration.id.to_s %>
-<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-amber-50 ring-2 ring-inset ring-amber-300" : "hover:bg-gray-50" %>">
+<tr id="<%= onboarding_row_id(registration) %>" class="scroll-mt-24 transition-colors duration-150 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "hover:bg-gray-50" %>">
   <% columns.each do |column| %>
     <% td_classes = [ "px-4 py-2 text-sm", align_class[column[:align]] ]
        if column[:sticky]
          # The row's inset ring is painted over by this sticky cell, so re-draw the
-         # amber border on the cell itself (same ring utility as the row).
-         td_classes << (highlighted ? "sticky left-0 bg-amber-50 ring-2 ring-inset ring-amber-300" : "sticky left-0 bg-white")
+         # highlight border on the cell itself (same ring utility as the row).
+         td_classes << (highlighted ? "sticky left-0 bg-yellow-50 ring-2 ring-inset ring-yellow-300" : "sticky left-0 bg-white")
        end %>
     <% case column[:kind]
        when :first_name %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -1,8 +1,18 @@
 <% content_for(:page_bg_class, "public") %>
 
 <% reg = @form_submission.person.event_registrations.find_by(event: @event) %>
-<% back_path = reg&.slug.present? ? registration_ticket_path(reg.slug) : event_path(@event) %>
-<% back_label = reg&.slug.present? ? "Back to ticket" : "Back to event" %>
+<%# Viewed from the admin Registrants roster (same-tab nav): return to that
+    registrant's row, not the public ticket. Falls back to ticket/event. %>
+<% if params[:return_to] == "registrants" && reg && allowed_to?(:index?, EventRegistration) %>
+  <% back_path = registrants_event_row_path(@event, params[:return_registration_id].presence || reg.id) %>
+  <% back_label = "Back to registrants" %>
+<% elsif reg&.slug.present? %>
+  <% back_path = registration_ticket_path(reg.slug) %>
+  <% back_label = "Back to ticket" %>
+<% else %>
+  <% back_path = event_path(@event) %>
+  <% back_label = "Back to event" %>
+<% end %>
 <div class="max-w-3xl mx-auto px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -2,8 +2,9 @@
 <%# Returned from a registrant's profile link on the event registrants page. Shown
     above the profile topper; needs event_id since the profile isn't event-scoped. %>
 <% if params[:return_to] == "registrants" && params[:event_id].present? %>
+  <% back_registration = @person.event_registrations.find_by(event_id: params[:event_id]) %>
   <div class="mb-3">
-    <%= link_to registrants_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to(back_registration ? registrants_event_row_path(params[:event_id], back_registration.id) : registrants_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700") do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to registrants
     <% end %>
   </div>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -247,7 +247,7 @@
    elsif @allocatable.respond_to?(:event) && params[:return_to] == "onboarding"
      onboarding_event_row_path(@allocatable.event, @allocatable.id)
    elsif @allocatable.respond_to?(:event)
-     params[:return_to] == "registration" ? edit_event_registration_path(@allocatable) : registrants_event_path(@allocatable.event)
+     params[:return_to] == "registration" ? edit_event_registration_path(@allocatable) : registrants_event_row_path(@allocatable.event, @allocatable.id)
    elsif grant.present?
      grant_path(grant)
    else

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -23,7 +23,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% elsif grant.present? %>

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -17,7 +17,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% else %>

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -30,6 +30,7 @@ module DomainTheme
 
     banners:                  :yellow,
     users:                    :rose,
+    comments:                 :purple,
 
     # Event dashboard cards
     payments:                 :green,

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -213,6 +213,34 @@ RSpec.describe EventRegistration, type: :model do
         expect(EventRegistration.ce_status("bogus")).to include(complete_ce, missing_ce, no_ce)
       end
     end
+
+    describe ".comment_status" do
+      let!(:no_comment) { create(:event_registration, event: event) }
+      let!(:commented) { create(:event_registration, event: event).tap { |r| create(:comment, commentable: r, body: "Hi") } }
+      let!(:flagged) { create(:event_registration, event: event).tap { |r| create(:comment, commentable: r, body: "Flag", flagged: true) } }
+
+      it "maps 'none' to registrations without comments" do
+        results = EventRegistration.comment_status("none")
+        expect(results).to include(no_comment)
+        expect(results).not_to include(commented, flagged)
+      end
+
+      it "maps 'present' to registrations with any comment" do
+        results = EventRegistration.comment_status("present")
+        expect(results).to include(commented, flagged)
+        expect(results).not_to include(no_comment)
+      end
+
+      it "maps 'flagged' to registrations with a flagged comment" do
+        results = EventRegistration.comment_status("flagged")
+        expect(results).to include(flagged)
+        expect(results).not_to include(no_comment, commented)
+      end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.comment_status("bogus")).to include(no_comment, commented, flagged)
+      end
+    end
   end
 
   describe "#scholarship?" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -241,6 +241,43 @@ RSpec.describe EventRegistration, type: :model do
         expect(EventRegistration.comment_status("bogus")).to include(no_comment, commented, flagged)
       end
     end
+
+    describe ".account_status" do
+      # The person factory auto-builds a confirmed user, so each case sets the
+      # registrant's account state explicitly (user: nil for no account).
+      let!(:none_reg) { create(:event_registration, event: event, registrant: create(:person, user: nil)) }
+      let!(:access_reg) { create(:event_registration, event: event, registrant: create(:person, user: create(:user, confirmed_at: Time.current))) }
+      let!(:invited_reg) { create(:event_registration, event: event, registrant: create(:person, user: create(:user, confirmed_at: nil, welcome_instructions_sent_at: Time.current))) }
+      let!(:no_access_reg) { create(:event_registration, event: event, registrant: create(:person, user: create(:user, confirmed_at: nil, welcome_instructions_sent_at: nil))) }
+
+      it "maps 'none' to registrants without an account" do
+        results = EventRegistration.account_status("none")
+        expect(results).to include(none_reg)
+        expect(results).not_to include(access_reg, invited_reg, no_access_reg)
+      end
+
+      it "maps 'has_access' to confirmed, unlocked, active accounts" do
+        results = EventRegistration.account_status("has_access")
+        expect(results).to include(access_reg)
+        expect(results).not_to include(none_reg, invited_reg, no_access_reg)
+      end
+
+      it "maps 'invited' to invited accounts that don't yet have access" do
+        results = EventRegistration.account_status("invited")
+        expect(results).to include(invited_reg)
+        expect(results).not_to include(none_reg, access_reg, no_access_reg)
+      end
+
+      it "maps 'no_access' to accounts that are neither invited nor active" do
+        results = EventRegistration.account_status("no_access")
+        expect(results).to include(no_access_reg)
+        expect(results).not_to include(none_reg, access_reg, invited_reg)
+      end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.account_status("bogus")).to include(none_reg, access_reg, invited_reg, no_access_reg)
+      end
+    end
   end
 
   describe "#scholarship?" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -174,6 +174,45 @@ RSpec.describe EventRegistration, type: :model do
         expect(EventRegistration.payment_status("bogus")).to include(paid_reg, unpaid_reg)
       end
     end
+
+    describe ".ce_status" do
+      let!(:complete_ce) do
+        create(:event_registration, event: event, ce_credit_requested: true, ce_license_number: "ABC123", ce_hours_requested: 3).tap do |r|
+          create(:allocation, source: create(:payment, amount_cents: event.cost_cents, amount_cents_remaining: event.cost_cents),
+                              allocatable: r, amount: event.cost_cents)
+        end
+      end
+      let!(:missing_ce) { create(:event_registration, event: event, ce_credit_requested: true) }
+      let!(:no_ce) { create(:event_registration, event: event, ce_credit_requested: false) }
+
+      it "maps 'requested' to anyone who asked for CE credit" do
+        results = EventRegistration.ce_status("requested")
+        expect(results).to include(complete_ce, missing_ce)
+        expect(results).not_to include(no_ce)
+      end
+
+      it "maps 'license_not_provided' to CE requests missing a license number" do
+        results = EventRegistration.ce_status("license_not_provided")
+        expect(results).to include(missing_ce)
+        expect(results).not_to include(complete_ce, no_ce)
+      end
+
+      it "maps 'hours_not_provided' to CE requests missing hours" do
+        results = EventRegistration.ce_status("hours_not_provided")
+        expect(results).to include(missing_ce)
+        expect(results).not_to include(complete_ce, no_ce)
+      end
+
+      it "maps 'paid' to CE requests that are paid in full" do
+        results = EventRegistration.ce_status("paid")
+        expect(results).to include(complete_ce)
+        expect(results).not_to include(missing_ce, no_ce)
+      end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.ce_status("bogus")).to include(complete_ce, missing_ce, no_ce)
+      end
+    end
   end
 
   describe "#scholarship?" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -261,29 +261,6 @@ RSpec.describe Event, type: :model do
     end
   end
 
-  describe "#offers_ce?" do
-    let(:ce_identifier) { EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER }
-
-    it "is true when the registration form has the CE-interest question" do
-      form = create(:form)
-      event = create(:event)
-      create(:event_form, event: event, form: form, role: "registration")
-      create(:form_field, form: form, field_identifier: ce_identifier)
-      expect(event.offers_ce?).to be true
-    end
-
-    it "is false when the registration form lacks the CE-interest question" do
-      form = create(:form, :with_fields)
-      event = create(:event)
-      create(:event_form, event: event, form: form, role: "registration")
-      expect(event.offers_ce?).to be false
-    end
-
-    it "is false when no registration form is linked" do
-      expect(create(:event).offers_ce?).to be false
-    end
-  end
-
   describe "#one_click_for_signed_in?" do
     it "is true when no registration form is linked" do
       event = create(:event)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -261,6 +261,29 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#offers_ce?" do
+    let(:ce_identifier) { EventRegistrationServices::PublicRegistration::CE_CREDIT_INTEREST_IDENTIFIER }
+
+    it "is true when the registration form has the CE-interest question" do
+      form = create(:form)
+      event = create(:event)
+      create(:event_form, event: event, form: form, role: "registration")
+      create(:form_field, form: form, field_identifier: ce_identifier)
+      expect(event.offers_ce?).to be true
+    end
+
+    it "is false when the registration form lacks the CE-interest question" do
+      form = create(:form, :with_fields)
+      event = create(:event)
+      create(:event_form, event: event, form: form, role: "registration")
+      expect(event.offers_ce?).to be false
+    end
+
+    it "is false when no registration form is linked" do
+      expect(create(:event).offers_ce?).to be false
+    end
+  end
+
   describe "#one_click_for_signed_in?" do
     it "is true when no registration form is linked" do
       event = create(:event)

--- a/spec/requests/allocations_spec.rb
+++ b/spec/requests/allocations_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe "Allocations", type: :request do
       expect(response).to have_http_status(:success)
     end
 
-    it "links the back link to the registrants roster when return_to=registrants" do
+    it "links the back link to the registrants roster (anchored to the row) when return_to=registrants" do
       get allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "registrants")
 
-      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+      expect(response.body).to include("href=\"#{registrants_event_path(event, highlight: reg.id, anchor: "registrant-row-#{reg.id}")}\"")
     end
 
     it "links the back link to bulk payments, re-expanding the submission row, when return_to=bulk_payments" do

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -673,5 +673,22 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
         expect(response.body).not_to include("Back to linked organizations")
       end
     end
+
+    context "when viewed from the admin registrants roster" do
+      let(:admin) { create(:user, :admin) }
+      let!(:registration) { create(:event_registration, event: event, registrant: person) }
+
+      before { sign_in admin }
+
+      it "returns the eyebrow to the registrant's row instead of the ticket" do
+        get event_public_registration_path(event, person_id: person.id,
+          return_to: "registrants", return_registration_id: registration.id)
+
+        expect(response.body).to include("Back to registrants")
+        expect(response.body).to include("registrant-row-#{registration.id}")
+        expect(response.body).to include("highlight=#{registration.id}")
+        expect(response.body).not_to include("Back to ticket")
+      end
+    end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe "Events", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:event) { create(:event) }
 
+  # Attaches a registration form carrying the seeded CE-interest question so the
+  # event reports `offers_ce?`, which gates every CE column/filter/export.
+  def offer_ce!(target_event)
+    form = create(:form)
+    create(:event_form, event: target_event, form: form, role: "registration")
+    create(:form_field, form: form, field_identifier: "ce_credit_interest")
+    target_event
+  end
+
   let(:valid_params) do
     {
       event: {
@@ -854,11 +863,21 @@ RSpec.describe "Events", type: :request do
     let!(:missing_reg) { create(:event_registration, event: event, registrant: missing_person, ce_credit_requested: true) }
     let!(:none_reg) { create(:event_registration, event: event, registrant: none_person, ce_credit_requested: false) }
 
-    before { sign_in admin }
+    before do
+      offer_ce!(event)
+      sign_in admin
+    end
 
-    it "shows the CE status column and filter once an event has CE requests" do
+    it "shows the CE status column and filter when the event offers CE" do
       get registrants_event_path(event)
       expect(response.body).to include("CE status")
+      expect(response.body).to include('data-column-toggle-group-value="ce"')
+    end
+
+    it "renders the CE status column hidden by default, behind its toggle" do
+      get registrants_event_path(event)
+      # The CE column markers carry the `hidden` class until the toggle reveals them.
+      expect(response.body).to match(/class="[^"]*hidden[^"]*"[^>]*data-column-toggle-col="ce"/)
     end
 
     it "filters to all CE requests" do
@@ -891,9 +910,9 @@ RSpec.describe "Events", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "hides the CE column when no one requested CE credit" do
+    it "hides CE entirely when the event's registration form doesn't offer CE" do
       plain_event = create(:event)
-      create(:event_registration, event: plain_event)
+      create(:event_registration, event: plain_event, ce_credit_requested: true)
       get registrants_event_path(plain_event)
       expect(response.body).not_to include("CE status")
     end
@@ -955,7 +974,10 @@ RSpec.describe "Events", type: :request do
     let(:person) { create(:person, first_name: "Onboard", last_name: "Ready") }
     let!(:registration) { create(:event_registration, event: event, registrant: person) }
 
-    before { sign_in admin }
+    before do
+      offer_ce!(event)
+      sign_in admin
+    end
 
     it "renders the onboarding matrix with the checklist columns" do
       get onboarding_event_path(event)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -962,12 +962,12 @@ RSpec.describe "Events", type: :request do
       expect(ce_chip_text).to eq("No license #")
     end
 
-    it "shows the CE amount due once a license is on file but unpaid" do
+    it "shows Filed once a license is on file but the CE balance is unpaid" do
       reg = create(:event_registration, event: event, registrant: person, ce_credit_requested: true)
       create(:continuing_education_registration, event_registration: reg, cost_cents: 15_000,
         professional_license: create(:professional_license, person: person))
       get registrants_event_path(event)
-      expect(ce_chip_text).to eq("$150 due")
+      expect(ce_chip_text).to eq("Filed")
     end
 
     it "shows Recipient when the CE balance is paid" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -838,6 +838,73 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "GET /events/:id/registrants with the CE status filter" do
+    let(:event) { create(:event, cost_cents: 1_000) }
+    let(:complete_person) { create(:person, first_name: "Complete", last_name: "Person") }
+    let(:missing_person) { create(:person, first_name: "Missing", last_name: "Person") }
+    let(:none_person) { create(:person, first_name: "Noce", last_name: "Person") }
+
+    let!(:complete_reg) do
+      reg = create(:event_registration, event: event, registrant: complete_person,
+                                         ce_credit_requested: true, ce_license_number: "ABC123", ce_hours_requested: 3)
+      create(:allocation, source: create(:payment, amount_cents: 1_000, amount_cents_remaining: 1_000),
+                          allocatable: reg, amount: 1_000)
+      reg
+    end
+    let!(:missing_reg) { create(:event_registration, event: event, registrant: missing_person, ce_credit_requested: true) }
+    let!(:none_reg) { create(:event_registration, event: event, registrant: none_person, ce_credit_requested: false) }
+
+    before { sign_in admin }
+
+    it "shows the CE status column and filter once an event has CE requests" do
+      get registrants_event_path(event)
+      expect(response.body).to include("CE status")
+    end
+
+    it "filters to all CE requests" do
+      get registrants_event_path(event, ce_status: "requested")
+      expect(response.body).to include("Complete Person")
+      expect(response.body).to include("Missing Person")
+      expect(response.body).not_to include("Noce Person")
+    end
+
+    it "filters to CE requests missing a license number" do
+      get registrants_event_path(event, ce_status: "license_not_provided")
+      expect(response.body).to include("Missing Person")
+      expect(response.body).not_to include("Complete Person")
+    end
+
+    it "filters to CE requests missing hours" do
+      get registrants_event_path(event, ce_status: "hours_not_provided")
+      expect(response.body).to include("Missing Person")
+      expect(response.body).not_to include("Complete Person")
+    end
+
+    it "filters to paid CE requests" do
+      get registrants_event_path(event, ce_status: "paid")
+      expect(response.body).to include("Complete Person")
+      expect(response.body).not_to include("Missing Person")
+    end
+
+    it "does not crash on an invalid ce_status" do
+      get registrants_event_path(event, ce_status: "bogus")
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "hides the CE column when no one requested CE credit" do
+      plain_event = create(:event)
+      create(:event_registration, event: plain_event)
+      get registrants_event_path(plain_event)
+      expect(response.body).not_to include("CE status")
+    end
+
+    it "includes a CE status column in the CSV export" do
+      get registrants_event_path(event, format: :csv)
+      expect(response.body).to include("CE status")
+      expect(response.body).to include("Incomplete")
+    end
+  end
+
   describe "GET /events/:id/registrants with state and county filters" do
     let(:ca_person) { create(:person, first_name: "Cali", last_name: "Person") }
     let(:ny_person) { create(:person, first_name: "York", last_name: "Person") }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1082,7 +1082,7 @@ RSpec.describe "Events", type: :request do
       get onboarding_event_path(event, highlight: registration.id)
 
       expect(response.body).to include("id=\"onboarding-row-#{registration.id}\"")
-      expect(response.body).to include("ring-yellow-400")
+      expect(response.body).to include("ring-yellow-500")
     end
 
     it "shows an Onboarding back-link to the row on registration edit" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -562,6 +562,13 @@ RSpec.describe "Events", type: :request do
     context "organization column" do
       let(:organization) { create(:organization, name: "Helping Hands") }
 
+      # Scopes assertions to the registrant's org cell so generic words like
+      # "None" in unrelated filter dropdowns don't cause false matches.
+      def org_cell_text
+        Nokogiri::HTML(response.body)
+          .at_css("tr#registrant-row-#{registration.id} td[data-column-toggle-col='organization']")&.text&.squish
+      end
+
       # Stores a submitted "agency_name" answer for the registrant, mirroring what
       # public registration captures, so the Pending/None chip logic has data.
       def submit_agency_name(name)
@@ -587,15 +594,15 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include(">Pending<")
-        expect(response.body).not_to include(">None<")
+        expect(org_cell_text).to include("Pending")
+        expect(org_cell_text).not_to include("None")
       end
 
       it "shows a 'None' chip when a registrant has no linked org and submitted nothing" do
         get registrants_event_path(event)
 
-        expect(response.body).to include(">None<")
-        expect(response.body).not_to include(">Pending<")
+        expect(org_cell_text).to include("None")
+        expect(org_cell_text).not_to include("Pending")
       end
 
       it "does not show a 'Pending' chip when an org is linked, even if the submitted name differs" do
@@ -604,8 +611,8 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include(organization.name)
-        expect(response.body).not_to include(">Pending<")
+        expect(org_cell_text).to include(organization.name)
+        expect(org_cell_text).not_to include("Pending")
       end
 
       it "does not show 'Pending' when the submitted name matches a linked org" do
@@ -614,8 +621,8 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include(organization.name)
-        expect(response.body).not_to include(">Pending<")
+        expect(org_cell_text).to include(organization.name)
+        expect(org_cell_text).not_to include("Pending")
       end
     end
 
@@ -923,6 +930,57 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "GET /events/:id/registrants CE status column states" do
+    let(:event) { offer_ce!(create(:event, cost_cents: 1_000)) }
+    let(:person) { create(:person, first_name: "Cee", last_name: "Ee") }
+
+    before { sign_in admin }
+
+    # The CE chip is the only content of the CE column cell, so its squished text
+    # is the chip label (the trailing link arrow icon contributes no text).
+    def ce_chip_text
+      Nokogiri::HTML(response.body).at_css('td[data-column-toggle-col="ce"]')&.text&.squish
+    end
+
+    it "shows Create when CE was not requested" do
+      create(:event_registration, event: event, registrant: person, ce_credit_requested: false)
+      get registrants_event_path(event)
+      expect(ce_chip_text).to eq("Create")
+    end
+
+    it "shows Requested when requested but no CE registration record exists yet" do
+      create(:event_registration, event: event, registrant: person, ce_credit_requested: true)
+      get registrants_event_path(event)
+      expect(ce_chip_text).to eq("Requested")
+    end
+
+    it "shows No license # once a CE record exists without a license number" do
+      reg = create(:event_registration, event: event, registrant: person, ce_credit_requested: true)
+      create(:continuing_education_registration, event_registration: reg,
+        professional_license: create(:professional_license, :placeholder, person: person))
+      get registrants_event_path(event)
+      expect(ce_chip_text).to eq("No license #")
+    end
+
+    it "shows the CE amount due once a license is on file but unpaid" do
+      reg = create(:event_registration, event: event, registrant: person, ce_credit_requested: true)
+      create(:continuing_education_registration, event_registration: reg, cost_cents: 15_000,
+        professional_license: create(:professional_license, person: person))
+      get registrants_event_path(event)
+      expect(ce_chip_text).to eq("$150 due")
+    end
+
+    it "shows Recipient when the CE balance is paid" do
+      reg = create(:event_registration, event: event, registrant: person, ce_credit_requested: true)
+      cer = create(:continuing_education_registration, event_registration: reg, cost_cents: 15_000,
+        professional_license: create(:professional_license, person: person))
+      create(:allocation, source: create(:payment, amount_cents: 15_000, amount_cents_remaining: 15_000),
+        allocatable: cer, amount: 15_000)
+      get registrants_event_path(event)
+      expect(ce_chip_text).to eq("Recipient")
+    end
+  end
+
   describe "GET /events/:id/registrants with state and county filters" do
     let(:ca_person) { create(:person, first_name: "Cali", last_name: "Person") }
     let(:ny_person) { create(:person, first_name: "York", last_name: "Person") }
@@ -1024,7 +1082,7 @@ RSpec.describe "Events", type: :request do
       get onboarding_event_path(event, highlight: registration.id)
 
       expect(response.body).to include("id=\"onboarding-row-#{registration.id}\"")
-      expect(response.body).to include("ring-amber-300")
+      expect(response.body).to include("ring-yellow-300")
     end
 
     it "shows an Onboarding back-link to the row on registration edit" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -690,7 +690,6 @@ RSpec.describe "Events", type: :request do
       it "shows the due amount and no paid amount when nothing has been paid" do
         get registrants_event_path(event)
 
-        expect(response.body).to include("fa-circle-exclamation")
         expect(response.body).to include("$10 due")
         expect(response.body).not_to include("Partial")
       end
@@ -701,7 +700,6 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include("fa-circle-half-stroke")
         expect(response.body).to include("Partial payment · $6 due")
         expect(response.body).not_to include(">Partial payment<")
         expect(response.body).to include("$6 due")
@@ -713,7 +711,6 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include("fa-circle-exclamation")
         expect(response.body).to include("$6 due")
         expect(response.body).not_to include("Partial")
       end
@@ -724,7 +721,6 @@ RSpec.describe "Events", type: :request do
 
         get registrants_event_path(event)
 
-        expect(response.body).to include("fa-circle-check")
         expect(response.body).to include(">Paid</span>")
       end
 
@@ -872,10 +868,13 @@ RSpec.describe "Events", type: :request do
       expect(response.body).to include('data-column-toggle-group-value="ce"')
     end
 
-    it "renders the CE status column hidden by default, behind its toggle" do
+    it "renders the CE status column on by default, with a toggle to hide it" do
       get registrants_event_path(event)
-      # The CE column markers carry the `hidden` class until the toggle reveals them.
-      expect(response.body).to match(/class="[^"]*hidden[^"]*"[^>]*data-column-toggle-col="ce"/)
+      # CE column markers render visible (no `hidden` class) since the toggle defaults on…
+      expect(response.body).to include('data-column-toggle-col="ce"')
+      expect(response.body).not_to match(/class="[^"]*\bhidden\b[^"]*"[^>]*data-column-toggle-col="ce"/)
+      # …and the toggle switch shows its on-state.
+      expect(response.body).to include('data-column-toggle-group-value="ce"')
     end
 
     it "filters to all CE requests" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -750,23 +750,25 @@ RSpec.describe "Events", type: :request do
     context "registration form icon" do
       let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
 
-      it "shows green icon when person submitted the current registration form" do
+      it "shows a blue outline form icon when person submitted the current registration form" do
         create(:event_form, event: event, form: reg_form, role: "registration")
         create(:form_submission, person: person, form: reg_form)
 
         get registrants_event_path(event)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('fa-solid fa-file-lines')
+        expect(response.body).to include('fa-regular fa-file-lines')
+        expect(response.body).to include('text-blue-600')
       end
 
-      it "shows gray icon when person has not submitted any form" do
+      it "reserves an empty slot (no icon) when person has not submitted, keeping later icons aligned" do
         create(:event_form, event: event, form: reg_form, role: "registration")
 
         get registrants_event_path(event)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('fa-regular fa-file-lines')
+        expect(response.body).not_to include('fa-file-lines')
+        expect(response.body).to include('inline-flex w-4 justify-center')
       end
 
       it "does not show any form icon when event has no forms" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -5,12 +5,10 @@ RSpec.describe "Events", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:event) { create(:event) }
 
-  # Attaches a registration form carrying the seeded CE-interest question so the
-  # event reports `offers_ce?`, which gates every CE column/filter/export.
+  # Makes the event CE-eligible (offers a positive number of CE hours), which
+  # gates every CE column/filter/export.
   def offer_ce!(target_event)
-    form = create(:form)
-    create(:event_form, event: target_event, form: form, role: "registration")
-    create(:form_field, form: form, field_identifier: "ce_credit_interest")
+    target_event.update!(ce_hours_offered: 6)
     target_event
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1082,7 +1082,7 @@ RSpec.describe "Events", type: :request do
       get onboarding_event_path(event, highlight: registration.id)
 
       expect(response.body).to include("id=\"onboarding-row-#{registration.id}\"")
-      expect(response.body).to include("ring-yellow-300")
+      expect(response.body).to include("ring-yellow-400")
     end
 
     it "shows an Onboarding back-link to the row on registration edit" do

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -171,10 +171,10 @@ RSpec.describe "Scholarships", type: :request do
   end
 
   describe "back link follows the page the user came from" do
-    it "links the new page back to the registrants roster when return_to=registrants" do
+    it "links the new page back to the registrants roster (anchored to the row) when return_to=registrants" do
       get new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants")
 
-      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+      expect(response.body).to include("href=\"#{registrants_event_path(event, highlight: registration.id, anchor: "registrant-row-#{registration.id}")}\"")
       expect(response.body).not_to include("href=\"#{edit_event_registration_path(registration)}\"")
     end
 
@@ -184,10 +184,10 @@ RSpec.describe "Scholarships", type: :request do
       expect(response.body).to include("href=\"#{edit_event_registration_path(registration)}\"")
     end
 
-    it "links the edit page back to the registrants roster when return_to=registrants" do
+    it "links the edit page back to the registrants roster (anchored to the row) when return_to=registrants" do
       get edit_scholarship_path(scholarship, return_to: "registrants")
 
-      expect(response.body).to include("href=\"#{registrants_event_path(event)}\"")
+      expect(response.body).to include("href=\"#{registrants_event_path(event, highlight: registration.id, anchor: "registrant-row-#{registration.id}")}\"")
     end
 
     it "links the edit page back to the registration when return_to=registration" do

--- a/spec/services/reminder_recipient_filter_spec.rb
+++ b/spec/services/reminder_recipient_filter_spec.rb
@@ -110,30 +110,27 @@ RSpec.describe ReminderRecipientFilter do
       it "filters intends-to-pay registrants" do
         expect(matched({ payment_status: "intends_to_pay" }, [ paid, due, intends ])).to eq([ intends.id ].to_set)
       end
-
-      it "filters paid + intends registrants" do
-        expect(matched({ payment_status: "paid_or_intends" }, [ paid, due, intends ])).to eq([ paid.id, intends.id ].to_set)
-      end
     end
 
-    context "scholarship status" do
-      let!(:requested) { registration.tap { |r| r.update!(scholarship_requested: true) } }
+    # Shares the registrants-roster `scholarship` filter (yes/complete/incomplete).
+    context "scholarship" do
+      let!(:none) { registration.tap { |r| r.update!(scholarship_requested: true) } }
       let!(:allocated) { registration(first_name: "Alloc").tap { |r| award_scholarship(r) } }
       let!(:completed) { registration(first_name: "Done").tap { |r| award_scholarship(r, tasks_completed: true) } }
 
-      it "filters requested" do
-        expect(matched({ scholarship_status: "requested" }, [ requested, allocated, completed ]))
-          .to eq([ requested.id ].to_set)
-      end
-
-      it "filters allocated" do
-        expect(matched({ scholarship_status: "allocated" }, [ requested, allocated, completed ]))
+      it "filters all recipients" do
+        expect(matched({ scholarship: "yes" }, [ none, allocated, completed ]))
           .to eq([ allocated.id, completed.id ].to_set)
       end
 
-      it "filters tasks completed" do
-        expect(matched({ scholarship_status: "tasks_completed" }, [ requested, allocated, completed ]))
+      it "filters tasks complete" do
+        expect(matched({ scholarship: "complete" }, [ none, allocated, completed ]))
           .to eq([ completed.id ].to_set)
+      end
+
+      it "filters tasks not complete" do
+        expect(matched({ scholarship: "incomplete" }, [ none, allocated, completed ]))
+          .to eq([ allocated.id ].to_set)
       end
     end
 


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — substantive view/JS logic across the registrants roster plus a shared helper and the public-registration eyebrow

### What is the goal of this PR and why is this important?
- Give admins an at-a-glance, triage-friendly registrants roster: see CE credit standing, keep the table dense and readable, and navigate without losing their place.
- CE only applies to events that grant CE credit, so CE surfaces stay hidden elsewhere.

### How did you approach the change?
- **CE status**: new `EventRegistration.ce_status` scope + shared `ce_status_label`; a "CE status" column (scholarship-style pill linking to the registration's CE section) and dropdown filter, plus onboarding columns, bulk-reminder filter, and both CSV exports — all gated on `Event#ce_eligible?`.
- **Column toggles**: generalized the `column-toggle` Stimulus controller to multiple named groups. CE on by default, Attendance off by default, User confirmation off — each with its own switch.
- **Layout/density**: CE before Scholarship; Date registered moved to the far right after Edit; filters wrapped in a card; compact registrant profile button (small avatar/type, uniform width); leading chip icons removed; column widths/truncation retuned.
- **Navigation**: viewing a submission from the roster stays in the same tab and its eyebrow returns to that registrant's row (anchored + highlighted), instead of the public ticket.

### UI Testing Checklist
- [ ] CE-eligible event: CE column shows by default, toggle hides it; Attendance hidden until toggled; CE filter + CSV column present.
- [ ] Non-CE event: no CE anywhere (roster, onboarding, bulk reminders, CSVs).
- [ ] View-submission from roster: same tab, "Back to registrants" returns to the highlighted row.

### Anything else to add?
- Rebased on main; reuses main's `Event#ce_eligible?` (CE foundation PR #1916). Covered by model + request specs (scope, filter, CSV, toggle defaults, eyebrow).