### PR TITLE
Gate receipt/W-9 on actual payment; invoice reflects balance due

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This codebase (Rails 8.1)
 | `app/views/` | ERB templates | ~632 files |
 | `app/decorators/` | Draper decorators for view logic | ~40 files |
 | `app/policies/` | ActionPolicy authorization rules | ~55 files |
-| `app/presenters/` | Presentation objects | 3 files |
+| `app/presenters/` | Presentation objects | 5 files |
 | `app/helpers/` | View helpers | ~25 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
@@ -199,6 +199,7 @@ end
 - `RichTextMigrator` — Rich text migration utility
 - `DisplayImagePresenter` — Image display logic
 - `ScholarshipsGrouping` (presenter) — Groups scholarships into the index's funder → grant → recipient hierarchy; grant-free awards collect under a trailing "Unfunded" group
+- `AllocationLedgerLabel` (presenter) — Shared payment-method/label + check-number labelling for an allocation, used by the invoice and receipt ledgers so they can't drift
 
 ### Event Registrations
 

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -246,15 +246,30 @@ module Events
       if @event_registration.invoice_available?
         cards << document_card(title: "Invoice", subtitle: "Itemized invoice for this registration",
           icon: "fa-solid fa-file-invoice-dollar", href: registration_invoice_path(slug, return_to: "payment"))
+        # The receipt is proof money changed hands, so it links once an actual
+        # payment settles the balance in full; until then (balance owing, or a
+        # balance cleared only by scholarship/discount) it's a locked card.
         if @event_registration.receipt_available?
           cards << document_card(title: "Receipt", subtitle: "Paid-in-full receipt for this registration",
             icon: "fa-solid fa-receipt", href: registration_receipt_path(slug, return_to: "payment"))
+        else
+          cards << locked_document_card(title: "Receipt", icon: "fa-solid fa-receipt",
+            subtitle: "Available once your payment is received in full")
         end
       end
-      cards + payment_document_resources.map do |link|
-        link.decorate.to_card(registrant_slug: slug, return_to: "payment",
-                              icon: "fa-solid fa-file-pdf", color: "gray")
+      cards + payment_document_resources.map { |link| payment_resource_card(link, slug) }
+    end
+
+    # A payment-callout linked resource as a card. The W-9 only applies once an
+    # actual payment is on file, so it renders locked (naming what unlocks it)
+    # until then; every other document links straight through.
+    def payment_resource_card(link, slug)
+      if link.resource&.title == "W-9" && !@event_registration.w9_available?
+        return locked_document_card(title: link.resource.title, icon: "fa-solid fa-file-pdf",
+          subtitle: "Available once your payment is received")
       end
+      link.decorate.to_card(registrant_slug: slug, return_to: "payment",
+                            icon: "fa-solid fa-file-pdf", color: "gray")
     end
 
     # The payment callout's linked resource join rows (the W-9 by default on paid
@@ -273,6 +288,14 @@ module Events
     def document_card(title:, subtitle:, icon:, href:)
       MagicTicketCallouts::Card.new(icon_class: icon, color: "gray", title:, subtitle:,
                                     href:, target: "_blank", trailing_icon: "fa-solid fa-arrow-right")
+    end
+
+    # A greyed-out, non-navigating card (no href) for a document that isn't
+    # available yet; the payment view renders it as a plain div with a lock icon,
+    # and the subtitle names what unlocks it.
+    def locked_document_card(title:, subtitle:, icon:)
+      MagicTicketCallouts::Card.new(icon_class: icon, color: "gray", title:, subtitle:,
+                                    href: nil, target: nil, trailing_icon: "fa-solid fa-lock")
     end
 
     def redirect_to_ce_stripe_checkout(ce_registration)

--- a/app/models/concerns/registerable.rb
+++ b/app/models/concerns/registerable.rb
@@ -27,6 +27,13 @@ module Registerable
     allocations.where(source_type: Payment.polymorphic_name).sum(:amount)
   end
 
+  # True once actual money has been received (cash, check, or card) — as opposed
+  # to a balance settled purely by scholarship or discount. Gates the receipt and
+  # W-9, which only apply once a real payment is on file.
+  def payment_received?
+    payments_sum.positive?
+  end
+
   # Comp/discount coverage only (excludes payments and scholarships).
   def discount_sum
     return allocations.to_a.select { |a| a.source_type == "Discount" }.sum(&:amount) if allocations.loaded?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -376,9 +376,19 @@ class EventRegistration < ApplicationRecord
     event.cost_cents.to_i.positive?
   end
 
