### PR TITLE
Materialize per-resource callout copy (subtitle + page content), + admin Edit link

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -241,13 +241,15 @@ module Events
     end
 
     # The payment callout's linked documents (the W-9 by default on paid events),
-    # shown on the payment page's Documents section. Uses the materialized Payment
-    # row's resources when present (so admins can add/remove them), else the W-9
-    # for paid events not yet materialized.
+    # shown on the payment page's Documents section. Returns the join rows so each
+    # card reads its admin-editable subtitle from the materialized row. Uses the
+    # materialized Payment row's links when present (so admins can add/remove
+    # them), else transient links for the W-9 on paid events not yet materialized.
     def payment_document_resources
       payment_callout = @event.registration_ticket_callouts.find_by(magic_key: "payment")
-      return payment_callout.resources.to_a if payment_callout
-      @event.cost_cents.to_i.positive? ? Resource.where(title: "W-9").to_a : []
+      return payment_callout.registration_ticket_callout_resources.ordered.includes(:resource).to_a if payment_callout
+      return [] unless @event.cost_cents.to_i.positive?
+      Resource.where(title: "W-9").map { |resource| RegistrationTicketCalloutResource.new(resource:) }
     end
 
     # A blue callout card linking to a document. External/static links open in a

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -174,6 +174,7 @@ module Events
     # ticket context.
     def resource
       @resource = Resource.find(params[:resource_id]).decorate
+      @resource_subtitle = HANDOUT_SUBTITLES[@resource.title]
     end
 
     # Videoconference page: the join link and add-to-calendar options.

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -30,19 +30,6 @@ module Events
       "Letter to Supervisors"
     ].freeze
 
-    HANDOUT_SUBTITLES = {
-      "2-Day AWBW Facilitator Training Worksheets & Handouts" =>
-        "List of resources and worksheets we will reference and utilize during the training. You do not need to print them out, it may be helpful for you to access the links during the training.",
-      "AWBW Training Workshop Worksheets" =>
-        "Worksheets you can create on during all 5 of the art workshops at the training. Any art materials are welcomed during creation.",
-      "Aha Moments" =>
-        "Worksheet you can use to reflect on the workshop, its impact, and how you'd like to apply it.",
-      "Inviting and Responding to Participants' Sharing" =>
-        "A resource to invite and support sharing, active listening, and connection during breakout rooms.",
-      "Letter to Supervisors" =>
-        "Letter you can share to help relieve you from competing responsibilities during the two training days. So you can secure the time and space needed to fully engage in the training."
-    }.freeze
-
     # Payment page: the full allocation ledger with the running balance due, plus
     # the linked documents (the W-9 from the payment callout's resources, and the
     # dynamic invoice/receipt) for paid events.
@@ -155,26 +142,22 @@ module Events
 
     # Handouts page: callout-card links to the training worksheet/handout
     # resources, in display order, each opening its own registrant resource page
-    # (PDF preview + download, with a back-to-handouts eyebrow).
+    # (PDF preview + download, with a back-to-handouts eyebrow). Cards read their
+    # subtitle from the materialized handouts callout's join rows.
     def handouts
       return redirect_to registration_ticket_path(@event_registration.slug) unless @event.show_handouts_callout?
-      by_title = Resource.where(title: HANDOUT_RESOURCE_TITLES).index_by(&:title)
-      @handout_cards = HANDOUT_RESOURCE_TITLES.filter_map do |title|
-        resource = by_title[title]
-        next unless resource
-        resource_card(icon: "fa-solid fa-file-pdf", title: resource.title,
-                      subtitle: HANDOUT_SUBTITLES[resource.title] || "Open this training resource",
-                      href: registration_resource_path(@event_registration.slug, resource, return_to: "handouts"), target: nil)
-      end
+      callout = @event.registration_ticket_callouts.find_by(magic_key: "handouts")
+      @handout_cards = callout_resource_cards(callout, icon: "fa-solid fa-file-pdf", return_to: "handouts")
     end
 
     # Registrant-facing page for a single Resource, shown in the shared callout
     # chrome: the PDF first-page preview and a download button. Reached from the
     # handouts/forms callouts so a registrant views a document without leaving the
-    # ticket context.
+    # ticket context. The page content shown under the title comes from the join
+    # row on the callout the registrant arrived from.
     def resource
       @resource = Resource.find(params[:resource_id]).decorate
-      @resource_subtitle = HANDOUT_SUBTITLES[@resource.title]
+      @resource_page_content = origin_callout_link&.page_content.presence
     end
 
     # Videoconference page: the join link and add-to-calendar options.
@@ -212,11 +195,37 @@ module Events
     def set_builtin_content
       callout = @event.registration_ticket_callouts.find_by(magic_key: action_name)
       @builtin_intro = callout&.description.presence
-      resources = callout && action_name != "payment" ? callout.resources.to_a : []
-      @builtin_resource_cards = resources.map do |resource|
-        resource_card(icon: "fa-solid fa-file-lines", title: resource.title,
-                      subtitle: "Open this document",
-                      href: registration_resource_path(@event_registration.slug, resource, return_to: action_name), target: nil)
+      callout = nil if action_name == "payment"
+      @builtin_resource_cards = callout_resource_cards(callout, icon: "fa-solid fa-file-lines", return_to: action_name)
+    end
+
+    # Callout cards for a callout's linked resources, in display order, each
+    # linking to the resource's own registrant page. The card subtitle comes from
+    # the join row (materialized default, admin-editable).
+    def callout_resource_cards(callout, icon:, return_to:)
+      return [] unless callout
+      callout.registration_ticket_callout_resources.ordered.includes(:resource).filter_map do |link|
+        resource = link.resource
+        next unless resource
+        resource_card(icon: icon, title: resource.title,
+                      subtitle: link.subtitle.presence || "Open this document",
+                      href: registration_resource_path(@event_registration.slug, resource, return_to: return_to), target: nil)
+      end
+    end
+
+    # The join row for @resource on the callout the registrant arrived from
+    # (via return_to / callout_id), so the resource page can show that callout's
+    # editable page content under the title.
+    def origin_callout_link
+      origin_callout&.registration_ticket_callout_resources&.find_by(resource_id: @resource.id)
+    end
+
+    def origin_callout
+      case params[:return_to]
+      when "callout"
+        @event.registration_ticket_callouts.find_by(id: params[:callout_id])
+      when *RegistrationTicketCallout::MAGIC_KEYS
+        @event.registration_ticket_callouts.find_by(magic_key: params[:return_to])
       end
     end
 

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -147,7 +147,7 @@ module Events
     def handouts
       return redirect_to registration_ticket_path(@event_registration.slug) unless @event.show_handouts_callout?
       callout = @event.registration_ticket_callouts.find_by(magic_key: "handouts")
-      @handout_cards = callout_resource_cards(callout, icon: "fa-solid fa-file-pdf", return_to: "handouts")
+      @handout_cards = resource_cards_for(callout, icon: "fa-solid fa-file-pdf", return_to: "handouts")
     end
 
     # Registrant-facing page for a single Resource, shown in the shared callout
@@ -196,21 +196,16 @@ module Events
       callout = @event.registration_ticket_callouts.find_by(magic_key: action_name)
       @builtin_intro = callout&.description.presence
       callout = nil if action_name == "payment"
-      @builtin_resource_cards = callout_resource_cards(callout, icon: "fa-solid fa-file-lines", return_to: action_name)
+      @builtin_resource_cards = resource_cards_for(callout, icon: "fa-solid fa-file-lines", return_to: action_name)
     end
 
-    # Callout cards for a callout's linked resources, in display order, each
-    # linking to the resource's own registrant page. The card subtitle comes from
-    # the join row (materialized default, admin-editable).
-    def callout_resource_cards(callout, icon:, return_to:)
+    # This registrant's cards for a callout's linked resources (nil callout → none).
+    # Delegates to the shared decorator so every callout surface builds them the
+    # same way — subtitle from the materialized join row, linking to the resource
+    # page returning to this origin.
+    def resource_cards_for(callout, icon:, return_to:)
       return [] unless callout
