### PR TITLE
Disentangle sector field identifiers and tag primary vs additional distinctly

### DIFF
--- a/app/models/concerns/sectors_taggable.rb
+++ b/app/models/concerns/sectors_taggable.rb
@@ -17,7 +17,43 @@ module SectorsTaggable
     sectorable_items.sort_by { |item| [ item.is_primary? ? 0 : 1, item.sector&.name.to_s.downcase ] }
   end
 
+  # Additively tag sectors as primary/additional without disturbing other
+  # taggings — used by registration, where a respondent names a single primary
+  # sector (the dropdown) plus any number of additional sectors (the checkboxes).
+  # Mirrors AgeGroupTaggable#tag_age_groups, but upholds the single-primary rule:
+  # at most one id is promoted, and any prior primary the respondent didn't
+  # re-select is demoted first. A sector listed as both primary and additional is
+  # treated as primary.
+  def tag_sectors(primary_ids:, additional_ids:)
+    primary = sanitize_sector_ids(primary_ids).first(1)
+    additional = sanitize_sector_ids(additional_ids) - primary
+
+    demote_unselected_primary_sectors(primary) if primary.any?
+    upsert_sector_items(primary, is_primary: true)
+    upsert_sector_items(additional, is_primary: false)
+    sectorable_items.reset
+  end
+
   private
+
+  # Demote any currently-primary sector that isn't the newly selected primary, so
+  # promoting the new pick never leaves two primaries behind.
+  def demote_unselected_primary_sectors(primary_ids)
+    sectorable_items.where(is_primary: true).where.not(sector_id: primary_ids)
+      .update_all(is_primary: false)
+  end
+
+  def upsert_sector_items(sector_ids, is_primary:)
+    Sector.where(id: sector_ids).find_each do |sector|
+      item = sectorable_items.find_or_initialize_by(sector: sector)
+      item.is_primary = is_primary
+      item.save!
+    end
+  end
+
+  def sanitize_sector_ids(ids)
+    Array(ids).reject(&:blank?).map(&:to_i)
+  end
 
   def at_most_one_primary_sector
     # Count the in-memory set (not a DB query): with nested attributes both

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -15,10 +15,12 @@ class FormField < ApplicationRecord
   # "required" flag is meaningless for them (nothing to fill in).
   NON_INPUT_ANSWER_TYPES = %w[no_user_input group_header].freeze
 
-  # Multi-select "additional sectors" field identifiers. The current "sector"
-  # name and the legacy "service area" name are both accepted so existing form
-  # data keeps resolving.
-  ADDITIONAL_SECTOR_FIELD_IDENTIFIERS = %w[primary_sector primary_service_area].freeze
+  # Multi-select "additional sectors" field identifiers. "additional_sectors" is
+  # the canonical name new forms are built with; the older "primary_sector" name
+  # (a misnomer — it was always the multi-select additional field) and the legacy
+  # "service area" name are both still accepted so existing form data keeps
+  # resolving.
+  ADDITIONAL_SECTOR_FIELD_IDENTIFIERS = %w[additional_sectors primary_sector primary_service_area].freeze
 
   # Single-select "primary sector" field identifiers (current + legacy). Unlike
   # the multi-select "additional" field, these omit the catch-all "Other" sector

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -234,7 +234,7 @@ class Person < ApplicationRecord
 
   # Free-text "Other" sectors the person typed on registration forms.
   # They can't be Sector records, so they're surfaced beside the sector tags.
-  def other_service_area_responses
+  def other_sector_responses
     other_form_responses(FormField::SECTOR_FIELD_IDENTIFIERS)
   end
 

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,7 +1,7 @@
 class Sector < ApplicationRecord
   include NameFilterable, Publishable
-  # Canonical service-area sector tags, in display order. "Other" is kept at the end
-  # as the catch-all free-text fallback for additional service areas (see
+  # Canonical sector tags, in display order. "Other" is kept at the end
+  # as the catch-all free-text fallback for additional sectors (see
   # OTHER_SECTOR_NAME below) — it isn't a selectable tag itself. Descriptions for
   # these (the parenthetical clarifications) live in db/seeds.rb.
   SECTOR_TYPES = [
@@ -39,8 +39,8 @@ class Sector < ApplicationRecord
     "Other"
   ]
 
-  # The catch-all sector. Offered for "additional" service areas but not as a
-  # respondent's single "primary" service area.
+  # The catch-all sector. Offered for "additional" sectors but not as a
+  # respondent's single "primary" sector.
   OTHER_SECTOR_NAME = "Other"
 
   STORY_DISPLAY_TEXT = "Which sectors does this story fit into?"

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -689,7 +689,7 @@ class EventDashboard
       .sort_by(&:name)
   end
 
-  # The person's primary service area: the sector they marked primary, falling
+  # The person's primary sector: the sector they marked primary, falling
   # back to their first sector alphabetically. Nil when they have none.
   def primary_sector_name_for(person)
     person.sectorable_items_primary_first.first&.sector&.name

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -273,14 +273,17 @@ module EventRegistrationServices
     end
 
     def assign_tags(person, organization)
