### PR TITLE
Improve people index: primary-only sector/age columns, list affiliations

### DIFF
--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -84,7 +84,10 @@ class PersonDecorator < ApplicationDecorator
   end
 
   def affiliated_since_date
-    @affiliated_since_date ||= affiliations.minimum(:start_date)
+    # Compute in Ruby from the (eager-loaded) association so list pages that
+    # preload affiliations don't fire a MIN(start_date) query per row.
+    # `.minimum` would ignore the loaded records and hit the DB every time.
+    @affiliated_since_date ||= affiliations.filter_map(&:start_date).min
   end
 
   private

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,5 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {})
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {}, width_class: "w-full")
     if inactive
       bg = "bg-gray-100"
       hover_bg = "hover:bg-gray-200"
@@ -19,7 +19,7 @@ module PersonHelper
             data: { turbo_prefetch: false }.merge(data),
             title: hover_title,
             class: "group relative flex items-center gap-2
-                    w-full px-4 py-2
+                    #{width_class} px-4 py-2
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
                     font-medium shadow-sm leading-none

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :people_results do %>
   <%= turbo_stream.replace("people_count", partial: "people_count") %>
 
-  <div class="rounded-xl bg-white p-6 animate-fade blur-on-submit">
+  <div class="rounded-xl bg-white overflow-hidden animate-fade blur-on-submit">
     <% if @people.any? %>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse border border-gray-200">
@@ -9,8 +9,8 @@
             <tr>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Name</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">Affiliated since</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Sector(s)</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Age group(s)</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/5">Primary sector</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Primary age range</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">Affiliation(s)</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Socials</th>
               <% if allowed_to?(:manage?, Person) %>
@@ -25,7 +25,7 @@
                 <td class="px-4 py-2">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
                   <% if allowed_to?(:show?, person) %>
-                    <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }) %>
+                    <%= person_profile_button(person, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, width_class: "w-56 max-w-full") %>
                   <% else %>
                     <span class="font-semibold"><%= person.name %></span>
                     <% if show_email && person.preferred_email.present? %>
@@ -34,7 +34,7 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-2 text-center text-sm text-gray-800">
-                  <%= person.member_since&.year %>
+                  <%= (person.decorate.affiliated_since_date || person.member_since)&.year || "--" %>
                 </td>
                 <!-- Sectors -->
                 <td class="px-4 py-2 text-sm text-gray-800">
@@ -48,7 +48,9 @@
                                    sector: si.sector,
                                    is_primary: true,
                                    display_leader: true,
-                                   is_leader: si.is_leader %>
+                                   is_leader: si.is_leader,
+                                   max_width: "max-w-[200px]",
+                                   compact: true %>
                       <% end %>
                     </div>
                   <% else %>
@@ -58,9 +60,8 @@
                 <!-- Age groups -->
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <% primary_age = person.primary_age_groups.to_a %>
-                  <% additional_age = person.additional_age_groups.to_a %>
-                  <% if primary_age.any? || additional_age.any? %>
-                    <%= render "shared/age_group_tags", primary: primary_age, additional: additional_age, compact: true %>
+                  <% if primary_age.any? %>
+                    <%= render "shared/age_group_tags", primary: primary_age, additional: [], compact: true %>
                   <% else %>
                     <span>--</span>
                   <% end %>
