### PR TITLE
Fix forms so primary professional fields (Sector & AgeRange) as dropdowns, additional as multiselect (legacy-identifier coverage)

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,11 +1,6 @@
 class Category < ApplicationRecord
   include NameFilterable, Publishable
 
-  # The catch-all AgeRange category. Tagged wherever age ranges apply, but not
-  # offered on the registration form's "primary age group" question, where a
-  # respondent names the concrete age groups they serve.
-  MIXED_AGE_RANGE_NAME = "Mixed-age groups"
-
   positioned on: :category_type_id
 
   belongs_to :category_type, class_name: "CategoryType", foreign_key: :category_type_id
@@ -15,7 +10,6 @@ class Category < ApplicationRecord
   # Scopes
   # See NameFilterable, Publishable
   scope :age_ranges, -> { joins(:category_type).where(category_types: { name: "AgeRange" }) }
-  scope :excluding_mixed_age, -> { where.not(name: MIXED_AGE_RANGE_NAME) }
   scope :story_categories, -> { joins(:category_type).where(category_types: { name: "StoryCategory" }) }
   scope :ordered_by_position_and_name, -> { reorder(position: :asc, name: :asc) }
 

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -35,18 +35,14 @@ class FormField < ApplicationRecord
   # Field identifiers whose selectable options are sourced dynamically from a
   # CategoryType's published categories. The submitted value is a Category id
   # (as a string). Maps the field identifier to its backing CategoryType name.
+  # Both the "primary" and "additional" age group fields are backed by the
+  # published AgeRange categories. Unlike the sector fields, age groups have no
+  # catch-all option — the additional sector field keeps "Other", but neither age
+  # field offers one.
   DYNAMIC_FIELD_CATEGORY_TYPES = {
     "primary_age_group" => "AgeRange",
     "additional_age_group" => "AgeRange"
   }.freeze
-
-  # The "primary" and "additional" age group fields. Both are backed by AgeRange
-  # categories but omit the catch-all "Mixed-age groups" category — a respondent
-  # names the concrete age groups they serve, not the mixed bucket. (Unlike the
-  # sector fields, where the multi-select "additional" field keeps "Other".)
-  PRIMARY_AGE_GROUP_FIELD_IDENTIFIER = "primary_age_group"
-  ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER = "additional_age_group"
-  AGE_GROUP_FIELD_IDENTIFIERS = [ PRIMARY_AGE_GROUP_FIELD_IDENTIFIER, ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER ].freeze
 
   # The payment-method field. Its answer options ("Credit card (now)", etc.) are
   # wired to Stripe charge logic in the controllers, so they must not be edited
@@ -331,16 +327,13 @@ class FormField < ApplicationRecord
   end
 
   # The published Category records a category-backed dynamic field offers, in
-  # position/name order. Both the primary and additional age group fields omit the
-  # catch-all "Mixed-age groups" AgeRange category — a respondent names the
-  # concrete age groups they serve. Empty when the backing CategoryType is missing.
-  # Source of truth shared by the public form's rendering and submission validation.
+  # position/name order. Empty when the backing CategoryType is missing. Source of
+  # truth shared by the public form's rendering and submission validation.
   def dynamic_categories
     type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
     return Category.none unless type
 
-    scope = type.categories.published.order(:position, :name)
-    AGE_GROUP_FIELD_IDENTIFIERS.include?(field_identifier) ? scope.excluding_mixed_age : scope
+    type.categories.published.order(:position, :name)
   end
 
   # The "please specify" placeholder for an option label, or nil when the option

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -40,9 +40,12 @@ class FormField < ApplicationRecord
     "additional_age_group" => "AgeRange"
   }.freeze
 
-  # The "primary" and "additional" age group fields. Both are backed by AgeRange
-  # categories but omit the catch-all "Mixed-age groups" category — a respondent
-  # names the concrete age groups they serve, not the mixed bucket.
+  # The "primary" and "additional" age group fields, both backed by AgeRange
+  # categories. They mirror the two sector fields: the single-select "primary"
+  # field omits the catch-all "Mixed-age groups" category (a respondent names a
+  # concrete age group they primarily serve), while the multi-select "additional"
+  # field offers it — just as "primary sector" omits "Other" but "additional
+  # sectors" keeps it.
   PRIMARY_AGE_GROUP_FIELD_IDENTIFIER = "primary_age_group"
   ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER = "additional_age_group"
   AGE_GROUP_FIELD_IDENTIFIERS = [ PRIMARY_AGE_GROUP_FIELD_IDENTIFIER, ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER ].freeze
@@ -330,16 +333,18 @@ class FormField < ApplicationRecord
   end
 
   # The published Category records a category-backed dynamic field offers, in
-  # position/name order. The age group fields omit the catch-all "Mixed-age
-  # groups" AgeRange category — a respondent names the concrete age groups they
-  # serve. Empty when the backing CategoryType is missing. Source of truth shared
-  # by the public form's rendering and submission validation.
+  # position/name order. The single-select "primary age group" field omits the
+  # catch-all "Mixed-age groups" AgeRange category (a respondent names a concrete
+  # age group), while the multi-select "additional" field keeps it — mirroring how
+  # "primary sector" omits "Other" but "additional sectors" keeps it. Empty when
+  # the backing CategoryType is missing. Source of truth shared by the public
+  # form's rendering and submission validation.
   def dynamic_categories
     type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
     return Category.none unless type
 
     scope = type.categories.published.order(:position, :name)
-    AGE_GROUP_FIELD_IDENTIFIERS.include?(field_identifier) ? scope.excluding_mixed_age : scope
+    field_identifier == PRIMARY_AGE_GROUP_FIELD_IDENTIFIER ? scope.excluding_mixed_age : scope
   end
 
   # The "please specify" placeholder for an option label, or nil when the option
@@ -369,12 +374,28 @@ class FormField < ApplicationRecord
   end
 
   # The labels of this field's offered options that reveal a free-text box
-  # (e.g. "Other", "Word of Mouth"). Empty for dynamic fields, which never
-  # offer them.
+  # (e.g. "Other", "Word of Mouth"). Dynamic sector/category fields offer one
+  # only when their option set includes a catch-all "Other" (the published "Other"
+  # Sector, or an "Other"-named Category) — the multi-select "additional sectors"
+  # field is the common case. The single-select "primary" fields drop "Other" from
+  # their options, so they expose no specify option.
   def specify_option_labels
-    return [] if dynamic_options?
+    option_names = dynamic_options? ? dynamic_option_names : answer_options.map(&:name)
+    option_names.select { |name| FormField.specify_option?(name, field_identifier) }
+  end
 
