### PR TITLE
Remove dead migration-audit routes that 500 on bot probes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,6 @@
 Rails.application.routes.draw do
-  # temporary direct routes to images for migration audit
-  resources :attachments, only: [ :show ]
-  resources :media_files, only: [ :show ]
-  # namespace :assets do
-  #   resources :primary_assets, only: [ :show ]
-  #   resources :gallery_assets, only: [ :show ]
-  # end
   resources :primary_assets
   resources :rich_text_assets
-
-  namespace :images do
-    resources :primary_images, only: [ :show ]
-    resources :gallery_images, only: [ :show ]
-    resources :rich_texts, only: [ :show ]
-  end
-  resources :images, only: [ :show ]
 
   # mount Ckeditor::Engine, at: '/admin/ckeditor', as: 'ckeditor'
   authenticate :user, ->(user) { user.super_user? } do

--- a/spec/requests/dead_migration_audit_routes_spec.rb
+++ b/spec/requests/dead_migration_audit_routes_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+# Leftover "migration audit" routes pointed at controllers that never existed
+# (ImagesController, AttachmentsController, MediaFilesController, Images::*).
+# A bot probing GET /images/index.php matched `resources :images` and dispatched
+# to the missing ImagesController, raising ActionDispatch::MissingController (a
+# 500) instead of a plain 404. These paths must be unrouted, i.e. raise a
+# routing error rather than a missing-controller error.
+RSpec.describe "Removed migration-audit routes", type: :request do
+  [
+    "/images/index.php",
+    "/images/1",
+    "/images/primary_images/1",
+    "/images/gallery_images/1",
+    "/images/rich_texts/1",
+    "/attachments/1",
+    "/media_files/1"
+  ].each do |path|
+    it "404s for GET #{path} instead of erroring on a missing controller" do
+      get path
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: removes routes pointing at non-existent controllers; verified nothing references them

### What is the goal of this PR and why is this important?
Leftover "migration audit" routes (`images`, the `images` namespace, `attachments`, `media_files`) pointed at controllers that never existed, so any request matching them raised `ActionDispatch::MissingController` — a 500 instead of a 404. A bot probing `GET /images/index.php` matched `resources :images` and dispatched to the missing `ImagesController`, generating Honeybadger noise.

### How did you approach the change?
Removed the dead routes (keeping `primary_assets` and `rich_text_assets`, the only two backed by real controllers and actually used — no route helpers reference the removed ones). Added a request spec asserting each removed path now 404s; it fails 7/7 on the old routes and passes after the fix.

### Anything else to add?
This was purely bot/scanner traffic probing for PHP vulnerabilities — no real user or data was affected. A routing spec can't catch this since recognition masks the missing controller as a `RoutingError`; only full dispatch reproduces the 500, so the test is a request spec.