### PR TITLE
Connect only the form-submitted org to a registration

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -19,7 +19,6 @@ class EventRegistration < ApplicationRecord
   accepts_nested_attributes_for :registrant
 
   before_create :generate_slug
-  after_create :snapshot_registrant_organizations
   after_commit :send_cancellation_emails, if: :status_changed_to_cancelled?
 
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance ].freeze
@@ -406,17 +405,6 @@ class EventRegistration < ApplicationRecord
   end
 
   private
-
-  # Link each organization the registrant is actively affiliated with — but only
-  # once. A registrant can hold several active affiliations to the same org (e.g.
-  # different titles), so we dedupe the organization ids first; creating a second
-  # row for the same org would fail the uniqueness validation and leave an invalid
-  # record in the in-memory collection that breaks the next save of the registration.
-  def snapshot_registrant_organizations
-    registrant.affiliations.active.distinct.pluck(:organization_id).each do |organization_id|
-      event_registration_organizations.create(organization_id: organization_id)
-    end
-  end
 
   def generate_slug
     loop do

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -71,12 +71,14 @@ module EventRegistrationServices
             existing.update!(status: "registered")
             send_notifications(existing)
           end
+          connect_organization(existing, organization)
           submission = update_form_submission(person)
           save_scholarship_submission(person)
           return Result.new(success?: true, event_registration: existing, form_submission: submission, errors: [])
         end
 
         event_registration = create_event_registration(person)
+        connect_organization(event_registration, organization)
         submission = create_form_submission(person)
         save_scholarship_submission(person)
 
@@ -286,6 +288,18 @@ module EventRegistrationServices
       return nil if name.blank?
 
       Organization.find_by(name: name)
+    end
+
+    # Connect only the one organization the registrant submitted on this form —
+    # not every organization they're affiliated with. A registration accrues
+    # multiple orgs only deliberately: an admin links extra ones from the edit
+    # page, or the registrant applies again with a different org (each submission
+    # adds its single org to the same registration via find_or_create_by!).
+    def connect_organization(event_registration, organization)
+      return unless organization
+
+      event_registration.event_registration_organizations
+        .find_or_create_by!(organization: organization)
     end
 
     def create_affiliation(person, organization)

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -835,15 +835,17 @@ if lisa_w && roundtable
   registrations_data << { person: lisa_w, event: roundtable, status: "incomplete_attendance" }
 end
 
-# --- People with multiple active affiliations — ensures org snapshots get exercised ---
+# --- People with multiple active affiliations — exercise a registration linked to
+# one of the registrant's orgs (the org they registered with), not all of them ---
 mariana_j = Person.find_by(first_name: "Mariana", last_name: "Johnson")
 samuel_s = Person.find_by(first_name: "Samuel", last_name: "Smith")
 lisa_wn = Person.find_by(first_name: "Lisa", last_name: "Williamson")
 kim_dv = Person.find_by(first_name: "Kim", last_name: "Davidson")
 sarah_d = Person.find_by(first_name: "Sarah", last_name: "Davis")
 
-{ mariana_j => youth_day, samuel_s => mindful_art, lisa_wn => virtual_session,
-  kim_dv => family_day, sarah_d => roundtable }.each do |person, evt|
+multi_affiliation_registrations = { mariana_j => youth_day, samuel_s => mindful_art,
+  lisa_wn => virtual_session, kim_dv => family_day, sarah_d => roundtable }
+multi_affiliation_registrations.each do |person, evt|
   next unless person && evt
   registrations_data << { person: person, event: evt, status: "registered" }
 end
@@ -869,6 +871,17 @@ registrations_data.each do |data|
   registration.ce_credit_requested = data[:ce_credit_requested] || false
   registration.intends_to_pay = data[:intends_to_pay] || false
   registration.save!
