### PR TITLE
Surface pending email-change on person form and profile

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -212,7 +212,7 @@ class OrganizationsController < ApplicationController
       :categorizable_items,
       { comments: [ :created_by, :updated_by ] },
       { sectorable_items: :sector },
-      affiliations: :person
+      affiliations: { person: :user }
     ).find(params[:id])
   end
 

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -75,7 +75,7 @@ module PersonHelper
                     tag.i(class: "fa-solid fa-triangle-exclamation"),
                     class: "flex-shrink-0 ml-auto text-yellow-500",
                     title: "Email change to #{unconfirmed_email} awaiting confirmation. " \
-                           "Only the person and admins can see this; it is not shown on the public profile.")
+                           "Only the person and admins can see this; it is hidden from other profile visitors.")
       else
         "".html_safe
       end

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -22,8 +22,11 @@ module PersonHelper
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")
 
-    unconfirmed_email = person.user&.unconfirmed_email
-    show_email_change = unconfirmed_email.present? && allowed_to?(:show_email_change?, person)
+    # Only touch person.user when the viewer is actually allowed to see a pending
+    # email change — this keeps the button from firing an N+1 :user lookup per row
+    # for anonymous/public viewers on people-heavy pages (e.g. organizations#show).
+    unconfirmed_email = person.user&.unconfirmed_email if allowed_to?(:show_email_change?, person)
+    show_email_change = unconfirmed_email.present?
 
     link_to person_path(person, **path_params),
             data: { turbo_prefetch: false }.merge(data),

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -22,6 +22,9 @@ module PersonHelper
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")
 
+    unconfirmed_email = person.user&.unconfirmed_email
+    show_email_change = unconfirmed_email.present? && allowed_to?(:show_email_change?, person)
+
     link_to person_path(person, **path_params),
             data: { turbo_prefetch: false }.merge(data),
             title: hover_title,
@@ -67,7 +70,16 @@ module PersonHelper
         class: "flex flex-col leading-tight text-left min-w-0"
       )
 
-      avatar + text_block
+      warning_tag = if show_email_change
+        content_tag(:span,
+                    tag.i(class: "fa-solid fa-triangle-exclamation"),
+                    class: "flex-shrink-0 ml-auto text-yellow-500",
+                    title: "Email change to #{unconfirmed_email} awaiting confirmation")
+      else
+        "".html_safe
+      end
+
+      avatar + text_block + warning_tag
     end
   end
 end

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -74,7 +74,8 @@ module PersonHelper
         content_tag(:span,
                     tag.i(class: "fa-solid fa-triangle-exclamation"),
                     class: "flex-shrink-0 ml-auto text-yellow-500",
-                    title: "Email change to #{unconfirmed_email} awaiting confirmation")
+                    title: "Email change to #{unconfirmed_email} awaiting confirmation. " \
+                           "Only the person and admins can see this; it is not shown on the public profile.")
       else
         "".html_safe
       end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -13,6 +13,10 @@ class PersonPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def show_email_change?
+    admin? || owner?
+  end
+
   def checkout?
     admin?
   end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -31,7 +31,7 @@
                   <label class="block text-md font-medium text-gray-700 mb-1">Primary email</label>
                   <span class="text-gray-900 font-medium"><%= f.object.user&.email %></span>
                   <% if f.object.user.unconfirmed_email.present? %>
-                    <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Only the person and admins can see this pending change; it is not shown on the public profile.">
+                    <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Only the person and admins can see this pending change; it is hidden from other profile visitors.">
                       <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                       Change to <strong><%= f.object.user.unconfirmed_email %></strong> awaiting confirmation
                     </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -30,7 +30,7 @@
                 <div>
                   <label class="block text-md font-medium text-gray-700 mb-1">Primary email</label>
                   <span class="text-gray-900 font-medium"><%= f.object.user&.email %></span>
