### PR TITLE
Rename user-facing "Notifications" to "Communications" (i18n)

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -51,7 +51,7 @@ class NotificationsController < ApplicationController
       root_notification_id: root_id
     )
 
-    redirect_to @notification, notice: "Notification email has been resent successfully."
+    redirect_to @notification, notice: t("communications.resent")
   end
 
   private

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -31,7 +31,7 @@ module AdminCardsHelper
       model_card(:quotes, icon: "💬", intensity: 100),
       model_card(:payments, icon: "💳"),
       model_card(:scholarships, icon: "🎓"),
-      model_card(:notifications, icon: "🔔"),
+      model_card(:notifications, icon: "🔔", title: t("communications.title")),
       model_card(:story_ideas, icon: "✍🏾️", intensity: 100),
       custom_card("Tags", tags_path, icon: "🏷️", color: :lime, intensity: 100),
       model_card(:workshop_ideas, icon: "💡", intensity: 100),

--- a/app/views/event_registrations/_notifications.html.erb
+++ b/app/views/event_registrations/_notifications.html.erb
@@ -11,7 +11,7 @@
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:users, intensity: 100) %> <%= DomainTheme.text_class_for(:users, intensity: 600) %>">
       <i class="fa-solid fa-bell"></i>
     </span>
-    <h2 class="text-sm font-semibold text-gray-700">Registration communications</h2>
+    <h2 class="text-sm font-semibold text-gray-700"><%= t("communications.registration_title") %></h2>
     <% if email.present? %>
       <%= link_to notifications_path(email: email),
                   class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
@@ -42,7 +42,7 @@
         <div data-paginated-fields-target="nav"></div>
       </div>
     <% else %>
-      <p class="text-sm text-gray-400">No notifications for this registrant yet.</p>
+      <p class="text-sm text-gray-400"><%= t("communications.none_for_registrant") %></p>
     <% end %>
 
     <%# Inline add — manual log entries, saved with the registration form. %>
@@ -55,7 +55,7 @@
             render_options: { locals: { record: registration } },
             class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
         <i class="fa-solid fa-plus text-[0.6rem]"></i>
-        Add notification
+        <%= t("communications.add") %>
       <% end %>
     </div>
   </div>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -91,7 +91,7 @@
   <% if @notifications.empty? %>
     <tr>
       <td colspan="6" class="px-4 py-6 text-center text-gray-500">
-        No notifications found.
+        <%= t("communications.empty") %>
       </td>
     </tr>
   <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,7 @@
       <div class="flex justify-between items-center mb-6">
         <section class="w-full">
           <div class="flex flex-col items-start mb-4">
-            <h1 class="text-3xl font-bold text-gray-900 my-2">Notifications</h1>
+            <h1 class="text-3xl font-bold text-gray-900 my-2"><%= t("communications.log_title") %></h1>
           </div>
 
           <%= render "search_boxes" %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,7 @@
       <div class="flex justify-between items-center mb-6">
         <section class="w-full">
           <div class="flex flex-col items-start mb-4">
-            <h1 class="text-3xl font-bold text-gray-900 my-2"><%= t("communications.log_title") %></h1>
+            <h1 class="text-3xl font-bold text-gray-900 my-2"><%= t("communications.title") %></h1>
           </div>
 
           <%= render "search_boxes" %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -11,7 +11,7 @@
   <div class="flex items-start justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold text-gray-900">
-        Notification
+        <%= t("communications.detail_title") %>
       </h1>
 
       <p class="text-sm text-gray-500">
@@ -209,7 +209,7 @@
 
   <!-- Actions -->
   <div class="flex justify-between items-center">
-    <%= link_to "← Back to Notifications",
+    <%= link_to t("communications.back_link"),
                 notifications_path,
                 class: "text-sm text-blue-600 hover:underline" %>
   </div>

--- a/app/views/people/_notifications.html.erb
+++ b/app/views/people/_notifications.html.erb
@@ -11,7 +11,7 @@
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:users, intensity: 100) %> <%= DomainTheme.text_class_for(:users, intensity: 600) %>">
       <i class="fa-solid fa-bell"></i>
     </span>
