### PR TITLE
Gate field-identifier editing behind admin, enforce per-form uniqueness

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -100,6 +100,11 @@ class FormField < ApplicationRecord
   # Keeps an over-long name as a friendly validation error instead of a
   # database ValueTooLong exception (the column is text, this is the UX cap).
   validates :name, length: { maximum: 1000 }
+  # A field_identifier wires a field to backend logic (Stripe, service areas,
+  # email checks, etc.), so the same identifier must not appear twice on one form
+  # or that logic would target an ambiguous field. Ordinary fields carry no
+  # identifier, so blanks are exempt — any number of them may coexist.
+  validates :field_identifier, uniqueness: { scope: :form_id }, allow_blank: true
   validates :min_words, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :max_characters, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validate :max_characters_allows_min_words

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -150,6 +150,17 @@
                 class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0" %>
         </div>
 
+        <% if params[:admin] == "true" %>
+          <%# Field identifiers tie a field to backend logic (Stripe, service areas, email, etc.),
+              so they're only editable with ?admin=true on the URL. %>
+          <label class="flex items-center gap-2 text-xs text-gray-500">
+            <span class="shrink-0 font-medium">Field identifier</span>
+            <%= f.text_field :field_identifier, placeholder: "e.g. payment_method",
+                  class: "min-w-0 flex-1 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
+                  title: "Internal identifier linking this field to system logic — leave blank for an ordinary field" %>
+          </label>
+        <% end %>
+
         <% unless option_source %>
           <% options_locked = field.fixed_options? && params[:admin] != "true" %>
           <div class="hidden space-y-2 pl-1 border-t border-gray-100 pt-3" data-answer-options-target="list">

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -153,10 +153,10 @@
         <% if params[:admin] == "true" %>
           <%# Field identifiers tie a field to backend logic (Stripe, service areas, email, etc.),
               so they're only editable with ?admin=true on the URL. %>
-          <label class="flex items-center gap-2 text-xs text-gray-500">
+          <label class="flex items-center justify-end gap-2 text-xs text-gray-500">
             <span class="shrink-0 font-medium">Field identifier</span>
             <%= f.text_field :field_identifier, placeholder: "e.g. payment_method",
-                  class: "min-w-0 flex-1 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
+                  class: "w-1/4 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
                   title: "Internal identifier linking this field to system logic — leave blank for an ordinary field" %>
           </label>
         <% end %>

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -49,6 +49,29 @@ RSpec.describe FormField do
         expect(field).to be_valid
       end
     end
+
+    describe "field_identifier uniqueness" do
+      let(:form) { create(:form) }
+
+      it "rejects a second field on the same form with the same identifier" do
+        create(:form_field, form: form, field_identifier: "payment_method")
+        duplicate = build(:form_field, form: form, field_identifier: "payment_method")
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:field_identifier]).to be_present
+      end
+
+      it "allows the same identifier on a different form" do
+        create(:form_field, form: form, field_identifier: "payment_method")
+        other = build(:form_field, form: create(:form), field_identifier: "payment_method")
+        expect(other).to be_valid
+      end
+
+      it "allows multiple fields on the same form with a blank identifier" do
+        create(:form_field, form: form, field_identifier: nil)
+        expect(build(:form_field, form: form, field_identifier: nil)).to be_valid
+        expect(build(:form_field, form: form, field_identifier: "")).to be_valid
+      end
+    end
   end
 
   describe "#collects_input?" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -443,6 +443,16 @@ RSpec.describe "Forms", type: :request do
       expect(response).to redirect_to(edit_form_path(form))
     end
 
+    it "saves the field_identifier for a field" do
+      form = create(:form, :standalone)
+      field = create(:form_field, form: form, name: "Pick a payment method")
+      patch form_path(form), params: {
+        form: { form_fields_attributes: { "0" => { id: field.id, field_identifier: "payment_method" } } }
+      }
+      expect(field.reload.field_identifier).to eq("payment_method")
+      expect(response).to redirect_to(edit_form_path(form))
+    end
+
     it "updates hide_answered flags" do
       form = create(:form, :standalone)
       patch form_path(form), params: {


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Make a field's `field_identifier` editable from the form builder, but only under the existing `?admin=true` URL override — identifiers wire a field to backend logic (Stripe, service areas, email validation), so they shouldn't be edited casually.
- Guarantee a `field_identifier` can't appear twice on the same form. A duplicate would make that backend logic target an ambiguous field (e.g. two `payment_method` fields).

### How did you approach the change?
- **View** (`_form_field_fields.html.erb`): added an admin-gated `field_identifier` text input to the field's "More options" panel, reusing the `params[:admin] == "true"` convention already used one block below for the payment-method options lock. `field_identifier` was already permitted in `forms_controller` strong params, so no controller change was needed.
- **Model** (`form_field.rb`): added `validates :field_identifier, uniqueness: { scope: :form_id }, allow_blank: true`. Blanks are exempt because ordinary fields (and group headers) carry no identifier, so any number of them may coexist.
- **Tests** (`form_field_spec.rb`): TDD — added the duplicate-rejection test first, confirmed it failed (red), then added the validation (green). Specs cover: rejecting a duplicate on the same form, allowing the same identifier on a different form, and allowing multiple blank identifiers on one form.

### Anything else to add?
- Scoped uniqueness to `form_id` rather than global, since the same identifier (e.g. `primary_email`) legitimately recurs across different forms.
- No DB-level unique index added — the validation lives at the app layer where the blank-exemption and form scoping are expressed cleanly. Can add a partial index if we want a hard guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)