### PR TITLE
Warn (not block) on approximate email dupes; widen duplicate matching

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -348,6 +348,8 @@ class PeopleController < ApplicationController
       person.email.present? && person.email.downcase == entered_email.downcase
     secondary_email_match = exact && any_email_match && !primary_email_match
 
+    # Exact name + primary email is an "exact" match; exact name + a secondary or
+    # user email is "approximate" — distinct display, but both block creation.
     match_type = if primary_email_match
       "exact"
     elsif secondary_email_match
@@ -366,7 +368,7 @@ class PeopleController < ApplicationController
       labeled_emails: labeled_emails,
       match_type: match_type,
       name_match: exact,
-      blocked: primary_email_match
+      blocked: primary_email_match || secondary_email_match
     }
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -171,12 +171,16 @@ class PeopleController < ApplicationController
       @duplicates = find_duplicate_people(
         @person.first_name,
         @person.last_name,
-        @person.email
+        @person.email,
+        legal_first_name: @person.legal_first_name,
+        email_2: @person.email_2
       )
       if @duplicates.any?
         @first_name = @person.first_name
         @last_name = @person.last_name
         @email = @person.email
+        @legal_first_name = @person.legal_first_name
+        @email_2 = @person.email_2
         @blocked = @duplicates.any? { |d| d[:blocked] }
         set_form_variables
         respond_to do |format|
@@ -233,7 +237,12 @@ class PeopleController < ApplicationController
     @first_name = params[:first_name]
     @last_name = params[:last_name]
     @email = params[:email]
-    @duplicates = find_duplicate_people(@first_name, @last_name, @email)
+    @legal_first_name = params[:legal_first_name]
+    @email_2 = params[:email_2]
+    @duplicates = find_duplicate_people(
+      @first_name, @last_name, @email,
+      legal_first_name: @legal_first_name, email_2: @email_2
+    )
     @blocked = @duplicates.any? { |d| d[:blocked] }
   end
 
@@ -282,40 +291,56 @@ class PeopleController < ApplicationController
       .sort_by { |type, _| type&.name.to_s.downcase }
   end
 
-  def find_duplicate_people(first_name, last_name, email)
+  def find_duplicate_people(first_name, last_name, email, legal_first_name: nil, email_2: nil)
     duplicates = []
     duplicate_ids = Set.new
 
-    # Check for name matches (exact + nickname variants)
-    # Normalize removes periods and extra whitespace: "J. R." -> "jr"
+    # Entered emails (primary + secondary) drive both email matching and match
+    # classification. example.com addresses are seed/placeholder data, so they're
+    # excluded from the DB lookup.
+    entered_emails = [ email, email_2 ].filter_map { |e| e.presence&.downcase }.uniq
+    query_emails = entered_emails.reject { |e| e.end_with?("@example.com") }
+
+    # Entered first-name forms: the first name and legal first name, normalized.
+    # Normalize removes periods and extra whitespace: "J. R." -> "jr".
+    entered_first_forms = [ first_name, legal_first_name ].filter_map { |n| NicknameMap.normalize(n).presence }.uniq
+    normalized_last = NicknameMap.normalize(last_name)
+
+    # Check for name matches (exact + nickname variants), comparing both the
+    # entered first name and legal first name (and their nickname variants)
+    # against the stored first name and legal first name.
     if first_name.presence && last_name.presence
       first_variants = NicknameMap.variants_for(first_name)
-      normalized_last = NicknameMap.normalize(last_name)
-      normalized_first = NicknameMap.normalize(first_name)
+      first_variants += NicknameMap.variants_for(legal_first_name) if legal_first_name.present?
+      first_variants = first_variants.uniq
 
       name_matches = Person.includes(:user)
                            .where("REPLACE(REPLACE(LOWER(last_name), '.', ''), ' ', '') = ?", normalized_last)
-                           .where("REPLACE(REPLACE(LOWER(first_name), '.', ''), ' ', '') IN (?)", first_variants)
+                           .where(
+                             "REPLACE(REPLACE(LOWER(first_name), '.', ''), ' ', '') IN (:variants) OR " \
+                             "REPLACE(REPLACE(LOWER(legal_first_name), '.', ''), ' ', '') IN (:variants)",
+                             variants: first_variants
+                           )
                            .limit(10)
 
       name_matches.each do |person|
         next if duplicate_ids.include?(person.id)
 
         duplicate_ids.add(person.id)
