### PR TITLE
Capture mailing-list consent as structured data

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -396,6 +396,7 @@ class PeopleController < ApplicationController
       :credentials,
       :racial_ethnic_identity,
       :filemaker_code,
+      :mailing_list_consented,
       :bio, :shoutout_text, :notes,
       :display_name_preference,
       :pronouns,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -138,6 +138,28 @@ class Person < ApplicationRecord
     sectors.pluck(:name)
   end
 
+  # Virtual checkbox for the admin person form. Presence of a consent timestamp is
+  # the source of truth; this lets an admin grant or withdraw consent. Withdrawing
+  # clears both the timestamp and its source; granting (when none is on file)
+  # stamps the time and records that an admin did it. Re-checking an existing
+  # consent leaves the original timestamp/source intact.
+  def mailing_list_consented
+    mailing_list_consent_at.present?
+  end
+
+  def mailing_list_consented=(value)
+    consented = ActiveModel::Type::Boolean.new.cast(value)
+
+    if consented
+      return if mailing_list_consent_at.present?
+      self.mailing_list_consent_at = Time.current
+      self.mailing_list_consent_source = "Admin update"
+    else
+      self.mailing_list_consent_at = nil
+      self.mailing_list_consent_source = nil
+    end
+  end
+
   def name
     case display_name_preference
     when "full_name"

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -45,6 +45,7 @@ module EventRegistrationServices
       ActiveRecord::Base.transaction do
         person = find_or_create_person
         sync_person_profile(person)
+        record_mailing_list_consent(person)
 
         create_mailing_address(person) if field_value("mailing_city").present?
         create_phone_contact(person) if field_value("phone").present?
@@ -183,6 +184,31 @@ module EventRegistrationServices
     def apply_value(record, attribute, value)
       return if value.blank?
       record.update!(attribute => value.strip)
+    end
+
+    # Consent is opt-in only and recorded once. An affirmative answer grants
+    # consent (stamping the time and where it came from) when none is on file; we
+    # never clear it from here — withdrawal is a separate, deliberate action — and
+    # we don't keep re-stamping a registrant who already consented.
+    def record_mailing_list_consent(person)
+      return if person.mailing_list_consent_at.present?
+      return unless mailing_list_consent_given?
+
+      person.update!(
+        mailing_list_consent_at: Time.current,
+        mailing_list_consent_source: mailing_list_consent_source
+      )
+    end
+
+    def mailing_list_consent_given?
+      Array(field_value("communication_consent")).any? { |value| value.to_s.strip.present? }
+    end
+
+    # Identify the event by start date *and* title — many trainings share a title,
+    # so the leading date is what makes the consent source traceable to one event,
+    # e.g. "2026-06-23 Facilitator Training registration".
+    def mailing_list_consent_source
+      [ @event.start_date&.to_date&.iso8601, "#{@event.title} registration" ].compact.join(" ")
     end
 
     def create_mailing_address(person)

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -396,7 +396,7 @@
           </div>
         </div>
 
-        <div class="w-full sm:w-64">
+        <div class="w-full">
           <%= f.input :mailing_list_consented,
                       as: :boolean,
                       label: "Consented to mailing list",

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -395,6 +395,16 @@
                         wrapper_html: { class: "w-full" } %>
           </div>
         </div>
+
+        <div class="w-full sm:w-64">
+          <%= f.input :mailing_list_consented,
+                      as: :boolean,
+                      label: "Consented to mailing list",
+                      hint: f.object.mailing_list_consent_at.present? ?
+                              "Consented #{f.object.mailing_list_consent_at.to_date.to_fs(:long)} (#{f.object.mailing_list_consent_source}). Uncheck to withdraw." :
+                              "No consent on file. Check to record consent.",
+                      wrapper_html: { class: "w-full" } %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -165,6 +165,19 @@
               <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
             </div>
           <% end %>
