### PR TITLE
Credit the acting admin on updated_by across user account actions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -204,6 +204,10 @@ class UsersController < ApplicationController
 
   def send_reset_password_instructions
     authorize! @user
+    # Generating the reset token writes to the record, bumping updated_at; credit the
+    # sender on updated_by too so "Last updated" reflects who sent the reset, not
+    # whoever last edited the account.
+    @user.updated_by = current_user
     @user.send_reset_password_instructions
     redirect_to users_path, notice: "Reset password instructions sent to #{@user.email}."
   end
@@ -217,11 +221,11 @@ class UsersController < ApplicationController
 
     if @user.locked_at.present?
       # Unlock the user
-      @user.update(locked_at: nil, failed_attempts: 0)
+      @user.update(locked_at: nil, failed_attempts: 0, updated_by: current_user)
       message = "User has been unlocked."
     else
       # Lock the user
-      @user.update(locked_at: Time.current)
+      @user.update(locked_at: Time.current, updated_by: current_user)
       message = "User has been locked."
     end
 
@@ -241,7 +245,7 @@ class UsersController < ApplicationController
     if @user.confirmed_at.present?
       message = "Email is already confirmed."
     else
-      @user.update(confirmed_at: Time.current)
+      @user.update(confirmed_at: Time.current, updated_by: current_user)
       message = "Email has been manually confirmed."
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -204,9 +204,7 @@ class UsersController < ApplicationController
 
   def send_reset_password_instructions
     authorize! @user
-    # Generating the reset token writes to the record, bumping updated_at; credit the
-    # sender on updated_by too so "Last updated" reflects who sent the reset, not
-    # whoever last edited the account.
+    # Set before the Devise call, which saves the reset token onto the record.
     @user.updated_by = current_user
     @user.send_reset_password_instructions
     redirect_to users_path, notice: "Reset password instructions sent to #{@user.email}."

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -14,9 +14,10 @@ class WelcomeController < ApplicationController
   end
 
   def update
-    # The invited user sets their own password here — no admin is acting, so clear
-    # updated_by rather than leaving it crediting whoever created/invited the account.
-    if @user.update(password_params.merge(updated_by: nil))
+    # This page is public: the invited user may set their own password, or an admin
+    # may do it on their behalf. Credit the signed-in admin if there is one, otherwise
+    # the account owner — either way, not whoever last edited the account before this.
+    if @user.update(password_params.merge(updated_by: current_user || @user))
       @user.track_auth_event("auth.password_first_set")
       @user.clear_welcome_instructions_token!
       @user.track_auth_event("auth.account_setup_completed")

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -14,7 +14,9 @@ class WelcomeController < ApplicationController
   end
 
   def update
-    if @user.update(password_params)
+    # The invited user sets their own password here — no admin is acting, so clear
+    # updated_by rather than leaving it crediting whoever created/invited the account.
+    if @user.update(password_params.merge(updated_by: nil))
       @user.track_auth_event("auth.password_first_set")
       @user.clear_welcome_instructions_token!
       @user.track_auth_event("auth.account_setup_completed")

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -14,9 +14,9 @@ class WelcomeController < ApplicationController
   end
 
   def update
-    # This page is public: the invited user may set their own password, or an admin
-    # may do it on their behalf. Credit the signed-in admin if there is one, otherwise
-    # the account owner — either way, not whoever last edited the account before this.
+    # Credit whoever is signed in (could be an admin acting on their behalf, could be
+    # the user themselves), or the account owner if no one is — never whoever last
+    # edited the account before this.
     if @user.update(password_params.merge(updated_by: current_user || @user))
       @user.track_auth_event("auth.password_first_set")
       @user.clear_welcome_instructions_token!

--- a/app/services/user_services/process_email_change.rb
+++ b/app/services/user_services/process_email_change.rb
@@ -29,7 +29,13 @@ module UserServices
     def send_confirmation_email
       return unless @user.unconfirmed_email.present?
 
+      # Sending instructions regenerates the confirmation token and saves the record,
+      # bumping updated_at; credit the acting admin so attribution isn't left on
+      # whoever last edited the account. Devise only saves when it regenerates the
+      # token, so persist the attribution ourselves if it was left dirty.
+      @user.updated_by = @current_user
       @user.send_confirmation_instructions
+      @user.save(validate: false) if @user.changed?
       @actions_taken << "A confirmation email has been sent to #{@user.unconfirmed_email}"
     end
   end