-    answer_options.map(&:name).select { |name| FormField.specify_option?(name, field_identifier) }
+  # The names of this field's dynamically-sourced options (Sector or Category),
+  # mirroring what the public form renders and what allowed_answer_values keys
+  # off. Used to detect a catch-all "Other" option on a dynamic field. Empty for
+  # non-dynamic fields.
+  def dynamic_option_names
+    if field_identifier.in?(SECTOR_FIELD_IDENTIFIERS)
+      sector_options.pluck(:name)
+    elsif DYNAMIC_FIELD_CATEGORY_TYPES.key?(field_identifier)
+      dynamic_categories.pluck(:name)
+    else
+      []
+    end
   end
 
   # True when a submitted value is a valid "specify" answer for one of this

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -40,12 +40,10 @@ class FormField < ApplicationRecord
     "additional_age_group" => "AgeRange"
   }.freeze
 
-  # The "primary" and "additional" age group fields, both backed by AgeRange
-  # categories. They mirror the two sector fields: the single-select "primary"
-  # field omits the catch-all "Mixed-age groups" category (a respondent names a
-  # concrete age group they primarily serve), while the multi-select "additional"
-  # field offers it — just as "primary sector" omits "Other" but "additional
-  # sectors" keeps it.
+  # The "primary" and "additional" age group fields. Both are backed by AgeRange
+  # categories but omit the catch-all "Mixed-age groups" category — a respondent
+  # names the concrete age groups they serve, not the mixed bucket. (Unlike the
+  # sector fields, where the multi-select "additional" field keeps "Other".)
   PRIMARY_AGE_GROUP_FIELD_IDENTIFIER = "primary_age_group"
   ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER = "additional_age_group"
   AGE_GROUP_FIELD_IDENTIFIERS = [ PRIMARY_AGE_GROUP_FIELD_IDENTIFIER, ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIER ].freeze
@@ -333,18 +331,16 @@ class FormField < ApplicationRecord
   end
 
   # The published Category records a category-backed dynamic field offers, in
-  # position/name order. The single-select "primary age group" field omits the
-  # catch-all "Mixed-age groups" AgeRange category (a respondent names a concrete
-  # age group), while the multi-select "additional" field keeps it — mirroring how
-  # "primary sector" omits "Other" but "additional sectors" keeps it. Empty when
-  # the backing CategoryType is missing. Source of truth shared by the public
-  # form's rendering and submission validation.
+  # position/name order. Both the primary and additional age group fields omit the
+  # catch-all "Mixed-age groups" AgeRange category — a respondent names the
+  # concrete age groups they serve. Empty when the backing CategoryType is missing.
+  # Source of truth shared by the public form's rendering and submission validation.
   def dynamic_categories
     type = CategoryType.find_by(name: DYNAMIC_FIELD_CATEGORY_TYPES[field_identifier])
     return Category.none unless type
 
     scope = type.categories.published.order(:position, :name)
-    field_identifier == PRIMARY_AGE_GROUP_FIELD_IDENTIFIER ? scope.excluding_mixed_age : scope
+    AGE_GROUP_FIELD_IDENTIFIERS.include?(field_identifier) ? scope.excluding_mixed_age : scope
   end
 
   # The "please specify" placeholder for an option label, or nil when the option

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -20,7 +20,10 @@
       <div class="py-2">
         <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide"><%= display_question_label(field, response) %></dt>
         <dd class="mt-1 text-sm text-gray-900">