-        exact_name = NicknameMap.normalize(person.first_name) == normalized_first
-        duplicates << format_duplicate(person, exact: exact_name, entered_email: email)
+        exact_name = exact_first_name_match?(entered_first_forms, person)
+        duplicates << format_duplicate(person, exact: exact_name, entered_email: email, entered_emails: entered_emails)
       end
     end
 
-    # Check for email matches (skip example.com)
+    # Check for email matches on the primary or secondary entered email.
     # Only match person.email when person has no user (otherwise it's a stale copy of user.email)
-    if email.presence && !email.downcase.end_with?("@example.com") && duplicates.size < 10
-      email_lower = email.downcase
+    if query_emails.any? && duplicates.size < 10
       email_query = Person.includes(:user)
                           .left_joins(:user)
                           .where(
-                            "(users.id IS NULL AND LOWER(people.email) = :email) OR LOWER(people.email_2) = :email OR LOWER(users.email) = :email",
-                            email: email_lower
+                            "(users.id IS NULL AND LOWER(people.email) IN (:emails)) OR " \
+                            "LOWER(people.email_2) IN (:emails) OR LOWER(users.email) IN (:emails)",
+                            emails: query_emails
                           )
                           .limit(10)
 
@@ -323,10 +348,10 @@ class PeopleController < ApplicationController
         next if duplicate_ids.include?(person.id)
 
         duplicate_ids.add(person.id)
-        name_matches = first_name.present? && last_name.present? &&
-          NicknameMap.normalize(person.first_name) == NicknameMap.normalize(first_name) &&
-          NicknameMap.normalize(person.last_name) == NicknameMap.normalize(last_name)
-        duplicates << format_duplicate(person, exact: name_matches, entered_email: email)
+        exact_name = last_name.present? &&
+          NicknameMap.normalize(person.last_name) == normalized_last &&
+          exact_first_name_match?(entered_first_forms, person)
+        duplicates << format_duplicate(person, exact: exact_name, entered_email: email, entered_emails: entered_emails)
         break if duplicates.size >= 10
       end
     end
@@ -335,21 +360,31 @@ class PeopleController < ApplicationController
     duplicates.sort_by { |d| [ d[:blocked] ? -1 : 0, sort_order[d[:match_type]] || 4 ] }
   end
 
-  def format_duplicate(person, exact: true, entered_email: nil)
+  # True when any entered first-name form (first or legal, normalized) matches
+  # the stored person's first name or legal first name directly — a real name
+  # match rather than only a nickname bridge.
+  def exact_first_name_match?(entered_first_forms, person)
+    stored_forms = [ person.first_name, person.legal_first_name ].filter_map { |n| NicknameMap.normalize(n).presence }
+    (entered_first_forms & stored_forms).any?
+  end
+
+  def format_duplicate(person, exact: true, entered_email: nil, entered_emails: nil)
+    entered_emails = (Array(entered_emails).presence || [ entered_email ]).filter_map { |e| e.presence&.downcase }.uniq
+
     labeled_emails = []
     # Skip person.email when person has a user (it's a stale copy of user.email)
     labeled_emails << { label: "Email", value: person.email } if person.email.present? && person.user.blank?
     labeled_emails << { label: "Secondary email", value: person.email_2 } if person.email_2.present?
     labeled_emails << { label: "User email", value: person.user.email } if person.user&.email.present?
     emails = labeled_emails.map { |e| e[:value] }.uniq
-    any_email_match = entered_email.present? &&
-      emails.any? { |e| e.downcase == entered_email.downcase }
+    any_email_match = emails.any? { |e| entered_emails.include?(e.downcase) }
     primary_email_match = exact && entered_email.present? &&
       person.email.present? && person.email.downcase == entered_email.downcase
     secondary_email_match = exact && any_email_match && !primary_email_match
 
-    # Exact name + primary email is an "exact" match; exact name + a secondary or
-    # user email is "approximate" — distinct display, but both block creation.
+    # Exact name + primary email is an "exact" match and blocks creation. Exact
+    # name plus a secondary or user email is "approximate" — the admin is warned
+    # but can still create the person (they may legitimately share an email).
     match_type = if primary_email_match
       "exact"
     elsif secondary_email_match
