### PR TITLE
Fix calendar issue and add admin-authored short description for "Add to calendar" links

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -81,7 +81,9 @@ class EventDecorator < ApplicationDecorator
     # If both: URL in location field, physical location in description
     # If only URL: URL in location field
     # If only location: location in location field
-    event_description = object.rhino_description.to_plain_text
+    # Prefer the admin-authored, calendar-specific blurb; fall back to a
+    # flattened version of the rich show-page description when it's blank.
+    event_description = object.calendar_description.presence || object.rhino_description.to_plain_text
 
     if has_url && has_location
       cal_location = object.videoconference_url

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -81,9 +81,9 @@ class EventDecorator < ApplicationDecorator
     # If both: URL in location field, physical location in description
     # If only URL: URL in location field
     # If only location: location in location field
-    # Prefer the admin-authored, calendar-specific blurb; fall back to a
-    # flattened version of the rich show-page description when it's blank.
-    event_description = object.calendar_description.presence || object.rhino_description.to_plain_text
+    # Prefer the admin-authored short description; fall back to a flattened
+    # version of the rich show-page description when it's blank.
+    event_description = object.short_description.presence || object.rhino_description.to_plain_text
 
     if has_url && has_location
       cal_location = object.videoconference_url

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -109,6 +109,7 @@ class EventPolicy < ApplicationPolicy
                   :videoconference_url,
                   :videoconference_label,
                   :videoconference_passcode,
+                  :calendar_description,
                   :rhino_header,
                   :rhino_description,
                   :event_details,

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -109,7 +109,7 @@ class EventPolicy < ApplicationPolicy
                   :videoconference_url,
                   :videoconference_label,
                   :videoconference_passcode,
-                  :calendar_description,
+                  :short_description,
                   :rhino_header,
                   :rhino_description,
                   :event_details,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -176,37 +176,13 @@
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <%= f.input :videoconference_url,
-                      label: "Videoconference URL",
-                      as: :url,
-                      input_html: {
-                        placeholder: "https://…",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-          <%= f.input :videoconference_label,
-                      label: "Videoconference label",
-                      input_html: {
-                        placeholder: "Virtual event",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-          <%= f.input :videoconference_passcode,
-                      label: "Videoconference passcode",
-                      hint: "Shown alongside the join link. The meeting ID/code is read from the URL automatically.",
-                      input_html: {
-                        placeholder: "e.g. 123456",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-          <%= f.input :calendar_description,
-                      label: "Calendar description",
-                      as: :text,
-                      hint: "Plain-text blurb for the \"Add to calendar\" links. Calendars don't render HTML — leave blank to fall back to the page description.",
-                      input_html: {
-                        rows: 3,
-                        placeholder: "Short description for calendar entries…",
-                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                      } %>
-        </div>
+        <%= f.input :videoconference_url,
+                    label: "Videoconference URL",
+                    as: :url,
+                    input_html: {
+                      placeholder: "https://…",
+                      class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                    } %>
 
         <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">
           <%= f.input :location_id,
@@ -221,6 +197,32 @@
                       } %>
         </div>
       </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <%= f.input :videoconference_label,
+                    label: "Videoconference label",
+                    input_html: {
+                      placeholder: "Virtual event",
+                      class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                    } %>
+        <%= f.input :videoconference_passcode,
+                    label: "Videoconference passcode",
+                    hint: "Shown alongside the join link. The meeting ID/code is read from the URL automatically.",
+                    input_html: {
+                      placeholder: "e.g. 123456",
+                      class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                    } %>
+      </div>
+
+      <%= f.input :calendar_description,
+                  label: "Calendar description",
+                  as: :text,
+                  hint: "Plain-text blurb for the \"Add to calendar\" links. Calendars don't render HTML — leave blank to fall back to the page description.",
+                  input_html: {
+                    rows: 3,
+                    placeholder: "Short description for calendar entries…",
+                    class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                  } %>
 
     </div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -197,6 +197,15 @@
                         placeholder: "e.g. 123456",
                         class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                       } %>
+          <%= f.input :calendar_description,
+                      label: "Calendar description",
+                      as: :text,
+                      hint: "Plain-text blurb for the \"Add to calendar\" links. Calendars don't render HTML — leave blank to fall back to the page description.",
+                      input_html: {
+                        rows: 3,
+                        placeholder: "Short description for calendar entries…",
+                        class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                      } %>
         </div>
 
         <div data-controller="searchable-select" data-searchable-select-placeholder-value="Search locations…">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -214,8 +214,8 @@
                     } %>
       </div>
 