-          <%= response&.submitted_answer.presence || tag.span("—", class: "text-gray-400") %>
+          <%# Resolves the sector / age-group ids stored behind the professional
+              fields to their names; free-text ("Other: …") and plain answers pass
+              through unchanged. %>
+          <%= display_response_text(field, response) %>
         </dd>
       </div>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -185,7 +185,6 @@ category_type_categories = [
   [ "AgeRange", "Teens (13-17)" ],
   [ "AgeRange", "Adults (18+)" ],
   [ "AgeRange", "Elders (65+)" ],
-  [ "AgeRange", "Mixed-age groups" ],
   # ["ArtType", "Boxes", 1],
   [ "ArtType", "Clay", 11 ],
   [ "ArtType", "Collage", 2 ],

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1053,11 +1053,6 @@ puts "Recording professional answers (age group / sector) on registration submis
 # people who have a submission (so the "registered but didn't fill the form"
 # scenarios stay answer-free).
 age_range_categories = Category.age_ranges.published.order(:position, :name).to_a
-# Primary age group is a single-select dropdown that omits the catch-all
-# "Mixed-age groups" (a respondent names a concrete age group), so draw the
-# primary from the concrete ranges only — the multi-select additional field keeps
-# the catch-all and can carry it.
-primary_age_categories = age_range_categories.reject { |category| category.name == Category::MIXED_AGE_RANGE_NAME }
 # Exclude the catch-all "Other" sector: it's the free-text fallback registrants
 # type into (surfaced via Person#other_sector_responses), not a selectable
 # sector. Seeding it as a sector tag would list "Other" as a real sector.
@@ -1068,7 +1063,7 @@ record_professional_answers = ->(submission, i) do
   form = submission.form
 
   # Primary age group is a single-select dropdown, so store one AgeRange category id.
-  age = primary_age_categories[i % primary_age_categories.size] if primary_age_categories.any?
+  age = age_range_categories[i % age_range_categories.size] if age_range_categories.any?
   age_field = form.form_fields.find_by(field_identifier: "primary_age_group")
   if age_field && age && submission.form_answers.where(form_field: age_field).none?
     submission.form_answers.create!(form_field: age_field,
@@ -1076,10 +1071,9 @@ record_professional_answers = ->(submission, i) do
                                     question_name_when_answered: age_field.name)
   end
 
-  # Additional age groups are multi-select checkboxes, but like the primary field
-  # they omit the catch-all "Mixed-age groups", so draw from the concrete ranges
-  # and store a couple of ", "-joined ids the way public registration does.
-  additional_ages = primary_age_categories.rotate(i + 1).reject { |category| category == age }.first(2)
+  # Additional age groups are multi-select checkboxes, so store a couple of
+  # ", "-joined AgeRange ids the way public registration does.
+  additional_ages = age_range_categories.rotate(i + 1).reject { |category| category == age }.first(2)
   additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_group")
   if additional_age_field && additional_ages.present? && submission.form_answers.where(form_field: additional_age_field).none?
     submission.form_answers.create!(form_field: additional_age_field,

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1076,10 +1076,10 @@ record_professional_answers = ->(submission, i) do
                                     question_name_when_answered: age_field.name)
   end
 
-  # Additional age groups are multi-select checkboxes that keep the catch-all
-  # "Mixed-age groups", so store a couple of ", "-joined ids (sometimes including
-  # it) the same way public registration does.
-  additional_ages = age_range_categories.rotate(i + 1).reject { |category| category == age }.first(2)
+  # Additional age groups are multi-select checkboxes, but like the primary field
+  # they omit the catch-all "Mixed-age groups", so draw from the concrete ranges
+  # and store a couple of ", "-joined ids the way public registration does.
+  additional_ages = primary_age_categories.rotate(i + 1).reject { |category| category == age }.first(2)
   additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_group")
   if additional_age_field && additional_ages.present? && submission.form_answers.where(form_field: additional_age_field).none?
     submission.form_answers.create!(form_field: additional_age_field,

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1053,6 +1053,11 @@ puts "Recording professional answers (age group / sector) on registration submis
 # people who have a submission (so the "registered but didn't fill the form"
 # scenarios stay answer-free).
 age_range_categories = Category.age_ranges.published.order(:position, :name).to_a
+# Primary age group is a single-select dropdown that omits the catch-all
+# "Mixed-age groups" (a respondent names a concrete age group), so draw the
+# primary from the concrete ranges only — the multi-select additional field keeps
+# the catch-all and can carry it.
+primary_age_categories = age_range_categories.reject { |category| category.name == Category::MIXED_AGE_RANGE_NAME }
 # Exclude the catch-all "Other" sector: it's the free-text fallback registrants
 # type into (surfaced via Person#other_sector_responses), not a selectable
 # sector. Seeding it as a sector tag would list "Other" as a real sector.
@@ -1063,12 +1068,23 @@ record_professional_answers = ->(submission, i) do
   form = submission.form
 
   # Primary age group is a single-select dropdown, so store one AgeRange category id.
+  age = primary_age_categories[i % primary_age_categories.size] if primary_age_categories.any?
   age_field = form.form_fields.find_by(field_identifier: "primary_age_group")
-  age = age_range_categories[i % age_range_categories.size] if age_range_categories.any?
   if age_field && age && submission.form_answers.where(form_field: age_field).none?
     submission.form_answers.create!(form_field: age_field,
                                     submitted_answer: age.id.to_s,
                                     question_name_when_answered: age_field.name)
+  end
+
+  # Additional age groups are multi-select checkboxes that keep the catch-all
+  # "Mixed-age groups", so store a couple of ", "-joined ids (sometimes including
+  # it) the same way public registration does.
+  additional_ages = age_range_categories.rotate(i + 1).reject { |category| category == age }.first(2)
+  additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_group")
+  if additional_age_field && additional_ages.present? && submission.form_answers.where(form_field: additional_age_field).none?
+    submission.form_answers.create!(form_field: additional_age_field,
+                                    submitted_answer: additional_ages.map(&:id).join(", "),
+                                    question_name_when_answered: additional_age_field.name)
   end
 
   sectors = selectable_sectors.empty? ? [] : [ selectable_sectors[i % selectable_sectors.size], selectable_sectors[(i + 4) % selectable_sectors.size] ].uniq
@@ -1094,6 +1110,7 @@ record_professional_answers = ->(submission, i) do
   # the All-sectors chart has data and the recipients page + profile crown a single
   # primary that matches the form. Idempotent (a person enriched once per event).
   person.tag_sectors(primary_ids: [ primary_sector&.id ].compact, additional_ids: additional_sectors.map(&:id))
+  person.tag_age_groups(primary_ids: [ age&.id ].compact, additional_ids: additional_ages.map(&:id))
 end
 
 # Real orgs (minus the AWBW house org) to link registrations against and match on,

--- a/db/seeds/dev/legacy_form_identifiers.rb
+++ b/db/seeds/dev/legacy_form_identifiers.rb
@@ -1,0 +1,99 @@
+# Legacy field-identifier registration forms (dev-only).
+#
+# The four professional questions — primary/additional sector and
+# primary/additional age group — resolve their options dynamically from Sector /
+# AgeRange records, and the code still accepts several *legacy* field_identifiers
+# for the sector fields so older forms keep working (see
+# FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS / ADDITIONAL_SECTOR_FIELD_IDENTIFIERS).
+# The canonical combination already ships as "Training Registration Form"; these
+# extra standalone forms each carry a different legacy combination, with a demo
+# registrant + submission + tags, so every surface (form rendering, the form
+# submission show, and the registrant's profile/edit pages) can be eyeballed on
+# real data for every identifier scheme.
+#
+# Loaded last in the dev seed order so its extra role: "registration" forms can't
+# shadow the canonical one that events_management.rb / scholarships.rb look up via
+# `Form.standalone.find_by(role: "registration")`. Idempotent throughout.
+
+puts "Creating legacy field-identifier registration forms…"
+
+# The dynamic option pools, mirroring the canonical lists. The single-select
+# "primary" fields omit the catch-all ("Other" sector / "Mixed-age groups"); the
+# multi-select "additional" fields keep them, so the demo answers exercise both.
+concrete_sectors = Sector.published.excluding_other.order(:name).to_a
+other_sector = Sector.published.find_by(name: Sector::OTHER_SECTOR_NAME)
+concrete_ages = Category.age_ranges.published.excluding_mixed_age.order(:position, :name).to_a
+mixed_age = Category.age_ranges.published.find_by(name: Category::MIXED_AGE_RANGE_NAME)
+
+# Each scheme renames the two canonical sector fields onto a legacy combination.
+# The age-group fields have never been renamed, so they stay canonical.
+legacy_schemes = [
+  { suffix: "legacy service area",
+    primary_sector: "primary_service_area_single", additional_sector: "primary_service_area",
+    first_name: "Lee", last_name: "Servicearea", email: "legacy.servicearea@example.com" },
+  { suffix: "legacy additional name",
+    primary_sector: "primary_sector_single", additional_sector: "primary_sector",
+    first_name: "Morgan", last_name: "Additionalname", email: "legacy.additional@example.com" },
+  { suffix: "legacy mixed",
+    primary_sector: "primary_service_area_single", additional_sector: "additional_sectors",
+    first_name: "Rae", last_name: "Mixedscheme", email: "legacy.mixed@example.com" }
+]
+
+legacy_schemes.each_with_index do |scheme, i|
+  form_name = "Training Registration Form (#{scheme[:suffix]})"
+
+  form = Form.standalone.find_by(name: form_name)
+  unless form
+    form = FormBuilderService.new(
+      name: form_name,
+      sections: %i[person_identifier professional_info],
+      role: "registration"
+    ).call
+    { "primary_sector_single" => scheme[:primary_sector],
+      "additional_sectors" => scheme[:additional_sector] }.each do |canonical, legacy|
+      next if canonical == legacy
+      form.form_fields.find_by(field_identifier: canonical)&.update!(field_identifier: legacy)
+    end
+  end
+
+  # A demo registrant whose submission + tags back the form, so the profile and
+  # submission pages have data to render for this scheme.
+  person = Person.find_or_create_by!(email: scheme[:email]) do |p|
+    p.first_name = scheme[:first_name]
+    p.last_name = scheme[:last_name]
+  end
+
+  submission = FormSubmission.find_or_create_by!(form: form, person: person, role: "registration")
+
+  primary_sector = concrete_sectors[i % concrete_sectors.size] if concrete_sectors.any?
+  additional_sectors = concrete_sectors.rotate(i + 1).reject { |sector| sector == primary_sector }.first(2)
+  primary_age = concrete_ages[i % concrete_ages.size] if concrete_ages.any?
+  # Always include the catch-all "Mixed-age groups" in the additional answer so the
+  # multi-select age field's inclusion of it is visible on the seeded data.
+  additional_ages = (concrete_ages.rotate(i + 1).reject { |age| age == primary_age }.first(1) + [ mixed_age ]).compact
+
+  # Mirror how public registration stores the answers: a single id for the
+  # dropdowns, ", "-joined ids for the checkboxes, and a folded "Other: <text>" for
+  # the additional sectors so the free-text path is represented too.
+  additional_sector_value = (additional_sectors.map(&:id) +
+    [ ("Other: Equine-assisted therapy" if other_sector) ].compact).join(", ")
+  {
+    scheme[:primary_sector] => primary_sector&.id&.to_s,
+    scheme[:additional_sector] => additional_sector_value.presence,
+    "primary_age_group" => primary_age&.id&.to_s,
+    "additional_age_group" => additional_ages.map(&:id).join(", ").presence
+  }.each do |identifier, value|
+    next if value.blank?
+    field = form.form_fields.find_by(field_identifier: identifier)
+    next unless field
+    next if submission.form_answers.where(form_field: field).any?
+    submission.form_answers.create!(form_field: field,
+                                    submitted_answer: value,
+                                    question_name_when_answered: field.name)
+  end
+
+  # Tag the registrant with the same primary/additional split assign_tags applies,
+  # so the profile/edit pages crown the right primary and list the additional ones.
+  person.tag_sectors(primary_ids: [ primary_sector&.id ].compact, additional_ids: additional_sectors.map(&:id))
+  person.tag_age_groups(primary_ids: [ primary_age&.id ].compact, additional_ids: additional_ages.map(&:id))
+end

--- a/db/seeds/dev/legacy_form_identifiers.rb
+++ b/db/seeds/dev/legacy_form_identifiers.rb
@@ -18,12 +18,11 @@
 puts "Creating legacy field-identifier registration forms…"
 
 # The dynamic option pools, mirroring the canonical lists. The single-select
-# "primary" fields omit the catch-all ("Other" sector / "Mixed-age groups"). The
-# additional sector field keeps "Other" (offered as a folded "Other: <text>"),
-# but the additional age field — like the primary — drops "Mixed-age groups".
+# primary sector field omits the catch-all "Other"; the additional sector field
+# keeps it (offered as a folded "Other: <text>"). Age groups have no catch-all.
 concrete_sectors = Sector.published.excluding_other.order(:name).to_a
 other_sector = Sector.published.find_by(name: Sector::OTHER_SECTOR_NAME)
-concrete_ages = Category.age_ranges.published.excluding_mixed_age.order(:position, :name).to_a
+age_categories = Category.age_ranges.published.order(:position, :name).to_a
 
 # Each scheme renames the two canonical sector fields onto a legacy combination.
 # The age-group fields have never been renamed, so they stay canonical.
@@ -67,10 +66,8 @@ legacy_schemes.each_with_index do |scheme, i|
 
   primary_sector = concrete_sectors[i % concrete_sectors.size] if concrete_sectors.any?
   additional_sectors = concrete_sectors.rotate(i + 1).reject { |sector| sector == primary_sector }.first(2)
-  primary_age = concrete_ages[i % concrete_ages.size] if concrete_ages.any?
-  # Additional age groups omit the catch-all "Mixed-age groups" (same as the
-  # primary field), so draw the extras from the concrete ranges too.
-  additional_ages = concrete_ages.rotate(i + 1).reject { |age| age == primary_age }.first(2)
+  primary_age = age_categories[i % age_categories.size] if age_categories.any?
+  additional_ages = age_categories.rotate(i + 1).reject { |age| age == primary_age }.first(2)
 
   # Mirror how public registration stores the answers: a single id for the
   # dropdowns, ", "-joined ids for the checkboxes, and a folded "Other: <text>" for

--- a/db/seeds/dev/legacy_form_identifiers.rb
+++ b/db/seeds/dev/legacy_form_identifiers.rb
@@ -18,12 +18,12 @@
 puts "Creating legacy field-identifier registration forms…"
 
 # The dynamic option pools, mirroring the canonical lists. The single-select
-# "primary" fields omit the catch-all ("Other" sector / "Mixed-age groups"); the
-# multi-select "additional" fields keep them, so the demo answers exercise both.
+# "primary" fields omit the catch-all ("Other" sector / "Mixed-age groups"). The
+# additional sector field keeps "Other" (offered as a folded "Other: <text>"),
+# but the additional age field — like the primary — drops "Mixed-age groups".
 concrete_sectors = Sector.published.excluding_other.order(:name).to_a
 other_sector = Sector.published.find_by(name: Sector::OTHER_SECTOR_NAME)
 concrete_ages = Category.age_ranges.published.excluding_mixed_age.order(:position, :name).to_a
-mixed_age = Category.age_ranges.published.find_by(name: Category::MIXED_AGE_RANGE_NAME)
 
 # Each scheme renames the two canonical sector fields onto a legacy combination.
 # The age-group fields have never been renamed, so they stay canonical.
@@ -68,9 +68,9 @@ legacy_schemes.each_with_index do |scheme, i|
   primary_sector = concrete_sectors[i % concrete_sectors.size] if concrete_sectors.any?
   additional_sectors = concrete_sectors.rotate(i + 1).reject { |sector| sector == primary_sector }.first(2)
   primary_age = concrete_ages[i % concrete_ages.size] if concrete_ages.any?
-  # Always include the catch-all "Mixed-age groups" in the additional answer so the
-  # multi-select age field's inclusion of it is visible on the seeded data.
-  additional_ages = (concrete_ages.rotate(i + 1).reject { |age| age == primary_age }.first(1) + [ mixed_age ]).compact
+  # Additional age groups omit the catch-all "Mixed-age groups" (same as the
+  # primary field), so draw the extras from the concrete ranges too.
+  additional_ages = concrete_ages.rotate(i + 1).reject { |age| age == primary_age }.first(2)
 
   # Mirror how public registration stores the answers: a single id for the
   # dropdowns, ", "-joined ids for the checkboxes, and a folded "Other: <text>" for

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -183,7 +183,7 @@ scholarship_answer_sets = [
       "I've wanted formal facilitation training for years but our continuing-education budget was cut. This scholarship would change that.",
     "scholarship_contribution" => "I could personally cover roughly $150.",
     "sector" => "Mental Health",
-    "age_group" => "Mixed-age groups",
+    "age_group" => "Adults (18+)",
     "title" => "Behavioral Health Clinician"
   },
   {

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -22,6 +22,7 @@ namespace :db do
       payments
       scholarships
       bulk_payments
+      legacy_form_identifiers
     ]
 
     desc "Generate representative sample data for development"
@@ -115,6 +116,11 @@ namespace :db do
     desc "Seed bulk payment demo submissions, payments, and allocations (dev only)"
     task bulk_payments: :environment do
       load Rails.root.join("db/seeds/dev/bulk_payments.rb")
+    end
+
+    desc "Seed registration forms using legacy professional-field identifiers (dev only)"
+    task legacy_form_identifiers: :environment do
+      load Rails.root.join("db/seeds/dev/legacy_form_identifiers.rb")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -482,15 +482,15 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(descriptions["Mental Health"]).to be_nil
     end
 
-    it "omits the Mixed-age groups category for the primary age group field" do
+    it "offers the published AgeRange categories for the primary age group field" do
       type = create(:category_type, name: "AgeRange")
-      create(:category, :published, category_type: type, name: "3-5")
-      create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
+      create(:category, :published, category_type: type, name: "Children (0-12)")
+      create(:category, :unpublished, category_type: type, name: "Retired range")
       field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_age_group")
 
       labels = helper.dynamic_form_field_options(field).map(&:first)
-      expect(labels).to include("3-5")
-      expect(labels).not_to include(Category::MIXED_AGE_RANGE_NAME)
+      expect(labels).to include("Children (0-12)")
+      expect(labels).not_to include("Retired range")
     end
   end
 end

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -431,29 +431,19 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error([ other_type_category.id.to_s ])).to eq("has an invalid selection")
       end
 
-      it "rejects the Mixed-age groups category for the primary age group field" do
+      it "offers every published AgeRange category to both age group fields (no catch-all)" do
         type = create(:category_type, name: "AgeRange")
-        concrete = create(:category, :published, category_type: type, name: "3-5")
-        mixed = create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
-        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "primary_age_group")
-
-        expect(field.answer_inclusion_error([ concrete.id.to_s ])).to be_nil
-        expect(field.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
-      end
-
-      it "omits Mixed-age groups from both the primary and additional age group fields" do
-        type = create(:category_type, name: "AgeRange")
-        concrete = create(:category, :published, category_type: type, name: "3-5")
-        mixed = create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
+        children = create(:category, :published, category_type: type, name: "Children (0-12)")
+        adults = create(:category, :published, category_type: type, name: "Adults (18+)")
+        unpublished = create(:category, :unpublished, category_type: type, name: "Retired range")
         primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_age_group")
         additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
 
-        # Unlike the sector fields (where the additional field keeps "Other"), both
-        # age fields drop the catch-all "Mixed-age groups".
-        expect(primary.dynamic_categories).to eq([ concrete ])
-        expect(additional.dynamic_categories).to eq([ concrete ])
-        expect(additional.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
-        expect(primary.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
+        # Age groups have no catch-all to drop (unlike the additional sector field's
+        # "Other"), so both fields offer exactly the published categories.
+        expect(primary.dynamic_categories).to contain_exactly(children, adults)
+        expect(additional.dynamic_categories).to contain_exactly(children, adults)
+        expect(additional.answer_inclusion_error([ unpublished.id.to_s ])).to eq("has an invalid selection")
       end
 
       it "accepts a folded \"Other: <text>\" value for the additional sectors field" do

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -441,18 +441,18 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
       end
 
-      it "offers Mixed-age groups for the additional age group field but not the primary one" do
+      it "omits Mixed-age groups from both the primary and additional age group fields" do
         type = create(:category_type, name: "AgeRange")
         concrete = create(:category, :published, category_type: type, name: "3-5")
         mixed = create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
         primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_age_group")
         additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
 
-        # The catch-all "Mixed-age groups" mirrors the "Other" sector: dropped from
-        # the single-select primary, kept on the multi-select additional.
+        # Unlike the sector fields (where the additional field keeps "Other"), both
+        # age fields drop the catch-all "Mixed-age groups".
         expect(primary.dynamic_categories).to eq([ concrete ])
-        expect(additional.dynamic_categories).to contain_exactly(concrete, mixed)
-        expect(additional.answer_inclusion_error([ mixed.id.to_s ])).to be_nil
+        expect(additional.dynamic_categories).to eq([ concrete ])
+        expect(additional.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
         expect(primary.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
       end
 

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -441,15 +441,33 @@ RSpec.describe FormField do
         expect(field.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
       end
 
-      it "offers the same AgeRange categories for the additional age group field as the primary one" do
+      it "offers Mixed-age groups for the additional age group field but not the primary one" do
         type = create(:category_type, name: "AgeRange")
         concrete = create(:category, :published, category_type: type, name: "3-5")
         mixed = create(:category, :published, category_type: type, name: Category::MIXED_AGE_RANGE_NAME)
-        field = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
+        primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_age_group")
+        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
 
-        expect(field.dynamic_categories).to eq([ concrete ])
-        expect(field.answer_inclusion_error([ concrete.id.to_s ])).to be_nil
-        expect(field.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
+        # The catch-all "Mixed-age groups" mirrors the "Other" sector: dropped from
+        # the single-select primary, kept on the multi-select additional.
+        expect(primary.dynamic_categories).to eq([ concrete ])
+        expect(additional.dynamic_categories).to contain_exactly(concrete, mixed)
+        expect(additional.answer_inclusion_error([ mixed.id.to_s ])).to be_nil
+        expect(primary.answer_inclusion_error([ mixed.id.to_s ])).to eq("has an invalid selection")
+      end
+
+      it "accepts a folded \"Other: <text>\" value for the additional sectors field" do
+        create(:sector, :published, name: "Other")
+        mental_health = create(:sector, :published, name: "Mental Health")
+        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_sectors")
+        primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_sector_single")
+
+        # The "Other" Sector renders a free-text box on the additional checkboxes,
+        # which submits the folded "Other: <text>" (or a bare "Other"); both pass.
+        expect(additional.answer_inclusion_error([ mental_health.id.to_s, "Other: equine therapy" ])).to be_nil
+        expect(additional.answer_inclusion_error([ "Other" ])).to be_nil
+        # The primary dropdown drops "Other" from its options, so it stays invalid there.
+        expect(primary.answer_inclusion_error([ "Other: equine therapy" ])).to eq("has an invalid selection")
       end
     end
   end

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -1,0 +1,218 @@
+require "rails_helper"
+
+# The four professional registration questions (primary/additional sector and
+# primary/additional age group) resolve their options dynamically from Sector /
+# AgeRange records and must keep working across every legacy field_identifier a
+# form might still carry. For each identifier scheme this exercises, end to end:
+#
+#   * option rendering — the "primary" fields are dropdowns of the published
+#     options minus the catch-all ("Other" sector / "Mixed-age groups"), while
+#     the "additional" fields are checkboxes of every published option including
+#     the catch-all;
+#   * submission storage into form_answers (including a folded "Other: <text>");
+#   * the primary/additional split recorded as person sector/age tags; and
+#   * that the stored selections are readable on the person show, person edit,
+#     and form-submission show pages.
+RSpec.describe "Events::PublicRegistrations professional fields", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, cost_cents: 0) }
+
+  # An AgeRange type (profile-specific so the person edit form lists it) with the
+  # concrete ranges, the catch-all "Mixed-age groups", and an unpublished range
+  # that must never be offered.
+  let!(:age_type) { create(:category_type, name: "AgeRange", published: true, profile_specific: true) }
+  let!(:age_children) { create(:category, category_type: age_type, name: "Children (0-12)", published: true) }
+  let!(:age_teens)    { create(:category, category_type: age_type, name: "Teens (13-17)", published: true) }
+  let!(:age_adults)   { create(:category, category_type: age_type, name: "Adults (18+)", published: true) }
+  let!(:age_mixed)    { create(:category, category_type: age_type, name: Category::MIXED_AGE_RANGE_NAME, published: true) }
+  let!(:age_hidden)   { create(:category, category_type: age_type, name: "Unpublished range", published: false) }
+
+  let!(:sector_education) { create(:sector, :published, name: "Education") }
+  let!(:sector_mh)        { create(:sector, :published, name: "Mental Health") }
+  let!(:sector_other)     { create(:sector, :published, name: Sector::OTHER_SECTOR_NAME) }
+  let!(:sector_hidden)    { create(:sector, name: "Hidden sector") }
+
+  # Each scheme maps the two sector fields onto a canonical or legacy identifier;
+  # the age-group fields have never been renamed, so they stay constant.
+  {
+    "canonical identifiers"         => { primary_sector: "primary_sector_single",       additional_sector: "additional_sectors" },
+    "legacy additional-sector name" => { primary_sector: "primary_sector_single",       additional_sector: "primary_sector" },
+    "legacy service-area names"     => { primary_sector: "primary_service_area_single", additional_sector: "primary_service_area" }
+  }.each do |scheme_name, ids|
+    context "with #{scheme_name}" do
+      let(:form) { build_professional_form(ids) }
+      let(:primary_sector_field)    { form.form_fields.find_by!(field_identifier: ids[:primary_sector]) }
+      let(:additional_sector_field) { form.form_fields.find_by!(field_identifier: ids[:additional_sector]) }
+      let(:primary_age_field)       { form.form_fields.find_by!(field_identifier: "primary_age_group") }
+      let(:additional_age_field)    { form.form_fields.find_by!(field_identifier: "additional_age_group") }
+
+      before { EventForm.create!(event: event, form: form, role: "registration") }
+
+      describe "GET new (option rendering)" do
+        before { get new_event_public_registration_path(event) }
+
+        it "renders the primary fields as dropdowns of published options minus the catch-all" do
+          expect(select_option_values(primary_sector_field)).to include(sector_education.id.to_s, sector_mh.id.to_s)
+          expect(select_option_values(primary_sector_field)).not_to include(sector_other.id.to_s, sector_hidden.id.to_s)
+
+          expect(select_option_values(primary_age_field)).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s)
+          expect(select_option_values(primary_age_field)).not_to include(age_mixed.id.to_s, age_hidden.id.to_s)
+        end
+
+        it "renders the additional fields as checkboxes of all published options including the catch-all" do
+          sector_values = checkbox_values(additional_sector_field)
+          expect(sector_values).to include(sector_education.id.to_s, sector_mh.id.to_s)
+          # The "Other" sector renders a free-text box, so its checkbox submits the
+          # literal "Other" rather than the sector id.
+          expect(sector_values).to include(Sector::OTHER_SECTOR_NAME)
+          expect(sector_values).not_to include(sector_hidden.id.to_s)
+
+          age_values = checkbox_values(additional_age_field)
+          expect(age_values).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s, age_mixed.id.to_s)
+          expect(age_values).not_to include(age_hidden.id.to_s)
+        end
+      end
+
+      describe "POST create (storage, tags, and display)" do
+        let(:registrant) { Person.find_by!(email: "robin.avery@example.com") }
+        let(:submission) { form.form_submissions.find_by!(person: registrant) }
+
+        before do
+          post event_public_registration_path(event), params: { public_registration: { form_fields: {
+            fid("first_name") => "Robin",
+            fid("last_name") => "Avery",
+            fid("primary_email") => "robin.avery@example.com",
+            fid("confirm_email") => "robin.avery@example.com",
+            primary_sector_field.id.to_s => sector_education.id.to_s,
+            additional_sector_field.id.to_s => [ sector_mh.id.to_s, "Other: Equine therapy" ],
+            primary_age_field.id.to_s => age_adults.id.to_s,
+            additional_age_field.id.to_s => [ age_teens.id.to_s, age_mixed.id.to_s ]
+          } } }
+        end
+
+        it "succeeds rather than rejecting the dynamic Other selection" do
+          expect(response).to have_http_status(:found)
+          expect(EventRegistration.where(registrant: registrant)).to exist
+        end
+
+        it "stores each professional answer in form_answers" do
+          expect(answers_by_identifier(submission)).to include(
+            ids[:primary_sector] => sector_education.id.to_s,
+            ids[:additional_sector] => "#{sector_mh.id}, Other: Equine therapy",
+            "primary_age_group" => age_adults.id.to_s,
+            "additional_age_group" => "#{age_teens.id}, #{age_mixed.id}"
+          )
+        end
+
+        it "tags the person with the primary/additional split and captures the Other free text" do
+          expect(primary_sector_of(registrant)).to eq(sector_education)
+          expect(additional_sectors_of(registrant)).to contain_exactly(sector_mh)
+          expect(registrant.other_sector_responses).to include("Equine therapy")
+          expect(registrant.primary_age_groups).to contain_exactly(age_adults)
+          expect(registrant.additional_age_groups).to contain_exactly(age_teens, age_mixed)
+        end
+
+        it "shows the resolved names on the person show page" do
+          sign_in admin
+          get person_path(registrant)
+
+          expect(response.body).to include("Education", "Mental Health", "Adults (18+)", "Teens (13-17)", "Mixed-age groups")
+          expect(response.body).to include("Equine therapy")
+        end
+
+        it "shows the tagged sectors and the checked age groups on the person edit page" do
+          sign_in admin
+          get edit_person_path(registrant)
+          page = dom
+
+          # Sector chips render only for tagged sectors, so their presence proves the tag.
+          expect(page.text).to include("Education", "Mental Health", "Equine therapy")
+          # Age categories all render as checkboxes; the tagged ones are checked, with
+          # the primary toggle set only on the primary age group.
+          expect(membership_checked?(page, age_adults)).to be(true)
+          expect(membership_checked?(page, age_teens)).to be(true)
+          expect(membership_checked?(page, age_mixed)).to be(true)
+          expect(primary_age_checked?(page, age_adults)).to be(true)
+          expect(primary_age_checked?(page, age_teens)).to be(false)
+        end
+
+        it "resolves the stored ids to names on the form submission show page" do
+          sign_in admin
+          get form_submission_path(submission)
+
+          expect(response.body).to include("Education")
+          expect(response.body).to include("Mental Health, Other: Equine therapy")
+          expect(response.body).to include("Adults (18+)")
+          expect(response.body).to include("Teens (13-17), Mixed-age groups")
+        end
+      end
+    end
+  end
+
+  # ---- Form construction ----
+
+  # Builds a registration form with just the identity + professional sections,
+  # then renames the two sector fields onto the scheme's identifiers (the age
+  # fields keep their canonical names — they were never renamed).
+  def build_professional_form(ids)
+    form = FormBuilderService.new(
+      name: "Reg #{ids[:primary_sector]} / #{ids[:additional_sector]}",
+      sections: %i[person_identifier professional_info],
+      role: "registration"
+    ).call
+    rename_field(form, "primary_sector_single", ids[:primary_sector])
+    rename_field(form, "additional_sectors", ids[:additional_sector])
+    form
+  end
+
+  def rename_field(form, from, to)
+    return if from == to
+    form.form_fields.find_by!(field_identifier: from).update!(field_identifier: to)
+  end
+
+  def fid(identifier)
+    form.form_fields.find_by!(field_identifier: identifier).id.to_s
+  end
+
+  # ---- DOM helpers ----
+
+  def dom(body = response.body)
+    Nokogiri::HTML(body)
+  end
+
+  def select_option_values(field)
+    dom.at_css("#public_registration_form_fields_#{field.id}")
+       .css("option").map { |option| option["value"] }.reject(&:blank?)
+  end
+
+  def checkbox_values(field)
+    dom.css("input[type=checkbox][name='public_registration[form_fields][#{field.id}][]']").map { |node| node["value"] }
+  end
+
+  def membership_checked?(page, category)
+    box = page.at_css("input[name='person[category_ids][]'][value='#{category.id}']")
+    box&.key?("checked") || false
+  end
+
+  def primary_age_checked?(page, category)
+    box = page.at_css("input[name='person[primary_age_category_ids][]'][value='#{category.id}']")
+    box&.key?("checked") || false
+  end
+
+  # ---- Assertions ----
+
+  def answers_by_identifier(submission)
+    submission.form_answers.includes(:form_field).each_with_object({}) do |answer, hash|
+      identifier = answer.form_field.field_identifier
+      hash[identifier] = answer.submitted_answer if identifier.present?
+    end
+  end
+
+  def primary_sector_of(person)
+    person.sectorable_items.find(&:is_primary?)&.sector
+  end
+
+  def additional_sectors_of(person)
+    person.sectorable_items.reject(&:is_primary?).map(&:sector)
+  end
+end

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 # AgeRange records and must keep working across every legacy field_identifier a
 # form might still carry. For each identifier scheme this exercises, end to end:
 #
-#   * option rendering — the "primary" fields are dropdowns of the published
-#     options minus the catch-all ("Other" sector / "Mixed-age groups"); the
-#     additional sector field keeps "Other", but the additional age field also
-#     drops "Mixed-age groups" (age groups never offer a catch-all);
+#   * option rendering — the primary sector field is a dropdown of the published
+#     sectors minus the catch-all "Other"; the additional sector field keeps
+#     "Other"; both age fields offer every published AgeRange (no catch-all);
 #   * submission storage into form_answers (including a folded "Other: <text>");
 #   * the primary/additional split recorded as person sector/age tags; and
 #   * that the stored selections are readable on the person show, person edit,
@@ -18,13 +17,11 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
   let(:event) { create(:event, cost_cents: 0) }
 
   # An AgeRange type (profile-specific so the person edit form lists it) with the
-  # concrete ranges, the catch-all "Mixed-age groups", and an unpublished range
-  # that must never be offered.
+  # published ranges plus an unpublished range that must never be offered.
   let!(:age_type) { create(:category_type, name: "AgeRange", published: true, profile_specific: true) }
   let!(:age_children) { create(:category, category_type: age_type, name: "Children (0-12)", published: true) }
   let!(:age_teens)    { create(:category, category_type: age_type, name: "Teens (13-17)", published: true) }
   let!(:age_adults)   { create(:category, category_type: age_type, name: "Adults (18+)", published: true) }
-  let!(:age_mixed)    { create(:category, category_type: age_type, name: Category::MIXED_AGE_RANGE_NAME, published: true) }
   let!(:age_hidden)   { create(:category, category_type: age_type, name: "Unpublished range", published: false) }
 
   let!(:sector_education) { create(:sector, :published, name: "Education") }
@@ -51,15 +48,15 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
       describe "GET new (option rendering)" do
         before { get new_event_public_registration_path(event) }
 
-        it "renders the primary fields as dropdowns of published options minus the catch-all" do
+        it "renders the primary sector as a dropdown minus Other, and primary age as a dropdown of all published ranges" do
           expect(select_option_values(primary_sector_field)).to include(sector_education.id.to_s, sector_mh.id.to_s)
           expect(select_option_values(primary_sector_field)).not_to include(sector_other.id.to_s, sector_hidden.id.to_s)
 
           expect(select_option_values(primary_age_field)).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s)
-          expect(select_option_values(primary_age_field)).not_to include(age_mixed.id.to_s, age_hidden.id.to_s)
+          expect(select_option_values(primary_age_field)).not_to include(age_hidden.id.to_s)
         end
 
-        it "renders the additional fields as checkboxes — sectors keep Other, age groups drop Mixed-age groups" do
+        it "renders the additional fields as checkboxes — sectors keep Other, age groups offer every published range" do
           sector_values = checkbox_values(additional_sector_field)
           expect(sector_values).to include(sector_education.id.to_s, sector_mh.id.to_s)
           # The "Other" sector renders a free-text box, so its checkbox submits the
@@ -69,9 +66,8 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
 
           age_values = checkbox_values(additional_age_field)
           expect(age_values).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s)
-          # Additional age groups drop the catch-all "Mixed-age groups" (and never
-          # offer an "Other"), unlike additional sectors.
-          expect(age_values).not_to include(age_mixed.id.to_s, age_hidden.id.to_s)
+          # Age groups have no catch-all; only the unpublished range is withheld.
+          expect(age_values).not_to include(age_hidden.id.to_s)
         end
       end
 

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -6,9 +6,9 @@ require "rails_helper"
 # form might still carry. For each identifier scheme this exercises, end to end:
 #
 #   * option rendering — the "primary" fields are dropdowns of the published
-#     options minus the catch-all ("Other" sector / "Mixed-age groups"), while
-#     the "additional" fields are checkboxes of every published option including
-#     the catch-all;
+#     options minus the catch-all ("Other" sector / "Mixed-age groups"); the
+#     additional sector field keeps "Other", but the additional age field also
+#     drops "Mixed-age groups" (age groups never offer a catch-all);
 #   * submission storage into form_answers (including a folded "Other: <text>");
 #   * the primary/additional split recorded as person sector/age tags; and
 #   * that the stored selections are readable on the person show, person edit,
@@ -59,7 +59,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
           expect(select_option_values(primary_age_field)).not_to include(age_mixed.id.to_s, age_hidden.id.to_s)
         end
 
-        it "renders the additional fields as checkboxes of all published options including the catch-all" do
+        it "renders the additional fields as checkboxes — sectors keep Other, age groups drop Mixed-age groups" do
           sector_values = checkbox_values(additional_sector_field)
           expect(sector_values).to include(sector_education.id.to_s, sector_mh.id.to_s)
           # The "Other" sector renders a free-text box, so its checkbox submits the
@@ -68,8 +68,10 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
           expect(sector_values).not_to include(sector_hidden.id.to_s)
 
           age_values = checkbox_values(additional_age_field)
-          expect(age_values).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s, age_mixed.id.to_s)
-          expect(age_values).not_to include(age_hidden.id.to_s)
+          expect(age_values).to include(age_children.id.to_s, age_teens.id.to_s, age_adults.id.to_s)
+          # Additional age groups drop the catch-all "Mixed-age groups" (and never
+          # offer an "Other"), unlike additional sectors.
+          expect(age_values).not_to include(age_mixed.id.to_s, age_hidden.id.to_s)
         end
       end
 
