### PR TITLE
Add CE request/payment deadlines to events

### DIFF
--- a/app/models/professional_license.rb
+++ b/app/models/professional_license.rb
@@ -17,11 +17,12 @@ class ProfessionalLicense < ApplicationRecord
   # different kinds is allowed; only a duplicate (kind, number) pair is rejected.
   validates :number, uniqueness: { scope: [ :person_id, :kind ] }, allow_nil: true
 
-  # Find the person's license for this number, or create it. A blank number
-  # resolves to the person's single placeholder license (number nil) so a CE
-  # opt-in without a number on file never spawns duplicate placeholders.
-  def self.find_or_create_for(person:, number: nil)
-    find_or_create_by(person: person, number: number.presence)
+  # Find the person's license for this type + number, or create it. Licenses are
+  # identified by (kind, number), so an opt-in without either on file resolves to
+  # the person's single placeholder license (both nil) rather than spawning
+  # duplicate placeholders.
+  def self.find_or_create_for(person:, number: nil, kind: nil)
+    find_or_create_by(person: person, number: number.presence, kind: kind.presence)
   end
 
   # Completeness: have we recorded the actual license number yet?

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -129,6 +129,8 @@ class EventPolicy < ApplicationPolicy
                   :ce_hours_details_label,
                   :ce_hours_offered,
                   :ce_hours_cost,
+                  :ce_hours_request_deadline,
+                  :ce_payment_due_deadline,
                   :autoshow_cost,
                   :autoshow_date,
                   :autoshow_location,

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -11,6 +11,10 @@ module EventRegistrationServices
     # seeds the registrant's ProfessionalLicense.
     CE_LICENSE_NUMBER_IDENTIFIER = "ce_license_number".freeze
 
+    # Well-known field_identifier of the CE license-type question (e.g. "LCSW").
+    # Its answer seeds the ProfessionalLicense's kind.
+    CE_LICENSE_KIND_IDENTIFIER = "ce_license_kind".freeze
+
     # Well-known field_identifier of the "Additional forms" multi-select question.
     # Checking "Invoice" / "W-9" toggles the registration's invoice_requested /
     # w9_requested flags, which the digital ticket reads to surface those downloads.
@@ -412,7 +416,7 @@ module EventRegistrationServices
       return unless ce_credit_requested?
       return if event_registration.continuing_education_registrations.exists?
 
-      license = ProfessionalLicense.find_or_create_for(person: person, number: ce_license_number)
+      license = ProfessionalLicense.find_or_create_for(person: person, number: ce_license_number, kind: ce_license_kind)
       event_registration.continuing_education_registrations.create!(professional_license: license)
     end
 
@@ -426,6 +430,12 @@ module EventRegistrationServices
       return nil unless @continuing_education_form
 
       ce_field_value(CE_LICENSE_NUMBER_IDENTIFIER)&.strip.presence
+    end
+
+    def ce_license_kind
+      return nil unless @continuing_education_form
+
+      ce_field_value(CE_LICENSE_KIND_IDENTIFIER)&.strip.presence
     end
 
     def ce_field_value(key)

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -15,6 +15,12 @@ module EventRegistrationServices
     # Its answer seeds the ProfessionalLicense's kind.
     CE_LICENSE_KIND_IDENTIFIER = "ce_license_kind".freeze
 
+    # Well-known field_identifiers of the CE license issuing-state and expiry
+    # questions. Their answers fill in the ProfessionalLicense's issuing_state
+    # and expires_on (both optional — registrants can supply them later).
+    CE_LICENSE_ISSUING_STATE_IDENTIFIER = "ce_license_issuing_state".freeze
+    CE_LICENSE_EXPIRES_ON_IDENTIFIER = "ce_license_expires_on".freeze
+
     # Well-known field_identifier of the "Additional forms" multi-select question.
     # Checking "Invoice" / "W-9" toggles the registration's invoice_requested /
     # w9_requested flags, which the digital ticket reads to surface those downloads.
@@ -417,6 +423,9 @@ module EventRegistrationServices
       return if event_registration.continuing_education_registrations.exists?
 
       license = ProfessionalLicense.find_or_create_for(person: person, number: ce_license_number, kind: ce_license_kind)
+      if ce_license_issuing_state || ce_license_expires_on
+        license.update!(issuing_state: ce_license_issuing_state, expires_on: ce_license_expires_on)
+      end
       event_registration.continuing_education_registrations.create!(professional_license: license)
     end
 
@@ -436,6 +445,18 @@ module EventRegistrationServices
       return nil unless @continuing_education_form
 
       ce_field_value(CE_LICENSE_KIND_IDENTIFIER)&.strip.presence
+    end
+
+    def ce_license_issuing_state
+      return nil unless @continuing_education_form
+
+      ce_field_value(CE_LICENSE_ISSUING_STATE_IDENTIFIER)&.strip.presence
+    end
+
+    def ce_license_expires_on
+      return nil unless @continuing_education_form
+
+      ce_field_value(CE_LICENSE_EXPIRES_ON_IDENTIFIER).presence
     end
 
     def ce_field_value(key)
@@ -524,7 +545,6 @@ module EventRegistrationServices
 
     def save_continuing_education_submission(person)
       return unless @continuing_education_form && @continuing_education_params.present?
