### PR TITLE
Fix videoconference details to withhold until a week before, for paid registrants

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -62,12 +62,19 @@ class EventDecorator < ApplicationDecorator
     length ? description&.truncate(length) : description
   end
 
-  def calendar_links
+  # `show_videoconference_details` controls whether the join link/ID/passcode are
+  # carried into the calendar entry. Callers with a registration pass that
+  # registrant's gate (date + paid/intends); the default falls back to the
+  # event-level date gate for registration-less contexts.
+  def calendar_links(show_videoconference_details: object.videoconference_details_visible?)
     start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
     end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
     title_encoded = ERB::Util.url_encode(object.title)
 
-    has_url      = object.videoconference_url.present?
+    # The join URL doubles as the calendar location, so withhold it from there
+    # too until the details may be shared — a physical location (if any) takes
+    # its place, otherwise the entry is left without a location.
+    has_url      = object.videoconference_url.present? && show_videoconference_details
     has_location = object.location.present?
     location_name = has_location ? object.location.name : nil
 
@@ -91,8 +98,10 @@ class EventDecorator < ApplicationDecorator
     end
 
     # Carry the join link, meeting ID/code, and passcode into the calendar entry
-    # so registrants have everything they need to connect straight from the event.
-    description = [ videoconference_calendar_details, base_description ].compact_blank.join("\n\n")
+    # so registrants have everything they need to connect straight from the event
+    # — but only once the details may be shared (date + paid/intends).
+    vc_details = videoconference_calendar_details if show_videoconference_details
+    description = [ vc_details, base_description ].compact_blank.join("\n\n")
 
     desc_encoded     = ERB::Util.url_encode(description)
     location_encoded = ERB::Util.url_encode(cal_location.to_s)
@@ -317,6 +326,7 @@ class EventDecorator < ApplicationDecorator
 
   # The videoconference connection block (join link, meeting ID/code, passcode)
   # as plain text for embedding in calendar entries. Nil when there's no link.
+  # Whether it's actually embedded is the caller's call (see #calendar_links).
   def videoconference_calendar_details
     return if videoconference_url.blank?
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,12 @@ class Event < ApplicationRecord
   # link is available to paid registrants.
   VIDEOCONFERENCE_JOIN_BUFFER = 30.minutes
 
+  # How far ahead of the start the videoconference connection details (join link,
+  # meeting ID, passcode) may be shared. Kept hidden until then so the link isn't
+  # exposed — on the ticket, the videoconference page, or in calendar entries —
+  # more than a week in advance.
+  VIDEOCONFERENCE_DETAILS_LEAD = 7.days
+
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
@@ -134,6 +140,13 @@ class Event < ApplicationRecord
     return false unless start_date && end_date
     now = Time.current
     now >= start_date - VIDEOCONFERENCE_JOIN_BUFFER && now <= end_date + VIDEOCONFERENCE_JOIN_BUFFER
+  end
+
+  # Whether the videoconference connection details may be revealed yet: only once
+  # the event is within VIDEOCONFERENCE_DETAILS_LEAD of starting.
+  def videoconference_details_visible?
+    return false unless start_date
+    Time.current >= start_date - VIDEOCONFERENCE_DETAILS_LEAD
   end
 
   def registerable?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -314,6 +314,16 @@ class EventRegistration < ApplicationRecord
     active? && payment_access_granted? && event.videoconference_window_open?
   end
 
+  # Whether this registrant may see the videoconference connection details yet
+  # (join link, meeting ID, passcode) — on the ticket, the videoconference page,
+  # and in calendar entries. Gated on payment access (paid or intends to pay) AND
+  # the event being within a week of starting, so the link isn't shared early.
+  # Distinct from #joinable?, which is the tight 30-minute "click to join now"
+  # window for the live link.
+  def videoconference_details_visible?
+    payment_access_granted? && event.videoconference_details_visible?
+  end
+
   # Bucket the registrant's login account into one of four states for the bulk
   # reminder filters. Precedence matters: a confirmed, unlocked, active account
   # has access regardless of when it was invited; a still-pending account counts

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -36,17 +36,13 @@
       </p>
     <% end %>
 
-    <% if @event.videoconference_url.present? %>
+    <%# Virtual events show only the platform label (e.g. "Zoom") — the join link,
+        meeting ID, and passcode are withheld until a week before and live on the
+        ticket/videoconference pages, not in the confirmation. %>
+    <% if event_platform_label(@event).present? %>
       <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
