### PR TITLE
Sync registration "Other" organization type onto the linked org

### DIFF
--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -44,6 +44,18 @@ class OrganizationDecorator < ApplicationDecorator
                   class: "inline-flex shrink-0 items-center justify-center w-5 h-5 rounded-full border text-xs font-semibold #{self.class.program_status_classes(status)}")
   end
 
+  # The org form's type dropdown offers Organization::AGENCY_TYPES. A record may
+  # still hold a value that is no longer offered (e.g. the pre-rename legacy label
+  # "Other (please specify below)"); rendered as-is the select finds no match and
+  # an untouched save would silently reclassify the org as the first option. Fold
+  # any unrecognized non-blank value into the catch-all "Other". Blank stays blank.
+  def agency_type_option
+    return object.agency_type if object.agency_type.blank?
+    return object.agency_type if Organization::AGENCY_TYPES.include?(object.agency_type)
+
+    Organization::AGENCY_TYPE_OTHER
+  end
+
   def detail(length: nil)
     length ? description&.truncate(length) : description
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -31,6 +31,14 @@ class Organization < ApplicationRecord
       saver: { quality: 80 }
   end
 
+  # The organization classifications offered by the org form and the registration
+  # form's "Organization Type" question, in display order. "Other" is the generic
+  # catch-all; any stored value not in this list (e.g. a legacy label like the
+  # pre-rename "Other (please specify below)") is folded into it for display so an
+  # unmatched select can't silently save as the first option.
+  AGENCY_TYPE_OTHER = "Other"
+  AGENCY_TYPES = [ "501c3/nonprofit", "For-profit", "Government agency", AGENCY_TYPE_OTHER ].freeze
+
   # Validations
   validates :logo,
             content_type: %w[image/png image/jpeg image/webp],

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -187,7 +187,23 @@ module EventRegistrationServices
 
     def sync_organization_profile(organization)
       apply_value(organization, :website_url, field_value("agency_website"))
-      apply_value(organization, :agency_type, field_value("agency_type"))
+      sync_agency_type(organization)
+    end
+
+    # The "Organization Type" answer folds an "Other" choice's free text in as
+    # "Other: <text>" (a specify option). Split the option label from the typed
+    # text: the label drives agency_type and the stripped text fills
+    # agency_type_other, which is cleared for the non-"Other" classifications so
+    # no stale free text lingers. Follows the same latest-wins / never-clobber-on-
+    # blank contract as apply_value.
+    def sync_agency_type(organization)
+      raw = field_value("agency_type")
+      return if raw.blank?
+
+      label, _separator, specified = raw.strip.partition(":")
+      label = label.strip
+      other_text = FormField.other_option?(label) ? specified.strip.presence : nil
+      organization.update!(agency_type: label, agency_type_other: other_text)
     end
 
     # Write value onto attribute when a non-blank value was submitted, overwriting

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -197,11 +197,12 @@ module EventRegistrationServices
     # no stale free text lingers. Follows the same latest-wins / never-clobber-on-
     # blank contract as apply_value.
     def sync_agency_type(organization)
-      raw = field_value("agency_type")
+      raw = field_value("agency_type")&.strip
       return if raw.blank?
 
-      label, _separator, specified = raw.strip.partition(":")
+      label, _separator, specified = raw.partition(":")
       label = label.strip