-  # A paid-in-full receipt is available once a paid event carries no balance.
+  # A receipt is proof money changed hands, so it's available only once a paid
+  # event is settled in full AND at least some of that settlement was an actual
+  # payment. A balance cleared purely by scholarship or discount (no money
+  # received) gets no receipt — nor does merely intending to pay.
   def receipt_available?
-    invoice_available? && remaining_cost.zero?
+    invoice_available? && remaining_cost.zero? && payment_received?
+  end
+
+  # AWBW's own W-9 is only useful to a payer who actually paid us, so it's gated on
+  # a paid event AND an actual payment being on file (cash, check, or card). A
+  # balance cleared purely by scholarship or discount doesn't unlock it.
+  def w9_available?
+    invoice_available? && payment_received?
   end
 
   # Cost source for the Registerable payment interface: the event's price.

--- a/app/presenters/allocation_ledger_label.rb
+++ b/app/presenters/allocation_ledger_label.rb
@@ -1,0 +1,33 @@
+# Shared labelling for an allocation shown in a money-document ledger — the
+# invoice's applied-payments list and the receipt's payment ledger — so the two
+# can't drift. Payment is an STI base whose polymorphic source_type is always
+# "Payment"; the concrete subclass tells us how it was paid, so payments are named
+# by method (Cash/Check/Credit card), with the check number as a reference.
+# Non-payment allocations (scholarships, discounts) fall back to their humanized
+# type.
+module AllocationLedgerLabel
+  PAYMENT_METHOD_LABELS = {
+    "CashPayment" => "Cash",
+    "CheckPayment" => "Check",
+    "ExternalProcessorPayment" => "Credit card",
+    "FilemakerPayment" => "Payment"
+  }.freeze
+
+  module_function
+
+  def method_label(allocation)
+    if allocation.source_type == Payment.polymorphic_name
+      PAYMENT_METHOD_LABELS[allocation.source&.class&.name] || "Payment"
+    else
+      allocation.source_type.underscore.humanize
+    end
+  end
+
+  # Check number, when the payment was a check — so the payer can reconcile it
+  # against their own records.
+  def reference_for(allocation)
+    source = allocation.source
+    return unless source.is_a?(CheckPayment) && source.check_number.present?
+    "Check ##{source.check_number}"
+  end
+end

--- a/app/presenters/event_invoice.rb
+++ b/app/presenters/event_invoice.rb
@@ -18,17 +18,25 @@ class EventInvoice
     end
   end
 
+  # One applied payment or credit (scholarship/discount) that reduces the balance
+  # due. Payments are itemized by method (Cash/Check/Credit card), with the check
+  # number as a reference; scholarships/discounts show their kind.
+  Entry = Struct.new(:date, :method, :reference, :amount_cents, keyword_init: true)
+
   attr_reader :event, :number, :date, :reference, :client_id,
               :bill_to_name, :bill_to_address_lines, :bill_to_email,
-              :attention, :line_items
+              :attention, :line_items, :entries, :amount_applied_cents
 
-  # One registration → one attendee billed at the event cost. The registrant's
-  # snapshotted organization (if any) is the bill-to; otherwise bill the person.
+  # One registration → one attendee billed at the event cost, less anything
+  # already applied (payments, scholarships, discounts) so the invoice reflects
+  # the balance actually due. The registrant's snapshotted organization (if any)
+  # is the bill-to; otherwise bill the person.
   def self.from_registration(registration)
     event = registration.event
     registrant = registration.registrant
     organization = registration.organizations.first
     addressable = organization || registrant
+    allocations = registration.allocations.includes(:source).order(:created_at)
 
     new(
       event: event,
@@ -46,9 +54,21 @@ class EventInvoice
           quantity: 1,
           unit_price_cents: event.cost_cents.to_i
         )
-      ]
+      ],
+      entries: allocations.map { |allocation| entry_for(allocation) },
+      amount_applied_cents: allocations.sum(&:amount)
     )
   end
+
+  def self.entry_for(allocation)
+    Entry.new(
+      date: allocation.created_at.to_date,
+      method: AllocationLedgerLabel.method_label(allocation),
+      reference: AllocationLedgerLabel.reference_for(allocation),
+      amount_cents: allocation.amount
+    )
+  end
+  private_class_method :entry_for
 
   # A blank invoice template carrying only the event's content (one attendee at
   # the event cost). The bill-to and attention are left empty to be filled in.
