### PR TITLE
Make event registrations deletable only when safe

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -277,7 +277,7 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration
     event = @event_registration.event
     if !@event_registration.deletable?
-      flash[:alert] = "This registration can't be deleted because it has payments, scholarships, or attendance on record."
+      flash[:alert] = "This registration can't be deleted because it has financial records (payments, scholarships, or the like) or attendance on record."
     elsif @event_registration.destroy
       flash[:notice] = "Registration deleted."
     else

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -276,7 +276,9 @@ class EventRegistrationsController < ApplicationController
   def destroy
     authorize! @event_registration
     event = @event_registration.event
-    if @event_registration.destroy
+    if !@event_registration.deletable?
+      flash[:alert] = "This registration can't be deleted because it has payments, scholarships, or attendance on record."
+    elsif @event_registration.destroy
       flash[:notice] = "Registration deleted."
     else
       flash[:alert] = @event_registration.errors.full_messages.to_sentence

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -1,8 +1,8 @@
 module Events
   class RegistrationsController < ApplicationController
-    before_action :authenticate_user!, only: [ :create, :destroy ]
-    before_action :set_event, only: [ :create, :destroy ]
-    before_action :set_registrant, only: [ :create, :destroy ]
+    before_action :authenticate_user!, only: [ :create ]
+    before_action :set_event, only: [ :create ]
+    before_action :set_registrant, only: [ :create ]
     before_action :set_event_registration, only: [ :show, :invoice, :receipt, :resend_confirmation, :cancel, :reactivate, :pay ]
 
     def show
@@ -58,7 +58,7 @@ module Events
       authorize! @event_registration, to: :show_public?
 
       if @event_registration.active?
-        @event_registration.update!(status: "cancelled")
+        @event_registration.cancel!
         redirect_to registration_ticket_path(@event_registration.slug), notice: "Your registration has been cancelled."
       else
         redirect_to registration_ticket_path(@event_registration.slug), alert: "Registration is already cancelled."
@@ -120,45 +120,6 @@ module Events
             format.turbo_stream { flash.now[:notice] = success }
             format.html { redirect_to registration_ticket_path(@event_registration.slug), notice: success }
           end
-        end
-      else
-        error = @event_registration.errors.full_messages.to_sentence
-        respond_to do |format|
-          format.turbo_stream { flash.now[:alert] = error }
-          format.html { redirect_to @event, alert: error }
-        end
-      end
-    end
-
-    def destroy
-      @event_registration = @event.event_registrations.find_by(registrant: @registrant)
-
-      unless @event_registration
-        skip_verify_authorized!
-        alert = "Registration not found"
-        respond_to do |format|
-          format.turbo_stream { flash.now[:alert] = alert }
-          format.html { redirect_to @event, alert: alert }
-        end
-        return
-      end
-
-      authorize! @event_registration
-
-      unless @event_registration.deletable?
-        alert = "You can't de-register because there are payments or attendance on record. Cancel your registration instead."
-        respond_to do |format|
-          format.turbo_stream { flash.now[:alert] = alert }
-          format.html { redirect_to @event, alert: alert }
-        end
-        return
-      end
-
-      if @event_registration.destroy
-        success = "You are no longer registered."
-        respond_to do |format|
-          format.turbo_stream { flash.now[:notice] = success }
-          format.html { redirect_to @event, notice: success }
         end
       else
         error = @event_registration.errors.full_messages.to_sentence

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -145,6 +145,15 @@ module Events
 
       authorize! @event_registration
 
+      unless @event_registration.deletable?
+        alert = "You can't de-register because there are payments or attendance on record. Cancel your registration instead."
+        respond_to do |format|
+          format.turbo_stream { flash.now[:alert] = alert }
+          format.html { redirect_to @event, alert: alert }
+        end
+        return
+      end
+
       if @event_registration.destroy
         success = "You are no longer registered."
         respond_to do |format|

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -10,6 +10,18 @@ class EventRegistrationDecorator < ApplicationDecorator
     h.registration_ticket_path(slug)
   end
 
+  # Human-readable explanation of why the Delete button is unavailable, or nil
+  # when the registration is deletable. Reverted payments still leave allocation
+  # rows, so they count here even though they net to zero — hence the aside.
+  def deletion_blocked_reason
+    return if deletable?
+
+    reasons = []
+    reasons << "payment or scholarship records (reverted payments still count)" if allocations.exists?
+    reasons << "attendance on record" if attendance_recorded?
+    "Can't be deleted — this registration has #{reasons.to_sentence}."
+  end
+
   def default_display_image
     return event.primary_asset.file if event.respond_to?(:primary_asset) && event.primary_asset&.file&.attached?
     "theme_default.png"

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -17,7 +17,7 @@ class EventRegistrationDecorator < ApplicationDecorator
     return if deletable?
 
     reasons = []
