### PR TITLE
Collapse persisted address fields behind a details/summary header

### DIFF
--- a/app/views/addresses/_address_fields.html.erb
+++ b/app/views/addresses/_address_fields.html.erb
@@ -1,9 +1,15 @@
-<div class="nested-fields rounded-lg bg-white border border-gray-200 p-6 mb-4">
-  <div class="text-lg font-semibold text-gray-800 mb-4">
-    Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
-  </div>
+<%# Persisted addresses start collapsed to a single-line header; new/blank ones
+    stay expanded so their fields are ready to fill in. Native <details>/<summary>
+    toggles the editable fields on click — no JavaScript needed. %>
+<details class="nested-fields group rounded-lg bg-white border border-gray-200 p-6 mb-4"<%= " open".html_safe unless f.object.persisted? %>>
+  <summary class="flex items-center justify-between gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+    <div class="text-lg font-semibold text-gray-800">
+      Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
+    </div>
+    <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open:rotate-180"></i>
+  </summary>
 
-  <hr class="mb-6 border-gray-200">
+  <hr class="my-6 border-gray-200">
 
   <!-- LOCATION + DISTRICT + LOCALITY -->
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
@@ -134,4 +140,4 @@
   <%= link_to_remove_association "Remove",
                                  f,
                                  class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap" %>
-</div>
+</details>

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -1,9 +1,15 @@
-<div class="nested-fields rounded-lg bg-white border border-gray-200 p-6 mb-4">
-  <div class="text-lg font-semibold text-gray-800 mb-4">
-    Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
-  </div>
+<%# Persisted addresses start collapsed to a single-line header; new/blank ones
+    stay expanded so their fields are ready to fill in. Native <details>/<summary>
+    toggles the editable fields on click — no JavaScript needed. %>
+<details class="nested-fields group rounded-lg bg-white border border-gray-200 p-6 mb-4"<%= " open".html_safe unless f.object.persisted? %>>
+  <summary class="flex items-center justify-between gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+    <div class="text-lg font-semibold text-gray-800">
+      Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
+    </div>
+    <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open:rotate-180"></i>
+  </summary>
 
-  <hr class="mb-6 border-gray-200">
+  <hr class="my-6 border-gray-200">
 
   <!-- LOCATION + DISTRICT + LOCALITY -->
   <%# Organization addresses are always "work" — the type designation only matters
@@ -133,4 +139,4 @@
   <%= link_to_remove_association "Remove",
                                  f,
                                  class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap" %>
-</div>
+</details>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup; native details/summary, no JS or data changes

### Why
On the person/org edit forms, each saved address rendered all its fields expanded, making a long list of addresses hard to scan.

### What
- Persisted addresses collapse to a single-line header (`Address #N: …`) with a chevron; clicking the header toggles the editable fields.
- New/blank addresses stay expanded so they're ready to fill in.
- Pure HTML `<details>`/`<summary>` — no JavaScript. Chevron rotates via CSS (`group-open:rotate-180`).
- Applied to both person (`addresses/_address_fields`) and organization (`organizations/_address_fields`) editors.
