### PR TITLE
Ignore pay Paddle webhook HMAC advisory (GHSA-mjgf-xj26-9qf9)

### DIFF
--- a/config/bundler-audit.yml
+++ b/config/bundler-audit.yml
@@ -8,3 +8,8 @@ ignore:
   - CVE-2021-41183
   - CVE-2021-41184
   - CVE-2022-31160
+  # pay: non-constant-time HMAC comparison in the Paddle Billing webhook
+  # signature verifier. We only use the Stripe processor (see config/initializers/pay.rb),
+  # never Paddle, so the vulnerable code path is unreachable. No patched pay
+  # release exists (affects all versions <= 11.6.1). Remove this once upstream ships a fix.
+  - GHSA-mjgf-xj26-9qf9


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line bundler-audit ignore; the judgment call (Paddle path unreachable) is what to check

## Why

`bundler-audit` in CI fails on `GHSA-mjgf-xj26-9qf9` — a non-constant-time HMAC comparison in pay's **Paddle Billing** webhook signature verifier.

- We only run the **Stripe** processor (`config/initializers/pay.rb`); there is no Paddle code anywhere, so the vulnerable path is unreachable.
- **No patched pay release exists** — the advisory flags all versions ≤ 11.6.1 (we're on 11.4.3), so a version bump can't resolve it.

## What

- Add `GHSA-mjgf-xj26-9qf9` to `config/bundler-audit.yml` ignore list, with a comment explaining the reasoning and a note to remove it once upstream ships a fix.

Verified `bin/bundler-audit` now reports **No vulnerabilities found**.