### PR TITLE
Drop dead as_visitor param from dashboard registration links

### DIFF
--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -30,7 +30,7 @@
   <% link_base = "inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors" %>
   <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-8">
     <% if @event.event_forms.registration.exists? %>
-      <%= link_to new_event_public_registration_path(@event, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+      <%= link_to new_event_public_registration_path(@event), target: "_blank", rel: "noopener noreferrer",
             class: "#{link_base} #{DomainTheme.border_class_for(:events, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:events, intensity: 300)} hover:bg-gray-50" do %>
         <i class="fa-solid fa-clipboard-list <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
         Public registration form
@@ -39,7 +39,7 @@
     <% end %>
 
     <% if @event.event_forms.registration.exists? && @event.scholarship_form %>
-      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true, as_visitor: true), target: "_blank", rel: "noopener noreferrer",
+      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true), target: "_blank", rel: "noopener noreferrer",
             class: "#{link_base} #{DomainTheme.border_class_for(:scholarships, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:scholarships, intensity: 300)} hover:bg-gray-50" do %>
         <i class="fa-solid fa-graduation-cap <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>"></i>
         Scholarship form


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Removes the dead `as_visitor=true` query param from the public registration and scholarship form links on the event dashboard.
- The param was never read anywhere in the app, so it only added noise to the URLs without affecting behavior.

### How did you approach the change?
- Dropped `as_visitor: true` from both `new_event_public_registration_path` calls in `app/views/events/dashboard.html.erb`.
- Confirmed via a repo-wide search that `as_visitor` appears nowhere else (no controller, model, service, policy, or spec reads it).

### UI Testing Checklist
- [ ] On the event dashboard, the "Public registration form" link opens the public registration page (no `as_visitor` param in the URL).
- [ ] The "Scholarship form" link still opens with `scholarship_requested=true` and pre-selects the scholarship flow.

### Anything else to add?
- Behavior is unchanged since the param was already inert; this is purely a cleanup.
