### PR TITLE
Make Faker available on staging for dev sample-data seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ group :development, :test do
   gem "bundler-audit", require: false
   gem "capybara", "~> 3.36"
   gem "dotenv-rails"
-  gem "faker"
   gem "factory_bot_rails"
   gem "launchy"
   gem "listen"
@@ -100,6 +99,12 @@ group :development, :test do
   gem "shoulda-matchers", require: false
   gem "debug", "~> 1.11"
   gem "bullet"
+end
+
+# Faker also needs to load on staging: the dev sample-data seeds (db/seeds/dev)
+# call Faker, and db:seed:dev is run on staging to populate demo data.
+group :development, :test, :staging do
+  gem "faker"
 end
 
 gem "rack-mini-profiler", "~> 4.0"


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: one-line Gemfile group change, but it affects what loads on staging

## Why

`db:seed:dev` is run on staging to populate demo data, but the dev seeds
(`db/seeds/dev/*`) call `Faker` in ~25 places. `faker` was only in the
`:development, :test` Gemfile groups, so `Bundler.require(*Rails.groups)`
never loaded it on staging and the seed task aborted:

```
NameError: uninitialized constant Faker
  street_address: Faker::Address.street_address,
```

## What

- Add `:staging` to `faker`'s Gemfile groups so it loads on staging too.

Verified booting in `RAILS_ENV=staging` now defines `Faker` (`Rails.groups` → `[:default, "staging"]`). `Gemfile.lock` is unchanged (same resolved version).