-      callout.registration_ticket_callout_resources.ordered.includes(:resource).filter_map do |link|
-        resource = link.resource
-        next unless resource
-        resource_card(icon: icon, title: resource.title,
-                      subtitle: link.subtitle.presence || "Open this document",
-                      href: registration_resource_path(@event_registration.slug, resource, return_to: return_to), target: nil)
-      end
+      callout.decorate.resource_cards(registrant_slug: @event_registration.slug, return_to:, icon:)
     end
 
     # The join row for @resource on the callout the registrant arrived from
@@ -250,14 +245,6 @@ module Events
       return payment_callout.registration_ticket_callout_resources.ordered.includes(:resource).to_a if payment_callout
       return [] unless @event.cost_cents.to_i.positive?
       Resource.where(title: "W-9").map { |resource| RegistrationTicketCalloutResource.new(resource:) }
-    end
-
-    # A blue callout card linking to a document. External/static links open in a
-    # new tab (target: "_blank"); registrant resource pages stay in-tab so the
-    # back-to-ticket eyebrow works (pass target: nil).
-    def resource_card(icon:, title:, subtitle:, href:, target: "_blank", trailing_icon: "fa-solid fa-arrow-right")
-      MagicTicketCallouts::Card.new(icon_class: icon, color: "blue", title: title, subtitle: subtitle,
-                                    href: href, target: target, trailing_icon: trailing_icon)
     end
 
     def redirect_to_ce_stripe_checkout(ce_registration)

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -35,7 +35,7 @@ module Events
     # dynamic invoice/receipt) for paid events.
     def payment
       @allocations = @event_registration.allocations.includes(:source).order(:created_at)
-      @document_resources = payment_document_resources
+      @document_cards = payment_document_cards
     end
 
     # Certificate of completion, rendered like the invoice. Only reachable once
@@ -235,16 +235,44 @@ module Events
       answer.update!(submitted_answer: number.to_s, question_name_when_answered: field.name)
     end
 
-    # The payment callout's linked documents (the W-9 by default on paid events),
-    # shown on the payment page's Documents section. Returns the join rows so each
-    # card reads its admin-editable subtitle from the materialized row. Uses the
-    # materialized Payment row's links when present (so admins can add/remove
-    # them), else transient links for the W-9 on paid events not yet materialized.
+    # The payment page's Documents section as grey callout cards, rendered through
+    # the shared card partial like every other callout surface: the dynamic
+    # invoice/receipt first, then the payment callout's linked resources (the W-9
+    # by default on paid events), each reading its admin-editable subtitle from the
+    # materialized join row.
+    def payment_document_cards
+      slug = @event_registration.slug
+      cards = []
+      if @event_registration.invoice_available?
+        cards << document_card(title: "Invoice", subtitle: "Itemized invoice for this registration",
+          icon: "fa-solid fa-file-invoice-dollar", href: registration_invoice_path(slug, return_to: "payment"))
+        if @event_registration.receipt_available?
+          cards << document_card(title: "Receipt", subtitle: "Paid-in-full receipt for this registration",
+            icon: "fa-solid fa-receipt", href: registration_receipt_path(slug, return_to: "payment"))
+        end
+      end
+      cards + payment_document_resources.map do |link|
+        link.decorate.to_card(registrant_slug: slug, return_to: "payment",
+                              icon: "fa-solid fa-file-pdf", color: "gray")
+      end
+    end
+
+    # The payment callout's linked resource join rows (the W-9 by default on paid
+    # events). Uses the materialized Payment row's links when present (so admins
+    # can add/remove them), else transient links for the W-9 on paid events not
+    # yet materialized.
     def payment_document_resources
       payment_callout = @event.registration_ticket_callouts.find_by(magic_key: "payment")
       return payment_callout.registration_ticket_callout_resources.ordered.includes(:resource).to_a if payment_callout
       return [] unless @event.cost_cents.to_i.positive?
       Resource.where(title: "W-9").map { |resource| RegistrationTicketCalloutResource.new(resource:) }
+    end
+
+    # A grey document card for a non-resource payment document (the dynamic
+    # invoice/receipt). Opens in a new tab, matching the callout-card contract.
+    def document_card(title:, subtitle:, icon:, href:)
+      MagicTicketCallouts::Card.new(icon_class: icon, color: "gray", title:, subtitle:,
+                                    href:, target: "_blank", trailing_icon: "fa-solid fa-arrow-right")
     end
 
     def redirect_to_ce_stripe_checkout(ce_registration)

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -42,19 +42,23 @@ class RegistrationTicketCalloutsController < ApplicationController
   private
 
   # This callout's resources as clickable cards linking to each resource's own
-  # page (never inline). A registrant reaching the page carries their ticket slug
-  # in `reg`, so links go to the in-ticket registrant resource page returning here;
-  # without a slug (e.g. an admin preview) they fall back to the resource's own page.
+  # page (never inline). Each card's subtitle reads from the materialized join
+  # row (admin-editable), not a hard-coded default. A registrant reaching the page
+  # carries their ticket slug in `reg`, so links go to the in-ticket registrant
+  # resource page returning here; without a slug (e.g. an admin preview) they fall
+  # back to the resource's own page.
   def build_resource_cards
     reg_slug = params[:reg].presence
-    @callout.resources.map do |resource|
+    @callout.registration_ticket_callout_resources.ordered.includes(:resource).filter_map do |link|
+      resource = link.resource
+      next unless resource
       href = if reg_slug
         registration_resource_path(reg_slug, resource, return_to: "callout", callout_id: @callout.id)
       else
         resource_path(resource)
       end
       MagicTicketCallouts::Card.new(icon_class: "fa-solid fa-file-lines", color: "blue",
-                                    title: resource.title, subtitle: "Open this document",
+                                    title: resource.title, subtitle: link.subtitle.presence || "Open this document",
                                     href:, target: nil, trailing_icon: "fa-solid fa-arrow-right")
     end
   end

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -21,7 +21,7 @@ class RegistrationTicketCalloutsController < ApplicationController
       return
     end
 
-    @resource_cards = build_resource_cards
+    @resource_cards = @callout.decorate.resource_cards(registrant_slug: params[:reg].presence, return_to: "callout")
     @event = @event.decorate
   end
 
@@ -40,28 +40,6 @@ class RegistrationTicketCalloutsController < ApplicationController
   end
 
   private
-
-  # This callout's resources as clickable cards linking to each resource's own
-  # page (never inline). Each card's subtitle reads from the materialized join
-  # row (admin-editable), not a hard-coded default. A registrant reaching the page
-  # carries their ticket slug in `reg`, so links go to the in-ticket registrant
-  # resource page returning here; without a slug (e.g. an admin preview) they fall
-  # back to the resource's own page.
-  def build_resource_cards
-    reg_slug = params[:reg].presence
-    @callout.registration_ticket_callout_resources.ordered.includes(:resource).filter_map do |link|
-      resource = link.resource
-      next unless resource
-      href = if reg_slug
-        registration_resource_path(reg_slug, resource, return_to: "callout", callout_id: @callout.id)
-      else
-        resource_path(resource)
-      end
-      MagicTicketCallouts::Card.new(icon_class: "fa-solid fa-file-lines", color: "blue",
-                                    title: resource.title, subtitle: link.subtitle.presence || "Open this document",
-                                    href:, target: nil, trailing_icon: "fa-solid fa-arrow-right")
-    end
-  end
 
   def set_event
     @event = Event.find(params[:event_id])