-                  <% if f.object.user.unconfirmed_email.present? %>
+                  <% if f.object.user.unconfirmed_email.present? && allowed_to?(:show_email_change?, f.object) %>
                     <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Only the person and admins can see this pending change; it is hidden from other profile visitors.">
                       <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                       Change to <strong><%= f.object.user.unconfirmed_email %></strong> awaiting confirmation

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -31,7 +31,7 @@
                   <label class="block text-md font-medium text-gray-700 mb-1">Primary email</label>
                   <span class="text-gray-900 font-medium"><%= f.object.user&.email %></span>
                   <% if f.object.user.unconfirmed_email.present? %>
-                    <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800">
+                    <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Only the person and admins can see this pending change; it is not shown on the public profile.">
                       <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                       Change to <strong><%= f.object.user.unconfirmed_email %></strong> awaiting confirmation
                     </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -30,6 +30,12 @@
                 <div>
                   <label class="block text-md font-medium text-gray-700 mb-1">Primary email</label>
                   <span class="text-gray-900 font-medium"><%= f.object.user&.email %></span>
+                  <% if f.object.user.unconfirmed_email.present? %>
+                    <div class="mt-1 inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800">
+                      <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
+                      Change to <strong><%= f.object.user.unconfirmed_email %></strong> awaiting confirmation
+                    </div>
+                  <% end %>
 
                   <p class="text-sm text-gray-500 mt-1">
                     Only

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -96,7 +96,7 @@
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
-              <span class="inline-flex items-center gap-1.5 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only you and admins can see this — it is not shown on your public profile.">
+              <span class="inline-flex items-center gap-1.5 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is not shown on the public profile.">
                 <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                 Email change pending
                 <span class="inline-flex items-center gap-1 pl-1.5 ml-0.5 border-l border-yellow-300 text-yellow-700 italic">

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -95,7 +95,7 @@
                 📧 <!--email_off--><%= mail_to email, email, class: "text-blue-600 hover:underline" %><!--email_on-->
               </span>
             <% end %>
-            <% if @person.user&.unconfirmed_email.present? %>
+            <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
               <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation">
                 <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                 Email change pending

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -95,6 +95,12 @@
                 📧 <!--email_off--><%= mail_to email, email, class: "text-blue-600 hover:underline" %><!--email_on-->
               </span>
             <% end %>
+            <% if @person.user&.unconfirmed_email.present? %>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation">
+                <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
+                Email change pending
+              </span>
+            <% end %>
           <% end %>
           <% phone = @person.phone_number || @person.user&.phone %>
           <% if @person.profile_show_phone? && phone.present? %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -96,9 +96,13 @@
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation">
+              <span class="inline-flex items-center gap-1.5 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only you and admins can see this — it is not shown on your public profile.">
                 <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                 Email change pending
+                <span class="inline-flex items-center gap-1 pl-1.5 ml-0.5 border-l border-yellow-300 text-yellow-700 italic">
+                  <i class="fa-solid fa-eye-slash"></i>
+                  Private
+                </span>
               </span>
             <% end %>
           <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -96,10 +96,10 @@
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
-              <span class="inline-flex items-center gap-1.5 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is not shown on the public profile.">
+              <span class="inline-flex items-center gap-2 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is not shown on the public profile.">
                 <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
                 Email change pending
-                <span class="inline-flex items-center gap-1 pl-1.5 ml-0.5 border-l border-yellow-300 text-yellow-700 italic">
+                <span class="inline-flex items-center gap-1 text-yellow-700 italic">
                   <i class="fa-solid fa-eye-slash"></i>
                   Private
                 </span>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -96,9 +96,9 @@
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
-              <span class="inline-flex items-center gap-2 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is not shown on the public profile.">
+              <span class="inline-flex items-center gap-2 px-2 py-0.5 bg-yellow-50 border border-yellow-300 rounded-full text-xs font-medium text-yellow-800" title="Change to <%= @person.user.unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is hidden from other profile visitors.">
                 <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i>