@@ -368,7 +403,7 @@ class PeopleController < ApplicationController
       labeled_emails: labeled_emails,
       match_type: match_type,
       name_match: exact,
-      blocked: primary_email_match || secondary_email_match
+      blocked: primary_email_match
     }
   end
 

--- a/app/views/people/_duplicate_people_warning.html.erb
+++ b/app/views/people/_duplicate_people_warning.html.erb
@@ -30,7 +30,11 @@
                   <%= link_to dup[:name], person_path(dup[:id]), target: "_blank", class: "text-blue-600 hover:text-blue-800 underline" %>
 
                   <% if dup[:blocked] %>
-                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+                    <% if dup[:match_type] == "approximate" %>
+                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
+                    <% else %>
+                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+                    <% end %>
                   <% else %>
                     <% if dup[:name_match] %>
                       <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700">name match</span>
@@ -38,7 +42,7 @@
                     <% if dup[:match_type] == "nickname" %>
                       <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-100 text-yellow-700">similar name</span>
                     <% end %>
-                    <% if %w[email approximate].include?(dup[:match_type]) %>
+                    <% if dup[:match_type] == "email" %>
                       <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700">email match</span>
                     <% end %>
                   <% end %>
@@ -60,10 +64,17 @@
           </div>
 
           <% if @blocked %>
-            <p class="text-sm text-red-600 font-medium m-2">An <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">existing user</span> with this email already exists.</p>
-            <p class="text-sm text-gray-500 mb-6">
-              Edit the existing user or change this user's email.
-            </p>
+            <% if @duplicates.any? { |d| d[:match_type] == "exact" } %>
+              <p class="text-sm text-red-600 font-medium m-2">An <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">existing user</span> with this email already exists.</p>
+              <p class="text-sm text-gray-500 mb-6">
+                Edit the existing user or change this user's email.
+              </p>
+            <% else %>
+              <p class="text-sm text-orange-600 font-medium m-2">A person with this name has a matching <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">secondary or user email</span>.</p>
+              <p class="text-sm text-gray-500 mb-6">
+                Edit the existing person or change this email.
+              </p>
+            <% end %>
           <% end %>
 
           <% unless @blocked %>

--- a/app/views/people/_duplicate_people_warning.html.erb
+++ b/app/views/people/_duplicate_people_warning.html.erb
@@ -21,7 +21,7 @@
         <div class="flex-1">
           <h3 class="text-sm font-medium text-yellow-800">Possible duplicate person</h3>
 
-          <p class="text-sm text-yellow-700 mt-1">We found existing people with a similar name or email. <%= link_to "View details", check_duplicates_people_path(first_name: @first_name, last_name: @last_name, email: @email), target: "_blank", class: "underline hover:text-yellow-900" %></p>
+          <p class="text-sm text-yellow-700 mt-1">We found existing people with a similar name or email. <%= link_to "View details", check_duplicates_people_path(first_name: @first_name, last_name: @last_name, email: @email, legal_first_name: @legal_first_name, email_2: @email_2), target: "_blank", class: "underline hover:text-yellow-900" %></p>
 
           <div class="mt-3 bg-white">
             <ul class="divide-y divide-gray-300 border border-gray-300 rounded-md text-sm overflow-y-auto">
@@ -30,11 +30,9 @@
                   <%= link_to dup[:name], person_path(dup[:id]), target: "_blank", class: "text-blue-600 hover:text-blue-800 underline" %>
 
                   <% if dup[:blocked] %>
-                    <% if dup[:match_type] == "approximate" %>
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
-                    <% else %>
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
-                    <% end %>
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+                  <% elsif dup[:match_type] == "approximate" %>
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
                   <% else %>
                     <% if dup[:name_match] %>
                       <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700">name match</span>
@@ -64,17 +62,12 @@
           </div>
 
           <% if @blocked %>
