### PR TITLE
Capture contact and organization answers as structured data

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -304,18 +304,21 @@ module EventRegistrationServices
         new_city&.downcase, new_state&.downcase.to_s
       )
 
+      # Unlike a person's mailing address, an organization accumulates work
+      # addresses from every registrant, so we never demote its existing primary:
+      # a registrant's address becomes primary only when the org has none yet.
+      make_primary = organization.addresses.active.where(primary: true).none?
+
       if existing
         existing.update!(
           street_address: field_value("agency_street"),
           zip_code: field_value("agency_zip"),
-          primary: true,
+          primary: existing.primary? || make_primary,
           inactive: false
         )
         apply_value(existing, :country, field_value("agency_country"))
         return existing
       end
-
-      organization.addresses.where(primary: true).update_all(primary: false, inactive: true)
 
       organization.addresses.create!(
         street_address: field_value("agency_street"),
@@ -325,7 +328,7 @@ module EventRegistrationServices
         country: field_value("agency_country")&.strip,
         locality: "Unknown",
         address_type: "work",
-        primary: true
+        primary: make_primary
       )
     end
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -51,8 +51,11 @@ module EventRegistrationServices
         create_phone_contact(person) if field_value("phone").present?
 
         organization = find_organization if field_value(ORGANIZATION_NAME_IDENTIFIER).present?
-        create_affiliation(person, organization) if organization
-        create_agency_address(organization) if organization && field_value("agency_city").present?
+        if organization
+          create_affiliation(person, organization)
+          sync_organization_profile(organization)
+          create_agency_address(organization) if field_value("agency_city").present?
+        end
 
         assign_tags(person, organization)
 
@@ -178,6 +181,11 @@ module EventRegistrationServices
       apply_value(person, :racial_ethnic_identity, field_value("racial_ethnic_identity"))
     end
 
+    def sync_organization_profile(organization)
+      apply_value(organization, :website_url, field_value("agency_website"))
+      apply_value(organization, :agency_type, field_value("agency_type"))
+    end
+
     # Write value onto attribute when a non-blank value was submitted, overwriting
     # any existing value. A no-op when the value is unchanged (update! records no
     # change, so no spurious audit event).
@@ -227,6 +235,7 @@ module EventRegistrationServices
           primary: true,
           inactive: false
         )
+        apply_value(existing, :country, field_value("mailing_country"))
         return existing
       end
 
@@ -237,6 +246,7 @@ module EventRegistrationServices
         city: new_city,
         state: new_state,
         zip_code: field_value("mailing_zip"),
+        country: field_value("mailing_country")&.strip,
         locality: "Unknown",
         address_type: field_value("mailing_address_type")&.downcase || "unknown",
         primary: true
@@ -301,6 +311,7 @@ module EventRegistrationServices
           primary: true,
           inactive: false
         )
+        apply_value(existing, :country, field_value("agency_country"))
         return existing
       end
 
@@ -311,6 +322,7 @@ module EventRegistrationServices
         city: new_city,
         state: new_state,
         zip_code: field_value("agency_zip"),
+        country: field_value("agency_country")&.strip,
         locality: "Unknown",
         address_type: "work",
         primary: true

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -6,17 +6,10 @@
   <hr class="mb-6 border-gray-200">
 
   <!-- LOCATION + DISTRICT + LOCALITY -->
+  <%# Organization addresses are always "work" — the type designation only matters
+      for Person addresses — so persist it with a hidden field rather than a selector. %>
+  <%= f.hidden_field :address_type, value: "work" %>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-    <%= f.input :address_type,
-                label: "Address type",
-                as: :select,
-                required: true,
-                collection: Address::CONTACT_TYPES.compact.map { |type| [type.titleize, type] },
-                selected: f.object.address_type,
-                input_html: {
-                  value: f.object.address_type,
-                  class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
-                } %>
     <div class="flex items-center gap-6">
       <%= f.input :primary,
                   as: :boolean,

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -176,6 +176,46 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
 
         expect(organization.reload.website_url).to include("helpinghands.org")
       end