-      sector_ids = FormField::SECTOR_FIELD_IDENTIFIERS.flat_map { |id| collect_ids_from_checkboxes(id) }
+      primary_sector_ids = collect_sector_ids(FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS)
+      additional_sector_ids = collect_sector_ids(FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS)
       primary_age_ids = collect_ids_from_checkboxes("primary_age_group")
       additional_age_ids = collect_ids_from_checkboxes("additional_age_group")
 
-      if sector_ids.any?
-        sectors = Sector.where(id: sector_ids)
-        assign_primary_sectors(person, sectors)
-        organization.sectors = (organization.sectors + sectors).uniq if organization
+      if primary_sector_ids.any? || additional_sector_ids.any?
+        person.tag_sectors(primary_ids: primary_sector_ids, additional_ids: additional_sector_ids)
+        # Organizations aggregate sectors across many people and have no single
+        # "primary", so union everyone's selections in as additional tags rather
+        # than churning the org's primary on each registration.
+        organization&.tag_sectors(primary_ids: [], additional_ids: primary_sector_ids + additional_sector_ids)
       end
 
       if primary_age_ids.any? || additional_age_ids.any?
@@ -289,11 +292,8 @@ module EventRegistrationServices
       end
     end
 
-    def assign_primary_sectors(person, sectors)
-      sectors.each do |sector|
-        item = person.sectorable_items.find_or_initialize_by(sector: sector)
-        item.update!(is_primary: true)
-      end
+    def collect_sector_ids(identifiers)
+      identifiers.flat_map { |id| collect_ids_from_checkboxes(id) }
     end
 
     def collect_ids_from_checkboxes(identifier)

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -49,7 +49,7 @@ class FormBuilderService
       agency_street agency_city agency_state agency_zip agency_country
     ],
     person_background: %w[racial_ethnic_identity],
-    professional_info: %w[primary_sector_single primary_sector primary_age_group additional_age_group],
+    professional_info: %w[primary_sector_single additional_sectors primary_age_group additional_age_group],
     marketing: %w[referral_source training_motivation interested_in_more],
     scholarship: %w[scholarship_eligibility scholarship_contribution impact_description implementation_plan additional_comments],
     payment: %w[payment_method],
@@ -448,7 +448,7 @@ class FormBuilderService
                          key: "primary_sector_single", group: "professional", required: false,
                          subtitle: "Select the option that best represents those you primarily intend to serve through the art workshops")
     position = add_field(form, position, "Additional sectors", :multi_select_checkbox,
-                         key: "primary_sector", group: "professional", required: false,
+                         key: "additional_sectors", group: "professional", required: false,
                          subtitle: "Select all options that represent who you intend to serve through the art workshops (check all that apply)")
     position = add_field(form, position, "Primary Age Group(s) Served", :single_select_dropdown,
                          key: "primary_age_group", group: "professional", required: false,

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -74,7 +74,7 @@
               <%= "required" if field.required %>><%= value %></textarea>
 
   <% when "single_select_radio" %>
-    <%# Dynamic fields (e.g. primary_sector) source options from Sector/Category
+    <%# Dynamic fields (e.g. additional_sectors) source options from Sector/Category
         data and store none of their own, so fall back to those when present. %>
     <% radio_options = dynamic_form_field_options(field) ||
          field.form_field_answer_options.includes(:answer_option).map { |ffao| [ ffao.answer_option.name, ffao.answer_option.name ] } %>
@@ -133,7 +133,7 @@
   <% when "multi_select_checkbox" %>
     <% checkbox_name = "public_registration[form_fields][#{field.id}][]" %>
     <% selected_values = Array(value) %>
-    <%# Dynamic fields (e.g. primary_sector) source options from Sector/Category
+    <%# Dynamic fields (e.g. additional_sectors) source options from Sector/Category
         data; everything else uses the field's own stored answer options. Sector and
         Category options carry an optional description, shown as subtext under the label. %>
     <% checkbox_options = dynamic_form_field_options(field) ||

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -56,10 +56,10 @@
         <% participant_slug = @dashboard.registration_slug_by_registrant[person.id] %>
         <% answers = (answers_by_applicant[person.id] || []).reject { |a| a.form_field&.field_identifier == "scholarship_eligibility" } %>
         <% header = header_answers[person.id] || {} %>
-        <% service_area_answer = header[EventDashboard::HEADER_SECTOR_KEY] %>
+        <% sector_answer = header[EventDashboard::HEADER_SECTOR_KEY] %>
         <% age_group_answer = header["primary_age_group"] %>
         <%# Prefer the registrant's form answers; fall back to their profile data. %>
-        <% service_area_text = resolve_answer_text(service_area_answer&.form_field, service_area_answer&.submitted_answer).presence || person.sectors.map(&:name).join(", ").presence %>
+        <% sector_text = resolve_answer_text(sector_answer&.form_field, sector_answer&.submitted_answer).presence || person.sectors.map(&:name).join(", ").presence %>
         <% age_group_text = resolve_answer_text(age_group_answer&.form_field, age_group_answer&.submitted_answer).presence || person.categories.select { |c| c.category_type&.name == "AgeRange" }.map(&:name).join(", ").presence %>
         <%# The affiliation active at the time of the event, excluding facilitator roles. %>
         <% recipient_affiliations = person.affiliations.select { |a|
@@ -125,7 +125,7 @@
                 </div>
 
                 <%# Serves / Ages — parallel with the name %>
-                <% if has_sectors || service_area_text.present? || has_age_groups || age_group_text.present? %>
+                <% if has_sectors || sector_text.present? || has_age_groups || age_group_text.present? %>
                   <div class="flex flex-wrap items-center gap-x-8 gap-y-2">
                     <% if has_sectors %>
                       <div class="flex flex-wrap items-center gap-2">
@@ -134,10 +134,10 @@
                           <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
                         <% end %>
                       </div>
-                    <% elsif service_area_text.present? %>
+                    <% elsif sector_text.present? %>
                       <div class="text-sm text-gray-600">
                         <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
-                        <%= service_area_text %>
+                        <%= sector_text %>
                       </div>
                     <% end %>
                     <% if has_age_groups %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -138,7 +138,7 @@
                                       .reject { |_, id| (@current_sector_ids || []).include?(id) },
                                               show_admin_flags: true } },
                                   class: "btn btn-secondary-outline" %>
