### PR TITLE
Use short_description in confirmation email; stop the rich-description fallback

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -104,13 +104,14 @@ class EventDecorator < ApplicationDecorator
     # If both: URL in location field, physical location in description
     # If only URL: URL in location field
     # If only location: location in location field
-    # Prefer the admin-authored short description; fall back to a flattened
-    # version of the rich show-page description when it's blank.
-    event_description = object.short_description.presence || object.rhino_description.to_plain_text
+    # Only the admin-authored plain-text short description. The rich show-page
+    # description is intentionally not used — it can't render in a calendar entry
+    # and may embed images. Blank leaves the calendar entry without a blurb.
+    event_description = object.short_description.presence
 
     if has_url && has_location
       cal_location = object.videoconference_url
-      base_description = "#{location_name}\n\n#{event_description}"
+      base_description = [ location_name, event_description ].compact_blank.join("\n\n")
     elsif has_url
       cal_location = object.videoconference_url
       base_description = event_description

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -55,6 +55,16 @@
 
   <%= render "ce_deadlines", event: @event %>
 
+  <%# Admin-authored plain-text blurb (also used for calendar invites). The full
+      rich show-page description is intentionally NOT rendered here — it can carry
+      embedded images that flatten to "[filename.jpg]" alt text in email. %>
+  <% if @event.short_description.present? %>
+    <span style="padding-bottom: 12px"><strong>Details</strong></span><br>
+    <p>
+      <%= simple_format(@event.short_description) %>
+    </p>
+    <hr style="margin: 24px 0;">
+  <% end %>
 </div>
 
 <p>

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -56,8 +56,7 @@
   <%= render "ce_deadlines", event: @event %>
 
   <%# Admin-authored plain-text blurb (also used for calendar invites). The full
-      rich show-page description is intentionally NOT rendered here — it can carry
-      embedded images that flatten to "[filename.jpg]" alt text in email. %>
+      rich show-page description is intentionally NOT rendered here. %>
   <% if @event.short_description.present? %>
     <span style="padding-bottom: 12px"><strong>Details</strong></span><br>
     <p>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -20,9 +20,9 @@ Videoconference: <%= event_platform_label(@event) %>
   <%= @event.labelled_cost %>
 <% end %>
 
-<% if @event.rhino_description.present? %>
-  Event details:
-  <%= @event.rhino_description.to_plain_text %>
+<% if @event.short_description.present? %>
+  Details:
+  <%= @event.short_description %>
 <% end %>
 
 View your ticket:

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -211,7 +211,7 @@
           <%= f.input :short_description,
                   label: "Short description",
                   as: :text,
