### PR TITLE
Give every seeded notification an email body

### DIFF
--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -2,13 +2,38 @@
 # as part of `rake db:seed:dev`. Seeds contact-us and a few FYI notifications.
 
 puts "Creating Notifications…"
+
+# Shared HTML wrapper so every seeded body renders like a real (mailer-rendered)
+# email in the admin "Email Preview" pane (notifications/show), rather than the
+# "No email body captured." placeholder you get when email_body_* is blank.
+quoted_block = ->(subject, message) do
+  <<~HTML.strip
+    <div style="background-color:#f3f4f6;border-radius:6px;padding:12px;margin:16px 0;text-align:left;">
+      <p><strong>Subject:</strong> #{subject}</p>
+      <p>#{message}</p>
+    </div>
+  HTML
+end
+
 contact_us_samples = [
-  { from: "jordan.hayes@example.com", subject: "Question about facilitating Comfort Journals" },
-  { from: "priya.patel@example.com",  subject: "Interested in starting a chapter" },
-  { from: "sam.wong@example.com",     subject: "Press inquiry — Survivor Voices article" },
-  { from: "lee.morgan@example.com",   subject: "Donation receipt request" },
-  { from: "chris.alvarez@example.com", subject: "Workshop materials availability" },
-  { from: "robin.singh@example.com",  subject: "Volunteer opportunities" }
+  { first_name: "Jordan", last_name: "Hayes", from: "jordan.hayes@example.com",
+    subject: "Question about facilitating Comfort Journals",
+    message: "I recently completed the facilitator training and would love guidance on running my first Comfort Journals workshop. Are there sample session plans you can share?" },
+  { first_name: "Priya", last_name: "Patel", from: "priya.patel@example.com",
+    subject: "Interested in starting a chapter",
+    message: "Our community shelter would like to bring AWBW programming to our residents. What does starting a local chapter involve?" },
+  { first_name: "Sam", last_name: "Wong", from: "sam.wong@example.com",
+    subject: "Press inquiry — Survivor Voices article",
+    message: "I'm writing a feature on trauma-informed art programs and would like to interview someone from your team. What's the best way to coordinate?" },
+  { first_name: "Lee", last_name: "Morgan", from: "lee.morgan@example.com",
+    subject: "Donation receipt request",
+    message: "I made a donation last month but never received a receipt for my records. Could you resend it to this address?" },
+  { first_name: "Chris", last_name: "Alvarez", from: "chris.alvarez@example.com",
+    subject: "Workshop materials availability",
+    message: "Do you ship the workshop supply kits internationally, or are they only available within the US?" },
+  { first_name: "Robin", last_name: "Singh", from: "robin.singh@example.com",
+    subject: "Volunteer opportunities",
+    message: "I have a background in counseling and would like to volunteer. Where can I learn about current openings?" }
 ]
 
 reply_to_email = ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
@@ -17,7 +42,28 @@ sample_user = User.where.not(person_id: nil).first
 contact_us_samples.each_with_index do |sample, i|
   delivered_at = (contact_us_samples.size - i).days.ago
 