-      <%= render "people/other_responses", responses: @person.other_service_area_responses %>
+      <%= render "people/other_responses", responses: @person.other_sector_responses %>
     </div>
   </div>
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -137,10 +137,10 @@
                 chip, followed by the additional sectors alphabetically and any
                 free-text "Other" responses. %>
             <% sectorable_items = @person.sectorable_items.includes(:sector).sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } %>
-            <% other_service_areas = @person.other_service_area_responses %>
+            <% other_sectors = @person.other_sector_responses %>
             <div class="md:col-span-2 p-3">
               <h2 class="text-lg font-semibold text-gray-800 mb-3">Sectors</h2>
-              <% if sectorable_items.any? || other_service_areas.any? %>
+              <% if sectorable_items.any? || other_sectors.any? %>
                 <div class="flex flex-wrap gap-2">
                   <% sectorable_items.each do |si| %>
                     <%= render "sectors/tagging_label",
@@ -149,7 +149,7 @@
                                  display_leader: true,
                                  is_leader: si.is_leader %>
                   <% end %>
-                  <%= render "people/other_responses", responses: other_service_areas %>
+                  <%= render "people/other_responses", responses: other_sectors %>
                 </div>
               <% else %>
                 <p class="text-gray-500 italic">None selected.</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -150,8 +150,8 @@ end
 
 puts "Creating Sectors…"
 # Optional descriptions clarify a sector on the public registration form: shown as
-# subtext under the checkbox in the additional service-areas list, and folded into
-# the "Name (description)" label in the single primary service-area dropdown (which
+# subtext under the checkbox in the additional sectors list, and folded into
+# the "Name (description)" label in the single primary sector dropdown (which
 # can't show subtext). They come from the parenthetical clarifications on the
 # canonical sector list. Names without an entry below have no description. Admins
 # can edit each from the Sectors admin once seeded.

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1022,7 +1022,7 @@ puts "Giving Amy a free-text \"Other\" answer on her Facilitator Training submis
 # Demo data for the "Other" chip on the person profile + edit pages: a registrant
 # who picked the "Other" option (folded into "Other: <text>") on a sector-backed
 # field (Additional sectors). The free-text value can't be a Sector record, so it
-# only surfaces via Person#other_service_area_responses.
+# only surfaces via Person#other_sector_responses.
 # Seeded before the professional-answer enrichment below so the primary_sector
 # value survives its "skip if already answered" guard. Idempotent.
 if facilitator_training && amy_person
@@ -1039,20 +1039,20 @@ if facilitator_training && amy_person
   end
 end
 
-puts "Recording professional answers (age group / service area) on registration submissions…"
+puts "Recording professional answers (age group / sector) on registration submissions…"
 # The Background page charts the registrants' "Primary Age Group(s) Served" and
-# "Primary Service Area(s)" registration answers. Public registration stores
+# "Primary Sector(s)" registration answers. Public registration stores
 # these checkbox answers as ", "-joined category / sector ids (see
 # PublicRegistration#save_form_answers + assign_tags); seed them the same way so
-# the charts have data. Age group is read from the form answers; service area is
+# the charts have data. Age group is read from the form answers; the sector is
 # read from SectorableItem tags, so write both. Idempotent: skips a field already
 # answered on a submission, and only enriches people who have a submission (so the
 # "registered but didn't fill the form" scenarios stay answer-free).
 age_range_categories = Category.age_ranges.published.order(:position, :name).to_a
 # Exclude the catch-all "Other" sector: it's the free-text fallback registrants
