### PR TITLE
Fix display of scholarship answers wherever they were captured, across edit/public/callout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~78 files |
-| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~28 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~29 files |
 | `app/jobs/` | SolidQueue background jobs | 3 files |
 | `app/models/concerns/` | Shared model modules | 15 concerns |
 
@@ -181,6 +181,7 @@ end
 ### Business Logic
 
 - `EventDashboard` — Aggregates per-event dashboard metrics (registrant/org/sector/state/county counts, scholarship totals, payment received/outstanding/total)
+- `ScholarshipApplication` — Gathers one person's scholarship-application answers for an event by field across all their submissions, so answers surface whether captured on a dedicated scholarship form, an embedded registration section, or the registration submission itself (used by the scholarship edit page and the public submission view)
 - `WorkshopSearchService` — Complex filtering, sorting, pagination with ActionPolicy
 - `WorkshopFromIdeaService` — Converts WorkshopIdea to Workshop with asset migration
 - `WorkshopVariationFromIdeaService` — Variation creation from ideas

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -41,6 +41,7 @@ module Events
       end
 
       @scholarship = @event_registration.scholarships.first
+      @form_responses_available = @event.registration_form&.form_submissions&.exists?(person: @event_registration.registrant)
     end
 
     # CE hours status: requested hours, amount owed, and license number.

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -171,21 +171,24 @@ module Events
       @event.registration_form
     end
 
-    # Surface the separate scholarship-form application (its own role: "scholarship"
-    # submission) on the view-submission page when the registrant filled it out.
-    # Only set when answers are actually on file so the view renders nothing for
-    # plain registrations.
+    # Surface the dedicated scholarship form's application in its own card on the
+    # view-submission page when the registrant filled it out. Answers are gathered
+    # by field identifier (they may live on the scholarship submission or on the
+    # registration submission), so a registrant who answered the questions while
+    # registering still sees them. Only set when answers are on file, so plain
+    # registrations render nothing. Embedded-section scholarship questions need no
+    # separate card — they already render inline with the registration answers.
     def load_scholarship_submission(person)
       scholarship_form = @event.scholarship_form
       return unless scholarship_form
 
-      submission = scholarship_form.form_submissions.find_by(person: person, role: "scholarship")
-      return unless submission&.form_answers&.exists?
+      application = ScholarshipApplication.new(event: @event, person: person)
+      return unless application.answered?
 
-      @scholarship_submission = submission
+      @scholarship_submission = application.submission
       @scholarship_form = scholarship_form
       @scholarship_fields = scholarship_form.form_fields.reorder(position: :asc)
-      @scholarship_responses = submission.form_answers.index_by(&:form_field_id)
+      @scholarship_responses = application.answers_by_field_id
     end
 
     def scholarship_mode?

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -187,17 +187,37 @@ class ScholarshipsController < ApplicationController
     return unless @allocatable.respond_to?(:event)
 
     @event = @allocatable.event
-    form = @event&.registration_form
+    return unless @event
+
+    form, fields = scholarship_form_and_fields
     return unless form
 
-    @form_submission = form.form_submissions.find_by(person: @scholarship.recipient)
+    @form_submission = scholarship_submission_for(form)
     answers = @form_submission ? @form_submission.form_answers.index_by(&:form_field_id) : {}
 
-    @scholarship_answers = form.form_fields
-      .select { |field| field.section == "scholarship" || field.scholarship_only? }
+    @scholarship_answers = fields
       .reject { |field| field.group_header? || field.no_user_input? }
       .sort_by { |field| field.position.to_i }
       .map { |field| [ field, answers[field.id] ] }
+  end
+
+  # The scholarship questions live on the event's dedicated scholarship form
+  # (role: "scholarship") when one is linked; older events embed them in a
+  # "scholarship" section of the registration form instead. Prefer the former,
+  # fall back to the latter so both layouts surface the answers.
+  def scholarship_form_and_fields
+    if (scholarship_form = @event.scholarship_form)
+      [ scholarship_form, scholarship_form.form_fields.to_a ]
+    elsif (registration_form = @event.registration_form)
+      [ registration_form, registration_form.form_fields.select { |field| field.section == "scholarship" || field.scholarship_only? } ]
+    else
+      [ nil, [] ]
+    end
+  end
+
+  def scholarship_submission_for(form)
+    form.form_submissions.find_by(person: @scholarship.recipient, role: "scholarship") ||
+      form.form_submissions.find_by(person: @scholarship.recipient)
   end
 
   def locate_allocatable

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -181,43 +181,18 @@ class ScholarshipsController < ApplicationController
     root_path
   end
 
