### PR TITLE
Unify workshop_variations index onto the shared sortable-table pattern

### DIFF
--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -3,19 +3,31 @@ class WorkshopVariationsController < ApplicationController
   def index
     authorize!
     @author = Person.find_by(id: params[:author_id]) if params[:author_id].present?
+    if turbo_frame_request?
+      per_page = params[:number_of_items_per_page].presence || 25
+      base_scope = WorkshopVariation.includes(:workshop, :author, :windows_type,
+                                              :workshop_variation_idea, created_by: :person)
+                                    .joins(:workshop).where(workshops: { published: true })
+      filtered = base_scope.search_by_params(params)
+      @sort = %w[name author updated_at created_at].include?(params[:sort]) ? params[:sort] : "created_at"
+      @sort_direction = params[:direction] == "asc" ? "asc" : "desc"
+      filtered = case @sort
+      when "author"
+        filtered.order_by_author(@sort_direction)
+      when "name"
+        filtered.reorder(Arel.sql("workshop_variations.name #{@sort_direction}"))
+      when "updated_at"
+        filtered.reorder(updated_at: @sort_direction.to_sym)
+      else
+        filtered.reorder(Arel.sql("workshop_variations.created_at #{@sort_direction}, workshops.title, workshop_variations.name"))
+      end
+      @workshop_variations = filtered.paginate(page: params[:page], per_page: per_page).decorate
+      @count_display = filtered.count == base_scope.count ? base_scope.count : "#{filtered.count}/#{base_scope.count}"
 
-    base_scope = WorkshopVariation.includes(:workshop, :author, created_by: :person)
-                                  .joins(:workshop).where(workshops: { published: true })
-    @sort = params[:sort]
-    @sort_direction = params[:direction] == "asc" ? "asc" : "desc"
-    filtered = base_scope.search_by_params(params)
-    filtered = if @sort == "author"
-      filtered.order_by_author(@sort_direction)
+      render :workshop_variations_results
     else
-      filtered.order("workshop_variations.created_at DESC, workshops.title, workshop_variations.name")
+      render :index
     end
-    @workshop_variations = filtered.paginate(page: params[:page], per_page: 25).decorate
-    @workshop_variations_count = filtered.count == base_scope.count ? base_scope.count : "#{filtered.count}/#{base_scope.count}"
   end
 
   def new

--- a/app/helpers/sortable_header_helper.rb
+++ b/app/helpers/sortable_header_helper.rb
@@ -1,0 +1,32 @@
+module SortableHeaderHelper
+  # Font Awesome icon class for a sortable column, reflecting the active
+  # @sort / @sort_direction. Inactive columns show the neutral two-way arrow.
+  def sort_icon_class(column)
+    return "fa-sort" unless @sort.to_s == column.to_s
+
+    @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
+  end
+
+  # Builds a click-to-sort column-header link generator for the lazy
+  # index/filter frames (stories, community_news, bookmarks,
+  # workshop_variations). Bind it once per results partial, then call it per
+  # column:
+  #
+  #   sort_link = sort_header_link(frame: "stories_results",
+  #                                path: ->(p) { stories_path(p) },
+  #                                base: params.permit(:query, :year).to_h.symbolize_keys)
+  #   sort_link.call("title", "Title")
+  #
+  # `base` carries the current search/filter params so they survive a re-sort.
+  # Clicking a fresh column sorts descending, then toggles to ascending.
+  def sort_header_link(frame:, path:, base: {})
+    ->(column, label) do
+      direction = (@sort.to_s == column.to_s && @sort_direction == "desc") ? "asc" : "desc"
+      link_to path.call(base.merge(sort: column, direction: direction, page: nil)),
+              data: { turbo_frame: frame },
+              class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do
+        safe_join([ label, tag.i("", class: "fa-solid #{sort_icon_class(column)} text-xs opacity-70") ], " ")
+      end
+    end
+  end
+end

