### PR TITLE
Add communications/notifications section to person edit

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -209,6 +209,10 @@ class PeopleController < ApplicationController
     @person.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
     @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
+    # Inline-logged notifications are addressed to the person.
+    recipient_email = @person.preferred_email.presence || "n/a"
+    @person.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
+
     if @person.save
       assign_associations(@person) if params.dig(:person, :category_ids)
       redirect_to person_update_return_path, notice: "Person was successfully updated."
@@ -488,6 +492,7 @@ class PeopleController < ApplicationController
         :_destroy
       ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id ]
     )
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -60,6 +60,7 @@ class Notification < ApplicationRecord
   NOTICEABLE_TYPES = %w[
     EventRegistration
     FormSubmission
+    Person
     Report
     StoryIdea
     User

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -17,6 +17,7 @@ class Person < ApplicationRecord
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :contact_methods, as: :contactable, dependent: :destroy
   has_many :categorizable_items, inverse_of: :categorizable, as: :categorizable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :destroy
   has_many :sectorable_items, as: :sectorable, dependent: :destroy
   has_many :stories_as_spotlighted_facilitator, inverse_of: :spotlighted_facilitator, class_name: "Story",
            dependent: :restrict_with_error
@@ -69,6 +70,7 @@ class Person < ApplicationRecord
   accepts_nested_attributes_for :affiliations, allow_destroy: true,
     reject_if: proc { |attrs| attrs["organization_id"].blank? }
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+  accepts_nested_attributes_for :notifications, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   # Search Cop
   include SearchCop

--- a/app/views/notifications/_notification_fields.html.erb
+++ b/app/views/notifications/_notification_fields.html.erb
@@ -7,10 +7,10 @@
 <% sender_users |= [ current_user ] if current_user %>
 <% sender_options = sender_users.sort_by { |u| u.full_name.to_s.downcase }.map { |u| [ u.full_name, u.id ] } %>
 <% channel_default = Notification::MANUAL_CHANNELS.include?(f.object.channel) ? f.object.channel : "email" %>
-<% record = local_assigns[:event_registration] %>
+<% record = local_assigns[:record] %>
 <div class="nested-fields rounded-md border border-amber-200 bg-amber-50 p-3">
-  <%# Record this communication against the event registration (the "Record"
-      column in the notifications index). %>
+  <%# Record this communication against its parent (the "Record" column in the
+      notifications index) — e.g. an event registration or a person. %>
   <% if record %>
     <%= f.hidden_field :noticeable_type, value: record.class.name %>
     <%= f.hidden_field :noticeable_id, value: record.id %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -446,6 +446,11 @@
   </div>
 
   <% if f.object.persisted? %>
+    <!-- Notifications -->
+    <% if allowed_to?(:index?, with: NotificationPolicy) %>
+      <%= render "notifications", f: f %>
+    <% end %>
+
     <!-- Comments -->
     <% if allowed_to?(:manage?, Comment) %>
       <div class="admin-only bg-blue-100 form-group space-y-4" id="comments-section">

--- a/app/views/people/_notifications.html.erb
+++ b/app/views/people/_notifications.html.erb
@@ -1,17 +1,17 @@
-<%# ---- Notifications — communications for this registrant, newest first.
+<%# ---- Notifications — communications addressed to this person, newest first.
     Persisted entries are read-only and paginated like the comments box; new
     manual log entries (email/phone/text/video) can be added inline and are
-    saved with the registration form. Links open in a new tab so unsaved edits
-    aren't lost. ---- %>
-<% registration = f.object %>
-<% email = registration.registrant.preferred_email %>
+    saved with the person form. Links open in a new tab so unsaved edits aren't
+    lost. Mirrors the registration edit notifications section. ---- %>
+<% person = f.object %>
+<% email = person.preferred_email %>
 <% notifications = email.present? ? Notification.email(email).order(created_at: :desc) : Notification.none %>
 <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
   <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:users, intensity: 100) %> <%= DomainTheme.text_class_for(:users, intensity: 600) %>">
       <i class="fa-solid fa-bell"></i>
     </span>
-    <h2 class="text-sm font-semibold text-gray-700">Registration communications</h2>
+    <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
     <% if email.present? %>
       <%= link_to notifications_path(email: email),
                   class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
@@ -42,17 +42,17 @@
         <div data-paginated-fields-target="nav"></div>
       </div>
     <% else %>
