### PR TITLE
Add comma-separated emails on bulk-email confirm page; rename to "Send bulk emails"

### DIFF
--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -13,7 +13,7 @@
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
     <%= link_to "Onboarding tracker", onboarding_event_path(@event), class: item_class %>
-    <%= link_to "Send reminder emails", preview_reminder_event_path(@event), class: item_class %>
+    <%= link_to "Send bulk emails", preview_reminder_event_path(@event), class: item_class %>
     <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: item_class %>
     <%= link_to registrants_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
       Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900">Send reminder emails</h1>
+    <h1 class="text-2xl font-semibold text-gray-900">Send bulk emails</h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
@@ -30,7 +30,7 @@
 
     <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated</h3>
     <p class="text-sm text-gray-700 mb-4 break-words">
-      <%= @event_registrations.map { |reg| reg.registrant.full_name }.join(", ") %>
+      <%= @event_registrations.map { |reg| reg.registrant.preferred_email }.join(", ") %>
     </p>
 
     <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Full list</h3>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -28,7 +28,12 @@
   <div class="bg-white border border-gray-200 rounded-lg p-4 mb-6">
     <h2 class="text-lg font-semibold text-gray-800 mb-3">Recipients <span class="text-gray-400 font-normal">(<%= count %>)</span></h2>
 
-    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated</h3>
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated names</h3>
+    <p class="text-sm text-gray-700 mb-4 break-words">
+      <%= @event_registrations.map { |reg| reg.registrant.full_name }.join(", ") %>
+    </p>
+
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated emails</h3>
     <p class="text-sm text-gray-700 mb-4 break-words">
       <%= @event_registrations.map { |reg| reg.registrant.preferred_email }.join(", ") %>
     </p>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -52,14 +52,14 @@
                   rows: 4,
                   class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
                   data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
-            <p class="text-xs text-gray-500 mt-1">
+            <p class="text-xs text-gray-400 mt-1.5">
               Accepts basic HTML — bold, italics, links, lists, and line breaks.
             </p>
           </div>
         </div>
       </div>
       <% if @reminder_preview_html.present? %>
-        <div class="mb-6">
+        <div class="mt-12 mb-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">Preview (sample registrant)</h2>
           <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
             <div class="border-b border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -8,7 +8,7 @@
 
   <div class="mb-6">
     <h1 class="text-2xl font-semibold text-gray-900">
-      Send reminder emails
+      Send bulk emails
     </h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -66,7 +66,7 @@
               <span class="font-semibold text-gray-500">Subject:</span>
               <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
             </div>
-            <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
+            <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif; zoom: 0.8;">
               <%= raw @reminder_preview_html %>
             </div>
           </div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -37,7 +37,7 @@
           The subject line recipients will see. Edit it as you like — leave it as is to use the default.
         </p>
         <%= text_field_tag :custom_subject, @custom_subject,
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm",
+              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm bg-white",
               data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
       </div>
       <div class="mb-6">
@@ -50,7 +50,7 @@
         </p>
         <%= text_area_tag :custom_message, @custom_message,
               rows: 4,
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono",
+              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
               data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
       </div>
       <% if @reminder_preview_html.present? %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -48,13 +48,13 @@
             <p class="text-gray-600 mb-2">
               The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
             </p>
-            <p class="text-xs text-gray-500 mb-2">
-              Accepts basic HTML — bold, italics, links, lists, and line breaks.
-            </p>
             <%= text_area_tag :custom_message, @custom_message,
                   rows: 4,
                   class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
                   data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
+            <p class="text-xs text-gray-500 mt-1">
+              Accepts basic HTML — bold, italics, links, lists, and line breaks.
+            </p>
           </div>
         </div>
       </div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -21,8 +21,8 @@
     <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
     <p class="text-gray-600 mb-3">
       Choose who will receive this reminder. Filters keep everyone in the list and