--- a/app/decorators/registration_ticket_callout_decorator.rb
+++ b/app/decorators/registration_ticket_callout_decorator.rb
@@ -1,0 +1,15 @@
+class RegistrationTicketCalloutDecorator < ApplicationDecorator
+  # This callout's linked resources as cards, in display order, each reading its
+  # subtitle from the materialized join row and linking to the resource's own
+  # page. Shared by every surface that lists a callout's resources (the handouts
+  # and built-in callout pages, and the generic callout page) so they can't drift.
+  # `return_to` identifies this origin for the resource page's eyebrow; the
+  # callout id is passed only for the generic callout page (return_to "callout").
+  def resource_cards(registrant_slug:, return_to:, icon: "fa-solid fa-file-lines")
+    registration_ticket_callout_resources.ordered.includes(:resource).filter_map do |link|
+      next unless link.resource
+      link.decorate.to_card(registrant_slug:, return_to:, icon:,
+                            callout_id: (id if return_to == "callout"))
+    end
+  end
+end

--- a/app/decorators/registration_ticket_callout_resource_decorator.rb
+++ b/app/decorators/registration_ticket_callout_resource_decorator.rb
@@ -10,10 +10,11 @@ class RegistrationTicketCalloutResourceDecorator < ApplicationDecorator
   # without a slug (the sample ticket / admin preview) it falls back to the
   # resource's plain admin page. `return_to` names the origin so the resource
   # page's eyebrow returns here; `callout_id` is only needed for the generic
-  # callout page and is dropped from the URL when nil.
-  def to_card(registrant_slug:, return_to:, icon: "fa-solid fa-file-lines", callout_id: nil)
+  # callout page and is dropped from the URL when nil. `color` themes the card —
+  # blue on the callout pages, grey in the payment page's documents list.
+  def to_card(registrant_slug:, return_to:, icon: "fa-solid fa-file-lines", color: "blue", callout_id: nil)
     MagicTicketCallouts::Card.new(
-      icon_class: icon, color: "blue", title: resource.title, subtitle: card_subtitle,
+      icon_class: icon, color:, title: resource.title, subtitle: card_subtitle,
       href: card_href(registrant_slug:, return_to:, callout_id:),
       target: nil, trailing_icon: "fa-solid fa-arrow-right"
     )

--- a/app/decorators/registration_ticket_callout_resource_decorator.rb
+++ b/app/decorators/registration_ticket_callout_resource_decorator.rb
@@ -1,0 +1,28 @@
+class RegistrationTicketCalloutResourceDecorator < ApplicationDecorator
+  # The short line shown on this resource's callout card: the admin-editable
+  # subtitle materialized on the join row, or a neutral fallback when blank.
+  def card_subtitle
+    subtitle.presence || "Open this document"
+  end
+
+  # This linked resource rendered as a callout card. A registrant (with a ticket
+  # slug) stays in-tab on the resource's own page and returns to this origin;
+  # without a slug (the sample ticket / admin preview) it falls back to the
+  # resource's plain admin page. `return_to` names the origin so the resource
+  # page's eyebrow returns here; `callout_id` is only needed for the generic
+  # callout page and is dropped from the URL when nil.
+  def to_card(registrant_slug:, return_to:, icon: "fa-solid fa-file-lines", callout_id: nil)
+    MagicTicketCallouts::Card.new(
+      icon_class: icon, color: "blue", title: resource.title, subtitle: card_subtitle,
+      href: card_href(registrant_slug:, return_to:, callout_id:),
+      target: nil, trailing_icon: "fa-solid fa-arrow-right"
+    )
+  end
+
+  private
+
+  def card_href(registrant_slug:, return_to:, callout_id:)
+    return h.resource_path(resource) unless registrant_slug
+    h.registration_resource_path(registrant_slug, resource, return_to:, callout_id:)
+  end
+end

--- a/app/models/registration_ticket_callout_resource.rb
+++ b/app/models/registration_ticket_callout_resource.rb
@@ -2,6 +2,11 @@ class RegistrationTicketCalloutResource < ApplicationRecord
   # Ordered join between a callout and the resources it links to (e.g. the
   # Handouts card's worksheets, or a custom callout's supporting documents).
   # Reordered like the callouts themselves via the positioning gem.
+  #
+  # `subtitle` is the short line shown on the callout card for this resource;
+  # `page_content` is the longer copy shown under the title on the resource's own
+  # detail page. Both are editable per event (materialized from
+  # DefaultTicketCallouts for the built-in handouts).
   belongs_to :registration_ticket_callout
   belongs_to :resource
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -160,7 +160,7 @@ class EventPolicy < ApplicationPolicy
                   primary_asset_attributes: [ :id, :file, :_destroy ],
                   gallery_assets_attributes: [ :id, :file, :_destroy ],
                   registration_ticket_callouts_attributes: [ :id, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :display_from, :payment_access_gated, :published, :reset_to_default, :_destroy,
-                    { registration_ticket_callout_resources_attributes: [ :id, :resource_id, :_destroy ] } ]
+                    { registration_ticket_callout_resources_attributes: [ :id, :resource_id, :subtitle, :page_content, :_destroy ] } ]
         ]
 
     permitted.prepend(:ga4_snippet, :gtm_head_snippet, :gtm_body_snippet) if admin?

--- a/app/services/default_ticket_callouts.rb
+++ b/app/services/default_ticket_callouts.rb
@@ -54,6 +54,34 @@ class DefaultTicketCallouts
            "The membership fee covers all facilitators connected to the same program or organization for the calendar year, regardless of the number of facilitators participating. Only one membership fee payment is required per program annually." ] }
   ].freeze
 
+  # Default per-resource copy for the built-in handout links, keyed by resource
+  # title. `subtitle` is the short line on the handouts card; `page_content` is
+  # the longer copy shown under the title on the resource's own page. Materialized
+  # onto each join row so admins edit it per event (previously hard-coded in
+  # Events::CalloutsController::HANDOUT_SUBTITLES and rendered from there).
+  HANDOUT_LINK_DEFAULTS = {
+    "2-Day AWBW Facilitator Training Worksheets & Handouts" => {
+      subtitle: "Worksheets we'll reference throughout the training",
+      page_content: "List of resources and worksheets we will reference and utilize during the training. You do not need to print them out, it may be helpful for you to access the links during the training."
+    },
+    "AWBW Training Workshop Worksheets" => {
+      subtitle: "Create-along worksheets for the five art workshops",
+      page_content: "Worksheets you can create on during all 5 of the art workshops at the training. Any art materials are welcomed during creation."
+    },
+    "Aha Moments" => {
+      subtitle: "Reflect on the workshop and its impact",
+      page_content: "Worksheet you can use to reflect on the workshop, its impact, and how you'd like to apply it."
+    },
+    "Inviting and Responding to Participants' Sharing" => {
+      subtitle: "Support sharing and connection in breakout rooms",
+      page_content: "A resource to invite and support sharing, active listening, and connection during breakout rooms."
+    },
+    "Letter to Supervisors" => {
+      subtitle: "Secure the time and space to fully engage",
+      page_content: "Letter you can share to help relieve you from competing responsibilities during the two training days. So you can secure the time and space needed to fully engage in the training."
+    }
+  }.freeze
+
   # magic_keys this service knows how to materialize.
   def self.seedable_keys
     new(nil).send(:definitions).map { |definition| definition[:magic_key] }
@@ -104,7 +132,8 @@ class DefaultTicketCallouts
       hidden: definition[:hidden].call(@event),
       display_from: definition[:display_from]&.call(@event)
     )
-    callout.resources = definition[:resources]&.call || []
+    callout.registration_ticket_callout_resources.destroy_all
+    build_resource_links(callout, definition)
     callout
   end
 
@@ -120,7 +149,8 @@ class DefaultTicketCallouts
       callout.color_class != definition[:color_class] ||
       callout.hidden != definition[:hidden].call(@event) ||
       callout.display_from != definition[:display_from]&.call(@event) ||
-      callout.resource_ids.sort != Array(definition[:resources]&.call).map(&:id).sort
+      callout.resource_ids.sort != Array(definition[:resources]&.call).map(&:id).sort ||
+      resource_content_customized?(callout, definition)
   end
 
   private
@@ -217,7 +247,9 @@ class DefaultTicketCallouts
         icon_class: "fa-solid fa-folder-open",
         color_class: "blue",
         hidden: ->(event) { !event.facilitator_training? },
