### PR TITLE
Use "Submit" label on /new form buttons

### DIFF
--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -41,7 +41,7 @@
     </div>
     <%= f.input :amount_dollars, label: "Amount ($)", input_html: { min: 0, step: 0.01, placeholder: "0.00", data: { controller: "currency-input", action: "currency-input#format" } } %>
     <div class="mt-6">
-      <%= f.button :submit, "Create Allocation", class: "btn btn-primary" %>
+      <%= f.button :submit, "Submit", class: "btn btn-primary" %>
       <% if source.present? %>
         <%= link_to "Cancel", payment_path(source), class: "btn btn-secondary-outline ml-2" %>
       <% else %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -450,7 +450,7 @@
 
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", cancel_path, class: "btn btn-secondary-outline" %>
-        <%= f.button :submit, f.object.persisted? ? "Save changes" : "Create registration", class: "btn btn-primary" %>
+        <%= f.button :submit, f.object.persisted? ? "Save changes" : "Submit", class: "btn btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -83,7 +83,7 @@
 
         <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
           <div class="flex items-center gap-3">
-            <%= f.submit "Create form", class: "btn btn-primary cursor-pointer" %>
+            <%= f.submit "Submit", class: "btn btn-primary cursor-pointer" %>
             <%= link_to "Cancel", forms_path, class: "btn btn-secondary-outline" %>
           </div>
         </div>

--- a/app/views/payments/_form.html.erb
+++ b/app/views/payments/_form.html.erb
@@ -40,6 +40,6 @@
       <%= f.input :check_number, input_html: { class: "bg-white" } %>
       <%= f.input :memo, label: "Memo", input_html: { class: "bg-white", placeholder: "Memo line on the check" } %>
     <% end %>
-    <div class="mt-6"><%= f.button :submit, "Create Payment", class: "btn btn-primary" %><%= link_to "Cancel", payments_path, class: "btn btn-secondary-outline ml-2" %></div>
+    <div class="mt-6"><%= f.button :submit, "Submit", class: "btn btn-primary" %><%= link_to "Cancel", payments_path, class: "btn btn-secondary-outline ml-2" %></div>
   <% end %>
 </div>

--- a/app/views/refunds/new.html.erb
+++ b/app/views/refunds/new.html.erb
@@ -68,7 +68,7 @@
 
     <%= f.input :amount_dollars, label: "Amount ($)", input_html: { min: 0, step: 0.01, placeholder: "0.00", data: { controller: "currency-input", action: "currency-input#format" } } %>
     <div class="mt-6">
-      <%= f.button :submit, @payment.is_a?(ExternalProcessorPayment) ? "Refund via Stripe" : "Create Refund", class: "btn btn-primary" %>
+      <%= f.button :submit, @payment.is_a?(ExternalProcessorPayment) ? "Refund via Stripe" : "Submit", class: "btn btn-primary" %>
       <% if @payment.present? %>
         <%= link_to "Cancel", payment_path(@payment), class: "btn btn-secondary ml-2" %>
       <% else %>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -267,6 +267,6 @@
 
   <div class="ml-auto flex items-center gap-3">
     <%= link_to "Cancel", cancel_path, class: "btn btn-secondary-outline" %>
-    <%= f.submit f.object.persisted? ? "Save changes" : "Create scholarship", class: "btn btn-primary" %>
+    <%= f.submit f.object.persisted? ? "Save changes" : "Submit", class: "btn btn-primary" %>
   </div>
 </div>


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Standardizes the submit call to action on new-record forms to read **"Submit"** instead of "Create &lt;Model&gt;"
- Gives creation screens a consistent label across the app

### How did you approach the change?

- Replaced explicit `"Create …"` submit labels with `"Submit"` on forms served from `/new` endpoints
- For partials shared between `new` and `edit`, only the new-record branch was changed; the edit label (e.g. "Save changes" / "Update") is preserved
- Files touched:
  - `forms/new.html.erb` — "Create form" → "Submit"
  - `payments/_form.html.erb` (rendered only by `payments/new`) — "Create Payment" → "Submit"
  - `allocations/new.html.erb` — "Create Allocation" → "Submit"
  - `refunds/new.html.erb` — "Create Refund" → "Submit" (kept "Refund via Stripe" branch)
  - `scholarships/_form.html.erb` — new branch "Create scholarship" → "Submit"
  - `event_registrations/_form.html.erb` — new branch "Create registration" → "Submit"

### Anything else to add?

- **Marked HOLD** pending confirmation on scope.
- **Intentionally left unchanged** (flagging for reviewer):
  - `payments/_allocation_form.html.erb` and `discounts/_allocation_form.html.erb` ("Create Payment"/"Create Discount") render via the custom `allocation_form` turbo action, **not** a `/new` route.
  - ~30 forms use bare `f.button :submit` (no explicit label); simple_form auto-renders these as "Create &lt;Model&gt;" on new / "Update &lt;Model&gt;" on edit. Switching those to "Submit" would require a per-form `persisted?` conditional in each shared partial — held off pending direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)