### PR TITLE
Reveal videoconference immediately when there's no drip date; dated calendar hover

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -176,19 +176,26 @@ class Event < ApplicationRecord
   # When the videoconference connection details unlock. Driven by the drip date on
   # the materialized videoconference callout (admin-editable), falling back to
   # VIDEOCONFERENCE_DETAILS_LEAD before the start for events that haven't
-  # materialized the built-in callouts.
+  # materialized the built-in callouts. nil when there's no date to gate on — a
+  # materialized callout whose drip date was cleared, or an event with no start
+  # date — in which case the details are available immediately (see below).
   def videoconference_details_available_from
     return @videoconference_details_available_from if defined?(@videoconference_details_available_from)
-    return unless start_date
-    override = registration_ticket_callouts.magic.find_by(magic_key: "videoconference")&.display_from
-    @videoconference_details_available_from = override || start_date - VIDEOCONFERENCE_DETAILS_LEAD
+    @videoconference_details_available_from =
+      if (callout = registration_ticket_callouts.magic.find_by(magic_key: "videoconference"))
+        callout.display_from
+      elsif start_date
+        start_date - VIDEOCONFERENCE_DETAILS_LEAD
+      end
   end
 
-  # Whether the videoconference connection details may be revealed yet: only once
-  # we've reached the drip date above.
+  # Whether the videoconference connection details may be revealed yet. A drip
+  # date gates them until it arrives; with no drip date there's nothing to wait
+  # on, so they're available immediately (still subject to the per-registration
+  # payment gate in EventRegistration#videoconference_details_visible?).
   def videoconference_details_visible?(now = Time.current)
     from = videoconference_details_available_from
-    from.present? && now >= from
+    from.blank? || now >= from
   end
 
   def registerable?

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -177,15 +177,14 @@
 
         <!-- Add to calendar (secondary utility, kept at the bottom) -->
         <div class="flex flex-col items-center pt-5 border-t border-gray-100">
-          <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
-            Add to your calendar
-          </p>
+          <div class="flex items-center gap-1 mb-2">
+            <p class="text-xs font-bold text-gray-400 uppercase tracking-wide">
+              Add to your calendar
+            </p>
+            <%= render "events/videoconference_calendar_notice", event: event_registration.event, registration: event_registration %>
+          </div>
 
           <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?) %></div>
-
-          <% if event_registration.event.videoconference_url.present? && !event_registration.videoconference_details_visible? %>
-            <p class="mt-2 text-xs text-gray-400 text-center max-w-sm">The videoconference join link isn't in this calendar entry yet — add it again once the link is available to include it.</p>
-          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -60,9 +60,12 @@
     <!-- CALENDAR LINKS -->
     <% calendar_registration = registered ? event.active_registration_for(current_user&.person) : slug_registration %>
     <div class="flex flex-col items-center mt-4">
-      <p class="text-xs font-bold text-gray-400 uppercase tracking-wide mb-2">
-        Add to Your Calendar
-      </p>
+      <div class="flex items-center gap-1 mb-2">
+        <p class="text-xs font-bold text-gray-400 uppercase tracking-wide">
+          Add to Your Calendar
+        </p>
+        <%= render "events/videoconference_calendar_notice", event: event, registration: calendar_registration %>
+      </div>
       <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?) %></div>
     </div>
   <% end %>

--- a/app/views/events/_videoconference_calendar_notice.html.erb
+++ b/app/views/events/_videoconference_calendar_notice.html.erb
@@ -1,0 +1,16 @@
+<%# Hover info icon shown beside an "Add to your calendar" label, warning that a
+    calendar entry added now won't carry the videoconference join link, and
+    naming the date it unlocks (or a generic fallback). Shown only for events
+    that have a videoconference whose details this viewer can't see yet.
+    `registration` may be nil (event-level calendar links), in which case the
+    event's own drip gate is used. %>
+<% visible = registration ? registration.videoconference_details_visible? : event.videoconference_details_visible? %>
+<% if event.videoconference_url.present? && !visible %>
+  <% reveal = event.videoconference_details_available_from %>
+  <span class="relative group cursor-help inline-flex">
+    <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+    <span class="hidden group-hover:block absolute z-50 left-1/2 -translate-x-1/2 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal normal-case tracking-normal font-normal text-left">
+      The videoconference join link isn't in this calendar entry yet. Add the event again <%= reveal.present? ? "on #{reveal.to_date.strftime('%B %-d, %Y')}" : "once the link is available" %> to include it.
+    </span>
+  </span>
+<% end %>

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -39,11 +39,11 @@
     <% end %>
 
     <div class="border-t border-gray-100 pt-5">
