### PR TITLE
Capture racial/ethnic identity as structured person data

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -394,6 +394,7 @@ class PeopleController < ApplicationController
       :license_number,
       :license_type,
       :credentials,
+      :racial_ethnic_identity,
       :bio, :shoutout_text, :notes,
       :display_name_preference,
       :pronouns,

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -44,6 +44,7 @@ module EventRegistrationServices
     def call
       ActiveRecord::Base.transaction do
         person = find_or_create_person
+        sync_person_profile(person)
 
         create_mailing_address(person) if field_value("mailing_city").present?
         create_phone_contact(person) if field_value("phone").present?
@@ -164,6 +165,24 @@ module EventRegistrationServices
         .where("LOWER(last_name) = ? AND LOWER(email) = ?", last_name.downcase, email.downcase)
         .where("LOWER(first_name) IN (:names) OR LOWER(COALESCE(legal_first_name, '')) IN (:names)", names: first_names)
         .first
+    end
+
+    # Populate the structured columns that the registration form collects but that
+    # we historically stored only as form answers. A non-blank submitted value
+    # overwrites whatever was on file: the latest registration is treated as the
+    # freshest source of truth, and the prior value is preserved in the audit trail
+    # — every model includes AhoyTrackable, whose after_update logs an Ahoy::Event
+    # capturing the change. A blank answer never clobbers existing data.
+    def sync_person_profile(person)
+      apply_value(person, :racial_ethnic_identity, field_value("racial_ethnic_identity"))
+    end
+
+    # Write value onto attribute when a non-blank value was submitted, overwriting
+    # any existing value. A no-op when the value is unchanged (update! records no
+    # change, so no spurious audit event).
+    def apply_value(record, attribute, value)
+      return if value.blank?
+      record.update!(attribute => value.strip)
     end
 
     def create_mailing_address(person)

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -343,7 +343,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col lg:flex-row gap-6 items-start">
+  <div class="flex flex-col lg:flex-row gap-6 items-stretch">
     <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm lg:flex-1">
       <div class="flex flex-col sm:flex-row gap-6 items-start">
         <div class="w-full sm:w-56">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -308,14 +308,10 @@
                       },
                       hint: "Maximum 250 characters" %>
 
-          <% if allowed_to?(:manage?, Person) %>
-            <div class="w-full admin-only bg-blue-100 rounded-lg p-2">
-              <%= f.input :racial_ethnic_identity,
-                          label: "Racial/ethnic identity",
-                          input_html: { class: "w-full" },
-                          wrapper_html: { class: "w-full" } %>
-            </div>
-          <% end %>
+          <%= f.input :credentials,
+                      label: "Credentials",
+                      input_html: { class: "w-full" },
+                      wrapper_html: { class: "w-full" } %>
         </div>
 
         <%= f.input :shoutout_text,
@@ -370,12 +366,14 @@
 
     <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
       <div class="flex flex-col sm:flex-row gap-6 items-start">
-        <div class="w-full sm:w-36">
-          <%= f.input :credentials,
-                      label: "Credentials",
-                      input_html: { class: "w-full" },
-                      wrapper_html: { class: "w-full" } %>
-        </div>
+        <% if allowed_to?(:manage?, Person) %>
+          <div class="w-full sm:w-64 admin-only bg-blue-100 rounded-lg p-2">
+            <%= f.input :racial_ethnic_identity,
+                        label: "Racial/ethnic identity",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full" } %>
+          </div>
+        <% end %>
 
         <div class="w-full sm:w-36">
           <%= f.input :license_type,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -325,7 +325,7 @@
                         class: "w-full rounded-md border-gray-300 shadow-sm
                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
                       },
-                      hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+                      hint: "Shown on an event's scholarship recipients page if designated for a shout-out" %>
 
           <div class="flex flex-col sm:flex-row gap-4 items-start">
             <%= f.input :license_type,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -372,12 +372,14 @@
                       wrapper_html: { class: "w-full" } %>
         </div>
 
-        <div class="w-full sm:w-64">
-          <%= f.input :racial_ethnic_identity,
-                      label: "Racial/ethnic identity",
-                      input_html: { class: "w-full" },
-                      wrapper_html: { class: "w-full" } %>
-        </div>
+        <% if allowed_to?(:manage?, Person) %>
+          <div class="w-full sm:w-64 admin-only bg-blue-100 rounded-lg p-2">
+            <%= f.input :racial_ethnic_identity,
+                        label: "Racial/ethnic identity",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full" } %>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -312,6 +312,18 @@
                       label: "Credentials",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
