### PR TITLE
Uniform-size image carousel on workshop variation show

### DIFF
--- a/app/frontend/javascript/controllers/carousel_controller.js
+++ b/app/frontend/javascript/controllers/carousel_controller.js
@@ -6,15 +6,18 @@ import 'swiper/css'
 import 'swiper/css/navigation'
 
 // Connects to data-controller="carousel"
+// Pass Swiper overrides via data-carousel-options-value='{ "slidesPerView": 2, ... }'.
+// Any keys provided there win over the defaults below (breakpoints replace wholesale).
 export default class extends Controller {
+  static values = { options: Object }
 
   connect() {
-    this.swiper = new Swiper(this.element, {
+    const defaults = {
       modules: [Navigation],
       loop: true,
       speed: 1400,
       spaceBetween: 30,
-      
+
       breakpoints: {
         320: {
           slidesPerView: 1,
@@ -29,12 +32,14 @@ export default class extends Controller {
           slidesPerView: 4,
         }
       },
-      
+
       navigation: {
         nextEl: '.swiper-button-next-custom',
         prevEl: '.swiper-button-prev-custom',
       }
-    })
+    }
+
+    this.swiper = new Swiper(this.element, { ...defaults, ...this.optionsValue })
   }
 
   disconnect() {

--- a/app/views/assets/_display_assets_carousel.html.erb
+++ b/app/views/assets/_display_assets_carousel.html.erb
@@ -1,0 +1,36 @@
+<%# Renders a resource's primary + gallery images as one carousel of uniform-size slides. %>
+<%# Every image is forced into the same fixed aspect box, so there is no hero/thumbnail size split. %>
+<%
+  assets = []
+  assets << resource.primary_asset if resource.respond_to?(:primary_asset) && resource.primary_asset&.file&.attached?
+  assets += resource.gallery_assets.select { |asset| asset.file.attached? } if resource.respond_to?(:gallery_assets)
+%>
+<% if assets.any? %>
+  <div data-controller="carousel"
+       class="relative swiper my-6 max-w-2xl mx-auto"
+       data-carousel-options-value='{ "loop": false, "spaceBetween": 16, "slidesPerView": 1, "breakpoints": {} }'>
+    <div class="swiper-wrapper">
+      <% assets.each_with_index do |asset, idx| %>
+        <div class="swiper-slide">
+          <div class="aspect-[3/2] overflow-hidden rounded-lg bg-gray-100">
+            <%= render "assets/display_image",
+                       item: asset, idx: idx,
+                       variant: :index, width: "full", height: "full",
+                       link: true, item_type: asset.class.name %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <% if assets.size > 1 %>
+      <button class="swiper-button-next-custom absolute top-1/2 -translate-y-1/2 right-2 w-12 h-12 rounded-full bg-white border border-gray-300 text-gray-700 shadow-md hover:shadow-lg flex items-center justify-center transition hover:bg-gray-50 z-40"
+              aria-label="Next">
+        <i class="fa-solid fa-chevron-right text-xl"></i>
+      </button>
+      <button class="swiper-button-prev-custom absolute top-1/2 -translate-y-1/2 left-2 w-12 h-12 rounded-full bg-white border border-gray-300 text-gray-700 shadow-md hover:shadow-lg flex items-center justify-center transition hover:bg-gray-50 z-40"
+              aria-label="Previous">
+        <i class="fa-solid fa-chevron-left text-xl"></i>
+      </button>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -47,8 +47,8 @@
         </div>
       </div>
 
-      <!-- Primary Asset -->
-      <%= render "assets/display_assets", resource: @workshop_variation, link: true %>
+      <!-- Images (uniform-size carousel) -->
+      <%= render "assets/display_assets_carousel", resource: @workshop_variation %>
 
       <!-- URL -->
       <% if @workshop_variation.youtube_url.present? %>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained view/JS change on one page; carousel controller now reads its options value (touches a second carousel's gap)

## What
- Workshop variation **show** page now renders primary + gallery images as a single Swiper carousel where every image is forced into the same `aspect-[3/2]` box — no more full-width hero + 128px thumbnails.
- Made `carousel_controller.js` read `data-carousel-options-value` (was declared but ignored). New `_display_assets_carousel.html.erb` uses it for a one-at-a-time, `max-w-2xl`-centered layout.

## Why
- Hero image was too large and secondary images too small, on the variation page. Rachel suggested a carousel forcing all images to one size.

## Notes
- Side effect: the tagged-items carousel's declared `spaceBetween: 16` now actually applies (gap 30→16) since its options are no longer ignored. Its slide count is unchanged.
- Scope limited to the variation show page per request; the workshop page and index thumbnails are untouched.