### PR TITLE
Remove obsolete brakeman.ignore entry for organizations/show

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -238,40 +238,6 @@
         79
       ],
       "note": "Admin-only reminder confirmation. Same as preview_reminder: the raw value is the server-rendered email HTML; the embedded custom message is sanitized via reminder_message_html (SafeListSanitizer) and the custom subject is shown escaped, separately, so no unsanitized user input reaches the page."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "081b76f4d760b6f2879493fdde335a57dfc310ba0adfb28d5abe40d5f983189f",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/organizations/show.html.erb",
-      "line": 88,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_url, Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_link_url, :target => \"_blank\", :rel => \"noopener noreferrer\", :class => \"text-blue-600 hover:underline\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "OrganizationsController",
-          "method": "show",
-          "line": 74,
-          "file": "app/controllers/organizations_controller.rb",
-          "rendered": {
-            "name": "organizations/show",
-            "file": "app/views/organizations/show.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "organizations/show"
-      },
-      "user_input": "Organization.includes(:organization_status, :windows_type, :addresses, :categorizable_items, { :comments => ([:created_by, :updated_by]) }, { :sectorable_items => :sector }, :affiliations => :person).find(params[:id]).website_link_url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": "Organization#website_link_url only ever returns an http(s):// URL (it requires a URI::HTTP with a host), so the href can't carry a javascript: or data: scheme."
     }
   ],
   "brakeman_version": "8.0.4",


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: security-config cleanup, no code or data changes

- Removes a stale `LinkToHref` ignore entry (fingerprint `081b76f4…`) for `organizations/show.html.erb`. Main’s churn changed the code around that `link_to`, so brakeman no longer generates that fingerprint — the entry matched nothing.
- Brakeman itself flagged it in its `obsolete` list. After removal: `active=0 ignored=8 obsolete=[]`, exits clean. No new fingerprint appeared, so nothing needs re-ignoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)