-            <% if @duplicates.any? { |d| d[:match_type] == "exact" } %>
-              <p class="text-sm text-red-600 font-medium m-2">An <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">existing user</span> with this email already exists.</p>
-              <p class="text-sm text-gray-500 mb-6">
-                Edit the existing user or change this user's email.
-              </p>
-            <% else %>
-              <p class="text-sm text-orange-600 font-medium m-2">A person with this name has a matching <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">secondary or user email</span>.</p>
-              <p class="text-sm text-gray-500 mb-6">
-                Edit the existing person or change this email.
-              </p>
-            <% end %>
+            <p class="text-sm text-red-600 font-medium m-2">An <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">existing user</span> with this email already exists.</p>
+            <p class="text-sm text-gray-500 mb-6">
+              Edit the existing user or change this user's email.
+            </p>
+          <% elsif @duplicates.any? { |d| d[:match_type] == "approximate" } %>
+            <p class="text-sm text-orange-600 font-medium m-2">A person with this name has a matching <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">secondary or user email</span>. Confirm this is a different person before continuing.</p>
           <% end %>
 
           <% unless @blocked %>

--- a/app/views/people/check_duplicates.html.erb
+++ b/app/views/people/check_duplicates.html.erb
@@ -47,11 +47,9 @@
                           class: "text-blue-600 hover:text-blue-800 underline font-medium" %>
 
               <% if dup[:blocked] %>
-                <% if dup[:match_type] == "approximate" %>
-                  <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
-                <% else %>
-                  <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
-                <% end %>
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+              <% elsif dup[:match_type] == "approximate" %>
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
               <% else %>
                 <% if dup[:name_match] %>
                   <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700">name match</span>
@@ -79,21 +77,16 @@
       </ul>
 
       <% if @blocked %>
-        <% if @duplicates.any? { |d| d[:match_type] == "exact" } %>
-          <p class="text-sm text-red-600 font-medium">
-            A person with this exact name and primary email already exists.
-          </p>
-          <p class="text-sm text-red-600 font-medium mb-6">
-            Please edit the existing record instead.
-          </p>
-        <% else %>
-          <p class="text-sm text-orange-600 font-medium">
-            A person with this name has a matching secondary or user email.
-          </p>
-          <p class="text-sm text-orange-600 font-medium mb-6">
-            Please edit the existing record instead.
-          </p>
-        <% end %>
+        <p class="text-sm text-red-600 font-medium">
+          A person with this exact name and primary email already exists.
+        </p>
+        <p class="text-sm text-red-600 font-medium mb-6">
+          Please edit the existing record instead.
+        </p>
+      <% elsif @duplicates.any? { |d| d[:match_type] == "approximate" } %>
+        <p class="text-sm text-orange-600 font-medium mb-6">
+          A person with this name has a matching secondary or user email. You can still create them if this is a different person.
+        </p>
       <% end %>
 
       <% if @email.present? && @duplicates.any? { |d| d[:labeled_emails]&.any? { |e| e[:value]&.downcase == @email.downcase } } %>
@@ -103,7 +96,7 @@
       <% end %>
 
       <div class="flex flex-col items-center gap-3">
-        <% shareable_url = check_duplicates_people_url(first_name: @first_name, last_name: @last_name, email: @email) %>
+        <% shareable_url = check_duplicates_people_url(first_name: @first_name, last_name: @last_name, email: @email, legal_first_name: @legal_first_name, email_2: @email_2) %>
 
         <%= mail_to "",
               "Ask a colleague",

--- a/app/views/people/check_duplicates.html.erb
+++ b/app/views/people/check_duplicates.html.erb
@@ -47,7 +47,11 @@
                           class: "text-blue-600 hover:text-blue-800 underline font-medium" %>
 
               <% if dup[:blocked] %>
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+                <% if dup[:match_type] == "approximate" %>
+                  <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-100 text-orange-700">approximate match</span>
+                <% else %>
+                  <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">exact match</span>
+                <% end %>
               <% else %>
                 <% if dup[:name_match] %>
                   <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-100 text-green-700">name match</span>
@@ -55,7 +59,7 @@
                 <% if dup[:match_type] == "nickname" %>
                   <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-100 text-yellow-700">similar name</span>
                 <% end %>
-                <% if %w[email approximate].include?(dup[:match_type]) %>
+                <% if dup[:match_type] == "email" %>
                   <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700">email match</span>
                 <% end %>
               <% end %>
@@ -75,16 +79,21 @@
       </ul>
 
       <% if @blocked %>