-      <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Add to your calendar</p>
+      <div class="flex items-center gap-1 mb-2">
+        <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Add to your calendar</p>
+        <%= render "events/videoconference_calendar_notice", event: @event, registration: @event_registration %>
+      </div>
       <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?) %></div>
-      <% if @event.videoconference_url.present? && !@event_registration.videoconference_details_visible? %>
-        <p class="mt-2 text-xs text-gray-500">The join link isn't in this calendar entry yet — add the event to your calendar again once the link is available to include it.</p>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -661,6 +661,13 @@ RSpec.describe EventRegistration, type: :model do
       reg = create(:event_registration, event: event, registrant: user.person)
       expect(reg.videoconference_details_visible?).to be true
     end
+
+    it "is visible immediately once paid when the callout has no drip date" do
+      event = create(:event, cost_cents: 1099, start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, magic_key: "videoconference", display_from: nil)
+      reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
+      expect(reg.videoconference_details_visible?).to be true
+    end
   end
 
   describe ".payment_status scope" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe Event, type: :model do
   end
 
   describe "#videoconference_details_visible?" do
-    it "returns false when there is no start_date" do
+    it "returns true when there is no drip date to wait on (no start_date)" do
       event = build(:event, start_date: nil)
-      expect(event.videoconference_details_visible?).to be false
+      expect(event.videoconference_details_visible?).to be true
     end
 
     it "returns false more than a week before the start" do
@@ -117,6 +117,13 @@ RSpec.describe Event, type: :model do
       # Within the week-before default (which would be true), but before the
       # callout's later drip date.
       expect(event.videoconference_details_visible?).to be false
+    end
+
+    it "is visible immediately when the callout's drip date has been cleared" do
+      event = create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, magic_key: "videoconference", display_from: nil)
+
+      expect(event.videoconference_details_visible?).to be true
     end
   end
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -112,8 +112,14 @@ RSpec.describe "Events::Callouts", type: :request do
 
       expect(response.body).to include("unlocks once both of these are met")
       expect(response.body).to include("Your payment is on file")
-      expect(response.body).to include("The join link isn't in this calendar entry yet")
       expect(response.body).not_to include("https://example.com/zoom")
+
+      # The checklist and the calendar hover surface the same unlock date (read
+      # from the body to stay independent of the request's time zone).
+      reveal_date = response.body[/Available from ([A-Z][a-z]+ \d{1,2}, \d{4})/, 1]
+      expect(reveal_date).to be_present
+      expect(response.body).to include("isn't in this calendar entry yet")
+      expect(response.body).to include("Add the event again on #{reveal_date}")
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small model gate change + a shared view partial, covered by specs

### What is the goal of this PR and why is this important?
Builds on the drip-date videoconference reveal (#1983) with two refinements:
- **No drip date ⇒ show the videoconference immediately.** When the callout's drip date is cleared (or the event has no start date), the join link, page details, and calendar links are available right away instead of staying hidden — still behind the per-registration payment gate.
- **Consistent, dated calendar hover.** One shared hover note beside every "Add to your calendar" label warns that a calendar entry added now won't include the join link, and names the unlock date. Replaces the two divergent plain-text notes (callout page + ticket) and adds the same note to the event registration section.

### How did you approach the change?
- `Event#videoconference_details_available_from` now returns `nil` when there's genuinely no drip date, and `#videoconference_details_visible?` treats a blank drip date as "visible now."
- New `events/_videoconference_calendar_notice` partial, rendered on the callout page, the ticket, and the registration section so all three read identically.
- Specs updated for the immediate-visibility behavior; the callout request spec asserts the checklist and the hover surface the *same* date (kept timezone-independent).

### Anything else to add?
Edge case: a cleared drip date + unpaid registrant shows the hover's generic "once the link is available" wording (no date left to name), which is correct.