### PR TITLE
Fix dev seeds broken by resource author association (#1938)

### DIFF
--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1442,8 +1442,14 @@ if facilitator_training && registration_form
   end
 
   # Recreate from scratch each run so re-seeding refreshes labels and link state.
-  Person.where("email LIKE ? OR email LIKE ?",
-    "orgchip.demo.%@seed.example.com", "affdemo.%@seed.example.com").find_each(&:destroy)
+  # Release any resource authorship first: resources.rb (which runs after this) can
+  # credit these demo people, and Person#resources_as_author is restrict_with_error,
+  # so the destroy below silently fails and the re-create hits the name/email
+  # uniqueness validation. Clearing author_id here keeps the block idempotent.
+  demo_people = Person.where("email LIKE ? OR email LIKE ?",
+    "orgchip.demo.%@seed.example.com", "affdemo.%@seed.example.com")
+  Resource.where(author_id: demo_people).update_all(author_id: nil)
+  demo_people.find_each(&:destroy)
 
   # Each scenario => one registrant. :orgs link real orgs (→ chip shows links);
   # :agency stores a submitted name. A typed name matching an existing org is linked

--- a/db/seeds/dev/resources.rb
+++ b/db/seeds/dev/resources.rb
@@ -22,7 +22,9 @@ puts "Creating Resources…"
   Resource.where(title: Faker::Book.title).first_or_create!(
     body: resource_body,
     rhino_body: resource_body,
-    author: [ Faker::Name.name, nil ].sample,
+    author: [ Person.all.sample, nil, nil ].sample,
+    author_credit_preference: AuthorCreditable::AUTHOR_CREDIT_PREFERENCES.sample,
+    legacy_author_name: [ Faker::Name.name, nil, nil ].sample,
     agency: [ Faker::Company.name, nil ].sample,
     kind: kind,
     url: [ "https://example.com/resource/#{SecureRandom.hex(4)}", nil ].sample,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 dev-seed-only logic fix (association + idempotency), no app/runtime code touched

### What is the goal of this PR and why is this important?
`bin/setup` / `db:seed:dev` was aborting on a fresh DB. #1938 turned `Resource#author` from a free-text string into a `Person` association but left the dev seed assigning a Faker string → `AssociationTypeMismatch`.

### How did you approach the change?
- `resources.rb`: credit a real `Person` (via the association), keep the old free-text in `legacy_author_name`, and set `author_credit_preference` — mirroring the other AuthorCreditable seeds.
- `events_management.rb`: #1938 also made `Person#resources_as_author` `restrict_with_error`, so a demo registrant credited on a resource could no longer be destroyed — the "recreate from scratch each run" cleanup silently failed and re-seeding crashed on the name/email uniqueness validation. Release the credit before destroying so the block stays idempotent.

Verified `db:seed:dev` runs clean on a fresh DB and idempotently across repeated runs.