-# type into (surfaced via Person#other_service_area_responses), not a selectable
-# service area. Seeding it as a sector tag would list "Other" as a real service area.
-service_area_sectors = Sector.published.excluding_other.order(:name).to_a
+# type into (surfaced via Person#other_sector_responses), not a selectable
+# sector. Seeding it as a sector tag would list "Other" as a real sector.
+selectable_sectors = Sector.published.excluding_other.order(:name).to_a
 
 record_professional_answers = ->(submission, i) do
   person = submission.person
@@ -1068,15 +1068,15 @@ record_professional_answers = ->(submission, i) do
   end
 
   service_field = form.form_fields.find_by(field_identifier: "primary_sector")
-  sectors = service_area_sectors.empty? ? [] : [ service_area_sectors[i % service_area_sectors.size], service_area_sectors[(i + 4) % service_area_sectors.size] ].uniq
+  sectors = selectable_sectors.empty? ? [] : [ selectable_sectors[i % selectable_sectors.size], selectable_sectors[(i + 4) % selectable_sectors.size] ].uniq
   if service_field && sectors.present? && submission.form_answers.where(form_field: service_field).none?
     submission.form_answers.create!(form_field: service_field,
                                     submitted_answer: sectors.map(&:id).join(", "),
                                     question_name_when_answered: service_field.name)
   end
-  # Service area chart reads SectorableItem tags, mirroring assign_tags.
+  # Sector chart reads SectorableItem tags, mirroring assign_tags.
   sectors.each { |sector| SectorableItem.find_or_create_by!(sector: sector, sectorable: person) }
-  # Make the first submitted service area the person's single primary sector, so the
+  # Make the first submitted sector the person's single primary sector, so the
   # recipients page + profile crown a primary that matches what they selected on the
   # registration form. Demote any other primary first to keep exactly one (a person
   # registered for several events is enriched once per event). Idempotent.

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1023,13 +1023,13 @@ puts "Giving Amy a free-text \"Other\" answer on her Facilitator Training submis
 # who picked the "Other" option (folded into "Other: <text>") on a sector-backed
 # field (Additional sectors). The free-text value can't be a Sector record, so it
 # only surfaces via Person#other_sector_responses.
-# Seeded before the professional-answer enrichment below so the primary_sector
+# Seeded before the professional-answer enrichment below so the additional_sectors
 # value survives its "skip if already answered" guard. Idempotent.
 if facilitator_training && amy_person
   amy_submission = FormSubmission.find_by(person: amy_person, form: facilitator_training.registration_form)
   if amy_submission
     {
-      "primary_sector" => "Other: Equine-assisted therapy"
+      "additional_sectors" => "Other: Equine-assisted therapy"
     }.each do |identifier, value|
       field = amy_submission.form.form_fields.find_by(field_identifier: identifier)
       next unless field
@@ -1040,14 +1040,14 @@ if facilitator_training && amy_person
 end
 
 puts "Recording professional answers (age group / sector) on registration submissions…"
-# The Background page charts the registrants' "Primary Age Group(s) Served" and
-# "Primary Sector(s)" registration answers. Public registration stores
-# these checkbox answers as ", "-joined category / sector ids (see
-# PublicRegistration#save_form_answers + assign_tags); seed them the same way so
-# the charts have data. Age group is read from the form answers; the sector is
-# read from SectorableItem tags, so write both. Idempotent: skips a field already
-# answered on a submission, and only enriches people who have a submission (so the
-# "registered but didn't fill the form" scenarios stay answer-free).
+# The Background page charts the registrants' age-group and sector registration
+# answers. Public registration stores these as ", "-joined category / sector ids
+# (see PublicRegistration#save_form_answers + assign_tags); seed them the same way
+# so the charts have data. The age-group and primary-sector charts read the form
+# answers; the All-sectors chart reads SectorableItem tags, so write both.
+# Idempotent: skips a field already answered on a submission, and only enriches
+# people who have a submission (so the "registered but didn't fill the form"
+# scenarios stay answer-free).
 age_range_categories = Category.age_ranges.published.order(:position, :name).to_a
 # Exclude the catch-all "Other" sector: it's the free-text fallback registrants
 # type into (surfaced via Person#other_sector_responses), not a selectable
@@ -1067,24 +1067,29 @@ record_professional_answers = ->(submission, i) do
                                     question_name_when_answered: age_field.name)
   end
 
-  service_field = form.form_fields.find_by(field_identifier: "primary_sector")
   sectors = selectable_sectors.empty? ? [] : [ selectable_sectors[i % selectable_sectors.size], selectable_sectors[(i + 4) % selectable_sectors.size] ].uniq
-  if service_field && sectors.present? && submission.form_answers.where(form_field: service_field).none?
-    submission.form_answers.create!(form_field: service_field,
-                                    submitted_answer: sectors.map(&:id).join(", "),
-                                    question_name_when_answered: service_field.name)
-  end
-  # Sector chart reads SectorableItem tags, mirroring assign_tags.
-  sectors.each { |sector| SectorableItem.find_or_create_by!(sector: sector, sectorable: person) }
-  # Make the first submitted sector the person's single primary sector, so the
-  # recipients page + profile crown a primary that matches what they selected on the
-  # registration form. Demote any other primary first to keep exactly one (a person
-  # registered for several events is enriched once per event). Idempotent.
   primary_sector = sectors.first
