### PR TITLE
Shorten and standardize dev seed console output

### DIFF
--- a/db/seeds/dev/bookmarks.rb
+++ b/db/seeds/dev/bookmarks.rb
@@ -44,5 +44,5 @@ if amy && aisha
   puts "  Created #{amy.bookmarks.count} bookmarks for Amy, #{aisha.bookmarks.count} for Aisha"
   shared = amy.bookmarks.pluck(:bookmarkable_type, :bookmarkable_id) &
            aisha.bookmarks.pluck(:bookmarkable_type, :bookmarkable_id)
-  puts "  #{shared.size} bookmarks shared between both users"
+  puts "  #{shared.size} shared between both users"
 end

--- a/db/seeds/dev/bulk_payments.rb
+++ b/db/seeds/dev/bulk_payments.rb
@@ -41,7 +41,7 @@ unless bulk_form
   return
 end
 
-puts "Seeding bulk payment demo on '#{event.title}' (webhook, cash/check, and pending)…"
+puts "Creating bulk payment demo on '#{event.title}' (webhook, cash/check, and pending)…"
 
 cost_cents = event.cost_cents.to_i
 payer_domain = "bulkpaydemo.seed.example.com" # marks this seed's payers for teardown
@@ -227,7 +227,5 @@ build_submission.(payer: sam, method: "Credit card (later)",
 
 submissions = FormSubmission.where(person: Person.where("email LIKE ?", "%@#{payer_domain}"),
                                    form: bulk_form, role: "bulk_payment")
-paid = Payment.where(form_submission: submissions).group(:type).count
-puts "  Added #{submissions.count} bulk payments to '#{event.title}' " \
-     "(payments: #{paid.map { |t, c| "#{c} #{t}" }.join(', ')}; the rest pending)"
-puts "  Bulk payment seeds complete!"
+puts "  Created #{submissions.count} bulk payment submissions"
+puts "  #{Payment.where(form_submission: submissions).count} paid, the rest pending"

--- a/db/seeds/dev/monthly_reports.rb
+++ b/db/seeds/dev/monthly_reports.rb
@@ -139,7 +139,6 @@ if MonthlyReport.none?
         )
       end
     end
-    puts "  Created monthly reports for Aisha across #{1 + report_counts.size} batches"
   end
 
   # A few monthly reports for the admin user as well

--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -139,8 +139,7 @@ end
   notification.update!(email_body_html: body_html, email_body_text: body_text) if notification.email_body_html.blank?
 end
 
-puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications " \
-     "(#{Notification.where(kind: 'contact_us_fyi', responded: true).count} marked responded)"
+puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications"
 
 # Custom event reminders Amy received. These demonstrate the editable subject and
 # message on the bulk-reminder page: each is a delivered reminder with the

--- a/db/seeds/dev/payments.rb
+++ b/db/seeds/dev/payments.rb
@@ -1,7 +1,7 @@
 # Payment seeds (dev-only) - run on their own via `rake db:seed:payments`, or
 # as part of `rake db:seed:dev`.
 
-puts "Seeding Payments, Allocations, and Refunds..."
+puts "Creating Payments, Allocations, and Refunds..."
 
 payment_ids_start = Payment.maximum(:id) || 0
 allocation_ids_start = Allocation.maximum(:id) || 0
@@ -77,7 +77,6 @@ reg_frank = EventRegistration.find_or_create_by!(registrant: frank, event: event
 reg_gary = EventRegistration.find_or_create_by!(registrant: gary, event: event)
 reg_iris = EventRegistration.find_or_create_by!(registrant: iris, event: event)
 
-puts "  Payment made but allocation reverted)"
 payment1 = CashPayment.find_or_create_by!(
   person: bob,
   amount_cents: event_cost_cents
@@ -98,7 +97,6 @@ reversal_allocation1 = Allocation.create!(
 )
 original_allocation1.update!(reverted_id: reversal_allocation1.id)
 
-puts "  Overpayment with full allocation (Alice pays $6000, covers 4 people)"
 payment2 = CashPayment.find_or_create_by!(
   person: alice,
   amount_cents: 600000
@@ -110,7 +108,6 @@ Allocation.find_or_create_by!(source: payment2, allocatable: reg_charlie, amount
 Allocation.find_or_create_by!(source: payment2, allocatable: reg_diana, amount: event_cost_cents) { |a| a.created_at = 4.days.ago }
 Allocation.find_or_create_by!(source: payment2, allocatable: reg_eve, amount: event_cost_cents) { |a| a.created_at = 4.days.ago }
 
-puts "  Payment with remaining available ($2000 payment, $1500 allocated, $500 remaining)"
 payment3 = CashPayment.find_or_create_by!(
   person: frank,
   amount_cents: 200000
@@ -125,7 +122,6 @@ Allocation.find_or_create_by!(
   a.created_at = 3.days.ago
 end
 
-puts "  Full refund ($1500 payment, fully allocated, fully refunded)"
 payment4 = CashPayment.find_or_create_by!(
   person: gary,
   amount_cents: event_cost_cents
@@ -153,7 +149,6 @@ Refund.create!(
   created_at: 1.day.ago
 )
 
-puts "  Creating Scenario 8: Payment with no allocations ($10000, full amount remaining)"
 CashPayment.find_or_create_by!(
   person: holly,
   amount_cents: 1000000
@@ -161,7 +156,6 @@ CashPayment.find_or_create_by!(
   p.created_at = 7.days.ago
 end
 
-puts "  Partial payment"
 payment9 = CashPayment.find_or_create_by!(
   person: iris,
   amount_cents: 100000
@@ -336,11 +330,4 @@ register_with_payments.(facilitator_training,
 # across the full matrix of allocation states, using dedicated demo people so
 # those states stay clean and don't collide with the registrants funded above.
 
-[ facilitator_training, trauma_training, mindful_art ].compact.each do |event|
-  dashboard = EventDashboard.new(event)
-  puts "  #{event.title}: #{dashboard.registrant_count} registrants, " \
-       "received #{dashboard.received_cents / 100.0}, outstanding #{dashboard.outstanding_cents / 100.0}, " \
-       "scholarships #{dashboard.scholarship_total_cents / 100.0} (#{dashboard.scholarship_recipient_count})"
-end
-
-puts "  Payment seeds complete!"
+puts "  Created #{Payment.count} payments, #{Allocation.count} allocations, #{Refund.count} refunds"

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -21,12 +21,12 @@
 # events and people, skips gracefully when absent, and skips any registration
 # that already has a scholarship so it is safe to re-run.
 
-puts "Seeding Scholarships for dev event registrations…"
+puts "Creating Scholarships for dev event registrations…"
 
 facilitator_training = Event.find_by(title: "AWBW Facilitator Training")
 
 # Every event that asks the scholarship questions (has a scholarship EventForm).
-# Reused below to surface non-flagship applicants and print the per-event summary.
+# Reused below to surface non-flagship applicants.
 scholarship_events = Event.joins(:event_forms).where(event_forms: { role: "scholarship" }).distinct.to_a
 
 # These are AWBW facilitator trainings (the "TAC" a recipient attends). Flag them
@@ -44,7 +44,7 @@ end
 #   * a mix of donor types — three organization funders and two individual
 #     (Person) funders, since donor is polymorphic;
 #   * distinct donation totals, eligibility criteria, and tasks per grant.
-puts "Seeding Grants…"
+puts "Creating Grants…"
 
 # Resolve a grant's donor by type: organizations by name, individuals by their
 # first/last name (so a Person can fund a grant, mirroring the polymorphic donor).
@@ -146,7 +146,7 @@ end
 # with a matching primary sector, age group, and a non-facilitator agency
 # affiliation (title + organization) so the recipient header renders like the real
 # export.
-puts "Seeding Scholarship application answers…"
+puts "Creating Scholarship application answers…"
 
 # Keyed by the scholarship form's field identifiers (see
 # FormBuilderService#build_scholarship_fields).
@@ -426,19 +426,13 @@ end
   end
 end
 
-scholarship_events.each do |event|
-  dashboard = EventDashboard.new(event)
-  puts "  #{event.title}: scholarships #{dashboard.scholarship_total_cents / 100.0} " \
-       "(#{dashboard.scholarship_recipient_count} recipients)"
-end
-
 # --- Standalone grant-funded scholarships ----------------------------------
 # Beyond the event-allocated awards above (which now draw from these grants too),
 # seed a few standalone grant awards — recipient + grant, no event allocation —
 # mirroring the grant CRUD flow, so the grant pages show draws and remaining
 # balances. Idempotent: only adds standalone awards to a grant that has none yet,
 # and skips any award that would exceed the grant's remaining funds.
-puts "Seeding standalone grant-funded scholarships…"
+puts "Creating standalone grant-funded scholarships…"
 
 # Reuse existing dev people as recipients, cycling so each award goes to a
 # distinct person where the pool allows.
@@ -467,8 +461,6 @@ grant_plans.each do |(name, _donor_type, _donor_name, _amount_cents, awards, _el
     Scholarship.create!(recipient: next_recipient.(), grant: grant,
                         amount_cents: award_cents, tasks_completed: j.even?)
   end
-
-  puts "  #{grant.name}: #{grant.scholarships.count} scholarships, remaining #{grant.remaining_dollars}"
 end
 
 # --- Index demo states: multi-grant funder + Reinstate ---------------------
@@ -478,7 +470,7 @@ end
 # existing funder, with two recipients whose program orgs carry addresses — the
 # second's facilitator affiliation is lapsed, so its org reads as "Reinstate".
 # Idempotent: keyed on the sibling grant's name and its having no awards yet.
-puts "Seeding scholarship index demo states (multi-grant funder, Reinstate)…"
+puts "Creating scholarship index demo states (multi-grant funder, Reinstate)…"
 
 anchor_grant = grants.first
 if anchor_grant && recipient_orgs.any?
@@ -511,7 +503,6 @@ if anchor_grant && recipient_orgs.any?
     end
   end
 
-  puts "  #{sibling.funder_name}: now funds #{Grant.where(donor: anchor_grant.donor).count} grants"
 end
 
-puts "  Scholarship seeds complete!"
+puts "  Created #{Scholarship.count} scholarships across #{Grant.count} grants"

--- a/db/seeds/dev/users.rb
+++ b/db/seeds/dev/users.rb
@@ -3,7 +3,7 @@
 # must never run in production, so they live here rather than in `db/seeds.rb`
 # (which seeds only the required base users: Umberto, Amy, Aisha, Orphaned).
 
-puts "Seeding dev user variations (invite/lock/confirmation states)…"
+puts "Creating dev user variations (invite/lock/confirmation states)…"
 
 # created_by/updated_by point at the base admin, seeded by `db:seed` first.
 admin = User.find_by!(email: "umberto.user@example.com")

--- a/db/seeds/dev/workshops.rb
+++ b/db/seeds/dev/workshops.rb
@@ -365,8 +365,6 @@ workshops.each do |workshop|
     )
   end
 end
-puts "Done assigning categories and sectors."
-
 # A few unpublished (non-canonical) sectors that still carry taggings, so the
 # taggings admin has data exercising the "tagged but hidden" state. The base
 # db/seeds.rb only creates the canonical SECTOR_TYPES; these are dev-only and
@@ -385,8 +383,6 @@ workshop_pool = Workshop.all.to_a
     )
   end
 end
-puts "Done creating unpublished sectors with taggings."
-
 # A few unpublished (non-canonical) categories that still carry taggings, so the
 # taggings admin has data exercising the "tagged but hidden" state for categories
 # too. The base db/seeds.rb only creates canonical categories; these are dev-only,
@@ -407,8 +403,6 @@ art_type = CategoryType.where("LOWER(name) = LOWER(?)", "ArtType").first_or_crea
     )
   end
 end
-puts "Done creating unpublished categories with taggings."
-
 puts "Creating Workshop Variations…"
 # rubocop:disable Style/PercentLiteralDelimiters
 variations = [


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 dev-seed logging only — no seeding/data logic changed

### What is the goal of this PR and why is this important?
- A `db:seed:dev` run printed verbose per-scenario/per-record narration and flip-flopped between "Creating" and "Seeding" headers, making it hard to scan.

### How did you approach the change?
- Standardized every create header on **"Creating"**, dropped the per-scenario/per-record narration and "Done…/complete!" lines, and kept a couple of short aggregate count lines per section.
- Touched only `puts` output — no seeding/data logic changed; rubocop and `ruby -c` pass.

### UI Testing Checklist
- N/A — console output only, no UI.

### Anything else to add?
- Left the base `db/seeds.rb` and `events_management.rb` step headers as-is (already consistent / accurate non-create verbs).