### PR TITLE
Add tests for art_supplies content built-in + callout-row page copy

### DIFF
--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe RegistrationTicketCallout, type: :model do
       expect(other.payment?).to be(false)
       expect(custom.payment?).to be(false)
     end
+
+    it "treats art_supplies as a content built-in (renders its own page), not behavioral" do
+      event = create(:event)
+      art_supplies = create(:registration_ticket_callout, event:, builtin_key: "art_supplies")
+      certificate = create(:registration_ticket_callout, event:, builtin_key: "certificate")
+
+      expect(art_supplies.behavioral_builtin?).to be(false)
+      expect(certificate.behavioral_builtin?).to be(true)
+    end
   end
 
   describe "#published (inverse of hidden)" do

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe "Events::Callouts", type: :request do
     end
   end
 
+  # The intro copy an admin types into a built-in's materialized callout row (its
+  # "Callout page text" / description) renders on that built-in's public page. CE
+  # and scholarship previously had no request-layer coverage of this; the FAQ case
+  # is covered above, and handouts has no description intro (resource cards only).
+  describe "built-in page copy from the callout row description" do
+    it "renders the CE callout's description on the CE page" do
+      BuiltinCallouts.seed(event)
+      event.registration_ticket_callouts.find_by(builtin_key: "ce_hours")
+        .update!(description: "<p>Bring your license number.</p>", hidden: false)
+
+      get registration_ce_path(registration.slug)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Bring your license number.")
+    end
+
+    it "renders the scholarship callout's description on the scholarship page" do
+      registration.update!(scholarship_requested: true)
+      BuiltinCallouts.seed(event)
+      event.registration_ticket_callouts.find_by(builtin_key: "scholarship")
+        .update!(description: "<p>About your scholarship.</p>", hidden: false)
+
+      get registration_scholarship_path(registration.slug)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("About your scholarship.")
+    end
+  end
+
   describe "GET /registration/:slug/handouts" do
     it "renders the handouts page when its callout is published" do
       create(:registration_ticket_callout, event:, builtin_key: "handouts", hidden: false)


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 test-only; two green assertions salvaged from closed #1984

Salvaged from the closed #1984 (superseded by merged #1996), ported to current `builtin_key` vocabulary. #1996 landed the structural cleanup but left these two behavioral assertions uncovered at their layers:

- **Model** — `art_supplies` is a *content* built-in (`behavioral_builtin? == false`), unlike a behavioral built-in like `certificate`.
- **Request** — the CE and scholarship pages render the intro copy from their materialized callout row's `description`.
  - FAQ's description rendering is already covered (`callouts_spec.rb`); handouts has no description intro (resource cards only), so both are omitted.

`58 examples, 0 failures`.