-      simply check the registrants who match. Separate multiple values with
-      <code class="font-mono">--</code> to match any of them (e.g.
+      check the matches. Separate multiple values with
+      <code class="font-mono">'--'</code> to match multiple values (e.g.
       <code class="font-mono">amy--aisha</code>).
     </p>
     <%= render "events/reminder_recipient_filters" %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -31,7 +31,7 @@
         reminder-preview drives the live message/subject preview as the admin types. %>
     <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
       <%= render "events/reminder_recipients" %>
-      <div class="my-10">
+      <div class="my-14">
         <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email draft</h2>
         <div class="bg-white border border-gray-200 rounded-lg p-6 pb-8 space-y-6">
           <div>
@@ -59,7 +59,7 @@
         </div>
       </div>
       <% if @reminder_preview_html.present? %>
-        <div class="mt-12 mb-6">
+        <div class="mb-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">Preview (sample registrant)</h2>
           <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
             <div class="border-b border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -31,9 +31,9 @@
         reminder-preview drives the live message/subject preview as the admin types. %>
     <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
       <%= render "events/reminder_recipients" %>
-      <div class="mt-10 mb-6">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Email draft</h2>
-        <div class="pl-4 sm:pl-6 space-y-6">
+      <div class="my-10 bg-white border border-gray-200 rounded-lg p-6">
+        <h2 class="text-lg font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">Email draft</h2>
+        <div class="space-y-6">
           <div>
             <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
             <p class="text-gray-600 mb-2">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -31,9 +31,9 @@
         reminder-preview drives the live message/subject preview as the admin types. %>
     <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
       <%= render "events/reminder_recipients" %>
-      <div class="my-10 bg-white border border-gray-200 rounded-lg p-6">
-        <h2 class="text-lg font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">Email draft</h2>
-        <div class="space-y-6">
+      <div class="my-10">
+        <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email draft</h2>
+        <div class="bg-white border border-gray-200 rounded-lg p-6 pb-8 space-y-6">
           <div>
             <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
             <p class="text-gray-600 mb-2">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -31,27 +31,32 @@
         reminder-preview drives the live message/subject preview as the admin types. %>
     <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
       <%= render "events/reminder_recipients" %>
-      <div class="mb-6">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Subject</h2>
-        <p class="text-gray-600 mb-2">
-          The subject line recipients will see. Edit it as you like — leave it as is to use the default.
-        </p>
-        <%= text_field_tag :custom_subject, @custom_subject,
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm bg-white",
-              data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
-      </div>
-      <div class="mb-6">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Message</h2>
-        <p class="text-gray-600 mb-2">
-          The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
-        </p>
-        <p class="text-xs text-gray-500 mb-2">
-          Accepts basic HTML — bold, italics, links, lists, and line breaks.
-        </p>
-        <%= text_area_tag :custom_message, @custom_message,
-              rows: 4,
-              class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
-              data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
+      <div class="mt-10 mb-6">
+        <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Email draft</h2>
+        <div class="pl-4 sm:pl-6 space-y-6">
+          <div>
+            <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
+            <p class="text-gray-600 mb-2">
+              The subject line recipients will see. Edit it as you like — leave it as is to use the default.
+            </p>
+            <%= text_field_tag :custom_subject, @custom_subject,
+                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm bg-white",
+                  data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
+          </div>
+          <div>
+            <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
+            <p class="text-gray-600 mb-2">
+              The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
+            </p>
+            <p class="text-xs text-gray-500 mb-2">
+              Accepts basic HTML — bold, italics, links, lists, and line breaks.
+            </p>
+            <%= text_area_tag :custom_message, @custom_message,
+                  rows: 4,
+                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
+                  data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
+          </div>
+        </div>
       </div>
       <% if @reminder_preview_html.present? %>
         <div class="mb-6">

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -66,7 +66,7 @@
               <span class="font-semibold text-gray-500">Subject:</span>
               <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
             </div>
-            <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif; zoom: 0.8;">
+            <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif; zoom: 0.6;">
               <%= raw @reminder_preview_html %>
             </div>
           </div>


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: copy/markup, no logic or data changes

- The confirm page now shows **two** copy-paste blocks: "Comma-separated names" (unchanged) and a new "Comma-separated emails" so an admin can grab addresses for another tool.
- Renamed the bulk-actions menu link and the preview/confirm page titles from "Send reminder emails" to **"Send bulk emails"** — the flow isn't reminder-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)