-        resources: -> { handout_resources }
+        resources: -> { handout_resources },
+        # Per-link subtitle/page_content defaults, keyed by resource title.
+        resource_content: HANDOUT_LINK_DEFAULTS
       },
       {
         magic_key: "faq",
@@ -244,8 +276,37 @@ class DefaultTicketCallouts
       hidden: definition[:hidden].call(@event),
       display_from: definition[:display_from]&.call(@event)
     )
-    definition[:resources]&.call&.each { |resource| callout.resources << resource }
+    build_resource_links(callout, definition)
     callout
+  end
+
+  # Link the definition's resources in order, materializing each join row's
+  # subtitle/page_content from `resource_content` (keyed by resource title) when
+  # the definition supplies it. The positioning gem assigns each row's position.
+  def build_resource_links(callout, definition)
+    content = definition[:resource_content] || {}
+    Array(definition[:resources]&.call).each do |resource|
+      attrs = content[resource.title] || {}
+      callout.registration_ticket_callout_resources.create!(
+        resource: resource,
+        subtitle: attrs[:subtitle],
+        page_content: attrs[:page_content]
+      )
+    end
+  end
+
+  # Whether any link's subtitle/page_content has been edited away from its
+  # default, so "Restore default" is offered when only the copy was changed.
+  def resource_content_customized?(callout, definition)
+    content = definition[:resource_content]
+    return false if content.blank?
+
+    callout.registration_ticket_callout_resources.any? do |link|
+      defaults = content[link.resource.title]
+      next false if defaults.blank?
+      link.subtitle.to_s != defaults[:subtitle].to_s ||
+        link.page_content.to_s != defaults[:page_content].to_s
+    end
   end
 
   # The training worksheet resources, by title, in the display order the code

--- a/app/services/default_ticket_callouts.rb
+++ b/app/services/default_ticket_callouts.rb
@@ -180,7 +180,11 @@ class DefaultTicketCallouts
         # The W-9 is a removable linked resource, included by default only on paid
         # events (where a tax form applies); the invoice/receipt stay dynamic on
         # the payment page. Admins add/remove it per event.
-        resources: -> { @event.cost_cents.to_i.positive? ? [ Resource.find_by(title: "W-9") ].compact : [] }
+        resources: -> { @event.cost_cents.to_i.positive? ? [ Resource.find_by(title: "W-9") ].compact : [] },
+        # Its card subtitle is materialized here (admin-editable), not hard-coded in the view.
+        resource_content: {
+          "W-9" => { subtitle: "AWBW's W-9 tax form for your records" }
+        }
       },
       {
         magic_key: "certificate",

--- a/app/views/assets/_resource_display.html.erb
+++ b/app/views/assets/_resource_display.html.erb
@@ -1,7 +1,7 @@
 <% file = resource.downloadable_asset&.file&.attached? ? resource.downloadable_asset.file : resource.display_image %>
 
 <% if file.respond_to?(:content_type) && file.content_type == "application/pdf" %>
-  <div class="max-w-5xl mx-auto h-[95vh] rounded-lg border border-gray-200 overflow-hidden">
+  <div class="max-w-7xl mx-auto h-[95vh] rounded-lg border border-gray-200 overflow-hidden">
     <object
       data="<%= rails_storage_proxy_path(file, disposition: :inline) %>"
       type="application/pdf"

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -157,7 +157,7 @@
           </summary>
 
           <div class="mt-1">
-            <p class="text-xs text-gray-500 mb-1">Optional. Each resource links to its own page (PDF preview + download). The <strong>subtitle</strong> shows on this call-out's card; the <strong>page content</strong> shows under the title on the resource's page.</p>
+            <p class="text-xs text-gray-500 mb-1">Optional. Each resource links to its own callout page. <strong>Subtitle</strong> shows on the callout card; <strong>page content</strong> shows under the resource title on its callout page.</p>
 
             <div class="space-y-2">
               <%= f.fields_for :registration_ticket_callout_resources do |rf| %>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -163,11 +163,14 @@
               <%= f.fields_for :registration_ticket_callout_resources do |rf| %>
                 <%= render "events/registration_ticket_callout_resource_fields", f: rf %>
               <% end %>
-            </div>
 
-            <%= link_to_add_association "➕ Add resource", f, :registration_ticket_callout_resources,
-                  partial: "events/registration_ticket_callout_resource_fields",
-                  class: "mt-1 inline-block text-sm font-medium text-purple-600 hover:text-purple-800" %>
+              <%# Insert new rows at the end of the list (right before this link), not
+                  above the whole section — cocoon's default would prepend before the parent. %>
+              <%= link_to_add_association "➕ Add resource", f, :registration_ticket_callout_resources,
+                    partial: "events/registration_ticket_callout_resource_fields",
+                    data: { association_insertion_node: "this", association_insertion_method: "before" },
+                    class: "inline-block text-sm font-medium text-purple-600 hover:text-purple-800" %>
+            </div>
           </div>
         </details>
       </div>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -160,6 +160,18 @@
             <p class="text-xs text-gray-500 mb-1">Optional. Each resource links to its own callout page. <strong>Subtitle</strong> shows on the callout card; <strong>page content</strong> shows under the resource title on its callout page.</p>
 
             <div class="space-y-2">
+              <%# Column headers — mirror the row's flex + 3-col grid (plus a spacer
+                  for the remove button) so they line up. Hidden on mobile, where the
+                  fields stack to one column. %>
+              <div class="hidden sm:flex items-center gap-2 mt-2 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+                <div class="flex-1 min-w-0 grid grid-cols-3 gap-2">
+                  <span>Resource</span>
+                  <span>Card subtitle</span>
+                  <span>Page content</span>
+                </div>
+                <span class="shrink-0 w-3" aria-hidden="true"></span>
+              </div>
+
               <%= f.fields_for :registration_ticket_callout_resources do |rf| %>
                 <%= render "events/registration_ticket_callout_resource_fields", f: rf %>
               <% end %>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -157,7 +157,7 @@
           </summary>
 
           <div class="mt-1">
-            <p class="text-xs text-gray-500 mb-1">Optional. Shows each resource below the content on the call-out's page (PDF first-page preview, etc.), with a download button when the resource has a downloadable file.</p>
+            <p class="text-xs text-gray-500 mb-1">Optional. Each resource links to its own page (PDF preview + download). The <strong>subtitle</strong> shows on this call-out's card; the <strong>page content</strong> shows under the title on the resource's page.</p>
 
             <div class="space-y-2">
               <%= f.fields_for :registration_ticket_callout_resources do |rf| %>

--- a/app/views/events/_registration_ticket_callout_resource_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_resource_fields.html.erb
@@ -1,9 +1,17 @@
-<%# One linked-resource row: a single document dropdown + remove, added another
-    at a time (cocoon), mirroring the Sectors picker on Person edit. %>
-<div class="nested-fields flex items-center gap-2">
-  <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
-        { include_blank: "Select a document…" },
-        class: "flex-1 min-w-0 rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
+<%# One linked-resource row: the document dropdown plus its card subtitle and
+    detail-page content, added another at a time (cocoon), mirroring the Sectors
+    picker on Person edit. Subtitle shows on the callout card; page content shows
+    under the title on the resource's own page. %>
+<div class="nested-fields flex items-start gap-2">
+  <div class="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-3 gap-2">
+    <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
+          { include_blank: "Select a document…" },
+          class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
+    <%= f.text_field :subtitle, placeholder: "Card subtitle (short one-line)",
+          class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
+    <%= f.text_area :page_content, rows: 2, placeholder: "Page content (shown under the title)",
+          class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
+  </div>
   <%= link_to_remove_association "✖", f,
-        class: "shrink-0 text-gray-400 hover:text-red-600 font-bold text-xs" %>
+        class: "shrink-0 text-gray-400 hover:text-red-600 font-bold text-xs pt-1.5" %>
 </div>