+
+          <div class="flex flex-col sm:flex-row gap-4 items-start">
+            <%= f.input :license_type,
+                        label: "License type",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full sm:w-1/2" } %>
+
+            <%= f.input :license_number,
+                        label: "License number",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full sm:w-1/2" } %>
+          </div>
         </div>
 
         <%= f.input :shoutout_text,
@@ -364,32 +376,16 @@
       </div>
     </div>
 
-    <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-      <div class="flex flex-col sm:flex-row gap-6 items-start">
-        <% if allowed_to?(:manage?, Person) %>
-          <div class="w-full sm:w-64 admin-only bg-blue-100 rounded-lg p-2">
-            <%= f.input :racial_ethnic_identity,
-                        label: "Racial/ethnic identity",
-                        input_html: { class: "w-full" },
-                        wrapper_html: { class: "w-full" } %>
-          </div>
-        <% end %>
-
-        <div class="w-full sm:w-36">
-          <%= f.input :license_type,
-                      label: "License type",
-                      input_html: { class: "w-full" },
-                      wrapper_html: { class: "w-full" } %>
-        </div>
-
-        <div class="w-full sm:w-36">
-          <%= f.input :license_number,
-                      label: "License number",
+    <% if allowed_to?(:manage?, Person) %>
+      <div class="w-full lg:w-auto rounded-lg border border-gray-200 admin-only bg-blue-100 p-4 shadow-sm">
+        <div class="w-full sm:w-64">
+          <%= f.input :racial_ethnic_identity,
+                      label: "Racial/ethnic identity",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
 
   <div class="profile-preferences-section">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -288,30 +288,49 @@
   </div>
 
   <!-- PERSON FIELDS -->
-  <%# Bio and Shout-out share one row, each half width. %>
-  <div class="flex flex-col sm:flex-row gap-6 items-start">
-    <%= f.input :bio,
-                wrapper_html: { class: "w-full sm:w-1/2" },
-                as: :text,
-                input_html: {
-                  rows: 2,
-                  maxlength: 1650,
-                  class: "w-full rounded-md border-gray-300 shadow-sm
-                      focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                },
-                hint: "Maximum 250 characters" %>
+  <div class="form-group space-y-4">
+    <div class="font-semibold text-gray-700 mb-2">
+      Background
+    </div>
 
-    <%= f.input :shoutout_text,
-                label: "Shout-out",
-                wrapper_html: { class: "w-full sm:w-1/2" },
-                as: :text,
-                input_html: {
-                  rows: 2,
-                  maxlength: 1650,
-                  class: "w-full rounded-md border-gray-300 shadow-sm
-                      focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                },
-                hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+      <%# Bio and Shout-out share one row, each half width. %>
+      <div class="flex flex-col sm:flex-row gap-6 items-start">
+        <div class="w-full sm:w-1/2 space-y-4">
+          <%= f.input :bio,
+                      wrapper_html: { class: "w-full" },
+                      as: :text,
+                      input_html: {
+                        rows: 2,
+                        maxlength: 1650,
+                        class: "w-full rounded-md border-gray-300 shadow-sm
+                            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                      },
+                      hint: "Maximum 250 characters" %>
+
+          <% if allowed_to?(:manage?, Person) %>
+            <div class="w-full admin-only bg-blue-100 rounded-lg p-2">
+              <%= f.input :racial_ethnic_identity,
+                          label: "Racial/ethnic identity",
+                          input_html: { class: "w-full" },
+                          wrapper_html: { class: "w-full" } %>
+            </div>
+          <% end %>
+        </div>
+
+        <%= f.input :shoutout_text,
+                    label: "Shout-out",
+                    wrapper_html: { class: "w-full sm:w-1/2" },
+                    as: :text,
+                    input_html: {
+                      rows: 2,
+                      maxlength: 1650,
+                      class: "w-full rounded-md border-gray-300 shadow-sm
+                          focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                    },
+                    hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
+      </div>
+    </div>
   </div>
 
   <div class="flex flex-col lg:flex-row gap-6 items-start">
@@ -352,8 +371,8 @@
     <div class="w-full lg:w-auto rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
       <div class="flex flex-col sm:flex-row gap-6 items-start">
         <div class="w-full sm:w-36">
-          <%= f.input :license_number,
-                      label: "License number",
+          <%= f.input :credentials,
+                      label: "Credentials",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
@@ -366,20 +385,11 @@
         </div>
 
         <div class="w-full sm:w-36">
