### PR TITLE
Make the event-cost label sentence case with an inline hint

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -138,7 +138,7 @@
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <div class="flex items-center justify-between gap-2 mb-1"><%= f.label :cost, "Event Cost", class: "block font-medium" %><span class="text-sm text-gray-600">Enter $0 if the event is free</span></div>
+              <%= f.label :cost, class: "block font-medium mb-1" do %>Event cost <span class="text-xs font-normal text-gray-500">Enter $0 if the event is free</span><% end %>
 
               <div class="relative">
                 <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500">$</span>

--- a/spec/views/events/_form.html.erb_spec.rb
+++ b/spec/views/events/_form.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "events/_form", type: :view do
     render
 
     expect(rendered).to have_selector("label", text: "Event title")
-    expect(rendered).to have_selector("label", text: "Event Cost")
+    expect(rendered).to have_selector("label", text: "Event cost")
     expect(rendered).to have_selector("h3", text: "Start")
     expect(rendered).to have_selector("h3", text: "End")
     expect(rendered).to have_selector("h3", text: "Registration closed")


### PR DESCRIPTION
🤖 PR, suggested 👤 review level: 👀 Skim — view-only: label copy/styling, no logic or data changes

### What is the goal of this PR and why is this important?
- The event-cost field label read "Event Cost" (title case); the project standard is sentence case.

### How did you approach the change?
- Renamed to "Event cost" and inlined the "Enter $0 if the event is free" hint as small grey text on the label (matching the form's other hint treatments).
- Split out of #1744 as unrelated to that PR's optional-time work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