--- a/app/views/events/_registration_ticket_callout_resource_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_resource_fields.html.erb
@@ -5,7 +5,7 @@
 <div class="nested-fields flex items-start gap-2">
   <div class="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-3 gap-2">
     <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
-          { include_blank: "Select a document…" },
+          { include_blank: "Select a resource…" },
           class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
     <%= f.text_field :subtitle, placeholder: "Card subtitle (short one-line)",
           class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>

--- a/app/views/events/_registration_ticket_callout_resource_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_resource_fields.html.erb
@@ -7,9 +7,9 @@
     <%= f.collection_select :resource_id, Resource.order(:title), :id, :title,
           { include_blank: "Select a resource…" },
           class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
-    <%= f.text_field :subtitle, placeholder: "Card subtitle (short one-line)",
+    <%= f.text_field :subtitle, placeholder: "Short one-line",
           class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
-    <%= f.text_area :page_content, rows: 2, placeholder: "Page content (shown under the title)",
+    <%= f.text_area :page_content, rows: 2, placeholder: "Shown under the title",
           class: "rounded border-gray-300 bg-white shadow-sm px-2 py-1 text-sm" %>
   </div>
   <%= link_to_remove_association "✖", f,

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -1,39 +1,37 @@
 <% inline_title = local_assigns[:inline_title] %>
-<% subtitle = local_assigns[:subtitle] %>
+<% page_content = local_assigns[:page_content] %>
 <% show_actions = resource.downloadable_asset&.file&.attached? || allowed_to?(:edit?, resource) %>
 
