### PR TITLE
Add teal + fuchsia to swatch palette

### DIFF
--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -61,7 +61,7 @@ module DomainTheme
   # Ordered palette of colours offered as user-pickable swatches (e.g. the
   # callout colour dropdown). A curated subset of the full theme palette that
   # reads well as tinted boxes — add a colour here once and every picker updates.
-  SWATCH_COLORS = %i[ amber orange indigo blue green purple rose gray ].freeze
+  SWATCH_COLORS = %i[ amber orange indigo blue teal green purple fuchsia rose gray ].freeze
 
   # Semantic roles for a colour "swatch" — the full set of Tailwind utilities for
   # tinting a boxed UI element (callout cards today; the amount-due / scholarship


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 one-line palette constant addition, colours already safelisted

## What
- Add `teal` and `fuchsia` to `DomainTheme::SWATCH_COLORS`, widening the user-pickable colour swatch set.

## Why
- Every colour picker (callout dropdown, etc.) reads from this one constant, so adding a colour here surfaces it everywhere. Both colours are already generated by the `@source inline(...)` safelist in `application.tailwind.css`, so no CSS change is needed.