### PR TITLE
Rename bulk-payment form to "Pay for Other(s)" and steer self-payers to their ticket

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,7 @@ class Form < ApplicationRecord
   # Public-facing name for the "bulk payment" form — what visitors see on the
   # event page CTA and the form heading. Internal/admin labels still say "Bulk
   # payment" (the form role). Single source of truth so both ends stay in sync.
-  BULK_PAYMENT_PUBLIC_NAME = "Pay for Participant(s)".freeze
+  BULK_PAYMENT_PUBLIC_NAME = "Pay for Other(s)".freeze
 
   belongs_to :owner, polymorphic: true, optional: true
   has_many :form_fields, dependent: :destroy, inverse_of: :form

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -36,13 +36,19 @@
         </div>
         <div>
           <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> form</h2>
-          <p class="text-sm text-blue-200">Pay for one or more attendees.</p>
+          <p class="text-sm text-blue-200">Use this form to pay for one or more other attendees.</p>
         </div>
       </div>
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <div class="px-6 sm:px-8 py-7">
+      <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
+        <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
+        <span class="text-sm">Paying for yourself? Please pay through your own ticket on the
+          <%= link_to "event page", event_path(@event), class: "font-semibold underline hover:no-underline" %>
+          instead. Use this form only to pay for other attendees.</span>
+      </div>
       <% if flash[:alert] %>
         <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -46,10 +46,12 @@
       <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
         <div class="text-sm space-y-2">
-          <p>Paying for yourself? Don't use this form. Instead, check your email for the link to your
-            personalized registration ticket and pay from there.</p>
-          <p>Use this form if you will not be attending, but are paying for someone else who will attend.
-            Or, if you are attending and need to pay for yourself and multiple other attendees in one payment.</p>
+          <p><strong>Use this form to pay for other people who are attending.</strong> That includes
+            paying for one or more other attendees — and you can add yourself too, if you're attending
+            and want to cover yourself and others in a single payment.</p>
+          <p><strong>Only paying for your own spot?</strong> You don't need this form. When you
+            registered, we emailed you a confirmation with a link to your digital ticket — open that
+            ticket and use the payment link on it.</p>
         </div>
       </div>
       <% if flash[:alert] %>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -46,8 +46,8 @@
       <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
         <div class="text-sm space-y-2">
-          <p>Paying for yourself? Check your email for the link to your personalized registration
-            ticket and pay from there.</p>
+          <p>Paying for yourself? Don't use this form. Instead, check your email for the link to your
+            personalized registration ticket and pay from there.</p>
           <p>Use this form if you will not be attending, but are paying for someone else who will attend.
             Or, if you are attending and need to pay for yourself and multiple other attendees in one payment.</p>
         </div>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -35,7 +35,7 @@
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div>
-          <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> form</h2>
+          <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> Form</h2>
           <p class="text-sm text-blue-200">Use this form to pay for one or more other attendees.</p>
         </div>
       </div>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -48,8 +48,8 @@
         <div class="text-sm space-y-2">
           <p>Paying for yourself? Check your email for the link to your personalized registration
             ticket and pay from there.</p>
-          <p>Use this form if you are not attending but are paying for someone who is going to attend.
-            Or, if you are attending and need to pay for yourself and multiple other attendees.</p>
+          <p>Use this form if you will not be attending, but are paying for someone else who will attend.
+            Or, if you are attending and need to pay for yourself and multiple other attendees in one payment.</p>
         </div>
       </div>
       <% if flash[:alert] %>

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -45,9 +45,8 @@
     <div class="px-6 sm:px-8 py-7">
       <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
-        <span class="text-sm">Paying for yourself? Please pay through your own ticket on the
-          <%= link_to "event page", event_path(@event), class: "font-semibold underline hover:no-underline" %>
-          instead. Use this form only to pay for other attendees.</span>
+        <span class="text-sm">Paying for yourself? Check your email for the link to your personalized
+          registration ticket and pay from there. Use this form only to pay for other attendees.</span>
       </div>
       <% if flash[:alert] %>
         <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">

--- a/app/views/events/bulk_payments/new.html.erb
+++ b/app/views/events/bulk_payments/new.html.erb
@@ -45,8 +45,12 @@
     <div class="px-6 sm:px-8 py-7">
       <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
-        <span class="text-sm">Paying for yourself? Check your email for the link to your personalized
-          registration ticket and pay from there. Use this form only to pay for other attendees.</span>
+        <div class="text-sm space-y-2">
+          <p>Paying for yourself? Check your email for the link to your personalized registration
+            ticket and pay from there.</p>
+          <p>Use this form if you are not attending but are paying for someone who is going to attend.
+            Or, if you are attending and need to pay for yourself and multiple other attendees.</p>
+        </div>
       </div>
       <% if flash[:alert] %>
         <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 copy + one static info banner, no logic changes

### What is the goal of this PR and why is this important?
- The public bulk-payment form label was ambiguous about who it's for.
- Rename the public-facing label to "Pay for Other(s)" (internal code/role stays "bulk payment").
- Add a note at the top of the form clarifying who should use it, so self-payers don't misuse it.

### How did you approach the change?
- Updated the single source-of-truth constant `Form::BULK_PAYMENT_PUBLIC_NAME`.
- Sharpened the header subheading and added an info banner at the top of the form body that:
  - Leads with who *should* use the form (paying for one or more other attendees, optionally including yourself in one payment).
  - Tells self-payers not to use it, and points them to the digital-ticket payment link in their registration confirmation email.

### Anything else to add?
- No behavior/logic changes; copy + one static banner only.