-    reasons << "payment or scholarship records (reverted payments still count)" if allocations.exists?
+    reasons << "financial records — payments, scholarships, or the like (reverted payments still count)" if allocations.exists?
     reasons << "attendance on record" if attendance_recorded?
     "Can't be deleted — this registration has #{reasons.to_sentence}."
   end

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -17,8 +17,9 @@ class EventRegistrationDecorator < ApplicationDecorator
     return if deletable?
 
     reasons = []
-    reasons << "financial records — payments, scholarships, or the like (reverted payments still count)" if allocations.exists?
+    reasons << "financial records — payments, scholarships, discounts, or refunds (reverted payments still count)" if allocations.exists?
     reasons << "attendance on record" if attendance_recorded?
+    reasons << "a transfer to another event on record" if transferred_out?
     "Can't be deleted — this registration has #{reasons.to_sentence}."
   end
 

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -18,8 +18,8 @@ class EventRegistrationDecorator < ApplicationDecorator
 
     reasons = []
     reasons << "financial records — payments, scholarships, discounts, or refunds (reverted payments still count)" if allocations.exists?
-    reasons << "attendance on record" if attendance_recorded?
-    reasons << "a transfer to another event on record" if transferred_out?
+    reasons << "an attendance outcome on record (attended, incomplete, or no-show)" if attendance_recorded?
+    reasons << "a transfer to another event" if transferred_out?
     "Can't be deleted — this registration has #{reasons.to_sentence}."
   end
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -270,10 +270,11 @@ class EventRegistration < ApplicationRecord
   end
 
   # Safe to delete only when removing the record would not orphan financial
-  # data or erase attendance history. Allocations (payments and scholarships)
-  # have no dependent: :destroy, so a registration with any allocation must be
-  # kept — even a reverted payment leaves its (now net-zero) allocation rows —
-  # as must one with an attendance outcome (attended, incomplete, or no-show).
+  # data or erase attendance history. Allocations tie the registration to a
+  # financial source of any kind (payments, scholarships, and others) and have
+  # no dependent: :destroy, so a registration with any allocation must be kept —
+  # even a reverted payment leaves its (now net-zero) allocation rows — as must
+  # one with an attendance outcome (attended, incomplete, or no-show).
   def deletable?
     !allocations.exists? && !attendance_recorded?
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -253,12 +253,17 @@ class EventRegistration < ApplicationRecord
     status.in?(ACTIVE_STATUSES)
   end
 
+  def attendance_recorded?
+    status.in?(%w[ attended incomplete_attendance ])
+  end
+
   # Safe to delete only when removing the record would not orphan financial
   # data or erase attendance history. Allocations (payments and scholarships)
   # have no dependent: :destroy, so a registration with any allocation must be
-  # kept, as must one with attendance (attended or incomplete) on record.
+  # kept — even a reverted payment leaves its (now net-zero) allocation rows —
+  # as must one with attendance (attended or incomplete) on record.
   def deletable?
-    !allocations.exists? && !status.in?(%w[ attended incomplete_attendance ])
+    !allocations.exists? && !attendance_recorded?
   end
 
   def checked_in?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -253,6 +253,18 @@ class EventRegistration < ApplicationRecord
     status.in?(ACTIVE_STATUSES)
   end
 
+  def attended?
+    status.in?(%w[ attended incomplete_attendance ])
+  end
+
+  # Safe to delete only when removing the record would not orphan financial
+  # data or erase attendance history. Allocations (payments and scholarships)
+  # have no dependent: :destroy, so a registration with any allocation must be
+  # kept, as must one with attendance on record.
+  def deletable?
+    !allocations.exists? && !attended?
+  end
+
   def checked_in?
     # checked_in_at.present?
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -21,6 +21,7 @@ class EventRegistration < ApplicationRecord
   accepts_nested_attributes_for :registrant
 
   before_create :generate_slug
+  after_update :release_scholarships, if: :status_changed_to_cancelled?
   after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance transferred_in ].freeze
@@ -253,16 +254,11 @@ class EventRegistration < ApplicationRecord
     status.in?(ACTIVE_STATUSES)
   end
 
-  # Public self-service cancellation: mark the registration cancelled and release
-  # any scholarship award back to its grant by zeroing the scholarship amount
-  # (which syncs its allocation to 0 via Scholarship#sync_allocation_amount). The
-  # allocation rows remain, so financial history is preserved and the record stays
-  # non-deletable. Setting status fires the cancellation emails via after_commit.
+  # Cancel this registration. Releasing scholarships and sending cancellation
+  # emails hang off the status-change callbacks, so this and every other path to
+  # "cancelled" (e.g. the admin edit form's status dropdown) behave identically.
   def cancel!
-    transaction do
-      scholarships.each { |scholarship| scholarship.update!(amount_cents: 0) }
-      update!(status: "cancelled")
-    end
+    update!(status: "cancelled")
   end
 
   def attendance_recorded?
