### PR TITLE
Auto-sync attendance status from onboarding day checkboxes

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -131,6 +131,9 @@ class EventRegistrationsController < ApplicationController
       @event_registration.update(fee_note: params[:value])
     elsif EventRegistration::DAY_FIELDS.include?(@field)
       @event_registration.update(@field => completed)
+      # Toggling a day rolls the attendance status forward/back (registered →
+      # incomplete_attendance → attended). Flag it so the badge re-renders too.
+      @status_synced = @event_registration.sync_attendance_status_to_days!
     elsif EventRegistration::CHECKLIST_STEPS.key?(@field)
       toggle_checklist_step(@field, completed)
       @event_registration.checklist_completions.reload

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -321,6 +321,35 @@ class EventRegistration < ApplicationRecord
     DAY_FIELDS.include?("completed_day_#{day}") && public_send("completed_day_#{day}")
   end
 
+  # How many of the event's in-range days (the first event.day_count of them) are
+  # marked complete on this registration.
+  def completed_day_count
+    DAY_FIELDS.first(event.day_count).count { |field| public_send(field) }
+  end
+
+  # The attendance status implied purely by how many days are marked complete:
+  # none → registered, all → attended, some-but-not-all → incomplete_attendance.
+  # (A one-day event has no partial state: 0 → registered, 1 → attended.)
+  def attendance_status_for_days
+    completed = completed_day_count
+    return "registered" if completed.zero?
+    return "attended" if completed >= event.day_count
+    "incomplete_attendance"
+  end
+
+  # Realign the attendance status to match the completed-day count after a day
+  # checkbox is toggled on the Onboarding matrix. Only auto-managed while the
+  # registration is in an active status — cancelled and no_show are deliberate
+  # manual states we never override by toggling a day. Returns true if the status
+  # actually changed.
+  def sync_attendance_status_to_days!
+    return false unless status.in?(ACTIVE_STATUSES)
+    derived = attendance_status_for_days
+    return false if derived == status
+    update!(status: derived)
+    true
+  end
+
   # Program status(es) for THIS registration only: classify each organization
   # linked to the registration as of the training date (the 1st of the event's
   # month), excluding the registrant's own facilitator affiliation to that org so

--- a/app/views/event_registrations/update_onboarding.turbo_stream.erb
+++ b/app/views/event_registrations/update_onboarding.turbo_stream.erb
@@ -3,3 +3,9 @@
 <%= turbo_stream.replace dom_id(@event_registration, @field) do %>
   <%= render "events/onboarding/cell", registration: @event_registration, field: @field %>
 <% end %>
+<%# A day toggle may have rolled the attendance status forward/back — refresh the badge too. %>
+<% if @status_synced %>
+  <%= turbo_stream.replace dom_id(@event_registration, :attendance_status) do %>
+    <%= render "event_registrations/attendance_status_badge", registration: @event_registration %>
+  <% end %>
+<% end %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -50,6 +50,51 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#sync_attendance_status_to_days!" do
+    # A two-day event: start and end one day apart → day_count == 2.
+    let(:event) { create(:event, start_date: 12.days.from_now, end_date: 13.days.from_now) }
+    let(:registration) { create(:event_registration, event: event, status: "registered") }
+
+    it "flips registered → attended when all days are complete" do
+      registration.update!(completed_day_1: true, completed_day_2: true)
+      expect(registration.sync_attendance_status_to_days!).to be(true)
+      expect(registration.reload.status).to eq("attended")
+    end
+
+    it "flips to incomplete_attendance when only some days are complete" do
+      registration.update!(completed_day_1: true)
+      expect(registration.sync_attendance_status_to_days!).to be(true)
+      expect(registration.reload.status).to eq("incomplete_attendance")
+    end
+
+    it "rolls back to registered when no days are complete" do
+      registration.update!(status: "attended", completed_day_1: false, completed_day_2: false)
+      expect(registration.sync_attendance_status_to_days!).to be(true)
+      expect(registration.reload.status).to eq("registered")
+    end
+
+    it "treats a one-day event as registered/attended with no partial state" do
+      one_day = create(:event, start_date: 12.days.from_now, end_date: 12.days.from_now)
+      reg = create(:event_registration, event: one_day, status: "registered", completed_day_1: true)
+      expect(reg.sync_attendance_status_to_days!).to be(true)
+      expect(reg.reload.status).to eq("attended")
+    end
+
+    it "returns false and leaves the status untouched when it already matches" do
+      registration.update!(completed_day_1: true, completed_day_2: true, status: "attended")
+      expect(registration.sync_attendance_status_to_days!).to be(false)
+      expect(registration.reload.status).to eq("attended")
+    end
+
+    it "never overrides a deliberate inactive status (cancelled / no_show)" do
+      %w[ cancelled no_show ].each do |inactive|
+        reg = create(:event_registration, event: event, status: inactive, completed_day_1: true, completed_day_2: true)
+        expect(reg.sync_attendance_status_to_days!).to be(false)
+        expect(reg.reload.status).to eq(inactive)
+      end
+    end
+  end
+
   describe ".registrant_ids" do
     it "returns registrations for the registrants in a hyphenated id list" do
       person_a = create(:person)

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -108,6 +108,46 @@ RSpec.describe "EventRegistrations", type: :request do
       end
     end
 
+    describe "PATCH /event_registrations/:id/update_onboarding" do
+      # Two-day event (day_count == 2) so a single day is a partial attendance.
+      let(:two_day_event) { create(:event, start_date: 12.days.from_now, end_date: 13.days.from_now) }
+      let(:registration) { create(:event_registration, event: two_day_event, status: "registered") }
+
+      def toggle_day(field, value)
+        patch update_onboarding_event_registration_path(registration),
+              params: { field: field, value: value },
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+
+      it "flips registered → incomplete_attendance when one day is checked" do
+        toggle_day("completed_day_1", "1")
+        expect(registration.reload.status).to eq("incomplete_attendance")
+      end
+
+      it "flips to attended once both days are checked" do
+        registration.update!(completed_day_1: true, status: "incomplete_attendance")
+        toggle_day("completed_day_2", "1")
+        expect(registration.reload.status).to eq("attended")
+      end
+
+      it "rolls back to registered when the last checked day is unchecked" do
+        registration.update!(completed_day_1: true, status: "incomplete_attendance")
+        toggle_day("completed_day_1", "0")
+        expect(registration.reload.status).to eq("registered")
+      end
+
+      it "re-renders the attendance badge in the turbo stream when the status changes" do
+        toggle_day("completed_day_1", "1")
+        expect(response.body).to include("attendance_status_event_registration_#{registration.id}")
+      end
+
+      it "does not touch a cancelled registration" do
+        registration.update!(status: "cancelled")
+        toggle_day("completed_day_1", "1")
+        expect(registration.reload.status).to eq("cancelled")
+      end
+    end
+
     describe "POST /event_registrations" do
       it "creates registration and redirects admin to confirm page" do
         expect {


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — light-logic: small, contained logic change with new model method + tests

On the bulk Onboarding matrix, toggling per-day attendance checkboxes now rolls the attendance status automatically so admins don't set it in two places.

**Rules** (only applied while the status is *active* — `cancelled`/`no_show` are deliberate manual states and are never overridden):

- **0 days checked → `registered`**
- **some but not all days checked → `incomplete_attendance`**
- **all days checked → `attended`**

A one-day event has no partial state (0 → registered, 1 → attended). Derived from `event.day_count`, so it works for 1–5 day events.

When a toggle changes the status, the turbo-stream response also re-renders the attendance badge so the matrix updates live.