### PR TITLE
Explicitly require Faker in dev seeds so staging can run db:seed:dev

### DIFF
--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -3,6 +3,10 @@
 # dev events that share them, event registrations for named scenarios, and form submissions.
 # Named people are looked up when present (e.g. after `rake db:seed:people_profiles`).
 
+# Faker is installed but not auto-required on staging, where the app runs as
+# RAILS_ENV=production and Bundler.require only loads the production group.
+require "faker"
+
 puts "Creating standalone registration forms…"
 unless Form.standalone.exists?(name: "Training Registration Form")
   # Sections are built in this order (not the canonical SECTIONS order) so the

--- a/db/seeds/dev/home_page_content.rb
+++ b/db/seeds/dev/home_page_content.rb
@@ -3,6 +3,10 @@
 # CommunityNews, StoryIdeas, WorkshopIdeas, WorkshopVariationIdeas (and links some variations
 # to them), and Stories. Related records (organizations, workshops, people) are looked up when present.
 
+# Faker is installed but not auto-required on staging, where the app runs as
+# RAILS_ENV=production and Bundler.require only loads the production group.
+require "faker"
+
 puts "Creating CommunityNews…"
 [
   "Workshop Spotlight: Building Confidence Through Art",

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -2,6 +2,10 @@
 # or as part of `rake db:seed:dev`. Creates Person records for the seed users, a set of
 # search-disambiguation test people, their affiliations, and addresses/sectors.
 
+# Faker is installed but not auto-required on staging, where the app runs as
+# RAILS_ENV=production and Bundler.require only loads the production group.
+require "faker"
+
 puts "Creating Persons and Affiliations for seed users…"
 [
   User.find_by(email: "umberto.user@example.com"),

--- a/db/seeds/dev/resources.rb
+++ b/db/seeds/dev/resources.rb
@@ -1,6 +1,10 @@
 # Resource seeds (dev-only) - run on their own via `rake db:seed:resources`, or as
 # part of `rake db:seed:dev`.
 
+# Faker is installed but not auto-required on staging, where the app runs as
+# RAILS_ENV=production and Bundler.require only loads the production group.
+require "faker"
+
 puts "Creating Resources…"
 10.times do |i|
   kind = Resource::PUBLISHED_KINDS.sample


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — small, contained require-time fix to dev seed scripts

## Why

PR #1835 added `:staging` to faker's Gemfile group so the gem **installs** on staging, but `db:seed:dev` still aborts with `uninitialized constant Faker`. The staging container runs as `RAILS_ENV=production` (baked into the Dockerfile), so `Bundler.require(*Rails.groups)` in `config/application.rb:7` only auto-requires the `production` group — faker is installed and on the Bundler load path, but never `require`d.

## What

- Add an explicit `require "faker"` to the four dev seed files that use it (`people_profiles`, `resources`, `home_page_content`, `events_management`).
- The gem is on the load path regardless of which group Bundler auto-requires, so this works on staging without depending on `Rails.env` matching the Gemfile group.