-        <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= @event.decorate.videoconference_domain %></a>
+        <%= event_platform_label(@event) %>
       </p>
-      <% vc_room = @event.decorate.videoconference_room %>
-      <% if vc_room %>
-        <p style="font-size: 14px; color: #6b7280; margin: 0 0 4px;"><%= vc_room[:label] %>: <%= vc_room[:value] %></p>
-      <% end %>
-      <% if @event.videoconference_passcode.present? %>
-        <p style="font-size: 14px; color: #6b7280; margin: 0 0 8px;">Passcode: <%= @event.videoconference_passcode %></p>
-      <% end %>
     <% end %>
 
     <% if @event.registration_close_date %>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -12,12 +12,9 @@ This message confirms your registration for the following event:
 Location: <%= @event.location.name %>
 <% end %>
 
-<% if @event.videoconference_url.present? %>
-Videoconference URL: <%= @event.videoconference_url %>
-<% vc_room = @event.decorate.videoconference_room %>
-<% if vc_room %><%= vc_room[:label] %>: <%= vc_room[:value] %>
-<% end %><% if @event.videoconference_passcode.present? %>Passcode: <%= @event.videoconference_passcode %>
-<% end %><% end %>
+<% if event_platform_label(@event).present? %>
+Videoconference: <%= event_platform_label(@event) %>
+<% end %>
 
 <% if @event.labelled_cost.present? %>
   <%= @event.labelled_cost %>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -167,7 +167,7 @@
             Add to your calendar
           </p>
 
-          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links %></div>
+          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?) %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -58,11 +58,12 @@
 
   <% if (registered || slug_registered) && !event.ended? %>
     <!-- CALENDAR LINKS -->
+    <% calendar_registration = registered ? event.active_registration_for(current_user&.person) : slug_registration %>
     <div class="flex flex-col items-center mt-4">
       <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
         Add to Your Calendar
       </p>
-      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links %></div>
+      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?) %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -3,20 +3,30 @@
 <%= render layout: "events/callouts/callout_page", locals: { title: "Videoconference" } do %>
   <div class="space-y-6">
     <% if @event.videoconference_url.present? %>
-      <div>
-        <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Join link</p>
-        <%= link_to @event.videoconference_url, target: "_blank", rel: "noopener",
-                    class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700" do %>
-          <i class="fa-solid fa-video"></i> Join on <%= @event.videoconference_domain %>
-        <% end %>
-        <p class="mt-2 text-xs text-gray-500 break-all"><%= @event.videoconference_url %></p>
-        <%= render "events/videoconference_connection", event: @event %>
-      </div>
+      <% if @event_registration.videoconference_details_visible? %>
+        <div>
+          <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Join link</p>
+          <%= link_to @event.videoconference_url, target: "_blank", rel: "noopener",
+                      class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700" do %>
+            <i class="fa-solid fa-video"></i> Join on <%= @event.videoconference_domain %>
+          <% end %>
+          <p class="mt-2 text-xs text-gray-500 break-all"><%= @event.videoconference_url %></p>
+          <%= render "events/videoconference_connection", event: @event %>
+        </div>
+      <% elsif !@event_registration.payment_access_granted? %>
+        <div class="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+          The videoconference link unlocks once your payment is on file. Make your payment from your ticket to gain access.
+        </div>
+      <% else %>
+        <div class="rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-600">
+          The videoconference link will be available here about a week before the event.
+        </div>
+      <% end %>
     <% end %>
 
     <div class="border-t border-gray-100 pt-5">
       <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Add to your calendar</p>
-      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links %></div>
+      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?) %></div>
     </div>
   </div>
 <% end %>

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.html.erb
@@ -43,17 +43,12 @@
     </p>
   <% end %>
 
-  <% if @event.videoconference_url.present? %>
+  <%# Virtual events show only the platform label (e.g. "Zoom") — the join link,
+      meeting ID, and passcode are withheld and live on the ticket pages. %>
+  <% if event_platform_label(@event).present? %>
     <p style="font-size: 16px; color: #374151; margin: 0 0 8px;">
-      <a href="<%= @event.videoconference_url %>" style="color: #374151; text-decoration: underline;">Join us on <%= @event.decorate.videoconference_domain %></a>
+      <%= event_platform_label(@event) %>
     </p>
