### PR TITLE
Hide the scholarship card on free-event registrations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ When changing a model or controller, check whether these related files need upda
 - Prefer POROs over concerns when possible
 - **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
+- **Comment only when the reason isn't obvious from the code** — don't restate what the code already says. When a comment is warranted (a non-obvious why, a gotcha), keep it brief and clear.
 
 ## RuboCop (rubocop-rails-omakase)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ When changing a model or controller, check whether these related files need upda
 - Prefer POROs over concerns when possible
 - **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
+- **Comment only when the reason isn't obvious from the code** — don't restate what the code already says. When a comment is warranted (a non-obvious why, a gotcha), keep it brief and clear.
 
 ## RuboCop (rubocop-rails-omakase)
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -294,9 +294,6 @@ class Event < ApplicationRecord
     ce_hours_offered.to_f.positive?
   end
 
-  # A scholarship offsets a registration fee, so it only applies to paid events —
-  # a free event has nothing to subsidize. Mirrors #ce_eligible? as a named
-  # "does this apply" predicate, derived from the cost rather than a stored flag.
   def scholarship_eligible?
     cost_cents.to_i.positive?
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -294,6 +294,13 @@ class Event < ApplicationRecord
     ce_hours_offered.to_f.positive?
   end
 
+  # A scholarship offsets a registration fee, so it only applies to paid events —
+  # a free event has nothing to subsidize. Mirrors #ce_eligible? as a named
+  # "does this apply" predicate, derived from the cost rather than a stored flag.
+  def scholarship_eligible?
+    cost_cents.to_i.positive?
+  end
+
   def attachable_content_type
     "application/vnd.active_record.event"
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -295,7 +295,7 @@ class Event < ApplicationRecord
   end
 
   def scholarship_eligible?
-    cost_cents.to_i.positive?
+    cost_cents.to_i.positive? || scholarship_form.present?
   end
 
   def attachable_content_type

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -159,12 +159,19 @@
         </div>
       </div>
 
-      <%# ---- Organizations, scholarship, and continuing education — one row ---- %>
+      <%# ---- Organizations, scholarship, and continuing education — one row.
+          Scholarship shows only when the event offers scholarships, CE only when
+          it grants credit. Organizations fills whatever the hidden cards leave
+          behind: it absorbs one of the three columns for each card that's hidden. ---- %>
+      <% show_scholarship = f.object.event&.scholarship_eligible? %>
+      <% show_ce = f.object.event&.ce_eligible? %>
+      <% org_span = 1 + (show_scholarship ? 0 : 1) + (show_ce ? 0 : 1) %>
+      <% org_span_class = { 1 => "sm:col-span-1", 2 => "sm:col-span-2", 3 => "sm:col-span-3" }.fetch(org_span) %>
       <% active_orgs = f.object.registrant.affiliations.select { |a| !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) }.map(&:organization).compact.uniq.sort_by(&:name) %>
       <% connected_org_ids = f.object.organizations.map(&:id) %>
       <% addable_orgs = active_orgs.reject { |org| connected_org_ids.include?(org.id) } %>
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-3">
-        <section class="flex min-h-[12rem] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <section class="flex min-h-[12rem] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm <%= org_span_class %>">
           <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
             <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:organizations, f.object.organizations.any?) %>">
               <i class="fa-solid fa-building"></i>
@@ -241,9 +248,11 @@
           </div>
         </section>
 
-        <%= render "scholarship", event_registration: f.object, scholarship: f.object.scholarships.first %>
+        <% if show_scholarship %>
+          <%= render "scholarship", event_registration: f.object, scholarship: f.object.scholarships.first %>
+        <% end %>
 
-        <% if f.object.event&.ce_eligible? %>
+        <% if show_ce %>
           <%= render "continuing_education", event_registration: f.object, ce_registration: f.object.continuing_education_registrations.first %>
         <% end %>
       </div>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -159,10 +159,7 @@
         </div>
       </div>
 
-      <%# ---- Organizations, scholarship, and continuing education — one row.
-          Scholarship shows only when the event offers scholarships, CE only when
-          it grants credit. Organizations fills whatever the hidden cards leave
-          behind: it absorbs one of the three columns for each card that's hidden. ---- %>
+      <%# The org card widens to absorb a column for each of the other two cards that's hidden. %>
       <% show_scholarship = f.object.event&.scholarship_eligible? || f.object.scholarships.any? %>
       <% show_ce = f.object.event&.ce_eligible? %>
       <% org_span = 1 + (show_scholarship ? 0 : 1) + (show_ce ? 0 : 1) %>

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -163,7 +163,7 @@
           Scholarship shows only when the event offers scholarships, CE only when
           it grants credit. Organizations fills whatever the hidden cards leave
           behind: it absorbs one of the three columns for each card that's hidden. ---- %>
-      <% show_scholarship = f.object.event&.scholarship_eligible? %>
+      <% show_scholarship = f.object.event&.scholarship_eligible? || f.object.scholarships.any? %>
       <% show_ce = f.object.event&.ce_eligible? %>
       <% org_span = 1 + (show_scholarship ? 0 : 1) + (show_ce ? 0 : 1) %>
       <% org_span_class = { 1 => "sm:col-span-1", 2 => "sm:col-span-2", 3 => "sm:col-span-3" }.fetch(org_span) %>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -383,4 +383,18 @@ RSpec.describe Event, type: :model do
       expect(build(:event, ce_hours_offered: 0)).not_to be_ce_eligible
     end
   end
