### PR TITLE
Add shareable slug URLs for stories

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -160,6 +160,8 @@ class StoriesController < ApplicationController
   private
 
   def set_story
+    # Accepts both the bare id ("23") and the slugged param ("23-my-great-story");
+    # ActiveRecord casts the leading id via `to_i`, so both resolve the same story.
     @story = Story.find(params[:id])
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -118,6 +118,15 @@ class Story < ApplicationRecord
     stories
   end
 
+  # Shareable, readable URLs (story_path, polymorphic_path, etc.): the id followed
+  # by the title slugged with hyphens and bad URL characters stripped, e.g.
+  # "23-my-great-story". Rails resolves it back via `id.to_i`, so `/stories/23`
+  # and `/stories/23/edit` (which pass the bare id) keep working.
+  def to_param
+    return id&.to_s if title.blank?
+    "#{id}-#{title.parameterize}"
+  end
+
   def name
     title
   end

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -86,7 +86,7 @@
                                   class: "btn btn-secondary-outline" %>
               <% end %>
               <% if allowed_to?(:edit?, story) %>
-                <%= link_to "Edit", edit_story_path(story),
+                <%= link_to "Edit", edit_story_path(story.id),
                                   data: {turbo_frame: "_top"},
                                   class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
               <% end %>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <% if params[:admin] == 'true' %>
-            <%= turbo_frame_tag "editor_assets_lazy", src: edit_story_path(@story) do %>
+            <%= turbo_frame_tag "editor_assets_lazy", src: edit_story_path(@story.id) do %>
               <%= render "shared/loading" %>
             <% end %>
           <% end %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -8,7 +8,7 @@
         <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% if allowed_to?(:edit?, @story) %>
-          <%= link_to "Edit", edit_story_path(@story),
+          <%= link_to "Edit", edit_story_path(@story.id),
                       class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">

--- a/app/views/story_shares/show.html.erb
+++ b/app/views/story_shares/show.html.erb
@@ -41,7 +41,7 @@
       <%= link_to "Stories", stories_path, class: "btn btn-secondary-outline" %>
       <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
       <% if current_user&.super_user? %>
-        <%= link_to "Edit", edit_story_path(@story),
+        <%= link_to "Edit", edit_story_path(@story.id),
                     class: "btn btn-secondary-outline admin-only bg-blue-100" %>
       <% end %>
       <span class="inline-block text-sm">

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -178,4 +178,22 @@ RSpec.describe Story, type: :model do
       end
     end
   end
+
+  describe "#to_param" do
+    it "is the id followed by the title slugged with hyphens, stripping bad URL characters" do
+      story = create(:story, title: "My Great Story! #2 (2026)")
+      expect(story.to_param).to eq("#{story.id}-my-great-story-2-2026")
+    end
+
+    it "tracks the title when it changes" do
+      story = create(:story, title: "Original Title")
+      story.update!(title: "Brand New Title")
+      expect(story.to_param).to eq("#{story.id}-brand-new-title")
+    end
+
+    it "resolves back to the record via the leading id" do
+      story = create(:story, title: "Some Story")
+      expect(Story.find(story.to_param)).to eq(story)
+    end
+  end
 end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -320,6 +320,17 @@ RSpec.describe "/stories", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "resolves a story by its slugged param" do
+        get story_url(public_story)
+        expect(public_story.to_param).to match(/\A\d+-/)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "still resolves a story by its bare numeric id" do
+        get story_url(id: public_story.id)
+        expect(response).to have_http_status(:ok)
+      end
+
       it "cannot view published-only story" do
         get story_url(published_story)
         expect(response).to redirect_to(root_path)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained `to_param` change plus link tweaks, no schema change

### What is the goal of this PR and why is this important?
- Story links need to be *shareable* — a bare `/stories/23` says nothing. This adds a readable slug so a shared link carries the story's name.

### How did you approach the change?
- Override `Story#to_param` to return `"<id>-<title parameterized>"` (e.g. `/stories/23-my-great-story`), stripping bad URL characters via `parameterize`.
- No DB column: the slug is derived, and Rails resolves the URL back through the leading id's `to_i`, so `/stories/23` and `/stories/23/edit` keep working.
- Edit links pass the bare `@story.id` so edit stays `/stories/23/edit`.
- All site → story links (cards, social-share `story_url`, `polymorphic_path`) pick up the slug automatically via `to_param`.

### Anything else to add?
- Considered a stored `slug` column for a fully number-free URL (`/stories/my-great-story`), but that needs a migration, backfill, and collision handling; the id-prefix gives shareable readable links with zero schema change and can't break.