+          <!-- Mailing list consent (admin only) -->
+          <% if allowed_to?(:manage?, Person) %>
+            <div class="md:col-span-2 p-3 admin-only bg-blue-100 rounded-lg">
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Mailing list consent</h2>
+              <% if @person.mailing_list_consent_at.present? %>
+                <p class="text-gray-700">
+                  Consented <%= @person.mailing_list_consent_at.to_date.to_fs(:long) %><%= " — #{@person.mailing_list_consent_source}" if @person.mailing_list_consent_source.present? %>
+                </p>
+              <% else %>
+                <p class="text-gray-500 italic">No consent on file.</p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
       <!-- Bio -->

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -165,19 +165,6 @@
               <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
             </div>
           <% end %>
-          <!-- Mailing list consent (admin only) -->
-          <% if allowed_to?(:manage?, Person) %>
-            <div class="md:col-span-2 p-3 admin-only bg-blue-100 rounded-lg">
-              <h2 class="text-lg font-semibold text-gray-800 mb-3">Mailing list consent</h2>
-              <% if @person.mailing_list_consent_at.present? %>
-                <p class="text-gray-700">
-                  Consented <%= @person.mailing_list_consent_at.to_date.to_fs(:long) %><%= " — #{@person.mailing_list_consent_source}" if @person.mailing_list_consent_source.present? %>
-                </p>
-              <% else %>
-                <p class="text-gray-500 italic">No consent on file.</p>
-              <% end %>
-            </div>
-          <% end %>
         </div>
       </div>
       <!-- Bio -->

--- a/db/migrate/20260623001313_add_mailing_list_consent_to_people.rb
+++ b/db/migrate/20260623001313_add_mailing_list_consent_to_people.rb
@@ -1,0 +1,11 @@
+class AddMailingListConsentToPeople < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :mailing_list_consent_at, :datetime
+    add_column :people, :mailing_list_consent_source, :string
+  end
+
+  def down
+    remove_column :people, :mailing_list_consent_at, if_exists: true
+    remove_column :people, :mailing_list_consent_source, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -963,6 +963,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_104203) do
     t.string "license_number"
     t.string "license_type"
     t.string "linked_in_url"
+    t.datetime "mailing_list_consent_at"
+    t.string "mailing_list_consent_source"
     t.date "member_since"
     t.text "notes"
     t.boolean "profile_is_searchable", default: true, null: false

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -432,6 +432,36 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe "#mailing_list_consented=" do
+    it "stamps consent and a source when granted with none on file" do
+      person = build(:person, mailing_list_consent_at: nil)
+
+      person.mailing_list_consented = "1"
+
+      expect(person.mailing_list_consent_at).to be_present
+      expect(person.mailing_list_consent_source).to eq("Admin update")
+    end
+
+    it "preserves the original timestamp and source when re-checked" do
+      original = 1.year.ago
+      person = build(:person, mailing_list_consent_at: original, mailing_list_consent_source: "Registration: X")
+
+      person.mailing_list_consented = "1"
+
+      expect(person.mailing_list_consent_at).to be_within(1.second).of(original)
+      expect(person.mailing_list_consent_source).to eq("Registration: X")
+    end
+
+    it "clears the timestamp and source when withdrawn" do
+      person = build(:person, mailing_list_consent_at: Time.current, mailing_list_consent_source: "Registration: X")
+
+      person.mailing_list_consented = "0"
+
+      expect(person.mailing_list_consent_at).to be_nil
+      expect(person.mailing_list_consent_source).to be_nil
+    end
+  end
 end
 
 RSpec.describe Person, "scholarship index helpers" do

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe "People authorization", type: :request do
       it "does not show the Comments section" do
         expect(response.body).not_to include("comment_form")
       end
+
+      it "shows the mailing list consent status" do
+        expect(response.body).to include("No consent on file")
+      end
     end
 
     context "as the owner" do
@@ -104,6 +108,10 @@ RSpec.describe "People authorization", type: :request do
 
       it "shows the Submitted content section" do
         expect(response.body).to include("Submitted content")
+      end
+
+      it "hides the mailing list consent status from the owner" do
+        expect(response.body).not_to include("No consent on file")
       end
     end
   end