-  Notification.find_or_create_by!(
+  confirmation_html = <<~HTML.strip
+    <h1>We received your message</h1>
+    <p>Hello #{sample[:first_name]},</p>
+    <p>Thank you for reaching out. A member of our team will review your inquiry and get back to you as soon as possible.</p>
+    #{quoted_block.call(sample[:subject], sample[:message])}
+    <p>In community,<br>AWBW Programs</p>
+  HTML
+  confirmation_text = <<~TEXT.strip
+    We received your message
+
+    Hello #{sample[:first_name]},
+
+    Thank you for reaching out. A member of our team will review your inquiry and get back to you as soon as possible.
+
+    Subject: #{sample[:subject]}
+    #{sample[:message]}
+
+    In community,
+    AWBW Programs
+  TEXT
+
+  confirmation = Notification.find_or_create_by!(
     recipient_email: sample[:from],
     email_subject: "We received your message",
     kind: "contact_us"
@@ -26,9 +72,30 @@ contact_us_samples.each_with_index do |sample, i|
     n.recipient_role = "person"
     n.notification_type = 0
     n.delivered_at = delivered_at
+    n.email_body_html = confirmation_html
+    n.email_body_text = confirmation_text
   end
+  # Backfill bodies on records seeded before email_body_* was added here
+  confirmation.update!(email_body_html: confirmation_html, email_body_text: confirmation_text) if confirmation.email_body_html.blank?
 
-  Notification.find_or_create_by!(
+  fyi_html = <<~HTML.strip
+    <h1>New contact form submission</h1>
+    <p><strong>#{sample[:first_name]} #{sample[:last_name]}</strong> has submitted a message through the contact form.</p>
+    <p><strong>Email:</strong> #{sample[:from]}</p>
+    #{quoted_block.call(sample[:subject], sample[:message])}
+  HTML
+  fyi_text = <<~TEXT.strip
+    New contact form submission
+
+    #{sample[:first_name]} #{sample[:last_name]} has submitted a message through the contact form.
+
+    Email: #{sample[:from]}
+
+    Subject: #{sample[:subject]}
+    #{sample[:message]}
+  TEXT
+
+  fyi = Notification.find_or_create_by!(
     recipient_email: reply_to_email,
     email_subject: "[FYI] New contact form submission from #{sample[:from]}: #{sample[:subject]}",
     kind: "contact_us_fyi"
@@ -39,16 +106,25 @@ contact_us_samples.each_with_index do |sample, i|
     n.delivered_at = delivered_at
     # Mark older submissions as already responded so the green checks are visible
     n.responded = i < (contact_us_samples.size / 2)
+    n.email_body_html = fyi_html
+    n.email_body_text = fyi_text
   end
+  fyi.update!(email_body_html: fyi_html, email_body_text: fyi_text) if fyi.email_body_html.blank?
 end
 
 # A few non-contact-us notifications so the em-dash rendering is visible too
 [
-  { kind: "event_registration_confirmation_fyi", subject: "[FYI] New event registration" },
-  { kind: "idea_submitted_fyi", subject: "[FYI] New story idea submission by a contributor" },
-  { kind: "workshop_log_submitted_fyi", subject: "New WorkshopLog submission" }
+  { kind: "event_registration_confirmation_fyi", subject: "[FYI] New event registration",
+    body: "A new event registration has been submitted through the portal. Review the registrant's details and form answers in the events dashboard." },
+  { kind: "idea_submitted_fyi", subject: "[FYI] New story idea submission by a contributor",
+    body: "A contributor has submitted a new story idea. Review the submission and any attached quotes or images in the admin area." },
+  { kind: "workshop_log_submitted_fyi", subject: "New WorkshopLog submission",
+    body: "A facilitator has logged a completed workshop. Review the session details and participant counts in the reporting dashboard." }
 ].each_with_index do |attrs, i|
-  Notification.find_or_create_by!(
+  body_html = "<h1>#{attrs[:subject]}</h1>\n<p>#{attrs[:body]}</p>"
+  body_text = "#{attrs[:subject]}\n\n#{attrs[:body]}"
+
+  notification = Notification.find_or_create_by!(
     recipient_email: reply_to_email,
     email_subject: attrs[:subject],
     kind: attrs[:kind]
@@ -57,7 +133,10 @@ end
     n.recipient_role = "admin"
     n.notification_type = 0
     n.delivered_at = (i + 1).days.ago
+    n.email_body_html = body_html
+    n.email_body_text = body_text
   end
+  notification.update!(email_body_html: body_html, email_body_text: body_text) if notification.email_body_html.blank?
 end
 
 puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications " \


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — dev-seed data only: adds email bodies to seeded notifications, no app/logic changes

## Why
Seeded contact-us and FYI notifications set an `email_subject` but never `email_body_html`/`email_body_text`, so opening one in the admin **Email Preview** pane (`notifications/show`) rendered the *"No email body captured."* placeholder. This is also what made the user suspect seeded emails had no body.

## What
- Render realistic HTML + plain-text bodies for every seeded notification (contact-us confirmation, contact-us FYI, and the registration/idea/workshop-log FYIs), modeled on the real mailer templates.
- Enrich `contact_us_samples` with sender names + a message so bodies read like genuine submissions.
- Backfill `email_body_*` on re-run for records that were seeded before this change (the `find_or_create_by!` block only fires on create).

## Not in scope
The "Pending, no subject" **registration confirmation** rows in the screenshot are **not** seeded — they come from the real registration flow, where `NotificationMailerJob` fills in subject/body asynchronously. On staging they stay pending if the job queue worker isn't running or the job is failing. That's a separate ops issue, called out so it isn't lost.