-      <p class="text-sm text-gray-400">No notifications for this registrant yet.</p>
+      <p class="text-sm text-gray-400">No notifications for this person yet.</p>
     <% end %>
 
-    <%# Inline add — manual log entries, saved with the registration form. %>
+    <%# Inline add — manual log entries, saved with the person form. %>
     <div class="space-y-2 border-t border-gray-100 pt-3">
-      <%= f.simple_fields_for :notifications, registration.notifications.select(&:new_record?) do |nf| %>
-        <%= render "notifications/notification_fields", f: nf, record: registration %>
+      <%= f.simple_fields_for :notifications, person.notifications.select(&:new_record?) do |nf| %>
+        <%= render "notifications/notification_fields", f: nf, record: person %>
       <% end %>
       <%= link_to_add_association f, :notifications,
             partial: "notifications/notification_fields",
-            render_options: { locals: { record: registration } },
+            render_options: { locals: { record: person } },
             class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
         <i class="fa-solid fa-plus text-[0.6rem]"></i>
         Add notification

--- a/spec/requests/people_notifications_spec.rb
+++ b/spec/requests/people_notifications_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Person notifications", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+
+  before { sign_in admin }
+
+  describe "PATCH /people/:id logging a notification" do
+    it "creates a manual notification log from nested attributes" do
+      expect {
+        patch person_path(person), params: {
+          person: {
+            notifications_attributes: { "0" => { channel: "phone", email_subject: "Left a voicemail" } }
+          }
+        }
+      }.to change { person.notifications.count }.by(1)
+
+      notification = person.notifications.order(:created_at).last
+      expect(notification.channel).to eq("phone")
+      expect(notification.kind).to eq("manual_log")
+      expect(notification.email_subject).to eq("Left a voicemail")
+      expect(notification.recipient_email).to eq(person.preferred_email)
+      expect(notification.noticeable).to eq(person)
+    end
+
+    it "ignores a blank notification with no note" do
+      expect {
+        patch person_path(person), params: {
+          person: {
+            notifications_attributes: { "0" => { channel: "email", email_subject: "" } }
+          }
+        }
+      }.not_to change(Notification, :count)
+    end
+  end
+
+  describe "GET /people/:id/edit" do
+    it "lists past communications addressed to the person" do
+      person = create(:person, user: nil, email: "comms@example.com")
+      create(:notification, recipient_email: "comms@example.com", email_subject: "Welcome aboard",
+                            kind: "manual_log", recipient_role: "person", notification_type: 0)
+
+      get edit_person_path(person)
+
+      expect(response.body).to include("Communications")
+      expect(response.body).to include("Welcome aboard")
+    end
+  end
+end


### PR DESCRIPTION
### What is the goal of this PR and why is this important?

- Admins managing event registrations already get a communications log on the registration edit page; the same context is valuable when working a person record directly.
- This mirrors that section on the person edit page so admins can see and log communications without bouncing through a registration.

### How did you approach the change?

- Added a `notifications` polymorphic association (`as: :noticeable`) and nested attributes to `Person`, matching `EventRegistration`.
- Added `Person` to `Notification::NOTICEABLE_TYPES` so person-logged communications appear in the notifications index "Record" filter and links resolve.
- Permitted `notifications_attributes` in `PeopleController#person_params` and set `recipient_email` on new manual logs in `#update` (mirrors the registration controller).
- New `app/views/people/_notifications.html.erb` partial mirroring `event_registrations/_notifications` — read-only paginated history (matched by `preferred_email`, newest first) plus inline "Add notification" logging.
- Rendered the section in the person form above comments, gated by `NotificationPolicy#index?` (admin-only — owners editing their own profile don't see it).
- Generalized the shared `notifications/_notification_fields` partial's `event_registration:` local to a neutral `record:` local; updated both the registration and person callers.

### Anything else to add?

- **Marked HOLD** pending review — confirm the desired styling/placement and admin-only gating before merging.
- Rebased onto current `main` (resolved conflicts in `Notification::NOTICEABLE_TYPES` and `comments_attributes`).
- Tests: new `spec/requests/people_notifications_spec.rb` (creates a manual log from nested attributes, ignores blank entries, lists past communications on the edit page). Verified no regressions across `people_notifications`, `event_registrations`, and the `event_registration_edit` system spec (98 examples, 0 failures). Lint clean.
- No browser screenshot captured here; the shared-partial system spec passes, but a visual spot-check of the person edit page is worth doing before un-holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)