### PR TITLE
Credit stories to any person, not just active users

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -50,8 +50,9 @@ class PeopleController < ApplicationController
         @workshop_variations = @person.user&.workshop_variations_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
         render partial: "people/sections/workshop_variations", locals: { person: @person, workshop_variations: @workshop_variations }
       when "stories"
-        story_ids = @person.user&.stories_as_creator&.pluck(:id).to_a +
-          @person.stories_as_author.pluck(:id) +
+        # Credit the person for stories they authored or were spotlighted in —
+        # not ones their user merely entered (created_by is a pure audit trail).
+        story_ids = @person.stories_as_author.pluck(:id) +
           @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -50,7 +50,9 @@ class PeopleController < ApplicationController
         @workshop_variations = @person.user&.workshop_variations_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
         render partial: "people/sections/workshop_variations", locals: { person: @person, workshop_variations: @workshop_variations }
       when "stories"
-        story_ids = @person.user&.stories_as_creator&.pluck(:id).to_a + @person.stories_as_spotlighted_facilitator.pluck(:id)
+        story_ids = @person.user&.stories_as_creator&.pluck(:id).to_a +
+          @person.stories_as_author.pluck(:id) +
+          @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }
       when "events"

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -9,8 +9,8 @@ class StoriesController < ApplicationController
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 12
       base_scope = authorized_scope(Story.includes(:windows_type, :organization, :workshop,
-                                                   :created_by, :bookmarks, :primary_asset,
-                                                   :story_idea))
+                                                   :author, :bookmarks, :primary_asset,
+                                                   :story_idea, created_by: :person))
       filtered = base_scope.search_by_params(params)
       sortable = %w[title updated_at created_at windows_type workshop author organization]
       @sort = sortable.include?(params[:sort]) ? params[:sort] : "created_at"
@@ -62,6 +62,7 @@ class StoriesController < ApplicationController
 
   def create
     @story = Story.new(story_params.except(:category_ids, :sector_ids))
+    @story.created_by = current_user
     authorize! @story
 
     success = false
@@ -131,7 +132,6 @@ class StoriesController < ApplicationController
                             .references(:users)
                             .order(:created_at)
     @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
-    @users = User.has_access.includes(:person).left_joins(:person).order(Arel.sql("people.first_name IS NULL, LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email)"))
     @windows_types = WindowsType.all
     @workshops = authorized_scope(Workshop.all).includes(:windows_type).order(:title)
     @categories_grouped =
@@ -189,7 +189,7 @@ class StoriesController < ApplicationController
     params.require(:story).permit(
       :title, :rhino_body, :featured, :published, :publicly_visible, :publicly_featured, :youtube_url, :website_url,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
-      :created_by_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
+      :author_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],
@@ -206,6 +206,7 @@ class StoriesController < ApplicationController
       external_workshop_title: idea.external_workshop_title,
       windows_type_id: idea.windows_type_id,
       youtube_url: idea.youtube_url,
+      author_id: idea.created_by&.person_id,
       author_credit_preference: idea.author_credit_preference
     }
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -174,8 +174,16 @@ class StoriesController < ApplicationController
       scope.left_joins(:workshop)
            .reorder(Workshop.arel_table[:title].public_send(dir))
     when "author"
-      scope.left_joins(created_by: :person)
-           .reorder(Person.arel_table[:first_name].public_send(dir))
+      # Match Story#author_person, which the column renders: sort by the explicit
+      # author, falling back to the creating user's person. `created_by: :person`
+      # is the second join to `people`, so Rails aliases it `people_users`.
+      creator_person = Person.arel_table.alias("people_users")
+      author_first_name = Arel::Nodes::NamedFunction.new(
+        "COALESCE",
+        [ Person.arel_table[:first_name], creator_person[:first_name] ]
+      )
+      scope.left_joins(:author, created_by: :person)
+           .reorder(author_first_name.public_send(dir))
     when "organization"
       scope.left_joins(:organization)
            .reorder(Organization.arel_table[:name].public_send(dir))

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -19,10 +19,10 @@ module AuthorCreditable
     "Anonymous" => "anonymous"
   }.freeze
 
-  # The person whose name is credited. Defaults to the creating user's person;
-  # models with a dedicated author association (e.g. Story) override this.
+  # The person whose name is credited: the explicitly chosen author when the
+  # model has one (e.g. Story), otherwise the creating user's person.
   def author_person
-    created_by&.person
+    (author if respond_to?(:author)) || created_by&.person
   end
 
   def author_credit

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -19,8 +19,14 @@ module AuthorCreditable
     "Anonymous" => "anonymous"
   }.freeze
 
