### PR TITLE
Backfill payer fields from profile on logged-in bulk payments

### DIFF
--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -17,7 +17,11 @@ module EventRegistrationServices
     def call
       ActiveRecord::Base.transaction do
         person = find_or_create_person
+        # Backfill after the phone-contact guard: create_phone_contact should only
+        # fire for a phone the payer actually typed, not one we copied from their
+        # own profile (which would needlessly rewrite their contact methods).
         create_phone_contact(person) if field_value("payer_phone").present?
+        backfill_payer_fields(person)
         submission = create_form_submission(person)
         send_notifications(submission, person)
         Result.new(success?: true, form_submission: submission, errors: [])
@@ -48,6 +52,34 @@ module EventRegistrationServices
         recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
         notification_type: 0
       )
+    end
+
+    # Logged-in payers don't see the logged_out_only payer fields, so those keys
+    # never reach @form_params and the payer's identity would be missing from the
+    # saved form answers. Backfill them from the known person, without clobbering
+    # anything that was actually submitted.
+    def backfill_payer_fields(person)
+      {
+        "payer_first_name" => person.first_name,
+        "payer_last_name" => person.last_name,
+        "payer_email" => person.preferred_email,
+        "payer_phone" => person.phone_number,
+        "payer_organization" => payer_organization_name(person)
+      }.each do |key, value|
+        next if value.blank?
+
+        field = @form.form_fields.find_by(field_identifier: key)
+        next unless field
+        next if @form_params[field.id.to_s].present?
+
+        @form_params[field.id.to_s] = value
+      end
+    end
+
+    # Prefer the org the payer facilitates for, falling back to their most recent
+    # active affiliation when they have no facilitator affiliation.
+    def payer_organization_name(person)
+      (person.program_organization || person.primary_organization)&.name
     end
 
     def field_value(key)

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -49,6 +49,99 @@ RSpec.describe EventRegistrationServices::BulkPayment do
     end
   end
 
+  describe "logged-in payer" do
+    let(:person) do
+      create(:person, first_name: "Logged", last_name: "In",
+             user: create(:user, email: "logged.in@example.com"))
+    end
+
+    # Logged-in payers don't see the logged_out_only payer fields, so those keys
+    # never reach @form_params. Without a backfill the payer's email/name would be
+    # missing from the saved form answers even though we know who they are.
+    def answer(submission, key)
+      field = form.form_fields.find_by!(field_identifier: key)
+      submission.form_answers.find_by(form_field: field)&.submitted_answer
+    end
+
+    it "saves the payer's email, name, phone, and organization from their profile" do
+      person.contact_methods.create!(kind: :phone, value: "555-987-6543", primary: true)
+      # Facilitator org wins even though a non-facilitator affiliation is more recent.
+      person.affiliations.create!(organization: create(:organization, name: "Acme Co"), title: "Facilitator")
+      person.affiliations.create!(organization: create(:organization, name: "Other Org"), title: "Member")
+
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: {
+          field_id("payment_method") => "Check",
+          field_id("number_of_attendees") => "3"
+        },
+        person: person
+      )
+
+      expect(result.success?).to be true
+      submission = result.form_submission
+      expect(answer(submission, "payer_email")).to eq("logged.in@example.com")
+      expect(answer(submission, "payer_first_name")).to eq("Logged")
+      expect(answer(submission, "payer_last_name")).to eq("In")
+      expect(answer(submission, "payer_phone")).to eq("555-987-6543")
+      expect(answer(submission, "payer_organization")).to eq("Acme Co")
+    end
+
+    it "falls back to the most recent active org when the payer has no facilitator affiliation" do
+      person.affiliations.create!(organization: create(:organization, name: "Older Org"),
+                                  title: "Member", updated_at: 2.days.ago)
+      person.affiliations.create!(organization: create(:organization, name: "Newer Org"),
+                                  title: "Member", updated_at: 1.day.ago)
+
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: {
+          field_id("payment_method") => "Check",
+          field_id("number_of_attendees") => "3"
+        },
+        person: person
+      )
+
+      expect(answer(result.form_submission, "payer_organization")).to eq("Newer Org")
+    end
+
+    it "does not rewrite the payer's existing phone contact when backfilling" do
+      contact = person.contact_methods.create!(
+        kind: :phone, value: "555-987-6543", primary: true, contact_type: "work"
+      )
+
+      described_class.call(
+        event: event,
+        form: form,
+        form_params: {
+          field_id("payment_method") => "Check",
+          field_id("number_of_attendees") => "3"
+        },
+        person: person
+      )
+
+      expect(contact.reload).to have_attributes(contact_type: "work", value: "555-987-6543")
+      expect(person.contact_methods.where(kind: :phone).count).to eq(1)
+    end
+
+    it "does not overwrite a payer field that was submitted" do
+      result = described_class.call(
+        event: event,
+        form: form,
+        form_params: {
+          field_id("payer_email") => "typed@example.com",
+          field_id("payment_method") => "Check",
+          field_id("number_of_attendees") => "3"
+        },
+        person: person
+      )
+
+      expect(answer(result.form_submission, "payer_email")).to eq("typed@example.com")
+    end
+  end
+
   describe "notifications" do
     it "sends the payer confirmation and the staff FYI" do
       expect(NotificationServices::CreateNotification).to receive(:call).with(


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained service change with new tests

### What is the goal of this PR and why is this important?
- Logged-in payers don't see the `logged_out_only` payer fields, so those keys never reached the submitted params — the payer's email/name/phone/org were silently missing from the saved form answers, even though we know who they are.

### How did you approach the change?
- `BulkPayment#backfill_payer_fields` fills `payer_first_name`, `payer_last_name`, `payer_email`, `payer_phone`, and `payer_organization` from the known person, only when the field is empty (never clobbers a submitted value).
- Backfill runs **after** the `create_phone_contact` guard, so copying the payer's own phone doesn't rewrite their existing contact methods.
- Organization prefers the facilitator org (`program_organization`), then most recent active affiliation (`primary_organization`).

### Anything else to add?
- New service specs cover each field, the facilitator-org preference + fallback, the no-overwrite rule, and the no-contact-rewrite guarantee.