-  # Pull the recipient's scholarship-section answers from the event's
-  # registration form submission, plus a link to the full public submission.
+  # Pull the recipient's scholarship-application answers — wherever they were
+  # captured (dedicated scholarship form, embedded registration section, or
+  # against the registration submission) — plus a link to the full submission.
   def load_scholarship_submission
     return unless @allocatable.respond_to?(:event)
 
     @event = @allocatable.event
     return unless @event
 
-    form, fields = scholarship_form_and_fields
-    return unless form
-
-    @form_submission = scholarship_submission_for(form)
-    answers = @form_submission ? @form_submission.form_answers.index_by(&:form_field_id) : {}
-
-    @scholarship_answers = fields
-      .reject { |field| field.group_header? || field.no_user_input? }
-      .sort_by { |field| field.position.to_i }
-      .map { |field| [ field, answers[field.id] ] }
-  end
-
-  # The scholarship questions live on the event's dedicated scholarship form
-  # (role: "scholarship") when one is linked; older events embed them in a
-  # "scholarship" section of the registration form instead. Prefer the former,
-  # fall back to the latter so both layouts surface the answers.
-  def scholarship_form_and_fields
-    if (scholarship_form = @event.scholarship_form)
-      [ scholarship_form, scholarship_form.form_fields.to_a ]
-    elsif (registration_form = @event.registration_form)
-      [ registration_form, registration_form.form_fields.select { |field| field.section == "scholarship" || field.scholarship_only? } ]
-    else
-      [ nil, [] ]
-    end
-  end
-
-  def scholarship_submission_for(form)
-    form.form_submissions.find_by(person: @scholarship.recipient, role: "scholarship") ||
-      form.form_submissions.find_by(person: @scholarship.recipient)
+    application = ScholarshipApplication.new(event: @event, person: @scholarship.recipient)
+    @form_submission = application.submission
+    @scholarship_answers = application.answer_pairs
   end
 
   def locate_allocatable