-      <%= f.input :calendar_description,
-                  label: "Calendar description",
+      <%= f.input :short_description,
+                  label: "Short description",
                   as: :text,
                   hint: "Plain-text blurb for the \"Add to calendar\" links. Calendars don't render HTML — leave blank to fall back to the page description.",
                   input_html: {

--- a/db/migrate/20260622154549_add_calendar_description_to_events.rb
+++ b/db/migrate/20260622154549_add_calendar_description_to_events.rb
@@ -1,0 +1,9 @@
+class AddCalendarDescriptionToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :calendar_description, :text
+  end
+
+  def down
+    remove_column :events, :calendar_description, if_exists: true
+  end
+end

--- a/db/migrate/20260622154549_add_calendar_description_to_events.rb
+++ b/db/migrate/20260622154549_add_calendar_description_to_events.rb
@@ -1,9 +1,0 @@
-class AddCalendarDescriptionToEvents < ActiveRecord::Migration[8.1]
-  def up
-    add_column :events, :calendar_description, :text
-  end
-
-  def down
-    remove_column :events, :calendar_description, if_exists: true
-  end
-end

--- a/db/migrate/20260622154549_add_short_description_to_events.rb
+++ b/db/migrate/20260622154549_add_short_description_to_events.rb
@@ -1,0 +1,9 @@
+class AddShortDescriptionToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :short_description, :text
+  end
+
+  def down
+    remove_column :events, :short_description, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_154549) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -517,6 +517,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_213947) do
     t.boolean "autoshow_title", default: true, null: false
     t.boolean "autoshow_videoconference_label", default: true, null: false
     t.boolean "autoshow_videoconference_link", default: true, null: false
+    t.text "calendar_description"
     t.text "ce_hours_details"
     t.string "ce_hours_details_label", default: "CE hours", null: false
     t.integer "cost_cents"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -517,7 +517,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_154549) do
     t.boolean "autoshow_title", default: true, null: false
     t.boolean "autoshow_videoconference_label", default: true, null: false
     t.boolean "autoshow_videoconference_link", default: true, null: false
-    t.text "calendar_description"
     t.text "ce_hours_details"
     t.string "ce_hours_details_label", default: "CE hours", null: false
     t.integer "cost_cents"
@@ -544,6 +543,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_154549) do
     t.boolean "publicly_visible", default: false, null: false
     t.boolean "published", default: false, null: false
     t.datetime "registration_close_date", precision: nil
+    t.text "short_description"
     t.boolean "signed_in_one_click_enabled", default: false, null: false
     t.datetime "start_date", precision: nil
     t.string "title"

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe EventDecorator do
   end
 
   describe "#calendar_links" do
-    it "falls back to rhino_description plain text when calendar_description is blank" do
+    it "falls back to rhino_description plain text when short_description is blank" do
       event = create(:event)
       event.update!(rhino_description: "<div>Join us for healing through art</div>")
       decorated = event.decorate
@@ -159,8 +159,8 @@ RSpec.describe EventDecorator do
       expect(yahoo["href"]).to include("desc=#{desc_encoded}")
     end
 
-    it "uses calendar_description over rhino_description when present" do
-      event = create(:event, calendar_description: "Bring a friend!")
+    it "uses short_description over rhino_description when present" do
+      event = create(:event, short_description: "Bring a friend!")
       event.update!(rhino_description: "<div>Join us for healing through art</div>")
       decorated = event.decorate
 

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe EventDecorator do
   end
 
   describe "#calendar_links" do
-    it "includes rhino_description plain text in all calendar links" do
+    it "falls back to rhino_description plain text when calendar_description is blank" do
       event = create(:event)
       event.update!(rhino_description: "<div>Join us for healing through art</div>")
       decorated = event.decorate
@@ -157,6 +157,24 @@ RSpec.describe EventDecorator do
 
       yahoo = links.find { |a| a.text == "Yahoo" }
       expect(yahoo["href"]).to include("desc=#{desc_encoded}")
+    end
+
+    it "uses calendar_description over rhino_description when present" do
+      event = create(:event, calendar_description: "Bring a friend!")
+      event.update!(rhino_description: "<div>Join us for healing through art</div>")
+      decorated = event.decorate
+
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      links = doc.css("a")
+
+      desc_encoded = ERB::Util.url_encode("Bring a friend!")
+
+      google = links.find { |a| a.text == "Google" }
+      expect(google["href"]).to include("details=#{desc_encoded}")
+      expect(google["href"]).not_to include(ERB::Util.url_encode("healing through art"))
+
+      apple = links.find { |a| a.text == "Apple" }
+      expect(apple["href"]).to include("DESCRIPTION:Bring a friend!")
     end
 
     it "embeds the join link, meeting ID, and passcode within a week of the event" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained logic changes with low blast radius

Calendar "Add to calendar" links were feeding the full rich show-page description (`rhino_description`) into each calendar entry, flattened with `.to_plain_text`. Calendars don't render that markup — ICS `DESCRIPTION` is plain text per RFC 5545, and the Google/Outlook/Yahoo URL params render HTML inconsistently — so admins had no real control over the calendar blurb.

**Why:** give admins a dedicated, plain-text short description, while keeping existing events unaffected.

- New nullable `events.short_description` text column.
- Decorator uses it when present, **falls back** to the flattened `rhino_description` when blank.
- Field added to the videoconference section of the event admin form (full width, below the paired label/passcode row).
- Permitted in `EventPolicy`.