@@ -120,7 +140,7 @@ class EventInvoice
 
   def initialize(event:, number:, date:, client_id:, bill_to_name:,
                  bill_to_address_lines:, bill_to_email:, attention:, line_items:,
-                 reference: nil)
+                 reference: nil, entries: [], amount_applied_cents: 0)
     @event = event
     @number = number
     @date = date
@@ -131,10 +151,19 @@ class EventInvoice
     @attention = attention
     @line_items = line_items
     @reference = reference
+    @entries = entries
+    @amount_applied_cents = amount_applied_cents
   end
 
   def total_cents
     line_items.sum(&:amount_cents)
+  end
+
+  # The full charge net of everything already applied, floored at zero — what the
+  # invoice actually asks the payer for. Equals the total when nothing's applied
+  # (the blank template and bulk-payment invoices, which carry no allocations).
+  def balance_due_cents
+    [ total_cents - amount_applied_cents, 0 ].max
   end
 
   def issuer_name = ISSUER_NAME

--- a/app/presenters/event_receipt.rb
+++ b/app/presenters/event_receipt.rb
@@ -9,17 +9,6 @@ class EventReceipt
   ISSUER_EMAIL = "info@awbw.org".freeze
   THANK_YOU_NOTE = "Payment received in full — thank you. Please retain this receipt for your records.".freeze
 
-  # Friendly payment-method names for the ledger. Payment is an STI base whose
-  # polymorphic source_type is always "Payment"; the concrete subclass tells us
-  # how it was paid. Non-payment allocations (scholarships, discounts) fall back
-  # to their humanized type.
-  PAYMENT_METHOD_LABELS = {
-    "CashPayment" => "Cash",
-    "CheckPayment" => "Check",
-    "ExternalProcessorPayment" => "Credit card",
-    "FilemakerPayment" => "Payment"
-  }.freeze
-
   LineItem = Struct.new(:date, :description, :quantity, :unit_price_cents, keyword_init: true) do
     def amount_cents
       unit_price_cents.to_i * quantity.to_i
@@ -69,30 +58,12 @@ class EventReceipt
   def self.entry_for(allocation)
     Entry.new(
       date: allocation.created_at.to_date,
-      method: method_label(allocation),
-      reference: reference_for(allocation),
+      method: AllocationLedgerLabel.method_label(allocation),
+      reference: AllocationLedgerLabel.reference_for(allocation),
       amount_cents: allocation.amount
     )
   end
   private_class_method :entry_for
