### PR TITLE
Remove Credit Card option from payment and allocation filters

### DIFF
--- a/app/views/allocations/_search_boxes.html.erb
+++ b/app/views/allocations/_search_boxes.html.erb
@@ -17,7 +17,7 @@
         <div>
           <label for="source_type" class="<%= label_class %>">Source type</label>
           <%= select_tag "source_type[]",
-          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Credit Card" => "CreditCardPayment", "Stripe" => "ExternalProcessorPayment", "Discount" => "Discount" }, Array(params[:source_type]).first),
+          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment", "Discount" => "Discount" }, Array(params[:source_type]).first),
           class: field_class %>
         </div>
         <div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -15,7 +15,7 @@
         <label for="type" class="text-sm font-medium text-gray-500 mb-1 block">Type</label>
 
         <%= select_tag "type[]",
-          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Credit Card" => "CreditCardPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
+          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
           class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
       </div>
 


### PR DESCRIPTION
## Why

- The `CreditCardPayment` payment type is no longer used, but it still appears as a "Credit Card" option in two filter dropdowns. Selecting it can only ever return zero results.
- Removing it keeps the filters limited to payment types that actually exist.

## What

- Drop **Credit Card → CreditCardPayment** from the payments **Type** filter (`app/views/payments/_search_boxes.html.erb`).
- Drop the same option from the allocations **Source type** filter (`app/views/allocations/_search_boxes.html.erb`).

## Notes

- `HOLD:` — opening as a placeholder; confirm `CreditCardPayment` is truly retired (no historical records still typed as `CreditCardPayment` that admins need to filter for) before merging.
- Left `Events::PublicRegistrationsController#credit_card_payment?` untouched — that's the event-registration "payment method" form field that routes to Stripe checkout, unrelated to the `CreditCardPayment` polymorphic type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
