### PR TITLE
Attribute welcome invite to the admin who actually sent it

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -297,6 +297,10 @@ class UsersController < ApplicationController
   def send_welcome_instructions
     authorize! @user, to: :send_welcome_instructions?
 
+    # Sending the invite writes to the record (token + timestamps), so credit the
+    # sender on updated_by too — otherwise "Last updated" attributes it to whoever
+    # last edited the account, not who actually sent the invite.
+    @user.updated_by = current_user
     @user.set_welcome_instructions_token!
     @user.update(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: current_user)
     @user.send_confirmation_instructions

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
-      base_scope = authorized_scope(User.includes(:created_by, :updated_by,
+      base_scope = authorized_scope(User.includes(:created_by, :updated_by, :welcome_instructions_sent_by,
                                                   person: { avatar_attachment: :blob }))
       filtered = base_scope.search_by_params(params).order(:first_name, :last_name)
       @users_count = filtered.count
@@ -298,7 +298,7 @@ class UsersController < ApplicationController
     authorize! @user, to: :send_welcome_instructions?
 
     @user.set_welcome_instructions_token!
-    @user.update(welcome_instructions_sent_at: Time.current)
+    @user.update(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: current_user)
     @user.send_confirmation_instructions
 
     redirect_to users_path(search: params[:search],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   belongs_to :person, optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
+  belongs_to :welcome_instructions_sent_by, class_name: "User", optional: true
   belongs_to :favorite_event, class_name: "Event", optional: true
   has_many :bookmarks, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy

--- a/app/services/event_registration_services/process_confirmation.rb
+++ b/app/services/event_registration_services/process_confirmation.rb
@@ -71,7 +71,7 @@ module EventRegistrationServices
       return unless user
 
       user.set_welcome_instructions_token!
-      user.update!(welcome_instructions_sent_at: Time.current)
+      user.update!(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: @current_user)
       user.send_confirmation_instructions
 
       @actions_taken << "System invite sent"

--- a/app/services/event_registration_services/process_confirmation.rb
+++ b/app/services/event_registration_services/process_confirmation.rb
@@ -70,6 +70,7 @@ module EventRegistrationServices
       user = @person.user
       return unless user
 
+      user.updated_by = @current_user
       user.set_welcome_instructions_token!
       user.update!(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: @current_user)
       user.send_confirmation_instructions

--- a/app/views/users/_confirmed_status.html.erb
+++ b/app/views/users/_confirmed_status.html.erb
@@ -5,7 +5,7 @@
   <% end %>
 <% elsif user.welcome_instructions_sent_at.present? %>
   <% sent_info = "Confirmation instructions sent #{l(user.welcome_instructions_sent_at, format: :long)}"
-     sent_info += " by #{user.updated_by.name}" if user.updated_by.present? %>
+     sent_info += " by #{user.welcome_instructions_sent_by.name}" if user.welcome_instructions_sent_by.present? %>
   <i class="fa-solid fa-clock text-warning" title="<%= sent_info %>"></i>
 <% else %>
   <%= link_to "Invite",

--- a/db/migrate/20260729020406_add_welcome_instructions_sent_by_to_users.rb
+++ b/db/migrate/20260729020406_add_welcome_instructions_sent_by_to_users.rb
@@ -1,0 +1,11 @@
+class AddWelcomeInstructionsSentByToUsers < ActiveRecord::Migration[7.2]
+  def up
+    add_column :users, :welcome_instructions_sent_by_id, :integer
+    add_index :users, :welcome_instructions_sent_by_id
+  end
+
+  def down
+    remove_index :users, :welcome_instructions_sent_by_id, if_exists: true
+    remove_column :users, :welcome_instructions_sent_by_id, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_053137) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_29_020406) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1377,6 +1377,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_053137) do
     t.integer "updated_by_id"
     t.datetime "welcome_instructions_created_at"
     t.datetime "welcome_instructions_sent_at"
