### PR TITLE
Dedupe org snapshot so paid public registrations don't crash

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -407,9 +407,14 @@ class EventRegistration < ApplicationRecord
 
   private
 
+  # Link each organization the registrant is actively affiliated with — but only
+  # once. A registrant can hold several active affiliations to the same org (e.g.
+  # different titles), so we dedupe the organization ids first; creating a second
+  # row for the same org would fail the uniqueness validation and leave an invalid
+  # record in the in-memory collection that breaks the next save of the registration.
   def snapshot_registrant_organizations
-    registrant.affiliations.active.includes(:organization).find_each do |aff|
-      event_registration_organizations.create(organization: aff.organization)
+    registrant.affiliations.active.distinct.pluck(:organization_id).each do |organization_id|
+      event_registration_organizations.create(organization_id: organization_id)
     end
   end
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -615,6 +615,20 @@ RSpec.describe EventRegistration, type: :model do
       reg = create(:event_registration, registrant: person)
       expect(reg.organizations).to be_empty
     end
+
+    it "links an organization once even with multiple active affiliations to it" do
+      org = create(:organization)
+      person = create(:person)
+      create(:affiliation, person: person, organization: org, title: "Facilitator")
+      create(:affiliation, person: person, organization: org, title: "Program Director")
+
+      reg = create(:event_registration, registrant: person)
+
+      expect(reg.organizations).to contain_exactly(org)
+      # A duplicate org left an invalid record in the in-memory collection, which
+      # blew up later saves (e.g. recording a Stripe checkout session id).
+      expect { reg.update!(checkout_session_id: "cs_test_123") }.not_to raise_error
+    end
   end
 
   describe "slug" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained fix to an after_create hook with a regression test

### What is the goal of this PR and why is this important?
Fixes a production crash (`ActiveRecord::RecordInvalid: Event registration organizations is invalid`) that hit paid public registrations at Stripe checkout. A registrant can hold multiple active affiliations to the same organization (e.g. different titles), and `EventRegistration#snapshot_registrant_organizations` created one link row per affiliation — the duplicate failed the uniqueness validation and left an invalid, unsaved record in the in-memory collection, which then blew up the next registration save (recording the checkout session id).

### How did you approach the change?
Dedupe the organization ids before creating link rows so each org is snapshotted once (also one query instead of N). Added a regression spec that reproduced the exact crash (red first, then green).

### Anything else to add?
Only the Stripe-paying path re-saves the registration after creation, which is why this was the only surface that crashed.