+  # The person whose name is credited. Defaults to the creating user's person;
+  # models with a dedicated author association (e.g. Story) override this.
+  def author_person
+    created_by&.person
+  end
+
   def author_credit
-    person = created_by&.person
+    person = author_person
     case author_credit_preference
     when "full_name" then person&.full_name || "Anonymous"
     when "first_name_last_initial"

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,6 +21,8 @@ class Person < ApplicationRecord
   has_many :sectorable_items, as: :sectorable, dependent: :destroy
   has_many :stories_as_spotlighted_facilitator, inverse_of: :spotlighted_facilitator, class_name: "Story",
            dependent: :restrict_with_error
+  has_many :stories_as_author, inverse_of: :author, class_name: "Story", foreign_key: :author_id,
+           dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :event_staffs, dependent: :destroy

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -10,6 +10,7 @@ class Story < ApplicationRecord
   belongs_to :organization, optional: true
   belongs_to :spotlighted_facilitator, class_name: "Person",
              foreign_key: "spotlighted_facilitator_id", optional: true
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :story_idea, optional: true
   belongs_to :workshop, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
@@ -87,6 +88,12 @@ class Story < ApplicationRecord
 
   def name
     title
+  end
+
+  # AuthorCreditable: prefer the explicitly chosen author, falling back to the
+  # creating user's person so stories predating the author field stay credited.
+  def author_person
+    author || created_by&.person
   end
 
   def organization_name

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -90,12 +90,6 @@ class Story < ApplicationRecord
     title
   end
 
-  # AuthorCreditable: prefer the explicitly chosen author, falling back to the
-  # creating user's person so stories predating the author field stay credited.
-  def author_person
-    author || created_by&.person
-  end
-
   def organization_name
     organization&.name
   end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -55,6 +55,7 @@ class PersonPolicy < ApplicationPolicy
   def has_associated_data?
     record.user.present? ||
       record.affiliations.exists? ||
-      record.stories_as_spotlighted_facilitator.exists?
+      record.stories_as_spotlighted_facilitator.exists? ||
+      record.stories_as_author.exists?
   end
 end

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -250,24 +250,6 @@
         <br>
         <div class="italic"><%= link_to story_idea.author_credit_preference, edit_story_idea_path(story_idea, anchor: "publish-preferences"), class: "hover:underline hover:text-blue-600" %></div>
       </div>
-
-      <% if f.object.persisted? %>
-        <div class="flex-1 mb-4 md:mb-0 ms-3 ps-3 text-gray-500">
-          Last updated by:
-          <br>
-          <%= f.object.updated_by&.full_name %>
-          <br>
-          <%= f.object.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %>
-        </div>
-      <% end %>
-    </div>
-  <% elsif f.object.persisted? %>
-    <div class="flex-1 mb-4 md:mb-0 ms-3 ps-3 text-gray-500">
-      Last updated by:
-      <br>
-      <%= f.object.updated_by&.full_name %>
-      <br>
-      <%= f.object.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %>
     </div>
   <% end %>
 

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -273,16 +273,18 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4">
     <div class="flex-1 mb-4 md:mb-0">
-      <%= f.input :created_by_id,
-                  collection: @users.map { |u| [ u.full_name_with_email, u.id ] },
+      <%= f.input :author_id,
+                  collection: @people.map { |p| [ p.full_name_with_email, p.id ] },
                   prompt: "Select an author",