@@ -86,7 +88,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
             primary_sector_field.id.to_s => sector_education.id.to_s,
             additional_sector_field.id.to_s => [ sector_mh.id.to_s, "Other: Equine therapy" ],
             primary_age_field.id.to_s => age_adults.id.to_s,
-            additional_age_field.id.to_s => [ age_teens.id.to_s, age_mixed.id.to_s ]
+            additional_age_field.id.to_s => [ age_teens.id.to_s, age_children.id.to_s ]
           } } }
         end
 
@@ -100,7 +102,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
             ids[:primary_sector] => sector_education.id.to_s,
             ids[:additional_sector] => "#{sector_mh.id}, Other: Equine therapy",
             "primary_age_group" => age_adults.id.to_s,
-            "additional_age_group" => "#{age_teens.id}, #{age_mixed.id}"
+            "additional_age_group" => "#{age_teens.id}, #{age_children.id}"
           )
         end
 
@@ -109,14 +111,14 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
           expect(additional_sectors_of(registrant)).to contain_exactly(sector_mh)
           expect(registrant.other_sector_responses).to include("Equine therapy")
           expect(registrant.primary_age_groups).to contain_exactly(age_adults)
-          expect(registrant.additional_age_groups).to contain_exactly(age_teens, age_mixed)
+          expect(registrant.additional_age_groups).to contain_exactly(age_teens, age_children)
         end
 
         it "shows the resolved names on the person show page" do
           sign_in admin
           get person_path(registrant)
 
