### PR TITLE
Allow bare domains in the agency website field

### DIFF
--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -48,12 +48,12 @@
         html_type = case field.field_identifier
                      when /email(?!_type)/ then "email"
                      when "phone" then "tel"
-                     when "agency_website" then "url"
                      else
                        field.number_integer? ? "number" : "text"
                      end
         extra_attrs = []
         extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
+        extra_attrs << 'inputmode="url"' if field.field_identifier == "agency_website"
         extra_attrs << %(maxlength="#{field.effective_max_characters}") if field.effective_max_characters
       %>
       <input type="<%= html_type %>"

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -384,6 +384,21 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("Healthcare")
     end
 
+    it "renders the agency website as a text input so bare domains pass validation" do
+      website_field = create(:form_field, form: form, answer_type: :free_form_input_one_line,
+             field_identifier: "agency_website", name: "Organization website", required: false)
+
+      get new_event_public_registration_path(event)
+
+      input_id = "public_registration_form_fields_#{website_field.id}"
+      website_input = response.body[/<input[^>]*id="#{input_id}"[^>]*>/]
+      # type="url" makes browsers reject bare domains like "awbw.org"; a text
+      # input with inputmode="url" keeps the URL keyboard without that rejection.
+      expect(website_input).to include('type="text"')
+      expect(website_input).to include('inputmode="url"')
+      expect(website_input).not_to include('type="url"')
+    end
+
     it "shows the maximum character hint below the field" do
       create(:form_field, form: form, answer_type: :free_form_input_paragraph,
              name: "Bio", required: false, max_characters: 250)


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — small, contained view + spec change with low blast radius

### What is the goal of this PR and why is this important?

- The organization website field on the public registration form rendered as `<input type="url">`, so browsers blocked submission of bare domains like `awbw.org` (they require an `http://`/`https://` scheme).
- The server already accepts bare domains — `Organization#website_link_url` prepends `https://` when there's no scheme — so the browser was the only thing rejecting valid input.

### How did you approach the change?

- Render the `agency_website` field as `type="text"` with `inputmode="url"`, keeping the URL-optimized mobile keyboard without the strict scheme requirement.
- Added a request spec asserting the field renders as a text input with `inputmode="url"` and not `type="url"`.