+
+      it "stores the org address as a work address" do
+        register_with_org(
+          field_id("agency_street") => "5 Oak Ave",
+          field_id("agency_city") => "Reno",
+          field_id("agency_state") => "NV",
+          field_id("agency_zip") => "89501"
+        )
+
+        expect(organization.addresses.last.address_type).to eq("work")
+      end
+
+      it "makes the first org address primary" do
+        register_with_org(
+          field_id("agency_street") => "5 Oak Ave",
+          field_id("agency_city") => "Reno",
+          field_id("agency_state") => "NV",
+          field_id("agency_zip") => "89501"
+        )
+
+        expect(organization.addresses.find_by(city: "Reno")).to be_primary
+      end
+
+      it "does not demote the org's existing primary when another registrant adds an address" do
+        existing = organization.addresses.create!(
+          street_address: "1 First St", city: "Tahoe", state: "CA", zip_code: "96150",
+          locality: "Unknown", address_type: "work", primary: true
+        )
+
+        register_with_org(
+          field_id("agency_street") => "5 Oak Ave",
+          field_id("agency_city") => "Reno",
+          field_id("agency_state") => "NV",
+          field_id("agency_zip") => "89501"
+        )
+
+        expect(existing.reload).to be_primary
+        expect(existing).not_to be_inactive
+        expect(organization.addresses.find_by(city: "Reno")).not_to be_primary
+      end
     end
   end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -126,6 +126,59 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "structured contact and organization data" do
+    it "stores the mailing country on a new registrant's address" do
+      params = base_form_params(first_name: "Ada", last_name: "Lin", email: "ada@example.com").merge(
+        field_id("mailing_street") => "1 Main St",
+        field_id("mailing_city") => "Oakland",
+        field_id("mailing_state") => "CA",
+        field_id("mailing_zip") => "94601",
+        field_id("mailing_country") => "USA"
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+      person = Person.find_by!(email: "ada@example.com")
+
+      expect(person.addresses.find_by(primary: true).country).to eq("USA")
+    end
+
+    context "with a matched organization" do
+      let!(:organization) { create(:organization, name: "Helping Hands") }
+
+      def register_with_org(extra)
+        params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
+          field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => "Helping Hands"
+        ).merge(extra)
+        described_class.call(event: event, form: form, form_params: params)
+      end
+
+      it "fills website, agency type, and address country" do
+        register_with_org(
+          field_id("agency_website") => "helpinghands.org",
+          field_id("agency_type") => "501c3/nonprofit",
+          field_id("agency_street") => "5 Oak Ave",
+          field_id("agency_city") => "Reno",
+          field_id("agency_state") => "NV",
+          field_id("agency_zip") => "89501",
+          field_id("agency_country") => "USA"
+        )
+        organization.reload
+
+        expect(organization.agency_type).to eq("501c3/nonprofit")
+        expect(organization.website_url).to include("helpinghands.org")
+        expect(organization.addresses.find_by(primary: true).country).to eq("USA")
+      end
+
+      it "overwrites an existing website with the latest answer" do
+        organization.update!(website_url: "https://existing.org")
+
+        register_with_org(field_id("agency_website") => "helpinghands.org")
+
+        expect(organization.reload.website_url).to include("helpinghands.org")
+      end
+    end
+  end
+
   describe "matching an existing registrant by name" do
     it "matches a person stored under a nickname when the registrant types their legal first name" do
       existing = create(:person, first_name: "Bob", legal_first_name: "Robert",


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — service mapping + tests, no migration (columns already exist)

### What & why
`mailing_country`/`agency_country`, `agency_website`, and `agency_type` were collected on the registration form but saved only as `form_answers`. Map them onto their existing model columns.

### Approach
- `Address.country` for mailing and agency addresses (set on create, overwritten on an existing address).
- `Organization.website_url` and `Organization.agency_type` for a matched org.
- Overwrite-with-audit: a non-blank answer wins; the prior value is preserved by `AhoyTrackable`'s `after_update` event; a blank answer never clobbers. Introduces the shared `apply_value` helper.

_Note: shares `apply_value` with the racial-identity, payment-method, and consent PRs; whichever merges first carries it._