### PR TITLE
Hide empty life experiences and settings background cards

### DIFF
--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -231,13 +231,14 @@
     <% if school_district_data.any? %>
       <%= render "breakdown_card", title: "School districts", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>
     <% end %>
-    <%# Life experiences and settings come from registration answers; always show
-        the card (with a no-data box when empty) so the section reads even before
-        anyone has answered those questions. %>
-    <%= render "breakdown_card", title: "Life experiences", data: life_experience_data, chart: :bar, palette: palette,
-                                 empty_message: "No life experiences from registration answers yet.", row_paths: life_experience_paths %>
-    <%= render "breakdown_card", title: "Settings", data: settings_data, chart: :bar, palette: palette,
-                                 empty_message: "No settings from registration answers yet.", row_paths: settings_paths %>
+    <%# Life experiences and settings come from registration answers; hide each
+        card entirely when no one has answered those questions. %>
+    <% if life_experience_data.any? %>
+      <%= render "breakdown_card", title: "Life experiences", data: life_experience_data, chart: :bar, palette: palette, row_paths: life_experience_paths %>
+    <% end %>
+    <% if settings_data.any? %>
+      <%= render "breakdown_card", title: "Settings", data: settings_data, chart: :bar, palette: palette, row_paths: settings_paths %>
+    <% end %>
     <% if org_data.any? %>
       <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
     <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1289,13 +1289,11 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Veterans")
       end
 
-      it "shows no-data boxes for life experiences and settings when registrants have no tags" do
+      it "hides the life experiences and settings cards when registrants have no tags" do
         get background_event_path(event)
 
-        expect(response.body).to include("Life experiences")
-        expect(response.body).to include("No life experiences from registration answers yet.")
-        expect(response.body).to include("Settings")
-        expect(response.body).to include("No settings from registration answers yet.")
+        expect(response.body).not_to include("Life experiences")
+        expect(response.body).not_to include("Settings")
       end
 
       it "links scholarship recipients to their entry on the recipients page" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
The Life experiences and Settings breakdown cards on the event background page always rendered a "no data yet" empty box, unlike every other card on that page, which hides itself when there's nothing to show. For events whose registrants have no StoryPopulation/WorkshopEnvironment tags, that left two permanently-empty cards cluttering the section.

### How did you approach the change?
Wrapped both cards in `if life_experience_data.any?` / `if settings_data.any?` guards so they render only when registrants actually have those tags, matching the sibling cards (sectors, states, school districts, etc.), and dropped the now-unused `empty_message:` args. Updated the request spec that previously asserted the always-on empty boxes to instead assert the cards are hidden when there are no tags.

### UI Testing Checklist
- [ ] Background page hides Life experiences / Settings cards when no registrants are tagged.
- [ ] Both cards still appear when registrants have StoryPopulation / WorkshopEnvironment tags.

### Anything else to add?
The `empty_message` support in `_breakdown_card` is left intact since the Primary age group card still uses it.