+
+  describe "#scholarship_eligible?" do
+    it "is true when the event has a cost" do
+      expect(build(:event, cost_cents: 1_000)).to be_scholarship_eligible
+    end
+
+    it "is false for a free event" do
+      expect(build(:event, cost_cents: 0)).not_to be_scholarship_eligible
+    end
+
+    it "is false when the cost is unset" do
+      expect(build(:event, cost_cents: nil)).not_to be_scholarship_eligible
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -389,12 +389,18 @@ RSpec.describe Event, type: :model do
       expect(build(:event, cost_cents: 1_000)).to be_scholarship_eligible
     end
 
-    it "is false for a free event" do
-      expect(build(:event, cost_cents: 0)).not_to be_scholarship_eligible
+    it "is true for a free event that offers a scholarship form" do
+      event = create(:event, cost_cents: 0)
+      create(:event_form, :scholarship, event: event)
+      expect(event).to be_scholarship_eligible
     end
 
-    it "is false when the cost is unset" do
-      expect(build(:event, cost_cents: nil)).not_to be_scholarship_eligible
+    it "is false for a free event with no scholarship form" do
+      expect(create(:event, cost_cents: 0)).not_to be_scholarship_eligible
+    end
+
+    it "is false when the cost is unset and there is no scholarship form" do
+      expect(create(:event, cost_cents: nil)).not_to be_scholarship_eligible
     end
   end
 end

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -321,6 +321,17 @@ RSpec.describe "Event registration edit page", type: :system do
       expect(page).to have_css("section.sm\\:col-span-2", text: "organizations")
     end
 
+    it "still shows the scholarship box when a scholarship was awarded before the event became free" do
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+      event.update!(cost_cents: 0)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      expect(page).to have_css("h2", text: "Scholarship")
+    end
+
     it "fills the full row with organizations for a free event with no CE hours" do
       event.update!(cost_cents: 0)
       sign_in(admin)

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -291,6 +291,47 @@ RSpec.describe "Event registration edit page", type: :system do
     end
   end
 
+  describe "Organizations / scholarship / CE row visibility" do
+    it "shows scholarship (paid) and hides CE (no hours), widening organizations to two columns" do
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      expect(page).to have_css("h2", text: "Scholarship")
+      expect(page).to have_no_css("h2", text: "Continuing education")
+      expect(page).to have_css("section.sm\\:col-span-2", text: "organizations")
+    end
+
+    it "shows scholarship and CE for a paid, CE-eligible event with organizations at one column" do
+      event.update!(ce_hours_offered: 6)
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      expect(page).to have_css("h2", text: "Scholarship")
+      expect(page).to have_css("h2", text: "Continuing education")
+      expect(page).to have_css("section.sm\\:col-span-1", text: "organizations")
+    end
+
+    it "hides the scholarship box for a free event" do
+      event.update!(cost_cents: 0, ce_hours_offered: 6)
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      expect(page).to have_no_css("h2", text: "Scholarship")
+      expect(page).to have_css("h2", text: "Continuing education")
+      expect(page).to have_css("section.sm\\:col-span-2", text: "organizations")
+    end
+
+    it "fills the full row with organizations for a free event with no CE hours" do
+      event.update!(cost_cents: 0)
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      expect(page).to have_no_css("h2", text: "Scholarship")
+      expect(page).to have_no_css("h2", text: "Continuing education")
+      expect(page).to have_css("section.sm\\:col-span-3", text: "organizations")
+    end
+  end
+
   describe "delete button" do
     it "deletes the registration" do
       sign_in(admin)


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 📖 Read — small, contained view/logic change gated by a new predicate

### What is the goal of this PR and why is this important?

- On the registration edit form, the **Scholarship** card rendered for every event, even free ones — where a scholarship (which offsets a fee) has nothing to do.
- The neighboring **CE credits** card already hides itself when the event grants no CE hours (`event.ce_eligible?`); scholarship had no equivalent gate.

### How did you approach the change?

- Added `Event#scholarship_eligible?`, mirroring the existing `#ce_eligible?` predicate: true when the event has a **cost** (a scholarship offsets a fee) **or** offers a **scholarship form** (it invites applications even when free).
- Gated the Scholarship card on it, **plus** the registration's own scholarships — so an award made before the event became free/formless stays visible instead of vanishing.
- The **Organizations** card absorbs whatever columns the hidden cards leave behind (`sm:col-span-1/2/3`), so the row never has a gap:
  - paid + CE hours → Orgs (1) · Scholarship · CE
  - paid, no CE hours → Orgs (2) · Scholarship
  - free + CE hours → Orgs (2) · CE
  - free, no CE hours, no form → Orgs (3, full width)

### UI Testing Checklist

- [ ] Paid event: Scholarship card shows
- [ ] Free event with no scholarship form: Scholarship card hidden, Organizations widens
- [ ] Free event that offers a scholarship form: card still shows
- [ ] Free event that already has an awarded scholarship: card still shows
- [ ] Row never leaves an empty column in any paid/free × CE combination

### Anything else to add?

- Supersedes the closed HOLD PR #1867, whose CE half was already implemented on main by the CE cutover (#1917).

🤖 Generated with [Claude Code](https://claude.com/claude-code)