### PR TITLE
Credit resources to any person, not just active users

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -60,6 +60,11 @@ class PeopleController < ApplicationController
           @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }
+      when "resources"
+        # Credit the person for resources they authored — not ones their user
+        # merely entered (created_by is a pure audit trail).
+        @resources = @person.resources_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        render partial: "people/sections/resources", locals: { person: @person, resources: @resources }
       when "events"
         @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/events", locals: { person: @person, event_registrations: @event_registrations }
@@ -480,6 +485,7 @@ class PeopleController < ApplicationController
       :profile_show_workshops,
       :profile_show_workshop_ideas,
       :profile_show_workshop_logs,
+      :profile_show_resources,
       :member_since,
       :linked_in_url,
       :facebook_url,

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -53,6 +53,7 @@ class ResourcesController < ApplicationController
   def show
     @resource = Resource.includes(
       :created_by,
+      :author,
       :bookmarks,
       primary_asset:  :file_attachment,
       downloadable_asset:  :file_attachment,
@@ -151,10 +152,7 @@ class ResourcesController < ApplicationController
     @resource.build_downloadable_asset if @resource.downloadable_asset.blank?
     @resource.gallery_assets.build
     @windows_types = WindowsType.all
-    @authors = authorized_scope(User.has_access.or(User.where(id: @resource.created_by_id)))
-                   .includes(:person)
-                   .order("people.first_name, people.last_name")
-                   .map { |u| [ u.full_name, u.id ] }
+    @people = Person.order(Arel.sql("LOWER(first_name), LOWER(last_name)"))
     @categories_grouped =
       Category
         .includes(:category_type)
@@ -174,7 +172,7 @@ class ResourcesController < ApplicationController
     params.require(:resource).permit(
       :rhino_body, :kind, :male, :female, :title, :featured, :published, :publicly_visible, :publicly_featured,
       :hidden_from_search,
-      :agency, :author, :filemaker_code, :windows_type_id, :position,
+      :agency, :author_id, :author_credit_preference, :filemaker_code, :windows_type_id, :position,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       downloadable_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -13,7 +13,23 @@ class ResourceDecorator < ApplicationDecorator
   end
 
   def truncated_author
-    h.truncate author, length: 20
+    h.truncate credited_author_name, length: 20
+  end
+
+  # Name shown on the author/credit line: the chosen person's credit when a
+  # person author is set, otherwise the preserved legacy free-text author,
+  # otherwise the creating user's person credit (AuthorCreditable fallback).
+  def credited_author_name
+    return author_credit if author.present?
+    legacy_author_name.presence || author_credit
+  end
+
+  # The person to link the credit to, when there is a linkable one. A legacy
+  # free-text author is just a string, so it links nowhere.
+  def credited_author_link_person
+    return author if author.present?
+    return nil if legacy_author_name.present?
+    created_by&.person
   end
 
   def truncated_title
@@ -37,7 +53,7 @@ class ResourceDecorator < ApplicationDecorator
   end
 
   def author_full_name
-    author || created_by.name
+    credited_author_name
   end
 
   def display_date

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -30,6 +30,8 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   has_many :community_news_as_author, inverse_of: :author, class_name: "CommunityNews", foreign_key: :author_id,
            dependent: :restrict_with_error
+  has_many :resources_as_author, inverse_of: :author, class_name: "Resource", foreign_key: :author_id,
+           dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :event_staffs, dependent: :destroy

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,5 @@
 class Resource < ApplicationRecord
-  include Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
+  include AuthorCreditable, Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
   include Rails.application.routes.url_helpers
   include ActionText::Attachable
   include Mentionable
@@ -20,6 +20,7 @@ class Resource < ApplicationRecord
   has_rich_text :rhino_body
 
   belongs_to :created_by, class_name: "User"
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :workshop, optional: true
   belongs_to :windows_type, optional: true
   has_one :form, as: :owner
@@ -74,7 +75,7 @@ class Resource < ApplicationRecord
 
   include SearchCop
   search_scope :search do
-    attributes all: [ :title, :author ]
+    attributes all: [ :title, :legacy_author_name ]
     options :all, type: :text, default: true, default_operator: :or
 
     scope { join_rich_texts }

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -59,6 +59,7 @@ class PersonPolicy < ApplicationPolicy
       record.stories_as_author.exists? ||
       record.workshop_variations_as_author.exists? ||
       record.workshops_as_author.exists? ||
-      record.community_news_as_author.exists?
+      record.community_news_as_author.exists? ||
+      record.resources_as_author.exists?
   end
 end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -498,6 +498,7 @@
           <%= f.input :profile_show_workshops, label: "Show workshops" %>
           <%= f.input :profile_show_workshop_variations, label: "Show workshop variations" %>
           <%= f.input :profile_show_stories, label: "Show stories" %>
+          <%= f.input :profile_show_resources, label: "Show resources" %>
           <%= f.input :profile_show_events_registered, label: "Show registrations" %>
         </div>
 

--- a/app/views/people/sections/_resources.html.erb
+++ b/app/views/people/sections/_resources.html.erb
@@ -1,0 +1,14 @@
+<%= turbo_frame_tag "person_resources_section" do %>
+  <% if resources.any? %>
+    <div class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 gap-6 blur-on-submit">
+      <% resources.each do |resource| %>
+        <%= render "show_card", record: resource.decorate, title_font_size: "text-sm" %>
+      <% end %>
+    </div>
+    <div class="mt-6 flex justify-center">
+      <%= tailwind_paginate resources, params: { section: "resources" } %>
+    </div>
+  <% else %>
+    <p class="text-gray-500 italic">No resources yet.</p>
+  <% end %>
+<% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -200,7 +200,8 @@
       <!-- AUTHORED SECTION -->
       <% if @person.profile_show_workshops? ||
               @person.profile_show_workshop_variations? ||
-              @person.profile_show_stories?  %>
+              @person.profile_show_stories? ||
+              @person.profile_show_resources?  %>
       <div class="person-only <%= DomainTheme.bg_class_for(:workshops) %> border <%= DomainTheme.border_class_for(:workshops) %> rounded-lg shadow-sm">
         <!-- Header -->
         <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3 border-b <%= DomainTheme.border_class_for(:workshops) %>">
@@ -234,6 +235,15 @@
               <h2 class="text-lg font-semibold text-gray-800 mb-3">Stories authored/featured</h2>
               <%= turbo_frame_tag "person_stories_section", src: person_path(@person, section: "stories"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading stories...</p>
+              <% end %>
+            </div>
+          <% end %>
+          <!-- Resources authored -->
+          <% if @person.profile_show_resources? %>
+            <div class="p-3">
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Resources authored</h2>
+              <%= turbo_frame_tag "person_resources_section", src: person_path(@person, section: "resources"), loading: :lazy do %>
+                <p class="text-gray-500 italic">Loading resources...</p>
               <% end %>
             </div>
           <% end %>

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -56,6 +56,39 @@
 
   </div>
 
+  <!-- Author -->
+  <div class="flex flex-col md:flex-row md:space-x-4 mb-6">
+    <div class="flex-1 mb-4 md:mb-0" data-controller="searchable-select" data-searchable-select-mode-value="person">
+      <%= f.input :author_id,
+                  as: :select,
+                  collection: @people.map { |p| [ p.full_name_with_email, p.id ] },
+                  include_blank: "Select an author",
+                  selected: (f.object.author_person&.id || current_user.person_id),
+                  label: (f.object.author ? (
+                    link_to "Resource author",
+                            person_path(f.object.author),
+                            class: "hover:underline") : "Resource author").html_safe,
+                  label_html: { class: "block font-medium mb-1 text-gray-700" },
+                  input_html: { class: "w-full rounded border-gray-300",
+                                data: { searchable_select_target: "select" } } %>
+      <% if f.object.legacy_author_name.present? %>
+        <p class="mt-1 text-xs text-gray-500 italic">Legacy author credit: <%= f.object.legacy_author_name %></p>
+      <% end %>
+    </div>
+
+    <div class="flex-1 mb-4 md:mb-0">
+      <%= f.input :author_credit_preference,
+                  as: :select,
+                  collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
+                  include_blank: "Select a preference",
+                  selected: f.object.author_credit_preference || "full_name",
+                  label: "Author credit preference",
+                  hint: "Controls how the author’s name is displayed",
+                  label_html: { class: "block font-medium mb-1 text-gray-700" },
+                  input_html: { class: "w-full rounded border-gray-300" } %>
+    </div>
+  </div>
+
   <!-- Second Row -->
   <div class="form-group <%= 'has-error' if f.object.errors[:rhino_body].present? %>">
     <%= rhino_editor(f, :body, label: "Description") %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -28,9 +28,17 @@
         <div class="flex flex-col gap-1">
           <% unless @resource.toolkit_and_form? %>
             <div class="flex items-center text-gray-600 text-sm gap-2">
-              <span><%= @resource.author %></span>
+              <% credited_name = @resource.credited_author_name %>
+              <% link_person = @resource.credited_author_link_person %>
+              <span>
+                <% if link_person&.profile_is_searchable %>
+                  <%= link_to credited_name, person_path(link_person), class: "hover:underline" %>
+                <% else %>
+                  <%= credited_name %>
+                <% end %>
+              </span>
               <% unless @resource.story? %>
-                <span class="<%= "border-l border-gray-400 pl-2" if @resource.author.present? %>">
+                <span class="<%= "border-l border-gray-400 pl-2" if credited_name.present? %>">
                   <%= @resource.display_date %>
                 </span>
               <% end %>

--- a/db/migrate/20260705013635_add_author_to_resources.rb
+++ b/db/migrate/20260705013635_add_author_to_resources.rb
@@ -1,0 +1,15 @@
+class AddAuthorToResources < ActiveRecord::Migration[8.1]
+  def up
+    # Preserve the old free-text author string as a legacy field; the new
+    # author is a Person reference, mirroring stories and workshop variations.
+    rename_column :resources, :author, :legacy_author_name if column_exists?(:resources, :author)
+    add_reference :resources, :author, foreign_key: { to_table: :people }, index: true, null: true unless column_exists?(:resources, :author_id)
+    add_column :resources, :author_credit_preference, :string unless column_exists?(:resources, :author_credit_preference)
+  end
+
+  def down
+    remove_column :resources, :author_credit_preference, if_exists: true
+    remove_reference :resources, :author, foreign_key: { to_table: :people }, if_exists: true
+    rename_column :resources, :legacy_author_name, :author if column_exists?(:resources, :legacy_author_name)
+  end
+end

--- a/db/migrate/20260705014631_add_profile_show_resources_to_people.rb
+++ b/db/migrate/20260705014631_add_profile_show_resources_to_people.rb
@@ -1,0 +1,10 @@
+class AddProfileShowResourcesToPeople < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:people, :profile_show_resources)
+    add_column :people, :profile_show_resources, :boolean, default: true, null: false
+  end
+
+  def down
+    remove_column :people, :profile_show_resources, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_013635) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_014631) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -997,6 +997,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_013635) do
     t.boolean "profile_show_member_since", default: true, null: false
     t.boolean "profile_show_phone", default: true, null: false
     t.boolean "profile_show_pronouns", default: true, null: false
