### PR TITLE
Sync org status from facilitator affiliations and surface mismatches in the form

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -31,9 +31,9 @@ class Affiliation < ApplicationRecord
 
   before_validation :skip_if_duplicate
   before_save :set_inactive_from_dates
-  after_save :deactivate_organization_if_no_active_people
+  after_save :sync_organization_status_with_affiliations
   after_save :sync_organization_affiliation_dates
-  after_destroy :deactivate_organization_if_no_active_people
+  after_destroy :sync_organization_status_with_affiliations
   after_destroy :sync_organization_affiliation_dates
 
   # Methods
@@ -107,9 +107,17 @@ class Affiliation < ApplicationRecord
     org.update_columns(updates) if updates.any?
   end
 
-  def deactivate_organization_if_no_active_people
-    return if organization.affiliations.active.exists?
+  # Org status tracks active *Facilitator* affiliations specifically (mirroring the
+  # form's status indicator) — a non-facilitator affiliation does not keep an org active.
+  def sync_organization_status_with_affiliations
+    if organization.affiliations.facilitators.active.exists?
+      reactivate_organization_if_inactive
+    else
+      deactivate_organization_if_no_active_people
+    end
+  end
 
+  def deactivate_organization_if_no_active_people
     inactive_status = OrganizationStatus.find_by(name: "Inactive")
     return unless inactive_status
     return if organization.organization_status_id == inactive_status.id
@@ -123,6 +131,26 @@ class Affiliation < ApplicationRecord
       resource_title: organization.name,
       change: "status_set_to_inactive",
       reason: "no_active_affiliations"
+    )
+  end
+
+  # Only flip back from "Inactive" — the status the deactivation callback sets.
+  # Leave Pending/Reinstate/Unknown (and Active) untouched.
+  def reactivate_organization_if_inactive
+    inactive_status = OrganizationStatus.find_by(name: "Inactive")
+    active_status = OrganizationStatus.find_by(name: "Active")
+    return unless inactive_status && active_status
+    return unless organization.organization_status_id == inactive_status.id
+
+    organization.update_column(:organization_status_id, active_status.id)
+
+    Ahoy::Tracker.new(user: Current.user).track(
+      "autochange.organization",
+      resource_type: "Organization",
+      resource_id: organization.id,
+      resource_title: organization.name,
+      change: "status_set_to_active",
+      reason: "regained_active_affiliation"
     )
   end
 end

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -160,17 +160,11 @@
       </div>
     <% end %>
 
-    <% if params[:admin] && allowed_to?(:manage?, Organization) %>
-      <%= f.input :organization_status_id,
-                  as: :select,
-                  collection: @organization_statuses,
-                  include_blank: true,
-                  label: "Status",
-                  required: true,
-                  input_html: {
-                    class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
-                  } %>
-    <% else %>
+    <% facilitator_status_name = f.object.affiliations.facilitators.active.exists? ? "Active" : "Inactive" %>
+    <% status_matches_affiliations = f.object.organization_status&.name == facilitator_status_name %>
+    <% show_status_select = allowed_to?(:manage?, Organization) &&
+         (params[:admin] || (f.object.persisted? && !status_matches_affiliations)) %>
+    <% unless show_status_select %>
       <%= f.hidden_field :organization_status_id, value: f.object.organization_status_id || OrganizationStatus.find_by(name: "Active")&.id %>
     <% end %>
   </div>
@@ -252,7 +246,24 @@
       Affiliations
     </div>
 
-    <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:people) %> p-4 mb-4 shadow-sm">
+    <div class="relative rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:people) %> p-4 mb-4 shadow-sm">
+      <% if show_status_select %>
+        <div class="absolute top-4 right-4 z-10 w-56">
+          <%= f.input :organization_status_id,
+                      as: :select,
+                      collection: @organization_statuses,
+                      include_blank: true,
+                      label: "Organization status",
+                      required: true,
+                      wrapper_html: { class: "mb-0" },
+                      input_html: {
+                        class: "w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
+                      } %>
+          <% unless status_matches_affiliations %>
+            <p class="mt-1 text-xs text-red-600">Does not match affiliations status</p>
+          <% end %>
+        </div>
+      <% end %>
       <% org_earliest_aff = f.object.persisted? ? f.object.affiliations.minimum(:start_date) : nil %>
       <% org_aff_ended = f.object.persisted? && f.object.affiliations.any? && !f.object.affiliations.active.exists? %>
       <% org_latest_end = f.object.persisted? ? f.object.affiliations.maximum(:end_date) : nil %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -36,11 +36,6 @@
       <div class="flex-1 text-center md:text-left">
         <h1 class="text-3xl font-bold text-gray-900">
           <%= @organization.name %>
-          <% if @organization.organization_status.present? && @organization.organization_status.name != "Active" %>
-            <span class="ml-2 text-sm font-medium text-gray-500 bg-gray-100 border border-gray-300 rounded-full px-3 py-0.5 align-middle">
-              <%= @organization.organization_status.name %>
-            </span>
-          <% end %>
         </h1>
         <% address = if @organization.addresses.loaded?
                        @organization.addresses.find { |a| !a.inactive? }

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -130,6 +130,46 @@ RSpec.describe Affiliation do
     end
   end
 