+end
+
+# Connect each multi-affiliation registrant's registration to a single one of
+# their orgs — mirroring a real registration, which links only the org submitted
+# on the form, not every active affiliation.
+multi_affiliation_registrations.each do |person, evt|
+  next unless person && evt
+  org = person.affiliations.active.first&.organization
+  next unless org
+  registration = EventRegistration.find_by(event: evt, registrant: person)
+  registration&.event_registration_organizations&.find_or_create_by!(organization: org)
 end
 
 # Give the flagship training its demo cohort: top up to 10 active registrants with

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1583,4 +1583,32 @@ if facilitator_training && registration_form
     add_affiliation.call(person, aff_org, title: "Facilitator")
     add_affiliation.call(person, other_org, title: "Board Member")
   end
+
+  # The two ways a single registration ends up with more than one org. A
+  # registration no longer snapshots every affiliation, so multiple orgs are
+  # always deliberate — these two demos show each path side by side.
+
+  # A5: the registrant submitted one org on the form, then an admin linked a
+  # second org by hand → two linked orgs but a single submission.
+  if aff_org && other_org
+    person = Person.create!(email: "affdemo.5@seed.example.com", first_name: "Demo Affiliation", last_name: "A5 Admin-linked second org")
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
+    submit_field.call(registration, agency_field, aff_org.name)
+    link_org.call(registration, aff_org)
+    # Admin adds the second org later — no matching submission (mirrors the
+    # select/create_organization controller path: affiliation + connection).
+    link_org.call(registration, other_org)
+  end
+
+  # A6: the registrant applied twice, each submission naming a different org →
+  # two submissions, each adding its single org, so the registration links both.
+  if aff_org && other_org
+    person = Person.create!(email: "affdemo.6@seed.example.com", first_name: "Demo Affiliation", last_name: "A6 Applied twice, two orgs")
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
+    [ aff_org, other_org ].each do |org|
+      submission = FormSubmission.create!(person: person, form: registration_form, event: facilitator_training)
+      submission.form_answers.create!(form_field: agency_field, submitted_answer: org.name, question_name_when_answered: agency_field.name) if agency_field
+      link_org.call(registration, org)
+    end
+  end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -571,63 +571,14 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
-  describe "snapshot_registrant_organizations" do
-    it "copies active affiliations to the registration on create" do
+  describe "registration organizations" do
+    it "does not auto-connect the registrant's affiliations on create" do
       org = create(:organization)
       person = create(:person)
       create(:affiliation, person: person, organization: org)
 
       reg = create(:event_registration, registrant: person)
-      expect(reg.organizations).to include(org)
-    end
-
-    it "copies multiple active affiliations" do
-      org1 = create(:organization)
-      org2 = create(:organization)
-      person = create(:person)
-      create(:affiliation, person: person, organization: org1)
-      create(:affiliation, person: person, organization: org2)
-
-      reg = create(:event_registration, registrant: person)
-      expect(reg.organizations).to contain_exactly(org1, org2)
-    end
-
-    it "skips inactive affiliations" do
-      org = create(:organization)
-      person = create(:person)
-      create(:affiliation, person: person, organization: org, inactive: true)
-
-      reg = create(:event_registration, registrant: person)
       expect(reg.organizations).to be_empty
-    end
-
-    it "skips affiliations with past end dates" do
-      org = create(:organization)
-      person = create(:person)
-      create(:affiliation, person: person, organization: org, end_date: 1.day.ago)
-
-      reg = create(:event_registration, registrant: person)
-      expect(reg.organizations).to be_empty
-    end
-
-    it "creates no records when registrant has no affiliations" do
-      person = create(:person)
-      reg = create(:event_registration, registrant: person)
-      expect(reg.organizations).to be_empty
-    end
-
-    it "links an organization once even with multiple active affiliations to it" do
-      org = create(:organization)
-      person = create(:person)
-      create(:affiliation, person: person, organization: org, title: "Facilitator")
-      create(:affiliation, person: person, organization: org, title: "Program Director")
-
-      reg = create(:event_registration, registrant: person)
-
-      expect(reg.organizations).to contain_exactly(org)
-      # A duplicate org left an invalid record in the in-memory collection, which
-      # blew up later saves (e.g. recording a Stripe checkout session id).
-      expect { reg.update!(checkout_session_id: "cs_test_123") }.not_to raise_error
     end
   end
 