@@ -509,6 +505,14 @@ class EventRegistration < ApplicationRecord
 
   def status_changed_to_cancelled?
     saved_change_to_status? && status == "cancelled"
+  end
+
+  # On cancellation, release any awarded scholarship back to its grant by zeroing
+  # the amount (Scholarship#sync_allocation_amount zeroes the allocation to match).
+  # scholarship_requested is left set on purpose: reactivating won't re-award, but
+  # the registration should still reflect that a scholarship was requested.
+  def release_scholarships
+    scholarships.each { |scholarship| scholarship.update!(amount_cents: 0) }
   end
 
   def send_cancellation_emails

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -269,14 +269,22 @@ class EventRegistration < ApplicationRecord
     status.in?(%w[ attended incomplete_attendance no_show ])
   end
 
-  # Safe to delete only when removing the record would not orphan financial
-  # data or erase attendance history. Allocations tie the registration to a
-  # financial source of any kind (payments, scholarships, and others) and have
-  # no dependent: :destroy, so a registration with any allocation must be kept —
-  # even a reverted payment leaves its (now net-zero) allocation rows — as must
-  # one with an attendance outcome (attended, incomplete, or no-show).
+  # Transferred out to another event. The trail to where the registrant went is
+  # history worth keeping, so it blocks deletion. Transferred_in is deliberately
+  # excluded: it's an ordinary active registration here, and the source event's
+  # transferred_out record already preserves the transfer trail.
+  def transferred_out?
+    status == "transferred_out"
+  end
+
+  # Safe to delete only when removing the record would not orphan financial data
+  # or erase history. Allocations tie the registration to a financial source of
+  # any kind (payments, scholarships, and others) and have no dependent: :destroy,
+  # so a registration with any allocation must be kept — even a reverted payment
+  # leaves its (now net-zero) allocation rows. An attendance outcome (attended,
+  # incomplete, or no-show) or a transfer out is likewise history worth keeping.
   def deletable?
-    !allocations.exists? && !attendance_recorded?
+    !allocations.exists? && !attendance_recorded? && !transferred_out?
   end
 
   def checked_in?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -253,16 +253,12 @@ class EventRegistration < ApplicationRecord
     status.in?(ACTIVE_STATUSES)
   end
 
-  def attended?
-    status.in?(%w[ attended incomplete_attendance ])
-  end
-
   # Safe to delete only when removing the record would not orphan financial
   # data or erase attendance history. Allocations (payments and scholarships)
   # have no dependent: :destroy, so a registration with any allocation must be
-  # kept, as must one with attendance on record.
+  # kept, as must one with attendance (attended or incomplete) on record.
   def deletable?
-    !allocations.exists? && !attended?
+    !allocations.exists? && !status.in?(%w[ attended incomplete_attendance ])
   end
 
   def checked_in?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -261,15 +261,19 @@ class EventRegistration < ApplicationRecord
     update!(status: "cancelled")
   end
 
+  # True once the event has happened and an attendance outcome is on record —
+  # attended, partially attended, or a no-show. Cancelled/transferred are not
+  # attendance outcomes. (Distinct from #active?, which is about registration
+  # standing, and #attended?, which is specifically "fully attended".)
   def attendance_recorded?
-    status.in?(%w[ attended incomplete_attendance ])
+    status.in?(%w[ attended incomplete_attendance no_show ])
   end
 
   # Safe to delete only when removing the record would not orphan financial
   # data or erase attendance history. Allocations (payments and scholarships)
   # have no dependent: :destroy, so a registration with any allocation must be
   # kept — even a reverted payment leaves its (now net-zero) allocation rows —
-  # as must one with attendance (attended or incomplete) on record.
+  # as must one with an attendance outcome (attended, incomplete, or no-show).
   def deletable?
     !allocations.exists? && !attendance_recorded?
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -253,6 +253,18 @@ class EventRegistration < ApplicationRecord
     status.in?(ACTIVE_STATUSES)
   end
 
+  # Public self-service cancellation: mark the registration cancelled and release
+  # any scholarship award back to its grant by zeroing the scholarship amount
+  # (which syncs its allocation to 0 via Scholarship#sync_allocation_amount). The
+  # allocation rows remain, so financial history is preserved and the record stays
+  # non-deletable. Setting status fires the cancellation emails via after_commit.
+  def cancel!
+    transaction do
+      scholarships.each { |scholarship| scholarship.update!(amount_cents: 0) }
+      update!(status: "cancelled")
+    end
+  end
+
   def attendance_recorded?
     status.in?(%w[ attended incomplete_attendance ])
   end

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -444,6 +444,11 @@
           <i class="fa-solid fa-trash-can"></i>
           Delete
         <% end %>