-    <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
+    <h2 class="text-sm font-semibold text-gray-700"><%= t("communications.title") %></h2>
     <% if email.present? %>
       <%= link_to notifications_path(email: email),
                   class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
@@ -42,7 +42,7 @@
         <div data-paginated-fields-target="nav"></div>
       </div>
     <% else %>
-      <p class="text-sm text-gray-400">No notifications for this person yet.</p>
+      <p class="text-sm text-gray-400"><%= t("communications.none_for_person") %></p>
     <% end %>
 
     <%# Inline add — manual log entries, saved with the person form. %>
@@ -55,7 +55,7 @@
             render_options: { locals: { record: person } },
             class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
         <i class="fa-solid fa-plus text-[0.6rem]"></i>
-        Add notification
+        <%= t("communications.add") %>
       <% end %>
     </div>
   </div>

--- a/app/views/scholarships/_notifications.html.erb
+++ b/app/views/scholarships/_notifications.html.erb
@@ -10,7 +10,7 @@
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:users, intensity: 100) %> <%= DomainTheme.text_class_for(:users, intensity: 600) %>">
       <i class="fa-solid fa-bell"></i>
     </span>
-    <h2 class="text-sm font-semibold text-gray-700">Scholarship communications</h2>
+    <h2 class="text-sm font-semibold text-gray-700"><%= t("communications.scholarship_title") %></h2>
     <% if email.present? %>
       <%= link_to notifications_path(email: email),
                   class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
@@ -52,7 +52,7 @@
             render_options: { locals: { event_registration: scholarship } },
             class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
         <i class="fa-solid fa-plus text-[0.6rem]"></i>
-        Add notification
+        <%= t("communications.add") %>
       <% end %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,6 @@ en:
   # rename "Communications" everywhere it appears in the UI.
   communications:
     title: "Communications"
-    log_title: "Communication log"
     detail_title: "Communication"
     back_link: "← Back to communications"
     empty: "No communications found."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,20 @@
 
 en:
   hello: "Hello world"
+  # Public-facing name for the notifications feature. Change these values to
+  # rename "Communications" everywhere it appears in the UI.
+  communications:
+    title: "Communications"
+    log_title: "Communication log"
+    detail_title: "Communication"
+    back_link: "← Back to communications"
+    empty: "No communications found."
+    add: "Add communication"
+    resent: "Communication has been resent successfully."
+    registration_title: "Registration communications"
+    scholarship_title: "Scholarship communications"
+    none_for_person: "No communications for this person yet."
+    none_for_registrant: "No communications for this registrant yet."
   activerecord:
     attributes:
       workshop_variation:

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "Notifications", type: :request do
 
         expect(response).to redirect_to(notification_path(notification))
         follow_redirect!
-        expect(response.body).to include("Notification email has been resent successfully")
+        expect(response.body).to include("Communication has been resent successfully")
       end
 
       it "denies resending Devise-originated notifications" do

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Event registration edit page", type: :system do
       visit edit_event_registration_path(registration)
 
       within("section", text: "Registration communications") do
-        click_on "Add notification"
+        click_on "Add communication"
         fill_in "Subject", with: "Called about parking"
       end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mechanical string→i18n swap across a few views + helper; two specs updated to match

### What is the goal of this PR and why is this important?
- Renames the public-facing "Notifications" feature to **"Communications"** — the term staff actually use for outbound emails and manual contact logs.
- Routes every user-facing string through a single `communications:` namespace in `config/locales/en.yml`, so the wording is a one-line change in future.

### How did you approach the change?
- Added `communications.*` keys to `en.yml`; replaced hard-coded strings in the index/show pages, the admin dashboard card, and the person/registration/scholarship boxes with `t(...)` lookups.
- Left the `Notification` model, routes, controller actions, and params untouched — only presentation text changed.
- One label — **"Communications"** — for the nav card, the admin index heading, and the per-record boxes.
- Updated the two specs that asserted the old copy.

### Anything else to add?
- No model/schema changes; no migration.