-<% if inline_title.present? || show_actions %>
-  <div class="flex items-start gap-4 mb-1">
-    <% if inline_title.present? %>
-      <h2 class="flex-1 min-w-0 text-2xl font-semibold text-gray-900 break-words"><%= inline_title %></h2>
+<% if show_actions %>
+  <%# Floated right so the title and page content flow full-width beneath it.
+      Download sits on top; the admin-only Edit link tucks in below (new tab so
+      the callout context isn't lost). %>
+  <div class="float-right ml-4 flex flex-col items-end gap-2">
+    <% if resource.downloadable_asset&.file&.attached? %>
+      <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
+        Download
+        <i class="fa-solid fa-download"></i>
+      <% end %>
     <% end %>
-    <% if show_actions %>
-      <%# Download sits parallel with the title; the admin-only Edit link tucks
-          in below it. Edit opens in a new tab so the callout context isn't lost. %>
-      <div class="ml-auto flex flex-col items-end gap-2 shrink-0">
-        <% if resource.downloadable_asset&.file&.attached? %>
-          <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
-            Download
-            <i class="fa-solid fa-download"></i>
-          <% end %>
-        <% end %>
-        <% if allowed_to?(:edit?, resource) %>
-          <%= link_to edit_resource_path(resource), target: "_blank", rel: "noopener",
-                class: "admin-only inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
-            <i class="fa-solid fa-pen-to-square text-[0.6rem]"></i>
-            Edit resource
-            <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
-          <% end %>
-        <% end %>
-      </div>
+    <% if allowed_to?(:edit?, resource) %>
+      <%= link_to edit_resource_path(resource), target: "_blank", rel: "noopener",
+            class: "admin-only inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
+        <i class="fa-solid fa-pen-to-square text-[0.6rem]"></i>
+        Edit resource
+        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+      <% end %>
     <% end %>
   </div>
 <% end %>
 
-<% if subtitle.present? %>
-  <p class="text-gray-600 max-w-3xl mb-4"><%= subtitle %></p>
+<% if inline_title.present? %>
+  <h2 class="text-2xl font-semibold text-gray-900 break-words"><%= inline_title %></h2>
 <% end %>
 
-<p class="text-xs text-gray-400 mb-3">The preview below may take a moment to load.</p>
+<% if page_content.present? %>
+  <p class="text-gray-600 max-w-3xl mt-1"><%= page_content %></p>
+<% end %>
+
+<p class="clear-both text-xs text-gray-400 pt-3 mb-3">The preview below may take a moment to load.</p>
 
 <%= render "assets/resource_display", resource: resource %>

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -1,11 +1,13 @@
 <% if resource.downloadable_asset&.file&.attached? || allowed_to?(:edit?, resource) %>
-  <div class="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 mb-4">
+  <div class="flex flex-col items-end gap-2 mb-4">
     <% if allowed_to?(:edit?, resource) %>
       <%# Admins can jump to the resource edit form to change the PDF. Opens in a
           new tab so the registrant-facing callout context isn't lost. %>
-      <%= link_to edit_resource_path(resource), target: "_blank", class: "admin-only bg-blue-100 btn btn-utility" do %>
-        Edit
-        <i class="fa-solid fa-pen"></i>
+      <%= link_to edit_resource_path(resource), target: "_blank", rel: "noopener",
+            class: "admin-only inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
+        <i class="fa-solid fa-pen-to-square text-[0.6rem]"></i>
+        Edit resource
+        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
       <% end %>
     <% end %>
     <% if resource.downloadable_asset&.file&.attached? %>

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -1,22 +1,37 @@
-<% if resource.downloadable_asset&.file&.attached? || allowed_to?(:edit?, resource) %>
-  <div class="flex flex-col items-end gap-2 mb-4">
-    <% if allowed_to?(:edit?, resource) %>
-      <%# Admins can jump to the resource edit form to change the PDF. Opens in a
-          new tab so the registrant-facing callout context isn't lost. %>
-      <%= link_to edit_resource_path(resource), target: "_blank", rel: "noopener",
-            class: "admin-only inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
-        <i class="fa-solid fa-pen-to-square text-[0.6rem]"></i>
-        Edit resource
-        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
-      <% end %>
+<% inline_title = local_assigns[:inline_title] %>
+<% subtitle = local_assigns[:subtitle] %>
+<% show_actions = resource.downloadable_asset&.file&.attached? || allowed_to?(:edit?, resource) %>
+
+<% if inline_title.present? || show_actions %>
+  <div class="flex items-start gap-4 mb-1">
+    <% if inline_title.present? %>
+      <h2 class="flex-1 min-w-0 text-2xl font-semibold text-gray-900 break-words"><%= inline_title %></h2>
     <% end %>
-    <% if resource.downloadable_asset&.file&.attached? %>
-      <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
-        Download
-        <i class="fa-solid fa-download"></i>
-      <% end %>
+    <% if show_actions %>
+      <%# Download sits parallel with the title; the admin-only Edit link tucks
+          in below it. Edit opens in a new tab so the callout context isn't lost. %>
+      <div class="ml-auto flex flex-col items-end gap-2 shrink-0">
+        <% if resource.downloadable_asset&.file&.attached? %>
+          <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
+            Download
+            <i class="fa-solid fa-download"></i>
+          <% end %>
+        <% end %>
+        <% if allowed_to?(:edit?, resource) %>
+          <%= link_to edit_resource_path(resource), target: "_blank", rel: "noopener",
+                class: "admin-only inline-flex items-center gap-1 text-xs rounded-full border px-2 py-0.5 bg-sky-100 text-sky-700 border-sky-200 hover:bg-sky-200 transition" do %>
+            <i class="fa-solid fa-pen-to-square text-[0.6rem]"></i>
+            Edit resource
+            <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
   </div>
+<% end %>
+
+<% if subtitle.present? %>
+  <p class="text-gray-600 max-w-3xl mb-4"><%= subtitle %></p>
 <% end %>
 
 <p class="text-xs text-gray-400 mb-3">The preview below may take a moment to load.</p>

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -1,8 +1,18 @@
-<% if resource.downloadable_asset&.file&.attached? %>
+<% if resource.downloadable_asset&.file&.attached? || allowed_to?(:edit?, resource) %>
   <div class="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 mb-4">
-    <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
-      Download
-      <i class="fa-solid fa-download"></i>
+    <% if allowed_to?(:edit?, resource) %>
+      <%# Admins can jump to the resource edit form to change the PDF. Opens in a
+          new tab so the registrant-facing callout context isn't lost. %>
+      <%= link_to edit_resource_path(resource), target: "_blank", class: "admin-only bg-blue-100 btn btn-utility" do %>
+        Edit
+        <i class="fa-solid fa-pen"></i>
+      <% end %>
+    <% end %>
+    <% if resource.downloadable_asset&.file&.attached? %>
+      <%= link_to url_for(resource.downloadable_asset.file), download: true, class: "btn btn-utility" do %>
+        Download
+        <i class="fa-solid fa-download"></i>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -84,7 +84,7 @@
           <i class="fa-solid fa-file-pdf text-gray-400 text-xl shrink-0"></i>
           <div class="flex-1 min-w-0 text-left">
             <p class="font-semibold text-gray-900"><%= resource.title %></p>
-            <p class="text-sm text-gray-500"><%= link.subtitle.presence || "Open this document" %></p>
+            <p class="text-sm text-gray-500"><%= link.decorate.card_subtitle %></p>
           </div>
           <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
         <% end %>

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -77,13 +77,14 @@
         <% end %>
       <% end %>
 
-      <% @document_resources.each do |resource| %>
+      <% @document_resources.each do |link| %>
+        <% resource = link.resource %>
         <%= link_to registration_resource_path(@event_registration.slug, resource, return_to: "payment"),
                       class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
           <i class="fa-solid fa-file-pdf text-gray-400 text-xl shrink-0"></i>
           <div class="flex-1 min-w-0 text-left">
             <p class="font-semibold text-gray-900"><%= resource.title %></p>
-            <p class="text-sm text-gray-500"><%= resource.title == "W-9" ? "AWBW's W-9 tax form for your records" : "Open this document" %></p>
+            <p class="text-sm text-gray-500"><%= link.subtitle.presence || "Open this document" %></p>
           </div>
           <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
         <% end %>

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -50,44 +50,12 @@
 
   <%# Documents for paid events, available regardless of balance: the invoice
       always, the paid-in-full receipt once there's no balance due, and the W-9
-      (the payment callout's linked resources) last. %>
-  <% if @document_resources.any? || @event_registration.invoice_available? %>
+      (the payment callout's linked resources) last. Rendered as grey callout
+      cards through the shared partial, like every other callout resource list. %>
+  <% if @document_cards.any? %>
     <div class="mt-10 space-y-3">
-      <% if @event_registration.invoice_available? %>
-        <%= link_to registration_invoice_path(@event_registration.slug, return_to: "payment"), target: "_blank", rel: "noopener",
-                      class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
-          <i class="fa-solid fa-file-invoice-dollar text-gray-400 text-xl shrink-0"></i>
-          <div class="flex-1 min-w-0 text-left">
-            <p class="font-semibold text-gray-900">Invoice</p>
-            <p class="text-sm text-gray-500">Itemized invoice for this registration</p>
-          </div>
-          <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
-        <% end %>
-
-        <% if @event_registration.receipt_available? %>
-          <%= link_to registration_receipt_path(@event_registration.slug, return_to: "payment"), target: "_blank", rel: "noopener",
-                        class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
-            <i class="fa-solid fa-receipt text-gray-400 text-xl shrink-0"></i>
-            <div class="flex-1 min-w-0 text-left">
-              <p class="font-semibold text-gray-900">Receipt</p>
-              <p class="text-sm text-gray-500">Paid-in-full receipt for this registration</p>
-            </div>
-            <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
-          <% end %>
-        <% end %>
-      <% end %>
-
-      <% @document_resources.each do |link| %>
-        <% resource = link.resource %>
-        <%= link_to registration_resource_path(@event_registration.slug, resource, return_to: "payment"),
-                      class: "flex items-center gap-3 rounded-xl border-2 border-gray-200 bg-white px-4 py-3 hover:bg-gray-50 transition-colors" do %>
-          <i class="fa-solid fa-file-pdf text-gray-400 text-xl shrink-0"></i>
-          <div class="flex-1 min-w-0 text-left">
-            <p class="font-semibold text-gray-900"><%= resource.title %></p>
-            <p class="text-sm text-gray-500"><%= link.decorate.card_subtitle %></p>
-          </div>
-          <i class="fa-solid fa-arrow-right text-gray-400 shrink-0"></i>
-        <% end %>
+      <% @document_cards.each do |card| %>
+        <%= render "event_registrations/callout_card", callout: card %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/events/callouts/resource.html.erb
+++ b/app/views/events/callouts/resource.html.erb
@@ -27,8 +27,7 @@
      [ registration_ticket_path(@event_registration.slug), "Back to ticket", nil ]
    end %>
 <%= render layout: "events/callouts/callout_page", locals: { title: detail_label || @resource.title, back_path: back_path, back_label: back_label, container_width: "max-w-7xl" } do %>
-  <% if detail_label %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-4"><%= @resource.title %></h2>
-  <% end %>
-  <%= render "events/callouts/resource_body", resource: @resource %>
+  <%# When the header already reads "<Origin> detail", the resource's own title is
+      shown inline next to the actions; reached directly, the header IS the title. %>
+  <%= render "events/callouts/resource_body", resource: @resource, inline_title: (detail_label ? @resource.title : nil), subtitle: @resource_subtitle %>
 <% end %>

--- a/app/views/events/callouts/resource.html.erb
+++ b/app/views/events/callouts/resource.html.erb
@@ -29,5 +29,5 @@
 <%= render layout: "events/callouts/callout_page", locals: { title: detail_label || @resource.title, back_path: back_path, back_label: back_label, container_width: "max-w-7xl" } do %>
   <%# When the header already reads "<Origin> detail", the resource's own title is
       shown inline next to the actions; reached directly, the header IS the title. %>
-  <%= render "events/callouts/resource_body", resource: @resource, inline_title: (detail_label ? @resource.title : nil), subtitle: @resource_subtitle %>
+  <%= render "events/callouts/resource_body", resource: @resource, inline_title: (detail_label ? @resource.title : nil), page_content: @resource_page_content %>
 <% end %>

--- a/app/views/events/callouts/resource.html.erb
+++ b/app/views/events/callouts/resource.html.erb
@@ -26,7 +26,7 @@
    else
      [ registration_ticket_path(@event_registration.slug), "Back to ticket", nil ]
    end %>
-<%= render layout: "events/callouts/callout_page", locals: { title: detail_label || @resource.title, back_path: back_path, back_label: back_label, container_width: "max-w-5xl" } do %>
+<%= render layout: "events/callouts/callout_page", locals: { title: detail_label || @resource.title, back_path: back_path, back_label: back_label, container_width: "max-w-7xl" } do %>
   <% if detail_label %>
     <h2 class="text-lg font-semibold text-gray-800 mb-4"><%= @resource.title %></h2>
   <% end %>

--- a/db/migrate/20260715000553_add_content_to_callout_resources.rb
+++ b/db/migrate/20260715000553_add_content_to_callout_resources.rb
@@ -1,0 +1,54 @@
+class AddContentToCalloutResources < ActiveRecord::Migration[8.1]
+  # Per-link copy shown on the callout card (subtitle) and the resource's own
+  # detail page (page_content). Previously the handout copy was hard-coded in
+  # Events::CalloutsController::HANDOUT_SUBTITLES and rendered from there; these
+  # columns materialize it so admins can edit it per event.
+
+  # Self-contained snapshot of the handout defaults so the one-time backfill
+  # doesn't depend on app constants that may change later. The canonical copy
+  # lives in DefaultTicketCallouts::HANDOUT_LINK_DEFAULTS for future seeds/resets.
+  BACKFILL = {
+    "2-Day AWBW Facilitator Training Worksheets & Handouts" => {
+      subtitle: "Worksheets we'll reference throughout the training",
+      page_content: "List of resources and worksheets we will reference and utilize during the training. You do not need to print them out, it may be helpful for you to access the links during the training."
+    },
+    "AWBW Training Workshop Worksheets" => {
+      subtitle: "Create-along worksheets for the five art workshops",
+      page_content: "Worksheets you can create on during all 5 of the art workshops at the training. Any art materials are welcomed during creation."
+    },
+    "Aha Moments" => {
+      subtitle: "Reflect on the workshop and its impact",
+      page_content: "Worksheet you can use to reflect on the workshop, its impact, and how you'd like to apply it."
+    },
+    "Inviting and Responding to Participants' Sharing" => {
+      subtitle: "Support sharing and connection in breakout rooms",
+      page_content: "A resource to invite and support sharing, active listening, and connection during breakout rooms."
+    },
+    "Letter to Supervisors" => {
+      subtitle: "Secure the time and space to fully engage",
+      page_content: "Letter you can share to help relieve you from competing responsibilities during the two training days. So you can secure the time and space needed to fully engage in the training."
+    }
+  }.freeze
+
+  def up
+    add_column :registration_ticket_callout_resources, :subtitle, :string unless column_exists?(:registration_ticket_callout_resources, :subtitle)
+    add_column :registration_ticket_callout_resources, :page_content, :text unless column_exists?(:registration_ticket_callout_resources, :page_content)
+
+    say_with_time "Backfilling handout resource content" do
+      BACKFILL.each do |title, content|
+        execute(ActiveRecord::Base.sanitize_sql_array([
+          "UPDATE registration_ticket_callout_resources rcr " \
+          "JOIN resources r ON r.id = rcr.resource_id " \
+          "SET rcr.subtitle = ?, rcr.page_content = ? " \
+          "WHERE r.title = ? AND rcr.subtitle IS NULL AND rcr.page_content IS NULL",
+          content[:subtitle], content[:page_content], title
+        ]))
+      end
+    end
+  end
+
+  def down
+    remove_column :registration_ticket_callout_resources, :page_content, if_exists: true
+    remove_column :registration_ticket_callout_resources, :subtitle, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_130312) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_15_000553) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1095,9 +1095,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_130312) do
 
   create_table "registration_ticket_callout_resources", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.text "page_content"
     t.integer "position", null: false
     t.bigint "registration_ticket_callout_id", null: false
     t.integer "resource_id", null: false