-  if primary_sector
-    person.sectorable_items.where(is_primary: true).where.not(sector: primary_sector).update_all(is_primary: false)
-    person.sectorable_items.find_by(sector: primary_sector)&.update!(is_primary: true)
+  additional_sectors = sectors.drop(1)
+
+  # Mirror the registration form's two sector fields: the single-select primary
+  # sector dropdown and the multi-select additional sectors checkboxes.
+  primary_field = form.form_fields.find_by(field_identifier: "primary_sector_single")
+  if primary_field && primary_sector && submission.form_answers.where(form_field: primary_field).none?
+    submission.form_answers.create!(form_field: primary_field,
+                                    submitted_answer: primary_sector.id.to_s,
+                                    question_name_when_answered: primary_field.name)
   end
+  additional_field = form.form_fields.find_by(field_identifier: "additional_sectors")
+  if additional_field && additional_sectors.present? && submission.form_answers.where(form_field: additional_field).none?
+    submission.form_answers.create!(form_field: additional_field,
+                                    submitted_answer: additional_sectors.map(&:id).join(", "),
+                                    question_name_when_answered: additional_field.name)
+  end
+
+  # Tag the person with the same primary/additional split assign_tags applies, so
+  # the All-sectors chart has data and the recipients page + profile crown a single
+  # primary that matches the form. Idempotent (a person enriched once per event).
+  person.tag_sectors(primary_ids: [ primary_sector&.id ].compact, additional_ids: additional_sectors.map(&:id))
 end
 
 # Real orgs (minus the AWBW house org) to link registrations against and match on,

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -234,10 +234,10 @@ scholarship_fields = scholarship_form ? scholarship_form.form_fields.where.not(a
 # answers — the recipients page reads those first, then falls back to the
 # person's profile (sectors / age-range tags).
 registration_form = Form.standalone.find_by(role: "registration")
-if registration_form && registration_form.form_fields.where(field_identifier: "primary_sector").none?
+if registration_form && registration_form.form_fields.where(field_identifier: "additional_sectors").none?
   FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
 end
-sector_field = registration_form&.form_fields&.find_by(field_identifier: "primary_sector")
+sector_field = registration_form&.form_fields&.find_by(field_identifier: "additional_sectors")
 age_group_field = registration_form&.form_fields&.find_by(field_identifier: "primary_age_group")
 
 # Existing dev organizations (excluding AWBW itself) to affiliate recipients

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -143,7 +143,7 @@ end
 # scholarship submission). Recipients are flagged scholarship_requested so they
 # appear on that page. Reasonable answers to every scholarship question, inspired
 # by actual recipient responses, are cycled across recipients for variety, along
-# with a matching primary service area, age group, and a non-facilitator agency
+# with a matching primary sector, age group, and a non-facilitator agency
 # affiliation (title + organization) so the recipient header renders like the real
 # export.
 puts "Seeding Scholarship application answers…"
@@ -165,7 +165,7 @@ scholarship_answer_sets = [
       "Thank you for considering my application. A scholarship is the only way my small agency can send me to this training right now, " \
       "and the ripple effect on the survivors we serve would be immediate.",
     "scholarship_contribution" => "Our agency can contribute about $250 toward the cost.",
-    "service_area" => "Sexual Assault",
+    "sector" => "Sexual Assault",
     "age_group" => "Adults (18+)",
     "title" => "Prevention, Education, and Outreach Specialist"
   },
@@ -182,7 +182,7 @@ scholarship_answer_sets = [
     "additional_comments" =>
       "I've wanted formal facilitation training for years but our continuing-education budget was cut. This scholarship would change that.",
     "scholarship_contribution" => "I could personally cover roughly $150.",
-    "service_area" => "Mental Health",
+    "sector" => "Mental Health",
     "age_group" => "Mixed-age groups",
     "title" => "Behavioral Health Clinician"
   },
@@ -199,7 +199,7 @@ scholarship_answer_sets = [
     "additional_comments" =>
       "Our program serves families at no cost, so outside funding for my training is what makes this possible. Thank you.",
     "scholarship_contribution" => "Unfortunately we can't contribute anything at this time.",
-    "service_area" => "Child Abuse/Neglect",
+    "sector" => "Child Abuse/Neglect",
     "age_group" => "Children (0-12)",
     "title" => "Youth Program Coordinator"
   },
@@ -216,7 +216,7 @@ scholarship_answer_sets = [
     "additional_comments" =>
       "I'm so grateful for this opportunity. Investing in me is investing in everyone I'll go on to support.",
     "scholarship_contribution" => "I'm able to pay up to $100 out of pocket.",
-    "service_area" => "Domestic Violence",
+    "sector" => "Domestic Violence",
     "age_group" => "Adults (18+)",
     "title" => "Peer Support Specialist"
   }
@@ -230,14 +230,14 @@ scholarship_form = Form.standalone.find_by(role: "scholarship")
 scholarship_fields = scholarship_form ? scholarship_form.form_fields.where.not(answer_type: :group_header).to_a : []
 
 # Make sure the registration form asks the professional questions, so each
-# recipient's primary service area and age group are captured as registration
+# recipient's primary sector and age group are captured as registration
 # answers — the recipients page reads those first, then falls back to the
 # person's profile (sectors / age-range tags).
 registration_form = Form.standalone.find_by(role: "registration")
 if registration_form && registration_form.form_fields.where(field_identifier: "primary_sector").none?
   FormBuilderService.update_sections!(registration_form, (registration_form.sections || []).map(&:to_sym) | [ :professional_info ])
 end
-service_area_field = registration_form&.form_fields&.find_by(field_identifier: "primary_sector")
+sector_field = registration_form&.form_fields&.find_by(field_identifier: "primary_sector")
 age_group_field = registration_form&.form_fields&.find_by(field_identifier: "primary_age_group")
 
 # Existing dev organizations (excluding AWBW itself) to affiliate recipients
@@ -247,9 +247,9 @@ recipient_orgs = Organization.where.not(name: "A Window Between Worlds").order(:
 # Capture the recipient's professional answers on their registration submission,
 # storing the sector / age-range ids the professional fields expect.
 attach_header_answers = ->(submission, set) do
-  sector = Sector.published.find_by(name: set["service_area"])
-  if service_area_field && sector && submission.form_answers.where(form_field: service_area_field).none?
-    submission.form_answers.create!(form_field: service_area_field, submitted_answer: sector.id.to_s, question_name_when_answered: service_area_field.name)
+  sector = Sector.published.find_by(name: set["sector"])
+  if sector_field && sector && submission.form_answers.where(form_field: sector_field).none?
+    submission.form_answers.create!(form_field: sector_field, submitted_answer: sector.id.to_s, question_name_when_answered: sector_field.name)
   end
 
   age_category = Category.age_ranges.published.find_by(name: set["age_group"])

--- a/spec/models/concerns/sectors_taggable_spec.rb
+++ b/spec/models/concerns/sectors_taggable_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+# Person is used as the host model; the concern is also mixed into Organization
+# and exercised there via the registration / aggregation specs.
+RSpec.describe SectorsTaggable do
+  let!(:health) { create(:sector, name: "Healthcare") }
+  let!(:education) { create(:sector, name: "Education") }
+  let!(:housing) { create(:sector, name: "Housing") }
+
+  let(:person) { create(:person) }
+
+  describe "#tag_sectors" do
+    it "tags the primary id as primary and the additional ids as non-primary" do
+      person.tag_sectors(primary_ids: [ health.id ], additional_ids: [ education.id, housing.id ])
+
+      expect(person.sectorable_items.find_by(sector: health).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: education).is_primary).to be false
+      expect(person.sectorable_items.find_by(sector: housing).is_primary).to be false
+    end
+
+    it "treats a sector named in both lists as primary" do
+      person.tag_sectors(primary_ids: [ health.id ], additional_ids: [ health.id, education.id ])
+
+      expect(person.sectorable_items.find_by(sector: health).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: education).is_primary).to be false
+    end
+
+    it "demotes a prior primary the caller did not re-select, keeping one primary" do
+      person.sectorable_items.create!(sector: education, is_primary: true)
+
+      person.tag_sectors(primary_ids: [ health.id ], additional_ids: [])
+
+      expect(person.sectorable_items.find_by(sector: health).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: education).is_primary).to be false
+      expect(person.sectorable_items.where(is_primary: true).count).to eq(1)
+    end
+
+    it "is additive — it leaves sectors tagged earlier in place" do
+      person.tag_sectors(primary_ids: [ health.id ], additional_ids: [])
+      person.tag_sectors(primary_ids: [], additional_ids: [ education.id ])
+
+      expect(person.sectors).to include(health, education)
+      expect(person.sectorable_items.find_by(sector: health).is_primary).to be true
+    end
+
+    it "promotes a sector already tagged as additional" do
+      person.sectorable_items.create!(sector: health, is_primary: false)
+
+      person.tag_sectors(primary_ids: [ health.id ], additional_ids: [])
+
+      expect(person.sectorable_items.find_by(sector: health).is_primary).to be true
+    end
+  end
+end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -403,10 +403,12 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error("999999")).to eq("has an invalid selection")
       end
 
