### PR TITLE
Gate training-only ticket callouts to facilitator trainings

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -64,8 +64,9 @@ module Events
 
     # Forms page: callout-card links to the W-9 (when seeded) and, for paid
     # events, the invoice and the paid-in-full receipt (once settled), each
-    # returning to forms.
+    # returning to forms. Only reachable when the event shows the Forms callout.
     def forms
+      return redirect_to registration_ticket_path(@event_registration.slug) unless @event.show_forms_callout?
       @form_cards = build_form_cards
     end
 
@@ -73,6 +74,7 @@ module Events
     # resources, in display order, each opening its own registrant resource page
     # (PDF preview + download, with a back-to-handouts eyebrow).
     def handouts
+      return redirect_to registration_ticket_path(@event_registration.slug) unless @event.show_handouts_callout?
       by_title = Resource.where(title: HANDOUT_RESOURCE_TITLES).index_by(&:title)
       @handout_cards = HANDOUT_RESOURCE_TITLES.filter_map do |title|
         resource = by_title[title]
@@ -96,8 +98,10 @@ module Events
       @event = @event_registration.event.decorate
     end
 
-    # FAQ for the training, with a folded-in contact link.
+    # FAQ for the training, with a folded-in contact link. Only reachable when
+    # the event shows the FAQ callout.
     def faq
+      redirect_to registration_ticket_path(@event_registration.slug) unless @event.show_faq_callout?
     end
 
     private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -121,6 +121,28 @@ class Event < ApplicationRecord
     signed_in_one_click_enabled? || registration_form.nil?
   end
 
+  # Whether the built-in "training" ticket callouts (Handouts, FAQ, Forms) appear
+  # on this event's registration tickets. Their content is written for the 2-Day
+  # AWBW Facilitator Training, so they only belong on those events — a public,
+  # non-training event (often with no registration process) should not surface
+  # training worksheets or "2-day training" FAQ on its ticket. Handouts and FAQ
+  # are pure training curriculum; Forms (W-9, invoice, receipt) also belongs on
+  # any paid event, whose registrants need their invoice and receipt.
+  #
+  # These are the default rules; a later change adds a per-event override so
+  # admins can force a callout on or off from the event's callouts section.
+  def show_handouts_callout?
+    facilitator_training?
+  end
+
+  def show_faq_callout?
+    facilitator_training?
+  end
+
+  def show_forms_callout?
+    facilitator_training? || cost_cents.to_i.positive?
+  end
+
   def scholarship_form
     forms.find_by(event_forms: { role: "scholarship" })
   end

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -45,9 +45,9 @@ class MagicTicketCallouts
       EditorCard.new(:ce_hours, "fa-solid fa-graduation-cap", "teal", event.ce_hours_details_label, "Continuing education — requirements & how to request", "When a registrant requests CE credit", nil),
       EditorCard.new(:event_details, "fa-solid fa-palette", "blue", event.event_details_label, "Important info for this event — please read", "When the content below is filled in", nil),
       EditorCard.new(nil, "fa-solid fa-video", "blue", "Videoconference", "Join link and how to add it to your calendar", "When the event has a videoconference link", "Details come from this event's videoconference settings."),
-      EditorCard.new(nil, "fa-solid fa-file-lines", "blue", "Forms", "W-9, invoice, and receipt", "Always shown", "Items link to their relevant resources."),
-      EditorCard.new(nil, "fa-solid fa-folder-open", "blue", "Handouts", "Worksheets and resources for the training", "Always shown", "Items link to their relevant resources."),
-      EditorCard.new(nil, "fa-solid fa-circle-question", "blue", "Frequently asked questions", "Common questions about the 2-day training", "Always shown", nil)
+      EditorCard.new(nil, "fa-solid fa-file-lines", "blue", "Forms", "W-9, invoice, and receipt", "On facilitator trainings and paid events", "Items link to their relevant resources."),
+      EditorCard.new(nil, "fa-solid fa-folder-open", "blue", "Handouts", "Worksheets and resources for the training", "On facilitator trainings", "Items link to their relevant resources."),
+      EditorCard.new(nil, "fa-solid fa-circle-question", "blue", "Frequently asked questions", "Common questions about the 2-day training", "On facilitator trainings", nil)
     ]
   end
 
@@ -181,9 +181,11 @@ class MagicTicketCallouts
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
 
-  # Always-present. Its page links to the W-9, the invoice, and the paid-in-full
-  # receipt (once settled).
+  # Its page links to the W-9, the invoice, and the paid-in-full receipt (once
+  # settled). Shown for facilitator trainings and any paid event (whose
+  # registrants need their invoice/receipt) — see Event#show_forms_callout?.
   def forms_card