-          expect(response.body).to include("Education", "Mental Health", "Adults (18+)", "Teens (13-17)", "Mixed-age groups")
+          expect(response.body).to include("Education", "Mental Health", "Adults (18+)", "Teens (13-17)", "Children (0-12)")
           expect(response.body).to include("Equine therapy")
         end
 
@@ -131,7 +133,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
           # the primary toggle set only on the primary age group.
           expect(membership_checked?(page, age_adults)).to be(true)
           expect(membership_checked?(page, age_teens)).to be(true)
-          expect(membership_checked?(page, age_mixed)).to be(true)
+          expect(membership_checked?(page, age_children)).to be(true)
           expect(primary_age_checked?(page, age_adults)).to be(true)
           expect(primary_age_checked?(page, age_teens)).to be(false)
         end
@@ -143,7 +145,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
           expect(response.body).to include("Education")
           expect(response.body).to include("Mental Health, Other: Equine therapy")
           expect(response.body).to include("Adults (18+)")
-          expect(response.body).to include("Teens (13-17), Mixed-age groups")
+          expect(response.body).to include("Teens (13-17), Children (0-12)")
         end
       end
     end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("Organization")
         expect(response.body).to include("AWBW")
       end
+
+      it "resolves the sector/age-group ids stored behind the professional fields to names" do
+        sector = create(:sector, :published, name: "Mental Health")
+        sector_field = create(:form_field, form: submission.form, name: "Additional sectors",
+                              answer_type: :multi_select_checkbox, field_identifier: "additional_sectors")
+        create(:form_answer, form_submission: submission, form_field: sector_field,
+               submitted_answer: "#{sector.id}, Other: Equine therapy")
+
+        get form_submission_path(submission)
+
+        # The stored ids resolve to names; the free-text "Other:" answer passes through.
+        expect(response.body).to include("Mental Health, Other: Equine therapy")
+        expect(response.body).not_to match(/>\s*#{sector.id},/)
+      end
     end
 
     context "when arriving from the bulk payments index" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — a validation fix, a display fix, retiring the Mixed-age groups category, and new seed forms across legacy identifiers

### Goal
The four professional registration questions (primary/additional sector, primary/additional age group) should behave consistently and keep resolving across every legacy `field_identifier`. Adding coverage + seed data surfaced two real bugs (fixed), and the "Mixed-age groups" age category is retired here.

### Behavior
- **Primary** sector / age group → single-select **dropdowns**. Primary sector drops the catch-all "Other"; age groups have no catch-all, so the primary age dropdown offers every published range.
- **Additional sectors** → checkboxes of all published sectors **including "Other"** (free-text).
- **Additional age groups** → checkboxes of every published age range.

### Mixed-age groups removed
The "Mixed-age groups" AgeRange catch-all is retired: dropped the `Category::MIXED_AGE_RANGE_NAME` constant + `excluding_mixed_age` scope, the exclusion in `FormField#dynamic_categories`, the now-unused age-group identifier constants, and the seed category (re-seeding unpublishes any existing one). The legacy `data:convert_age_ranges` one-off rake task is left untouched (it already references other retired buckets).

### Fixes
- **Dynamic "Other" validates on submit.** The published "Other" sector on *additional sectors* submitted `Other: <text>`, which validation rejected as "has an invalid selection." Dynamic fields now expose their "Other" as a specify option.
- **Form-submission show resolves ids → names** via `display_response_text`.

### Seeds & tests
New registration forms using different legacy sector-identifier combinations (demo registrant/submission/tags incl. a folded "Other"). Model unit coverage + a parameterized request spec across the canonical and both legacy schemes: rendering, storage, person tags, and visibility on person show / edit / form-submission show.