--- a/app/services/user_services/process_email_change.rb
+++ b/app/services/user_services/process_email_change.rb
@@ -29,10 +29,8 @@ module UserServices
     def send_confirmation_email
       return unless @user.unconfirmed_email.present?
 
-      # Sending instructions regenerates the confirmation token and saves the record,
-      # bumping updated_at; credit the acting admin so attribution isn't left on
-      # whoever last edited the account. Devise only saves when it regenerates the
-      # token, so persist the attribution ourselves if it was left dirty.
+      # Credit the acting admin. Devise saves only when it regenerates the token,
+      # so persist the attribution ourselves if it's left dirty.
       @user.updated_by = @current_user
       @user.send_confirmation_instructions
       @user.save(validate: false) if @user.changed?

--- a/app/services/user_services/process_email_manual_confirm.rb
+++ b/app/services/user_services/process_email_manual_confirm.rb
@@ -32,9 +32,8 @@ module UserServices
 
     def resend_confirmation
       target_email = @user.unconfirmed_email.presence || @user.email
-      # Regenerating the confirmation token saves the record; credit the acting admin.
-      # Devise only saves when it regenerates the token, so persist the attribution
-      # ourselves if it was left dirty (no-op when Devise already saved it).
+      # Credit the acting admin. Devise saves only when it regenerates the token,
+      # so persist the attribution ourselves if it's left dirty.
       @user.updated_by = @current_user
       @user.send_confirmation_instructions
       @user.save(validate: false) if @user.changed?

--- a/app/services/user_services/process_email_manual_confirm.rb
+++ b/app/services/user_services/process_email_manual_confirm.rb
@@ -32,12 +32,18 @@ module UserServices
 
     def resend_confirmation
       target_email = @user.unconfirmed_email.presence || @user.email
+      # Regenerating the confirmation token saves the record; credit the acting admin.
+      # Devise only saves when it regenerates the token, so persist the attribution
+      # ourselves if it was left dirty (no-op when Devise already saved it).
+      @user.updated_by = @current_user
       @user.send_confirmation_instructions
+      @user.save(validate: false) if @user.changed?
       @actions_taken << "Confirmation email has been resent to #{target_email}"
     end
 
     def manually_confirm
       pending_email = @user.unconfirmed_email
+      @user.updated_by = @current_user
       @user.confirm
       if pending_email.present?
         @actions_taken << "Email change to #{pending_email} has been manually confirmed"

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -352,6 +352,18 @@ RSpec.describe "/users", type: :request do
         post toggle_lock_status_user_url(user)
         expect(response).to redirect_to(edit_user_path(user))
       end
+
+      it "records the admin who locked the account as updated_by" do
+        user.update_columns(updated_by_id: create(:user, :admin).id)
+        post toggle_lock_status_user_url(user)
+        expect(user.reload.updated_by).to eq(admin)
+      end
+
+      it "records the admin who unlocked the account as updated_by" do
+        user.update_columns(locked_at: Time.current, updated_by_id: create(:user, :admin).id)
+        post toggle_lock_status_user_url(user)
+        expect(user.reload.updated_by).to eq(admin)
+      end
     end
 
     context "as regular_user" do
@@ -390,6 +402,12 @@ RSpec.describe "/users", type: :request do
         user.reload
         expect(user.confirmed_at).not_to be_nil
         expect(flash[:notice]).to eq("Email has been manually confirmed.")
+      end
+
+      it "records the admin who confirmed the email as updated_by" do
+        user.update_columns(updated_by_id: create(:user, :admin).id)
+        post confirm_email_user_url(user)
+        expect(user.reload.updated_by).to eq(admin)
       end
     end
 
@@ -598,6 +616,12 @@ RSpec.describe "/users", type: :request do
         post send_reset_password_instructions_user_url(user)
         expect(flash[:notice]).to include("Reset password instructions sent")
         expect(response).to redirect_to(users_path)
+      end
+
+      it "records the admin who sent the instructions as updated_by" do
+        user.update_columns(updated_by_id: create(:user, :admin).id)
+        post send_reset_password_instructions_user_url(user)
+        expect(user.reload.updated_by).to eq(admin)
       end
     end
 

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe "/users/welcome", type: :request do
         expect(user.welcome_instructions_sent_at).to be_nil
       end
 
