### PR TITLE
Show scholarship-application icon on registrants list

### DIFF
--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -116,6 +116,8 @@
 
     <% event_form_ids = @event.registration_form_ids %>
     <% form_submissions = event_form_ids.any? ? FormSubmission.joins(:form).where(form_id: event_form_ids, person_id: @event_registrations.map(&:registrant_id)).pluck(:person_id, :created_at, Arel.sql("forms.name")).group_by(&:first).transform_values { |rows| rows.map { |_, ts, name| [ name, ts ] } } : {} %>
+    <% scholarship_form = @event.scholarship_form %>
+    <% scholarship_submitter_ids = scholarship_form ? FormSubmission.joins(:form_answers).where(form_id: scholarship_form.id, role: "scholarship", person_id: @event_registrations.map(&:registrant_id)).distinct.pluck(:person_id).to_set : Set.new %>
     <% registration_form = @event.registration_form %>
     <% agency_name_field = registration_form&.form_fields&.find_by(field_identifier: "agency_name") %>
     <% submitted_org_names = agency_name_field ? FormAnswer.joins(:form_submission).where(form_submissions: { person_id: @event_registrations.map(&:registrant_id), form_id: registration_form.id }, form_field_id: agency_name_field.id).pluck(Arel.sql("form_submissions.person_id"), :submitted_answer).to_h : {} %>
@@ -186,12 +188,12 @@
                       <%= person_profile_button(person, truncate_at: 30, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
                     </div>
 
+                    <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
                     <% if event_form_ids.any? %>
                       <%# Reserve a fixed slot so the comment/warning icons stay aligned
                           across rows whether or not this registrant submitted a form. %>
                       <span class="inline-flex w-4 justify-center">
                         <% if (submissions = form_submissions[person.id]) %>
-                          <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>
                           <% tooltip_parts = submissions.map { |name, ts| "#{name} — Submitted #{ts.strftime('%B %d, %Y at %l:%M %P')}" } %>
                           <% tooltip_parts << "Scholarship requested" if registration.scholarship_requested? %>
                           <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id),
@@ -202,6 +204,15 @@
                           <% end %>
                         <% end %>
                       </span>
+                    <% end %>
+
+                    <% if scholarship_submitter_ids.include?(person.id) %>
+                      <%= link_to event_public_registration_path(@event, **form_show_params, return_to: "registrants", return_registration_id: registration.id, anchor: "scholarship-application"),
+                                  class: "text-purple-600 hover:text-purple-800",
+                                  title: "Scholarship application submitted",
+                                  data: { turbo_frame: "_top" } do %>
+                        <i class="fa-solid fa-hand-holding-heart"></i>
+                      <% end %>
                     <% end %>
 
                     <% if registration.comments.any? %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -86,7 +86,7 @@
   <%# ---- SCHOLARSHIP APPLICATION CARD — only when the registrant filled out the
       separate scholarship form (its own role: "scholarship" submission). ---- %>
   <% if @scholarship_submission %>
-    <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8">
+    <div id="scholarship-application" class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8 scroll-mt-24">
 
       <%# Card Header %>
       <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -798,6 +798,38 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include('inline-flex w-4 justify-center')
       end
     end
+
+    context "scholarship application icon" do
+      let(:scholarship_form) { create(:form, :standalone, name: "Scholarship Form") }
+
+      before { create(:event_form, event: event, form: scholarship_form, role: "scholarship") }
+
+      it "shows the scholarship icon when the person submitted the scholarship form" do
+        submission = create(:form_submission, person: person, form: scholarship_form, role: "scholarship")
+        create(:form_answer, form_submission: submission)
+
+        get registrants_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("fa-solid fa-hand-holding-heart")
+      end
+
+      it "does not show the scholarship icon for a submission with no answers" do
+        create(:form_submission, person: person, form: scholarship_form, role: "scholarship")
+
+        get registrants_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("fa-hand-holding-heart")
+      end
+
+      it "does not show the scholarship icon when the person has no scholarship submission" do
+        get registrants_event_path(event)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("fa-hand-holding-heart")
+      end
+    end
   end
 
   describe "GET /events/:id/registrants with payment and scholarship filters" do


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- On the event **Registrants** list, admins could not tell at a glance who had filled out the separate scholarship application form — only whether a scholarship was *requested* at registration time.
- This adds a distinct second icon so completed scholarship applications are visible without opening each registrant.

### How did you approach the change?
- Next to the existing green registration-form icon, render a purple `fa-hand-holding-heart` icon (matching the scholarship application card) when the registrant has a `role: "scholarship"` form submission with answers on file.
- The icon links to the view-submission page, anchored to the scholarship application card (added `id`/`scroll-mt-24` so it scrolls into view).

### UI Testing Checklist
- [ ] Registrant who submitted the scholarship form shows the purple hand-holding-heart icon, which opens the submission scrolled to the scholarship card.
- [ ] Registrant with no scholarship submission (or an empty one) shows no scholarship icon.

### Anything else to add?
- "Filled out the form" is defined as a scholarship submission with at least one answer, mirroring the view-submission page logic. Added request specs covering all three cases.