--- a/app/services/scholarship_application.rb
+++ b/app/services/scholarship_application.rb
@@ -1,0 +1,111 @@
+# Gathers one person's scholarship-application answers for an event, regardless of
+# which submission they were captured on.
+#
+# The scholarship questions can be asked on a dedicated scholarship form (its own
+# role: "scholarship" submission), as a "scholarship" section embedded in the
+# registration form, or — for a registrant who answered them while registering —
+# stored against the registration submission. A by-submission lookup misses some
+# of those shapes, so this gathers a person's answers across every submission they
+# made for the event's forms and keeps the ones that belong to a scholarship
+# question, the same spirit as EventDashboard's recipients gathering.
+class ScholarshipApplication
+  # Canonical scholarship question identifiers, used as a backstop so answers
+  # recorded against another form's copy of a standard question are still found.
+  IDENTIFIERS = FormBuilderService::SECTION_FIELD_IDENTIFIERS[:scholarship].freeze
+
+  def initialize(event:, person:)
+    @event = event
+    @person = person
+  end
+
+  # The scholarship questions in display order: every field on a dedicated
+  # scholarship form, plus any "scholarship" section / scholarship-only fields on
+  # the registration form.
+  def fields
+    @fields ||= question_fields.sort_by { |field| field.position.to_i }
+  end
+
+  # Visible questions paired with the person's answer (nil when unanswered),
+  # dropping group headers and no-input fields. Suitable for a definition list.
+  def answer_pairs
+    fields
+      .reject { |field| field.group_header? || field.no_user_input? }
+      .map { |field| [ field, answer_for(field) ] }
+  end
+
+  # Answers keyed by their form field id, for views that look up by field.id.
+  def answers_by_field_id
+    @answers_by_field_id ||= answers.index_by(&:form_field_id)
+  end
+
+  def answered?
+    answers.any? { |answer| answer.submitted_answer.present? }
+  end
+
+  # A submission carrying these answers, for the "submitted on" line and to gate
+  # the "view full submission" link: the dedicated scholarship submission when
+  # present, otherwise whichever event submission holds the answers (the
+  # registration submission for embedded / while-registering answers).
+  def submission
+    @submission ||= answer_submissions.find { |sub| sub.role == "scholarship" } ||
+      answer_submissions.first ||
+      submissions.first
+  end
+
+  private
+
+  def answer_for(field)
+    answers_by_field_id[field.id] || answers_by_identifier[field.field_identifier]
+  end
+
+  def answers_by_identifier
+    @answers_by_identifier ||= answers
+      .reject { |answer| answer.form_field.field_identifier.blank? }
+      .index_by { |answer| answer.form_field.field_identifier }
+  end
+
+  def question_fields
+    fields = []
+    fields.concat(@event.scholarship_form.form_fields.to_a) if @event.scholarship_form
+    if (registration_form = @event.registration_form)
+      fields.concat(registration_form.form_fields.select { |field| field.section == "scholarship" || field.scholarship_only? })
+    end
+    fields
+  end
+
+  def question_field_ids
+    @question_field_ids ||= question_fields.map(&:id).to_set
+  end
+
+  def question_field_identifiers
+    @question_field_identifiers ||= (question_fields.map(&:field_identifier).compact + IDENTIFIERS).to_set
+  end
+
+  # The person's non-blank answers — across every submission they made for the
+  # event's forms — that belong to a scholarship question, matched by the field
+  # itself or, to bridge an answer captured on another form's copy of the same
+  # question, by its identifier. Deduplicated to one answer per question.
+  def answers
+    @answers ||= FormAnswer
+      .where(form_submission: submissions)
+      .where.not(submitted_answer: [ nil, "" ])
+      .includes(:form_field, :form_submission)
+      .select { |answer| scholarship_answer?(answer.form_field) }
+      .group_by { |answer| answer.form_field.field_identifier.presence || "field-#{answer.form_field_id}" }
+      .values
+      .map(&:first)
+  end
+
+  def scholarship_answer?(field)
+    question_field_ids.include?(field.id) ||
+      (field.field_identifier.present? && question_field_identifiers.include?(field.field_identifier))
+  end
+
+  def submissions
+    @submissions ||= FormSubmission.where(person: @person, form_id: @event.forms.ids).to_a
+  end
+
+  def answer_submissions
+    answers.map(&:form_submission).uniq
+  end
+end

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -64,6 +64,20 @@
           </div>
         </div>
       <% end %>
+
+      <%# Jump to the registrant's full submission, where their scholarship
+          application answers are surfaced (inline for embedded-section forms, or
+          in a dedicated "Scholarship application" card for separate forms). %>
+      <% if @form_responses_available %>
+        <div class="border-t border-gray-100 pt-5">
+          <%= link_to event_public_registration_path(@event, reg: @event_registration.slug),
+                      class: "inline-flex items-center gap-1.5 text-sm font-medium #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:underline" do %>
+            <i class="fa-solid fa-file-lines"></i>
+            Review your form responses
+            <i class="fa-solid fa-arrow-right text-xs"></i>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -17,7 +17,7 @@
       <% end %>
     <% end %>
     <% if reg && allowed_to?(:index?, EventRegistration) %>
-      <%= link_to "Registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
   </div>
 </div>
@@ -57,11 +57,9 @@
             </div>
           <% else %>
             <% response = @responses[field.id] %>
-            <div class="<%= field.grid_span_class %> py-2">
+            <div class="<%= field.grid_span_class %> pb-8">
               <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
-              <dd class="mt-1 text-sm text-gray-900">
-                <%= display_response_text(field, response) %>
-              </dd>
+              <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
             </div>
           <% end %>
         <% end %>
@@ -108,11 +106,9 @@
               </div>
             <% else %>
               <% response = @scholarship_responses[field.id] %>
-              <div class="<%= field.grid_span_class %> py-2">
+              <div class="<%= field.grid_span_class %> pb-8">
                 <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
-                <dd class="mt-1 text-sm text-gray-900 whitespace-pre-line">
-                  <%= display_response_text(field, response) %>
-                </dd>
+                <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
               </div>
             <% end %>
           <% end %>