-          <%= f.input :credentials,
-                      label: "Credentials",
+          <%= f.input :license_number,
+                      label: "License number",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
-
-        <% if allowed_to?(:manage?, Person) %>
-          <div class="w-full sm:w-64 admin-only bg-blue-100 rounded-lg p-2">
-            <%= f.input :racial_ethnic_identity,
-                        label: "Racial/ethnic identity",
-                        input_html: { class: "w-full" },
-                        wrapper_html: { class: "w-full" } %>
-          </div>
-        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -312,6 +312,20 @@
                       label: "Credentials",
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
+        </div>
+
+        <div class="w-full sm:w-1/2 space-y-4">
+          <%= f.input :shoutout_text,
+                      label: "Shout-out",
+                      wrapper_html: { class: "w-full" },
+                      as: :text,
+                      input_html: {
+                        rows: 2,
+                        maxlength: 1650,
+                        class: "w-full rounded-md border-gray-300 shadow-sm
+                            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                      },
+                      hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
 
           <div class="flex flex-col sm:flex-row gap-4 items-start">
             <%= f.input :license_type,
@@ -325,18 +339,6 @@
                         wrapper_html: { class: "w-full sm:w-1/2" } %>
           </div>
         </div>
-
-        <%= f.input :shoutout_text,
-                    label: "Shout-out",
-                    wrapper_html: { class: "w-full sm:w-1/2" },
-                    as: :text,
-                    input_html: {
-                      rows: 2,
-                      maxlength: 1650,
-                      class: "w-full rounded-md border-gray-300 shadow-sm
-                          focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                    },
-                    hint: "Shown on an event's scholarship recipients page when this person opts into a shout-out" %>
       </div>
     </div>
   </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -371,6 +371,13 @@
                       input_html: { class: "w-full" },
                       wrapper_html: { class: "w-full" } %>
         </div>
+
+        <div class="w-full sm:w-64">
+          <%= f.input :racial_ethnic_identity,
+                      label: "Racial/ethnic identity",
+                      input_html: { class: "w-full" },
+                      wrapper_html: { class: "w-full" } %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -165,13 +165,6 @@
               <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
             </div>
           <% end %>
-          <!-- Racial/ethnic identity (admin only) -->
-          <% if allowed_to?(:manage?, Person) && @person.racial_ethnic_identity.present? %>
-            <div class="md:col-span-2 p-3 admin-only bg-blue-100 rounded-lg">
-              <h2 class="text-lg font-semibold text-gray-800 mb-3">Racial/ethnic identity</h2>
-              <p class="text-gray-700"><%= @person.racial_ethnic_identity %></p>
-            </div>
-          <% end %>
         </div>
       </div>
       <!-- Bio -->

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -165,6 +165,13 @@
               <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
             </div>
           <% end %>
+          <!-- Racial/ethnic identity (admin only) -->
+          <% if allowed_to?(:manage?, Person) && @person.racial_ethnic_identity.present? %>
+            <div class="md:col-span-2 p-3 admin-only bg-blue-100 rounded-lg">
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Racial/ethnic identity</h2>
+              <p class="text-gray-700"><%= @person.racial_ethnic_identity %></p>
+            </div>
+          <% end %>
         </div>
       </div>
       <!-- Bio -->

--- a/db/migrate/20260622202122_add_racial_ethnic_identity_to_people.rb
+++ b/db/migrate/20260622202122_add_racial_ethnic_identity_to_people.rb
@@ -1,0 +1,9 @@
+class AddRacialEthnicIdentityToPeople < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :racial_ethnic_identity, :string
+  end
+
+  def down
+    remove_column :people, :racial_ethnic_identity, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_154549) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_202122) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -983,6 +983,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_154549) do
     t.boolean "profile_show_workshop_variations", default: true, null: false
     t.boolean "profile_show_workshops", default: true, null: false
     t.string "pronouns"
+    t.string "racial_ethnic_identity"
     t.text "shoutout_text"
     t.string "twitter_url"
     t.datetime "updated_at", null: false

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe "People authorization", type: :request do
       it "does not show the Comments section" do
         expect(response.body).not_to include("comment_form")
       end
+
+      it "shows the racial/ethnic identity" do
+        other_person.update!(racial_ethnic_identity: "Multi-racial")
+        get person_path(other_person)
+        expect(response.body).to include("Multi-racial")
+      end
     end
 
     context "as the owner" do