+    t.boolean "profile_show_resources", default: true, null: false
     t.boolean "profile_show_sectors", default: true, null: false
     t.boolean "profile_show_social_media", default: true, null: false
     t.boolean "profile_show_stories", default: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_011531) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_013635) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1149,7 +1149,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_011531) do
 
   create_table "resources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "agency"
-    t.string "author"
+    t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "body", size: :long
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
@@ -1160,6 +1161,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_011531) do
     t.boolean "inactive", default: true
     t.string "kind"
     t.boolean "legacy"
+    t.string "legacy_author_name"
     t.integer "legacy_id"
     t.boolean "male", default: false
     t.integer "position"
@@ -1171,6 +1173,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_011531) do
     t.string "url"
     t.integer "windows_type_id"
     t.integer "workshop_id"
+    t.index ["author_id"], name: "index_resources_on_author_id"
     t.index ["created_by_id"], name: "index_resources_on_created_by_id"
     t.index ["published"], name: "index_resources_on_published"
     t.index ["windows_type_id"], name: "index_resources_on_windows_type_id"
@@ -1749,6 +1752,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_011531) do
   add_foreign_key "reports", "organizations"
   add_foreign_key "reports", "users", column: "created_by_id"
   add_foreign_key "reports", "windows_types"
+  add_foreign_key "resources", "people", column: "author_id"
   add_foreign_key "resources", "users", column: "created_by_id"
   add_foreign_key "resources", "windows_types"
   add_foreign_key "resources", "workshops"

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -2,13 +2,37 @@ require 'rails_helper'
 
 RSpec.describe Resource do
   it_behaves_like "featureable", factory: :resource
