### PR TITLE
Capture the expected payment method as structured data on registrations

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -330,6 +330,7 @@ class EventRegistrationsController < ApplicationController
       :scholarship_requested,
       :shoutout,
       :intends_to_pay,
+      :expected_payment_method,
       :ce_credit_requested,
       :ce_hours_requested,
       :ce_license_number,

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -65,6 +65,8 @@ module EventRegistrationServices
           existing.update!(ce_credit_requested: true, ce_hours_requested: ce_hours_requested) if ce_credit_requested?
           existing.update!(w9_requested: true) if w9_requested?
           existing.update!(invoice_requested: true) if invoice_requested?
+          payment_method = field_value("payment_method")&.strip
+          existing.update!(expected_payment_method: payment_method) if payment_method.present?
           if existing.status == "cancelled"
             existing.update!(status: "registered")
             send_notifications(existing)
@@ -371,7 +373,8 @@ module EventRegistrationServices
         ce_credit_requested: ce_credit_requested?,
         ce_hours_requested: ce_hours_requested,
         w9_requested: w9_requested?,
-        invoice_requested: invoice_requested?
+        invoice_requested: invoice_requested?,
+        expected_payment_method: field_value("payment_method")&.strip.presence
       )
     end
 

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -291,12 +291,6 @@
           <% end %>
         </div>
       <% end %>
-      <% if f.object.expected_payment_method.present? %>
-        <div class="mt-3 text-xs text-gray-500">
-          Expected payment method:
-          <span class="font-medium text-gray-700"><%= f.object.expected_payment_method %></span>
-        </div>
-      <% end %>
       <%= render "payment_history", event_registration: f.object %>
 
       <% if allowed_to?(:index?, with: NotificationPolicy) %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -291,6 +291,12 @@
           <% end %>
         </div>
       <% end %>
+      <% if f.object.expected_payment_method.present? %>
+        <div class="mt-3 text-xs text-gray-500">
+          Expected payment method:
+          <span class="font-medium text-gray-700"><%= f.object.expected_payment_method %></span>
+        </div>
+      <% end %>
       <%= render "payment_history", event_registration: f.object %>
 
       <% if allowed_to?(:index?, with: NotificationPolicy) %>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -46,22 +46,39 @@
         </div>
       </dl>
 
-      <%# Intends to pay — grants ticket/material access while the balance above is
-          still owed, for registrants who've committed to paying after the deadline.
-          Does not change the amount due or mark the registration as paid. %>
-      <label class="mt-4 flex items-start gap-2.5 border-t border-gray-100 pt-4 cursor-pointer">
-        <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
-        <input type="checkbox"
-               name="event_registration[intends_to_pay]"
-               value="1"
-               <%= "checked" if event_registration.intends_to_pay %>
-               class="sr-only peer">
-        <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
-        <span>
-          <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
-          <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
-        </span>
-      </label>
+      <%# Expected payment method (left) alongside Intends to pay (right). The
+          expected method is prefilled from the registration form answer but stays
+          editable, so staff can record what they anticipate even when the
+          registrant never filled out the form. %>
+      <% payment_options = FormBuilderService::PAYMENT_METHOD_OPTIONS %>
+      <% payment_options |= [ event_registration.expected_payment_method ] if event_registration.expected_payment_method.present? %>
+      <div class="mt-4 grid grid-cols-1 gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 sm:items-start">
+        <div>
+          <label class="block text-sm font-medium text-gray-700" for="expected_payment_method">Expected payment method</label>
+          <span class="mt-0.5 block text-xs text-gray-400">How we expect this registrant to pay. Prefilled from their form answer; edit to record an expectation.</span>
+          <%= select_tag "event_registration[expected_payment_method]",
+                options_for_select([ [ "Not specified", "" ] ] + payment_options, event_registration.expected_payment_method),
+                id: "expected_payment_method",
+                class: "mt-2 w-full rounded-lg border border-gray-300 bg-white py-2 pl-3 pr-8 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none cursor-pointer" %>
+        </div>
+
+        <%# Intends to pay — grants ticket/material access while the balance above is
+            still owed, for registrants who've committed to paying after the deadline.
+            Does not change the amount due or mark the registration as paid. %>
+        <label class="flex items-start gap-2.5 cursor-pointer">
+          <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
+          <input type="checkbox"
+                 name="event_registration[intends_to_pay]"
+                 value="1"
+                 <%= "checked" if event_registration.intends_to_pay %>
+                 class="sr-only peer">
+          <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
+          <span>
+            <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
+            <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
+          </span>
+        </label>
+      </div>
     <% else %>
       <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-0.5 text-xs font-medium text-gray-500">
         <i class="fa-solid fa-gift"></i>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -55,7 +55,7 @@
       <div class="mt-4 grid grid-cols-1 gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 sm:items-start">
         <div>
           <label class="block text-sm font-medium text-gray-700" for="expected_payment_method">Expected payment method</label>
-          <span class="mt-0.5 block text-xs text-gray-400">How we expect them to pay — prefilled from their form, editable.</span>
+          <span class="mt-0.5 block text-xs text-gray-400">Anticipated payment type, prefilled from form</span>
           <%= select_tag "event_registration[expected_payment_method]",
                 options_for_select([ [ "Not specified", "" ] ] + payment_options, event_registration.expected_payment_method),
                 id: "expected_payment_method",

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -55,7 +55,7 @@
       <div class="mt-4 grid grid-cols-1 gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 sm:items-start">
         <div>
           <label class="block text-sm font-medium text-gray-700" for="expected_payment_method">Expected payment method</label>
