### PR TITLE
Unify sector/age-range chip colors; surface sector leaders on people index

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -149,10 +149,13 @@ class Person < ApplicationRecord
     joins(:affiliations)
       .where(affiliations: { organization_id: organization_id })
       .distinct }
+  scope :sector_leaders, -> {
+    joins(:sectorable_items).where(sectorable_items: { is_leader: true }).distinct }
 
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.search(params[:contact_info]) if params[:contact_info].present?
+    results = results.sector_leaders if ActiveModel::Type::Boolean.new.cast(params[:sector_leaders_only])
     results = results.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
     results = results.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
     results = results.organization_name(params[:organization_name]) if params[:organization_name].present?

--- a/app/views/people/_search_boxes.html.erb
+++ b/app/views/people/_search_boxes.html.erb
@@ -48,6 +48,15 @@
       </div>
     </div>
 
+    <!-- Sector leaders only -->
+    <div class="w-full md:w-auto flex items-center">
+      <label class="inline-flex items-center gap-2 text-sm font-medium text-gray-700 cursor-pointer py-2">
+        <%= check_box_tag :sector_leaders_only, "1", params[:sector_leaders_only].present?,
+                          class: "rounded border-gray-300 text-blue-600 focus:ring focus:ring-blue-200" %>
+        <span>Sector leaders only</span>
+      </label>
+    </div>
+
     <!-- Clear filters -->
     <div class="w-full md:w-auto flex justify-end">
       <%= link_to "Clear filters", people_path,

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -45,7 +45,7 @@
 
 <% if sector %>
   <%= link_to taggings_path(sector_names_all: sector.name),
-    title: sector.name,
+    title: (display_leader && is_leader ? "#{sector.name} (Sector leader)" : sector.name),
     data: { turbo_frame: "_top", sector_name: sector.name, controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
               class: "inline-flex items-center
                       #{ max_width } #{ "min-w-0" if max_width }
@@ -55,7 +55,7 @@
                       #{ text_color }
                       #{ chip_size } font-medium
                       transition" do %>
-    <span data-tag-link-loading-target="text" class="<%= "truncate min-w-0" if max_width %>"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary sector"></i><% end %><%= sector.name %><% if display_leader && is_leader %><span class="ml-1 text-xs text-indigo-600">(Leader)</span><% end %></span>
+    <span data-tag-link-loading-target="text" class="<%= "truncate min-w-0" if max_width %>"><% if is_hidden %><%= render "shared/hidden_tag_icon" %><% end %><% if is_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary sector"></i><% end %><%= sector.name %></span><% if display_leader && is_leader %><span class="ml-1 flex-shrink-0 text-xs text-indigo-600">(Leader)</span><% end %>
     <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
   <% end %>
 <% end %>

--- a/app/views/shared/_age_group_tags.html.erb
+++ b/app/views/shared/_age_group_tags.html.erb
@@ -1,18 +1,19 @@
-<%# Age-group chips. Primary groups lead with a star in amber; additional groups
-    follow in gray. `primary` and `additional` are arrays of Category records.
-    `compact` shrinks the chips for dense table cells. %>
+<%# Age-group chips, themed in lime to match the sector chips. Primary groups lead
+    with an amber star on a darker lime chip; additional groups follow in a lighter
+    lime. `primary` and `additional` are arrays of Category records. `compact`
+    shrinks the chips for dense table cells. %>
 <% primary ||= [] %>
 <% additional ||= [] %>
 <% compact = local_assigns.fetch(:compact, false) %>
 <% padding = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
 <div class="flex flex-wrap gap-1.5">
   <% primary.each do |category| %>
-    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-amber-200 bg-amber-50 <%= padding %> font-medium text-amber-800">
+    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-200 <%= padding %> font-medium text-lime-800">
       <i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><%= category.name %>
     </span>
   <% end %>
   <% additional.each do |category| %>
-    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-gray-200 bg-gray-50 <%= padding %> font-medium text-gray-600">
+    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-50 <%= padding %> font-medium text-gray-500">
       <%= category.name %>
     </span>
   <% end %>

--- a/app/views/shared/_age_range_item_fields.html.erb
+++ b/app/views/shared/_age_range_item_fields.html.erb
@@ -6,7 +6,7 @@
 <% collection ||= @age_ranges_collection || Category.age_ranges.published.order(:position, :name).pluck(:name, :id) %>
 <% is_primary = f.object&.is_primary? %>
 <div class="nested-fields inline-flex items-center gap-2
-            rounded-md border <%= is_primary ? "border-amber-300 bg-amber-50" : "border-gray-300 bg-white" %>
+            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-200" : "bg-lime-50" %>
             text-gray-700 px-3 py-1 text-sm font-medium transition"
      data-primary-tag-target="chip">
   <% if f.object&.category_id.present? %>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -3,7 +3,7 @@
 <% is_primary = f.object&.is_primary? %>
 
 <div class="nested-fields inline-flex items-center gap-2
-            rounded-md border <%= is_primary ? "border-lime-500 bg-lime-200" : "border-gray-300 bg-white" %>
+            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-200" : "bg-lime-50" %>
             text-gray-700 px-3 py-1 text-sm font-medium transition"
      data-primary-tag-target="chip">
   <% if f.object&.sector_id.present? %>

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -352,6 +352,32 @@ RSpec.describe Person, type: :model do
         Person.with_active_affiliations.search_by_params(organization_name: 'Alpha').to_a
       }.not_to raise_error
     end