--- a/spec/requests/organizations_events_section_spec.rb
+++ b/spec/requests/organizations_events_section_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe "Organization profile events-attended section", type: :request do
         headers: { "Turbo-Frame" => "organization_events_section" }
   end
 
-  # A registration snapshots the registrant's active org affiliations on create,
-  # which is what links the event to the organization profile.
+  # A registration is linked to the organization the registrant submitted on the
+  # form (or that an admin connected), which is what surfaces the event on the
+  # organization profile.
   def register(event:, status: "registered")
     person = create(:person)
     create(:affiliation, organization: organization, person: person)
-    create(:event_registration, registrant: person, event: event, status: status)
+    registration = create(:event_registration, registrant: person, event: event, status: status)
+    registration.event_registration_organizations.create!(organization: organization)
+    registration
   end
 
   it "shows events members are actively registered for" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -51,6 +51,51 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "registration organizations" do
+    let!(:organization) { create(:organization, name: "Helping Hands") }
+
+    def register_with_org(org_name)
+      params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
+        field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => org_name
+      )
+      described_class.call(event: event, form: form, form_params: params)
+      event.event_registrations.find_by!(registrant: Person.find_by(email: "sam@example.com"))
+    end
+
+    it "connects only the organization submitted through the form" do
+      registration = register_with_org("Helping Hands")
+
+      expect(registration.organizations).to contain_exactly(organization)
+    end
+
+    it "does not connect the registrant's other active affiliations" do
+      person = create(:person, email: "sam@example.com", last_name: "Rowe", first_name: "Sam")
+      other_org = create(:organization, name: "Unrelated Org")
+      create(:affiliation, person: person, organization: other_org)
+
+      registration = register_with_org("Helping Hands")
+
+      expect(registration.organizations).to contain_exactly(organization)
+    end
+
+    it "connects no organizations when none is submitted" do
+      params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com")
+      described_class.call(event: event, form: form, form_params: params)
+      registration = event.event_registrations.find_by!(registrant: Person.find_by(email: "sam@example.com"))
+
+      expect(registration.organizations).to be_empty
+    end
+
+    it "adds the new org to the same registration when the registrant applies again" do
+      second_org = create(:organization, name: "Second Org")
+      first = register_with_org("Helping Hands")
+      second = register_with_org("Second Org")
+
+      expect(second).to eq(first)
+      expect(first.organizations).to contain_exactly(organization, second_org)
+    end
+  end
+
   describe "racial/ethnic identity" do
     it "stores the racial/ethnic identity on a new registrant" do
       params = base_form_params(first_name: "Ada", last_name: "Lin", email: "ada@example.com").merge(


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small change to which orgs a registration links, with tests + demo seeds

### What is the goal of this PR and why is this important?
- Registrations auto-snapshotted **every** active affiliation of the registrant on create. A returning facilitator accumulates affiliations across trainings, so each new registration got mislabeled with all their orgs.
- Now a registration connects only the **one** org submitted on the form (or none).

### How did you approach the change?
- Removed the `after_create :snapshot_registrant_organizations` callback from `EventRegistration`.
- `PublicRegistration` connects only the form-submitted org, on both new and repeat submissions (`find_or_create_by!`).
- Multiple orgs now accrue only deliberately: an admin links extras from the edit page, or the registrant applies again with a different org (each submission adds its single org to the same registration).
- Updated dev seeds that relied on the snapshot to link orgs explicitly, and added two demo registrants for the multi-org paths: **A5** (form-submitted org + admin-linked second org → two orgs, one submission) and **A6** (applied twice with different orgs → two orgs, two submissions).

### Anything else to add?
- Admin-created registrations (the `new` form has no org section) now start with no orgs; admins link via the existing "Connect organization" UI.
- Affiliations are still created via the shared `AffiliationServices::CreateFromRegistration` (same as admin Link Organization). The public flow only resolves *existing* orgs (`find_by(name:)`) — it does not create an org from an unmatched typed name; that stays an admin step.