@@ -69,29 +70,38 @@
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <% affiliations = person.affiliations.select { |a| a.organization.present? && !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
                   <% if affiliations.any? %>
-                    <div class="flex flex-wrap gap-2">
+                    <%# Org names are long and multi-word, so a stacked list of
+                        truncated links reads better than chips, which squeeze the
+                        name into a tall vertically-wrapped box. Full name on hover;
+                        non-facilitator roles show their title in muted text. %>
+                    <ul class="flex flex-col gap-1">
                       <% affiliations.first(3).each do |affiliation| %>
-                        <% org_classes = "inline-block px-3 py-1 rounded-md text-sm font-medium #{DomainTheme.bg_class_for(:organizations, intensity: 100)} #{DomainTheme.text_class_for(:organizations)}" %>
-                        <% org_style = affiliation.facilitator? ? nil : "border-left: 4px solid #d1d5db" %>
-                        <% if allowed_to?(:show?, affiliation.organization) %>
-                          <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
-                              data: { turbo_frame: "_top" },
-                              class: "#{org_classes} #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)}",
-                              style: org_style %>
-                        <% else %>
-                          <span class="<%= org_classes %>" style="<%= org_style %>"><%= affiliation.organization.name %></span>
-                        <% end %>
+                        <li class="min-w-0">
+                          <% if allowed_to?(:show?, affiliation.organization) %>
+                            <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
+                                data: { turbo_frame: "_top" },
+                                title: affiliation.organization.name,
+                                class: "block max-w-[180px] truncate font-medium #{DomainTheme.text_class_for(:organizations)} hover:underline" %>
+                          <% else %>
+                            <span class="block max-w-[180px] truncate font-medium" title="<%= affiliation.organization.name %>"><%= affiliation.organization.name %></span>
+                          <% end %>
+                          <% unless affiliation.facilitator? %>
+                            <span class="block max-w-[180px] truncate text-xs text-gray-500"><%= affiliation.title %></span>
+                          <% end %>
+                        </li>
                       <% end %>
                       <% if affiliations.size > 3 %>
-                        <% if allowed_to?(:show?, person) %>
-                          <%= link_to "+#{affiliations.size - 3}", person_path(person),
-                              data: { turbo_frame: "_top" },
-                              class: "inline-block px-3 py-1 rounded-md text-sm font-medium text-gray-500 hover:text-gray-700" %>
-                        <% else %>
-                          <span class="inline-block px-3 py-1 rounded-md text-sm font-medium text-gray-500">+<%= affiliations.size - 3 %></span>
-                        <% end %>
+                        <li>
+                          <% if allowed_to?(:show?, person) %>
+                            <%= link_to "+#{affiliations.size - 3} more", person_path(person),
+                                data: { turbo_frame: "_top" },
+                                class: "text-xs text-gray-500 hover:text-gray-700" %>
+                          <% else %>
+                            <span class="text-xs text-gray-500">+<%= affiliations.size - 3 %> more</span>
+                          <% end %>
+                        </li>
                       <% end %>
-                    </div>
+                    </ul>
                   <% else %>
                     <span>--</span>
                   <% end %>
@@ -105,10 +115,10 @@
                   <td class="px-4 py-2 justify-center gap-2">
                     <%= link_to "User", user_path(person.user),
                             data: { turbo_frame: "_top" },
-                            class: "admin-only bg-blue-100 btn btn-secondary-outline" if person.user %>
+                            class: "admin-only bg-blue-100 btn btn-secondary-outline px-2.5 py-1 text-xs" if person.user %>
                     <%= link_to "Edit", edit_person_path(person),
                             data: { turbo_frame: "_top" },
-                            class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+                            class: "admin-only bg-blue-100 btn btn-secondary-outline px-2.5 py-1 text-xs" %>
                   </td>
                 <% end %>
               </tr>
@@ -118,7 +128,7 @@
         </table>
       </div>
     <% else %>
-      <p class="text-gray-500 text-center py-6">
+      <p class="text-gray-500 text-center px-6 py-6">
         No <%= Person.model_name.human.pluralize.downcase %> found.
       </p>
     <% end %>

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -6,6 +6,15 @@
 
 <% is_primary ||= false %>
 
+<%# Optional max-width class (e.g. "max-w-[200px]"). When set, the chip caps its
+    width and truncates the name with an ellipsis; the full name stays available
+    via the link's title tooltip. Off by default so other callers are unchanged. %>
+<% max_width ||= nil %>
+
+<%# Compact shrinks the chip to match the age-range chips in dense table cells. %>
+<% compact ||= false %>
+<% chip_size = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
+
 <%# Tags hidden from the public (unpublished) are only ever shown to admins, so
     they read as a muted grey chip with an eye-slash icon — the same "hidden" cue
     used on password fields — to flag at a glance what the public can't see. %>
@@ -36,16 +45,17 @@
 
 <% if sector %>
   <%= link_to taggings_path(sector_names_all: sector.name),
+    title: sector.name,
     data: { turbo_frame: "_top", sector_name: sector.name, controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
               class: "inline-flex items-center
+                      #{ max_width } #{ "min-w-0" if max_width }
                       rounded-md
                       border #{ border_class } hover:#{ border_hover_class }
                       #{ bg_color } hover:#{ bg_hover_color }
                       #{ text_color }
-                      px-3 py-1
-                      text-sm font-medium
+                      #{ chip_size } font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary sector"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
+    <span data-tag-link-loading-target="text" class="<%= "truncate min-w-0" if max_width %>"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary sector"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/app/views/shared/_age_group_tags.html.erb
+++ b/app/views/shared/_age_group_tags.html.erb
@@ -7,12 +7,12 @@
 <% padding = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
 <div class="flex flex-wrap gap-1.5">
   <% primary.each do |category| %>
-    <span class="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 <%= padding %> font-medium text-amber-800">
+    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-amber-200 bg-amber-50 <%= padding %> font-medium text-amber-800">
       <i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><%= category.name %>
     </span>
   <% end %>
   <% additional.each do |category| %>
-    <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 <%= padding %> font-medium text-gray-600">
+    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-gray-200 bg-gray-50 <%= padding %> font-medium text-gray-600">
       <%= category.name %>
     </span>
   <% end %>

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -27,4 +27,29 @@ RSpec.describe PersonDecorator do
       expect(person.decorate.active_facilitator_organization_names).to be_empty
     end
   end
+
+  describe "#affiliated_since_date" do
+    let(:person) { create(:person) }
+
+    it "returns the earliest affiliation start date" do
+      create(:affiliation, person: person, start_date: Date.new(2024, 5, 1))
+      create(:affiliation, person: person, start_date: Date.new(2022, 3, 1))
+      create(:affiliation, person: person, start_date: Date.new(2023, 8, 1))
+
+      expect(person.decorate.affiliated_since_date).to eq(Date.new(2022, 3, 1))
+    end
+
+    it "ignores affiliations without a start date" do
+      create(:affiliation, person: person, start_date: nil)
+      create(:affiliation, person: person, start_date: Date.new(2021, 1, 1))
+
+      expect(person.decorate.affiliated_since_date).to eq(Date.new(2021, 1, 1))
+    end
+
+    it "is nil when there are no affiliations with a start date" do
+      create(:affiliation, person: person, start_date: nil)
+
+      expect(person.decorate.affiliated_since_date).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — view-only styling, one data-source swap on "Affiliated since", and an N+1 fix

### What is the goal of this PR and why is this important?
Make the people index scan better in its dense, many-column layout. Sector and age columns showed extra values and chips wrapped or squeezed long names into tall boxes, hurting readability.

### How did you approach the change?
- Sector/age columns now show **only the primary** value, relabeled "Primary sector" / "Primary age range"; chips no longer wrap mid-value (sector chips truncate with full name on hover, sized to match age-range chips).
- Affiliations render as a **stacked list of truncated org links** (full name on hover, role shown for non-facilitators) instead of chips that vertically stacked long org names.
- "Affiliated since" now derives from the earliest affiliation start year (falling back to legacy `member_since`) instead of the usually-empty `member_since` column, so it actually populates — and `affiliated_since_date` now computes in Ruby from the eager-loaded association, removing a per-row `MIN(start_date)` query (N+1).
- Table fills the card with rounded corners; profile button is fixed-width; User/Edit actions shrunk. Sector-chip and profile-button changes are opt-in params, so other callers are unaffected.

### Anything else to add?
Per-row `person.decorate` was kept (not hoisted to the controller) because the index passes records into `allowed_to?(:show?, person)`, and Action Policy resolves the policy from the object's class — a decorator would break that lookup. With the N+1 removed, the decorate call is just a cheap wrapper.
