### PR TITLE
Clear pre-existing CI failures: bulk-payment icon test + bundler-audit CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,8 +168,9 @@ GEM
     country_select (11.0.0)
       countries (> 6.0, < 9.0)
     crass (1.0.7)
-    css_parser (2.2.0)
+    css_parser (3.0.0)
       addressable
+      ssrf_filter (~> 1.5)
     csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
@@ -311,7 +312,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
@@ -713,6 +714,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.5.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -884,7 +886,7 @@ CHECKSUMS
   countries (8.1.0) sha256=4d6b318b8e906f1f769d5c021c13a418d33e917dc96ceb625a91d8e7ab2d192e
   country_select (11.0.0) sha256=0ab0a385fa70eadc71473af4b21b9b4d09f75660cc1c282a5bf6ec873719204b
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
-  css_parser (2.2.0) sha256=23d1b247d7bc78cb2f2fe54629fb755e68d3004f1d1bd5c66d5096d42bff6325
+  css_parser (3.0.0) sha256=eaf0e9283fd581d06e815235ceef4f0910c0b394c606355dbc69f93e84443885
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
@@ -952,7 +954,7 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
@@ -1094,6 +1096,7 @@ CHECKSUMS
   solid_queue (1.3.1) sha256=d9580111180c339804ff1a810a7768f69f5dc694d31e86cf1535ff2cd7a87428
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.2.2) sha256=62862bce136e31d7497eededde5f7730d4096bc8ef33ef7037c41423ccf89557
+  ssrf_filter (1.5.0) sha256=e03dcdb9d1730d7f6710532a606b3543df2a448a0293ce04a2d995523c5a97f6
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   stripe (18.4.2) sha256=fd08a73ab87fc0b0ad938ca71293e1051e593001b70de5e9fcf12d1097133831

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include('fa-file-lines')
       end
 
-      it "shows a gray icon when the only submission is for a bulk payment form" do
+      it "shows no form icon when the only submission is for a bulk payment form" do
         bulk_payment_form = create(:form, :standalone, name: "Bulk Payment Form")
         create(:event_form, event: event, form: reg_form, role: "registration")
         create(:event_form, event: event, form: bulk_payment_form, role: "bulk_payment")
@@ -794,8 +794,8 @@ RSpec.describe "Events", type: :request do
         get registrants_event_path(event)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('fa-regular fa-file-lines')
-        expect(response.body).not_to include('fa-solid fa-file-lines')
+        expect(response.body).not_to include('fa-file-lines')
+        expect(response.body).to include('inline-flex w-4 justify-center')
       end
     end
   end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 spec correction + conservative transitive dep bump; mailer specs verified

Two pre-existing failures on `main` (surfaced on full-suite PR CI, not main's RuboCop-only push CI), fixed here:

### build-and-test — self-contradictory test from #1848
- #1848 correctly restricted the registrants form icon to registration-role forms, so a bulk-payment-only submission renders **no** icon.
- Its accompanying test asserted a "gray icon" the implementation never produces. Flipped it to assert no icon (empty slot reserved), matching the sibling empty-slot test and #1848's intent. Spec-only, no implementation change.

### scan_ruby — bundler-audit CVEs
- `css_parser` 2.2.0→3.0.0 (CVE-2026-53727 — SSRF/local file disclosure in `read_remote_file`)
- `msgpack` 1.8.0→1.8.3 (CVE-2026-54522 — use-after-free)
- Both transitive; bumped conservatively so nothing else moves. `premailer` requires `css_parser >= 1.19.0`, so the major bump is compatible — all 88 mailer specs pass. `bundler-audit` now reports no vulnerabilities.

### Notes for reviewers
- None of this originates from the branch's own feature work — both were red on clean `main`.