--- a/app/views/bookmarks/_bookmarks_results.html.erb
+++ b/app/views/bookmarks/_bookmarks_results.html.erb
@@ -1,13 +1,7 @@
 <%= turbo_stream.replace("bookmarks_count", partial: "bookmarks_count") %>
 <%
   sort_base = params.permit(:keyword, :user_id, :bookmarkable_type, :windows_type, :number_of_items_per_page).to_h.symbolize_keys
-  sort_icon = ->(column) {
-    if @sort == column
-      @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
-    else
-      "fa-sort"
-    end
-  }
+  sort_link = sort_header_link(frame: "bookmarks_results", path: ->(p) { bookmarks_path(p) }, base: sort_base)
 %>
 <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @bookmarks.any? %>">
   <table class="min-w-full divide-y divide-gray-200">
@@ -16,30 +10,9 @@
         <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">ID</th>
         <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">User</th>
         <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Type</th>
-        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">
-          <%= link_to bookmarks_path(sort_base.merge(sort: "title", direction: (@sort == "title" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "bookmarks_results" },
-                      class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Title
-            <i class="fa-solid <%= sort_icon.call("title") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
-        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">
-          <%= link_to bookmarks_path(sort_base.merge(sort: "created_at", direction: (@sort == "created_at" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "bookmarks_results" },
-                      class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Created At
-            <i class="fa-solid <%= sort_icon.call("created_at") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
-        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">
-          <%= link_to bookmarks_path(sort_base.merge(sort: "popularity", direction: (@sort == "popularity" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "bookmarks_results" },
-                      class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Bookmark count
-            <i class="fa-solid <%= sort_icon.call("popularity") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
+        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("title", "Title") %></th>
+        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("created_at", "Created At") %></th>
+        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("popularity", "Bookmark count") %></th>
       </tr>
     </thead>
 

--- a/app/views/community_news/_community_news_results.html.erb
+++ b/app/views/community_news/_community_news_results.html.erb
@@ -1,50 +1,16 @@
 <%= turbo_stream.replace("community_news_count", partial: "community_news_count") %>
 <%
   sort_base = params.permit(:title, :query, :published, :year, :author_id, :number_of_items_per_page).to_h.symbolize_keys
-  sort_icon = ->(column) {
-    if @sort == column
-      @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
-    else
-      "fa-sort"
-    end
-  }
+  sort_link = sort_header_link(frame: "community_news_results", path: ->(p) { community_news_index_path(p) }, base: sort_base)
 %>
 <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @community_news.any? %>">
   <table class="w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-          <%= link_to community_news_index_path(sort_base.merge(sort: "title", direction: (@sort == "title" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "community_news_results" },
-                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Title
-            <i class="fa-solid <%= sort_icon.call("title") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
-        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-          <%= link_to community_news_index_path(sort_base.merge(sort: "author", direction: (@sort == "author" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "community_news_results" },
-                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Author
-            <i class="fa-solid <%= sort_icon.call("author") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
-        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">
-          <%= link_to community_news_index_path(sort_base.merge(sort: "organization", direction: (@sort == "organization" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "community_news_results" },
-                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Organization
-            <i class="fa-solid <%= sort_icon.call("organization") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
-        <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700 whitespace-nowrap min-w-[7rem]">
-          <%= link_to community_news_index_path(sort_base.merge(sort: "created_at", direction: (@sort == "created_at" && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-                      data: { turbo_frame: "community_news_results" },
-                      class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-            Created At
-            <i class="fa-solid <%= sort_icon.call("created_at") %> text-xs opacity-70"></i>
-          <% end %>
-        </th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("title", "Title") %></th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("author", "Author") %></th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("organization", "Organization") %></th>
+        <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700 whitespace-nowrap min-w-[7rem]"><%= sort_link.call("created_at", "Created At") %></th>
         <th class="px-6 py-3 text-center text-sm font-semibold text-gray-700">Actions</th>
       </tr>
     </thead>

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -1,21 +1,7 @@
 <%= turbo_stream.replace("stories_count", partial: "stories_count") %>
 <%
   sort_base = params.permit(:title, :query, :published, :year, :author_id, :number_of_items_per_page).to_h.symbolize_keys
-  sort_icon = ->(column) {
-    if @sort == column
-      @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
-    else
-      "fa-sort"
-    end
-  }
-  sort_link = ->(column, label) {
-    link_to stories_path(sort_base.merge(sort: column, direction: (@sort == column && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
-            data: { turbo_frame: "stories_results" },
-            class: "inline-flex items-center gap-1 text-gray-700 hover:text-gray-900" do
-      concat label
-      concat content_tag(:i, "", class: "fa-solid #{sort_icon.call(column)} text-xs opacity-70")
-    end
-  }
+  sort_link = sort_header_link(frame: "stories_results", path: ->(p) { stories_path(p) }, base: sort_base)
 %>
 <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @stories.any? %>">
   <table class="w-full divide-y divide-gray-200">

--- a/app/views/workshop_variations/_results_skeleton.html.erb
+++ b/app/views/workshop_variations/_results_skeleton.html.erb
@@ -1,0 +1,34 @@
+<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50 animate-pulse">
+      <tr>
+        <th class="px-4 py-3 text-center"><div class="h-4 w-6 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="h-4 w-10 mx-auto rounded bg-gray-200"></div></th>
+      </tr>
+    </thead>
+
+    <tbody class="divide-y divide-gray-100 animate-pulse">
+      <% 3.times do %>
+        <tr>
+          <td class="px-4 py-3"><div class="w-12 h-9 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3">
+            <div class="flex flex-col gap-2">
+              <div class="h-5 w-48 rounded bg-gray-200"></div>
+              <div class="h-3 w-32 rounded bg-gray-200"></div>
+            </div>
+          </td>
+          <td class="px-4 py-3"><div class="h-4 w-6 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="h-4 w-24 mx-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="h-8 w-14 mx-auto rounded bg-gray-200"></div></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/workshop_variations/_search_boxes.html.erb
+++ b/app/views/workshop_variations/_search_boxes.html.erb
@@ -1,4 +1,5 @@
-<%= form_tag(workshop_variations_path, method: :get, class: "space-y-4", data: { controller: "collection" }) do %>
+<%= form_tag(workshop_variations_path, method: :get, class: "space-y-4",
+             data: { controller: "collection", turbo_frame: "workshop_variations_results" }) do %>
   <div class="flex flex-col md:flex-row md:items-end md:gap-4 mb-6">
     <!-- Search -->
     <div class="w-full md:flex-1 mb-3 md:mb-0">
@@ -9,8 +10,7 @@
                                  focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
 
         <button type="submit"
-                class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600"
-                onclick="this.closest('form').submit()">
+                class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
           <i class="fa fa-search"></i>
         </button>
       </div>

--- a/app/views/workshop_variations/_workshop_variations_count.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_count.html.erb
@@ -1,0 +1,7 @@
+<div id="workshop_variations_count">
+  <hr class="border-gray-300 my-6">
+  <div class="filters-applied w-full flex gap-3 items-center">
+    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide"><%= WorkshopVariation.model_name.human.pluralize %> (<%= @count_display %>)</h3>
+  </div>
+  <hr class="border-gray-300 my-6">
+</div>

--- a/app/views/workshop_variations/_workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_results.html.erb
@@ -1,0 +1,106 @@
+<%= turbo_stream.replace("workshop_variations_count", partial: "workshop_variations_count") %>
+<%
+  sort_base = params.permit(:query, :author_id, :number_of_items_per_page).to_h.symbolize_keys
+  sort_link = sort_header_link(frame: "workshop_variations_results", path: ->(p) { workshop_variations_path(p) }, base: sort_base)
+%>
+<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @workshop_variations.any? %>">
+  <table class="table table-responsive table-bordered table-curved">
+    <thead>
+      <tr id="table-thead-tr">
+        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]"></th>
+        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 whitespace-nowrap"><%= sort_link.call("name", "Name") %></th>
+        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Description</th>
+        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700"><%= sort_link.call("author", "Author") %></th>
+        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">From idea</th>
+        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700"><%= sort_link.call("updated_at", "Updated") %></th>
+        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]">Edit</th>
+      </tr>
+    </thead>
+
+    <tbody class="divide-y divide-gray-100">
+      <% if @workshop_variations.any? %>
+        <% @workshop_variations.each do |workshop_variation| %>
+          <tr class="hover:bg-gray-50 transition-colors duration-150">
+            <td class="px-4 py-2">
+              <div class="w-12 h-9 rounded bg-gray-200 overflow-hidden">
+                <%= render "assets/display_image",
+                           resource: workshop_variation,
+                           width: 12, height: 9,
+                           link: false,
+                           link_to_object: false,
+                           file: workshop_variation.display_image,
+                           variant: :gallery %>
+              </div>
+            </td>
+            <td class="px-4 py-2" title="<%= workshop_variation.name %>">
+              <div class="flex items-center gap-2 text-sm text-gray-800 font-semibold">
+                <%= link_to "#{truncate(workshop_variation.name, length: 30)} (#{workshop_variation.windows_type&.short_name || 'Combined'})", workshop_variation_path(workshop_variation), data: { turbo_frame: "_top" }, class: "hover:text-blue-600 hover:underline" %>
+                <% unless workshop_variation.published? %>
+                  <span class="inline-flex items-center pl-2 pr-3 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap">
+                    <span class="inline-flex justify-center w-4"><i class="fa-solid fa-eye-slash"></i></span>
+                    <span class="ml-1">Unpublished</span>
+                  </span>
+                <% end %>
+              </div>
+              <% if workshop_variation.workshop %>
+                <div class="text-xs text-gray-400">
+                  <%= link_to truncate(strip_tags(workshop_variation.workshop.name), length: 40),
+                              workshop_path(workshop_variation.workshop),
+                              data: { turbo_frame: "_top" },
+                              class: "hover:text-gray-600" %>
+                </div>
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-600">
+              <% plain = workshop_variation.rhino_body.to_plain_text %>
+              <% if plain.present? %>
+                <span title="<%= truncate(plain, length: 500) %>">
+                  <i class="fas fa-file-lines text-gray-400"></i>
+                </span>
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-800 text-center">
+              <%= credited_author_link(workshop_variation, class: "text-gray-500 hover:text-gray-700") %>
+            </td>
+            <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
+              <% if workshop_variation.workshop_variation_idea %>
+                <%= link_to "Idea ##{workshop_variation.workshop_variation_idea.id}",
+                            workshop_variation_idea_path(workshop_variation.workshop_variation_idea),
+                            data: { turbo_frame: "_top" },
+                            class: "text-purple-600 hover:text-purple-800 hover:underline" %>
+              <% else %>
+                <span class="text-gray-300">--</span>
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-500 text-center whitespace-nowrap"><%= workshop_variation.updated_at&.strftime('%m/%d/%y') %></td>
+            <td class="px-4 py-2 text-center whitespace-nowrap">
+              <%= link_to "Edit",
+                          edit_workshop_variation_path(workshop_variation),
+                          data: { turbo_frame: "_top" },
+                          class: "btn btn-secondary-outline" %>
+            </td>
+          </tr>
+        <% end %>
+      <% else %>
+        <tr>
+          <td colspan="7" class="text-center py-16">
+            <h2 class="text-gray-600 text-lg mb-2">No <%= WorkshopVariation.model_name.human.pluralize.downcase %> found.</h2>
+            <% if allowed_to?(:new?, WorkshopVariation) %>
+              <div class="p-3">
+                <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
+                            new_workshop_variation_path,
+                            data: { turbo_frame: "_top" },
+                            class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% if @workshop_variations.any? %>
+  <div class="mt-6 flex justify-center">
+    <div class="pagination mt-6"><%= tailwind_paginate @workshop_variations %></div>
+  </div>
+<% end %>

--- a/app/views/workshop_variations/index.html.erb
+++ b/app/views/workshop_variations/index.html.erb
@@ -4,7 +4,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
       <h1 class="text-2xl font-semibold text-gray-900">
-        <%= WorkshopVariation.model_name.human.pluralize %> (<%= @workshop_variations_count %>)
+        <%= WorkshopVariation.model_name.human.pluralize %>
       </h1>
       <div class="flex gap-2">
         <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
@@ -17,109 +17,12 @@
 
     <%= render "shared/filtered_to", record: @author, clear_path: workshop_variations_path %>
 
-    <div class="rounded-xl bg-white p-6">
-      <div class="overflow-x-auto">
-        <table class="table table-responsive table-bordered table-curved">
-          <thead>
-          <tr id="table-thead-tr">
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]"></th>
-            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 whitespace-nowrap">Name</th>
-            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Description</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">
-              <%= link_to workshop_variations_path(request.query_parameters.merge(sort: "author", direction: (@sort == "author" && @sort_direction == "asc") ? "desc" : "asc", page: nil)),
-                          class: "inline-flex items-center justify-center gap-1 text-gray-700 hover:text-gray-900" do %>
-                Author
-                <% if @sort == "author" %>
-                  <i class="fa-solid <%= @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down" %> text-xs opacity-70"></i>
-                <% end %>
-              <% end %>
-            </th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">From idea</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Updated</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]">Edit</th>
-          </tr>
-        </thead>
+    <%= render "workshop_variations_count" %>
 
-        <tbody class="divide-y divide-gray-100">
-          <% @workshop_variations.each do |workshop_variation| %>
-            <tr class="hover:bg-gray-50 transition-colors duration-150">
-              <td class="px-4 py-2">
-                <div class="w-12 h-9 rounded bg-gray-200 overflow-hidden">
-                  <%= render "assets/display_image",
-                             resource: workshop_variation,
-                             width: 12, height: 9,
-                             link: false,
-                             link_to_object: false,
-                             file: workshop_variation.display_image,
-                             variant: :gallery %>
-                </div>
-              </td>
-              <td class="px-4 py-2" title="<%= workshop_variation.name %>">
-                <div class="flex items-center gap-2 text-sm text-gray-800 font-semibold">
-                  <%= link_to "#{truncate(workshop_variation.name, length: 30)} (#{workshop_variation.windows_type&.short_name || 'Combined'})", workshop_variation_path(workshop_variation), class: "hover:text-blue-600 hover:underline" %>
-                  <% unless workshop_variation.published? %>
-                    <span class="inline-flex items-center pl-2 pr-3 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap">
-                      <span class="inline-flex justify-center w-4"><i class="fa-solid fa-eye-slash"></i></span>
-                      <span class="ml-1">Unpublished</span>
-                    </span>
-                  <% end %>
-                </div>
-                <% if workshop_variation.workshop %>
-                  <div class="text-xs text-gray-400">
-                    <%= link_to truncate(strip_tags(workshop_variation.workshop.name), length: 40),
-                                workshop_path(workshop_variation.workshop),
-                                class: "hover:text-gray-600" %>
-                  </div>
-                <% end %>
-              </td>
-              <td class="px-4 py-2 text-sm text-gray-600">
-                <% plain = workshop_variation.rhino_body.to_plain_text %>
-                <% if plain.present? %>
-                  <span title="<%= truncate(plain, length: 500) %>">
-                    <i class="fas fa-file-lines text-gray-400"></i>
-                  </span>
-                <% end %>
-              </td>
-              <td class="px-4 py-2 text-sm text-gray-800 text-center">
-                <%= credited_author_link(workshop_variation, class: "text-gray-500 hover:text-gray-700") %>
-              </td>
-              <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
-                <% if workshop_variation.workshop_variation_idea %>
-                  <%= link_to "Idea ##{workshop_variation.workshop_variation_idea.id}",
-                              workshop_variation_idea_path(workshop_variation.workshop_variation_idea),
-                              class: "text-purple-600 hover:text-purple-800 hover:underline" %>
-                <% else %>
-                  <span class="text-gray-300">--</span>
-                <% end %>
-              </td>
-              <td class="px-4 py-2 text-sm text-gray-500 text-center whitespace-nowrap"><%= workshop_variation.updated_at&.strftime('%m/%d/%y') %></td>
-              <td class="px-4 py-2 text-center whitespace-nowrap">
-                <%= link_to "Edit",
-                            edit_workshop_variation_path(workshop_variation),
-                            class: "btn btn-secondary-outline" %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-    </div>
+    <% result_src = workshop_variations_path + "?" + request.query_string %>
 
-    <!-- Empty state -->
-    <% unless @workshop_variations.any? %>
-      <p class="text-gray-500 text-center py-6">
-        No <%= WorkshopIdea.model_name.human.pluralize.downcase %> found.
-      </p>
-    <% end %>
-
-    <!-- Pagination -->
-    <% if @workshop_variations %>
-      <div class="mt-6 flex justify-center">
-        <div class="pagination">
-          <%= tailwind_paginate @workshop_variations %>
-        </div>
-      </div>
+    <%= turbo_frame_tag "workshop_variations_results", src: result_src do %>
+      <%= render "results_skeleton" %>
     <% end %>
   </div>
 </div>
-

--- a/app/views/workshop_variations/workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/workshop_variations_results.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "workshop_variations_results" do %>
+  <%= render "workshop_variations_results" %>
+<% end %>

--- a/spec/helpers/sortable_header_helper_spec.rb
+++ b/spec/helpers/sortable_header_helper_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe SortableHeaderHelper, type: :helper do
+  describe "#sort_icon_class" do
+    it "returns the neutral arrow for an inactive column" do
+      assign(:sort, "title")
+      assign(:sort_direction, "asc")
+      expect(helper.sort_icon_class("author")).to eq("fa-sort")
+    end
+
+    it "returns the up arrow for the active ascending column" do
+      assign(:sort, "title")
+      assign(:sort_direction, "asc")
+      expect(helper.sort_icon_class("title")).to eq("fa-arrow-up")
+    end
+
+    it "returns the down arrow for the active descending column" do
+      assign(:sort, "title")
+      assign(:sort_direction, "desc")
+      expect(helper.sort_icon_class("title")).to eq("fa-arrow-down")
+    end
+  end
+
+  describe "#sort_header_link" do
+    let(:link) do
+      helper.sort_header_link(frame: "stories_results",
+                              path: ->(p) { "/stories?#{p.to_query}" },
+                              base: { query: "art" })
+    end
+
+    it "toggles an active descending column to ascending" do
+      assign(:sort, "title")
+      assign(:sort_direction, "desc")
+      html = link.call("title", "Title")
+      expect(html).to include("direction=asc")
+      expect(html).to include("sort=title")
+      expect(html).to include("query=art")
+      expect(html).to include('data-turbo-frame="stories_results"')
+    end
+
+    it "defaults a fresh column to descending" do
+      assign(:sort, "created_at")
+      assign(:sort_direction, "asc")
+      html = link.call("title", "Title")
+      expect(html).to include("direction=desc")
+    end
+  end
+end

--- a/spec/requests/authored_content_author_filter_spec.rb
+++ b/spec/requests/authored_content_author_filter_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe "Authored-content indexes filtered by author", type: :request do
     create(:workshop_variation, name: "Other Variation", workshop: published_workshop, author: other)
 
     get workshop_variations_path(author_id: author.id)
-
     expect(response.body).to include("Filtered to")
+
+    get workshop_variations_path(author_id: author.id), headers: { "Turbo-Frame" => "workshop_variations_results" }
     expect(response.body).to include("Ada Variation")
     expect(response.body).not_to include("Other Variation")
   end

--- a/spec/requests/workshop_variations_spec.rb
+++ b/spec/requests/workshop_variations_spec.rb
@@ -178,23 +178,35 @@ RSpec.describe "/workshop_variations", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "sorts by the credited author's name" do
+      it "sorts by the credited author's name on the lazy turbo-frame request" do
         aaron = create(:person, first_name: "Aaron", last_name: "Adams")
         zoe = create(:person, first_name: "Zoe", last_name: "Zephyr")
         var_a = create(:workshop_variation, valid_attributes.merge(name: "First variation", author: aaron))
         var_z = create(:workshop_variation, valid_attributes.merge(name: "Second variation", author: zoe))
 
-        get workshop_variations_path, params: { sort: "author", direction: "asc" }
+        get workshop_variations_path, params: { sort: "author", direction: "asc" },
+                                      headers: { "Turbo-Frame" => "workshop_variations_results" }
 
         expect(response.body.index(var_a.name)).to be < response.body.index(var_z.name)
       end
 
-      it "matches a search query against the credited author's name" do
+      it "sorts by name on the lazy turbo-frame request" do
+        var_b = create(:workshop_variation, valid_attributes.merge(name: "Bravo variation"))
+        var_a = create(:workshop_variation, valid_attributes.merge(name: "Alpha variation"))
+
+        get workshop_variations_path, params: { sort: "name", direction: "asc" },
+                                      headers: { "Turbo-Frame" => "workshop_variations_results" }
+
+        expect(response.body.index(var_a.name)).to be < response.body.index(var_b.name)
+      end
+
+      it "matches a search query against the credited author's name on the lazy turbo-frame request" do
         person = create(:person, first_name: "Bartholomew", last_name: "Quill")
         authored = create(:workshop_variation, valid_attributes.merge(name: "Authored variation", author: person))
         other = create(:workshop_variation, valid_attributes.merge(name: "Other variation"))
 
-        get workshop_variations_path, params: { query: "Bartholomew" }
+        get workshop_variations_path, params: { query: "Bartholomew" },
+                                      headers: { "Turbo-Frame" => "workshop_variations_results" }
 
         expect(response.body).to include(authored.name)
         expect(response.body).not_to include(other.name)

--- a/spec/views/workshop_variations/index.html.erb_spec.rb
+++ b/spec/views/workshop_variations/index.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "workshop_variations/index", type: :view do
+  let(:admin) { create(:user, super_user: true) }
+  let(:variation1) { create(:workshop_variation, name: "Alpha variation") }
+  let(:variation2) { create(:workshop_variation, name: "Bravo variation") }
+
+  before(:each) do
+    sign_in admin
+    allow(view).to receive(:turbo_frame_request?).and_return(true)
+    assign(:workshop_variations,
+           WorkshopVariationDecorator.decorate_collection(paginated([ variation1, variation2 ])))
+  end
+
+  it "renders a list of workshop variations" do
+    render template: "workshop_variations/workshop_variations_results"
+    expect(rendered).to include(variation1.name, variation2.name)
+  end
+
+  it "renders sortable column headers" do
+    render template: "workshop_variations/workshop_variations_results"
+    expect(rendered).to include("sort=name", "sort=author", "sort=updated_at")
+  end
+
+  it "renders a friendly message when no workshop variations exist" do
+    assign(:workshop_variations, paginated([]))
+    render template: "workshop_variations/workshop_variations_results"
+    expect(rendered).to match(/No workshop variations found/)
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained refactor onto an existing index pattern + a helper extraction, covered by request/view/helper specs

### What is the goal of this PR and why is this important?
- Workshop variations was the only columnar index still rendered full-page with a single hand-rolled Author sort; every other table index (stories, community_news, bookmarks) uses a lazy Turbo-frame + sortable column headers.
- Brings it onto that shared pattern and removes the sort-header duplication those pages carried inline.

### How did you approach the change?
- Extracted `SortableHeaderHelper` (`sort_icon_class` + `sort_header_link`) from the `sort_base`/`sort_icon`/`sort_link` lambdas that were copy-pasted inline in **stories**, **community_news**, and **bookmarks**; all three now call the helper.
- Converted `workshop_variations#index` to branch on `turbo_frame_request?`, added the `_results`/`_count`/skeleton partials + `workshop_variations_results` frame, and made Name / Author / Updated sortable via the shared helper. Search box now submits into the frame.
- Specs: request specs use the `Turbo-Frame` header for sort/search; added an index view spec and a helper spec.

### Anything else to add?
- **Not changed:** `workshops` and `resources` are card/list layouts (radio-button sort / none) — column-header sorting doesn't fit them, so they're intentionally left alone.
- The other framed tables (allocations, payments, organizations, people, users, monthly_reports) currently have **no** sorting at all; they could adopt this helper if/when sorting is added, but that's out of scope here.
- Grants uses a different client-side Stimulus sort (`shared/_sortable_header`) and is deliberately not folded in.