-
-  def self.method_label(allocation)
-    if allocation.source_type == Payment.polymorphic_name
-      PAYMENT_METHOD_LABELS[allocation.source&.class&.name] || "Payment"
-    else
-      allocation.source_type.underscore.humanize
-    end
-  end
-  private_class_method :method_label
-
-  # Check number, when the payment was a check — standard receipt detail so the
-  # payer can reconcile it against their own records.
-  def self.reference_for(allocation)
-    source = allocation.source
-    return unless source.is_a?(CheckPayment) && source.check_number.present?
-    "Check ##{source.check_number}"
-  end
-  private_class_method :reference_for
 
   def initialize(event:, number:, date:, client_id:, bill_to_name:,
                  bill_to_address_lines:, bill_to_email:, attention:, line_items:,

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -55,7 +55,9 @@
   <% if @document_cards.any? %>
     <div class="mt-10 space-y-3">
       <% @document_cards.each do |card| %>
-        <%= render "event_registrations/callout_card", callout: card %>
+        <%# Locked documents (no href — a receipt/W-9 not yet unlocked) render as a
+            non-navigating card that names what unlocks them. %>
+        <%= render "event_registrations/callout_card", callout: card, linked: card.href.present? %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/events/invoices/_invoice.html.erb
+++ b/app/views/events/invoices/_invoice.html.erb
@@ -83,16 +83,63 @@
         </tr>
       <% end %>
     </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="3"></td>
-        <td class="pt-4 text-right text-sm font-bold">Total</td>
-        <td class="pt-4 text-right">
-          <span class="inline-block rounded-md border border-gray-400 px-3 py-1 text-sm font-bold tabular-nums whitespace-nowrap"><%= dollars_from_cents(invoice.total_cents) %></span>
-        </td>
-      </tr>
-    </tfoot>
+    <%# With nothing applied (the blank template and bulk-payment invoices) the
+        invoice just shows its charge total; the balance-due summary below takes
+        over once payments/credits have been applied. %>
+    <% unless invoice.amount_applied_cents.positive? %>
+      <tfoot>
+        <tr>
+          <td colspan="3"></td>
+          <td class="pt-4 text-right text-sm font-bold">Total</td>
+          <td class="pt-4 text-right">
+            <span class="inline-block rounded-md border border-gray-400 px-3 py-1 text-sm font-bold tabular-nums whitespace-nowrap"><%= dollars_from_cents(invoice.total_cents) %></span>
+          </td>
+        </tr>
+      </tfoot>
+    <% end %>
   </table>
+
+  <%# Payments and credits already applied, and the balance the payer still owes. %>
+  <% if invoice.amount_applied_cents.positive? %>
+    <div class="mt-8">
+      <p class="text-xs font-bold text-gray-700 uppercase tracking-wide mb-2">Payments &amp; credits applied</p>
+      <table class="w-full text-sm">
+        <tbody>
+          <% invoice.entries.each do |entry| %>
+            <tr class="border-b border-gray-100">
+              <td class="py-2 pr-3 whitespace-nowrap align-top"><%= entry.date&.strftime("%m/%d/%y") %></td>
+              <td class="py-2 pr-3 align-top">
+                <%= entry.method %>
+                <% if entry.reference.present? %>
+                  <span class="text-xs text-gray-500">· <%= entry.reference %></span>
+                <% end %>
+              </td>
+              <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap">-<%= dollars_from_cents(entry.amount_cents) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mt-8 flex justify-end">
+      <dl class="w-full max-w-xs text-sm">
+        <div class="flex items-center justify-between py-1">
+          <dt class="text-gray-600">Total charged</dt>
+          <dd class="tabular-nums"><%= dollars_from_cents(invoice.total_cents) %></dd>
+        </div>
+        <div class="flex items-center justify-between py-1">
+          <dt class="text-gray-600">Payments &amp; credits</dt>
+          <dd class="tabular-nums">-<%= dollars_from_cents(invoice.amount_applied_cents) %></dd>
+        </div>
+        <div class="mt-1 flex items-center justify-between border-t border-gray-300 pt-2 font-bold">
+          <dt>Balance due</dt>
+          <dd>
+            <span class="inline-block rounded-md border px-3 py-1 tabular-nums whitespace-nowrap <%= invoice.balance_due_cents.positive? ? "border-amber-500 bg-amber-50 text-amber-800" : "border-green-500 bg-green-50 text-green-700" %>"><%= dollars_from_cents(invoice.balance_due_cents) %></span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  <% end %>
 
   <footer class="mt-12 text-sm">
     <p><%= invoice.payable_to_note %></p>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1031,6 +1031,71 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#receipt_available?" do
+    let(:event) { create(:event, cost_cents: 10_000) }
+    let(:reg) { create(:event_registration, event: event) }
+
+    it "is false for a free event" do
+      free_reg = create(:event_registration, event: create(:event, cost_cents: 0))
+      expect(free_reg.receipt_available?).to be(false)
+    end
+
+    it "is true once an actual payment settles the balance in full" do
+      payment = create(:payment, type: "CashPayment", amount_cents: 10_000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 10_000)
+
+      expect(reg.reload.receipt_available?).to be(true)
+    end
+
+    it "is false when the balance is cleared purely by scholarship and discount" do
+      scholarship = create(:scholarship, recipient: reg.registrant, amount_cents: 6_000)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 6_000)
+      create(:allocation, source: create(:discount, amount_cents: 4_000), allocatable: reg, amount: 4_000)
+
+      expect(reg.reload.paid_in_full?).to be(true)  # balance is zero...
+      expect(reg.receipt_available?).to be(false)   # ...but no money was received
+    end
+
+    it "is false while a balance remains, even with a partial payment" do
+      payment = create(:payment, type: "CashPayment", amount_cents: 4_000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 4_000)
+
+      expect(reg.reload.receipt_available?).to be(false)
+    end
+  end
+
+  describe "#w9_available?" do
+    let(:event) { create(:event, cost_cents: 10_000) }
+    let(:reg) { create(:event_registration, event: event) }
+
+    it "is true on a paid event once an actual payment is on file (cash/check)" do
+      payment = create(:payment, type: "CheckPayment", amount_cents: 5_000, amount_cents_remaining: nil, check_number: "12")
+      create(:allocation, source: payment, allocatable: reg, amount: 5_000)
+
+      expect(reg.reload.w9_available?).to be(true)
+    end
+
+    it "is true for an automatic card charge too — any actual payment counts" do
+      payment = create(:external_processor_payment, amount_cents: 5_000, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: reg, amount: 5_000)
+
+      expect(reg.reload.w9_available?).to be(true)
+    end
+
+    it "is false when the balance is covered only by a scholarship or discount" do
+      scholarship = create(:scholarship, recipient: reg.registrant, amount_cents: 6_000)
+      create(:allocation, source: scholarship, allocatable: reg, amount: 6_000)
+      create(:allocation, source: create(:discount, amount_cents: 4_000), allocatable: reg, amount: 4_000)
+
+      expect(reg.reload.w9_available?).to be(false)
+    end
+
+    it "is false on a free event (nothing to pay)" do
+      free_reg = create(:event_registration, event: create(:event, cost_cents: 0))
+      expect(free_reg.w9_available?).to be(false)
+    end
+  end
+
   describe "payment reads from a preloaded allocations association" do
     it "issues no per-row queries when allocations are preloaded" do
       event = create(:event, cost_cents: 1_000)

