### PR TITLE
Show sector names in their stored casing (filter + story-shares header)

### DIFF
--- a/app/views/story_shares/_sector_index.html.erb
+++ b/app/views/story_shares/_sector_index.html.erb
@@ -3,7 +3,9 @@
 
     <!-- Section Title -->
     <h1 class="text-2xl font-bold text-red-700 mb-6">
-      <%= params[:sector_names_all].to_s.titleize %>
+      <%# Sector names carry intentional casing ("LGBTQIA+", "Self-Care/Personal
+          Growth"); render them as stored rather than running .titleize. %>
+      <%= @sector_names_all.to_sentence %>
     </h1>
 
     <% if @stories_by_sector.first.second.any? %>

--- a/app/views/workshops/_dropdown_filter.html.erb
+++ b/app/views/workshops/_dropdown_filter.html.erb
@@ -40,8 +40,10 @@
           params.dig(param_name, item.id.to_s).to_s == item.id.to_s,
           id: "#{param_name}_#{item.id}",
           class: "category-checkbox" %>
+          <%# Render the label as stored — sector names carry intentional casing
+              (e.g. "LGBTQIA+", "Child Abuse/Neglect") that .humanize would flatten. %>
           <%= label_tag "#{param_name}_#{item.id}",
-          item.public_send(label_method).humanize,
+          item.public_send(label_method),
           class: "text-sm text-gray-700" %>
         </div>
       <% end %>

--- a/spec/requests/workshops_spec.rb
+++ b/spec/requests/workshops_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe "/workshops", type: :request do
     end
   end
 
+  # --- SECTOR FILTER LABELS --------------------------------------------------
+  describe "sector filter dropdown labels" do
+    let(:admin) { create(:user, :admin) }
+    let!(:sector) { create(:sector, :published, name: "LGBTQIA+") }
+
+    before { sign_in admin }
+
+    it "renders sector names with their canonical casing, not sentence case" do
+      get workshops_url
+
+      expect(response.body).to include("LGBTQIA+")
+      expect(response.body).not_to include("Lgbtqia+")
+    end
+  end
+
   # --- DESTROY ---------------------------------------------------------------
   describe "DELETE /destroy" do
     let(:user) { create(:user) }


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: removes a `.humanize`/`.titleize` on two sector labels, no logic or data changes

## What & why
Two display sites distorted intentionally-cased sector names (`"LGBTQIA+"`, `"Child Abuse/Neglect"`, `"Self-Care/Personal Growth"`). Both now render the name as stored, matching the Sectors admin.

- **Workshops Sector filter** (`_dropdown_filter.html.erb`) — dropped `.humanize` (`"LGBTQIA+"` → `"Lgbtqia+"`). The same shared partial feeds the **Windows audience** filter, whose labels (`"Adult"`/`"Children"`/`"Combined"`) are already sentence case and unaffected.
- **Story shares sector header** (`story_shares/_sector_index.html.erb`) — dropped `.titleize`; render the already-parsed `@sector_names_all` instead.

I audited every other sector display site (forms, tag chips, admin, dashboard, decorators) — all already render `sector.name` verbatim, no other offenders.

## Tests
- Request spec asserts the workshops filter keeps canonical casing (`LGBTQIA+`, not `Lgbtqia+`).