+    t.string "subtitle"
     t.datetime "updated_at", null: false
     t.index ["registration_ticket_callout_id", "resource_id"], name: "index_callout_resources_on_callout_and_resource", unique: true
     t.index ["registration_ticket_callout_id"], name: "index_callout_resources_on_callout_id"

--- a/spec/decorators/registration_ticket_callout_decorator_spec.rb
+++ b/spec/decorators/registration_ticket_callout_decorator_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe RegistrationTicketCalloutDecorator, type: :decorator do
+  describe "#resource_cards" do
+    let(:callout) { create(:registration_ticket_callout) }
+    let(:resource) { create(:resource, title: "Worksheet") }
+
+    before do
+      create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
+             resource:, subtitle: "Short line")
+    end
+
+    it "builds a card per linked resource, reading the materialized subtitle" do
+      cards = callout.decorate.resource_cards(registrant_slug: "abc", return_to: "handouts")
+
+      expect(cards.map(&:title)).to eq([ "Worksheet" ])
+      expect(cards.first.subtitle).to eq("Short line")
+    end
+
+    it "carries the callout id in the href only for the generic callout origin" do
+      generic = callout.decorate.resource_cards(registrant_slug: "abc", return_to: "callout").first
+      handouts = callout.decorate.resource_cards(registrant_slug: "abc", return_to: "handouts").first
+
+      expect(generic.href).to include("callout_id=#{callout.id}")
+      expect(handouts.href).not_to include("callout_id")
+    end
+  end
+end

--- a/spec/decorators/registration_ticket_callout_resource_decorator_spec.rb
+++ b/spec/decorators/registration_ticket_callout_resource_decorator_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe RegistrationTicketCalloutResourceDecorator, type: :decorator do
+  include Rails.application.routes.url_helpers
+
+  describe "#card_subtitle" do
+    it "returns the materialized subtitle when present" do
+      link = build(:registration_ticket_callout_resource, subtitle: "Reflect on the workshop")
+      expect(link.decorate.card_subtitle).to eq("Reflect on the workshop")
+    end
+
+    it "falls back to a neutral label when the subtitle is blank" do
+      link = build(:registration_ticket_callout_resource, subtitle: "")
+      expect(link.decorate.card_subtitle).to eq("Open this document")
+    end
+  end
+
+  describe "#to_card" do
+    let(:resource) { create(:resource, title: "Worksheet") }
+    let(:link) { create(:registration_ticket_callout_resource, resource:, subtitle: "Short line") }
+
+    it "titles the card by the resource and reads the join-row subtitle" do
+      card = link.decorate.to_card(registrant_slug: "abc", return_to: "handouts")
+
+      expect(card.title).to eq("Worksheet")
+      expect(card.subtitle).to eq("Short line")
+    end
+
+    it "links a registrant to the resource page returning to this origin" do
+      card = link.decorate.to_card(registrant_slug: "abc", return_to: "handouts")
+
+      expect(card.href).to eq(registration_resource_path("abc", resource, return_to: "handouts"))
+    end
+
+    it "falls back to the resource's own page without a registrant slug" do
+      card = link.decorate.to_card(registrant_slug: nil, return_to: "callout")
+
+      expect(card.href).to eq(resource_path(resource))
+    end
+  end
+end

--- a/spec/factories/registration_ticket_callout_resources.rb
+++ b/spec/factories/registration_ticket_callout_resources.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :registration_ticket_callout_resource do
+    association :registration_ticket_callout
+    association :resource
+    subtitle { "A short card line" }
+    page_content { "Longer copy shown under the title on the resource page." }
+  end
+end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -105,6 +105,24 @@ RSpec.describe "Events::Callouts", type: :request do
       end
     end
 
+    context "admin edit button" do
+      let(:resource) { create(:resource) }
+
+      it "shows an admin-only Edit link to change the PDF when signed in as an admin" do
+        sign_in create(:user, super_user: true)
+
+        get registration_resource_path(registration.slug, resource)
+
+        expect(response.body).to include(edit_resource_path(resource))
+      end
+
+      it "hides the Edit link from registrants viewing the page" do
+        get registration_resource_path(registration.slug, resource)
+
+        expect(response.body).not_to include(edit_resource_path(resource))
+      end
+    end
+
     context "eyebrow" do
       let(:resource) { create(:resource) }
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe "Events::Callouts", type: :request do
         get registration_handouts_path(registration.slug)
         expect(response).to have_http_status(:success)
       end
+
+      it "shows each linked resource card with its join-row subtitle" do
+        callout = create(:registration_ticket_callout, event:, magic_key: "handouts")
+        resource = create(:resource, title: "Aha Moments")
+        create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
+               resource:, subtitle: "Reflect on the workshop", page_content: "Long detail copy.")
+
+        get registration_handouts_path(registration.slug)
+
+        expect(response.body).to include("Reflect on the workshop")
+        # Page content is detail-page only, never on the card.
+        expect(response.body).not_to include("Long detail copy.")
+      end
     end
 
     context "on a non-training event" do
@@ -123,24 +136,27 @@ RSpec.describe "Events::Callouts", type: :request do
       end
     end
 
-    context "supplemental subtitle" do
-      it "shows the handout's supplemental description below the title" do
-        title = Events::CalloutsController::HANDOUT_RESOURCE_TITLES.first
-        resource = create(:resource, title: title)
+    context "page content" do
+      let(:resource) { create(:resource) }
+
+      it "shows the join row's page content below the title" do
+        callout = create(:registration_ticket_callout, event:, magic_key: "handouts")
+        create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
+               resource:, subtitle: "Short card line", page_content: "The longer page content copy.")
 
         get registration_resource_path(registration.slug, resource, return_to: "handouts")
 