--- a/spec/presenters/event_invoice_spec.rb
+++ b/spec/presenters/event_invoice_spec.rb
@@ -22,6 +22,45 @@ RSpec.describe EventInvoice do
       expect(invoice.total_cents).to eq(150_000)
     end
 
+    it "carries no applied credits and a full balance due when nothing is paid" do
+      invoice = described_class.from_registration(registration)
+
+      expect(invoice.entries).to be_empty
+      expect(invoice.amount_applied_cents).to eq(0)
+      expect(invoice.balance_due_cents).to eq(150_000)
+    end
+
+    it "reduces the balance due by the payments, scholarships, and discounts applied" do
+      payment = create(:payment, type: "CashPayment", amount_cents: 40_000)
+      scholarship = create(:scholarship, recipient: registrant, amount_cents: 50_000)
+      discount = create(:discount, amount_cents: 10_000)
+      create(:allocation, source: payment, allocatable: registration, amount: 40_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 50_000)
+      create(:allocation, source: discount, allocatable: registration, amount: 10_000)
+
+      invoice = described_class.from_registration(registration)
+
+      expect(invoice.amount_applied_cents).to eq(100_000)
+      expect(invoice.balance_due_cents).to eq(50_000)  # 150,000 charged − 100,000 applied
+      expect(invoice.total_cents).to eq(150_000)       # the charge itself is unchanged
+    end
+
+    it "itemizes each payment by method, in order, with the check number as a reference" do
+      cash = create(:payment, type: "CashPayment", amount_cents: 30_000)
+      check = create(:payment, type: "CheckPayment", amount_cents: 20_000, check_number: "4821")
+      scholarship = create(:scholarship, recipient: registrant, amount_cents: 10_000)
+      create(:allocation, source: cash, allocatable: registration, amount: 30_000)
+      create(:allocation, source: check, allocatable: registration, amount: 20_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 10_000)
+
+      invoice = described_class.from_registration(registration)
+
+      expect(invoice.entries.map(&:method)).to eq([ "Cash", "Check", "Scholarship" ])
+      expect(invoice.entries.map(&:amount_cents)).to eq([ 30_000, 20_000, 10_000 ])
+      check_entry = invoice.entries.find { |entry| entry.method == "Check" }
+      expect(check_entry.reference).to eq("Check #4821")
+    end
+
     context "with a snapshotted organization" do
       let(:organization) { create(:organization, name: "A Greater Hope") }
 

--- a/spec/presenters/event_receipt_spec.rb
+++ b/spec/presenters/event_receipt_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe EventReceipt do
       expect(receipt.balance_cents).to eq(0)
     end
 
