### PR TITLE
Capture submitted amount on form submission

### DIFF
--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -101,6 +101,10 @@ module EventRegistrationServices
     def create_form_submission(person)
       submission = FormSubmission.create!(person: person, form: @form, event: @event, role: "bulk_payment")
       save_form_answers(submission)
+      # Snapshot the expected total (event cost times attendee count) now that the
+      # answers it derives from are saved, so the ticket can show the right figure
+      # before Stripe reports the actual payment back.
+      submission.update!(submitted_amount_cents: submission.bulk_payment_amount_cents(@event))
       submission
     end
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -351,7 +351,10 @@ module EventRegistrationServices
     end
 
     def create_form_submission(person)
-      submission = FormSubmission.create!(person: person, form: @form, event: @event)
+      submission = FormSubmission.create!(
+        person: person, form: @form, event: @event,
+        submitted_amount_cents: @event.cost_cents.to_i
+      )
       save_form_answers(submission)
       submission
     end
@@ -359,7 +362,9 @@ module EventRegistrationServices
     def update_form_submission(person)
       submission = FormSubmission.find_or_create_by!(person: person, form: @form) do |record|
         record.event = @event
+        record.submitted_amount_cents = @event.cost_cents.to_i
       end
+      submission.update!(submitted_amount_cents: @event.cost_cents.to_i)
       save_form_answers(submission)
       submission
     end

--- a/app/views/events/bulk_payments/ticket.html.erb
+++ b/app/views/events/bulk_payments/ticket.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "public") %>
 <%
   attendees = @submission.bulk_payment_attendees
-  total_cents = @payment&.amount_cents || @submission.bulk_payment_amount_cents(@event)
+  total_cents = @payment&.amount_cents || @submission.submitted_amount_cents || @submission.bulk_payment_amount_cents(@event)
 %>
 
 <div class="max-w-2xl mx-auto px-4 pt-4">

--- a/db/migrate/20260622114732_add_submitted_amount_cents_to_form_submissions.rb
+++ b/db/migrate/20260622114732_add_submitted_amount_cents_to_form_submissions.rb
@@ -1,0 +1,9 @@
+class AddSubmittedAmountCentsToFormSubmissions < ActiveRecord::Migration[8.0]
+  def up
+    add_column :form_submissions, :submitted_amount_cents, :integer
+  end
+
+  def down
+    remove_column :form_submissions, :submitted_amount_cents, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_114732) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -639,6 +639,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.bigint "person_id", null: false
     t.string "role"
     t.string "slug"
+    t.integer "submitted_amount_cents"
     t.datetime "updated_at", null: false
     t.index ["event_id"], name: "index_form_submissions_on_event_id"
     t.index ["form_id"], name: "index_form_submissions_on_form_id"

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe EventRegistrationServices::BulkPayment do
     end
   end
 
+  describe "submitted amount" do
+    it "snapshots the expected total (event cost times attendee count) on the submission" do
+      event.update!(cost_cents: 2_500)
+
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(field_id("number_of_attendees") => "3")
+      )
+
+      expect(result.success?).to be true
+      expect(result.form_submission.submitted_amount_cents).to eq(7_500)
+    end
+  end
+
   describe "notifications" do
     it "sends the payer confirmation and the staff FYI" do
       expect(NotificationServices::CreateNotification).to receive(:call).with(

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -24,6 +24,34 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     }
   end
 
+  describe "submitted amount" do
+    it "snapshots the event cost on the form submission at submission time" do
+      event.update!(cost_cents: 4_000)
+
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com")
+      )
+
+      expect(result.success?).to be true
+      expect(result.form_submission.submitted_amount_cents).to eq(4_000)
+    end
+
+    it "keeps the snapshot fixed to its original event cost when the event cost later changes" do
+      event.update!(cost_cents: 4_000)
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com")
+      )
+
+      event.update!(cost_cents: 9_000)
+
+      expect(result.form_submission.reload.submitted_amount_cents).to eq(4_000)
+    end
+  end
+
   describe "affiliation creation" do
     let!(:organization) { create(:organization, name: "Helping Hands") }
 


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?

- Form submissions for paid events depend on Stripe round-tripping the actual `Payment` back (via checkout metadata) before we know the amount. Until that webhook lands, tickets fall back to **recomputing** the expected total from `event.cost_cents` — which silently shifts if an admin edits the event cost after someone registers.
- This captures the amount **at submission time** into a new `form_submissions.submitted_amount_cents` column, so:
  - The ticket can show the correct figure immediately, with **no Stripe round-trip needed** (pay-later, check, or pre-webhook pay-now).
  - The figure is a **snapshot** — it stays fixed to what the registrant actually committed to, even if the event price later changes.
  - It opens the door to reconciliation (intended vs. actual paid) and expected-revenue reporting on still-pending submissions.

### How did you approach the change?

- **Migration** adds nullable `submitted_amount_cents` to `form_submissions` (reversible `up`/`down`).
- **Populate on save:**
  - `PublicRegistration` (registration) stores `event.cost_cents` on create and refreshes it on re-registration.
  - `BulkPayment` stores `event.cost_cents × attendee_count` (reusing `bulk_payment_amount_cents`) after the answers it derives from are saved.
- **Display precedence** on the bulk-payment ticket: actual `Payment` → captured `submitted_amount_cents` → derived total (the last only for legacy rows saved before this column existed). This matches the requested behavior of *referencing the captured value only until the Stripe payment comes in*.

### Anything else to add?

- Draft — capturing the value now; only the bulk-payment ticket consumes it so far. The registration ticket still drives its pending figure from `EventRegistration` allocations/`remaining_cost`; it can adopt the snapshot in a follow-up if we want the same decoupling there.
- `submitted_amount_cents` is the **gross** event price snapshot (before scholarships/discounts/allocations), kept consistent across registration and bulk paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)