-                  label: (f.object.created_by&.person ? (
+                  required: true,
+                  label: (f.object.author ? (
                     link_to "Story author",
-                            person_path(f.object.created_by.person),
+                            person_path(f.object.author),
                             class: "hover:underline") : "Story author").html_safe,
                   label_html: { class: "block font-medium mb-1 text-gray-700" },
                   input_html: {
-                    class: select_caret_class(blank: f.object.created_by_id.blank?),
+                    required: true,
+                    class: select_caret_class(blank: f.object.author_id.blank?),
                     style: custom_caret_style,
                     onchange: select_caret_onchange
                   } %>

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -62,7 +62,7 @@
               <span title="<%= story.workshop&.title %>"><%= story.workshop&.title&.truncate(30) %></span>
             </td>
 
-            <td class="px-4 py-2 text-sm text-gray-800"><%= story.author_credit %></td
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story.author_credit %></td>
 
             <td class="px-4 py-2 text-sm text-gray-800">
               <span title="<%= story.organization&.name %>"><%= story.organization&.name&.truncate(30) %></span>

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -62,7 +62,7 @@
               <span title="<%= story.workshop&.title %>"><%= story.workshop&.title&.truncate(30) %></span>
             </td>
 
-            <td class="px-4 py-2 text-sm text-gray-800"><%= story.created_by.name %></td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story.author_person&.name %></td>
 
             <td class="px-4 py-2 text-sm text-gray-800">
               <span title="<%= story.organization&.name %>"><%= story.organization&.name&.truncate(30) %></span>

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -62,7 +62,7 @@
               <span title="<%= story.workshop&.title %>"><%= story.workshop&.title&.truncate(30) %></span>
             </td>
 
-            <td class="px-4 py-2 text-sm text-gray-800"><%= story.author_person&.name %></td>
+            <td class="px-4 py-2 text-sm text-gray-800"><%= story.author_credit %></td
 
             <td class="px-4 py-2 text-sm text-gray-800">
               <span title="<%= story.organization&.name %>"><%= story.organization&.name&.truncate(30) %></span>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -28,8 +28,9 @@
         <!-- Meta Data (exact screenshot style) -->
         <div class="text-sm text-gray-600 space-y-0.5">
           <p><strong>Story by:</strong>
-            <% if @story.created_by.person&.profile_is_searchable %>
-              <%= link_to @story.author_credit, person_path(@story.created_by) %>
+            <% credited_person = @story.author_person %>
+            <% if credited_person&.profile_is_searchable %>
+              <%= link_to @story.author_credit, person_path(credited_person) %>
             <% else %>
               <%= @story.author_credit %>
             <% end %>

--- a/db/migrate/20260704193542_add_author_to_stories.rb
+++ b/db/migrate/20260704193542_add_author_to_stories.rb
@@ -1,0 +1,10 @@
+class AddAuthorToStories < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:stories, :author_id)
+    add_reference :stories, :author, foreign_key: { to_table: :people }, index: true, null: true
+  end
+
+  def down
+    remove_reference :stories, :author, foreign_key: { to_table: :people }, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_023519) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_193542) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1208,6 +1208,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_023519) do
 
   create_table "stories", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "body"
     t.datetime "created_at", null: false
     t.integer "created_by_id", null: false
@@ -1227,6 +1228,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_023519) do
     t.integer "windows_type_id", null: false
     t.integer "workshop_id"
     t.string "youtube_url"
+    t.index ["author_id"], name: "index_stories_on_author_id"
     t.index ["created_by_id"], name: "index_stories_on_created_by_id"
     t.index ["organization_id"], name: "index_stories_on_organization_id"
     t.index ["published"], name: "index_stories_on_published"
@@ -1746,6 +1748,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_023519) do
   add_foreign_key "scholarships", "people", column: "recipient_id"
   add_foreign_key "sectorable_items", "sectors"
   add_foreign_key "stories", "organizations"
+  add_foreign_key "stories", "people", column: "author_id"
   add_foreign_key "stories", "people", column: "spotlighted_facilitator_id"
   add_foreign_key "stories", "story_ideas"
   add_foreign_key "stories", "users", column: "created_by_id"

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,6 +3,27 @@ require 'rails_helper'
 RSpec.describe Story, type: :model do
   it_behaves_like "author_creditable", factory: :story
 
+  describe "#author_person" do
+    let(:creator) { create(:user, :with_person) }
+    let(:facilitator) { create(:person) }
+
+    it "returns the explicitly chosen author when present" do
+      story = create(:story, created_by: creator, author: facilitator)
+      expect(story.author_person).to eq(facilitator)
+    end
+
+    it "falls back to the creating user's person when no author is set" do
+      story = create(:story, created_by: creator, author: nil)
+      expect(story.author_person).to eq(creator.person)
+    end
+
+    it "credits the author over the creator via author_credit" do
+      story = create(:story, created_by: creator, author: facilitator,
+                             author_credit_preference: "full_name")
+      expect(story.author_credit).to eq(facilitator.full_name)
+    end
+  end
+
   describe "#attach_assets_from_idea!" do
     let(:idea) { create(:story_idea) }
     let(:story) { create(:story, story_idea: idea) }

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -137,6 +137,23 @@ RSpec.describe PersonPolicy, type: :policy do
     end
   end
 
+  describe "#destroy?" do
+    context "when person has authored stories" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:story, author: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+  end
+
   describe "relation_scope" do
     context "with admin user" do
       let(:policy) { policy_for(record: Person, user: admin_user) }