+  describe '#sync_organization_status_with_affiliations' do
+    let!(:active_status) { OrganizationStatus.find_or_create_by!(name: "Active") }
+    let!(:inactive_status) { OrganizationStatus.find_or_create_by!(name: "Inactive") }
+
+    it 'sets the organization to Inactive when its last active affiliation goes inactive' do
+      org = create(:organization, organization_status: active_status)
+      affiliation = create(:affiliation, organization: org, inactive: false, end_date: nil)
+
+      affiliation.update!(inactive: true)
+
+      expect(org.reload.organization_status).to eq(inactive_status)
+    end
+
+    it 'sets an Inactive organization back to Active when it regains an active affiliation' do
+      org = create(:organization, organization_status: inactive_status)
+
+      create(:affiliation, organization: org, inactive: false, end_date: nil)
+
+      expect(org.reload.organization_status).to eq(active_status)
+    end
+
+    it 'ignores non-facilitator affiliations when deciding status' do
+      org = create(:organization, organization_status: active_status)
+      create(:affiliation, organization: org, title: "Volunteer", inactive: false, end_date: nil)
+
+      expect(org.reload.organization_status).to eq(inactive_status)
+    end
+
+    %w[Pending Reinstate Unknown].each do |status_name|
+      it "leaves a #{status_name} organization untouched when it regains an active affiliation" do
+        status = OrganizationStatus.find_or_create_by!(name: status_name)
+        org = create(:organization, organization_status: status)
+
+        create(:affiliation, organization: org, inactive: false, end_date: nil)
+
+        expect(org.reload.organization_status).to eq(status)
+      end
+    end
+  end
+
   describe '#set_inactive_from_dates' do
     let(:op) { create(:affiliation, inactive: false, end_date: nil) }
 

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -22,16 +22,55 @@ RSpec.describe "organizations/edit", type: :view do
     assign(:organization, organization)
     allow(view).to receive(:current_user).and_return(admin)
     allow(view).to receive(:allowed_to?).and_return(true)
-    render
   end
 
   it "renders the edit organization form" do
+    render
     assert_select "form[action=?][method=?]", organization_path(organization), "post" do
       assert_select "select[name=?]", "organization[windows_type_id]"
 
       assert_select "textarea[name=?]", "organization[name]"
 
       assert_select "textarea[name=?]", "organization[description]"
+    end
+  end
+
+  describe "status select visibility" do
+    before(:each) { assign(:organization_statuses, OrganizationStatus.all) }
+
+    def org_with_status(name)
+      Organization.create!(
+        windows_type: windows_type,
+        organization_status: OrganizationStatus.find_or_create_by!(name: name),
+        name: "MyString",
+        description: "MyString",
+        notes: "MyText"
+      )
+    end
+
+    it "shows the status select for an org with no affiliations" do
+      assign(:organization, org_with_status("Active"))
+      render
+      assert_select "select[name=?]", "organization[organization_status_id]"
+    end
+
+    it "hides the status select (and the mismatch hint) when the status matches the affiliation-calculated status" do
+      org = org_with_status("Active")
+      create(:affiliation, organization: org, person: create(:person), inactive: false, end_date: nil)
+      assign(:organization, org.reload)
+      render
+      assert_select "select[name=?]", "organization[organization_status_id]", false
+      assert_select "input[type=hidden][name=?]", "organization[organization_status_id]"
+      expect(rendered).not_to include("Does not match affiliations status")
+    end
+
+    it "shows the status select and the red mismatch hint when the status does not match the affiliation-calculated status" do
+      org = org_with_status("Pending")
+      create(:affiliation, organization: org, person: create(:person), inactive: false, end_date: nil)
+      assign(:organization, org.reload)
+      render
+      assert_select "select[name=?]", "organization[organization_status_id]"
+      assert_select "p.text-red-600", text: "Does not match affiliations status"
     end
   end
 end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — small, contained model/view logic change

### What is the goal of this PR and why is this important?
Org status auto-sync keyed off **all** active affiliations, while the org form's status indicator keyed off active **Facilitator** affiliations — so the two could permanently disagree (e.g. an org with an active non-facilitator affiliation would be kept Active by the model but flagged "Does not match affiliations status" in the form, with no way to reconcile).

### How did you approach the change?
- Made **facilitator affiliations authoritative** on both sides: `Affiliation#sync_organization_status_with_affiliations` now keys off `affiliations.facilitators.active`. A non-facilitator affiliation no longer keeps an org Active.
- Form shows the status select + red mismatch hint only when the stored status diverges from the facilitator-calculated status (and always for admins).
- Reactivation only flips orgs back from Inactive (the status the deactivation callback sets); Pending/Reinstate/Unknown are left untouched. Both auto-changes are Ahoy-tracked.
- Removed the now-redundant status badge from the org show page.

### Anything else to add?
Covered by new model specs (incl. the non-facilitator case) and edit-view specs for select visibility / mismatch hint.