+  it_behaves_like "author_creditable", factory: :resource
 
   it { should have_many(:reports) } # As owner
 
   describe 'associations' do
+    it { should belong_to(:author).class_name("Person").optional }
+
     # Nested Attributes
     it { should accept_nested_attributes_for(:primary_asset).allow_destroy(true) }
     it { should accept_nested_attributes_for(:gallery_assets).allow_destroy(true) }
+  end
+
+  describe "#author_person" do
+    let(:creator) { create(:user, :with_person) }
+    let(:facilitator) { create(:person) }
+
+    it "returns the explicitly chosen author when present" do
+      resource = create(:resource, created_by: creator, author: facilitator)
+      expect(resource.author_person).to eq(facilitator)
+    end
+
+    it "falls back to the creating user's person when no author is set" do
+      resource = create(:resource, created_by: creator, author: nil)
+      expect(resource.author_person).to eq(creator.person)
+    end
+
+    it "credits the author over the creator via author_credit" do
+      resource = create(:resource, created_by: creator, author: facilitator,
+                                   author_credit_preference: "full_name")
+      expect(resource.author_credit).to eq(facilitator.full_name)
+    end
   end
 
   describe 'validations' do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -197,6 +197,21 @@ RSpec.describe PersonPolicy, type: :policy do
         expect(policy).not_to be_allowed_to(:destroy?)
       end
     end