+    it "lists scholarship and discount credits as ledger entries and counts them toward amount paid" do
+      payment = create(:payment, type: "CashPayment", amount_cents: 90_000)
+      scholarship = create(:scholarship, recipient: registrant, amount_cents: 50_000)
+      discount = create(:discount, amount_cents: 10_000)
+      create(:allocation, source: payment, allocatable: registration, amount: 90_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 50_000)
+      create(:allocation, source: discount, allocatable: registration, amount: 10_000)
+
+      receipt = described_class.from_registration(registration)
+
+      # Each allocation is its own ledger entry (so payments and credits are
+      # distinguishable), while the summary's amount paid reconciles to the total.
+      expect(receipt.entries.map(&:method)).to include("Cash", "Scholarship", "Discount")
+      expect(receipt.amount_paid_cents).to eq(150_000)
+      expect(receipt.balance_cents).to eq(0)
+    end
+
     context "with a snapshotted organization" do
       let(:organization) { create(:organization, name: "A Greater Hope") }
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -67,6 +67,9 @@ RSpec.describe "Events::Callouts", type: :request do
       w9 = create(:resource, title: "W-9")
       create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
              resource: w9, subtitle: "Custom W-9 line")
+      # The W-9 unlocks once an actual payment is on file.
+      payment = create(:payment, type: "CashPayment", amount_cents: event.cost_cents, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: registration, amount: event.cost_cents)
 
       get registration_payment_path(registration.slug)
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("$1,500")
     end
 
+    it "shows the balance due once a scholarship or payment is applied" do
+      scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 60_000)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 60_000)
+
+      get registration_invoice_path(registration.slug)
+      expect(response.body).to include("Scholarship")
+      expect(response.body).to include("Balance due")
+      expect(response.body).to include("$900")  # $1,500 charged − $600 scholarship
+    end
+
     it "defaults the eyebrow to the ticket" do
       get registration_invoice_path(registration.slug)
       expect(response.body).to include(registration_ticket_path(registration.slug))
@@ -291,12 +301,29 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include(registration_invoice_path(registration.slug, return_to: "payment"))
     end
 
-    it "links the W-9 to its resource page when present, returning to payment" do
+    it "links the W-9 to its resource page once a payment is on file, returning to payment" do
       w9 = create(:resource, title: "W-9", kind: "Form")
       DefaultTicketCallouts.seed(event)
+      payment = create(:payment, type: "CashPayment", amount_cents: event.cost_cents, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: registration, amount: event.cost_cents)
+
       get registration_payment_path(registration.slug)
       expect(response.body).to include(registration_resource_path(registration.slug, w9, return_to: "payment"))
       expect(response.body).not_to include("/documents/awbw-w9.pdf")
+    end
+
+    it "locks the W-9 (no link) until a payment is on file" do
+      w9 = create(:resource, title: "W-9", kind: "Form")
+      DefaultTicketCallouts.seed(event)
+
+      get registration_payment_path(registration.slug)
+      expect(response.body).not_to include(registration_resource_path(registration.slug, w9, return_to: "payment"))
+      expect(response.body).to include("Available once your payment is received")
+    end
+
+    it "shows a locked receipt card until an actual payment settles the balance" do
+      get registration_payment_path(registration.slug)
+      expect(response.body).to include("Available once your payment is received in full")
     end
 
     it "drops the W-9 when the payment callout's resource is removed" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained gating logic + invoice ledger math on public money-facing callouts

Rebased onto main after #1975 moved the W-9/invoice/receipt onto the **payment** callout.

### Receipt & W-9 — gate on an actual payment
- **Receipt** requires an actual payment settling the balance in full (`payment_received?`), not just `remaining_cost.zero?`. A balance cleared purely by scholarship/discount — or `intends_to_pay` — gets no receipt.
- **W-9** gated on a paid event **and** any actual payment on file (`w9_available?` = `invoice_available? && payment_received?`). Only scholarship/discount → no W-9; free event → none.
- **Made clear on the payment page:** an unavailable receipt/W-9 renders as a locked grey card naming what unlocks it, instead of vanishing.

### Invoice — reflect the balance due, itemized per payment
- The per-registration invoice billed the full event cost even after credits/payments. It now lists what's been applied and shows the **balance due** (floored at zero).
- Each payment is itemized **by method** (Cash / Check / Credit card, with the check number), not lumped; scholarships/discounts show their kind. Method labelling is extracted into `AllocationLedgerLabel`, shared with the receipt ledger so they can't drift.
- The blank template and bulk-payment invoices carry no allocations, so they're unchanged (plain charge total).

### Tests
Model gating, receipt/invoice ledger labelling, invoice balance-due + per-method itemization, and payment-page locked/linked states.