-      # Both the current "sector" identifiers and the legacy "service area"
-      # identifiers must behave identically so existing form data keeps resolving.
+      # The canonical identifiers, the legacy "primary_sector" additional name,
+      # and the legacy "service area" names must all behave identically so
+      # existing form data keeps resolving.
       {
-        "sector" => %w[primary_sector_single primary_sector],
+        "sector" => %w[primary_sector_single additional_sectors],
+        "sector (legacy additional name)" => %w[primary_sector_single primary_sector],
         "service area (legacy)" => %w[primary_service_area_single primary_service_area]
       }.each do |scheme, (primary_id, additional_id)|
         it "rejects the Other sector for the primary #{scheme} field but accepts it for additional" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -394,24 +394,26 @@ RSpec.describe Person, type: :model do
       create(:form_answer, form_submission: submission, form_field: field, submitted_answer: value)
     end
 
-    describe "#other_service_area_responses" do
-      it "returns free-text Other values from primary service area fields" do
+    describe "#other_sector_responses" do
+      # Exercises the legacy "service area" field identifiers on purpose — they
+      # must still resolve via FormField::SECTOR_FIELD_IDENTIFIERS.
+      it "returns free-text Other values from primary sector fields" do
         answer("primary_service_area", "5, Other: Equine therapy")
         answer("primary_service_area_single", "Other: Music therapy")
 
