### PR TITLE
Match ticket width to callout pages to avoid a width jump

### DIFF
--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -1,5 +1,5 @@
 <% preview = local_assigns.fetch(:preview, false) %>
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
+<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
   <!-- Ticket Container -->
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
     <!-- Ticket Header -->

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-2xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
+<div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
   <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
   <% end %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only Tailwind max-width tweak, no logic

### What is the goal of this PR and why is this important?
- The ticket page was `max-w-2xl` while base callout pages are `max-w-3xl`, so navigating from a ticket to a callout visibly widened the layout.

### How did you approach the change?
- Widen the ticket to `max-w-3xl` (eyebrow row + card) so it aligns with the base callout pages.
- Resource callouts intentionally stay wider at `max-w-5xl`.