### PR TITLE
set registration download link to direct url

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -14,7 +14,7 @@ module Events
     HANDOUT_RESOURCE_TITLES = [
       "2-Day AWBW Facilitator Training Worksheets & Handouts",
       "AWBW Training Workshop Worksheets",
-      "AHA Moments",
+      "Aha Moments",
       "Inviting and Responding to Participants' Sharing",
       "Letter to Supervisors"
     ].freeze
@@ -24,7 +24,7 @@ module Events
         "List of resources and worksheets we will reference and utilize during the training. You do not need to print them out, it may be helpful for you to access the links during the training.",
       "AWBW Training Workshop Worksheets" =>
         "Worksheets you can create on during all 5 of the art workshops at the training. Any art materials are welcomed during creation.",
-      "AHA Moments" =>
+      "Aha Moments" =>
         "Worksheet you can use to reflect on the workshop, its impact, and how you'd like to apply it.",
       "Inviting and Responding to Participants' Sharing" =>
         "A resource to invite and support sharing, active listening, and connection during breakout rooms.",

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -8,7 +8,7 @@
     <% unless resource.single_page_pdf? %>
       <span class="text-xs text-gray-500">The preview shows the first page only — download to get all pages.</span>
     <% end %>
-    <%= link_to resource_download_path(resource), download: true, class: "btn btn-utility" do %>
+    <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
       Download <i class="fa-solid fa-download"></i>
     <% end %>
   </div>

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Registration ticket callouts", type: :request do
       get event_registration_ticket_callout_path(event, callout)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(resource_download_path(resource))
+      expect(response.body).to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
     end
 
     it "does not find a callout belonging to a different event" do
@@ -68,7 +68,7 @@ RSpec.describe "Registration ticket callouts", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Read this first.")
-        expect(response.body).to include(resource_download_path(resource))
+        expect(response.body).to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe "Registration ticket callouts", type: :request do
         get event_registration_ticket_callout_path(event, callout)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).not_to include(resource_download_path(resource))
+        expect(response.body).not_to include("fa-download")
       end
     end
   end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("AHA Moments")
       expect(response.body).to include(registration_ticket_path(registration.slug))
-      expect(response.body).to include(resource_download_path(resource))
+      expect(response.body).to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
     end
 
     it "prompts to download for all pages on a multi-page resource" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Events::Registrations", type: :request do
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
     it "links each handout to its registrant resource page, returning to handouts" do
-      handout = create(:resource, title: "AHA Moments", kind: "Handout")
+      handout = create(:resource, title: "Aha Moments", kind: "Handout")
       get registration_handouts_path(registration.slug)
       expect(response).to have_http_status(:success)
       expect(response.body).to include(registration_resource_path(registration.slug, handout, return_to: "handouts"))
@@ -275,19 +275,19 @@ RSpec.describe "Events::Registrations", type: :request do
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
     it "renders the resource with a back-to-ticket link and a download button" do
-      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+      resource = create(:resource, title: "Aha Moments", kind: "Handout")
       create(:downloadable_asset, owner: resource)
 
       get registration_resource_path(registration.slug, resource)
 
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("AHA Moments")
+      expect(response.body).to include("Aha Moments")
       expect(response.body).to include(registration_ticket_path(registration.slug))
       expect(response.body).to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
     end
 
     it "prompts to download for all pages on a multi-page resource" do
-      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+      resource = create(:resource, title: "Aha Moments", kind: "Handout")
       create(:downloadable_asset, owner: resource)
 
       get registration_resource_path(registration.slug, resource)
@@ -305,7 +305,7 @@ RSpec.describe "Events::Registrations", type: :request do
     end
 
     it "is reachable by slug without logging in" do
-      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+      resource = create(:resource, title: "Aha Moments", kind: "Handout")
 
       get registration_resource_path(registration.slug, resource)
 
@@ -313,7 +313,7 @@ RSpec.describe "Events::Registrations", type: :request do
     end
 
     it "returns to the handouts callout with a 'Handouts detail' header when reached from handouts" do
-      resource = create(:resource, title: "AHA Moments", kind: "Handout")
+      resource = create(:resource, title: "Aha Moments", kind: "Handout")
 
       get registration_resource_path(registration.slug, resource, return_to: "handouts")
 
@@ -321,7 +321,7 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("Back to handouts")
       expect(response.body).not_to include("Back to ticket")
       expect(response.body).to include("Handouts detail")
-      expect(response.body).to include("AHA Moments")
+      expect(response.body).to include("Aha Moments")
     end
 
     it "returns to the forms callout with a 'Forms detail' header when reached from forms" do


### PR DESCRIPTION
<!-- 👋🏻 Hey, thank you for contributing!!! This template is here to help us understand your changes and help you go get them in faster 😊 -->

Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
<!-- What are you trying to achieve? Why does this matter? -->
This bypasses the resource policy. It's implied that if the admin want this resource on an event registration then registrations should have access to it.

### How did you approach the change?
<!-- What did you do and why? -->

### UI Testing Checklist
<!-- This will be automatically generated based on your changes. -->
<!-- Complete the auto-generated checklist below before marking as ready for review. -->
<!-- Add or remove items as needed for your specific changes. -->

### Anything else to add?
<!-- Any alternative approaches you considered? Special notes for reviewers? -->


