### PR TITLE
Treat an unrecognized ticket-callout builtin_key as custom

### DIFF
--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -45,12 +45,13 @@ class RegistrationTicketCallout < ApplicationRecord
   # blank one still falls back via #display_icon_class.
   attribute :icon_class, :string, default: -> { DEFAULT_ICONS["action"] }
 
-  # A custom callout has no built-in key. Persist that as NULL, never a blank
-  # string, so `builtin?`/`.present?`, the nil-keyed `custom`/`builtin` scopes,
-  # the inclusion validation (which allows nil, not blank), and the
-  # [event_id, builtin_key] unique index all agree. Guards against a "" that a
-  # stray blank form field or legacy data would otherwise wedge the event save on.
-  normalizes :builtin_key, with: ->(value) { value.presence }
+  # A custom callout has no built-in key: store NULL, never a blank string or a
+  # key we don't recognize. Anything that isn't a current built-in — a stray "",
+  # or a since-removed key like the legacy "event_details" — normalizes to nil so
+  # it's treated as a custom callout everywhere (`builtin?`/`.present?`, the
+  # nil-keyed custom/builtin scopes, the inclusion validation, the
+  # [event_id, builtin_key] unique index) instead of wedging the event save.
+  normalizes :builtin_key, with: ->(value) { value.presence_in(BUILTIN_KEYS) }
 
   belongs_to :event
 

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -45,6 +45,13 @@ class RegistrationTicketCallout < ApplicationRecord
   # blank one still falls back via #display_icon_class.
   attribute :icon_class, :string, default: -> { DEFAULT_ICONS["action"] }
 
+  # A custom callout has no built-in key. Persist that as NULL, never a blank
+  # string, so `builtin?`/`.present?`, the nil-keyed `custom`/`builtin` scopes,
+  # the inclusion validation (which allows nil, not blank), and the
+  # [event_id, builtin_key] unique index all agree. Guards against a "" that a
+  # stray blank form field or legacy data would otherwise wedge the event save on.
+  normalizes :builtin_key, with: ->(value) { value.presence }
+
   belongs_to :event
 
   # A callout can link many resources, shown in order on its detail page (PDF

--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -28,10 +28,11 @@ RSpec.describe RegistrationTicketCallout, type: :model do
       expect(callout).not_to be_valid
     end
 
-    it "rejects an unknown builtin_key" do
-      callout.builtin_key = "bogus"
-      expect(callout).not_to be_valid
-      expect(callout.errors[:builtin_key]).to be_present
+    it "treats an unknown/since-removed builtin_key as a custom (nil) callout" do
+      callout.builtin_key = "event_details" # a built-in that no longer exists
+      expect(callout).to be_valid
+      expect(callout.builtin_key).to be_nil
+      expect(callout).not_to be_builtin
     end
 
     it "allows only one callout per builtin_key within an event" do

--- a/spec/models/registration_ticket_callout_spec.rb
+++ b/spec/models/registration_ticket_callout_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe RegistrationTicketCallout, type: :model do
       create(:registration_ticket_callout, event:, builtin_key: nil)
       expect(build(:registration_ticket_callout, event:, builtin_key: nil)).to be_valid
     end
+
+    it "treats a blank builtin_key as a custom (nil) callout, not an invalid key" do
+      callout.builtin_key = ""
+      expect(callout).to be_valid
+      expect(callout.builtin_key).to be_nil
+      expect(callout).not_to be_builtin
+    end
   end
 
   describe "scopes and predicates" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -565,6 +565,19 @@ RSpec.describe "Events", type: :request do
         expect(event.reload.ce_hours_request_deadline).to eq(Date.new(2026, 7, 1))
         expect(event.ce_payment_due_deadline).to eq(Date.new(2026, 8, 15))
       end
+
+      it "saves an event whose callout carries a since-removed builtin_key, converting it to custom" do
+        legacy = create(:registration_ticket_callout, event:, title: "Event details", callout_type: "reference")
+        legacy.update_column(:builtin_key, "event_details") # a built-in that no longer exists
+
+        patch event_path(event), params: { event: { title: "Updated",
+          registration_ticket_callouts_attributes: { "0" => {
+            id: legacy.id, builtin_key: "event_details", title: "Event details", callout_type: "reference", published: "1" } } } }
+
+        expect(response).to redirect_to(dashboard_event_path(event))
+        expect(legacy.reload.builtin_key).to be_nil
+        expect(legacy).not_to be_builtin
+      end
     end
 
     context "as non-admin" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 model normalization + specs; changes validation behavior for unknown keys

### What is the goal of this PR and why is this important?
Editing an event 422'd with "Registration ticket callouts builtin key is not included in the list" whenever one of its callouts carried a `builtin_key` no longer in `BUILTIN_KEYS` — a since-removed built-in (prod has 3 `event_details` rows). Autosave re-validates that row on edit and the inclusion check blocks the whole save, with no way to fix it from the editor (the row renders as a built-in with no delete/reset).

### How did you approach the change?
`normalizes :builtin_key` now drops any key that isn't a current built-in (blank *or* removed) to `nil`, so the row becomes a plain custom callout — editable, deletable, valid — and heals to `nil` on the next save. A removed built-in has no card builder anyway, so it could never render as a real built-in. Test-first: model spec (blank + removed key → custom) and a request regression (editing a legacy-key event now saves and converts the row).

### Anything else to add?
Rows on events that are never edited stay as-is until touched (harmless/inert); an optional one-off `UPDATE registration_ticket_callouts SET builtin_key = NULL WHERE builtin_key NOT IN (...)` heals them all at once.