-    <% vc_room = @event.decorate.videoconference_room %>
-    <% if vc_room %>
-      <p style="font-size: 14px; color: #6b7280; margin: 0 0 4px;"><%= vc_room[:label] %>: <%= vc_room[:value] %></p>
-    <% end %>
-    <% if @event.videoconference_passcode.present? %>
-      <p style="font-size: 14px; color: #6b7280; margin: 0 0 8px;">Passcode: <%= @event.videoconference_passcode %></p>
-    <% end %>
   <% end %>
 </div>
 

--- a/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/event_registration_confirmation_fyi.text.erb
@@ -23,13 +23,10 @@ Event date
   <%= @event.location.name %>
 <% end %>
 
-<% if @event.videoconference_url.present? %>
-  Videoconference URL
-  <%= @event.videoconference_url %>
-<% vc_room = @event.decorate.videoconference_room %>
-<% if vc_room %>  <%= vc_room[:label] %>: <%= vc_room[:value] %>
-<% end %><% if @event.videoconference_passcode.present? %>  Passcode: <%= @event.videoconference_passcode %>
-<% end %><% end %>
+<% if event_platform_label(@event).present? %>
+  Videoconference
+  <%= event_platform_label(@event) %>
+<% end %>
 
 <% if @event.labelled_cost.present? %>
   Cost

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -159,8 +159,9 @@ RSpec.describe EventDecorator do
       expect(yahoo["href"]).to include("desc=#{desc_encoded}")
     end
 
-    it "embeds the join link, meeting ID, and passcode in the calendar description" do
+    it "embeds the join link, meeting ID, and passcode within a week of the event" do
       event = create(:event,
+                      start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours,
                       videoconference_url: "https://awbw.zoom.us/j/88285411273",
                       videoconference_passcode: "secret123")
       decorated = event.decorate
@@ -171,6 +172,21 @@ RSpec.describe EventDecorator do
       expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
       expect(apple["href"]).to include("Meeting ID: 882 8541 1273")
       expect(apple["href"]).to include("Passcode: secret123")
+    end
+
+    it "omits the join link, meeting ID, and passcode more than a week out" do
+      event = create(:event,
+                      start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours,
+                      videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                      videoconference_passcode: "secret123")
+      decorated = event.decorate
+
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      apple = doc.css("a").find { |a| a.text == "Apple" }
+
+      expect(apple["href"]).not_to include("88285411273")
+      expect(apple["href"]).not_to include("Meeting ID")
+      expect(apple["href"]).not_to include("secret123")
     end
   end
 

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -73,6 +73,23 @@ RSpec.describe EventMailer, type: :mailer do
         expect(mail.body.encoded).not_to include("<strong>Details</strong>")
       end
     end
+
+    context "for a virtual event" do
+      let(:event) { create(:event, videoconference_url: "https://zoom.us/j/123", videoconference_label: "Zoom", videoconference_passcode: "secret123") }
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "shows the platform label as plain text" do
+        expect(mail.html_part.body.encoded).to include("Zoom")
+        expect(mail.text_part.body.encoded).to include("Zoom")
+      end
+
+      it "does not include the join link, meeting ID, or passcode" do
+        body = mail.body.encoded
+        expect(body).not_to include("https://zoom.us/j/123")
+        expect(body).not_to include("secret123")
+        expect(body).not_to include("Meeting ID")
+      end
+    end
   end
 
   describe "#bulk_payment_confirmation" do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(subject).to include("New event scholarship registration by")
       end
     end
+
+    context "for a virtual event" do
+      let(:event) { create(:event, videoconference_url: "https://zoom.us/j/123", videoconference_label: "Zoom", videoconference_passcode: "secret123") }
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "shows the platform label as plain text" do
+        body = described_class.event_registration_confirmation_fyi(notification).body.encoded
+        expect(body).to include("Zoom")
+      end
+
+      it "does not include the join link, meeting ID, or passcode" do
+        body = described_class.event_registration_confirmation_fyi(notification).body.encoded
+        expect(body).not_to include("https://zoom.us/j/123")
+        expect(body).not_to include("secret123")
+        expect(body).not_to include("Meeting ID")
+      end
+    end
   end
 
   describe "#report_submitted_fyi" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -337,6 +337,34 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#videoconference_details_visible?" do