-        expect(person.other_service_area_responses).to contain_exactly("Equine therapy", "Music therapy")
+        expect(person.other_sector_responses).to contain_exactly("Equine therapy", "Music therapy")
       end
 
       it "ignores answers without an Other value" do
         answer("primary_service_area", "5, 12")
 
-        expect(person.other_service_area_responses).to be_empty
+        expect(person.other_sector_responses).to be_empty
       end
 
       it "does not pull from unrelated fields" do
         answer("primary_age_group", "Other: School")
 
-        expect(person.other_service_area_responses).to be_empty
+        expect(person.other_sector_responses).to be_empty
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1385,8 +1385,8 @@ RSpec.describe "Events", type: :request do
       create(:form_field, form: scholarship_form, name: "How will this help the people you serve?",
                           field_identifier: "impact_description")
     end
-    let(:service_area_field) do
-      create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_service_area")
+    let(:sector_field) do
+      create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_sector")
     end
 
     before do
@@ -1394,10 +1394,10 @@ RSpec.describe "Events", type: :request do
       create(:event_form, :scholarship, event: event, form: scholarship_form)
       create(:event_registration, event: event, registrant: applicant, status: "registered", scholarship_requested: true)
 
-      # Service area captured as a registration answer (resolved from the sector id).
+      # Sector captured as a registration answer (resolved from the sector id).
       sector = create(:sector, name: "Sexual Assault")
       reg_submission = create(:form_submission, person: applicant, form: registration_form)
-      create(:form_answer, form_submission: reg_submission, form_field: service_area_field, submitted_answer: sector.id.to_s)
+      create(:form_answer, form_submission: reg_submission, form_field: sector_field, submitted_answer: sector.id.to_s)
 
       # Scholarship answer rides on a separate scholarship submission.
       sch_submission = create(:form_submission, person: applicant, form: scholarship_form, role: "scholarship")
@@ -1407,7 +1407,7 @@ RSpec.describe "Events", type: :request do
     context "as admin" do
       before { sign_in admin }
 
-      it "renders each applicant with their service area resolved from the form answer and scholarship answers" do
+      it "renders each applicant with their sector resolved from the form answer and scholarship answers" do
         get recipients_event_path(event)
 
         expect(response).to have_http_status(:ok)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1386,7 +1386,7 @@ RSpec.describe "Events", type: :request do
                           field_identifier: "impact_description")
     end
     let(:sector_field) do
-      create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "primary_sector")
+      create(:form_field, form: registration_form, name: "Primary sector", field_identifier: "additional_sectors")
     end
 
     before do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -121,26 +121,27 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
-  describe "primary sector tagging" do
+  describe "sector tagging" do
     let!(:primary_sector) { create(:sector, name: "Healthcare") }
-    let!(:other_sector) { create(:sector, name: "Education") }
+    let!(:additional_sector) { create(:sector, name: "Education") }
 
-    it "tags the selected primary sector as primary on the person" do
+    it "marks the dropdown answer primary and the checkbox answers additional" do
       result = described_class.call(
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_sector") => [ primary_sector.id.to_s ]
+          field_id("primary_sector_single") => primary_sector.id.to_s,
+          field_id("additional_sectors") => [ additional_sector.id.to_s ]
         )
       )
 
       expect(result.success?).to be true
       person = result.event_registration.registrant
-      primary_item = person.sectorable_items.find_by(sector: primary_sector)
-      expect(primary_item.is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: additional_sector).is_primary).to be false
     end
 
-    it "marks an existing additional sector as primary when later selected" do
+    it "promotes an existing additional sector when later named as primary" do
       person = create(:person, first_name: "Pat", last_name: "Lee", email: "pat@example.com")
       person.sectorable_items.create!(sector: primary_sector, is_primary: false)
 
@@ -148,11 +149,28 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         event: event,
         form: form,
         form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
-          field_id("primary_sector") => [ primary_sector.id.to_s ]
+          field_id("primary_sector_single") => primary_sector.id.to_s
         )
       )
 
       expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+    end
+
+    it "demotes a prior primary that the registrant did not re-select as primary" do
+      person = create(:person, first_name: "Pat", last_name: "Lee", email: "pat@example.com")
+      person.sectorable_items.create!(sector: additional_sector, is_primary: true)
+
+      described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Pat", last_name: "Lee", email: "pat@example.com").merge(
+          field_id("primary_sector_single") => primary_sector.id.to_s
+        )
+      )
+
+      person.reload
+      expect(person.sectorable_items.find_by(sector: primary_sector).is_primary).to be true
+      expect(person.sectorable_items.find_by(sector: additional_sector).is_primary).to be false
     end
   end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe FormBuilderService do
 
       it "asks for a single primary sector via a dropdown before the additional sectors checkboxes" do
         primary = form.form_fields.find_by(field_identifier: "primary_sector_single")