+    t.integer "welcome_instructions_sent_by_id"
     t.string "welcome_instructions_token"
     t.string "zip"
     t.string "zip2"
@@ -1389,6 +1390,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_053137) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
     t.index ["updated_by_id"], name: "index_users_on_updated_by_id"
+    t.index ["welcome_instructions_sent_by_id"], name: "index_users_on_welcome_instructions_sent_by_id"
     t.index ["welcome_instructions_token"], name: "index_users_on_welcome_instructions_token", unique: true
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -546,7 +546,9 @@ RSpec.describe "/users", type: :request do
 
       it "records the admin who sent the invitation" do
         post send_welcome_instructions_user_url(user)
-        expect(user.reload.welcome_instructions_sent_by).to eq(admin)
+        user.reload
+        expect(user.welcome_instructions_sent_by).to eq(admin)
+        expect(user.updated_by).to eq(admin)
       end
 
       xit "sends welcome email" do # TODO fix this testing to make sure notification and email get sent

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -544,6 +544,11 @@ RSpec.describe "/users", type: :request do
         expect(user.welcome_instructions_sent_at).not_to be_nil
       end
 
+      it "records the admin who sent the invitation" do
+        post send_welcome_instructions_user_url(user)
+        expect(user.reload.welcome_instructions_sent_by).to eq(admin)
+      end
+
       xit "sends welcome email" do # TODO fix this testing to make sure notification and email get sent
         expect {
           post send_welcome_instructions_user_url(user)

--- a/spec/services/event_registration_services/process_confirmation_spec.rb
+++ b/spec/services/event_registration_services/process_confirmation_spec.rb
@@ -106,7 +106,9 @@ RSpec.describe EventRegistrationServices::ProcessConfirmation do
           current_user: admin
         )
 
-        expect(user.reload.welcome_instructions_sent_by).to eq(admin)
+        user.reload
+        expect(user.welcome_instructions_sent_by).to eq(admin)
+        expect(user.updated_by).to eq(admin)
       end
 
       it "does nothing when person has no user" do

--- a/spec/services/event_registration_services/process_confirmation_spec.rb
+++ b/spec/services/event_registration_services/process_confirmation_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe EventRegistrationServices::ProcessConfirmation do
         expect(user.reload.welcome_instructions_token).to be_present
       end
 
+      it "records the current user as the sender" do
+        user = person.user
+
+        described_class.call(
+          event_registration: registration,
+          person: person,
+          create_user: false,
+          send_invite: true,
+          send_confirmation_email: false,
+          send_admin_fyi: false,
+          current_user: admin
+        )
+
+        expect(user.reload.welcome_instructions_sent_by).to eq(admin)
+      end
+
       it "does nothing when person has no user" do
         person.user.destroy!
         person.reload


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small logic change plus a nullable-column migration; blast radius limited to the invite attribution

### What is the goal of this PR and why is this important?
- When an admin sent a portal invite, the account showed the action as done by the wrong person: both the "Confirmation instructions sent … by X" tooltip and the "Last updated … by X" line credited whoever previously created/edited the account (e.g. the person who registered the trainee), not whoever actually pressed **Invite**. Reported in Slack.

### How did you approach the change?
- Added a dedicated `welcome_instructions_sent_by_id` column on `users` and set it to the acting user at each interactive send path (`UsersController#send_welcome_instructions`, `ProcessConfirmation#send_welcome_instructions`). The tooltip now shows the sender, and drops the "by …" suffix when unknown (legacy records) rather than the stale `updated_by`.
- Sending an invite writes the token + timestamps, so it bumps `updated_at`. Also stamp `updated_by` with the sender at those paths so "Last updated" agrees with the sent-by attribution instead of crediting the previous editor.
- `BulkInviteService` runs without a `current_user`, so it leaves both fields untouched.
- Eager-loaded the new association in the users index to avoid an N+1.

### Anything else to add?
- Legacy invited-but-unconfirmed rows have no recorded sender, so they show the timestamp without attribution instead of the previous (incorrect) name.