### PR TITLE
Anchor event dashboard org breakdown to the event date

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -23,6 +23,16 @@ class Affiliation < ApplicationRecord
 
   scope :active, -> { active_or_pending }
 
+  # Affiliations that overlapped a given date, judged purely by their start/end
+  # dates rather than the cached `inactive` flag (which reflects "now"). Use this
+  # when a view must reflect a fixed point in time — e.g. the event dashboard
+  # reporting organizations as they stood at the time of the event, so the
+  # numbers don't drift as affiliations end after the fact.
+  scope :active_on, ->(date) {
+    where("affiliations.start_date IS NULL OR affiliations.start_date <= ?", date)
+      .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", date)
+  }
+
   # Only the exact, case-sensitive title "Facilitator" counts — variants like
   # "Lead Facilitator" or "facilitator" are deliberately excluded. BINARY forces
   # a case-sensitive comparison under MySQL's default case-insensitive collation;

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -255,7 +255,8 @@ class EventDashboard
   end
 
   # Unique orgs from both the snapshot taken at registration time and the
-  # registrants' currently-active affiliations.
+  # registrants' affiliations that were active at the time of the event
+  # (#reference_date).
   def organizations
     @organizations ||= Organization.where(id: organization_ids).order(:name)
   end
@@ -300,14 +301,15 @@ class EventDashboard
   end
 
   # Distinct registrant ids per organization, across the registration-time
-  # snapshot and registrants' currently-active affiliations.
+  # snapshot and registrants' affiliations active at the time of the event
+  # (#reference_date).
   def organization_registrant_ids_by_org
     @organization_registrant_ids_by_org ||= begin
       snapshot = EventRegistrationOrganization
         .joins(:event_registration)
         .where(event_registration_id: active_registration_ids)
         .pluck(:organization_id, "event_registrations.registrant_id")
-      affiliated = Affiliation.active
+      affiliated = Affiliation.active_on(reference_date)
         .where(person_id: registrant_ids)
         .pluck(:organization_id, :person_id)
       (snapshot + affiliated).each_with_object(Hash.new { |hash, key| hash[key] = Set.new }) do |(organization_id, person_id), map|
@@ -650,23 +652,37 @@ class EventDashboard
   def program_status_for(organization)
     reference = registrant_affiliations_by_org[organization.id]
       &.select(&:facilitator?)
-      &.min_by { |affiliation| affiliation.start_date || Date.current }
-    return organization.facilitator_status(reference) if reference
+      &.min_by { |affiliation| affiliation.start_date || reference_date }
+    if reference
+      return organization.facilitator_status_on(reference.start_date || reference_date,
+                                                excluding_affiliation_id: reference.id)
+    end
 
-    # The registrant has no facilitator affiliation to this org yet (admins create
-    # those manually after the fact). Classify the org as of today rather than
-    # treating it as new by default, so an org that already has an active
-    # facilitator reads as :ongoing and a lapsed one as :reinstated.
-    organization.facilitator_status_on(Date.current)
+    # The registrant has no facilitator affiliation to this org as of the event
+    # (admins create those manually after the fact). Classify the org as it stood
+    # at the time of the event rather than today, so an org that already had an
+    # active facilitator reads as :ongoing and a lapsed one as :reinstated — and
+    # the breakdown doesn't drift as affiliations change afterward.
+    organization.facilitator_status_on(reference_date)
   end
 
-  # This event's active registrants' active affiliations, grouped by organization
-  # id — the reference points for the program-status breakdown.
+  # This event's active registrants' affiliations that overlapped the event date,
+  # grouped by organization id — the reference points for the program-status
+  # breakdown. Anchored to the event (#reference_date) rather than "now" so the
+  # breakdown reflects the programs as they stood at the time of the event.
   def registrant_affiliations_by_org
-    @registrant_affiliations_by_org ||= Affiliation.active
+    @registrant_affiliations_by_org ||= Affiliation.active_on(reference_date)
       .where(person_id: registrant_ids)
       .includes(:organization)
       .group_by(&:organization_id)
+  end
+
+  # The fixed point in time the organization breakdown is reported as of: the
+  # event's start. Everything keyed off affiliations being "active" uses this
+  # instead of the current date, so revisiting a past event always shows the same
+  # numbers regardless of affiliations that have started or ended since.
+  def reference_date
+    @reference_date ||= (event.start_date || Date.current).to_date
   end
 
   def scholarship_applicant_ids
@@ -779,7 +795,7 @@ class EventDashboard
       snapshot_ids = EventRegistrationOrganization
         .where(event_registration_id: active_registration_ids)
         .pluck(:organization_id)