--- a/spec/requests/people_stories_section_spec.rb
+++ b/spec/requests/people_stories_section_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Person profile stories section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_stories_section
+    get person_path(person, section: "stories"),
+        headers: { "Turbo-Frame" => "person_stories_section" }
+  end
+
+  it "shows stories the person authored" do
+    create(:story, :published, title: "Authored Story", author: person)
+
+    get_stories_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Authored Story")
+  end
+
+  it "shows stories the person was spotlighted in" do
+    create(:story, :published, title: "Spotlight Story", spotlighted_facilitator: person)
+
+    get_stories_section
+
+    expect(response.body).to include("Spotlight Story")
+  end
+
+  it "excludes stories the person's user merely created (audit trail only)" do
+    create(:story, :published, title: "Only Created Story", created_by: owner_user)
+
+    get_stories_section
+
+    expect(response.body).not_to include("Only Created Story")
+  end
+end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -196,6 +196,18 @@ RSpec.describe "/stories", type: :request do
           expect(titles_in_response).to eq([ "Alpha Story", "Zulu Story" ])
         end
 
+        it "sorts by the credited author, not the creator, when they differ" do
+          # Explicit authors invert the creators: story_a is created by Alice but
+          # authored by Zeke; story_z is created by Zara but authored by Aaron.
+          # The column shows the author, so the sort must key off it too — keying
+          # off the creator would put Alpha before Zulu.
+          story_a.update!(author: create(:person, first_name: "Zeke", last_name: "Zimmer"))
+          story_z.update!(author: create(:person, first_name: "Aaron", last_name: "Adams"))
+
+          get stories_url, params: { sort: "author", direction: "asc" }, headers: turbo_headers
+          expect(titles_in_response).to eq([ "Zulu Story", "Alpha Story" ])
+        end
+
         it "sorts by organization asc" do
           get stories_url, params: { sort: "organization", direction: "asc" }, headers: turbo_headers
           expect(titles_in_response).to eq([ "Alpha Story", "Zulu Story" ])

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -228,6 +228,20 @@ RSpec.describe "/stories", type: :request do
 
         expect(response).to redirect_to(story_url(Story.last))
       end
+
+      it "records the current user as created_by regardless of submitted value" do
+        someone_else = create(:user)
+        post stories_url, params: { story: base_attributes.merge(created_by_id: someone_else.id) }
+
+        expect(Story.last.created_by).to eq(admin)
+      end
+
+      it "assigns the chosen person as author" do
+        facilitator = create(:person)
+        post stories_url, params: { story: base_attributes.merge(author_id: facilitator.id) }
+
+        expect(Story.last.author).to eq(facilitator)
+      end
     end
   end
 

--- a/spec/views/stories/edit.html.erb_spec.rb
+++ b/spec/views/stories/edit.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "stories/edit", type: :view do
 
       assert_select "select[name=?]", "story[author_credit_preference]"
 
-      assert_select "select[name=?]", "story[created_by_id]"
+      assert_select "select[name=?]", "story[author_id]"
     end
   end
 

--- a/spec/views/stories/new.html.erb_spec.rb
+++ b/spec/views/stories/new.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "stories/new", type: :view do
       assert_select "select[name=?]", "story[workshop_id]"
       assert_select "input[name=?][type=?]", "story[rhino_body]", "hidden"
       assert_select "textarea[name=?]", "story[youtube_url]"
-      assert_select "select[name=?]", "story[created_by_id]"
+      assert_select "select[name=?]", "story[author_id]"
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 data-model change (new author FK), controller create semantics, and author-credit fallback across public/profile display

Fixes #1515.

## Why
The story author dropdown was gated to active users (`User.has_access`), so facilitators with unconfirmed logins (e.g. Courtney Koczka, Lemny Perez) couldn't be credited. Spotlighted-facilitator already pulls from all people; author now does too.

## What
- New nullable `stories.author_id` → Person FK, mirroring `spotlighted_facilitator`. The "Story author" field now lists **all people** and is **required in the form** (model stays optional).
- `created_by` stays a `User` but is now pure audit — set to `current_user` on create, no longer the author picker.
- `AuthorCreditable` gains an overridable `author_person` (default `created_by.person`, unchanged for the 5 other models); `Story` overrides it to `author || created_by.person`, so **existing stories keep their attribution with no backfill**.
- Public show page, admin index "Author" column, and person-profile stories section now reflect the author.
- Admin index **"Author" sort** keys off `author_person` too (COALESCE of author + creator's person), so the column and its sort agree even when author ≠ creator.
- Person profile **stories section** now lists only stories the person **authored or was spotlighted in** — not ones their user merely entered — matching the "Stories authored/featured" heading.
- Converting a story idea pre-fills the author from the idea's submitter.
- Dropped the redundant "Last updated by" name/timestamp block from the story form (still recorded on save; only the form display is removed).

## Not included
- #1516 (author search box) and the first-name-only free-text case — deferred per request.
