### PR TITLE
Show registrants form icon only for registration-role forms

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -101,6 +101,10 @@ class Event < ApplicationRecord
     forms.find_by(event_forms: { role: "registration" })
   end
 
+  def registration_form_ids
+    event_forms.registration.pluck(:form_id)
+  end
+
   # Whether a signed-in user should register in one click rather than being
   # routed to the registration form. True when no registration form is linked,
   # or when an admin has explicitly opted members out of the form. A linked form

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -32,7 +32,7 @@
       </label>
     </div>
 
-    <% event_form_ids = @event.form_ids %>
+    <% event_form_ids = @event.registration_form_ids %>
     <% form_submissions = event_form_ids.any? ? FormSubmission.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
     <% registration_form = @event.registration_form %>
     <% agency_name_field = registration_form&.form_fields&.find_by(field_identifier: "agency_name") %>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -239,6 +239,23 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#registration_form_ids" do
+    it "returns only the ids of forms linked with the registration role" do
+      event = create(:event)
+      registration_form = create(:form, name: "Registration")
+      bulk_payment_form = create(:form, name: "Bulk payment")
+      create(:event_form, event: event, form: registration_form, role: "registration")
+      create(:event_form, event: event, form: bulk_payment_form, role: "bulk_payment")
+
+      expect(event.registration_form_ids).to contain_exactly(registration_form.id)
+    end
+
+    it "returns an empty array when no registration form is linked" do
+      event = create(:event)
+      expect(event.registration_form_ids).to eq([])
+    end
+  end
+
   describe "#one_click_for_signed_in?" do
     it "is true when no registration form is linked" do
       event = create(:event)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -773,6 +773,19 @@ RSpec.describe "Events", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).not_to include('fa-file-lines')
       end
+
+      it "shows a gray icon when the only submission is for a bulk payment form" do
+        bulk_payment_form = create(:form, :standalone, name: "Bulk Payment Form")
+        create(:event_form, event: event, form: reg_form, role: "registration")
+        create(:event_form, event: event, form: bulk_payment_form, role: "bulk_payment")
+        create(:form_submission, person: person, form: bulk_payment_form)
+
+        get registrants_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('fa-regular fa-file-lines')
+        expect(response.body).not_to include('fa-solid fa-file-lines')
+      end
     end
   end
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- The registrants index showed the green "submitted" file icon based on **all** linked forms, so a bulk-payment (or scholarship) form submission lit up the icon as if the person had completed the registration form.
- This change restricts the indicator to registration-role forms so the icon accurately reflects registration form submission.

### How did you approach the change?
- Added `Event#registration_form_ids`, returning only form IDs linked with the `registration` role, and used it in `_registrants_results.html.erb` in place of `@event.form_ids`.
- Added model specs for the new method and a request spec asserting a bulk-payment-only submission shows the gray icon, not the green one.

### UI Testing Checklist
- [ ] On an event with both a registration form and a bulk payment form, a registrant who submitted only the bulk payment form shows the gray icon.
- [ ] A registrant who submitted the registration form still shows the green icon with the correct tooltip.

### Anything else to add?
- Display-only change; submission storage and lookups are otherwise unchanged.
