### PR TITLE
Validate grant amount covers scholarships already issued

### DIFF
--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -10,6 +10,7 @@ class Grant < ApplicationRecord
   validates :name, presence: true
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :donor_type, inclusion: { in: DONOR_TYPES }
+  validate :amount_covers_scholarships_already_issued
 
   scope :by_deadline, -> { order(Arel.sql("application_deadline IS NULL, application_deadline ASC")) }
 
@@ -93,6 +94,18 @@ class Grant < ApplicationRecord
   end
 
   private
+
+  # A grant's amount can't be lowered below what has already been awarded against
+  # it — the scholarships are committed, so the grant must at least cover them.
+  # Mirrors Scholarship#within_grant_budget from the other side of the ledger.
+  def amount_covers_scholarships_already_issued
+    return unless amount_cents
+
+    issued = scholarships_total_cents
+    if amount_cents < issued
+      errors.add(:amount_cents, "can't be less than the #{MoneyFormatter.dollars_from_cents(issued)} already awarded in scholarships")
+    end
+  end
 
   def text_to_list(text)
     text.to_s.split("\n").map(&:strip).reject(&:blank?)

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -19,6 +19,37 @@ RSpec.describe Grant, type: :model do
     it "is valid with a person donor" do
       expect(build(:grant, :donated_by_person)).to be_valid
     end
+
+    describe "amount cannot drop below scholarships already issued" do
+      it "is invalid when the amount is reduced below the total awarded" do
+        grant = create(:grant, amount_cents: 100_000)
+        create(:scholarship, grant:, amount_cents: 60_000)
+
+        grant.amount_cents = 50_000
+        expect(grant).not_to be_valid
+        expect(grant.errors[:amount_cents]).to include("can't be less than the $600 already awarded in scholarships")
+      end
+
+      it "is valid when the amount equals the total awarded" do
+        grant = create(:grant, amount_cents: 100_000)
+        create(:scholarship, grant:, amount_cents: 60_000)
+
+        grant.amount_cents = 60_000
+        expect(grant).to be_valid
+      end
+
+      it "is valid when the amount stays above the total awarded" do
+        grant = create(:grant, amount_cents: 100_000)
+        create(:scholarship, grant:, amount_cents: 60_000)
+
+        grant.amount_cents = 70_000
+        expect(grant).to be_valid
+      end
+
+      it "is valid for a new grant with no scholarships" do
+        expect(build(:grant, amount_cents: 0)).to be_valid
+      end
+    end
   end
 
   describe "money accessors" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained logic changes with low blast radius

### What is the goal of this PR and why is this important?
- Prevent saving a grant with an `amount_cents` lower than the total scholarships already awarded against it. Those draws are committed, so an amount below them would leave scholarships unbacked.

### How did you approach the change?
- Added a `Grant` model validation (`amount_covers_scholarships_already_issued`) that compares the proposed amount against the existing `scholarships_total_cents` helper.
- Mirrors `Scholarship#within_grant_budget`, which guards each new draw from the other side of the ledger. Equality is allowed; new grants with no scholarships are unaffected.
- Error message uses `MoneyFormatter.dollars_from_cents` (e.g. "can't be less than the $600 already awarded in scholarships").

### Anything else to add?
- TDD: added four model specs (below/equal/above total, plus fresh grant). All grant + scholarship specs pass; RuboCop clean.