### PR TITLE
Add FileMaker code field to person edit

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -395,6 +395,7 @@ class PeopleController < ApplicationController
       :license_type,
       :credentials,
       :racial_ethnic_identity,
+      :filemaker_code,
       :bio, :shoutout_text, :notes,
       :display_name_preference,
       :pronouns,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -380,11 +380,20 @@
 
     <% if allowed_to?(:manage?, Person) %>
       <div class="w-full lg:w-auto rounded-lg border border-gray-200 admin-only bg-blue-100 p-4 shadow-sm">
-        <div class="w-full sm:w-64">
-          <%= f.input :racial_ethnic_identity,
-                      label: "Racial/ethnic identity",
-                      input_html: { class: "w-full" },
-                      wrapper_html: { class: "w-full" } %>
+        <div class="flex flex-col sm:flex-row gap-6 items-start">
+          <div class="w-full sm:w-64">
+            <%= f.input :racial_ethnic_identity,
+                        label: "Racial/ethnic identity",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full" } %>
+          </div>
+
+          <div class="w-full sm:w-64">
+            <%= f.input :filemaker_code,
+                        label: "FileMaker code",
+                        input_html: { class: "w-full" },
+                        wrapper_html: { class: "w-full" } %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/db/migrate/20260623104203_add_filemaker_code_to_people.rb
+++ b/db/migrate/20260623104203_add_filemaker_code_to_people.rb
@@ -1,0 +1,9 @@
+class AddFilemakerCodeToPeople < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :filemaker_code, :string
+  end
+
+  def down
+    remove_column :people, :filemaker_code, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_202122) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_104203) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -955,6 +955,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_202122) do
     t.string "email_2_type"
     t.string "email_type"
     t.string "facebook_url"
+    t.string "filemaker_code"
     t.string "first_name", null: false
     t.string "instagram_url"
     t.string "last_name", null: false

--- a/spec/requests/people_authorization_spec.rb
+++ b/spec/requests/people_authorization_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe "People authorization", type: :request do
         get edit_person_path(other_person)
         expect(response.body).to include("person[racial_ethnic_identity]")
       end
+
+      it "shows the FileMaker code field" do
+        get edit_person_path(other_person)
+        expect(response.body).to include("person[filemaker_code]")
+      end
     end
   end
 
@@ -155,6 +160,11 @@ RSpec.describe "People authorization", type: :request do
       it "updates the racial/ethnic identity" do
         patch person_path(other_person), params: { person: { racial_ethnic_identity: "Asian" } }
         expect(other_person.reload.racial_ethnic_identity).to eq("Asian")
+      end
+
+      it "updates the FileMaker code" do
+        patch person_path(other_person), params: { person: { filemaker_code: "FM-123" } }
+        expect(other_person.reload.filemaker_code).to eq("FM-123")
       end
     end
   end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: new string column + one admin-only form field, mirrors the recent racial/ethnic identity addition

## What & why
- Adds a `filemaker_code` string column to `people` so admins can reconcile records against the legacy FileMaker system of record.
- Surfaces it on person edit **only**, in the existing admin-only box beside racial/ethnic identity. Not shown on the profile, registration forms, or anywhere else.

## Changes
- Migration: `add_column :people, :filemaker_code, :string` (reversible)
- Permitted in `person_params`
- Form field in the admin-only box (`allowed_to?(:manage?, Person)`), wrapped both fields in a flex row
- Request specs: field renders for admins + admin can update it