### PR TITLE
Color the CE ticket card orange while a CE balance is due

### DIFF
--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -175,15 +175,19 @@ class MagicTicketCallouts
   def ce_hours_card
     return unless registration.ce_registered?
     complete = registration.ce_license_provided?
-    Card.new(icon_class: "fa-solid fa-graduation-cap", color: "teal",
+    # An outstanding CE balance turns the card orange (an action card), matching
+    # the payment card, rather than the resting teal.
+    due = registration.continuing_education_registrations.first&.remaining_cost.to_i.positive?
+    Card.new(icon_class: "fa-solid fa-graduation-cap", color: due ? "orange" : "teal",
              title: event.ce_hours_details_label,
              subtitle: ce_hours_subtitle,
              href: registration_ce_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
              badge: ce_hours_badge(complete),
-             # Amber while hours/license are still needed, teal once it's just the
-             # amount due (nil badge_classes falls back to amber in _callout_card).
-             badge_classes: complete ? "bg-teal-100 text-teal-800 border border-teal-300" : nil)
+             # Amber while money is due or hours/license are still needed (nil
+             # badge_classes falls back to amber in _callout_card); teal once it's
+             # complete and paid.
+             badge_classes: complete && !due ? "bg-teal-100 text-teal-800 border border-teal-300" : nil)
   end
 
   def ce_hours_subtitle
@@ -193,20 +197,22 @@ class MagicTicketCallouts
     "#{NumberFormatter.plain(hours)} hours"
   end
 
-  # Teal "$X due" once hours + license are on file and money is owed; otherwise an
-  # amber chip naming what's still needed, prefixed with the amount when the hours
-  # (and so the fee) are already known — e.g. "$250 · License number needed".
+  # "$X due" for the outstanding balance once hours + license are on file (no chip
+  # once paid in full); otherwise an amber chip naming what's still needed, prefixed
+  # with the fee when the hours (and so the cost) are already known — e.g.
+  # "$250 · License number needed".
   def ce_hours_badge(complete)
-    amount_cents = registration.continuing_education_registrations.first&.cost_cents.to_i
-    amount = MoneyFormatter.dollars_from_cents(amount_cents)
+    ce_registration = registration.continuing_education_registrations.first
+    remaining_cents = ce_registration&.remaining_cost.to_i
 
     if complete
-      return unless amount_cents.positive?
-      return "#{amount} due"
+      return unless remaining_cents.positive?
+      return "#{MoneyFormatter.dollars_from_cents(remaining_cents)} due"
     end
 
     needed = ce_missing_text
-    amount_cents.positive? ? "#{amount} · #{needed}" : needed
+    cost_cents = ce_registration&.cost_cents.to_i
+    cost_cents.positive? ? "#{MoneyFormatter.dollars_from_cents(cost_cents)} · #{needed}" : needed
   end
 
   # Hours are set by the event now, so the only thing a requesting registrant can

--- a/spec/services/magic_ticket_callouts_spec.rb
+++ b/spec/services/magic_ticket_callouts_spec.rb
@@ -81,22 +81,30 @@ RSpec.describe MagicTicketCallouts do
       expect(card_titles(registration.reload)).to include(event.ce_hours_details_label)
     end
 
-    it "shows a 'license needed' CE badge until provided, then a teal amount due" do
+    it "turns the CE card orange while a balance is due, teal once paid" do
       event.update!(ce_hours_offered: 6, ce_hours_cost_cents: 15_000)
       license = create(:professional_license, :placeholder, person: registration.registrant)
-      create(:continuing_education_registration, event_registration: registration, professional_license: license)
+      ce = create(:continuing_education_registration, event_registration: registration, professional_license: license)
 
+      # Balance due, license still needed: orange card, amber chip naming what's needed.
       needs = card(registration.reload, event.ce_hours_details_label)
-      expect(needs.theme).to eq(DomainTheme.swatch("teal"))
+      expect(needs.theme).to eq(DomainTheme.swatch("orange"))
       expect(needs.subtitle).to eq("6 hours")
       expect(needs.badge).to eq("$150 · License number needed")
       expect(needs.badge_classes).to be_nil
 
+      # License provided but still owing: orange card, amber "$X due" chip like the payment card.
       license.update!(number: "LIC123")
-      complete = card(registration.reload, event.ce_hours_details_label)
-      expect(complete.subtitle).to eq("6 hours")
-      expect(complete.badge).to eq("$150 due")
-      expect(complete.badge_classes).to include("teal")
+      due = card(registration.reload, event.ce_hours_details_label)
+      expect(due.theme).to eq(DomainTheme.swatch("orange"))
+      expect(due.badge).to eq("$150 due")
+      expect(due.badge_classes).to be_nil
+
+      # Paid in full: resting teal card, no "due" chip.
+      create(:allocation, allocatable: ce, amount: 15_000)
+      paid = card(registration.reload, event.ce_hours_details_label)
+      expect(paid.theme).to eq(DomainTheme.swatch("teal"))
+      expect(paid.badge).to be_nil
     end
 
     it "shows the scholarship card only when requested, without an amount chip until awarded" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained colour/badge logic in one service, covered by specs

## What
- CE ticket card now turns **orange while a CE balance is due** and rests **teal once paid**, mirroring the payment card (both keyed off `remaining_cost`).
- The "$X due" chip reflects the **remaining** balance, so a paid-in-full CE card no longer shows a stale "$X due" chip on a teal card.

## Why
- The CE card was always teal even when money was owed, so an outstanding CE fee didn't read as an action item the way the payment card does.

## Tests
- Rewrote the CE badge spec to cover license-needed + due (orange/amber), license-provided + due (orange/amber "$X due"), and paid-in-full (teal/no chip).