+
+    context 'sector_leaders_only' do
+      let(:sector) { create(:sector) }
+
+      before do
+        person_alice.sectorable_items.create!(sector: sector, is_leader: true)
+        person_bob.sectorable_items.create!(sector: sector, is_leader: false)
+      end
+
+      it 'returns only people who lead a sector when truthy' do
+        results = Person.search_by_params(sector_leaders_only: '1')
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+
+      it 'returns a person once even when they lead several sectors' do
+        person_alice.sectorable_items.create!(sector: create(:sector), is_leader: true)
+        results = Person.search_by_params(sector_leaders_only: '1')
+        expect(results.to_a.count(person_alice)).to eq(1)
+      end
+
+      it 'ignores the filter when unchecked' do
+        results = Person.search_by_params(sector_leaders_only: '0')
+        expect(results).to include(person_alice, person_bob)
+      end
+    end
   end
 
   describe ".published" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1844,8 +1844,8 @@ RSpec.describe "Events", type: :request do
         page = Capybara.string(response.body)
         expect(page).to have_content("13-17")
         expect(page).to have_content("18+")
-        # The primary group leads with the starred amber chip from the shared partial.
-        expect(page).to have_css("span.text-amber-800 i.fa-star")
+        # The primary group leads with the starred lime chip from the shared partial.
+        expect(page).to have_css("span.text-lime-800 i.fa-star")
       end
 
       it "shows the org linked to its website on the left and the bold recipient name linked to their profile on the right" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/scope changes plus one filter scope, with model spec coverage

### What is the goal of this PR and why is this important?
- **Age-range chips now match the lime sector chips.** They were amber/gray, reading as an unrelated tag family beside the lime sectors.
- **Edit-form chips match the profile.** Non-primary sector/age chips were white on edit but lime-50 on the profile — now identical on view and edit.
- **Sector leadership is visible and filterable on the people index.** The `(Leader)` badge was clipped (it sat inside the truncating name span); a "Sector leaders only" filter was added.

### How did you approach the change?
- Retheme age-range chips (`_age_group_tags`) to lime; align edit chips (`_sectorable_item_fields`, `_age_range_item_fields`) to the profile's lime scheme.
- Move `(Leader)` out of the truncating span (add `flex-shrink-0`) so it always shows; append "(Sector leader)" to the chip's hover tooltip.
- Add a `sector_leaders` scope + `sector_leaders_only` param to `Person.search_by_params`, and a checkbox to the people search (auto-submits via the existing `collection` controller).

### Anything else to add?
- The index sector column only renders **primary** sectors, so the crown/badge shows there only when someone leads their primary sector; the filter and the profile still reflect leadership on any sector.