### PR TITLE
Fix 500 in rich text asset mentions for decorated records

### DIFF
--- a/app/controllers/rich_text_asset_mentions_controller.rb
+++ b/app/controllers/rich_text_asset_mentions_controller.rb
@@ -2,8 +2,7 @@ class RichTextAssetMentionsController < ApplicationController
   skip_verify_authorized
   def index
     # authorize!
-    record = GlobalID::Locator.locate_signed(params[:sgid])
-    record = record.object if record.respond_to?(:decorated?) && record.decorated?
+    record = Draper.undecorate(GlobalID::Locator.locate_signed(params[:sgid]))
 
     unless record.respond_to?(:rich_text_assets)
       render json: [] and return

--- a/app/controllers/rich_text_asset_mentions_controller.rb
+++ b/app/controllers/rich_text_asset_mentions_controller.rb
@@ -3,8 +3,9 @@ class RichTextAssetMentionsController < ApplicationController
   def index
     # authorize!
     record = GlobalID::Locator.locate_signed(params[:sgid])
+    record = record.object if record.respond_to?(:decorated?) && record.decorated?
 
-    unless record
+    unless record.respond_to?(:rich_text_assets)
       render json: [] and return
     end
 

--- a/app/helpers/rhino_editor_helper.rb
+++ b/app/helpers/rhino_editor_helper.rb
@@ -1,8 +1,7 @@
 module RhinoEditorHelper
   # custom rhino editor with stimulus controller attached to edit raw source html
   def rhino_editor(form, base_attribute_name, label: nil, hint: nil)
-    object = form.object
-    object = object.object if object.respond_to?(:decorated?) && object.decorated?
+    object = Draper.undecorate(form.object)
     rhino_attr = :"rhino_#{base_attribute_name}"
     field_id = form.field_id(rhino_attr)
     value = object.public_send(rhino_attr)

--- a/app/helpers/rhino_editor_helper.rb
+++ b/app/helpers/rhino_editor_helper.rb
@@ -1,9 +1,11 @@
 module RhinoEditorHelper
   # custom rhino editor with stimulus controller attached to edit raw source html
   def rhino_editor(form, base_attribute_name, label: nil, hint: nil)
+    object = form.object
+    object = object.object if object.respond_to?(:decorated?) && object.decorated?
     rhino_attr = :"rhino_#{base_attribute_name}"
     field_id = form.field_id(rhino_attr)
-    value = form.object.public_send(rhino_attr)
+    value = object.public_send(rhino_attr)
 
     label_tag =
       if label.present?
@@ -70,7 +72,7 @@ module RhinoEditorHelper
       data: {
         blob_url_template: rails_service_blob_url(":signed_id", ":filename"),
         direct_upload_url: rails_direct_uploads_url,
-        model_sgid: form.object.persisted? ? form.object.to_sgid.to_s : nil
+        model_sgid: object.persisted? ? object.to_sgid.to_s : nil
       }
     )
 

--- a/spec/requests/rich_text_asset_mentions_spec.rb
+++ b/spec/requests/rich_text_asset_mentions_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "/rich_text_asset_mentions", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "GET /index" do
+    it "returns an empty list when the sgid resolves to a decorated record that owns no rich text assets" do
+      event = create(:event)
+      sgid = event.decorate.to_sgid.to_s
+
+      get rich_text_asset_mentions_path(format: :json, sgid: sgid, query: "1")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it "returns an empty list when the sgid cannot be located" do
+      get rich_text_asset_mentions_path(format: :json, sgid: "bogus", query: "1")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained controller/helper guard fix with a reproducing spec

### What is the goal of this PR and why is this important?
- Fixes a prod 500 (`NoMethodError: undefined method 'rich_text_assets' for an instance of EventDecorator`) when typing `!`-mentions in the Event editor.

### How did you approach the change?
- The rhino helper embedded the **decorator's** signed GlobalID (Event forms decorate the record), so the mentions endpoint located an `EventDecorator` and called `.rich_text_assets` — an association Event doesn't own.
- Emit the underlying **model's** sgid from the helper, and guard the association lookup in the controller so records that don't own rich text assets return `[]` instead of raising.
- Added a request spec that reproduces the exact 500 first, then passes.

### Anything else to add?
- Honeybadger doesn't record the offending user here (no `Honeybadger.context`); a follow-up PR adds that.