+    return unless event.show_forms_callout?
     Card.new(icon_class: "fa-solid fa-file-lines", color: "blue",
              title: "Forms",
              subtitle: "W-9, invoice, and receipt",
@@ -191,8 +193,10 @@ class MagicTicketCallouts
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
 
-  # Always-present. Its page links to the training worksheets and handouts.
+  # Links to the 2-day training worksheets and handouts, so shown only on
+  # facilitator trainings — see Event#show_handouts_callout?.
   def handouts_card
+    return unless event.show_handouts_callout?
     Card.new(icon_class: "fa-solid fa-folder-open", color: "blue",
              title: "Handouts",
              subtitle: "Worksheets and resources for the training",
@@ -200,8 +204,10 @@ class MagicTicketCallouts
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end
 
-  # Always-present reference card linking to the training FAQ page.
+  # Reference card linking to the 2-day training FAQ page, so shown only on
+  # facilitator trainings — see Event#show_faq_callout?.
   def faq_card
+    return unless event.show_faq_callout?
     Card.new(icon_class: "fa-solid fa-circle-question", color: "blue",
              title: "Frequently asked questions",
              subtitle: "Common questions about the 2-day training",

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -306,6 +306,25 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "built-in ticket callout visibility" do
+    it "shows Handouts and FAQ only for facilitator trainings" do
+      training = build(:event, facilitator_training: true)
+      other = build(:event, facilitator_training: false)
+
+      expect(training.show_handouts_callout?).to be true
+      expect(training.show_faq_callout?).to be true
+      expect(other.show_handouts_callout?).to be false
+      expect(other.show_faq_callout?).to be false
+    end
+
+    it "shows Forms for facilitator trainings and any paid event, but not free non-trainings" do
+      expect(build(:event, facilitator_training: true, cost_cents: 0).show_forms_callout?).to be true
+      expect(build(:event, facilitator_training: false, cost_cents: 1099).show_forms_callout?).to be true
+      expect(build(:event, facilitator_training: false, cost_cents: 0).show_forms_callout?).to be false
+      expect(build(:event, facilitator_training: false, cost_cents: nil).show_forms_callout?).to be false
+    end
+  end
+
   describe '.search_by_params' do
     let!(:art_event) { create(:event, title: 'Art Workshop Showcase', description: 'Annual art exhibition') }
     let!(:music_event) { create(:event, title: 'Music Therapy Session', description: 'Healing through music') }

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "Events::Callouts", type: :request do
+  let(:registration) { create(:event_registration, event: event) }
+
+  # These pages are reachable by slug (no login), so the built-in callout
+  # visibility rules are the only gate. Hidden callouts redirect back to the
+  # ticket so a stray link can't surface training content on a non-training event.
+  describe "GET /registration/:slug/faq" do
+    context "on a facilitator training" do
+      let(:event) { create(:event, facilitator_training: true) }
+
+      it "renders the FAQ" do
+        get registration_faq_path(registration.slug)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "on a non-training event" do
+      let(:event) { create(:event, facilitator_training: false) }
+
+      it "redirects to the ticket" do
+        get registration_faq_path(registration.slug)
+        expect(response).to redirect_to(registration_ticket_path(registration.slug))
+      end
+    end
+  end
+
+  describe "GET /registration/:slug/handouts" do
+    context "on a facilitator training" do
+      let(:event) { create(:event, facilitator_training: true) }
+
+      it "renders the handouts page" do
+        get registration_handouts_path(registration.slug)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "on a non-training event" do
+      let(:event) { create(:event, facilitator_training: false) }
+
+      it "redirects to the ticket" do
+        get registration_handouts_path(registration.slug)
+        expect(response).to redirect_to(registration_ticket_path(registration.slug))
+      end
+    end
+  end
+
+  describe "GET /registration/:slug/forms" do
+    context "on a paid non-training event" do
+      let(:event) { create(:event, facilitator_training: false, cost_cents: 1099) }
+
+      it "renders the forms page" do
+        get registration_forms_path(registration.slug)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "on a free non-training event" do
+      let(:event) { create(:event, facilitator_training: false, cost_cents: 0) }
+
+      it "redirects to the ticket" do
+        get registration_forms_path(registration.slug)
+        expect(response).to redirect_to(registration_ticket_path(registration.slug))
+      end
+    end
+  end
+end

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -48,12 +48,24 @@ RSpec.describe "Events::Registrations", type: :request do
     end
 
     context "magic callouts" do
+      # A facilitator training shows the full built-in set, including the
+      # training-only Handouts and FAQ cards.
+      let(:event) { create(:event, facilitator_training: true) }
+
       it "renders the consolidated magic callout cards" do
         get registration_ticket_path(registration.slug)
         expect(response.body).to include("view your balance")
         expect(response.body).to include("W-9, invoice, and receipt")
         expect(response.body).to include("Worksheets and resources for the training")
         expect(response.body).to include("Frequently asked questions")
+      end
+
+      it "omits the training-only Handouts and FAQ cards on a non-training event" do
+        non_training = create(:event, facilitator_training: false)
+        reg = create(:event_registration, event: non_training, registrant: user.person)
+        get registration_ticket_path(reg.slug)
+        expect(response.body).not_to include("Worksheets and resources for the training")
+        expect(response.body).not_to include("Frequently asked questions")
       end
     end
 
@@ -223,6 +235,7 @@ RSpec.describe "Events::Registrations", type: :request do
   end
 
   describe "GET /registration/:slug/faq" do
+    let(:event) { create(:event, facilitator_training: true) }
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
     it "renders the training FAQ with the folded-in contact link" do
@@ -328,6 +341,7 @@ RSpec.describe "Events::Registrations", type: :request do
   end
 
   describe "GET /registration/:slug/handouts" do
+    let(:event) { create(:event, facilitator_training: true) }
     let!(:registration) { create(:event_registration, event: event, registrant: user.person) }
 
     it "links each handout to its registrant resource page, returning to handouts" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe "Events", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Sample ticket preview")
         expect(response.body).to include("Sample Registrant")
-        # Magic callout cards render (always-present "Forms" card) without raising
-        # on the unsaved sample's sentinel slug.
+        # Magic callout cards render (the sample event is paid, so the "Forms"
+        # card shows) without raising on the unsaved sample's sentinel slug.
         expect(response.body).to include("Forms")
       end
 

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -13,15 +13,30 @@ RSpec.describe MagicTicketCallouts do
   end
 
   describe "#cards" do
-    it "shows the always-present cards for a bare paid-cost registration" do
-      expect(card_titles(registration)).to eq([
-        "Make your payment", "Forms", "Handouts", "Frequently asked questions"
-      ])
+    it "shows payment and forms for a bare paid, non-training registration" do
+      expect(card_titles(registration)).to eq([ "Make your payment", "Forms" ])
     end
 
     it "omits the payment card for a free event" do
       event.update!(cost_cents: 0)
       expect(card_titles(registration)).not_to include("Payment")
+    end
+
+    it "shows Handouts and FAQ only for facilitator trainings" do
+      expect(card_titles(registration)).not_to include("Handouts", "Frequently asked questions")
+
+      event.update!(facilitator_training: true)
+      expect(card_titles(registration)).to include("Handouts", "Frequently asked questions")
+    end
+
+    it "shows the Forms card for facilitator trainings and paid events, but not free non-trainings" do
+      expect(card_titles(registration)).to include("Forms")
+
+      event.update!(cost_cents: 0)
+      expect(card_titles(registration)).not_to include("Forms")
+
+      event.update!(facilitator_training: true)
+      expect(card_titles(registration)).to include("Forms")
     end
 
     it "makes the payment card an action card while a balance is due, reference once paid" do
@@ -117,7 +132,8 @@ RSpec.describe MagicTicketCallouts do
     end
 
     it "places payment first and FAQ last in the full ordering" do
-      event.update!(event_details: "Bring supplies", ce_hours_details: "6 hours",
+      event.update!(facilitator_training: true, event_details: "Bring supplies",
+                    ce_hours_details: "6 hours",
                     videoconference_url: "https://example.zoom.us/j/123",
                     start_date: 3.days.ago, end_date: 2.days.ago)
       registration.update!(status: "attended", scholarship_requested: true, ce_credit_requested: true)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained visibility guards on built-in ticket callouts + spec updates

### What is the goal of this PR and why is this important?
- The built-in **Handouts**, **FAQ**, and **Forms** ticket callouts rendered on *every* registration ticket, but their content is 2-Day AWBW Facilitator Training–specific (training worksheets, "2-day training" FAQ).
- Public, non-training events — including **live ones with no registration process** — were surfacing these irrelevant training callouts to registrants. This is the urgent fix.

### How did you approach the change?
- Added `Event#show_handouts_callout?` / `#show_faq_callout?` (→ `facilitator_training?`) and `#show_forms_callout?` (→ `facilitator_training?` **or** paid, since paying registrants still need their invoice/receipt).
- `MagicTicketCallouts` now returns those cards only when the predicate holds; the callout pages (`forms`/`handouts`/`faq`) redirect to the ticket when hidden.
- **No migration** — `facilitator_training` already partitions live data correctly, so this corrects every live event on deploy.
- Layer 1 of 2: a follow-up PR adds per-event Auto/Show/Hide overrides in the event's callouts section.

### Anything else to add?
- Editor preview visibility labels updated ("On facilitator trainings", "On facilitator trainings and paid events").
- The callout *content* is still hardcoded to the 2-day training even for trainings — out of scope here, worth revisiting.