### PR TITLE
Default new affiliations to first of month and unchecked primary contact

### DIFF
--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -69,7 +69,7 @@
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                     input_html: {
                       type: "date",
-                      value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
+                      value: (f.object.start_date || (Date.current.beginning_of_month unless f.object.persisted?))&.strftime("%Y-%m-%d"),
                       class: "rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
                       data: { action: "change->affiliation-dates#recalculate" }
                     } %>
@@ -94,7 +94,7 @@
       <div class="w-full sm:w-auto pb-3">
         <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1">Primary org<br>contact</label>
         <%= f.check_box :primary_contact,
-                        checked: f.object.primary_contact? || !f.object.persisted?,
+                        checked: f.object.primary_contact?,
                         class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
       </div>
 

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -73,4 +73,15 @@ RSpec.describe "organizations/edit", type: :view do
       assert_select "p.text-red-600", text: "Does not match affiliations status"
     end
   end
+
+  describe "new affiliation defaults" do
+    it "defaults the start date to the first of the current month and leaves primary contact unchecked" do
+      organization.affiliations.build
+      render
+      assert_select "input[name*='start_date'][value=?]",
+                    Date.current.beginning_of_month.strftime("%Y-%m-%d")
+      assert_select "input[type=checkbox][name*='primary_contact']"
+      assert_select "input[type=checkbox][name*='primary_contact'][checked]", false
+    end
+  end
 end


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: form default changes in a shared partial, no logic or data changes

## What & why

New affiliation rows in the people-edit and org-edit forms now default to:

- **Start date = first of the current month** (was today). Affiliations are tracked from the start of the month.
- **Primary org contact = unchecked** (was pre-checked). Most people on an org aren't its primary contact; the pre-check made admins accept a usually-wrong default.

Both are view-only changes in the shared partial `app/views/affiliations/_fields.html.erb`. Existing affiliations still render their stored values; the DB default for `primary_contact` was already `false`.

## Tests

- View spec asserting a newly-built affiliation renders the first-of-month start date and an unchecked primary-contact box.