@@ -165,6 +173,21 @@ RSpec.describe "People authorization", type: :request do
       it "updates the FileMaker code" do
         patch person_path(other_person), params: { person: { filemaker_code: "FM-123" } }
         expect(other_person.reload.filemaker_code).to eq("FM-123")
+      end
+
+      it "withdraws mailing list consent when the box is unchecked" do
+        other_person.update!(mailing_list_consent_at: Time.current, mailing_list_consent_source: "Registration: X")
+
+        patch person_path(other_person), params: { person: { mailing_list_consented: "0" } }
+
+        expect(other_person.reload.mailing_list_consent_at).to be_nil
+        expect(other_person.mailing_list_consent_source).to be_nil
+      end
+
+      it "records mailing list consent when the box is checked" do
+        patch person_path(other_person), params: { person: { mailing_list_consented: "1" } }
+
+        expect(other_person.reload.mailing_list_consent_at).to be_present
       end
     end
   end

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -90,10 +90,6 @@ RSpec.describe "People authorization", type: :request do
       it "does not show the Comments section" do
         expect(response.body).not_to include("comment_form")
       end
-
-      it "shows the mailing list consent status" do
-        expect(response.body).to include("No consent on file")
-      end
     end
 
     context "as the owner" do
@@ -108,10 +104,6 @@ RSpec.describe "People authorization", type: :request do
 
       it "shows the Submitted content section" do
         expect(response.body).to include("Submitted content")
-      end
-
-      it "hides the mailing list consent status from the owner" do
-        expect(response.body).not_to include("No consent on file")
       end
     end
   end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -87,6 +87,45 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "mailing list consent" do
+    it "stamps the consent time and source when the registrant opts in" do
+      params = base_form_params(first_name: "Coco", last_name: "Lee", email: "coco@example.com").merge(
+        field_id("communication_consent") => [ "Yes" ]
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+      person = Person.find_by!(email: "coco@example.com")
+
+      expect(person.mailing_list_consent_at).to be_present
+      expect(person.mailing_list_consent_source).to eq("#{event.start_date.to_date.iso8601} #{event.title} registration")
+    end
+
+    it "does not record consent when the box is left unchecked" do
+      params = base_form_params(first_name: "Coco", last_name: "Lee", email: "coco@example.com").merge(
+        field_id("communication_consent") => [ "" ]
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+
+      expect(Person.find_by!(email: "coco@example.com").mailing_list_consent_at).to be_nil
+    end
+
+    it "never re-stamps or clears consent already on file" do
+      original = 1.year.ago
+      create(:person, first_name: "Coco", last_name: "Lee", email: "coco@example.com",
+                      mailing_list_consent_at: original, mailing_list_consent_source: "Earlier")
+      params = base_form_params(first_name: "Coco", last_name: "Lee", email: "coco@example.com").merge(
+        field_id("communication_consent") => [ "Yes" ]
+      )
+
+      described_class.call(event: event, form: form, form_params: params)
+      person = Person.find_by!(email: "coco@example.com")
+
+      expect(person.mailing_list_consent_at).to be_within(1.second).of(original)
+      expect(person.mailing_list_consent_source).to eq("Earlier")
+    end
+  end
+
   describe "matching an existing registrant by name" do
     it "matches a person stored under a nickname when the registrant types their legal first name" do
       existing = create(:person, first_name: "Bob", legal_first_name: "Robert",


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 🔬 Inspect — new columns + consent capture/withdrawal + admin UI

### What & why
The "I agree to receive email communications" answer was saved only as a `form_answer`, with no way to query or manage consent — which is legally meaningful.

### Approach
- New `people.mailing_list_consent_at` + `mailing_list_consent_source`.
- Opt-in only: an affirmative answer stamps the time and source (`<date> <title> registration`, dated so same-title trainings are distinguishable) when none is on file; a blank answer never records consent; an existing consent is never re-stamped or cleared from registration.
- Consent is admin-only data: not shown on the public profile. An admin manages it via the `mailing_list_consented` checkbox in the person edit form, gated by `person :manage` like the other admin-only fields there.

_Note: independent of the other structured-data PRs (does not use the `apply_value` helper)._