--- a/app/views/scholarships/_form_submission.html.erb
+++ b/app/views/scholarships/_form_submission.html.erb
@@ -1,6 +1,6 @@
-<%# ---- Form submission — the recipient's scholarship-section answers from their
-    registration form, with a jump link to the full public submission (where the
-    complete application, if any, lives). ---- %>
+<%# ---- Form submission — the recipient's scholarship application answers (from
+    the event's dedicated scholarship form, or a "scholarship" section embedded in
+    the registration form), with a jump link to the full public submission. ---- %>
 <% submission_params = @allocatable.try(:slug).present? ? { reg: @allocatable.slug } : { person_id: @scholarship.recipient_id } %>
 <% answered = @scholarship_answers.to_a.any? { |_field, response| response&.submitted_answer.present? } %>
 <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -606,6 +606,32 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       end
     end
 
+    context "when the scholarship answers were captured on the registration submission" do
+      let(:scholarship_form) { create(:form, role: "scholarship") }
+      let!(:scholarship_field) do
+        create(:form_field, form: scholarship_form, section: "scholarship",
+               answer_type: :free_form_input_paragraph, name: "Why do you need a scholarship?", required: false)
+      end
+
+      before do
+        EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+        # No separate scholarship submission — the answer hangs off the
+        # registration submission, on a scholarship-form field.
+        reg_submission = FormSubmission.find_by(person: person, form: form)
+        reg_submission.form_answers.create!(form_field: scholarship_field,
+                                            submitted_answer: "Our agency training budget was cut.")
+      end
+
+      it "still surfaces them in the scholarship application card" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("Scholarship application")
+        expect(response.body).to include("Why do you need a scholarship?")
+        expect(response.body).to include("Our agency training budget was cut.")
+      end
+    end
+
     it "does not render a scholarship section when there is no scholarship submission" do
       get event_public_registration_path(event, person_id: person.id)
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -124,6 +124,26 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("Eligibility criteria")
       expect(response.body).to include("Tasks to complete")
     end
+
+    it "links to the registrant's form responses when a submission is on file" do
+      registration.update!(scholarship_requested: true)
+      form = create(:form)
+      create(:event_form, event: event, form: form, role: "registration")
+      create(:form_submission, :with_event, event: event, person: registration.registrant, form: form)
+
+      get registration_scholarship_path(registration.slug)
+
+      expect(response.body).to include("Review your form responses")
+      expect(response.body).to include(event_public_registration_path(event, reg: registration.slug))
+    end
+
+    it "omits the form-responses link when the registrant has no submission" do
+      registration.update!(scholarship_requested: true)
+
+      get registration_scholarship_path(registration.slug)
+
+      expect(response.body).not_to include("Review your form responses")
+    end
   end
 
   describe "GET /registration/:slug/faq" do

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe "Scholarships", type: :request do
       expect(response.body).to include(event_public_registration_path(event, reg: registration.slug))
     end
 
+    it "shows answers submitted on the event's dedicated scholarship form" do
+      scholarship_form = create(:form, name: "Scholarship Application")
+      create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+      field = create(:form_field, form: scholarship_form, section: "scholarship",
+                     name: "How much can you contribute?", answer_type: :free_form_input_one_line)
+      submission = create(:form_submission, person: registration.registrant, form: scholarship_form, role: "scholarship")
+      create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "$250")
+
+      get edit_scholarship_path(scholarship)
+
+      expect(response.body).to include("Form submission")
+      expect(response.body).to include("How much can you contribute?")
+      expect(response.body).to include("$250")
+    end
+
     it "renders the shared event header: event link, training date, and a profile-linked recipient" do
       get edit_scholarship_path(scholarship)
 