-      affiliated_ids = Affiliation.active
+      affiliated_ids = Affiliation.active_on(reference_date)
         .where(person_id: registrant_ids)
         .pluck(:organization_id)
       (snapshot_ids + affiliated_ids).compact.uniq

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -170,6 +170,36 @@ RSpec.describe Affiliation do
     end
   end
 
+  describe '.active_on' do
+    let(:date) { Date.new(2024, 6, 1) }
+    let!(:spanning) { create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: Date.new(2025, 1, 1)) }
+    let!(:open_ended) { create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: nil) }
+    let!(:ended_before) { create(:affiliation, start_date: Date.new(2020, 1, 1), end_date: Date.new(2021, 1, 1)) }
+    let!(:starts_after) { create(:affiliation, start_date: Date.new(2025, 1, 1), end_date: nil) }
+    let!(:no_dates) { create(:affiliation, start_date: nil, end_date: nil) }
+
+    it 'includes affiliations whose span covers the date' do
+      expect(described_class.active_on(date)).to include(spanning, open_ended)
+    end
+
+    it 'excludes affiliations that ended before the date' do
+      expect(described_class.active_on(date)).not_to include(ended_before)
+    end
+
+    it 'excludes affiliations that start after the date' do
+      expect(described_class.active_on(date)).not_to include(starts_after)
+    end
+
+    it 'includes affiliations with no dates on record' do
+      expect(described_class.active_on(date)).to include(no_dates)
+    end
+
+    it 'ignores the cached inactive flag, judging purely by dates' do
+      flagged = create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: nil, inactive: true)
+      expect(described_class.active_on(date)).to include(flagged)
+    end
+  end
+
   describe '#set_inactive_from_dates' do
     let(:op) { create(:affiliation, inactive: false, end_date: nil) }
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -760,7 +760,7 @@ RSpec.describe EventDashboard do
 
   # Admins create facilitator affiliations manually after registration, so a
   # registrant frequently has none yet. The org must still be classified by its
-  # own history as of today rather than defaulting to :new.
+  # own history as of the event rather than defaulting to :new.
   context "program-status when the registrant has no facilitator affiliation yet" do
     let(:event) { create(:event) }
     let(:person) { create(:person) }
@@ -793,6 +793,32 @@ RSpec.describe EventDashboard do
       it "classifies the org as reinstated" do
         expect(dashboard.program_statuses_by_registrant[person.id]).to eq([ :reinstated ])
       end
+    end
+  end
+
+  context "program-status breakdown for a past event whose affiliations have since ended" do
+    # The breakdown must reflect the organizations and statuses as they stood at
+    # the time of the event, not as they stand today. This registrant's
+    # facilitator affiliation was active during the event but has since ended;
+    # revisiting the dashboard must still count and classify the program the way
+    # it was at the event, rather than dropping it because the affiliation is no
+    # longer active right now.
+    let(:event) { create(:event, :ended) }
+    let(:org) { create(:organization, name: "Lapsed Program") }
+    let(:person) { create(:person) }
+
+    before do
+      create(:affiliation, organization: org, person: person, title: "Facilitator",
+             start_date: 1.year.ago, end_date: 2.days.ago)
+      create(:event_registration, event: event, registrant: person, status: "registered")
+    end
+
+    it "still counts the program as it was at the time of the event" do
+      expect(dashboard.program_status_counts).to eq(new: 1, ongoing: 0, reinstated: 0)
+    end
+
+    it "keeps the program in the organization count" do
+      expect(dashboard.organization_count).to eq(1)
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The event dashboard's organization breakdown (new / ongoing / reinstated) keyed off `Affiliation.active` ("active right now"), so revisiting a past event showed today's numbers instead of the programs as they stood at the time of the event.
- Admins also add facilitator affiliations after the fact, which silently shifted a past event's counts.

### How did you approach the change?
- Added an `Affiliation.active_on(date)` scope that judges overlap purely by start/end dates (ignoring the cached `inactive` flag, which reflects "now").
- Anchored `EventDashboard` to a single `reference_date` (the event's start), using `active_on(reference_date)` for the represented-org set, the registrant→org map, and each org's reference affiliation, and classifying via `facilitator_status_on(reference_date)` instead of `Date.current`.

### Anything else to add?
- Anchor is `event.start_date`; classification semantics are unchanged — only the point in time is fixed so the breakdown no longer drifts.
- Rebased on main, reusing its `facilitator_status_on(date)` API and exact-match `facilitators` scope.
