### PR TITLE
Drip callout page content (not the card); reveal videoconference by callout date

### DIFF
--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -4,19 +4,20 @@ class RegistrationTicketCalloutsController < ApplicationController
 
   # Public detail page for a single registration ticket callout, linked from the
   # call-out on the registration ticket (mirrors the events#details / #ce_hours
-  # pages). With no description and no linked resource there is nothing to show,
-  # so fall back to the event page.
+  # pages). With no content there is nothing to show, so fall back to the event
+  # page — unless the content is merely drip-scheduled, in which case the page
+  # shows a "coming soon" note until its display date.
   def show
     @callout = @event.registration_ticket_callouts.find(params[:id])
     authorize! @callout, to: :show?
 
-    # A hidden (draft/opted-out) or not-yet-dripped callout has no public page.
-    if @callout.hidden? || @callout.dripping?
+    # A hidden (draft/opted-out) callout has no public page.
+    if @callout.hidden?
       redirect_to event_path(@event, reg: params[:reg].presence)
       return
     end
 
-    if @callout.description.blank? && @callout.resources.empty?
+    if !@callout.page_content? && !@callout.dripping?
       redirect_to event_path(@event, reg: params[:reg].presence)
       return
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -173,11 +173,22 @@ class Event < ApplicationRecord
     now >= start_date - VIDEOCONFERENCE_JOIN_BUFFER && now <= end_date + VIDEOCONFERENCE_JOIN_BUFFER
   end
 
+  # When the videoconference connection details unlock. Driven by the drip date on
+  # the materialized videoconference callout (admin-editable), falling back to
+  # VIDEOCONFERENCE_DETAILS_LEAD before the start for events that haven't
+  # materialized the built-in callouts.
+  def videoconference_details_available_from
+    return @videoconference_details_available_from if defined?(@videoconference_details_available_from)
+    return unless start_date
+    override = registration_ticket_callouts.magic.find_by(magic_key: "videoconference")&.display_from
+    @videoconference_details_available_from = override || start_date - VIDEOCONFERENCE_DETAILS_LEAD
+  end
+
   # Whether the videoconference connection details may be revealed yet: only once
-  # the event is within VIDEOCONFERENCE_DETAILS_LEAD of starting.
-  def videoconference_details_visible?
-    return false unless start_date
-    Time.current >= start_date - VIDEOCONFERENCE_DETAILS_LEAD
+  # we've reached the drip date above.
+  def videoconference_details_visible?(now = Time.current)
+    from = videoconference_details_available_from
+    from.present? && now >= from
   end
 
   def registerable?

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -133,7 +133,16 @@ class RegistrationTicketCallout < ApplicationRecord
     APP_COLORED_MAGIC_KEYS.include?(magic_key.to_s)
   end
 
-  # Whether the callout is drip-scheduled to appear only from a future date.
+  # Whether the callout's own page has content to show — its editable text or any
+  # linked resources. Drives whether the ticket card links to a page and shows the
+  # trailing "go to page" arrow.
+  def page_content?
+    description.present? || resources.any?
+  end
+
+  # Whether the callout's page content is drip-scheduled to reveal only from a
+  # future date. The card still shows on the ticket; the page withholds its
+  # content until then (see the callout show page).
   def dripping?(now = Time.current)
     display_from.present? && display_from > now
   end

