### PR TITLE
Fix double-escaped apostrophe in the workshop variations list

### DIFF
--- a/app/views/workshop_variations/_workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_results.html.erb
@@ -34,7 +34,9 @@
             </td>
             <td class="px-4 py-2" title="<%= workshop_variation.name %>">
               <div class="flex items-center gap-2 text-sm text-gray-800 font-semibold">
-                <%= link_to "#{truncate(workshop_variation.name, length: 30)} (#{workshop_variation.windows_type&.short_name || 'Combined'})", workshop_variation_path(workshop_variation), data: { turbo_frame: "_top" }, class: "hover:text-blue-600 hover:underline" %>
+                <%= link_to workshop_variation_path(workshop_variation), data: { turbo_frame: "_top" }, class: "hover:text-blue-600 hover:underline" do %>
+                  <%= truncate(workshop_variation.name, length: 30) %> (<%= workshop_variation.windows_type&.short_name || "Combined" %>)
+                <% end %>
                 <% unless workshop_variation.published? %>
                   <span class="inline-flex items-center pl-2 pr-3 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap">
                     <span class="inline-flex justify-center w-4"><i class="fa-solid fa-eye-slash"></i></span>

--- a/spec/requests/workshop_variations_spec.rb
+++ b/spec/requests/workshop_variations_spec.rb
@@ -200,6 +200,16 @@ RSpec.describe "/workshop_variations", type: :request do
         expect(response.body.index(var_a.name)).to be < response.body.index(var_b.name)
       end
 
+      it "renders an apostrophe in the name without double-escaping it" do
+        create(:workshop_variation, valid_attributes.merge(name: "New Year's Resolution"))
+
+        get workshop_variations_path,
+            headers: { "Turbo-Frame" => "workshop_variations_results" }
+
+        expect(response.body).to include("New Year&#39;s Resolution")
+        expect(response.body).not_to include("New Year&amp;#39;s Resolution")
+      end
+
       it "matches a search query against the credited author's name on the lazy turbo-frame request" do
         person = create(:person, first_name: "Bartholomew", last_name: "Quill")
         authored = create(:workshop_variation, valid_attributes.merge(name: "Authored variation", author: person))


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line view fix, but the escaping mechanics are subtle

## Why

Item #4 from the July 7 workshop-variations walkthrough: a variation named like **New Year's Resolution** rendered the apostrophe as the literal text `New Year&#39;s` in the index list.

Cause is a double-escape on the name link:
- `truncate(name, length: 30)` returns an **HTML-escaped** SafeBuffer (`New Year&#39;s`).
- Interpolating it into a plain string — `"#{truncate(...)} (...)"` — flattens it back to an *unsafe* `String` still carrying the literal `&#39;`.
- `link_to` then escapes that a **second** time (`&` → `&amp;`), so the browser shows `New Year&#39;s`.

The sibling link on line 47 avoids this by passing `truncate(...)` directly to `link_to` (no interpolation, so it stays a SafeBuffer and isn't re-escaped).

## What

- Rewrite the name link using `link_to`'s block form so each fragment (`truncate(name)`, the ` (…)` suffix, the windows-type) is escaped exactly once.
- Add a request-spec asserting the list renders `New Year&#39;s` and **not** the double-escaped `New Year&amp;#39;s`.

## Notes

Scoped to the reported apostrophe glitch. Separately, a few spots (`workshop_variation_decorator#breadcrumbs`, `title_with_badges`'s `record_title.html_safe`, the `people` section `record_title`) emit the raw `name` via `.html_safe` — an HTML-injection risk for names containing real markup, but not the apostrophe symptom. Left for a follow-up.