### PR TITLE
Credit workshop variations to any person, not just active users

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -47,7 +47,9 @@ class PeopleController < ApplicationController
         @workshops = @person.user&.workshops&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
         render partial: "people/sections/workshops", locals: { person: @person, workshops: @workshops }
       when "workshop_variations"
-        @workshop_variations = @person.user&.workshop_variations_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
+        # Credit the person for variations they authored — not ones their user
+        # merely entered (created_by is a pure audit trail).
+        @workshop_variations = @person.workshop_variations_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variations", locals: { person: @person, workshop_variations: @workshop_variations }
       when "stories"
         # Credit the person for stories they authored or were spotlighted in —

--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -3,7 +3,8 @@ class WorkshopVariationsController < ApplicationController
   def index
     authorize!
 
-    base_scope = WorkshopVariation.includes(:workshop).joins(:workshop).where(workshops: { published: true })
+    base_scope = WorkshopVariation.includes(:workshop, :author, created_by: :person)
+                                  .joins(:workshop).where(workshops: { published: true })
     filtered = base_scope.search_by_params(params)
                          .order("workshop_variations.created_at DESC, workshops.title, workshop_variations.name")
     @workshop_variations = filtered.paginate(page: params[:page], per_page: 25).decorate
@@ -102,6 +103,7 @@ class WorkshopVariationsController < ApplicationController
   # end
 
   def set_form_variables
+    @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
     @workshop = @workshop_variation.workshop || (Workshop.find_by(id: params[:workshop_id]) if params[:workshop_id].present?)
     @workshop_variation_idea = WorkshopVariationIdea.find_by(id: params[:workshop_variation_idea_id]) if params[:workshop_variation_idea_id].present?
     @workshop_variation.build_primary_asset if @workshop_variation.primary_asset.blank?