--- a/app/services/magic_ticket_callouts.rb
+++ b/app/services/magic_ticket_callouts.rb
@@ -246,7 +246,7 @@ class MagicTicketCallouts
     return if event.videoconference_url.blank?
     Card.new(icon_class: "fa-solid fa-video", color: "blue",
              title: "Videoconference",
-             subtitle: registration.videoconference_details_visible? ? "Join link and add to your calendar" : "Unlocks once payment is on file",
+             subtitle: "Join link and how to add it to your calendar",
              href: registration_videoconference_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
   end

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -7,13 +7,18 @@
             linked (default true): when false the card renders as a non-navigating
             div — the sample-ticket preview has no real per-registration pages. %>
 <% theme = callout.theme %>
-<% linked = local_assigns.fetch(:linked, true) %>
 <% href = local_assigns.fetch(:href) { callout.href } %>
 <% target = local_assigns.fetch(:target) { callout.try(:target) } %>
 <% trailing = local_assigns.fetch(:trailing_icon) { callout.try(:trailing_icon) }.presence ||
               "fa-solid fa-arrow-right" %>
 <% badge = callout.try(:badge) %>
 <% badge_classes = callout.try(:badge_classes).presence || "bg-amber-100 text-amber-800 border border-amber-300" %>
+<%# A card leads to a page — so it links and shows the trailing "go to page"
+    arrow — always for magic cards (they carry their own page), and for admin
+    callouts only when they have page content of their own. Content-less callouts
+    render as a plain, non-navigating card. %>
+<% links_to_page = callout.respond_to?(:page_content?) ? callout.page_content? : true %>
+<% linked = local_assigns.fetch(:linked, true) && links_to_page %>
 <% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
 <% card_body = capture do %>
   <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
@@ -30,7 +35,9 @@
     <% end %>
   </div>
 
-  <i class="<%= trailing %> <%= theme[:icon] %> shrink-0"></i>
+  <% if links_to_page %>
+    <i class="<%= trailing %> <%= theme[:icon] %> shrink-0"></i>
+  <% end %>
 <% end %>
 <% if linked %>
   <%= link_to href, target: target, rel: (target.present? ? "noopener" : nil), class: card_class do %><%= card_body %><% end %>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -110,13 +110,13 @@
       <% end %>
 
       <!-- Ticket callouts: admin-authored plus any built-in cards materialized into
-           editable rows, in the one admin-ordered list. Hidden (draft/opted-out) and
-           not-yet-dripped callouts are omitted. A behavioral magic row (payment,
+           editable rows, in the one admin-ordered list. Hidden (draft/opted-out)
+           callouts are omitted; a drip date only withholds the callout's page
+           content, not the card itself. A behavioral magic row (payment,
            certificate, …) renders the app's live card; content/custom rows render
            their own copy. -->
       <% payment_access = event_registration.payment_access_granted? || @checkout_payment_status == "paid" %>
       <% event_registration.event.registration_ticket_callouts.visible.each do |callout| %>
-        <% next if callout.dripping? %>
         <% next if callout.payment_access_gated && !payment_access %>
         <% if callout.behavioral_magic? %>
           <% card = magic.card_for(callout) %>
@@ -182,6 +182,10 @@
           </p>
 
           <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?) %></div>
+
+          <% if event_registration.event.videoconference_url.present? && !event_registration.videoconference_details_visible? %>
+            <p class="mt-2 text-xs text-gray-400 text-center max-w-sm">The videoconference join link isn't in this calendar entry yet — add it again once the link is available to include it.</p>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -165,6 +165,7 @@
             <%= f.input :videoconference_url,
                     label: "Videoconference URL",
                     as: :url,
+                    hint: "Connects to the callout card on registrant tickets.",
                     input_html: {
                       placeholder: "https://…",
                       class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500",

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -13,13 +13,27 @@
           <p class="mt-2 text-xs text-gray-500 break-all"><%= @event.videoconference_url %></p>
           <%= render "events/videoconference_connection", event: @event %>
         </div>
-      <% elsif !@event_registration.payment_access_granted? %>
-        <div class="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
-          The videoconference link unlocks once your payment is on file. Make your payment from your ticket to gain access.
-        </div>
       <% else %>
-        <div class="rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-600">
-          The videoconference link will be available here about a week before the event.
+        <%# Not yet available: show both unlock conditions and which are met. %>
+        <% paid = @event_registration.payment_access_granted? %>
+        <% reveal = @event.videoconference_details_available_from %>
+        <% date_met = reveal.blank? || Time.current >= reveal %>
+        <div class="rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-600 space-y-2">
+          <p class="font-medium text-gray-700">The videoconference link unlocks once both of these are met:</p>
+          <ul class="space-y-1">
+            <li class="flex items-center gap-2">
+              <i class="fa-solid <%= paid ? "fa-circle-check text-green-600" : "fa-circle-xmark text-gray-300" %>"></i>
+              Your payment is on file
+            </li>
+            <li class="flex items-center gap-2">
+              <i class="fa-solid <%= date_met ? "fa-circle-check text-green-600" : "fa-circle-xmark text-gray-300" %>"></i>
+              <% if reveal.present? %>
+                Available from <%= reveal.to_date.strftime("%B %-d, %Y") %>
+              <% else %>
+                Available closer to the event
+              <% end %>
+            </li>
+          </ul>
         </div>
       <% end %>
     <% end %>
@@ -27,6 +41,9 @@
     <div class="border-t border-gray-100 pt-5">
       <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Add to your calendar</p>
       <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?) %></div>
+      <% if @event.videoconference_url.present? && !@event_registration.videoconference_details_visible? %>
+        <p class="mt-2 text-xs text-gray-500">The join link isn't in this calendar entry yet — add the event to your calendar again once the link is available to include it.</p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/registration_ticket_callouts/show.html.erb
+++ b/app/views/registration_ticket_callouts/show.html.erb
@@ -7,17 +7,23 @@
     <p class="text-base text-gray-500 mb-4"><%= @callout.subtitle %></p>
   <% end %>
 
-  <% if @callout.description.present? %>
-    <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
-      <%= form_label_html(@callout.description) %>
+  <% if @callout.dripping? %>
+    <div class="rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-600">
+      This content will be available on <%= @callout.display_from.to_date.strftime("%B %-d, %Y") %>. Check back then.
     </div>
-  <% end %>
+  <% else %>
+    <% if @callout.description.present? %>
+      <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
+        <%= form_label_html(@callout.description) %>
+      </div>
+    <% end %>
 
-  <% if @resource_cards.any? %>
-    <div class="mt-6 space-y-3">
-      <% @resource_cards.each do |card| %>
-        <%= render "event_registrations/callout_card", callout: card %>
-      <% end %>
-    </div>
+    <% if @resource_cards.any? %>
+      <div class="mt-6 space-y-3">
+        <% @resource_cards.each do |card| %>
+          <%= render "event_registrations/callout_card", callout: card %>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe Event, type: :model do
       event = build(:event, start_date: 1.hour.ago, end_date: 1.hour.from_now)
       expect(event.videoconference_details_visible?).to be true
     end
+
+    it "defers to the videoconference callout's drip date over the week-before default" do
+      event = create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, magic_key: "videoconference",
+        display_from: 2.days.from_now)
+
+      # Within the week-before default (which would be true), but before the
+      # callout's later drip date.
+      expect(event.videoconference_details_visible?).to be false
+    end
   end
 
   describe "#registerable?" do