-        <p class="text-sm text-red-600 font-medium">
-          A person with this exact name and primary email already exists.
-        </p>
-        <p class="text-sm text-red-600 font-medium mb-6">
-          Please edit the existing record instead.
-        </p>
-      <% elsif @duplicates.any? { |d| d[:match_type] == "approximate" } %>
-        <p class="text-sm text-orange-600 font-medium mb-6">
-          A person with this name has a matching secondary or user email.
-        </p>
+        <% if @duplicates.any? { |d| d[:match_type] == "exact" } %>
+          <p class="text-sm text-red-600 font-medium">
+            A person with this exact name and primary email already exists.
+          </p>
+          <p class="text-sm text-red-600 font-medium mb-6">
+            Please edit the existing record instead.
+          </p>
+        <% else %>
+          <p class="text-sm text-orange-600 font-medium">
+            A person with this name has a matching secondary or user email.
+          </p>
+          <p class="text-sm text-orange-600 font-medium mb-6">
+            Please edit the existing record instead.
+          </p>
+        <% end %>
       <% end %>
 
       <% if @email.present? && @duplicates.any? { |d| d[:labeled_emails]&.any? { |e| e[:value]&.downcase == @email.downcase } } %>

--- a/spec/requests/people_check_duplicates_spec.rb
+++ b/spec/requests/people_check_duplicates_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "/people/check_duplicates", type: :request do
       end
     end
 
-    # --- Blocked (exact name + primary email) ---
+    # --- Blocked (exact name + any email) ---
 
     context "when exact name and primary email match (blocked)" do
       it "shows the exact match badge and block message" do
@@ -145,10 +145,8 @@ RSpec.describe "/people/check_duplicates", type: :request do
       end
     end
 
-    # --- Name + email match (exact name + secondary/user email) ---
-
-    context "when exact name and secondary email match" do
-      it "shows both name match and email match badges" do
+    context "when exact name and secondary email match (blocked)" do
+      it "shows the approximate match badge and block message" do
         existing_person.update!(email_2: "jane.secondary@testmail.org")
 
         get check_duplicates_people_path, params: {
@@ -156,19 +154,42 @@ RSpec.describe "/people/check_duplicates", type: :request do
         }
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("name match")
-        expect(response.body).to include("email match")
+        expect(response.body).to include("approximate match")
+        expect(response.body).not_to include("exact match")
+        expect(response.body).to include("matching secondary or user email")
+        expect(response.body).to include("Please edit the existing record instead")
       end
 
-      it "shows the secondary email warning" do
+      it "hides the Create anyway button" do
         existing_person.update!(email_2: "jane.secondary@testmail.org")
 
         get check_duplicates_people_path, params: {
           first_name: "Jane", last_name: "Doe", email: "jane.secondary@testmail.org"
         }
 
+        expect(response.body).not_to include("Create anyway")
+      end
+    end
+
+    context "when exact name and user email match (blocked)" do
+      it "shows the approximate match badge and block message" do
+        get check_duplicates_people_path, params: {
+          first_name: "Jane", last_name: "Doe", email: existing_person.user.email
+        }
+
         expect(response).to have_http_status(:ok)
+        expect(response.body).to include("approximate match")
+        expect(response.body).not_to include("exact match")
         expect(response.body).to include("matching secondary or user email")
+        expect(response.body).to include("Please edit the existing record instead")
+      end
+
+      it "hides the Create anyway button" do
+        get check_duplicates_people_path, params: {
+          first_name: "Jane", last_name: "Doe", email: existing_person.user.email
+        }
+
+        expect(response.body).not_to include("Create anyway")
       end
     end
 

--- a/spec/requests/people_check_duplicates_spec.rb
+++ b/spec/requests/people_check_duplicates_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "/people/check_duplicates", type: :request do
       end
     end
 
-    # --- Blocked (exact name + any email) ---
+    # --- Blocked (exact name + primary email only) ---
 
     context "when exact name and primary email match (blocked)" do
       it "shows the exact match badge and block message" do
@@ -145,8 +145,10 @@ RSpec.describe "/people/check_duplicates", type: :request do
       end
     end
 