+      <% elsif allowed_to?(:destroy?, f.object) %>
+        <span class="inline-flex max-w-md items-start gap-2 text-sm text-gray-500">
+          <i class="fa-solid fa-circle-info mt-0.5 shrink-0 text-gray-400"></i>
+          <%= f.object.decorate.deletion_blocked_reason %>
+        </span>
       <% end %>
 
       <% cancel_path = case params[:return_to]

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -437,7 +437,7 @@
 
     <%# ---- Footer actions ---- %>
     <div class="flex items-center gap-3 border-t border-gray-200 pt-6">
-      <% if allowed_to?(:destroy?, f.object) %>
+      <% if allowed_to?(:destroy?, f.object) && f.object.deletable? %>
         <%= link_to event_registration_path(@event_registration, return_to: params[:return_to].presence),
                     class: "btn btn-danger-outline",
                     data: { turbo: true, turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } do %>

--- a/app/views/events/_registration_button.html.erb
+++ b/app/views/events/_registration_button.html.erb
@@ -7,11 +7,13 @@
     <span class="text-xs text-red-500">No event</span>
   <% elsif Current.user.nil? %>
     <span class="text-xs text-gray-500">Login to register</span>
-  <% elsif event.actively_registered?(Current.user.person) %>
-    <%= link_to "De-register",
-                event_registrant_registration_path(event_id: event),
-                data: { turbo_method: :delete, turbo_confirm: "Are you sure?"},
-                class: "btn btn-secondary-outline text-sm" %>
+  <% elsif (registration = event.active_registration_for(Current.user.person)) %>
+    <% if registration.deletable? %>
+      <%= link_to "De-register",
+                  event_registrant_registration_path(event_id: event),
+                  data: { turbo_method: :delete, turbo_confirm: "Are you sure?"},
+                  class: "btn btn-secondary-outline text-sm" %>
+    <% end %>
     <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">Registered</span>
   <% elsif event.ended? %>
     <span class="text-sm text-gray-500 italic">Event ended</span>

--- a/app/views/events/_registration_button.html.erb
+++ b/app/views/events/_registration_button.html.erb
@@ -7,13 +7,9 @@
     <span class="text-xs text-red-500">No event</span>
   <% elsif Current.user.nil? %>
     <span class="text-xs text-gray-500">Login to register</span>
-  <% elsif (registration = event.active_registration_for(Current.user.person)) %>
-    <% if registration.deletable? %>
-      <%= link_to "De-register",
-                  event_registrant_registration_path(event_id: event),
-                  data: { turbo_method: :delete, turbo_confirm: "Are you sure?"},
-                  class: "btn btn-secondary-outline text-sm" %>
-    <% end %>
+  <% elsif event.actively_registered?(Current.user.person) %>
+    <%# De-registering is a hard delete; the public self-service action is Cancel
+        (soft, reversible), offered on the registration ticket. ---- %>
     <span class="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">Registered</span>
   <% elsif event.ended? %>
     <span class="text-sm text-gray-500 italic">Event ended</span>

--- a/app/views/events/registrations/destroy.turbo_stream.erb
+++ b/app/views/events/registrations/destroy.turbo_stream.erb
@@ -1,8 +1,0 @@
-<%= turbo_stream.replace dom_id(@event, :card), partial: "events/card", locals: { event: @event } %>
-<% (1..5).each do |i| %>
-  <%= turbo_stream.replace dom_id(@event, "registration_section_#{i}"), partial: "events/registration_section", locals: { event: @event.decorate, instance: i } %>
-<% end %>
-
-<%= turbo_stream.replace_all ".inline-event-registration" , partial: "events/registration_button", locals: { event: @event.decorate } %>
-<%= turbo_stream.replace dom_id(@event, :videoconference_link), partial: "events/videoconference_link", locals: { event: @event.decorate } %>
-<%= turbo_stream.replace "flash_now", partial: "shared/flash_messages" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,7 @@ Rails.application.routes.draw do
       post :create_bulk_payment
     end
     resources :registration_ticket_callouts, only: [ :show, :update ]