-        expect(response.body).to include(Events::CalloutsController::HANDOUT_SUBTITLES[title])
+        expect(response.body).to include("The longer page content copy.")
+        # The subtitle is a card-only line, not shown on the resource page.
+        expect(response.body).not_to include("Short card line")
       end
 
-      it "omits the subtitle for a resource without one" do
-        resource = create(:resource, title: "Some other document")
+      it "shows no page content when the resource isn't linked to the origin callout" do
+        create(:registration_ticket_callout, :magic, event:, magic_key: "handouts")
 
         get registration_resource_path(registration.slug, resource, return_to: "handouts")
 
         expect(response).to have_http_status(:success)
-        subtitle_texts = Events::CalloutsController::HANDOUT_SUBTITLES.values
-        expect(subtitle_texts.any? { |text| response.body.include?(text) }).to be(false)
       end
     end
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -123,6 +123,27 @@ RSpec.describe "Events::Callouts", type: :request do
       end
     end
 
+    context "supplemental subtitle" do
+      it "shows the handout's supplemental description below the title" do
+        title = Events::CalloutsController::HANDOUT_RESOURCE_TITLES.first
+        resource = create(:resource, title: title)
+
+        get registration_resource_path(registration.slug, resource, return_to: "handouts")
+
+        expect(response.body).to include(Events::CalloutsController::HANDOUT_SUBTITLES[title])
+      end
+
+      it "omits the subtitle for a resource without one" do
+        resource = create(:resource, title: "Some other document")
+
+        get registration_resource_path(registration.slug, resource, return_to: "handouts")
+
+        expect(response).to have_http_status(:success)
+        subtitle_texts = Events::CalloutsController::HANDOUT_SUBTITLES.values
+        expect(subtitle_texts.any? { |text| response.body.include?(text) }).to be(false)
+      end
+    end
+
     context "eyebrow" do
       let(:resource) { create(:resource) }
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -59,6 +59,22 @@ RSpec.describe "Events::Callouts", type: :request do
     end
   end
 
+  describe "GET /registration/:slug/payment" do
+    let(:event) { create(:event, cost_cents: 10_000) }
+
+    it "shows the W-9 document's materialized join-row subtitle, not hard-coded copy" do
+      callout = create(:registration_ticket_callout, event:, magic_key: "payment")
+      w9 = create(:resource, title: "W-9")
+      create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
+             resource: w9, subtitle: "Custom W-9 line")
+
+      get registration_payment_path(registration.slug)
+
+      expect(response.body).to include("Custom W-9 line")
+      expect(response.body).not_to include("AWBW's W-9 tax form for your records")
+    end
+  end
+
   describe "GET /registration/:slug/videoconference" do
     let(:event) { create(:event, videoconference_url: "https://example.com/zoom") }
 

--- a/spec/requests/events/registration_ticket_callouts_spec.rb
+++ b/spec/requests/events/registration_ticket_callouts_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe "Registration ticket callouts", type: :request do
         expect(response.body).not_to include(rails_blob_path(resource.downloadable_asset.file, only_path: true))
       end
 
+      it "shows the resource card's materialized join-row subtitle, not a generic placeholder" do
+        callout.registration_ticket_callout_resources.first.update!(subtitle: "Reflect on the workshop")
+
+        get event_registration_ticket_callout_path(event, callout)
+
+        expect(response.body).to include("Reflect on the workshop")
+        expect(response.body).not_to include("Open this document")
+      end
+
       it "links to the in-ticket registrant page when a registration slug is present" do
         registration = create(:event_registration, event:)
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -482,6 +482,7 @@ RSpec.describe "Events::Registrations", type: :request do
 
     it "links each handout to its registrant resource page, returning to handouts" do
       handout = create(:resource, title: "Aha Moments", kind: "Handout")
+      DefaultTicketCallouts.seed(event) # materialize the handouts callout, linking the resource
       get registration_handouts_path(registration.slug)
       expect(response).to have_http_status(:success)
       expect(response.body).to include(registration_resource_path(registration.slug, handout, return_to: "handouts"))

--- a/spec/services/default_ticket_callouts_spec.rb
+++ b/spec/services/default_ticket_callouts_spec.rb
@@ -154,6 +154,34 @@ RSpec.describe DefaultTicketCallouts do
       expect(handouts.resources).to eq([ first, second ])
     end
 
+    it "materializes each handout link's default subtitle and page content" do
+      title = "Aha Moments"
+      create(:resource, title: title)
+      event = create(:event)
+
+      described_class.seed(event)
+
+      handouts = event.registration_ticket_callouts.find_by(magic_key: "handouts")
+      link = handouts.registration_ticket_callout_resources.joins(:resource).find_by(resources: { title: })
+      defaults = DefaultTicketCallouts::HANDOUT_LINK_DEFAULTS[title]
+      expect(link.subtitle).to eq(defaults[:subtitle])
+      expect(link.page_content).to eq(defaults[:page_content])
+    end
+
+    it "flags edited link copy as customized and restores it on reset" do
+      create(:resource, title: "Aha Moments")
+      event = create(:event)
+      described_class.seed(event)
+      handouts = event.registration_ticket_callouts.find_by(magic_key: "handouts")
+      expect(described_class.customized?(handouts)).to be(false)
+
+      handouts.registration_ticket_callout_resources.first.update!(subtitle: "Edited")
+      expect(described_class.customized?(handouts.reload)).to be(true)
+
+      described_class.reset(handouts)
+      expect(described_class.customized?(handouts.reload)).to be(false)
+    end
+
     it "shows Handouts and FAQ by default on a facilitator training" do
       event = create(:event, facilitator_training: true)
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 migration with a data backfill + materialization moving hard-coded copy onto the join, touching editor/controller/policy

### What is the goal of this PR and why is this important?
- Handout link copy lived hard-coded in `HANDOUT_SUBTITLES` and was rendered from the controller. Move it onto the callout↔resource join so admins can edit it per event.
- Split it into two purposes: a short **subtitle** (callout card) and longer **page content** (the resource's own detail page, under the title).
- Every page now reads a resource's subtitle/page-content from the **materialized join row** — hard-coded copy only seeds defaults at creation/reset.
- Also add an admin-only Edit link on the resource page and tidy that page's header.

### How did you approach the change?
- **Migration** adds `subtitle` + `page_content` to `registration_ticket_callout_resources` and backfills existing handout links with defaults.
- **`DefaultTicketCallouts`** holds the canonical defaults (`HANDOUT_LINK_DEFAULTS` + the W-9's copy in the Payment definition's `resource_content`) and materializes them onto each join row on seed/reset; `customized?` also detects edited copy.
- **Callout editor** — each linked-resource row gains two columns (Card subtitle, Page content) with column headers above the rows. New "Add resource" rows insert at the **end** of the list (cocoon default was prepending above the whole section); blank prompt renamed to "Select a resource…".
- **`EventPolicy`** permits the new nested params.
- **One shared card builder** — the handouts page, the built-in callout pages, and the generic callout page each had their own copy of the resource-card loop, and two hard-coded the subtitle (the "saved subtitle doesn't show" bugs). All now go through `RegistrationTicketCalloutDecorator#resource_cards` / `RegistrationTicketCalloutResourceDecorator#to_card`, so subtitle, href, and origin can't drift. The **payment page's Documents section** now renders through the same `_callout_card` partial too — the W-9 via the shared decorator, invoice/receipt as grey cards — passing the grey swatch to keep its muted look while dropping the last duplicated markup.
- **Resource page layout** — Download + admin Edit float right so the page content sits directly under the (enlarged) title.

### Anything else to add?
- New short one-line subtitles; the previous long copy becomes the default page content.
- Existing events are healed by the migration backfill; new/edited events materialize via the service. (No backfill for the W-9's Payment-callout copy — the app hasn't launched, so pre-existing rows with a blank W-9 subtitle fall back to a neutral label.)
- Specs: materialization defaults + reset/customized, card shows subtitle (not page content), resource page shows page content (not subtitle), admin Edit visibility, the generic callout + payment pages render the materialized subtitle, and the new decorators.