@@ -104,6 +110,12 @@ RSpec.describe "People authorization", type: :request do
 
       it "shows the Submitted content section" do
         expect(response.body).to include("Submitted content")
+      end
+
+      it "hides the racial/ethnic identity from the owner" do
+        regular_user.person.update!(racial_ethnic_identity: "Multi-racial")
+        get person_path(regular_user.person)
+        expect(response.body).not_to include("Multi-racial")
       end
     end
   end
@@ -145,6 +157,11 @@ RSpec.describe "People authorization", type: :request do
         patch person_path(other_person), params: { person: { first_name: "Updated" } }
         expect(response).to redirect_to(person_path(other_person))
         expect(other_person.reload.first_name).to eq("Updated")
+      end
+
+      it "updates the racial/ethnic identity" do
+        patch person_path(other_person), params: { person: { racial_ethnic_identity: "Asian" } }
+        expect(other_person.reload.racial_ethnic_identity).to eq("Asian")
       end
     end
   end

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -90,12 +90,6 @@ RSpec.describe "People authorization", type: :request do
       it "does not show the Comments section" do
         expect(response.body).not_to include("comment_form")
       end
-
-      it "shows the racial/ethnic identity" do
-        other_person.update!(racial_ethnic_identity: "Multi-racial")
-        get person_path(other_person)
-        expect(response.body).to include("Multi-racial")
-      end
     end
 
     context "as the owner" do
@@ -110,12 +104,6 @@ RSpec.describe "People authorization", type: :request do
 
       it "shows the Submitted content section" do
         expect(response.body).to include("Submitted content")
-      end
-
-      it "hides the racial/ethnic identity from the owner" do
-        regular_user.person.update!(racial_ethnic_identity: "Multi-racial")
-        get person_path(regular_user.person)
-        expect(response.body).not_to include("Multi-racial")
       end
     end
   end
@@ -136,6 +124,11 @@ RSpec.describe "People authorization", type: :request do
       it "renders successfully" do
         get edit_person_path(other_person)
         expect(response).to have_http_status(:ok)
+      end
+
+      it "shows the racial/ethnic identity field" do
+        get edit_person_path(other_person)
+        expect(response.body).to include("person[racial_ethnic_identity]")
       end
     end
   end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -51,6 +51,42 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "racial/ethnic identity" do
+    it "stores the racial/ethnic identity on a new registrant" do
+      params = base_form_params(first_name: "Ada", last_name: "Lin", email: "ada@example.com").merge(
+        field_id("racial_ethnic_identity") => "Asian"
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(Person.find_by!(email: "ada@example.com").racial_ethnic_identity).to eq("Asian")
+    end
+
+    it "overwrites a racial/ethnic identity already on file with the latest answer" do
+      existing = create(:person, first_name: "Ada", last_name: "Lin",
+                                 email: "ada@example.com", racial_ethnic_identity: "Multi-racial")
+      params = base_form_params(first_name: "Ada", last_name: "Lin", email: "ada@example.com").merge(
+        field_id("racial_ethnic_identity") => "Asian"
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(existing.reload.racial_ethnic_identity).to eq("Asian")
+    end
+
+    it "leaves a racial/ethnic identity on file untouched when the answer is blank" do
+      existing = create(:person, first_name: "Ada", last_name: "Lin",
+                                 email: "ada@example.com", racial_ethnic_identity: "Multi-racial")
+      params = base_form_params(first_name: "Ada", last_name: "Lin", email: "ada@example.com").merge(
+        field_id("racial_ethnic_identity") => ""
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(existing.reload.racial_ethnic_identity).to eq("Multi-racial")
+    end
+  end
+
   describe "matching an existing registrant by name" do
     it "matches a person stored under a nickname when the registrant types their legal first name" do
       existing = create(:person, first_name: "Bob", legal_first_name: "Robert",


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — new column + admin-gated profile UI + service mapping

### What & why
"How would you best describe yourself?" was saved only as a form answer with no structured home (no `Person` column, no category).

### Approach
- New `people.racial_ethnic_identity` column.
- Mapped from the registration form in `PublicRegistration` (overwrite-with-audit via `AhoyTrackable`; a blank answer never clobbers).
- Shown admin-gated on the person profile (`allowed_to?(:manage?, Person)`); editable on the admin-only edit form.

_Note: shares the `apply_value` helper with the contact/org, payment-method, and consent PRs; whichever merges first carries it._