-    resource :registrations, only: %i[ create destroy ], module: :events, as: :registrant_registration
+    resource :registrations, only: %i[ create ], module: :events, as: :registrant_registration
     resource :public_registration, only: [ :new, :create, :show ], module: :events
     resource :bulk_payment, only: [ :new, :create, :show ], module: :events
     resource :invoice, only: [ :show ], module: :events

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe EventRegistrationDecorator, type: :decorator do
+  describe "#deletion_blocked_reason" do
+    it "returns nil for a deletable registration" do
+      reg = create(:event_registration, status: "registered")
+      expect(reg.decorate.deletion_blocked_reason).to be_nil
+    end
+
+    it "explains a payment allocation, noting reverted payments still count" do
+      reg = create(:event_registration, status: "registered")
+      payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 1000)
+
+      reason = reg.decorate.deletion_blocked_reason
+      expect(reason).to include("payment or scholarship records")
+      expect(reason).to include("reverted payments still count")
+    end
+
+    it "still blocks (and explains) when the only payment has been reverted" do
+      reg = create(:event_registration, status: "registered")
+      payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)
+      allocation = create(:allocation, source: payment, allocatable: reg, amount: 1000)
+      revert = create(:allocation, source: payment, allocatable: reg, amount: -1000)
+      allocation.update!(reverted_id: revert.id)
+
+      expect(reg.decorate.deletable?).to be(false)
+      expect(reg.decorate.deletion_blocked_reason).to include("payment or scholarship records")
+    end
+
+    it "explains recorded attendance" do
+      reg = create(:event_registration, status: "attended")
+      expect(reg.decorate.deletion_blocked_reason).to eq(
+        "Can't be deleted — this registration has attendance on record."
+      )
+    end
+
+    it "combines both reasons when payment and attendance are present" do
+      reg = create(:event_registration, status: "attended")
+      payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 1000)
+
+      reason = reg.decorate.deletion_blocked_reason
+      expect(reason).to include("payment or scholarship records")
+      expect(reason).to include("attendance on record")
+    end
+  end
+end

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       expect(reason).to include("reverted payments still count")
     end
 
+    it "explains a non-payment allocation such as a discount" do
+      reg = create(:event_registration, status: "registered")
+      discount = create(:discount)
+      create(:allocation, source: discount, allocatable: reg, amount: -500)
+
+      reason = reg.decorate.deletion_blocked_reason
+      expect(reason).to include("financial records")
+      expect(reason).to include("discounts")
+    end
+
     it "still blocks (and explains) when the only payment has been reverted" do
       reg = create(:event_registration, status: "registered")
       payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)
@@ -40,6 +50,18 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       expect(reg.decorate.deletion_blocked_reason).to eq(
         "Can't be deleted — this registration has attendance on record."
       )
+    end
+
+    it "explains a transfer out to another event" do
+      reg = create(:event_registration, status: "transferred_out")
+      expect(reg.decorate.deletion_blocked_reason).to eq(
+        "Can't be deleted — this registration has a transfer to another event on record."
+      )
+    end
+
+    it "is deletable (no reason) when transferred in with no allocations" do
+      reg = create(:event_registration, status: "transferred_in")
+      expect(reg.decorate.deletion_blocked_reason).to be_nil
     end
 
     it "combines both reasons when payment and attendance are present" do

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       create(:allocation, source: payment, allocatable: reg, amount: 1000)
 
       reason = reg.decorate.deletion_blocked_reason
-      expect(reason).to include("payment or scholarship records")
+      expect(reason).to include("financial records")
       expect(reason).to include("reverted payments still count")
     end
 
@@ -25,7 +25,7 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       allocation.update!(reverted_id: revert.id)
 
       expect(reg.decorate.deletable?).to be(false)
-      expect(reg.decorate.deletion_blocked_reason).to include("payment or scholarship records")
+      expect(reg.decorate.deletion_blocked_reason).to include("financial records")
     end
 
     it "explains recorded attendance" do
@@ -48,7 +48,7 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       create(:allocation, source: payment, allocatable: reg, amount: 1000)
 
       reason = reg.decorate.deletion_blocked_reason
-      expect(reason).to include("payment or scholarship records")
+      expect(reason).to include("financial records")
       expect(reason).to include("attendance on record")
     end
   end

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       )
     end
 
+    it "treats a no-show as a recorded attendance outcome" do
+      reg = create(:event_registration, status: "no_show")
+      expect(reg.decorate.deletion_blocked_reason).to eq(
+        "Can't be deleted — this registration has attendance on record."
+      )
+    end
+
     it "combines both reasons when payment and attendance are present" do
       reg = create(:event_registration, status: "attended")
       payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -38,24 +38,24 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       expect(reg.decorate.deletion_blocked_reason).to include("financial records")
     end
 
-    it "explains recorded attendance" do
+    it "explains recorded attendance, enumerating the outcomes that count" do
       reg = create(:event_registration, status: "attended")
       expect(reg.decorate.deletion_blocked_reason).to eq(
-        "Can't be deleted — this registration has attendance on record."
+        "Can't be deleted — this registration has an attendance outcome on record (attended, incomplete, or no-show)."
       )
     end
 
     it "treats a no-show as a recorded attendance outcome" do
       reg = create(:event_registration, status: "no_show")
       expect(reg.decorate.deletion_blocked_reason).to eq(
-        "Can't be deleted — this registration has attendance on record."
+        "Can't be deleted — this registration has an attendance outcome on record (attended, incomplete, or no-show)."
       )
     end
 
     it "explains a transfer out to another event" do
       reg = create(:event_registration, status: "transferred_out")
       expect(reg.decorate.deletion_blocked_reason).to eq(
-        "Can't be deleted — this registration has a transfer to another event on record."
+        "Can't be deleted — this registration has a transfer to another event."
       )
     end
 