@@ -110,7 +112,7 @@ class WorkshopVariationsController < ApplicationController
 
   def workshop_variation_params
     params.require(:workshop_variation).permit(
-      [ :name, :rhino_body, :published, :publicly_visible, :position, :youtube_url, :created_by_id,
+      [ :name, :rhino_body, :published, :publicly_visible, :position, :youtube_url, :author_id,
         :organization_id, :workshop_id, :workshop_variation_idea_id, :author_credit_preference,
         :windows_type_id,
         primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -24,6 +24,8 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   has_many :stories_as_author, inverse_of: :author, class_name: "Story", foreign_key: :author_id,
            dependent: :restrict_with_error
+  has_many :workshop_variations_as_author, inverse_of: :author, class_name: "WorkshopVariation",
+           foreign_key: :author_id, dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :event_staffs, dependent: :destroy

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -23,6 +23,7 @@ class WorkshopVariation < ApplicationRecord
   belongs_to :organization, optional: true
   belongs_to :windows_type, optional: true
   belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :workshop_variation_idea, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :notifications, as: :noticeable, dependent: :destroy

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -56,6 +56,7 @@ class PersonPolicy < ApplicationPolicy
     record.user.present? ||
       record.affiliations.exists? ||
       record.stories_as_spotlighted_facilitator.exists? ||
-      record.stories_as_author.exists?
+      record.stories_as_author.exists? ||
+      record.workshop_variations_as_author.exists?
   end
 end

--- a/app/services/workshop_variation_from_idea_service.rb
+++ b/app/services/workshop_variation_from_idea_service.rb
@@ -21,6 +21,7 @@ class WorkshopVariationFromIdeaService
       "name", "youtube_url", "position", "workshop_id", "windows_type_id", "organization_id", "author_credit_preference"
     ).merge(
       created_by_id: user.id,
+      author_id: workshop_variation_idea.created_by&.person_id,
       workshop_variation_idea_id: workshop_variation_idea.id,
       inactive: true,
       rhino_body: workshop_variation_idea.rhino_body

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -106,7 +106,7 @@
                                     person_path(f.object.author),
                                     class: "hover:underline") : "Variation author").html_safe,
                           collection: @people.map { |p| [ p.full_name_with_email, p.id ] },
-                          selected: (f.object.author_id || current_user.person_id),
+                          selected: (f.object.author_person&.id || current_user.person_id),
                           input_html: { class: "w-full rounded-lg px-3 py-2",
                                         data: { searchable_select_target: "select" } } %>
               </div>

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -99,19 +99,18 @@
                 <%= f.input :position, as: :integer, label: "Ordering", input_html: { class: "w-24" } %>
               <% end %>
               <div data-controller="searchable-select" data-searchable-select-mode-value="person">
-                <%= f.input :created_by_id,
+                <%= f.input :author_id,
                           as: :select,
-                          label: "Variation author",
-                          collection: User.includes(:person).references(:person).order(Arel.sql("LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email), LOWER(people.email_2), LOWER(people.email)")),
-                          label_method: :full_name_with_email,
-                          value_method: :id,
-                          selected: (f.object.created_by_id || current_user.id),
+                          label: (f.object.author ? (
+                            link_to "Variation author",
+                                    person_path(f.object.author),
+                                    class: "hover:underline") : "Variation author").html_safe,
+                          collection: @people.map { |p| [ p.full_name_with_email, p.id ] },
+                          selected: (f.object.author_id || current_user.person_id),
                           input_html: { class: "w-full rounded-lg px-3 py-2",
                                         data: { searchable_select_target: "select" } } %>
               </div>
             </div>
-          <% else %>
-            <%= f.hidden_field :created_by_id, value: current_user.id %>
           <% end %>
         </div>
 

--- a/app/views/workshop_variations/index.html.erb
+++ b/app/views/workshop_variations/index.html.erb
@@ -71,13 +71,13 @@
                 <% end %>
               </td>
               <td class="px-4 py-2 text-sm text-gray-800 text-center">
-                <% display_name = workshop_variation.workshop_variation_idea&.author_credit || workshop_variation.created_by&.name %>
-                <% if workshop_variation.created_by&.person %>
-                  <%= link_to display_name,
-                              person_path(workshop_variation.created_by.person),
+                <% credited_person = workshop_variation.author_person %>
+                <% if credited_person %>
+                  <%= link_to workshop_variation.author_credit,
+                              person_path(credited_person),
                               class: "text-gray-500 hover:text-gray-700" %>
-                <% elsif display_name %>
-                  <%= display_name %>
+                <% else %>
+                  <%= workshop_variation.author_credit %>
                 <% end %>
               </td>
               <td class="px-4 py-2 text-sm text-center whitespace-nowrap">

--- a/db/migrate/20260705005115_add_author_to_workshop_variations.rb
+++ b/db/migrate/20260705005115_add_author_to_workshop_variations.rb
@@ -1,0 +1,10 @@
+class AddAuthorToWorkshopVariations < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:workshop_variations, :author_id)
+    add_reference :workshop_variations, :author, foreign_key: { to_table: :people }, index: true, null: true
+  end
+
+  def down
+    remove_reference :workshop_variations, :author, foreign_key: { to_table: :people }, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_193542) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_005115) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1536,6 +1536,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_193542) do
 
   create_table "workshop_variations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "body", size: :long
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
@@ -1552,6 +1553,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_193542) do
     t.integer "workshop_id"
     t.bigint "workshop_variation_idea_id"
     t.string "youtube_url"
+    t.index ["author_id"], name: "index_workshop_variations_on_author_id"
     t.index ["created_by_id"], name: "index_workshop_variations_on_created_by_id"
     t.index ["organization_id"], name: "index_workshop_variations_on_organization_id"
     t.index ["published"], name: "index_workshop_variations_on_published"
@@ -1790,6 +1792,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_193542) do
   add_foreign_key "workshop_variation_ideas", "windows_types"
   add_foreign_key "workshop_variation_ideas", "workshops"
   add_foreign_key "workshop_variations", "organizations"
