### PR TITLE
Show scholarship application answers on the new-scholarship page

### DIFF
--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -35,6 +35,7 @@ class ScholarshipsController < ApplicationController
     @scholarship = Scholarship.new(recipient: @allocatable.registrant)
     @grants = Grant.selectable_for(@scholarship)
     authorize! @scholarship
+    load_scholarship_submission
   end
 
   def create

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -42,4 +42,10 @@
   <%= simple_form_for @scholarship, url: form_url, html: { class: "space-y-6" }, data: { turbo: false, controller: "submit-once", "submit-once-submitting-text-value": "Saving…" } do |f| %>
     <%= render "form", f: f %>
   <% end %>
+
+  <% if @event %>
+    <div class="mt-6">
+      <%= render "form_submission" %>
+    </div>
+  <% end %>
 </div>

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -98,6 +98,40 @@ RSpec.describe "Scholarships", type: :request do
     end
   end
 
+  describe "GET /scholarships/new" do
+    it "shows the registrant's scholarship form answers with a link to the full submission" do
+      form = create(:form, name: "Registration Form")
+      create(:event_form, event: event, form: form, role: "registration")
+      field = create(:form_field, form: form, section: "scholarship",
+                     name: "Why do you need a scholarship?", answer_type: :free_form_input_paragraph)
+      submission = create(:form_submission, person: registration.registrant, form: form)
+      create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Limited budget")
+
+      get new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants")
+
+      expect(response.body).to include("Form submission")
+      expect(response.body).to include("Why do you need a scholarship?")
+      expect(response.body).to include("Limited budget")
+      expect(response.body).to include("View full submission")
+      expect(response.body).to include(event_public_registration_path(event, reg: registration.slug))
+    end
+
+    it "shows answers submitted on the event's dedicated scholarship form" do
+      scholarship_form = create(:form, name: "Scholarship Application")
+      create(:event_form, event: event, form: scholarship_form, role: "scholarship")
+      field = create(:form_field, form: scholarship_form, section: "scholarship",
+                     name: "How much can you contribute?", answer_type: :free_form_input_one_line)
+      submission = create(:form_submission, person: registration.registrant, form: scholarship_form, role: "scholarship")
+      create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "$250")
+
+      get new_scholarship_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registration")
+
+      expect(response.body).to include("Form submission")
+      expect(response.body).to include("How much can you contribute?")
+      expect(response.body).to include("$250")
+    end
+  end
+
   describe "PATCH /scholarships/:id from the registration Edit link" do
     it "returns to the event registration edit page" do
       patch scholarship_path(scholarship, return_to: "registration"),


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: surfaces an existing partial on one more page, no logic or data changes

### What is the goal of this PR and why is this important?
- The recipient's scholarship-application answers already show when editing a scholarship. This surfaces the same "Form submission" context on the new-scholarship page so an admin can read the application without leaving the form.

### How did you approach the change?
- Reused the existing `load_scholarship_submission` / `ScholarshipApplication` path and `form_submission` partial — the same block `edit.html.erb` already renders. The `new` action now loads the submission, and the view renders it (guarded by `if @event`, so the grant-funded path is unaffected).

### Anything else to add?
- Added two request specs mirroring the existing `edit` specs (embedded registration-form section and dedicated scholarship form).