-                  hint: "Plain-text blurb for the \"Add to calendar\" links. Calendars don't render HTML — leave blank to fall back to the page description.",
+                  hint: "Plain-text blurb shown on \"Add to calendar\" links and in registration confirmation emails. Calendars don't render HTML. Leave blank to omit it from emails (calendar links fall back to the page description).",
                   input_html: {
                     rows: 3,
                     placeholder: "Short description for calendar entries…",

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -211,7 +211,7 @@
           <%= f.input :short_description,
                   label: "Short description",
                   as: :text,
-                  hint: "Plain-text blurb shown on \"Add to calendar\" links and in registration confirmation emails. Calendars don't render HTML. Leave blank to omit it from emails (calendar links fall back to the page description).",
+                  hint: "Plain-text blurb shown on \"Add to calendar\" links and in registration confirmation emails. Calendars don't render HTML. Leave blank to omit it.",
                   input_html: {
                     rows: 3,
                     placeholder: "Short description for calendar entries…",

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -171,31 +171,17 @@ RSpec.describe EventDecorator do
   end
 
   describe "#calendar_links" do
-    it "falls back to rhino_description plain text when short_description is blank" do
-      event = create(:event)
+    it "does not fall back to rhino_description when short_description is blank" do
+      event = create(:event, short_description: nil)
       event.update!(rhino_description: "<div>Join us for healing through art</div>")
       decorated = event.decorate
 
-      html = decorated.calendar_links
-      doc = Nokogiri::HTML.fragment(html)
-      links = doc.css("a")
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      hrefs = doc.css("a").map { |a| a["href"] }
 
-      desc_encoded = ERB::Util.url_encode("Join us for healing through art")
+      rhino_encoded = ERB::Util.url_encode("Join us for healing through art")
 
-      google = links.find { |a| a.text == "Google" }
-      expect(google["href"]).to include("details=#{desc_encoded}")
-
-      apple = links.find { |a| a.text == "Apple" }
-      expect(apple["href"]).to include("DESCRIPTION:Join us for healing through art")
-
-      outlook = links.find { |a| a.text == "Outlook" }
-      expect(outlook["href"]).to include("body=#{desc_encoded}")
-
-      office365 = links.find { |a| a.text == "Office 365" }
-      expect(office365["href"]).to include("body=#{desc_encoded}")
-
-      yahoo = links.find { |a| a.text == "Yahoo" }
-      expect(yahoo["href"]).to include("desc=#{desc_encoded}")
+      expect(hrefs).to all(satisfy { |href| !href.include?(rhino_encoded) && !href.include?("healing through art") })
     end
 
     it "uses short_description over rhino_description when present" do

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -53,16 +53,35 @@ RSpec.describe EventMailer, type: :mailer do
       expect(body).not_to include("View event")
     end
 
-    context "when the event has a rhino_description" do
-      let(:event) { create(:event, rhino_description: "Join us for an art healing workshop") }
+    context "when the event has a rich rhino_description but no short_description" do
+      let(:event) { create(:event, rhino_description: "Join us for an art healing workshop", short_description: nil) }
       let(:event_registration) { create(:event_registration, event: event) }
 
-      it "includes the rhino_description in the body" do
-        expect(mail.body.encoded).to include("Join us for an art healing workshop")
+      it "does not dump the rich description into either part" do
+        expect(mail.html_part.body.encoded).not_to include("Join us for an art healing workshop")
+        expect(mail.text_part.body.encoded).not_to include("Join us for an art healing workshop")
+      end
+
+      it "does not include a Details section" do
+        expect(mail.body.encoded).not_to include("<strong>Details</strong>")
       end
     end
 
-    context "when the event has no rhino_description" do
+    context "when the event has a short_description" do
+      let(:event) { create(:event, short_description: "A two-day art healing workshop.") }
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      it "includes the short_description in both the HTML and text parts" do
+        expect(mail.html_part.body.encoded).to include("A two-day art healing workshop.")
+        expect(mail.text_part.body.encoded).to include("A two-day art healing workshop.")
+      end
+
+      it "includes the Details section in the HTML part" do
+        expect(mail.html_part.body.encoded).to include("<strong>Details</strong>")
+      end
+    end
+
+    context "when the event has no short_description" do
       let(:event_registration) { create(:event_registration) }
 
       it "does not include the Details section" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small mailer + decorator change, contained behavior swap

Follow-up to #2012, which removed the rich `rhino_description` dump from the confirmation email's **HTML** part but left it in the **text** part.

## Why
- The text part still ran `rhino_description.to_plain_text`, which flattens embedded images to `[filename.jpg]` alt text and reproduces the whole event body.
- The email (and calendar entry) should carry a short admin-authored blurb, not a copy of the rich show-page description.

## What
- Remove the leftover rich-description dump from the email's text part.
- Render the plain-text `short_description` in both email parts instead — no fallback to the rich description; blank → omitted.
- Calendar links (`EventDecorator#calendar_links`) likewise stop falling back to `rhino_description` when `short_description` is blank; the entry just carries no blurb.
- Update the event form hint to note `short_description` feeds both calendar links and confirmation emails.

Reuses the existing `short_description` column (added in #1876) — no schema change.