### PR TITLE
Fix idea-image promotion: transfer box on new, apply on update, guard save

### DIFF
--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -82,6 +82,7 @@ class WorkshopVariationsController < ApplicationController
     authorize! @workshop_variation
 
     if @workshop_variation.update(workshop_variation_params)
+      @workshop_variation.attach_assets_from_idea! if params[:promote_idea_assets] == "true"
       flash[:notice] = "Workshop Variation updated successfully."
       redirect_to @workshop_variation
     else

--- a/app/services/workshop_variation_from_idea_service.rb
+++ b/app/services/workshop_variation_from_idea_service.rb
@@ -7,9 +7,7 @@ class WorkshopVariationFromIdeaService
   end
 
   def call
-    WorkshopVariation.new(attributes_from_idea).tap do |workshop_variation|
-      duplicate_assets(workshop_variation)
-    end
+    WorkshopVariation.new(attributes_from_idea)
   end
 
   private
@@ -26,11 +24,5 @@ class WorkshopVariationFromIdeaService
       inactive: true,
       rhino_body: workshop_variation_idea.rhino_body
     )
-  end
-
-  def duplicate_assets(workshop_variation)
-    workshop_variation_idea.assets.each do |asset|
-      workshop_variation.assets.build(file: asset.file.blob)
-    end
   end
 end

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="rounded-xl bg-white p-6">
-  <%= simple_form_for @workshop_variation, html: { multipart: true }, data: { turbo: false } do |f| %>
+  <%= simple_form_for @workshop_variation, html: { multipart: true }, data: { turbo: false, controller: "submit-once", "submit-once-submitting-text-value": "Saving…" } do |f| %>
     <%= hidden_field_tag(:from, params[:from]) %>
 
     <%= render "shared/errors", resource: @workshop_variation if @workshop_variation.errors.any? %>
@@ -157,7 +157,7 @@
                   </span>
                   <p class="text-amber-600 text-sm mt-1 font-medium">
                     <i class="fas fa-triangle-exclamation"></i>
-                    This will replace any existing attachments on this variation once you click submit.
+                    This will add the idea’s attachments to any existing attachments on this variation once you click submit.
                   </p>
                 </div>
               <% end %>

--- a/spec/requests/workshop_variations_spec.rb
+++ b/spec/requests/workshop_variations_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe "/workshop_variations", type: :request do
         expect(response.body).to include(workshop_variation_idea.name)
         expect(response.body).to include("&lt;p&gt;Original idea body content&lt;/p&gt;")
       end
+
+      it "shows the asset-transfer checkbox when the idea has attachments" do
+        idea_with_asset = create(:workshop_variation_idea, workshop: workshop)
+        PrimaryAsset.create!(
+          owner: idea_with_asset,
+          file: fixture_file_upload("spec/fixtures/files/sample.png", "image/png")
+        )
+
+        get new_workshop_variation_path(workshop_variation_idea_id: idea_with_asset.id)
+
+        expect(response.body).to include("transfer attachments from the variation idea")
+      end
     end
 
     describe "POST /create from workshop_variation_idea" do
@@ -254,6 +266,20 @@ RSpec.describe "/workshop_variations", type: :request do
 
         expect(variation.reload.name).to eq("Updated Name")
         expect(response).to redirect_to(workshop_variation_path(variation))
+      end
+
+      it "attaches assets from the idea when promote_idea_assets is true" do
+        idea_with_asset = create(:workshop_variation_idea, workshop: workshop)
+        PrimaryAsset.create!(
+          owner: idea_with_asset,
+          file: fixture_file_upload("spec/fixtures/files/sample.png", "image/png")
+        )
+        variation = create(:workshop_variation, valid_attributes.merge(workshop_variation_idea: idea_with_asset))
+
+        expect {
+          patch workshop_variation_path(variation),
+                params: { workshop_variation: { name: "Updated Name" }, promote_idea_assets: "true" }
+        }.to change { variation.reload.assets.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained logic across a service, controller update action, and one form

### What is the goal of this PR and why is this important?
Fixes three bugs in the promote-workshop-variation-idea → workshop-variation flow around the "transfer attachments from the idea" box.

- **Box only showed on edit, not new.** The from-idea service pre-built (but never persisted) copies of the idea's assets on the unsaved variation, so the form's blob-id comparison thought they were already transferred and hid the box on `new`. Removed the counterproductive `duplicate_assets` (it never persisted — `create` rebuilds from params).
- **Checking the box on edit did nothing.** `create` called `attach_assets_from_idea!` when checked, but `update` didn't. Added the matching call.
- **Save button re-uploaded on double-click.** The form runs `turbo: false`, so rapid clicks fired multiple full POSTs. Added the existing `submit-once` Stimulus controller (built for `turbo: false` forms) to disable the button and show "Saving…".
- Corrected the box's warning copy — it *appends* the idea's attachments, it doesn't replace.

### How did you approach the change?
- Wrote failing request specs first: box renders on `GET /new` when the idea has attachments; `PATCH /update` with `promote_idea_assets: "true"` attaches them. Then applied the fixes.

### Anything else to add?
No migration, no schema change. Reused the existing `submit-once` controller rather than adding JS.