### PR TITLE
Gate remote_select style injection on an id to prevent <style> leak

### DIFF
--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -27,8 +27,16 @@ export default class extends Controller {
       },
     });
     this.addSearchIcon();
-    // Inject CSS to remove some default tom-select styles -might be a better way to do this.
+    this.injectStyles();
+  }
+
+  // Inject CSS to remove some default tom-select styles -might be a better way to do this.
+  // Gated on an id so repeated connects (Turbo nav, cocoon add, reconnect) don't append duplicates.
+  injectStyles() {
+    const styleId = "remote-select-styles";
+    if (document.getElementById(styleId)) return;
     const style = document.createElement("style");
+    style.id = styleId;
     style.textContent = `
       /* Remove border and shadow */
       .ts-control .ts-input,


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- `remote_select_controller.js` leaked a `<style>` tag on every Stimulus `connect()`
- `connect()` ran `document.head.appendChild(style)` unconditionally — no "append once" guard and no `disconnect()` cleanup
- Every connect (Turbo nav, cocoon add-field, reconnect) stacked another identical `<style>` into `<head>`, violating the lifecycle rule that anything created in `connect()` must be cleaned up

### How did you approach the change?

- Extracted the injection into an `injectStyles()` method gated on an element id (`remote-select-styles`)
- If a tag with that id already exists, the method returns early — the shared global stylesheet is appended once and reused across all controller instances
- Chose the id guard over a `disconnect()` removal because the stylesheet is global, not per-instance: multiple `remote_select` controllers can be live at once, so removing the tag on any one disconnect would break the others. The existing `disconnect()` still destroys the per-instance TomSelect.

### Anything else to add?

- **HOLD**: pre-existing issue surfaced while editing this block; holding for review/sequencing.