--- a/spec/services/scholarship_application_spec.rb
+++ b/spec/services/scholarship_application_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe ScholarshipApplication do
+  let(:event) { create(:event) }
+  let(:person) { create(:person) }
+
+  subject(:application) { described_class.new(event: event, person: person) }
+
+  context "with a dedicated scholarship form and its own scholarship submission" do
+    let(:scholarship_form) { create(:form, :scholarship) }
+    let(:question) do
+      create(:form_field, form: scholarship_form, section: "scholarship",
+             name: "How much can you contribute?", answer_type: :free_form_input_one_line)
+    end
+
+    before do
+      create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+      submission = create(:form_submission, :with_event, event: event, person: person,
+                          form: scholarship_form, role: "scholarship")
+      create(:form_answer, form_submission: submission, form_field: question, submitted_answer: "$250")
+    end
+
+    it "surfaces the answer paired with its question" do
+      expect(application).to be_answered
+      expect(application.answer_pairs).to contain_exactly([ question, have_attributes(submitted_answer: "$250") ])
+      expect(application.submission.role).to eq("scholarship")
+    end
+  end
+
+  context "with the answers stored on the registration submission (answered while registering)" do
+    let(:registration_form) { create(:form, name: "Registration Form") }
+    let(:scholarship_form) { create(:form, :scholarship) }
+    let(:question) do
+      create(:form_field, form: scholarship_form, section: "scholarship",
+             name: "Why do you need a scholarship?", answer_type: :free_form_input_paragraph)
+    end
+
+    before do
+      create(:event_form, event: event, form: registration_form, role: "registration")
+      create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+      # Answer hangs off the registration submission, but on a scholarship-form field.
+      reg_submission = create(:form_submission, :with_event, event: event, person: person, form: registration_form)
+      create(:form_answer, form_submission: reg_submission, form_field: question, submitted_answer: "Limited budget")
+    end
+
+    it "still finds the scholarship answer across the person's submissions" do
+      expect(application).to be_answered
+      expect(application.answer_pairs).to contain_exactly([ question, have_attributes(submitted_answer: "Limited budget") ])
+      expect(application.answers_by_field_id[question.id].submitted_answer).to eq("Limited budget")
+    end
+  end
+
+  context "with a scholarship section embedded in the registration form (no dedicated form)" do
+    let(:registration_form) { create(:form, name: "Registration Form") }
+    let(:question) do
+      create(:form_field, form: registration_form, section: "scholarship",
+             name: "Describe your need", answer_type: :free_form_input_paragraph)
+    end
+
+    before do
+      create(:event_form, event: event, form: registration_form, role: "registration")
+      submission = create(:form_submission, :with_event, event: event, person: person, form: registration_form)
+      create(:form_answer, form_submission: submission, form_field: question, submitted_answer: "I have a need")
+    end
+
+    it "surfaces the embedded-section answer" do
+      expect(application).to be_answered
+      expect(application.answer_pairs).to contain_exactly([ question, have_attributes(submitted_answer: "I have a need") ])
+    end
+  end
+
+  context "without any scholarship answers" do
+    let(:registration_form) { create(:form, name: "Registration Form") }
+
+    before do
+      create(:event_form, event: event, form: registration_form, role: "registration")
+      create(:form_field, form: registration_form, section: "scholarship", name: "Need?")
+      create(:form_submission, :with_event, event: event, person: person, form: registration_form)
+    end
+
+    it "is not answered but still reports the registration submission" do
+      expect(application).not_to be_answered
+      expect(application.answer_pairs.map(&:last)).to all(be_nil)
+      expect(application.submission).to be_present
+    end
+  end
+end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — display-only fix; new PORO + small view/controller changes, no data writes

### What & why
Scholarship answers were only found on a separate `role: "scholarship"` submission, so a registrant who answered the questions **while registering** (answers stored on the registration submission) showed *no* answers — on both the admin scholarship edit page and the public submission view. This is the common shape in our own seed data (4 of 6 flagship recipients).

### Approach
New `ScholarshipApplication` PORO gathers a person's scholarship answers **by field across all of their event submissions** — the same way `EventDashboard` does for the recipients page — so answers surface whether captured on a dedicated scholarship form, an embedded registration section, or the registration submission itself. Both the scholarship **edit page** and the **public submission view** now use it.

### Also
- Registrant-facing **scholarship callout** gains a "Review your form responses →" link to their submission (shown only when a submission exists).
- Public submission view: answers rendered **larger/bold** with tightened question→answer spacing; "Registration" admin button relabeled "Edit registration".

### Tests
- `spec/services/scholarship_application_spec.rb` — all three capture shapes + the unanswered case.
- Public-show request spec — combo case (answers on the registration submission) renders the scholarship card.
- Callout request spec — link present with a submission, absent without.