@@ -71,7 +71,7 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
 
       reason = reg.decorate.deletion_blocked_reason
       expect(reason).to include("financial records")
-      expect(reason).to include("attendance on record")
+      expect(reason).to include("an attendance outcome on record")
     end
   end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -107,22 +107,6 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
-  describe "#attended?" do
-    it "returns true for attended status" do
-      expect(create(:event_registration, status: "attended")).to be_attended
-    end
-
-    it "returns true for incomplete_attendance status" do
-      expect(create(:event_registration, status: "incomplete_attendance")).to be_attended
-    end
-
-    it "returns false for registered, cancelled, and no_show statuses" do
-      expect(create(:event_registration, status: "registered")).not_to be_attended
-      expect(create(:event_registration, status: "cancelled")).not_to be_attended
-      expect(create(:event_registration, status: "no_show")).not_to be_attended
-    end
-  end
-
   describe "#deletable?" do
     it "returns true for a plain registration with no allocations or attendance" do
       reg = create(:event_registration, status: "registered")

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -127,12 +127,14 @@ RSpec.describe EventRegistration, type: :model do
       expect(reg).not_to be_deletable
     end
 
-    it "returns false when the registration has attendance on record" do
+    it "returns false when the registration has an attendance outcome on record" do
       expect(create(:event_registration, status: "attended")).not_to be_deletable
       expect(create(:event_registration, status: "incomplete_attendance")).not_to be_deletable
+      expect(create(:event_registration, status: "no_show")).not_to be_deletable
     end
 
     it "returns true for a cancelled registration with no allocations" do
+      # Cancelling is a pre-event withdrawal, not an attendance outcome, so it stays deletable.
       expect(create(:event_registration, status: "cancelled")).to be_deletable
     end
   end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -137,6 +137,25 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#cancel!" do
+    it "marks the registration cancelled" do
+      reg = create(:event_registration, status: "registered")
+      reg.cancel!
+      expect(reg.reload.status).to eq("cancelled")
+    end
+
+    it "zeroes any scholarship award and its allocation" do
+      reg = create(:event_registration, event: create(:event, cost_cents: 50_000), status: "registered")
+      scholarship = create(:scholarship, recipient: reg.registrant, amount_cents: 50_000)
+      allocation = create(:allocation, source: scholarship, allocatable: reg, amount: 50_000)
+
+      reg.cancel!
+
+      expect(scholarship.reload.amount_cents).to eq(0)
+      expect(allocation.reload.amount).to eq(0)
+    end
+  end
+
   describe ".registrant_ids" do
     it "returns registrations for the registrants in a hyphenated id list" do
       person_a = create(:person)

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -143,16 +143,44 @@ RSpec.describe EventRegistration, type: :model do
       reg.cancel!
       expect(reg.reload.status).to eq("cancelled")
     end
+  end
 
-    it "zeroes any scholarship award and its allocation" do
-      reg = create(:event_registration, event: create(:event, cost_cents: 50_000), status: "registered")
+  describe "releasing scholarships when a registration is cancelled" do
+    # Returns a registered registration on a costed event with a $500 scholarship
+    # awarded against it (scholarship_requested flagged, as the real award flow does).
+    def registration_with_scholarship
+      reg = create(:event_registration, event: create(:event, cost_cents: 50_000),
+                                         status: "registered", scholarship_requested: true)
       scholarship = create(:scholarship, recipient: reg.registrant, amount_cents: 50_000)
       allocation = create(:allocation, source: scholarship, allocatable: reg, amount: 50_000)
+      [ reg, scholarship, allocation ]
+    end
+
+    it "zeroes the scholarship award and its allocation via #cancel!" do
+      reg, scholarship, allocation = registration_with_scholarship
 
       reg.cancel!
 
       expect(scholarship.reload.amount_cents).to eq(0)
       expect(allocation.reload.amount).to eq(0)
