### PR TITLE
Show new/confirmed email in account activity Changes column

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -125,9 +125,15 @@ class DeviseMailer < Devise::Mailer
 
     return unless event_name
 
+    properties = { record_id: @record.id, record_type: "User" }
+
+    if event_name == "auth.email_change_requested_email_sent"
+      properties[:changes] = { email: { after: @record.unconfirmed_email } }
+    end
+
     Analytics::AhoyTracker.track_auth_event(
       event_name,
-      { record_id: @record.id, record_type: "User" },
+      properties,
       user: Current.user
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,7 +271,7 @@ class User < ApplicationRecord
 
   def after_confirmation
     super
-    track_auth_event("auth.email_confirmed")
+    track_auth_event("auth.email_confirmed", { changes: { email: { after: email } } })
   end
 
   def after_lock


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Surface **which email address** was involved in account-email auth events in the account activity **Changes** column. Previously these events logged no detail, so the activity log couldn't show the address.
- Two events are affected:
  - **Email change requested** (`auth.email_change_requested_email_sent`) — shows the new (unconfirmed) email it was sent to.
  - **Email confirmed** (`auth.email_confirmed`) — shows the email that was confirmed.

### How did you approach the change?
- `app/mailers/devise_mailer.rb` — when tracking `auth.email_change_requested_email_sent`, attach `changes: { email: { after: @record.unconfirmed_email } }` to the event properties. The event already records `Current.user` via `user: Current.user`.
- `app/models/user.rb` — `after_confirmation` now tracks `auth.email_confirmed` with `changes: { email: { after: email } }`.
- No view changes needed: `_account_activity.html.erb` already renders `changes` entries as `<attr.titleize>: <after_value>`, so both display as **"Email: new@example.com"**.

### Anything else to add?
- **HOLD** — not ready for review/merge yet.
- The existing devise mailer spec uses `hash_including(record_id:, record_type:)`, which still matches since the new `changes` key is additive.