-      return unless ce_credit_requested?
 
       submission = FormSubmission.find_or_create_by!(
         person: person, form: @continuing_education_form, role: "continuing_education", event: @event

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -98,7 +98,9 @@ class FormBuilderService
     continuing_education: [
       "Do you seek Continuing Education (CE) hours for this training?",
       "If seeking CE hours, what is your license type? (e.g. LMFT, LCSW, LPCC, LEP)",
-      "What is your license number?"
+      "What is your license number?",
+      "In which state was your license issued?",
+      "When does your license expire?"
     ],
     scholarship: [
       "I and/or my organization cannot afford the full training cost and need a scholarship to attend.",
@@ -513,12 +515,14 @@ class FormBuilderService
     position = add_field(form, position,
                          "Do you seek Continuing Education (CE) hours for this training?",
                          :single_select_radio,
-                         key: "ce_credit_interest", group: "continuing_education", required: false,
+                         key: "ce_credit_interest", group: "continuing_education", required: true,
                          options: %w[Yes No])
     position = add_field(form, position,
                          "If seeking CE hours, what is your license type? (e.g. LMFT, LCSW, LPCC, LEP)",
                          :free_form_input_one_line,
-                         key: "ce_license_kind", group: "continuing_education", required: false)
+                         key: "ce_license_kind", group: "continuing_education", required: false,
+                         subtitle: "These license details are optional here — you can add or update them later " \
+                                   "from your registration ticket.")
     position = add_field(form, position,
                          "What is your license number?",
                          :free_form_input_one_line,
@@ -527,6 +531,15 @@ class FormBuilderService
                                    "and AWBW cannot guarantee your specific state board will accept them. " \
                                    "Participants are responsible for confirming whether the hours meet the requirements " \
                                    "for their specific license and state.")
+    position = add_field(form, position,
+                         "In which state was your license issued?",
+                         :free_form_input_one_line,
+                         key: "ce_license_issuing_state", group: "continuing_education", required: false)
+    position = add_field(form, position,
+                         "When does your license expire?",
+                         :free_form_input_one_line,
+                         key: "ce_license_expires_on", group: "continuing_education", required: false,
+                         datatype: :date)
     position
   end
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -97,7 +97,8 @@ class FormBuilderService
     ],
     continuing_education: [
       "Do you seek Continuing Education (CE) hours for this training?",
-      "If seeking CE hours, what is your LMFT, LCSW, LPCC or LEP license number?"
+      "If seeking CE hours, what is your license type? (e.g. LMFT, LCSW, LPCC, LEP)",
+      "What is your license number?"
     ],
     scholarship: [
       "I and/or my organization cannot afford the full training cost and need a scholarship to attend.",
@@ -515,7 +516,11 @@ class FormBuilderService
                          key: "ce_credit_interest", group: "continuing_education", required: false,
                          options: %w[Yes No])
     position = add_field(form, position,
-                         "If seeking CE hours, what is your LMFT, LCSW, LPCC or LEP license number?",
+                         "If seeking CE hours, what is your license type? (e.g. LMFT, LCSW, LPCC, LEP)",
+                         :free_form_input_one_line,
+                         key: "ce_license_kind", group: "continuing_education", required: false)
+    position = add_field(form, position,
+                         "What is your license number?",
                          :free_form_input_one_line,
                          key: "ce_license_number", group: "continuing_education", required: false,
                          subtitle: "Acceptance of continuing education hours is determined by each individual state board separately, " \

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -211,14 +211,18 @@ class MagicTicketCallouts
   # "$X due" for the outstanding balance once hours + license are on file (no chip
   # once paid in full); otherwise an amber chip naming what's still needed, prefixed
   # with the fee when the hours (and so the cost) are already known — e.g.
-  # "$250 · License number needed".
+  # "$250 · License number needed". Each deadline the event sets is appended to the
+  # relevant chip while still pending: the payment deadline on the amount-due chip
+  # (until paid), the request deadline on the license-needed chip.
   def ce_hours_badge(complete)
     ce_registration = registration.continuing_education_registrations.first
     remaining_cents = ce_registration&.remaining_cost.to_i
 
     if complete
       return unless remaining_cents.positive?
-      return "#{MoneyFormatter.dollars_from_cents(remaining_cents)} due"
+      amount = MoneyFormatter.dollars_from_cents(remaining_cents)
+      return "#{amount} due" if event.ce_payment_due_deadline.blank?
+      return "#{amount} due by #{ce_deadline_text(event.ce_payment_due_deadline)}"
     end
 
     needed = ce_missing_text
@@ -227,9 +231,16 @@ class MagicTicketCallouts
   end
 
   # Hours are set by the event now, so the only thing a requesting registrant can
-  # still be missing is their license number.
+  # still be missing is their license number. When the event sets a request
+  # deadline, name it so the registrant knows when their license is due.
   def ce_missing_text
-    "License number needed"
+    return "License number needed" if event.ce_hours_request_deadline.blank?
+    "License number needed by #{ce_deadline_text(event.ce_hours_request_deadline)}"
+  end
+
+  # Short month/day for a deadline shown inline on the CE card, e.g. "Jul 1".
+  def ce_deadline_text(deadline)
+    deadline.strftime("%b %-d")
   end
 
   # "Art supplies & what to bring" — the event's own details page.

--- a/app/views/event_mailer/_ce_deadlines.html.erb
+++ b/app/views/event_mailer/_ce_deadlines.html.erb
@@ -1,0 +1,22 @@
+<%# CE deadlines for a CE-eligible event, shown in the confirmation and reminder
+    emails so registrants are nudged before the request/payment cutoffs — gated on
+    the event offering CE, not on this registrant having requested it yet (the
+    confirmation fires before anyone opts in). Locals: event (decorated). The
+    deadlines are plain dates, so no time zone is applied. %>
+<% if event.ce_eligible? && (event.ce_hours_request_deadline || event.ce_payment_due_deadline) %>
+  <div style="text-align: left; background-color: #f0fdfa; border: 1px solid #99f6e4; border-radius: 6px; padding: 16px; margin: 16px 0;">
+    <p style="font-size: 14px; font-weight: 600; color: #115e59; margin: 0 0 8px;">
+      <%= event.ce_hours_details_label %>
+    </p>
+    <% if event.ce_hours_request_deadline %>
+      <p style="font-size: 14px; color: #374151; margin: 0 0 4px;">
+        Request CE credit by <strong><%= event.ce_hours_request_deadline.strftime("%B %-d, %Y") %></strong>
+      </p>
+    <% end %>
+    <% if event.ce_payment_due_deadline %>
+      <p style="font-size: 14px; color: #374151; margin: 0;">
+        CE payment due by <strong><%= event.ce_payment_due_deadline.strftime("%B %-d, %Y") %></strong>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/event_mailer/_ce_deadlines.text.erb
+++ b/app/views/event_mailer/_ce_deadlines.text.erb
@@ -1,0 +1,5 @@
+<% if event.ce_eligible? && (event.ce_hours_request_deadline || event.ce_payment_due_deadline) %>
+<%= event.ce_hours_details_label %>
+<% if event.ce_hours_request_deadline %>Request CE credit by <%= event.ce_hours_request_deadline.strftime("%B %-d, %Y") %>
+<% end %><% if event.ce_payment_due_deadline %>CE payment due by <%= event.ce_payment_due_deadline.strftime("%B %-d, %Y") %>
+<% end %><% end %>

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -53,6 +53,8 @@
     <% end %>
   </div>
 
+  <%= render "ce_deadlines", event: @event %>
+
   <% if @event.rhino_description.present? %>
     <span style="padding-bottom: 12px"><strong>Details</strong></span><br>
     <p>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -27,6 +27,7 @@ Videoconference: <%= event_platform_label(@event) %>
 
 View your ticket:
 <%= registration_ticket_url(@event_registration.slug) %>
+<%= render "ce_deadlines", event: @event %>
 
 <% if @event.registration_close_date %>
   Registration closes on

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -18,6 +18,8 @@
   <% end %>
 
   <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+
+  <%= render "ce_deadlines", event: @event %>
 </div>
 
 <% if @event_registration.persisted? && @event_registration.slug.present? %>

--- a/app/views/event_mailer/event_registration_reminder.text.erb
+++ b/app/views/event_mailer/event_registration_reminder.text.erb
@@ -22,7 +22,7 @@ Location: <%= event_location_label(@event.object) %>
 <% if @event.labelled_cost.present? %>
 <%= @event.labelled_cost %>
 <% end %>
-
+<%= render "ce_deadlines", event: @event %>
 <% if @event_registration.slug.present? %>
 View your ticket for event details, directions, and calendar links:
 <%= registration_ticket_url(@event_registration.slug) %>

--- a/app/views/events/_ce_config_fields.html.erb
+++ b/app/views/events/_ce_config_fields.html.erb
@@ -1,0 +1,32 @@
+<%# The CE settings an admin edits once continuing education is enabled: hours
+    offered, total cost, and the two optional deadlines. Rendered inside each
+    "Enable continuing education" box (single-form and multi-form variants).
+    Each field is labelled above its input so they read as distinct fields.
+    locals: f (event form builder). %>
+<div class="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+  <div>
+    <%= f.label :ce_hours_offered, "CE hours offered", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <%= f.number_field :ce_hours_offered, min: 0, step: 0.25,
+          class: "w-full rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
+  </div>
+  <div>
+    <%= f.label :ce_hours_cost, "Total CE cost", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <div class="relative">
+      <span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-gray-400">$</span>
+      <%= f.number_field :ce_hours_cost, min: 0, step: 1,
+            class: "w-full rounded-md border-gray-300 pl-6 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
+    </div>
+  </div>
+  <div>
+    <%= f.label :ce_hours_request_deadline, "Request CE credit by", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <%= f.text_field :ce_hours_request_deadline, type: "date",
+          class: "w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-200" %>
+    <p class="mt-1 text-xs text-gray-400">Optional</p>
+  </div>
+  <div>
+    <%= f.label :ce_payment_due_deadline, "Payment due by", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <%= f.text_field :ce_payment_due_deadline, type: "date",
+          class: "w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-200" %>
+    <p class="mt-1 text-xs text-gray-400">Optional</p>
+  </div>
+</div>

--- a/app/views/events/_ce_config_fields.html.erb
+++ b/app/views/events/_ce_config_fields.html.erb
@@ -19,15 +19,17 @@
     </div>
   </div>
   <div>
-    <%= f.label :ce_hours_request_deadline, "Request CE credit by", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <%= f.label :ce_hours_request_deadline, class: "block text-xs font-medium text-gray-600 mb-1" do %>
+      Request CE credit by <span class="font-normal text-gray-400">(optional)</span>
+    <% end %>
     <%= f.text_field :ce_hours_request_deadline, type: "date",
           class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 bg-white focus:ring-blue-500 focus:border-blue-500" %>
-    <p class="mt-1 text-xs text-gray-400">Optional</p>
   </div>
   <div>
-    <%= f.label :ce_payment_due_deadline, "Payment due by", class: "block text-xs font-medium text-gray-600 mb-1" %>
+    <%= f.label :ce_payment_due_deadline, class: "block text-xs font-medium text-gray-600 mb-1" do %>
+      Payment due by <span class="font-normal text-gray-400">(optional)</span>
+    <% end %>
     <%= f.text_field :ce_payment_due_deadline, type: "date",
           class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 bg-white focus:ring-blue-500 focus:border-blue-500" %>
-    <p class="mt-1 text-xs text-gray-400">Optional</p>
   </div>
 </div>

--- a/app/views/events/_ce_config_fields.html.erb
+++ b/app/views/events/_ce_config_fields.html.erb
@@ -1,32 +1,33 @@
 <%# The CE settings an admin edits once continuing education is enabled: hours
     offered, total cost, and the two optional deadlines. Rendered inside each
     "Enable continuing education" box (single-form and multi-form variants).
-    Each field is labelled above its input so they read as distinct fields.
-    locals: f (event form builder). %>
+    Each field is labelled above its own white input so they read as distinct
+    fields; the date inputs match the event start/end date style. locals: f
+    (event form builder). %>
 <div class="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
   <div>
     <%= f.label :ce_hours_offered, "CE hours offered", class: "block text-xs font-medium text-gray-600 mb-1" %>
     <%= f.number_field :ce_hours_offered, min: 0, step: 0.25,
-          class: "w-full rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
+          class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 bg-white tabular-nums focus:ring-blue-500 focus:border-blue-500" %>
   </div>
   <div>
     <%= f.label :ce_hours_cost, "Total CE cost", class: "block text-xs font-medium text-gray-600 mb-1" %>
     <div class="relative">
-      <span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-gray-400">$</span>
+      <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
       <%= f.number_field :ce_hours_cost, min: 0, step: 1,
-            class: "w-full rounded-md border-gray-300 pl-6 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
+            class: "w-full rounded border-gray-300 shadow-sm pl-7 pr-3 py-2 bg-white tabular-nums focus:ring-blue-500 focus:border-blue-500" %>
     </div>
   </div>
   <div>
     <%= f.label :ce_hours_request_deadline, "Request CE credit by", class: "block text-xs font-medium text-gray-600 mb-1" %>
     <%= f.text_field :ce_hours_request_deadline, type: "date",
-          class: "w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-200" %>
+          class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 bg-white focus:ring-blue-500 focus:border-blue-500" %>
     <p class="mt-1 text-xs text-gray-400">Optional</p>
   </div>
   <div>
     <%= f.label :ce_payment_due_deadline, "Payment due by", class: "block text-xs font-medium text-gray-600 mb-1" %>
     <%= f.text_field :ce_payment_due_deadline, type: "date",
-          class: "w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-200" %>
+          class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 bg-white focus:ring-blue-500 focus:border-blue-500" %>
     <p class="mt-1 text-xs text-gray-400">Optional</p>
   </div>
 </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -460,10 +460,11 @@
                     <% single_form = @continuing_education_forms.first %>
                     <%= check_box_tag "event[continuing_education_form_id]", single_form.id,
                             resubmitted ? params.dig(:event, :continuing_education_form_id).present? : @event.continuing_education_form.present?,
+                            id: "enable_continuing_education",
                             class: "peer rounded border-gray-300" %>
-                    <span class="text-sm font-medium text-gray-700">Enable continuing education</span>
+                    <label for="enable_continuing_education" class="text-sm font-medium text-gray-700 cursor-pointer">Enable continuing education</label>
                     <p class="text-xs text-gray-500 mt-1">Allow registrants to request CE hours.</p>
-                    <div class="hidden peer-checked:block rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
+                    <div class="hidden peer-checked:block rounded-md border border-teal-200 bg-teal-50 px-3 py-2.5">
                       <%= render "events/ce_config_fields", f: f %>
                     </div>
                     <p class="mt-1 text-xs text-gray-400">Edit the CE hours ticket card and its details below, under Registration ticket callouts.</p>
@@ -490,7 +491,7 @@
                       <% end %>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Select a continuing education form for registrants to request CE hours.</p>
-                    <div class="mt-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
+                    <div class="mt-2 rounded-md border border-teal-200 bg-teal-50 px-3 py-2.5">
                       <%= render "events/ce_config_fields", f: f %>
                     </div>
                   <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -463,13 +463,8 @@
                             class: "peer rounded border-gray-300" %>
                     <span class="text-sm font-medium text-gray-700">Enable continuing education</span>
                     <p class="text-xs text-gray-500 mt-1">Allow registrants to request CE hours.</p>
-                    <div class="hidden peer-checked:flex flex-wrap items-center gap-x-6 gap-y-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
-                      <label class="flex items-center gap-2 text-sm text-gray-700">CE hours offered <%= f.number_field :ce_hours_offered, min: 0, step: 0.25, class: "w-24 rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %></label>
-
-                      <label class="flex items-center gap-2 text-sm text-gray-700">
-                        Total CE cost <span class="text-gray-400">$</span> <%= f.number_field :ce_hours_cost, min: 0, step: 1,
-                      class: "w-24 rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
-                      </label>
+                    <div class="hidden peer-checked:block rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
+                      <%= render "events/ce_config_fields", f: f %>
                     </div>
                     <p class="mt-1 text-xs text-gray-400">Edit the CE hours ticket card and its details below, under Registration ticket callouts.</p>
                     <% if @event.continuing_education_form.present? %>
@@ -495,13 +490,8 @@
                       <% end %>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Select a continuing education form for registrants to request CE hours.</p>
-                    <div class="hidden peer-checked:flex flex-wrap items-center gap-x-6 gap-y-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
-                      <label class="flex items-center gap-2 text-sm text-gray-700">CE hours offered <%= f.number_field :ce_hours_offered, min: 0, step: 0.25, class: "w-24 rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %></label>
-
-                      <label class="flex items-center gap-2 text-sm text-gray-700">
-                        Total CE cost <span class="text-gray-400">$</span> <%= f.number_field :ce_hours_cost, min: 0, step: 1,
-                      class: "w-24 rounded-md border-gray-300 text-sm tabular-nums focus:border-teal-500 focus:ring-teal-200" %>
-                      </label>
+                    <div class="mt-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2.5">
+                      <%= render "events/ce_config_fields", f: f %>
                     </div>
                   <% end %>
                 </div>
@@ -588,22 +578,6 @@
                     title_placeholder: "CE hours",
                     content_help: "CE requirements, payment, sign-in rules, and the post-training evaluation — shown on its own page linked from the ticket. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Wrap a part in <details><summary>Title</summary>…</details> to make it a collapsible section.",
                     content_placeholder: "e.g. <p>AWBW is approved by CAMFT…</p><details><summary>Before the training</summary><ul><li>Email your license number</li></ul></details>" %>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2 pl-9">
-                <div>
-                  <%= f.label :ce_hours_request_deadline, "Request CE credit by", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-                  <p class="text-xs text-gray-500 mb-1">Deadline for registrants to request CE credit and submit their license. Shown on the CE callout. Leave blank to hide.</p>
-                  <%= f.text_field :ce_hours_request_deadline,
-                        type: "date",
-                        class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-                </div>
-                <div>
-                  <%= f.label :ce_payment_due_deadline, "Payment due by", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
-                  <p class="text-xs text-gray-500 mb-1">Deadline for CE payment. Shown on the CE callout. Leave blank to hide.</p>
-                  <%= f.text_field :ce_payment_due_deadline,
-                        type: "date",
-                        class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
-                </div>
-              </div>
             <% when :event_details %>
               <%= render "events/builtin_callout_card", f: f, card: card,
                     label_field: :event_details_label, content_field: :event_details,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -588,6 +588,22 @@
                     title_placeholder: "CE hours",
                     content_help: "CE requirements, payment, sign-in rules, and the post-training evaluation — shown on its own page linked from the ticket. Accepts basic HTML — bold, italics, links, lists, headings, and line breaks. Wrap a part in <details><summary>Title</summary>…</details> to make it a collapsible section.",
                     content_placeholder: "e.g. <p>AWBW is approved by CAMFT…</p><details><summary>Before the training</summary><ul><li>Email your license number</li></ul></details>" %>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2 pl-9">
+                <div>
+                  <%= f.label :ce_hours_request_deadline, "Request CE credit by", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+                  <p class="text-xs text-gray-500 mb-1">Deadline for registrants to request CE credit and submit their license. Shown on the CE callout. Leave blank to hide.</p>
+                  <%= f.text_field :ce_hours_request_deadline,
+                        type: "date",
+                        class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+                </div>
+                <div>
+                  <%= f.label :ce_payment_due_deadline, "Payment due by", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
+                  <p class="text-xs text-gray-500 mb-1">Deadline for CE payment. Shown on the CE callout. Leave blank to hide.</p>
+                  <%= f.text_field :ce_payment_due_deadline,
+                        type: "date",
+                        class: "w-full rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+                </div>
+              </div>
             <% when :event_details %>
               <%= render "events/builtin_callout_card", f: f, card: card,
                     label_field: :event_details_label, content_field: :event_details,

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -133,7 +133,7 @@
                       data: { callout_preview_target: "colorSelect", action: "callout-preview#update" } %>
 
                 <% if f.object.app_colored? %>
-                  <p class="text-xs text-gray-400 mt-0.5">The app overrides this with a live-status color when the registrant has action to take (e.g. amber while something's outstanding, orange while a balance is due).</p>
+                  <p class="text-xs text-gray-400 mt-0.5">This callout will be a different color when the registrant has action to take (e.g. amber if something's outstanding, orange if a balance is due).</p>
                 <% end %>
               </div>
 

--- a/app/views/events/callouts/ce.html.erb
+++ b/app/views/events/callouts/ce.html.erb
@@ -82,6 +82,9 @@
         </p>
 
         <% if ce_registration && ce_registration.remaining_cost.positive? %>
+          <% if @event.ce_payment_due_deadline %>
+            <p class="mt-3 text-sm text-amber-700">Payment due by <%= @event.ce_payment_due_deadline.to_fs(:long) %></p>
+          <% end %>
           <div class="mt-6 flex justify-center">
             <%= button_to "Pay with Credit Card",
                           registration_ce_pay_path(@event_registration.slug),
@@ -224,6 +227,9 @@
     <% end %>
   <% else %>
     <p class="text-sm text-gray-600">You haven't requested continuing education credit for this training. CE hours are available for an additional fee.</p>
+    <% if @event.ce_hours_request_deadline %>
+      <p class="mt-2 text-sm text-amber-700">Request CE credit by <%= @event.ce_hours_request_deadline.to_fs(:long) %>.</p>
+    <% end %>
     <%= form_with url: registration_ce_request_path(@event_registration.slug), method: :post, data: { turbo: false }, class: "mt-4" do |form| %>
       <%= form.submit "Request CE credit", class: "rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-300 cursor-pointer" %>
     <% end %>

--- a/app/views/events/ce_hours.html.erb
+++ b/app/views/events/ce_hours.html.erb
@@ -25,6 +25,22 @@
     </div>
 
     <div class="px-6 sm:px-8 py-7">
+      <% if @event.ce_hours_request_deadline || @event.ce_payment_due_deadline %>
+        <dl class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <% if @event.ce_hours_request_deadline %>
+            <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+              <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Request CE credit by</dt>
+              <dd class="mt-1 text-base font-semibold text-gray-900"><%= @event.ce_hours_request_deadline.strftime("%B %-d, %Y") %></dd>
+            </div>
+          <% end %>
+          <% if @event.ce_payment_due_deadline %>
+            <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+              <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Payment due by</dt>
+              <dd class="mt-1 text-base font-semibold text-gray-900"><%= @event.ce_payment_due_deadline.strftime("%B %-d, %Y") %></dd>
+            </div>
+          <% end %>
+        </dl>
+      <% end %>
       <%= render "events/callouts/rich_content", content: @event.ce_hours_details %>
     </div>
   </div>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -45,11 +45,15 @@
       </select>
     <% else %>
       <%
-        html_type = case field.field_identifier
-                     when /email(?!_type)/ then "email"
-                     when "phone" then "tel"
+        html_type = if field.date?
+                       "date"
                      else
-                       field.number_integer? ? "number" : "text"
+                       case field.field_identifier
+                       when /email(?!_type)/ then "email"
+                       when "phone" then "tel"
+                       else
+                         field.number_integer? ? "number" : "text"
+                       end
                      end
         extra_attrs = []
         extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -162,6 +162,22 @@
               <i class="fa-solid fa-certificate text-teal-600"></i><%= @continuing_education_form.display_name %>
             </h3>
             <%= render "forms/header", form: @continuing_education_form, event: @event %>
+            <% if @event.ce_hours_request_deadline || @event.ce_payment_due_deadline %>
+              <dl class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <% if @event.ce_hours_request_deadline %>
+                  <div class="rounded-lg border border-teal-200 bg-white px-3 py-2">
+                    <dt class="text-xs font-medium uppercase tracking-wide text-teal-700">Request CE credit by</dt>
+                    <dd class="mt-0.5 text-sm font-semibold text-gray-900"><%= @event.ce_hours_request_deadline.strftime("%B %-d, %Y") %></dd>
+                  </div>
+                <% end %>
+                <% if @event.ce_payment_due_deadline %>
+                  <div class="rounded-lg border border-teal-200 bg-white px-3 py-2">
+                    <dt class="text-xs font-medium uppercase tracking-wide text-teal-700">Payment due by</dt>
+                    <dd class="mt-0.5 text-sm font-semibold text-gray-900"><%= @event.ce_payment_due_deadline.strftime("%B %-d, %Y") %></dd>
+                  </div>
+                <% end %>
+              </dl>
+            <% end %>
             <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
               <% @continuing_education_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% if field.group_header? %>

--- a/db/migrate/20260622135205_add_ce_deadlines_to_events.rb
+++ b/db/migrate/20260622135205_add_ce_deadlines_to_events.rb
@@ -1,0 +1,11 @@
+class AddCeDeadlinesToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :ce_hours_request_deadline, :date unless column_exists?(:events, :ce_hours_request_deadline)
+    add_column :events, :ce_payment_due_deadline, :date unless column_exists?(:events, :ce_payment_due_deadline)
+  end
+
+  def down
+    remove_column :events, :ce_hours_request_deadline, if_exists: true
+    remove_column :events, :ce_payment_due_deadline, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -537,6 +537,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_000553) do
     t.text "ce_hours_details"
     t.string "ce_hours_details_label", default: "CE hours", null: false
     t.decimal "ce_hours_offered", precision: 5, scale: 2
+    t.date "ce_hours_request_deadline"
+    t.date "ce_payment_due_deadline"
     t.integer "cost_cents"
     t.datetime "created_at", null: false
     t.integer "created_by_id"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -408,7 +408,7 @@ if flagship && flagship.ce_hours_details.blank?
       <li>Complete the post-training evaluation within one week.</li>
       <li>Your CE certificate will be emailed within three weeks of the training.</li>
     </ul>
-    <p>Questions about continuing education? Reach out and our team will follow up with details.</p>
+    <p>Questions about continuing education? Reach out by email or Portal contact us form, and our team will follow up with details.</p>
   HTML
 end
 

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe EventMailer, type: :mailer do
         expect(body).not_to include("Meeting ID")
       end
     end
+
+    context "when the event is CE-eligible and has deadlines" do
+      let(:event) do
+        create(:event, ce_hours_offered: 6,
+                       ce_hours_request_deadline: Date.new(2026, 7, 1),
+                       ce_payment_due_deadline: Date.new(2026, 8, 15))
+      end
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "surfaces both CE deadlines in the body" do
+        expect(mail.body.encoded).to include("Request CE credit by")
+        expect(mail.body.encoded).to include("July 1, 2026")
+        expect(mail.body.encoded).to include("CE payment due by")
+        expect(mail.body.encoded).to include("August 15, 2026")
+      end
+    end
+
+    context "when the event is not CE-eligible" do
+      let(:event) { create(:event, ce_hours_offered: nil, ce_hours_request_deadline: Date.new(2026, 7, 1)) }
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "omits the CE deadlines" do
+        expect(mail.body.encoded).not_to include("Request CE credit by")
+      end
+    end
   end
 
   describe "#bulk_payment_confirmation" do
@@ -154,6 +179,22 @@ RSpec.describe EventMailer, type: :mailer do
 
     it "includes the registrant name in the body" do
       expect(mail.body.encoded).to include(event_registration.registrant.full_name)
+    end
+
+    context "when the event is CE-eligible and has deadlines" do
+      let(:event) do
+        create(:event, ce_hours_offered: 6,
+                       ce_hours_request_deadline: Date.new(2026, 7, 1),
+                       ce_payment_due_deadline: Date.new(2026, 8, 15))
+      end
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "surfaces both CE deadlines in the body" do
+        expect(mail.body.encoded).to include("Request CE credit by")
+        expect(mail.body.encoded).to include("July 1, 2026")
+        expect(mail.body.encoded).to include("CE payment due by")
+        expect(mail.body.encoded).to include("August 15, 2026")
+      end
     end
 
     context "with a custom subject" do

--- a/spec/models/professional_license_spec.rb
+++ b/spec/models/professional_license_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe ProfessionalLicense, type: :model do
       expect(first.number).to be_nil
       expect(person.professional_licenses.count).to eq(1)
     end
+
+    it "records the license type when given" do
+      license = described_class.find_or_create_for(person: person, number: "ABC-1", kind: "LCSW")
+
+      expect(license.kind).to eq("LCSW")
+      expect(license.number).to eq("ABC-1")
+    end
   end
 
   describe "#number_known?" do

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -263,6 +263,19 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("August 15, 2026")
     end
 
+    it "renders the CE license type, issuing-state dropdown, expiry date, and provide-later note" do
+      ce = FormBuilderService.new(name: "CE", sections: %i[continuing_education], role: "continuing_education").call
+      event.event_forms.create!(form: ce, role: "continuing_education")
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("what is your license type?")
+      expect(response.body).to include("In which state was your license issued?")
+      expect(response.body).to include("Select a state") # issuing state renders as the US-states dropdown
+      expect(response.body).to include('type="date"')     # expiry renders as a date input
+      expect(response.body).to include("add or update them later")
+    end
+
     it "renders a structured details panel from known event data when enabled" do
       pacific = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
       event.update!(

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -250,6 +250,19 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("Minimum of 5 words.")
     end
 
+    it "surfaces the CE deadlines on the continuing education section" do
+      ce = FormBuilderService.new(name: "CE", sections: %i[continuing_education], role: "continuing_education").call
+      event.event_forms.create!(form: ce, role: "continuing_education")
+      event.update!(ce_hours_request_deadline: Date.new(2026, 7, 1), ce_payment_due_deadline: Date.new(2026, 8, 15))
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("Request CE credit by")
+      expect(response.body).to include("July 1, 2026")
+      expect(response.body).to include("Payment due by")
+      expect(response.body).to include("August 15, 2026")
+    end
+
     it "renders a structured details panel from known event data when enabled" do
       pacific = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
       event.update!(

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -298,6 +298,14 @@ RSpec.describe "Events", type: :request do
       get edit_event_path(event)
       expect(response.body).to include("Frequently asked questions")
     end
+
+    it "renders the CE deadline fields in the continuing education settings" do
+      create(:form, :standalone, role: "continuing_education", name: "CE")
+      get edit_event_path(event)
+      expect(response.body).to include('name="event[ce_hours_request_deadline]"')
+      expect(response.body).to include('name="event[ce_payment_due_deadline]"')
+      expect(response.body).to include("Request CE credit by")
+    end
   end
 
   describe "POST /create" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -226,6 +226,17 @@ RSpec.describe "Events", type: :request do
       get ce_hours_event_path(event)
       expect(response).to redirect_to(event_path(event))
     end
+
+    it "surfaces the CE deadlines when set" do
+      event.update!(ce_hours_offered: 6, ce_hours_details: "<p>CE info</p>",
+                    ce_hours_request_deadline: Date.new(2026, 7, 1),
+                    ce_payment_due_deadline: Date.new(2026, 8, 15))
+      get ce_hours_event_path(event)
+      expect(response.body).to include("Request CE credit by")
+      expect(response.body).to include("July 1, 2026")
+      expect(response.body).to include("Payment due by")
+      expect(response.body).to include("August 15, 2026")
+    end
   end
 
   describe "GET /new" do
@@ -445,6 +456,15 @@ RSpec.describe "Events", type: :request do
         } }
         expect(event.reload.hint_dates).to eq("must attend both days")
         expect(event.hint_registration_cost).to eq("due within 3 weeks of registration")
+      end
+
+      it "persists the CE deadlines" do
+        patch event_path(event), params: { event: {
+          ce_hours_request_deadline: "2026-07-01",
+          ce_payment_due_deadline: "2026-08-15"
+        } }
+        expect(event.reload.ce_hours_request_deadline).to eq(Date.new(2026, 7, 1))
+        expect(event.ce_payment_due_deadline).to eq(Date.new(2026, 8, 15))
       end
     end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -542,14 +542,21 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       ce_form.form_fields.find_by!(field_identifier: key).id.to_s
     end
 
-    def register_with_ce(answer, license: nil, kind: nil)
+    def register_with_ce(answer, license: nil, kind: nil, issuing_state: nil, expires_on: nil)
       params = base_form_params(first_name: "Cy", last_name: "Reed", email: "cy@example.com")
       ce_params = {}
       ce_params[ce_field_id(described_class::CE_CREDIT_INTEREST_IDENTIFIER)] = answer unless answer.nil?
       ce_params[ce_field_id(described_class::CE_LICENSE_NUMBER_IDENTIFIER)] = license if license
       ce_params[ce_field_id(described_class::CE_LICENSE_KIND_IDENTIFIER)] = kind if kind
+      ce_params[ce_field_id(described_class::CE_LICENSE_ISSUING_STATE_IDENTIFIER)] = issuing_state if issuing_state
+      ce_params[ce_field_id(described_class::CE_LICENSE_EXPIRES_ON_IDENTIFIER)] = expires_on if expires_on
       described_class.call(event: event, registration_form: form, form_params: params,
                            continuing_education_form: ce_form, continuing_education_params: ce_params)
+    end
+
+    it "marks the CE interest question as required" do
+      field = ce_form.form_fields.find_by!(field_identifier: described_class::CE_CREDIT_INTEREST_IDENTIFIER)
+      expect(field.required).to be(true)
     end
 
     it "creates a CE registration when answered Yes" do
@@ -603,6 +610,13 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(license.number).to eq("555")
     end
 
+    it "records the license issuing state and expiry when given" do
+      result = register_with_ce("Yes", license: "555", issuing_state: "CA", expires_on: "2027-05-31")
+      license = result.event_registration.continuing_education_registrations.first.professional_license
+      expect(license.issuing_state).to eq("CA")
+      expect(license.expires_on).to eq(Date.new(2027, 5, 31))
+    end
+
     it "uses a placeholder license when no number is given" do
       result = register_with_ce("Yes")
       expect(result.event_registration.continuing_education_registrations.first.professional_license.number).to be_nil
@@ -623,9 +637,11 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(answers[described_class::CE_LICENSE_NUMBER_IDENTIFIER]).to eq("LMFT 555")
     end
 
-    it "does not persist a continuing_education submission when answered No" do
+    it "persists the CE interest answer even when answered No" do
       register_with_ce("No")
-      expect(FormSubmission.find_by(role: "continuing_education", event: event)).to be_nil
+      submission = FormSubmission.find_by(role: "continuing_education", event: event)
+      expect(submission).to be_present
+      expect(submission.answers_by_identifier[described_class::CE_CREDIT_INTEREST_IDENTIFIER]).to eq("No")
     end
   end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -542,11 +542,12 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       ce_form.form_fields.find_by!(field_identifier: key).id.to_s
     end
 
-    def register_with_ce(answer, license: nil)
+    def register_with_ce(answer, license: nil, kind: nil)
       params = base_form_params(first_name: "Cy", last_name: "Reed", email: "cy@example.com")
       ce_params = {}
       ce_params[ce_field_id(described_class::CE_CREDIT_INTEREST_IDENTIFIER)] = answer unless answer.nil?
       ce_params[ce_field_id(described_class::CE_LICENSE_NUMBER_IDENTIFIER)] = license if license
+      ce_params[ce_field_id(described_class::CE_LICENSE_KIND_IDENTIFIER)] = kind if kind
       described_class.call(event: event, registration_form: form, form_params: params,
                            continuing_education_form: ce_form, continuing_education_params: ce_params)
     end
@@ -593,6 +594,13 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       license = result.event_registration.continuing_education_registrations.first.professional_license
       expect(license.number).to eq("LMFT 555")
       expect(license.person).to eq(result.event_registration.registrant)
+    end
+
+    it "records the typed license type alongside the number" do
+      result = register_with_ce("Yes", license: "555", kind: "LCSW")
+      license = result.event_registration.continuing_education_registrations.first.professional_license
+      expect(license.kind).to eq("LCSW")
+      expect(license.number).to eq("555")
     end
 
     it "uses a placeholder license when no number is given" do

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe MagicTicketCallouts do
       expect(paid.badge).to be_nil
     end
 
+    it "names the CE request deadline on the license-needed badge" do
+      event.update!(ce_hours_cost_cents: 15_000, ce_hours_request_deadline: Date.new(2026, 7, 1))
+      license = create(:professional_license, :placeholder, person: registration.registrant)
+      create(:continuing_education_registration, event_registration: registration, professional_license: license)
+      expect(card(registration.reload, event.ce_hours_details_label).badge).to eq("$150 · License number needed by Jul 1")
+    end
+
+    it "appends the CE payment deadline to the amount-due badge, dropping it once paid" do
+      event.update!(ce_hours_cost_cents: 15_000, ce_payment_due_deadline: Date.new(2026, 8, 15))
+      license = create(:professional_license, person: registration.registrant, number: "LIC123")
+      ce_reg = create(:continuing_education_registration, event_registration: registration, professional_license: license)
+      expect(card(registration.reload, event.ce_hours_details_label).badge).to eq("$150 due by Aug 15")
+
+      create(:allocation, source: create(:payment), allocatable: ce_reg, amount: ce_reg.cost_cents)
+      expect(card(registration.reload, event.ce_hours_details_label).badge).to be_nil
+    end
+
     it "shows the scholarship card only when requested, without an amount chip until awarded" do
       expect(card_titles(registration)).not_to include("Scholarship")
       registration.update!(scholarship_requested: true)
@@ -203,6 +220,17 @@ RSpec.describe MagicTicketCallouts do
 
       # Certificate isn't unlocked (event not ended, not attended).
       expect(described_class.new(registration).card_for(callout)).to be_nil
+    end
+
+    it "keeps the live CE deadline badge on a materialized CE row" do
+      event.update!(ce_hours_cost_cents: 15_000, ce_payment_due_deadline: Date.new(2026, 8, 15))
+      license = create(:professional_license, person: registration.registrant, number: "LIC123")
+      create(:continuing_education_registration, event_registration: registration, professional_license: license)
+      callout = create(:registration_ticket_callout, event:, magic_key: "ce_hours", title: "CE credit")
+
+      card = described_class.new(registration.reload).card_for(callout)
+      expect(card.title).to eq("CE credit")            # row owns the text
+      expect(card.badge).to eq("$150 due by Aug 15")   # app keeps the live deadline badge
     end
   end
 end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe "Public form submissions", type: :system do
       choose_pr_radio reg_field("racial_ethnic_identity"), "Asian"
       choose_pr_radio reg_field("referral_source"), "Social Media"
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 
       expect { click_button "Register" }.not_to change(Person, :count)
@@ -174,6 +175,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       fill_full_registration
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio ce_field("ce_credit_interest"), "No"
 
       choose_pr_radio schol_field("scholarship_eligibility"), "Yes"
       fill_pr_text schol_field("scholarship_contribution"), with: "Our agency can pay $200."
@@ -205,6 +207,7 @@ RSpec.describe "Public form submissions", type: :system do
       visit new_event_public_registration_path(event, scholarship_requested: true)
 
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 
       choose_pr_radio schol_field("scholarship_eligibility"), "Yes"

--- a/test/mailers/previews/event_mailer_preview.rb
+++ b/test/mailers/previews/event_mailer_preview.rb
@@ -47,7 +47,14 @@ class EventMailerPreview < ActionMailer::Preview
     event = Event.first || create_event
     person = Person.first || create_person
 
-    EventRegistration.find_or_create_by!(event: event, registrant: person)
+    registration = EventRegistration.find_or_create_by!(event: event, registrant: person)
+    # Showcase the CE deadlines block (set in memory only, not persisted). The email
+    # gates on the event being CE-eligible, so give it offered hours + deadlines. Set
+    # on registration.event — the object the mailer decorates and reads.
+    registration.event.ce_hours_offered ||= 6
+    registration.event.ce_hours_request_deadline ||= 2.weeks.from_now.to_date
+    registration.event.ce_payment_due_deadline ||= 3.weeks.from_now.to_date
+    registration
   end
 
   def create_event


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — reworked onto main's CE cutover (new continuing_education_registrations model); logic + copy changes across card, callout, page, and emails

### What is the goal of this PR and why is this important?
- Lets admins set two per-event CE deadlines — **request CE credit by** and **CE payment due by** — so registrants are nudged before each cutoff.

### How did you approach the change?
- New `date` columns `ce_hours_request_deadline` / `ce_payment_due_deadline` on `events`; permitted in `EventPolicy`, edited in the CE callout section of the event form.
- Surfaced across the new (post-cutover) CE surfaces:
  - **CE card** (`MagicTicketCallouts`): payment deadline appended to the amount-due badge until `ce_paid_in_full?` (`$150 due by Aug 15`); request deadline appended to the license-needed badge (`License number needed by Jul 1`).
  - **CE callout page**: "Request CE credit by …" on the not-yet-requested branch; "Payment due by …" beside the pay button while a balance remains.
  - **Public CE page** (`ce_hours`): deadline panel.
  - **Confirmation + reminder emails**: shared `_ce_deadlines` partial, gated on `event.ce_eligible?` (not the individual registrant — the confirmation fires before anyone opts into CE, so event-level is the correct nudge audience).

### Anything else to add?
- **Framing shift from main's CE cutover:** hours are now event-set (`ce_hours_offered`), not registrant-requested, so "request your hours by" became **"request CE credit by"** (the outstanding registrant step is now the professional license). Column names kept as-is.
- Deadlines only render when set; events without them are unchanged.