### PR TITLE
Org "Pending" badge: suppress once linked, surface on the link editor

### DIFF
--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -54,7 +54,7 @@
                   <i class="fa-solid fa-file-lines"></i>
                 <% end %>
                 <div class="min-w-0">
-                  <p class="text-base text-gray-800">Organization: <strong><%= entry[:org_name].presence || "—" %></strong><% if entry[:organization]&.city_state.present? %> <span class="text-sm text-gray-500">· <%= entry[:organization].city_state %></span><% end %></p>
+                  <p class="text-base text-gray-800">Organization: <strong><%= entry[:org_name].presence || "—" %></strong><% if entry[:organization]&.city_state.present? %> <span class="text-sm text-gray-500">· <%= entry[:organization].city_state %></span><% end %><%# Mirror the roster's amber "Pending" chip so it's clear why this registrant was flagged — shown only while nothing is linked. %><% if entry[:org_name].present? && @linked_organizations.none? %> <span class="ml-1 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700" title="The registrant submitted this organization, but none is linked to the registration yet."><i class="fa-solid fa-circle-exclamation text-[0.65rem]"></i>Pending</span><% end %></p>
                   <p class="text-base text-gray-800">Position / title: <strong><%= entry[:position].presence || "—" %></strong></p>
                 </div>
               </li>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -118,10 +118,10 @@
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <% linked_orgs = registration.organizations %>
                   <% submitted_org_name = submitted_org_names[registration.registrant_id].to_s.strip %>
-                  <% linked_org_names = linked_orgs.map { |org| org.name.to_s.strip.downcase } %>
-                  <%# A submitted name not represented among the linked orgs still needs admin
-                      attention; a name matching a linked org is already resolved. %>
-                  <% needs_linking = submitted_org_name.present? && linked_org_names.exclude?(submitted_org_name.downcase) %>
+                  <%# A submitted org name needs admin attention only while nothing is linked
+                      yet; once an admin links any org they've made the call, so a non-matching
+                      submitted name is no longer treated as pending. %>
+                  <% needs_linking = submitted_org_name.present? && linked_orgs.none? %>
                   <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
                   <% pill_classes = "inline-flex items-center gap-1.5 rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
                   <div class="flex flex-wrap gap-1.5">

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -574,6 +574,24 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("No registration form was submitted")
         end
 
+        it "shows a 'Pending' badge next to the submitted org when nothing is linked" do
+          existing_registration.event_registration_organizations.destroy_all
+          submit_form(org_name: "Riverside Healing Arts Collective")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).to include("Riverside Healing Arts Collective")
+          expect(response.body).to include(">Pending<")
+        end
+
+        it "does not show the 'Pending' badge once an organization is linked" do
+          submit_form(org_name: "Riverside Healing Arts Collective")
+
+          get link_organization_event_registration_path(existing_registration)
+
+          expect(response.body).not_to include(">Pending<")
+        end
+
         it "shows 'Create org & link' when the submitted org has no existing match" do
           submit_form(org_name: "Brand New Unlisted Org")
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -591,14 +591,14 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include(">Pending<")
       end
 
-      it "shows the linked org AND a 'Pending' chip when the submitted name is not among the linked orgs" do
+      it "does not show a 'Pending' chip when an org is linked, even if the submitted name differs" do
         create(:event_registration_organization, event_registration: registration, organization: organization)
         submit_agency_name("A Different Unlisted Agency")
 
         get registrants_event_path(event)
 
         expect(response.body).to include(organization.name)
-        expect(response.body).to include(">Pending<")
+        expect(response.body).not_to include(">Pending<")
       end
 
       it "does not show 'Pending' when the submitted name matches a linked org" do


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: two ERB views + specs, no logic/data changes

### What is the goal of this PR and why is this important?
- The registrants roster's org **"Pending"** chip currently shows whenever a registrant's submitted org name doesn't match a linked org — even after an admin has linked one. That's noise: once an admin links *any* org, they've made the call.
- Now the chip shows **only while nothing is linked**. A non-matching submitted name on an already-linked registration is no longer flagged.
- For continuity, the **link-organization editor** shows the same amber "Pending" badge next to the submitted org name (while nothing is linked), so when you click through it's clear why the registrant was flagged.

### How did you approach the change?
- Roster (`_registrants_results.html.erb`): `needs_linking` now keys off `linked_orgs.none?` instead of comparing the submitted name against linked names.
- Editor (`link_organization.html.erb`): amber "Pending" badge in the "Registration form submission" section, shown only when `@linked_organizations.none?`.
- Updated the roster chip spec to the new behavior; added editor specs (badge present with no link, absent once linked).

### Anything else to add?
- Split out from the registrants readiness PR (#1925) at the reviewer's request. That PR's Status "Org validation" reason uses the same "no organization linked" rule; the two will reconcile when both land.