-          <span class="mt-0.5 block text-xs text-gray-400">How we expect this registrant to pay. Prefilled from their form answer; edit to record an expectation.</span>
+          <span class="mt-0.5 block text-xs text-gray-400">How we expect them to pay — prefilled from their form, editable.</span>
           <%= select_tag "event_registration[expected_payment_method]",
                 options_for_select([ [ "Not specified", "" ] ] + payment_options, event_registration.expected_payment_method),
                 id: "expected_payment_method",

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -52,7 +52,9 @@
           registrant never filled out the form. %>
       <% payment_options = FormBuilderService::PAYMENT_METHOD_OPTIONS %>
       <% payment_options |= [ event_registration.expected_payment_method ] if event_registration.expected_payment_method.present? %>
-      <div class="mt-4 grid grid-cols-1 gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 sm:items-start">
+      <%# relative z-10 lifts these controls above the card's stretched "View all"
+          link (after:inset-0), so the select and toggle stay clickable. %>
+      <div class="relative z-10 mt-4 grid grid-cols-1 gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 sm:items-start">
         <div>
           <label class="block text-sm font-medium text-gray-700" for="expected_payment_method">Expected payment method</label>
           <span class="mt-0.5 block text-xs text-gray-400">Anticipated payment type, prefilled from form</span>

--- a/db/migrate/20260623001312_add_expected_payment_method_to_event_registrations.rb
+++ b/db/migrate/20260623001312_add_expected_payment_method_to_event_registrations.rb
@@ -1,0 +1,9 @@
+class AddExpectedPaymentMethodToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    add_column :event_registrations, :expected_payment_method, :string
+  end
+
+  def down
+    remove_column :event_registrations, :expected_payment_method, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -473,6 +473,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_104203) do
     t.boolean "completed_day_5", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "event_id"
+    t.string "expected_payment_method"
     t.text "fee_note"
     t.boolean "intends_to_pay", default: false, null: false
     t.boolean "invoice_requested", default: false, null: false

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -224,6 +224,16 @@ RSpec.describe "EventRegistrations", type: :request do
       end
     end
 
+    describe "GET /event_registrations/:id/edit" do
+      it "shows the registrant's expected payment method when present" do
+        existing_registration.update!(expected_payment_method: "Check")
+
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include("Expected payment method").and include("Check")
+      end
+    end
+
     describe "PATCH /event_registrations/:id" do
       it "can update registration" do
         patch event_registration_path(existing_registration),

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -225,12 +225,14 @@ RSpec.describe "EventRegistrations", type: :request do
     end
 
     describe "GET /event_registrations/:id/edit" do
-      it "shows the registrant's expected payment method when present" do
+      it "renders the expected payment method as an editable select with the registrant's answer selected" do
         existing_registration.update!(expected_payment_method: "Check")
 
         get edit_event_registration_path(existing_registration)
 
-        expect(response.body).to include("Expected payment method").and include("Check")
+        expect(response.body).to include("Expected payment method")
+        expect(response.body).to include("name=\"event_registration[expected_payment_method]\"")
+        expect(response.body).to include("<option selected=\"selected\" value=\"Check\">Check</option>")
       end
     end
 
@@ -270,6 +272,22 @@ RSpec.describe "EventRegistrations", type: :request do
 
         expect(existing_registration.reload.shoutout).to be(true)
         expect(existing_registration.registrant.reload.shoutout_text).to eq("Grateful to bring art to survivors.")
+      end
+
+      it "records an admin-set expected payment method even when the form was never filled out" do
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { expected_payment_method: "Check" } }
+
+        expect(existing_registration.reload.expected_payment_method).to eq("Check")
+      end
+
+      it "clears the expected payment method when set back to not specified" do
+        existing_registration.update!(expected_payment_method: "Check")
+
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { expected_payment_method: "" } }
+
+        expect(existing_registration.reload.expected_payment_method).to be_blank
       end
     end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -87,6 +87,30 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "expected payment method" do
+    it "records the chosen payment method on a new registration" do
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("payment_method") => "Check"
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(EventRegistration.last.expected_payment_method).to eq("Check")
+    end
+
+    it "updates the expected payment method when an existing registrant re-registers" do
+      person = create(:person, first_name: "Pat", last_name: "Doe", email: "pat@example.com")
+      create(:event_registration, event: event, registrant: person, expected_payment_method: "Check")
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("payment_method") => "Credit card (now)"
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(event.event_registrations.find_by(registrant: person).expected_payment_method).to eq("Credit card (now)")
+    end
+  end
+
   describe "mailing list consent" do
     it "stamps the consent time and source when the registrant opts in" do
       params = base_form_params(first_name: "Coco", last_name: "Lee", email: "coco@example.com").merge(


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — one editable field in the payments section, narrow blast radius

### What & why
The chosen payment method was the one payment signal not otherwise visible for the non-Stripe paths (check / pay later). Staff also need to record what they *expect* a registrant to use even when the registrant never filled out the form — so this is an admin-editable expectation, not just a captured answer.

### Approach
- New `event_registrations.expected_payment_method` (string — stores the raw label).
- Captured at registration and overwritten on re-registration (latest intent wins).
- **Editable** in the admin registration form: a select in the payments section, placed beside the "Intends to pay" toggle (method on the left, intent on the right), prefilled from the form answer but overridable.
- Options come from the canonical `PAYMENT_METHOD_OPTIONS`; any non-canonical stored value is preserved as a selectable option.
- No backfill — historical registrations stay blank until edited or re-registered.
- Bulk payment keeps it as a form answer only (it creates no EventRegistration until allocation).