### PR TITLE
Stop flagging a "Facilitator" form title as differing from a facilitator affiliation

### DIFF
--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -6,7 +6,6 @@
   <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
   <% position = submitted_position.to_s.strip %>
   <% is_submitted_org = submitted_org_name.to_s.strip.present? && org.name.to_s.strip.casecmp?(submitted_org_name.to_s.strip) %>
-  <% role_affiliations = affiliations.reject(&:facilitator?) %>
   <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
     <span class="text-[0.65rem] font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
     <% affiliations.each do |a| %>
@@ -28,7 +27,7 @@
       <% title_attr = a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : nil %>
       <span class="<%= badge %> <%= color %>" title="<%= title_attr %>"><%= label %></span>
     <% end %>
-    <% if is_submitted_org && position.present? && role_affiliations.none? { |a| a.title.to_s.casecmp?(position) } %>
+    <% if is_submitted_org && position.present? && affiliations.none? { |a| a.title.to_s.casecmp?(position) } %>
       <span class="<%= badge %> bg-amber-50 text-amber-700 border-amber-200" title="Form: <%= position %>">Title differs from form (form: <%= position %>)</span>
     <% end %>
   </div>

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -467,6 +467,15 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("Title differs from form")
         end
 
+        it "does not show a title-comparison badge when a facilitator affiliation matches the submitted 'Facilitator' position" do
+          create(:affiliation, person: regular_user.person, organization: organization, title: "Facilitator")
+          submit_form(org_name: organization.name, position: "Facilitator")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).not_to include("Title differs from form")
+        end
+
         it "shows 'Title differs from form' when the affiliation title differs from the submitted position" do
           create(:affiliation, person: regular_user.person, organization: organization, title: "Counselor")
           submit_form(org_name: organization.name, position: "Director")


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: a one-line condition change with a covering test

### What is the goal of this PR and why is this important?
The "Title differs from form" badge on the org-affiliations panel was firing even when the title matched. A form whose Position/title is literally "Facilitator" was flagged as differing from an org's existing facilitator affiliation, which is wrong and confusing for admins reviewing registrations.

### How did you approach the change?
The comparison previously excluded facilitator affiliations (`role_affiliations`) before checking for a match, so a facilitator-only org always looked mismatched. Now the submitted position is compared against all affiliations — a facilitator affiliation's title is already "Facilitator", so it matches correctly via `casecmp?`. Added a request spec covering the facilitator/"Facilitator" match case (written failing-first).

### UI Testing Checklist
- [ ] Submit a registration with Position/title "Facilitator" for an org that has a facilitator affiliation → no "Title differs from form" badge
- [ ] Submit a position that genuinely differs (e.g. "Director" vs "Counselor") → badge still shows

### Anything else to add?
No data or schema changes.