-                Email change pending
+                Email change to <strong class="font-semibold"><%= @person.user.unconfirmed_email %></strong> pending
                 <span class="inline-flex items-center gap-1 text-yellow-700 italic">
                   <i class="fa-solid fa-eye-slash"></i>
                   Private

--- a/db/seeds/dev/users.rb
+++ b/db/seeds/dev/users.rb
@@ -182,6 +182,17 @@ unless invited_no_person.welcome_instructions_token.present?
   )
 end
 
+# Base user Aisha with a primary email change awaiting confirmation. Set the
+# reconfirmation columns directly so no confirmation email is sent on reseed.
+aisha = User.find_by!(email: "aisha.user@example.com")
+unless aisha.unconfirmed_email.present?
+  aisha.update_columns(
+    unconfirmed_email: "aisha.new@example.com",
+    confirmation_token: Devise.friendly_token,
+    confirmation_sent_at: 1.day.ago
+  )
+end
+
 # Reset only these dev users' passwords (mirrors the base seed reset), so they
 # stay loggable-in after a reseed without touching any other user.
 dev_user_emails = %w[

--- a/spec/helpers/person_helper_spec.rb
+++ b/spec/helpers/person_helper_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe PersonHelper, type: :helper do
+  describe "#person_profile_button" do
+    let(:person) { create(:person, user: create(:user, unconfirmed_email: unconfirmed)) }
+
+    before do
+      allow(helper).to receive(:allowed_to?).with(:show_email_change?, person).and_return(authorized)
+    end
+
+    context "when an email change is pending and the viewer may see it" do
+      let(:unconfirmed) { "new@example.com" }
+      let(:authorized) { true }
+
+      it "renders the pending email-change warning with the new address" do
+        html = helper.person_profile_button(person)
+
+        expect(html).to include("fa-triangle-exclamation")
+        expect(html).to include("new@example.com")
+      end
+    end
+
+    context "when the viewer may not see the change" do
+      let(:unconfirmed) { "new@example.com" }
+      let(:authorized) { false }
+
+      it "omits the warning" do
+        expect(helper.person_profile_button(person)).not_to include("fa-triangle-exclamation")
+      end
+    end
+
+    context "when no email change is pending" do
+      let(:unconfirmed) { nil }
+      let(:authorized) { true }
+
+      it "omits the warning" do
+        expect(helper.person_profile_button(person)).not_to include("fa-triangle-exclamation")
+      end
+    end
+  end
+end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -91,6 +91,32 @@ RSpec.describe PersonPolicy, type: :policy do
     end
   end
 
+  describe "#show_email_change?" do
+    context "with admin user" do
+      subject { policy_for(record: owned_person, user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:show_email_change?) }
+    end
+
+    context "with owner" do
+      subject { policy_for(record: owned_person, user: owner_user) }
+
+      it { is_expected.to be_allowed_to(:show_email_change?) }
+    end
+
+    context "with regular user who is not the owner" do
+      subject { policy_for(record: searchable_person, user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:show_email_change?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(record: searchable_person, user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:show_email_change?) }
+    end
+  end
+
   describe "#edit?" do
     context "with admin user" do
       subject { policy_for(record: searchable_person, user: admin_user) }

--- a/spec/requests/people_profile_flags_spec.rb
+++ b/spec/requests/people_profile_flags_spec.rb
@@ -156,6 +156,31 @@ RSpec.describe "Person profile flag visibility", type: :request do
         expect(response.body).to include(email)
       end
     end
+
+    context "with a pending email change" do
+      before do
+        person.update!(profile_show_email: true)
+        person.user.update_columns(unconfirmed_email: "aisha.new@example.com")
+      end
+
+      it "shows the pending address inline on own profile, not just in the hover title" do
+        sign_in owner_user
+        get person_path(person)
+        expect(response.body).to include("Email change to <strong class=\"font-semibold\">aisha.new@example.com</strong> pending")
+      end
+
+      it "shows the pending address inline when admin views profile" do
+        sign_in admin
+        get person_path(person)
+        expect(response.body).to include("Email change to <strong class=\"font-semibold\">aisha.new@example.com</strong> pending")
+      end
+
+      it "hides the pending change from other viewers" do
+        sign_in create(:user)
+        get person_path(person)
+        expect(response.body).not_to include("aisha.new@example.com")
+      end
+    end
   end
 
   # Flags inside the "Submitted content" section (gated by show? policy)

--- a/spec/views/people/show.html.erb_spec.rb
+++ b/spec/views/people/show.html.erb_spec.rb
@@ -8,12 +8,54 @@ RSpec.describe "people/show", type: :view do
   before do
     assign(:person, person.decorate)
     allow(view).to receive(:current_user).and_return(admin)
-    render
+    allow(view).to receive(:allowed_to?).and_return(false)
   end
 
-  it "renders attributes" do
-    expect(rendered).to match(person.first_name)
-    expect(rendered).to match(person.last_name)
-    expect(rendered).to match(person.user.email)
+  describe "attributes" do
+    before { render }
+
+    it "renders attributes" do
+      expect(rendered).to match(person.first_name)
+      expect(rendered).to match(person.last_name)
+      expect(rendered).to match(person.user.email)
+    end
+  end
+
+  describe "pending email-change chip" do
+    context "when the viewer is authorized to see the email change" do
+      before do
+        allow(view).to receive(:allowed_to?).with(:show_email_change?, anything).and_return(true)
+      end
+
+      context "and the user has a pending email change" do
+        let(:person) { create(:person, user: create(:user, unconfirmed_email: "changed@example.com")) }
+
+        before { render }
+
+        it "renders the chip and the pending address inline" do
+          expect(rendered).to include("Email change to")
+          expect(rendered).to include("changed@example.com")
+        end
+      end
+
+      context "and the user has no pending email change" do
+        before { render }
+
+        it "does not render the chip" do
+          expect(rendered).not_to include("Email change to")
+        end
+      end
+    end
+
+    context "when the viewer is not authorized to see the email change" do
+      let(:person) { create(:person, user: create(:user, unconfirmed_email: "changed@example.com")) }
+
+      before { render }
+
+      it "does not render the chip or leak the pending address" do
+        expect(rendered).not_to include("Email change to")
+        expect(rendered).not_to include("changed@example.com")
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
Neither admins nor the person themselves could tell that a primary email change was initiated but not yet confirmed, so the displayed address looked authoritative even though it may still revert. A pending change is private account state: it must be visible to the person and admins only, clearly marked as private, and never leaked to a public profile visitor.

### How did you approach the change?
Surfaced `User#unconfirmed_email` as an "awaiting confirmation" warning in three places — the person edit form, the profile, and the admin `person_profile_button` (a hover-titled triangle in member/search lists). Every surface is gated behind a new `PersonPolicy#show_email_change?` (admin or owner), the profile chip carries a visible eye-slash "Private" marker, and all three hovers state that only the person and admins can see it and that it is not shown on the public profile. Seeded base user **Aisha** with an in-progress reconfirmation so all states are visible via `rake db:seed:dev`.

### UI Testing Checklist
- [ ] As an admin, Aisha's edit form, profile chip, and profile-button all show the warning with `aisha.new@example.com`
- [ ] As Aisha herself, her profile shows the "Email change pending / Private" chip
- [ ] As a non-admin, non-owner, no pending-change notice appears anywhere
- [ ] Hover text on every surface explains it is private and not shown publicly
- [ ] No notice appears for a person with no pending email change

### Anything else to add?
Dev-only seed sets the reconfirmation columns directly so no confirmation email is sent on reseed. Adds specs for the policy predicate and the profile-button warning.