+      return if label.blank?
       other_text = FormField.other_option?(label) ? specified.strip.presence : nil
       organization.update!(agency_type: label, agency_type_other: other_text)
     end

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -406,9 +406,7 @@ class FormBuilderService
                          key: "agency_website", group: "person_contact_info", required: false)
     position = add_field(form, position, "Organization Type", :single_select_radio,
                          key: "agency_type", group: "person_contact_info", required: false,
-                         options: [
-                           "501c3/nonprofit", "For-profit", "Government agency", "Other"
-                         ])
+                         options: Organization::AGENCY_TYPES)
     position = add_field(form, position, "Organization Street Address", :free_form_input_one_line,
                          key: "agency_street", group: "person_contact_info", required: false)
     position = add_field(form, position, "Organization City", :free_form_input_one_line,

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -407,8 +407,7 @@ class FormBuilderService
     position = add_field(form, position, "Organization Type", :single_select_radio,
                          key: "agency_type", group: "person_contact_info", required: false,
                          options: [
-                           "501c3/nonprofit", "For-profit", "Government agency",
-                           "Other (please specify below)"
+                           "501c3/nonprofit", "For-profit", "Government agency", "Other"
                          ])
     position = add_field(form, position, "Organization Street Address", :free_form_input_one_line,
                          key: "agency_street", group: "person_contact_info", required: false)

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -113,7 +113,7 @@
                     "501c3/nonprofit",
                     "For-profit",
                     "Government agency",
-                    "Other (please specify below)"
+                    "Other"
                   ],
                   selected: f.object.agency_type,
                   input_html: {

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -105,19 +105,15 @@
 
   <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
     <div class="flex flex-col">
+      <% agency_type_option = f.object.decorate.agency_type_option %>
       <%= f.input :agency_type,
                   label: "Organization Type",
                   as: :select,
                   required: true,
-                  collection: [
-                    "501c3/nonprofit",
-                    "For-profit",
-                    "Government agency",
-                    "Other"
-                  ],
-                  selected: f.object.agency_type,
+                  collection: Organization::AGENCY_TYPES,
+                  selected: agency_type_option,
                   input_html: {
-                    value: f.object.agency_type,
+                    value: agency_type_option,
                     class: "rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                   } %>
       <%= f.input :agency_type_other,

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -41,4 +41,21 @@ RSpec.describe OrganizationDecorator do
       expect(organization.decorate.program_status_badge(nil)).to be_nil
     end
   end
+
+  describe "#agency_type_option" do
+    it "returns a recognized type unchanged" do
+      organization = create(:organization, agency_type: "For-profit")
+      expect(organization.decorate.agency_type_option).to eq("For-profit")
+    end
+
+    it "folds a legacy 'Other' label into the catch-all 'Other'" do
+      organization = create(:organization, agency_type: "Other (please specify below)")
+      expect(organization.decorate.agency_type_option).to eq("Other")
+    end
+
+    it "leaves a blank value blank" do
+      organization = create(:organization, agency_type: "")
+      expect(organization.decorate.agency_type_option).to eq("")
+    end
+  end
 end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -315,6 +315,59 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "organization type sync" do
+    let!(:organization) { create(:organization, name: "Helping Hands") }
+
+    def register_with_agency_type(value)
+      params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
+        field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => "Helping Hands",
+        field_id("agency_type") => value
+      )
+      described_class.call(event: event, form: form, form_params: params)
+      organization.reload
+    end
+
+    it "folds an 'Other' answer into agency_type and the stripped free text into agency_type_other" do
+      register_with_agency_type("Other: Equine therapy")
+
+      expect(organization.agency_type).to eq("Other")
+      expect(organization.agency_type_other).to eq("Equine therapy")
+    end
+
+    it "stores the answer as 'Other: <text>' on the form submission, like other specify options" do
+      register_with_agency_type("Other: Equine therapy")
+
+      answer = FormAnswer.joins(:form_field)
+        .find_by(form_fields: { field_identifier: "agency_type" })
+      expect(answer.submitted_answer).to eq("Other: Equine therapy")
+    end
+
+    it "stores a non-'Other' classification with no agency_type_other" do
+      register_with_agency_type("501c3/nonprofit")
+
+      expect(organization.agency_type).to eq("501c3/nonprofit")
+      expect(organization.agency_type_other).to be_nil
+    end
+
+    it "overwrites a previously stored type with the latest registrant's answer" do
+      organization.update!(agency_type: "501c3/nonprofit", agency_type_other: nil)
+
+      register_with_agency_type("Other: Equine therapy")
+
+      expect(organization.agency_type).to eq("Other")
+      expect(organization.agency_type_other).to eq("Equine therapy")
+    end
+
+    it "clears a stale agency_type_other when the latest answer is no longer 'Other'" do
+      organization.update!(agency_type: "Other", agency_type_other: "Equine therapy")
+
+      register_with_agency_type("Government agency")
+
+      expect(organization.agency_type).to eq("Government agency")
+      expect(organization.agency_type_other).to be_nil
+    end
+  end
+
   describe "matching an existing registrant by name" do
     it "matches a person stored under a nickname when the registrant types their legal first name" do
       existing = create(:person, first_name: "Bob", legal_first_name: "Robert",

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -75,8 +75,13 @@ RSpec.describe FormBuilderService do
       it "offers the agency type as the four organization classifications" do
         field = form.form_fields.find_by(field_identifier: "agency_type")
         expect(field.answer_options.pluck(:name)).to contain_exactly(
-          "501c3/nonprofit", "For-profit", "Government agency", "Other (please specify below)"
+          "501c3/nonprofit", "For-profit", "Government agency", "Other"
         )
+      end
+
+      it "treats the agency type 'Other' as a specify option that reveals a free-text box" do
+        field = form.form_fields.find_by(field_identifier: "agency_type")
+        expect(field.specify_option_labels).to contain_exactly("Other")
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 light-logic: refines the org-profile sync plus a small form-option change and a display fallback

### What is the goal of this PR and why is this important?
- When a registrant picks "Other" for **Organization Type**, the free text they typed was being dropped — the org's `agency_type_other` was only ever set from the admin edit form.
- Now "Other" behaves like every other specify option (reveals a "please specify" box, stores `"Other: <text>"`), and the answer is split onto the linked organization: option label → `agency_type`, stripped free text → `agency_type_other`.

### How did you approach the change?
- `public_registration.rb`: `sync_organization_profile` now calls `sync_agency_type`, which splits the label from the free text and fills/clears `agency_type_other`. Same latest-wins / never-clobber-on-blank contract as `apply_value`; `AhoyTrackable` records before/after.
- `organization.rb`: added `Organization::AGENCY_TYPES` (the classifications, with `"Other"` as catch-all), now the single source shared by the model, the org form, and the seeded registration form.
- `organization_decorator.rb`: `agency_type_option` folds any unrecognized non-blank stored value into `"Other"` so an org holding a value not offered by the dropdown can't be silently reclassified as the first option on an untouched save. Blank stays blank.
- `organizations/_form.html.erb` / `form_builder_service.rb`: both consume `Organization::AGENCY_TYPES`; the form's selected option uses the decorator fallback.

### Anything else to add?
- **No data migration needed**: prod has no legacy `"Other (please specify below)"` values; the decorator fallback is defensive only.
- Rebased on main (which introduced `sync_organization_profile`); the "Other" split lives in that method rather than a parallel path.
- Tests: full service, form-builder, and org-decorator suites green.