--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -85,6 +85,24 @@ RSpec.describe RegistrationTicketCallout, type: :model do
     end
   end
 
+  describe "#page_content?" do
+    it "is true with description text" do
+      callout.description = "<p>Read this.</p>"
+      expect(callout.page_content?).to be(true)
+    end
+
+    it "is true with a linked resource" do
+      persisted = create(:registration_ticket_callout, description: "")
+      persisted.resources << create(:resource)
+      expect(persisted.page_content?).to be(true)
+    end
+
+    it "is false with no description and no resources" do
+      callout.description = ""
+      expect(callout.page_content?).to be(false)
+    end
+  end
+
   describe "#dripping?" do
     it "is true only while display_from is in the future" do
       callout.display_from = 1.day.from_now

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe "Events::Callouts", type: :request do
       # The file itself is only shown on the resource's own page, not embedded here.
       expect(response.body).not_to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
     end
+
+    it "lists both unlock conditions while the details aren't visible yet" do
+      event.update!(start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours)
+
+      get registration_videoconference_path(registration.slug)
+
+      expect(response.body).to include("unlocks once both of these are met")
+      expect(response.body).to include("Your payment is on file")
+      expect(response.body).to include("The join link isn't in this calendar entry yet")
+      expect(response.body).not_to include("https://example.com/zoom")
+    end
   end
 
   # The single-resource page is where a document is actually shown: the inline

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -62,13 +62,15 @@ RSpec.describe "Registration ticket callouts", type: :request do
       expect(response).to redirect_to(event_path(event))
     end
 
-    it "redirects a not-yet-dripped callout's page back to the event" do
+    it "shows a coming-soon note instead of the content on a not-yet-dripped callout's page" do
       callout = create(:registration_ticket_callout, event:, description: "<p>Later.</p>",
         display_from: 1.day.from_now)
 
       get event_registration_ticket_callout_path(event, callout)
 
-      expect(response).to redirect_to(event_path(event))
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("This content will be available on")
+      expect(response.body).not_to include("Later.")
     end
 
     context "when linked to a resource" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -569,7 +569,8 @@ RSpec.describe "Events::Registrations", type: :request do
       get registration_videoconference_path(registration.slug)
       expect(response.body).not_to include("88285411273")
       expect(response.body).not_to include("secret123")
-      expect(response.body).to include("about a week before the event")
+      expect(response.body).to include("unlocks once both of these are met")
+      expect(response.body).to include("Available from")
     end
 
     it "withholds the link and credentials until the registrant has payment access" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained callout/videoconference display logic, well covered by specs

Builds on the callout feature already on main. Makes the callout **display date** gate *page content* rather than the whole card, and ties the videoconference reveal to that editable date.

### Why
- A drip date previously hid the entire card; it should only withhold the callout's page content while keeping the card visible.
- The videoconference "details lead" was a hard-coded 7 days. Admins should be able to set it via the built-in callout's drip date.

### What
- **Drip = content gate, not card gate.** The card always shows; its page shows a "coming soon" note until the display date. `show` no longer redirects dripping callouts.
- **Videoconference reveal driven by the callout's `display_from`** (`Event#videoconference_details_available_from`), falling back to `start_date − 7.days`. Flows to the join link, the videoconference page, the card subtitle, and the calendar entry.
- **Videoconference page** lists both unlock conditions (payment on file + reveal date) with met/unmet marks; calendar sections note the join link isn't in the entry yet.
- **Cards link + show the trailing arrow only when they lead to real page content** (`RegistrationTicketCallout#page_content?`); content-less callouts render as plain, non-navigating cards.
- Videoconference URL field hint: "Connects to the callout card on registrant tickets."

Supersedes the closed #1954 (that branch's base feature landed on main via other PRs); this is just the additive delta on top of current main.