+  add_foreign_key "workshop_variations", "people", column: "author_id"
   add_foreign_key "workshop_variations", "users", column: "created_by_id"
   add_foreign_key "workshop_variations", "windows_types"
   add_foreign_key "workshop_variations", "workshop_variation_ideas"

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -7,7 +7,29 @@ RSpec.describe WorkshopVariation do
     it { should belong_to(:workshop).optional }
     it { should belong_to(:windows_type).optional }
     it { should belong_to(:created_by).class_name("User").optional }
+    it { should belong_to(:author).class_name("Person").optional }
     it { should belong_to(:workshop_variation_idea).optional }
+  end
+
+  describe "#author_person" do
+    let(:creator) { create(:user, :with_person) }
+    let(:facilitator) { create(:person) }
+
+    it "returns the explicitly chosen author when present" do
+      variation = create(:workshop_variation, created_by: creator, author: facilitator)
+      expect(variation.author_person).to eq(facilitator)
+    end
+
+    it "falls back to the creating user's person when no author is set" do
+      variation = create(:workshop_variation, created_by: creator, author: nil)
+      expect(variation.author_person).to eq(creator.person)
+    end
+
+    it "credits the author over the creator via author_credit" do
+      variation = create(:workshop_variation, created_by: creator, author: facilitator,
+                                              author_credit_preference: "full_name")
+      expect(variation.author_credit).to eq(facilitator.full_name)
+    end
   end
 
   describe "validations" do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -152,6 +152,21 @@ RSpec.describe PersonPolicy, type: :policy do
         expect(policy).not_to be_allowed_to(:destroy?)
       end
     end
+
+    context "when person has authored workshop variations" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:workshop_variation, author: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
   end
 
   describe "relation_scope" do

--- a/spec/requests/people_workshop_variations_section_spec.rb
+++ b/spec/requests/people_workshop_variations_section_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Person profile workshop variations section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_workshop_variations_section
+    get person_path(person, section: "workshop_variations"),
+        headers: { "Turbo-Frame" => "person_workshop_variations_section" }
+  end
+
+  it "shows variations the person authored" do
+    create(:workshop_variation, name: "Authored Variation", author: person)
+
+    get_workshop_variations_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Authored Variation")
+  end
+
+  it "excludes variations the person's user merely created (audit trail only)" do
+    create(:workshop_variation, name: "Only Created Variation", created_by: owner_user)
+
+    get_workshop_variations_section
+
+    expect(response.body).not_to include("Only Created Variation")
+  end
+end

--- a/spec/requests/workshop_variations_spec.rb
+++ b/spec/requests/workshop_variations_spec.rb
@@ -183,6 +183,17 @@ RSpec.describe "/workshop_variations", type: :request do
 
           expect(response).to redirect_to(workshop_variation_path(WorkshopVariation.last))
         end
+
+        it "credits the chosen person as author and records the creator" do
+          facilitator = create(:person)
+
+          post workshop_variations_path,
+               params: { workshop_variation: valid_attributes.merge(author_id: facilitator.id) }
+
+          variation = WorkshopVariation.last
+          expect(variation.author).to eq(facilitator)
+          expect(variation.created_by).to eq(admin)
+        end
       end
 
       context "with invalid params" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mirrors the merged Story author change (#1934) — new author FK + credit fallback across form, index, profile

## Why
The variation author dropdown was gated to Users, so facilitators without a login couldn't be credited — same gap fixed for stories in #1934. Author is now a **Person** chosen from all people.

## What
- New nullable `workshop_variations.author_id` → Person FK. The admin "Variation author" picker now lists **all people**.
- `created_by` stays a `User`, now pure audit — set to `current_user` on create (via the `workshop_variations_as_creator` build), no longer the author picker.
- `AuthorCreditable#author_person` already prefers an explicit `author` over `created_by.person`, so **existing variations keep their attribution with no backfill**.
- Index "Author" column and the show page reflect the credited author.
- Person profile "Workshop variations authored" section now lists variations the person **authored**, not ones their user merely entered.
- Promoting a variation idea pre-fills the author from the idea's submitter.
- `PersonPolicy` blocks deleting a person who authored a variation.