### PR TITLE
Bump websocket-driver to 0.8.2 (clear CVE advisories)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -752,7 +752,7 @@ GEM
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -1119,7 +1119,7 @@ CHECKSUMS
   vite_ruby (3.9.2) sha256=e10a7c851b590cccab57904bc96c2eb078ed6e22560a778db1dcefa3818a4972
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   will_paginate (3.1.8) sha256=681ed5670a39ee8a5e0752f217416dbcd437633910b0696399755adad4e89d0e
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 lockfile-only security bump, single transitive gem

- `bundler-audit` was failing CI: websocket-driver 0.8.0 has four DoS/memory-exhaustion advisories (CVE-2026-54463/54464/54465, GHSA-2x63-gw47-w4mm).
- 0.8.2 is the first release patching all four.
- Conservative update — no other gems touched.