+    end
+
+    it "zeroes the scholarship on any transition to cancelled (e.g. admin edit form)" do
+      reg, scholarship, _allocation = registration_with_scholarship
+
+      reg.update!(status: "cancelled")
+
+      expect(scholarship.reload.amount_cents).to eq(0)
+    end
+
+    it "keeps scholarship_requested set and does not re-award when reactivated" do
+      reg, scholarship, _allocation = registration_with_scholarship
+
+      reg.cancel!
+      reg.update!(status: "registered")
+
+      expect(reg.reload.scholarship_requested).to be(true)
+      expect(scholarship.reload.amount_cents).to eq(0)
     end
   end
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -107,6 +107,52 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#attended?" do
+    it "returns true for attended status" do
+      expect(create(:event_registration, status: "attended")).to be_attended
+    end
+
+    it "returns true for incomplete_attendance status" do
+      expect(create(:event_registration, status: "incomplete_attendance")).to be_attended
+    end
+
+    it "returns false for registered, cancelled, and no_show statuses" do
+      expect(create(:event_registration, status: "registered")).not_to be_attended
+      expect(create(:event_registration, status: "cancelled")).not_to be_attended
+      expect(create(:event_registration, status: "no_show")).not_to be_attended
+    end
+  end
+
+  describe "#deletable?" do
+    it "returns true for a plain registration with no allocations or attendance" do
+      reg = create(:event_registration, status: "registered")
+      expect(reg).to be_deletable
+    end
+
+    it "returns false when the registration has a payment allocation" do
+      reg = create(:event_registration, status: "registered")
+      payment = create(:payment, person: reg.registrant, amount_cents: 1000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 1000)
+      expect(reg).not_to be_deletable
+    end
+
+    it "returns false when the registration has a scholarship allocation" do
+      reg = create(:event_registration, status: "registered")
+      scholarship = create(:scholarship, recipient: reg.registrant, amount_cents: 1000)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 1000)
+      expect(reg).not_to be_deletable
+    end
+
+    it "returns false when the registration has attendance on record" do
+      expect(create(:event_registration, status: "attended")).not_to be_deletable
+      expect(create(:event_registration, status: "incomplete_attendance")).not_to be_deletable
+    end
+
+    it "returns true for a cancelled registration with no allocations" do
+      expect(create(:event_registration, status: "cancelled")).to be_deletable
+    end
+  end
+
   describe ".registrant_ids" do
     it "returns registrations for the registrants in a hyphenated id list" do
       person_a = create(:person)

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -137,6 +137,17 @@ RSpec.describe EventRegistration, type: :model do
       # Cancelling is a pre-event withdrawal, not an attendance outcome, so it stays deletable.
       expect(create(:event_registration, status: "cancelled")).to be_deletable
     end
+
+    it "returns false for a transferred-out registration" do
+      # The trail to the destination event is history worth keeping.
+      expect(create(:event_registration, status: "transferred_out")).not_to be_deletable
+    end
+
+    it "returns true for a transferred-in registration with no allocations" do
+      # Transferred-in is an ordinary active registration here; the source event's
+      # transferred_out record preserves the transfer history.
+      expect(create(:event_registration, status: "transferred_in")).to be_deletable
+    end
   end
 
   describe "#cancel!" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -274,6 +274,24 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include("name=\"event_registration[expected_payment_method]\"")
         expect(response.body).to include("<option selected=\"selected\" value=\"Check\">Check</option>")
       end
+
+      it "shows a Delete button for a deletable registration" do
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include("fa-trash-can")
+        expect(response.body).not_to include("reverted payments still count")
+      end
+
+      it "hides Delete and explains why for a registration with payment records" do
+        payment = create(:payment, person: regular_user.person, amount_cents: 1000, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: existing_registration, amount: 1000)
+
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).not_to include("fa-trash-can")
+        expect(response.body).to include("payment or scholarship records")
+        expect(response.body).to include("reverted payments still count")
+      end
     end
 
     describe "PATCH /event_registrations/:id" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -396,6 +396,17 @@ RSpec.describe "EventRegistrations", type: :request do
           delete event_registration_path(existing_registration)
         }.to change(EventRegistration, :count).by(-1)
       end
+
+      it "refuses to delete a registration with payments on record" do
+        payment = create(:payment, person: regular_user.person, amount_cents: 1000, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: existing_registration, amount: 1000)
+
+        expect {
+          delete event_registration_path(existing_registration)
+        }.not_to change(EventRegistration, :count)
+
+        expect(flash[:alert]).to include("can't be deleted")
+      end
     end
 
     describe "organization linking" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -378,6 +378,16 @@ RSpec.describe "EventRegistrations", type: :request do
         expect { unrequest(existing_registration) }
           .not_to change { existing_registration.scholarships.count }
       end
+
+      it "zeroes a funded scholarship when the status is set to cancelled" do
+        scholarship = link_scholarship(existing_registration, amount_cents: 1000)
+
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { status: "cancelled" } }
+
+        expect(existing_registration.reload.status).to eq("cancelled")
+        expect(scholarship.reload.amount_cents).to eq(0)
+      end
     end
 
     describe "PATCH /event_registrations/:id logging a notification" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe "EventRegistrations", type: :request do
         get edit_event_registration_path(existing_registration)
 
         expect(response.body).not_to include("fa-trash-can")
-        expect(response.body).to include("payment or scholarship records")
+        expect(response.body).to include("financial records")
         expect(response.body).to include("reverted payments still count")
       end
     end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -497,6 +497,19 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(flash[:alert]).to eq("Registration is already cancelled.")
     end
 
