### PR TITLE
Fix dev seeds broken by author-crediting standardization (#1940)

### DIFF
--- a/db/seeds/dev/home_page_content.rb
+++ b/db/seeds/dev/home_page_content.rb
@@ -34,7 +34,7 @@ puts "Creating CommunityNews…"
                .first_or_create!(
                   body: body_content,
                   rhino_body: "<p>#{body_content}</p>",
-                  author_id: User.all.sample&.id,
+                  author_id: [ Person.all.sample, nil, nil ].sample&.id,
                   created_by_id: User.first&.id,
                   updated_by_id: User.first&.id,
                   organization_id: Organization.all.sample&.id,
@@ -73,6 +73,7 @@ puts "Creating WorkshopIdeas…"
   "Empowerment Through Mixed Media"
 ].each do |title|
   WorkshopIdea.where(title: title).first_or_create!(
+    author_credit_preference: AuthorCreditable::AUTHOR_CREDIT_PREFERENCES.sample,
     windows_type_id: WindowsType.all.sample&.id,
     created_by_id: User.first&.id,
     updated_by_id: User.first&.id,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two-line dev-seed fix, no app logic

### What is the goal of this PR and why is this important?
- `db:seed:dev` (and `bin/setup`) aborts after #1940 merged. Restores a working dev seed.

### How did you approach the change?
- `WorkshopIdea` now calls `require_author_credit_preference` (#1940 dropped its `full_name` default) — the seed now sets `author_credit_preference`, matching the sibling idea blocks.
- #1940 flipped `CommunityNews#author_id` from a User to a Person FK — the seed now assigns a `Person` id (nil-weighted like `resources.rb`) instead of a `User` id, which would FK-violate.

### Anything else to add?
- Checked every other author reference in the seeds (`resources.rb`, `workshops.rb`, `analytics.rb`, `events_management.rb`) — all already consistent with the current schema.