### PR TITLE
Bump pay to 11.6.2 + stripe to ~> 19 (fix webhook timing-attack advisory)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem "solid_cache"
 
 # Payments
 gem "pay", "~> 11.4"
-gem "stripe", "~> 18.0"
+gem "stripe", "~> 19.0"
 gem "paper_trail", "~> 17.0"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,7 +718,9 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
-    stripe (18.4.2)
+    stripe (19.3.0)
+      bigdecimal
+      logger
     thor (1.5.0)
     timeout (0.6.1)
     treetop (1.6.18)
@@ -832,7 +834,7 @@ DEPENDENCIES
   solid_queue (~> 1.3)
   sprockets-rails (~> 3.2.2)
   stimulus-rails (~> 1.3)
-  stripe (~> 18.0)
+  stripe (~> 19.0)
   trilogy (= 2.9.0)
   turbo-rails (~> 2.0)
   uglifier
@@ -1099,7 +1101,7 @@ CHECKSUMS
   ssrf_filter (1.5.0) sha256=e03dcdb9d1730d7f6710532a606b3543df2a448a0293ce04a2d995523c5a97f6
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
-  stripe (18.4.2) sha256=fd08a73ab87fc0b0ad938ca71293e1051e593001b70de5e9fcf12d1097133831
+  stripe (19.3.0) sha256=fcc356a2a552f8b0402dac78dfc439b6deaa77ad0203e80959558130e47e74bf
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   treetop (1.6.18) sha256=a3043f32f1c652aa2abdf3a3848edb2d2f69897257af2675516ac61355c183da

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -526,7 +526,7 @@ GEM
     parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    pay (11.4.3)
+    pay (11.6.2)
       rails (>= 7.0.0)
     polyglot (0.3.5)
     positioning (0.4.7)
@@ -1031,7 +1031,7 @@ CHECKSUMS
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parallel_tests (5.7.0) sha256=3f1762c46ca2c223b8af8ef877217f9d76974e191bfa934f2580b58bcf1d005c
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688
-  pay (11.4.3) sha256=f3d50b1a900ab0a7bfe9ba9fda631b2f5faf0c95236dd3d2afa9effc9bfb15e8
+  pay (11.6.2) sha256=dd5f57f58c94528923c1b063e1f905e28b48060ff402deffbd1235cd78dbc887
   polyglot (0.3.5) sha256=59d66ef5e3c166431c39cb8b7c1d02af419051352f27912f6a43981b3def16af
   positioning (0.4.7) sha256=c9a8cfba8b99180bd2b05022cdbcc7b234ea8bb1aa9101010e06bdda9a7bb220
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/config/bundler-audit.yml
+++ b/config/bundler-audit.yml
@@ -8,8 +8,3 @@ ignore:
   - CVE-2021-41183
   - CVE-2021-41184
   - CVE-2022-31160
-  # pay: non-constant-time HMAC comparison in the Paddle Billing webhook
-  # signature verifier. We only use the Stripe processor (see config/initializers/pay.rb),
-  # never Paddle, so the vulnerable code path is unreachable. No patched pay
-  # release exists (affects all versions <= 11.6.1). Remove this once upstream ships a fix.
-  - GHSA-mjgf-xj26-9qf9


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 major stripe bump (18→19) rides along by necessity — payment/webhook paths need eyes

- `bundler-audit` flags pay 11.4.3 (GHSA-mjgf-xj26-9qf9, **High**): Paddle Billing webhook signature verifier uses non-constant-time HMAC comparison.
- Bump pay to **11.6.2** (only patched release). Remove the matching `GHSA-mjgf-xj26-9qf9` ignore from `config/bundler-audit.yml` — it was a stopgap while no fix existed.
- **stripe 18 → 19 is forced, not optional:** pay 11.6.2's `Pay::Stripe.enabled?` hard-requires `stripe ~> 19` at boot. Under our old `~> 18` pin the app aborted at `db:load_config => environment`, failing CI before any test ran. Every pay ≥ 11.5.0 requires stripe 19, so there is no patched-pay-on-stripe-18 path.

**Why the stripe major bump is low-risk here:**
- Direct usage is stable API only: `Customer.retrieve`, `Charge.retrieve`, `Checkout::Session.retrieve/create`, `rescue Stripe::StripeError`.
- stripe 19's `decimal_string → BigDecimal` break only affects `*_decimal` fields; we use integer `unit_amount`/`.amount`.
- No direct `Stripe::Webhook` parsing (the other 19.0 break); Ruby 2.6 drop is moot (we're on 4.0).
- 229 payment/webhook specs green locally; `bin/bundler-audit` clean.