-    context "when exact name and secondary email match (blocked)" do
-      it "shows the approximate match badge and block message" do
+    # --- Approximate (exact name + secondary/user email): warned but allowed ---
+
+    context "when exact name and secondary email match (approximate)" do
+      it "shows the approximate match badge and warning, not a block" do
         existing_person.update!(email_2: "jane.secondary@testmail.org")
 
         get check_duplicates_people_path, params: {
@@ -157,22 +159,12 @@ RSpec.describe "/people/check_duplicates", type: :request do
         expect(response.body).to include("approximate match")
         expect(response.body).not_to include("exact match")
         expect(response.body).to include("matching secondary or user email")
-        expect(response.body).to include("Please edit the existing record instead")
-      end
-
-      it "hides the Create anyway button" do
-        existing_person.update!(email_2: "jane.secondary@testmail.org")
-
-        get check_duplicates_people_path, params: {
-          first_name: "Jane", last_name: "Doe", email: "jane.secondary@testmail.org"
-        }
-
-        expect(response.body).not_to include("Create anyway")
+        expect(response.body).not_to include("Please edit the existing record instead")
       end
     end
 
-    context "when exact name and user email match (blocked)" do
-      it "shows the approximate match badge and block message" do
+    context "when exact name and user email match (approximate)" do
+      it "shows the approximate match badge and warning, not a block" do
         get check_duplicates_people_path, params: {
           first_name: "Jane", last_name: "Doe", email: existing_person.user.email
         }
@@ -181,15 +173,54 @@ RSpec.describe "/people/check_duplicates", type: :request do
         expect(response.body).to include("approximate match")
         expect(response.body).not_to include("exact match")
         expect(response.body).to include("matching secondary or user email")
-        expect(response.body).to include("Please edit the existing record instead")
+        expect(response.body).not_to include("Please edit the existing record instead")
       end
+    end
 
-      it "hides the Create anyway button" do
+    # --- Legal first name matching ---
+
+    context "when the entered first name matches a stored legal first name" do
+      it "finds the person by their legal first name" do
+        create(:person, first_name: "Bob", last_name: "Mendez", legal_first_name: "Roberto")
+
         get check_duplicates_people_path, params: {
-          first_name: "Jane", last_name: "Doe", email: existing_person.user.email
+          first_name: "Roberto", last_name: "Mendez", email: ""
         }
 
-        expect(response.body).not_to include("Create anyway")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Bob Mendez")
+        expect(response.body).to include("name match")
+      end
+    end
+
+    context "when the entered legal first name matches a stored first name" do
+      it "finds the person by the entered legal first name" do
+        create(:person, first_name: "Roberto", last_name: "Mendez")
+
+        get check_duplicates_people_path, params: {
+          first_name: "Bob", last_name: "Mendez", legal_first_name: "Roberto", email: ""
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Roberto Mendez")
+        expect(response.body).to include("name match")
+      end
+    end
+
+    # --- Secondary entered email matching ---
+
+    context "when the entered secondary email matches an existing person" do
+      it "finds the person by the secondary email" do
+        create(:person, first_name: "Carol", last_name: "White", email: nil, email_2: "carol.alt@testmail.org")
+
+        get check_duplicates_people_path, params: {
+          first_name: "Different", last_name: "Name",
+          email: "unrelated@testmail.org", email_2: "carol.alt@testmail.org"
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Carol White")
+        expect(response.body).to include("email match")
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained duplicate-check change — widened matching logic + reverted blocking, covered by request specs

### What is the goal of this PR and why is this important?
- Two people can legitimately share an email, so an exact name + **secondary/user** email match should **warn**, not block. Only an exact name + **primary** email match blocks creation.
- Duplicate detection should catch a match across the full set of identity fields the form captures, not just first name + primary email.

### How did you approach the change?
- `blocked:` is now `primary_email_match` only. Exact name + secondary/user email is an `"approximate"` match: orange warning badge + note, with "Create anyway" available.
- Widened `find_duplicate_people` to consider **legal first name** (entered and stored, plus nickname variants) and the entered **secondary email** — so a match is caught regardless of which name/email pair lines up. New `exact_first_name_match?` helper decides exact-vs-nickname across first + legal forms.
- Passed the new fields through both `create` and `check_duplicates`, and carried them on the standalone page's "View details"/shareable links.

### UI Testing Checklist
- [ ] Exact name + matching **secondary** or **user** email shows the orange "approximate match" badge and warning, and still allows "Create anyway".
- [ ] Exact name + matching **primary** email still shows the red "exact match" badge and blocks.
- [ ] Entering a name whose **legal name** matches an existing record's first name (or vice versa) surfaces that record.
- [ ] Entering a **secondary email** that matches an existing record surfaces it.

### Anything else to add?
- No schema or model changes — controller/view logic only.
- The block remains UI-soft (server still honors `skip_duplicate_check`); unchanged from before, and only the approximate case was relaxed.