+    let(:user) { create(:user, :with_person) }
+
+    it "is true within a week of the start for a registrant with payment access" do
+      event = create(:event, cost_cents: 1099, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      expect(reg.videoconference_details_visible?).to be true
+    end
+
+    it "is false more than a week before the start" do
+      event = create(:event, cost_cents: 1099, start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
+      reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      expect(reg.videoconference_details_visible?).to be false
+    end
+
+    it "is false within a week when the registrant lacks payment access" do
+      event = create(:event, cost_cents: 1099, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      reg = create(:event_registration, event: event, registrant: user.person)
+      expect(reg.videoconference_details_visible?).to be false
+    end
+
+    it "is true within a week for a free event regardless of payment" do
+      event = create(:event, cost_cents: 0, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      reg = create(:event_registration, event: event, registrant: user.person)
+      expect(reg.videoconference_details_visible?).to be true
+    end
+  end
+
   describe ".payment_status scope" do
     let(:event) { create(:event, cost_cents: 1099) }
     let(:user) { create(:user, :with_person) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -88,6 +88,28 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#videoconference_details_visible?" do
+    it "returns false when there is no start_date" do
+      event = build(:event, start_date: nil)
+      expect(event.videoconference_details_visible?).to be false
+    end
+
+    it "returns false more than a week before the start" do
+      event = build(:event, start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
+      expect(event.videoconference_details_visible?).to be false
+    end
+
+    it "returns true within a week of the start" do
+      event = build(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      expect(event.videoconference_details_visible?).to be true
+    end
+
+    it "returns true once the event has started" do
+      event = build(:event, start_date: 1.hour.ago, end_date: 1.hour.from_now)
+      expect(event.videoconference_details_visible?).to be true
+    end
+  end
+
   describe "#registerable?" do
     it "returns true when registration_close_date is in the future" do
       event = build(:event, published: true, registration_close_date: 5.days.from_now)

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -277,8 +277,13 @@ RSpec.describe "Events::Registrations", type: :request do
   end
 
   describe "GET /registration/:slug/videoconference" do
-    let(:event) { create(:event, videoconference_url: "https://awbw.zoom.us/j/88285411273", videoconference_label: "Zoom", videoconference_passcode: "secret123") }
-    let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
+    let(:event) do
+      create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours,
+                     videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                     videoconference_label: "Zoom", videoconference_passcode: "secret123")
+    end
+    # Within a week and intends to pay → the connection details are visible.
+    let!(:registration) { create(:event_registration, event: event, registrant: user.person, intends_to_pay: true) }
 
     it "shows the join link and add-to-calendar options" do
       get registration_videoconference_path(registration.slug)
@@ -293,6 +298,22 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("882 8541 1273")
       expect(response.body).to include("Passcode")
       expect(response.body).to include("secret123")
+    end
+
+    it "withholds the link and credentials more than a week before the event" do
+      event.update!(start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
+      get registration_videoconference_path(registration.slug)
+      expect(response.body).not_to include("88285411273")
+      expect(response.body).not_to include("secret123")
+      expect(response.body).to include("about a week before the event")
+    end
+
+    it "withholds the link and credentials until the registrant has payment access" do
+      registration.update!(intends_to_pay: false)
+      get registration_videoconference_path(registration.slug)
+      expect(response.body).not_to include("88285411273")
+      expect(response.body).not_to include("secret123")
+      expect(response.body).to include("payment is on file")
     end
   end
 


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: contained visibility/copy changes, privacy-sensitive so worth a careful read

### What is the goal of this PR and why is this important?
Videoconference connection details (Zoom join link, meeting ID, passcode) were shared the moment someone registered — embedded in every add-to-calendar entry, shown on the videoconference page with no timing gate, and included in both the registrant confirmation and admin FYI emails (potentially months early). We only want to reveal them close to the event and only to registrants who have paid or committed to paying.

### How did you approach the change?
Added a per-registration gate, `EventRegistration#videoconference_details_visible?` = within 7 days of the start (`Event#videoconference_details_visible?`) AND payment access (paid or intends to pay), and threaded it through the ticket, event show page, and videoconference callout (both calendar entries via `EventDecorator#calendar_links` and on-page display). Both confirmation emails (registrant + admin FYI) now show only the platform label (e.g. "Zoom"), mirroring the reminder email — the join link lives on the now-gated ticket pages. Note: the live "join now" link keeps its stricter 30-minute window.

### UI Testing Checklist
- [ ] More than a week out: ticket / event show / videoconference page show no Zoom link, ID, or passcode; calendar entries omit them and the join URL.
- [ ] Within a week + paid/intends-to-pay: all connection details appear again.
- [ ] Within a week but unpaid: videoconference page shows the "payment is on file" message instead of the link.
- [ ] Registrant confirmation and admin FYI emails show only the platform label, no link/ID/passcode.

### Anything else to add?
Free events pass the payment check automatically.