+      it "clears updated_by since the setup is self-service, not an admin action" do
+        user.update_columns(updated_by_id: create(:user, :admin).id)
+
+        patch user_welcome_update_url(user.welcome_instructions_token), params: valid_params
+
+        expect(user.reload.updated_by).to be_nil
+      end
+
       it "signs in the user" do
         patch user_welcome_update_url(user.welcome_instructions_token), params: valid_params
         expect(request.env['warden'].user).to eq(user)

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -56,12 +56,21 @@ RSpec.describe "/users/welcome", type: :request do
         expect(user.welcome_instructions_sent_at).to be_nil
       end
 
-      it "clears updated_by since the setup is self-service, not an admin action" do
+      it "credits the user themselves when no admin is signed in" do
         user.update_columns(updated_by_id: create(:user, :admin).id)
 
         patch user_welcome_update_url(user.welcome_instructions_token), params: valid_params
 
-        expect(user.reload.updated_by).to be_nil
+        expect(user.reload.updated_by).to eq(user)
+      end
+
+      it "credits the acting admin when one is signed in" do
+        admin = create(:user, :admin)
+        sign_in admin
+
+        patch user_welcome_update_url(user.welcome_instructions_token), params: valid_params
+
+        expect(user.reload.updated_by).to eq(admin)
       end
 
       it "signs in the user" do

--- a/spec/services/user_services/process_email_change_spec.rb
+++ b/spec/services/user_services/process_email_change_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe UserServices::ProcessEmailChange do
 
         expect(result.summary).to include("confirmation email has been sent to new@example.com")
       end
+
+      it "credits the acting admin as updated_by" do
+        user.update_columns(updated_by_id: create(:user, :admin).id)
+
+        described_class.call(
+          user: user,
+          send_confirmation: true,
+          current_user: admin
+        )
+
+        expect(user.reload.updated_by).to eq(admin)
+      end
     end
 
     context "with send_confirmation false" do

--- a/spec/services/user_services/process_email_manual_confirm_spec.rb
+++ b/spec/services/user_services/process_email_manual_confirm_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe UserServices::ProcessEmailManualConfirm do
 
           expect(result.summary).to include("Confirmation email has been resent to #{user.email}")
         end
+
+        it "credits the acting admin as updated_by" do
+          user.update_columns(updated_by_id: create(:user, :admin).id)
+
+          described_class.call(
+            user: user,
+            action: "resend",
+            current_user: admin
+          )
+
+          expect(user.reload.updated_by).to eq(admin)
+        end
       end
 
       context "with action 'confirm'" do
@@ -47,6 +59,18 @@ RSpec.describe UserServices::ProcessEmailManualConfirm do
 
           user.reload
           expect(user.confirmed_at).not_to be_nil
+        end
+
+        it "credits the acting admin as updated_by" do
+          user.update_columns(updated_by_id: create(:user, :admin).id)
+
+          described_class.call(
+            user: user,
+            action: "confirm",
+            current_user: admin
+          )
+
+          expect(user.reload.updated_by).to eq(admin)
         end
 
         it "includes manually confirmed message in summary" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained attribution fixes with existing test coverage

### What is the goal of this PR and why is this important?
Follow-up to #2022. Several actions write the user record (bumping `updated_at`) but left `updated_by` crediting whoever last *edited* the account instead of who took the action — the same wrong attribution Rachel reported for the welcome invite.

Admin actions — credit the acting admin:
- `users_controller#toggle_lock_status` — lock/unlock
- `users_controller#confirm_email` — manual confirm
- `users_controller#send_reset_password_instructions`
- `UserServices::ProcessEmailChange` — already took `current_user`, never applied it
- `UserServices::ProcessEmailManualConfirm` — resend + confirm; same

Public setup page — `welcome_controller#update` (invited user sets their password):
- Credit the signed-in admin if one is acting on the user's behalf, otherwise the account owner (`current_user || @user`) — never whoever last edited the account.

### How did you approach the change?
- Set `updated_by` at each write path (TDD: failing request/service specs first).
- Devise's `send_confirmation_instructions` only saves when it regenerates a token, so the two services persist the attribution themselves (`save(validate: false) if changed?`) — a no-op when Devise already saved.

### Anything else to add?
Deliberately **out of scope**: `BulkInviteService` (runs from rake/console, no `current_user`) and the `people_controller` nested-user autosave path.