-        additional = form.form_fields.find_by(field_identifier: "primary_sector")
+        additional = form.form_fields.find_by(field_identifier: "additional_sectors")
 
         expect(primary).to have_attributes(name: "Primary sector", answer_type: "single_select_dropdown")
         expect(additional).to have_attributes(name: "Additional sectors", answer_type: "multi_select_checkbox")
@@ -229,7 +229,7 @@ RSpec.describe FormBuilderService do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include(
           "first_name", "nickname", "racial_ethnic_identity",
-          "primary_sector", "referral_source",
+          "additional_sectors", "referral_source",
           "scholarship_eligibility", "payment_method", "communication_consent"
         )
       end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Public form submissions", type: :system do
         "agency_type" => "501c3/nonprofit",
         "agency_country" => "United States",
         "primary_sector_single" => sector_education.id.to_s,
-        "primary_sector" => sector_mental_health.id.to_s,
+        "additional_sectors" => sector_mental_health.id.to_s,
         "primary_age_group" => age_adults.id.to_s,
         "additional_age_group" => age_teens.id.to_s,
         "racial_ethnic_identity" => "Multi-racial",
@@ -132,7 +132,7 @@ RSpec.describe "Public form submissions", type: :system do
       expect(page).not_to have_selector("##{pr_dom_id(reg_field('mailing_city'))}")
 
       select_pr reg_field("primary_sector_single"), "Education"
-      check_pr_box reg_field("primary_sector"), sector_dv.id.to_s
+      check_pr_box reg_field("additional_sectors"), sector_dv.id.to_s
       select_pr reg_field("primary_age_group"), "Teens (13-17)"
       choose_pr_radio reg_field("racial_ethnic_identity"), "Asian"
       choose_pr_radio reg_field("referral_source"), "Social Media"
@@ -148,7 +148,7 @@ RSpec.describe "Public form submissions", type: :system do
       answers = answers_by_identifier(registration_form.form_submissions.find_by!(person: logged_in_person))
       expect(answers).to include(
         "primary_sector_single" => sector_education.id.to_s,
-        "primary_sector" => sector_dv.id.to_s,
+        "additional_sectors" => sector_dv.id.to_s,
         "primary_age_group" => age_teens.id.to_s,
         "racial_ethnic_identity" => "Asian",
         "referral_source" => "Social Media",
@@ -391,7 +391,7 @@ RSpec.describe "Public form submissions", type: :system do
     fill_pr_text reg_field("agency_country"), with: "United States"
 
     select_pr reg_field("primary_sector_single"), "Education"
-    check_pr_box reg_field("primary_sector"), sector_mental_health.id.to_s
+    check_pr_box reg_field("additional_sectors"), sector_mental_health.id.to_s
     select_pr reg_field("primary_age_group"), "Adults (18+)"
     check_pr_box reg_field("additional_age_group"), age_teens.id.to_s
 


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — substantive logic: registration sector tagging changes behavior; new shared concern method; field-identifier rename with legacy compat

## Why
The sector fields were tangled: the multi-select **"Additional sectors"** field was built with the misleading `field_identifier: "primary_sector"`, and registration marked **every** submitted sector `is_primary: true` — lumping the primary dropdown and the additional checkboxes together. A profile crowned all of them, and a seed workaround had to demote the extras. Separately, "service area" naming lingered well beyond the legacy-acceptance constants.

## What
**Phase 1 — naming cleanup** (the only remaining "service area" is now the legacy constants + the specs that exercise them)
- `Person#other_service_area_responses` → `other_sector_responses` (+ callers / view locals)
- view/seed local vars, seed data keys, and comments renamed to `sector`

**Phase 2 — disentangle identifiers + fix tagging**
- New canonical `additional_sectors` identifier for the multi-select field; `primary_sector` / `primary_service_area` (and `primary_service_area_single`) stay in `FormField`'s constants as legacy so existing form data keeps resolving.
- `SectorsTaggable#tag_sectors(primary_ids:, additional_ids:)` — mirrors `AgeGroupTaggable#tag_age_groups` but upholds the single-primary rule (demotes any prior primary not re-selected).
- `PublicRegistration#assign_tags` now splits the dropdown answer (primary) from the checkbox answers (additional); `assign_primary_sectors` removed.
- Seeds write both fields and tag via `tag_sectors`, dropping the manual demote workaround.

## Verification
- Full affected spec suite + new `sectors_taggable_spec` green; rubocop clean.
- Ran `db:seed:dev`: 0 people with >1 primary sector; legacy `primary_sector` forms still resolve.

## Out of scope / notes
- `EventDashboard` recipient header still reads the *additional* sector identifiers (unchanged display behavior); only the field-identifier set was updated. Worth a follow-up if it should show the primary sector instead.