+    it "zeroes any scholarship award when cancelling" do
+      costed_registration = create(:event_registration, event: create(:event, cost_cents: 50_000),
+                                                         registrant: user.person, status: "registered")
+      scholarship = create(:scholarship, recipient: user.person, amount_cents: 50_000)
+      allocation = create(:allocation, source: scholarship, allocatable: costed_registration, amount: 50_000)
+
+      post registration_cancel_path(costed_registration.slug)
+
+      expect(costed_registration.reload.status).to eq("cancelled")
+      expect(scholarship.reload.amount_cents).to eq(0)
+      expect(allocation.reload.amount).to eq(0)
+    end
+
     context "as a guest" do
       before { sign_out user }
 
@@ -708,74 +721,6 @@ RSpec.describe "Events::Registrations", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq("text/vnd.turbo-stream.html")
         expect(flash.now[:alert]).to eq("Cannot register")
-      end
-    end
-  end
-
-  describe "DELETE /events/:event_id/registrations" do
-    context "when registration exists" do
-      let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
-
-      it "destroys registration and returns turbo stream" do
-        expect {
-          delete event_registrant_registration_path(event_id: event.id),
-            headers: turbo_headers
-        }.to change(EventRegistration, :count).by(-1)
-
-        expect(response).to have_http_status(:ok)
-        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
-        expect(flash.now[:notice]).to eq("You are no longer registered.")
-      end
-    end
-
-    context "when registration does not exist" do
-      it "returns turbo stream with alert" do
-        delete event_registrant_registration_path(event_id: event.id),
-          headers: turbo_headers
-
-        expect(response).to have_http_status(:ok)
-        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
-        expect(flash.now[:alert]).to eq("Registration not found")
-      end
-    end
-
-    context "when the registration has payments on record" do
-      let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
-
-      before do
-        payment = create(:payment, person: user.person, amount_cents: 1000, amount_cents_remaining: nil)
-        create(:allocation, source: payment, allocatable: registration, amount: 1000)
-      end
-
-      it "refuses to destroy and returns an alert" do
-        expect {
-          delete event_registrant_registration_path(event_id: event.id),
-            headers: turbo_headers
-        }.not_to change(EventRegistration, :count)
-
-        expect(flash.now[:alert]).to include("Cancel your registration instead")
-      end
-    end
-
-    context "when destroy fails" do
-      let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
-
-      before do
-        allow_any_instance_of(EventRegistration)
-          .to receive(:destroy)
-          .and_return(false)
-        allow_any_instance_of(EventRegistration)
-          .to receive_message_chain(:errors, :full_messages)
-          .and_return([ "Cannot delete" ])
-      end
-
-      it "returns turbo stream with alert" do
-        delete event_registrant_registration_path(event_id: event.id),
-          headers: turbo_headers
-
-        expect(response).to have_http_status(:ok)
-        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
-        expect(flash.now[:alert]).to eq("Cannot delete")
       end
     end
   end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -739,6 +739,24 @@ RSpec.describe "Events::Registrations", type: :request do
       end
     end
 
+    context "when the registration has payments on record" do
+      let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+
+      before do
+        payment = create(:payment, person: user.person, amount_cents: 1000, amount_cents_remaining: nil)
+        create(:allocation, source: payment, allocatable: registration, amount: 1000)
+      end
+
+      it "refuses to destroy and returns an alert" do
+        expect {
+          delete event_registrant_registration_path(event_id: event.id),
+            headers: turbo_headers
+        }.not_to change(EventRegistration, :count)
+
+        expect(flash.now[:alert]).to include("Cancel your registration instead")
+      end
+    end
+
     context "when destroy fails" do
       let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 


### PR DESCRIPTION
### What is the goal of this PR and why is this important?
- Prevent event registrations from being deleted when doing so would orphan financial records or erase attendance history.
- Allocations (payments, scholarships, and other financial sources) have no `dependent: :destroy`, so deleting such a registration leaves dangling records; attended/incomplete-attendance registrations are kept as a record.

### How did you approach the change?
- Added `EventRegistration#deletable?` (`!allocations.exists?` and no recorded attendance) as the single source of truth.
- **Admin:** hid the Delete button on the edit form (with a note explaining why it's absent) and enforced the same guard server-side in `EventRegistrationsController#destroy` — hiding a button alone leaves the DELETE route open.
- **Public:** replaced the public self-service "De-register" (a hard delete) with a **Cancel** action. Cancelling releases the scholarship and keeps the record, so it can never orphan financial or attendance data — no `deletable?` guard is needed. The public `destroy` route and `Events::RegistrationsController#destroy` action were removed.

### UI Testing Checklist
- [ ] Admin edit form: Delete button hidden (with reason note) for a registration with an allocation or recorded attendance; shown for a plain registered/cancelled one.
- [ ] Attempting the admin DELETE directly when not deletable shows an alert and does not destroy the record.
- [ ] Public event page: the self-service action is **Cancel** (not De-register); cancelling releases any scholarship and keeps the record.

### Anything else to add?
- Rebased onto current main; reconciled with main's newer `attended?` (used by certificate/joinable logic) by inlining the attendance check in `deletable?` rather than redefining the method.
