### PR TITLE
Add signed-in user to Honeybadger fault context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user! # ensures only logged-in users can access pages
   before_action :track_user_with_ahoy, unless: :devise_controller?
   before_action :set_current_user # for AhoyTrackable in models
+  before_action :set_honeybadger_context # so faults name the affected user
   before_action :set_paper_trail_whodunnit
   before_action :preload_current_user_associations
 
@@ -72,5 +73,11 @@ class ApplicationController < ActionController::Base
 
   def set_current_user
     Current.user = current_user if user_signed_in? # needed for Ahoy tracking in models
+  end
+
+  def set_honeybadger_context
+    return unless user_signed_in?
+
+    Honeybadger.context(user_id: current_user.id, user_email: current_user.email)
   end
 end

--- a/spec/requests/honeybadger_context_spec.rb
+++ b/spec/requests/honeybadger_context_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Honeybadger context", type: :request do
+  before { allow(Honeybadger).to receive(:context) }
+
+  it "records the signed-in user so faults name who hit them" do
+    user = create(:user)
+
+    sign_in user
+    get root_path
+
+    expect(Honeybadger).to have_received(:context)
+      .with(hash_including(user_id: user.id, user_email: user.email))
+  end
+
+  it "does not set user context for anonymous visitors" do
+    get root_path
+
+    expect(Honeybadger).not_to have_received(:context).with(hash_including(:user_id))
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one before_action adding user context to error reports, with a spec

### What is the goal of this PR and why is this important?
- Faults (e.g. the recent rich-text-mentions 500) don't name the affected user, forcing triage to decode request params to figure out who hit the error.

### How did you approach the change?
- Add a `set_honeybadger_context` before_action in `ApplicationController` that attaches `user_id`/`user_email` for authenticated requests only; anonymous visitors get no user context.
- Added a request spec covering both the signed-in and anonymous cases.

### Anything else to add?
- Follow-up to #1961 (the fix for the fault that surfaced this gap).