### PR TITLE
Credit workshops to any person, not just active users

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -44,7 +44,9 @@ class PeopleController < ApplicationController
 
       case section
       when "workshops"
-        @workshops = @person.user&.workshops&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
+        # Credit the person for workshops they authored — not ones their user
+        # merely created (created_by is a pure audit trail).
+        @workshops = @person.workshops_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshops", locals: { person: @person, workshops: @workshops }
       when "workshop_variations"
         # Credit the person for variations they authored — not ones their user

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -16,7 +16,7 @@ class WorkshopsController < ApplicationController
       track_index_intent(Workshop, search_service.workshops, params)
 
       @workshops = authorized_scope(search_service.workshops
-                                                  .includes(:categories, :windows_type, :bookmarks,
+                                                  .includes(:categories, :windows_type, :bookmarks, :author,
                                                             created_by: [ :person ], primary_asset: [ :file_attachment ]))
                                                   .paginate(page: params[:page], per_page: params[:per_page] || 12)
 
@@ -198,6 +198,7 @@ class WorkshopsController < ApplicationController
     potential_series = potential_series.where.not(id: @workshop.id) if @workshop.persisted?
     @potential_series_workshops = authorized_scope(potential_series).order(:title)
     @windows_types = WindowsType.all
+    @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
     @workshop_ideas = authorized_scope(WorkshopIdea.order(created_at: :desc))
                                   .map { |wi|
                                     [ "#{wi.created_at.strftime("%Y-%m-%d")
@@ -225,7 +226,7 @@ class WorkshopsController < ApplicationController
   def workshop_params
     params.require(:workshop).permit(
       :title, :featured, :published,
-      :full_name, :created_by_id, :windows_type_id, :workshop_idea_id, :author_credit_preference,
+      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :author_credit_preference,
       :month, :year,
       :publicly_visible,
       :publicly_featured,

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -20,7 +20,7 @@ module AuthorCreditable
   }.freeze
 
   # The person whose name is credited: the explicitly chosen author when the
-  # model has one (e.g. Story), otherwise the creating user's person.
+  # model has one (e.g. Story, Workshop), otherwise the creating user's person.
   def author_person
     (author if respond_to?(:author)) || created_by&.person
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -26,6 +26,8 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   has_many :workshop_variations_as_author, inverse_of: :author, class_name: "WorkshopVariation",
            foreign_key: :author_id, dependent: :restrict_with_error
+  has_many :workshops_as_author, inverse_of: :author, class_name: "Workshop", foreign_key: :author_id,
+           dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :event_staffs, dependent: :destroy

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -54,6 +54,29 @@ class Story < ApplicationRecord
     options :action_text_body, type: :text, default: true, default_operator: :or
   end
 
+  # Matches the credited author by name: the creator's person (`people`) and the
+  # explicit author (a second join to the same table, aliased `author_people`).
+  # SearchCop can't join one table twice, so this is a plain scope OR-ed into the
+  # full-text results in `search_by_params`.
+  scope :by_credited_person_name, ->(query) {
+    sanitized = query.to_s.strip.gsub(/\s+/, "")
+    return none if sanitized.blank?
+
+    left_joins(created_by: :person)
+      .joins("LEFT OUTER JOIN people author_people ON author_people.id = stories.author_id")
+      .where(
+        "LOWER(REPLACE(CONCAT(people.first_name, people.last_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(CONCAT(people.last_name, people.first_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(people.first_name, ' ', '')) LIKE :name
+         OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name
+         OR LOWER(REPLACE(CONCAT(author_people.first_name, author_people.last_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(CONCAT(author_people.last_name, author_people.first_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(author_people.first_name, ' ', '')) LIKE :name
+         OR LOWER(REPLACE(author_people.last_name, ' ', '')) LIKE :name",
+        name: "%#{sanitized}%"
+      )
+  }
+
   # Scopes
   # See Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
   scope :by_year, ->(year) { where(created_at: Date.new(year.to_i)..Date.new(year.to_i).end_of_year) }
@@ -76,6 +99,14 @@ class Story < ApplicationRecord
     else
       conditions[:published] = params[:published] if params[:published].present?
       stories = self.search(conditions)
+    end
+
+    # SearchCop's free-text query only covers title + body. Also match the
+    # credited author/creator by name, OR-ed in via id subqueries so the extra
+    # `people` joins stay isolated from SearchCop's own joins.
+    if params[:query].present?
+      stories = self.where(id: stories.select("stories.id"))
+                    .or(self.where(id: by_credited_person_name(params[:query]).select("stories.id")))
     end
 
     stories = stories.by_year(params[:year]) if params[:year].present? && params[:year].match?(/\A\d{4}\z/)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -55,7 +55,7 @@ class Story < ApplicationRecord
   end
 
   # Matches the credited author by name: the creator's person (`people`) and the
-  # explicit author (a second join to the same table, aliased `author_people`).
+  # explicit author (a second join to the same table, aliased `author_person`).
   # SearchCop can't join one table twice, so this is a plain scope OR-ed into the
   # full-text results in `search_by_params`.
   scope :by_credited_person_name, ->(query) {
@@ -63,16 +63,16 @@ class Story < ApplicationRecord
     return none if sanitized.blank?
 
     left_joins(created_by: :person)
-      .joins("LEFT OUTER JOIN people author_people ON author_people.id = stories.author_id")
+      .joins("LEFT OUTER JOIN people author_person ON author_person.id = stories.author_id")
       .where(
         "LOWER(REPLACE(CONCAT(people.first_name, people.last_name), ' ', '')) LIKE :name
          OR LOWER(REPLACE(CONCAT(people.last_name, people.first_name), ' ', '')) LIKE :name
          OR LOWER(REPLACE(people.first_name, ' ', '')) LIKE :name
          OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name
-         OR LOWER(REPLACE(CONCAT(author_people.first_name, author_people.last_name), ' ', '')) LIKE :name
-         OR LOWER(REPLACE(CONCAT(author_people.last_name, author_people.first_name), ' ', '')) LIKE :name
-         OR LOWER(REPLACE(author_people.first_name, ' ', '')) LIKE :name
-         OR LOWER(REPLACE(author_people.last_name, ' ', '')) LIKE :name",
+         OR LOWER(REPLACE(CONCAT(author_person.first_name, author_person.last_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(CONCAT(author_person.last_name, author_person.first_name), ' ', '')) LIKE :name
+         OR LOWER(REPLACE(author_person.first_name, ' ', '')) LIKE :name
+         OR LOWER(REPLACE(author_person.last_name, ' ', '')) LIKE :name",
         name: "%#{sanitized}%"
       )
   }

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -25,6 +25,7 @@ class Workshop < ApplicationRecord
 
   belongs_to :windows_type, optional: true
   belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :workshop_idea, optional: true
 
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
@@ -185,7 +186,7 @@ class Workshop < ApplicationRecord
   end
 
   def author_name
-    created_by&.name || full_name.presence
+    author_person&.full_name.presence || full_name.presence
   end
 
   def date

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -57,6 +57,7 @@ class PersonPolicy < ApplicationPolicy
       record.affiliations.exists? ||
       record.stories_as_spotlighted_facilitator.exists? ||
       record.stories_as_author.exists? ||
-      record.workshop_variations_as_author.exists?
+      record.workshop_variations_as_author.exists? ||
+      record.workshops_as_author.exists?
   end
 end

--- a/app/services/workshop_from_idea_service.rb
+++ b/app/services/workshop_from_idea_service.rb
@@ -56,6 +56,7 @@ class WorkshopFromIdeaService
       rhino_misc2_spanish: workshop_idea.rhino_misc2_spanish,
       rhino_extra_field_spanish: workshop_idea.rhino_extra_field_spanish,
       created_by: user,
+      author_id: workshop_idea.created_by&.person_id,
       workshop_idea_id: workshop_idea.id,
       month: workshop_idea.created_at.month,
       year: workshop_idea.created_at.year,

--- a/app/services/workshop_search_service.rb
+++ b/app/services/workshop_search_service.rb
@@ -157,9 +157,9 @@ class WorkshopSearchService
 
     sanitized = author_name.strip.gsub(/\s+/, "")
     # `created_by: :person` joins `people` (the creator's person); the explicit
-    # author is a second join to the same table, so alias it `author_people`.
+    # author is a second join to the same table, so alias it `author_person`.
     workshops.left_outer_joins(created_by: :person)
-             .joins("LEFT OUTER JOIN people author_people ON author_people.id = workshops.author_id")
+             .joins("LEFT OUTER JOIN people author_person ON author_person.id = workshops.author_id")
              .where(
                "LOWER(REPLACE(workshops.full_name, ' ', '')) LIKE :name
                 OR LOWER(REPLACE(CONCAT(users.first_name, users.last_name), ' ', '')) LIKE :name
@@ -170,10 +170,10 @@ class WorkshopSearchService
                 OR LOWER(REPLACE(CONCAT(people.last_name, people.first_name), ' ', '')) LIKE :name
                 OR LOWER(REPLACE(people.first_name, ' ', '')) LIKE :name
                 OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name
-                OR LOWER(REPLACE(CONCAT(author_people.first_name, author_people.last_name), ' ', '')) LIKE :name
-                OR LOWER(REPLACE(CONCAT(author_people.last_name, author_people.first_name), ' ', '')) LIKE :name
-                OR LOWER(REPLACE(author_people.first_name, ' ', '')) LIKE :name
-                OR LOWER(REPLACE(author_people.last_name, ' ', '')) LIKE :name",
+                OR LOWER(REPLACE(CONCAT(author_person.first_name, author_person.last_name), ' ', '')) LIKE :name
+                OR LOWER(REPLACE(CONCAT(author_person.last_name, author_person.first_name), ' ', '')) LIKE :name
+                OR LOWER(REPLACE(author_person.first_name, ' ', '')) LIKE :name
+                OR LOWER(REPLACE(author_person.last_name, ' ', '')) LIKE :name",
                name: "%#{sanitized}%"
              )
   end

--- a/app/services/workshop_search_service.rb
+++ b/app/services/workshop_search_service.rb
@@ -156,7 +156,10 @@ class WorkshopSearchService
     return workshops if author_name.blank?
 
     sanitized = author_name.strip.gsub(/\s+/, "")
+    # `created_by: :person` joins `people` (the creator's person); the explicit
+    # author is a second join to the same table, so alias it `author_people`.
     workshops.left_outer_joins(created_by: :person)
+             .joins("LEFT OUTER JOIN people author_people ON author_people.id = workshops.author_id")
              .where(
                "LOWER(REPLACE(workshops.full_name, ' ', '')) LIKE :name
                 OR LOWER(REPLACE(CONCAT(users.first_name, users.last_name), ' ', '')) LIKE :name
@@ -166,7 +169,11 @@ class WorkshopSearchService
                 OR LOWER(REPLACE(CONCAT(people.first_name, people.last_name), ' ', '')) LIKE :name
                 OR LOWER(REPLACE(CONCAT(people.last_name, people.first_name), ' ', '')) LIKE :name
                 OR LOWER(REPLACE(people.first_name, ' ', '')) LIKE :name
-                OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name",
+                OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name
+                OR LOWER(REPLACE(CONCAT(author_people.first_name, author_people.last_name), ' ', '')) LIKE :name
+                OR LOWER(REPLACE(CONCAT(author_people.last_name, author_people.first_name), ' ', '')) LIKE :name
+                OR LOWER(REPLACE(author_people.first_name, ' ', '')) LIKE :name
+                OR LOWER(REPLACE(author_people.last_name, ' ', '')) LIKE :name",
                name: "%#{sanitized}%"
              )
   end

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -255,18 +255,19 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4">
     <div class="flex-1 mb-4 md:mb-0">
+      <% story_author_id = f.object.author_person&.id || current_user.person_id %>
       <%= f.input :author_id,
                   collection: @people.map { |p| [ p.full_name_with_email, p.id ] },
                   prompt: "Select an author",
-                  required: true,
+                  selected: story_author_id,
+                  hint: "Defaults to the creator; change to credit someone else.",
                   label: (f.object.author ? (
                     link_to "Story author",
                             person_path(f.object.author),
                             class: "hover:underline") : "Story author").html_safe,
                   label_html: { class: "block font-medium mb-1 text-gray-700" },
                   input_html: {
-                    required: true,
-                    class: select_caret_class(blank: f.object.author_id.blank?),
+                    class: select_caret_class(blank: story_author_id.blank?),
                     style: custom_caret_style,
                     onchange: select_caret_onchange
                   } %>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -58,14 +58,16 @@
           <div data-controller="searchable-select" data-searchable-select-mode-value="person">
             <%= f.input :author_id,
                         as: :select,
-                        label: "Author",
+                        label: (f.object.author ? (
+                          link_to "Author",
+                                  person_path(f.object.author),
+                                  class: "hover:underline") : "Author").html_safe,
                         collection: @people,
                         label_method: :full_name_with_email,
                         value_method: :id,
-                        required: true,
-                        hint: "Credited author — any person, not just active users",
+                        selected: (f.object.author_person&.id || current_user.person_id),
+                        hint: "Credited author — any person, not just active users. Defaults to the creator; change to credit someone else.",
                         input_html: {
-                          required: true,
                           class: "block w-full rounded-md border-gray-300 shadow-sm
                           focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
                           data: { searchable_select_target: "select" } } %>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -56,14 +56,16 @@
           <% end %>
 
           <div data-controller="searchable-select" data-searchable-select-mode-value="person">
-            <%= f.input :created_by_id,
+            <%= f.input :author_id,
                         as: :select,
                         label: "Author",
-                        collection: User.includes(:person).references(:person).order(Arel.sql("LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email), LOWER(people.email_2), LOWER(people.email)")),
+                        collection: @people,
                         label_method: :full_name_with_email,
                         value_method: :id,
-                        hint: "aka Created By",
+                        required: true,
+                        hint: "Credited author — any person, not just active users",
                         input_html: {
+                          required: true,
                           class: "block w-full rounded-md border-gray-300 shadow-sm
                           focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
                           data: { searchable_select_target: "select" } } %>
@@ -118,8 +120,6 @@
 
           <%# end %>
         </div>
-      <% else %>
-        <%= f.hidden_field :created_by_id, value: current_user&.id %>
       <% end %>
     </div>
 

--- a/app/views/workshops/_index_row.html.erb
+++ b/app/views/workshops/_index_row.html.erb
@@ -53,9 +53,10 @@
         <!-- Author + date -->
         <div class="text-sm text-gray-600 leading-tight">
           By:
-          <% if workshop.created_by&.person %>
+          <% credited_person = workshop.author_person %>
+          <% if credited_person %>
             <%= link_to workshop.author_name,
-                        person_path(workshop.created_by.person),
+                        person_path(credited_person),
                         class: "hover:underline",
                         data: { turbo: false } %>
           <% else %>

--- a/db/migrate/20260705003948_add_author_to_workshops.rb
+++ b/db/migrate/20260705003948_add_author_to_workshops.rb
@@ -1,0 +1,10 @@
+class AddAuthorToWorkshops < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:workshops, :author_id)
+    add_reference :workshops, :author, foreign_key: { to_table: :people }, index: true, null: true
+  end
+
+  def down
+    remove_reference :workshops, :author, foreign_key: { to_table: :people }, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1566,6 +1566,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_005115) do
     t.text "age_range", size: :long
     t.text "age_range_spanish", size: :long
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.string "author_location"
     t.text "closing", size: :long
     t.text "closing_spanish", size: :long
@@ -1646,6 +1647,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_005115) do
     t.integer "windows_type_id"
     t.bigint "workshop_idea_id"
     t.integer "year"
+    t.index ["author_id"], name: "index_workshops_on_author_id"
     t.index ["created_at"], name: "index_workshops_on_created_at"
     t.index ["created_by_id"], name: "index_workshops_on_created_by_id"
     t.index ["inactive", "led_count", "title"], name: "index_workshops_on_inactive_and_led_count_and_title"
@@ -1797,6 +1799,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_005115) do
   add_foreign_key "workshop_variations", "windows_types"
   add_foreign_key "workshop_variations", "workshop_variation_ideas"
   add_foreign_key "workshop_variations", "workshops"
+  add_foreign_key "workshops", "people", column: "author_id"
   add_foreign_key "workshops", "users", column: "created_by_id"
   add_foreign_key "workshops", "windows_types"
   add_foreign_key "workshops", "workshop_ideas"

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -159,5 +159,23 @@ RSpec.describe Story, type: :model do
       expect(results).to include(org_story)
       expect(results).not_to include(published_story, draft_story, old_story)
     end
+
+    context 'when the query matches a credited person name' do
+      let(:creator) { create(:user, person: create(:person, first_name: 'Zephyrina', last_name: 'Quackenbush')) }
+      let(:facilitator) { create(:person, first_name: 'Bartholomew', last_name: 'Snazzlepants') }
+      let!(:authored_story) { create(:story, :published, title: 'No Name Match', created_by: creator, author: facilitator) }
+
+      it 'finds stories by the explicit author name' do
+        results = Story.search_by_params(query: 'Bartholomew')
+        expect(results).to include(authored_story)
+        expect(results).not_to include(published_story)
+      end
+
+      it "finds stories by the creating user's person name" do
+        created_story = create(:story, :published, title: 'Creator Only', created_by: creator)
+        results = Story.search_by_params(query: 'Zephyrina')
+        expect(results).to include(created_story)
+      end
+    end
   end
 end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Workshop do
     subject { create(:workshop) } # Assumes functional factory
 
     it { should belong_to(:created_by).optional }
+    it { should belong_to(:author).class_name("Person").optional }
     it { should belong_to(:windows_type).optional }
 
     it { should have_many(:sectorable_items).dependent(:destroy).inverse_of(:sectorable) }
@@ -88,6 +89,27 @@ RSpec.describe Workshop do
   end
 
   it_behaves_like "author_creditable", factory: :workshop
+
+  describe "#author_person" do
+    let(:creator) { create(:user, :with_person) }
+    let(:facilitator) { create(:person) }
+
+    it "returns the explicitly chosen author when present" do
+      workshop = create(:workshop, created_by: creator, author: facilitator)
+      expect(workshop.author_person).to eq(facilitator)
+    end
+
+    it "falls back to the creating user's person when no author is set" do
+      workshop = create(:workshop, created_by: creator, author: nil)
+      expect(workshop.author_person).to eq(creator.person)
+    end
+
+    it "credits the author over the creator via author_credit" do
+      workshop = create(:workshop, created_by: creator, author: facilitator,
+                                   author_credit_preference: "full_name")
+      expect(workshop.author_credit).to eq(facilitator.full_name)
+    end
+  end
 
   describe "#remote_search_label" do
     it "returns title with windows type short_name" do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -167,6 +167,21 @@ RSpec.describe PersonPolicy, type: :policy do
         expect(policy).not_to be_allowed_to(:destroy?)
       end
     end
+
+    context "when person has authored workshops" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:workshop, author: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
   end
 
   describe "relation_scope" do

--- a/spec/requests/people_stories_section_spec.rb
+++ b/spec/requests/people_stories_section_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe "Person profile stories section", type: :request do
     expect(response.body).to include("Spotlight Story")
   end
 
-  it "excludes stories the person's user merely created (audit trail only)" do
-    create(:story, :published, title: "Only Created Story", created_by: owner_user)
+  it "excludes stories the person only created but credited to someone else" do
+    create(:story, :published, title: "Only Created Story",
+                               created_by: owner_user, author: create(:person))
 
     get_stories_section
 

--- a/spec/requests/people_workshops_section_spec.rb
+++ b/spec/requests/people_workshops_section_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Person profile workshops section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_workshops_section
+    get person_path(person, section: "workshops"),
+        headers: { "Turbo-Frame" => "person_workshops_section" }
+  end
+
+  it "shows workshops the person authored" do
+    create(:workshop, :published, title: "Authored Workshop", author: person)
+
+    get_workshops_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Authored Workshop")
+  end
+
+  it "excludes workshops the person's user merely created (audit trail only)" do
+    create(:workshop, :published, title: "Only Created Workshop", created_by: owner_user)
+
+    get_workshops_section
+
+    expect(response.body).not_to include("Only Created Workshop")
+  end
+end

--- a/spec/requests/workshops_spec.rb
+++ b/spec/requests/workshops_spec.rb
@@ -117,6 +117,33 @@ RSpec.describe "/workshops", type: :request do
   end
 
   # --- RECORD NOT UNIQUE HANDLING -----------------------------------------------
+  describe "author crediting" do
+    let(:admin) { create(:user, :admin) }
+    let!(:windows_type) { create(:windows_type) }
+
+    before { sign_in admin }
+
+    it "records the current user as created_by regardless of the submitted value" do
+      someone_else = create(:user)
+      post workshops_url, params: {
+        workshop: { title: "Audit Workshop", windows_type_id: windows_type.id,
+                    category_ids: [ "" ], created_by_id: someone_else.id }
+      }
+
+      expect(Workshop.last.created_by).to eq(admin)
+    end
+
+    it "assigns the chosen person as author" do
+      facilitator = create(:person)
+      post workshops_url, params: {
+        workshop: { title: "Authored Workshop", windows_type_id: windows_type.id,
+                    category_ids: [ "" ], author_id: facilitator.id }
+      }
+
+      expect(Workshop.last.author).to eq(facilitator)
+    end
+  end
+
   describe "RecordNotUnique handling" do
     let(:admin) { create(:user, :admin) }
 

--- a/spec/services/workshop_search_service_spec.rb
+++ b/spec/services/workshop_search_service_spec.rb
@@ -432,6 +432,19 @@ RSpec.describe WorkshopSearchService, type: :service do
         service = WorkshopSearchService.new({ author_name: "" }, user: user).call
         expect(service.workshops).to include(workshop_by_user, workshop_no_match)
       end
+
+      context "with an explicit person author who is not the creator" do
+        let!(:facilitator) { create(:person, first_name: "Bartholomew", last_name: "Snazzlepants") }
+        let!(:workshop_by_author) do
+          create(:workshop, :published, title: "Authored Workshop", created_by: author_user, author: facilitator)
+        end
+
+        it "finds workshops by the credited author's name" do
+          service = WorkshopSearchService.new({ author_name: "Bartholomew" }, user: user).call
+          expect(service.workshops).to include(workshop_by_author)
+          expect(service.workshops).not_to include(workshop_no_match)
+        end
+      end
     end
   end
 end

--- a/spec/views/workshops/edit.html.erb_spec.rb
+++ b/spec/views/workshops/edit.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "workshops/edit", type: :view do
     assign(:workshop, workshop)
     assign(:potential_series_workshops, [])
     assign(:windows_types, [])
+    assign(:people, [])
     assign(:workshop_ideas, [])
     assign(:sectors, [])
     assign(:categories_grouped, [])
@@ -25,6 +26,11 @@ RSpec.describe "workshops/edit", type: :view do
 
     it "displays the edit form" do
       expect(rendered).to match(/Edit workshop/)
+    end
+
+    it "credits the author via a person picker, not a user picker" do
+      expect(rendered).to have_css("select[name='workshop[author_id]']")
+      expect(rendered).not_to have_css("select[name='workshop[created_by_id]']")
     end
 
     it "displays the View button" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new author FK + create-semantics + author-credit fallback + author-name search across index/profile

Applies the story author change from #1934 to workshops, plus author-name search for both.

### What is the goal of this PR and why is this important?
- The workshop "Author" dropdown listed **Users**, so facilitators without a confirmed login couldn't be credited. Author is now a **Person** chosen from all people — mirroring the story change.

### How did you approach the change?
- New nullable `workshops.author_id` → Person FK. The admin "Author" field now lists **all people** and **pre-selects the creator's person** (still overridable), so a blank submission credits the creator without forcing a choice.
- `created_by` stays a `User` but is now pure audit — set to `current_user` on create, no longer the author picker.
- `AuthorCreditable#author_person` (default `created_by.person`) is overridden by the `author` association when present, so **existing workshops keep their attribution with no backfill**. `author_credit`, the decorator byline, and the index "By:" line all follow it.
- Person profile **"Workshops authored"** section now lists workshops the person authored (via `author_id`); person deletion is blocked when they've authored workshops.
- Converting a workshop idea pre-fills the author from the idea's submitter.

### Author-name search (both workshops and stories)
- `WorkshopSearchService#search_by_author_name` now also matches the explicit **author** Person (aliased `author_people` join), alongside `full_name` and the creator's person.
- Stories gain a `by_credited_person_name` scope OR-ed into the free-text query via id subqueries (SearchCop can't join the `people` table twice), so story search matches the credited author or creator by name.

### Anything else to add?
- Author is **optional** on the form (defaults to the creator); the model column stays nullable.