+
+    context "when person has authored resources" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:resource, author: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
   end
 
   describe "relation_scope" do

--- a/spec/requests/people_profile_flags_spec.rb
+++ b/spec/requests/people_profile_flags_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Person profile flag visibility", type: :request do
     profile_show_workshops: "mb-3\">Workshops authored</h2>",
     profile_show_workshop_variations: "Workshop variations authored",
     profile_show_stories: "Stories authored/featured",
+    profile_show_resources: "mb-3\">Resources authored</h2>",
     profile_show_events_registered: "Participation history"
   }.each do |flag, marker|
     describe "##{flag}" do

--- a/spec/requests/people_resources_section_spec.rb
+++ b/spec/requests/people_resources_section_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Person profile resources section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_resources_section
+    get person_path(person, section: "resources"),
+        headers: { "Turbo-Frame" => "person_resources_section" }
+  end
+
+  it "shows resources the person authored" do
+    create(:resource, :published, title: "Authored Resource", author: person)
+
+    get_resources_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Authored Resource")
+  end
+
+  it "excludes resources the person's user merely created (audit trail only)" do
+    create(:resource, :published, title: "Only Created Resource", created_by: owner_user)
+
+    get_resources_section
+
+    expect(response.body).not_to include("Only Created Resource")
+  end
+end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe "/resources", type: :request do
 
         expect(response).to redirect_to(resource_url(Resource.last))
       end
+
+      it "credits the chosen person as author and records the creator" do
+        facilitator = create(:person)
+
+        post resources_url, params: { resource: valid_attributes.merge(author_id: facilitator.id) }
+
+        resource = Resource.last
+        expect(resource.author).to eq(facilitator)
+        expect(resource.created_by).to eq(user)
+      end
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 data-model change — column rename + new author FK, credit fallback, and a new person-profile section behind a preference flag

Parity with stories (#1934) and workshop variations (#1936), applied to resources.

## Why
The resource "author" was a free-text string (its old users-only picker was dead code, removed in #985), so a resource couldn't be credited to a real, linkable person.

## What
- New nullable `resources.author_id` → **Person** FK + `author_credit_preference`; `Resource` now `include`s `AuthorCreditable`. `created_by` stays a `User` (pure audit — set to `current_user` on create).
- Renamed the old free-text `resources.author` → **`legacy_author_name`** (no backfill). It's shown as a fallback credit for old resources and surfaced read-only under the picker in the form, so no existing attribution is lost.
- Resource form now lists **all people** for the author (searchable select), defaulting to the current user's person, plus a credit-preference dropdown. Author stays optional.
- Public show page credits the person via `author_credit`, links to searchable profiles, and falls back to `legacy_author_name` then the creator.
- `Person#resources_as_author` (`restrict_with_error`) blocks deleting a person credited on a resource; `PersonPolicy#has_associated_data?` respects it.
- SearchCop now searches `legacy_author_name` in place of the removed `author` column.
- **New "Resources authored" person-profile section**, behind a new `profile_show_resources` preference (default on) — mirrors the stories/workshop-variations sections so a credited person can see and share their resources.

## Notes
- Rebased on main after #1935 (workshops) and #1937 (community news) landed the same pattern; resolved the shared `person.rb` / `person_policy.rb` / schema edits so all four author associations coexist.