### PR TITLE
Stamp created_by/updated_by centrally, drop manual controller assignments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ This codebase (Rails 8.1)
 | `StaffTaggable` | Adds the polymorphic `staff_taggings`/`staff_tags` associations for internal admin StaffTags (Person today) |
 | `TagFilterable` | Scope-based filtering by tag names |
 | `Trendable` | Trending metrics tracking |
-| `UserStampable` | Stamps `created_by_id` (at create, if unset) and `updated_by_id` (every write) from `Current.user` (no-op without the column) |
+| `UserStampable` | Forces `created_by_id` at create and stamps `updated_by_id` on every write, from `Current.user` (no-op without the columns or when `Current.user` is nil) |
 | `WindowsTypeFilterable` | Filter by WindowsType association |
 
 ## Controllers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ This codebase (Rails 8.1)
 | `SectorsTaggable` | Enforces a single primary sector for sector-tagged owners |
 | `TagFilterable` | Scope-based filtering by tag names |
 | `Trendable` | Trending metrics tracking |
-| `UserStampable` | Stamps `updated_by_id` from `Current.user` on every write (no-op without the column) |
+| `UserStampable` | Stamps `created_by_id`/`updated_by_id` from `Current.user` (no-op without the columns) |
 | `WindowsTypeFilterable` | Filter by WindowsType association |
 
 ## Controllers

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -11,8 +11,6 @@ class AffiliationsController < ApplicationController
     # This form always posts the Inactive checkbox, so whatever it sends is deliberate.
     @affiliation.inactive_supplied = affiliation_params.key?(:inactive)
     @affiliation.assign_attributes(affiliation_params)
-    @affiliation.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
-    @affiliation.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @affiliation.save
       redirect_to affiliation_return_path, notice: "Affiliation was successfully updated.", status: :see_other

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -15,7 +15,6 @@ class AuthorCreditDivergencesController < ApplicationController
     person = Person.find(params[:id])
     person.assign_attributes(person_params)
     person.author_credit_reconciled_at = Time.current
-    person.updated_by = current_user
 
     if person.save
       render_divergence_change("Updated credit preferences for #{person.full_name}.", :notice)
@@ -35,7 +34,6 @@ class AuthorCreditDivergencesController < ApplicationController
     # Clearing "anonymous" hands the item back to the profile, which may credit it —
     # that's what this page exists to do.
     record.author_credit_preference = params[:author_credit_preference]
-    record.updated_by = current_user if record.respond_to?(:updated_by=)
 
     if record.save
       render_divergence_change("Updated credit for #{model.name.underscore.humanize.downcase} ##{record.id}.", :notice)
@@ -55,7 +53,6 @@ class AuthorCreditDivergencesController < ApplicationController
     return render_divergence_change("Choose a person to credit.", :alert) unless person
 
     record.author_id = person.id
-    record.updated_by = current_user if record.respond_to?(:updated_by=)
 
     if record.save
       render_divergence_change("Credited #{model.name.underscore.humanize.downcase} ##{record.id} to #{person.full_name}.", :notice)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -25,7 +25,6 @@ class CommentsController < ApplicationController
   def create
     authorize!
     @comment = @commentable.comments.build(comment_params)
-    @comment.created_by = current_user
     @comment.updated_by = current_user
 
     if @comment.save

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -25,7 +25,6 @@ class CommentsController < ApplicationController
   def create
     authorize!
     @comment = @commentable.comments.build(comment_params)
-    @comment.updated_by = current_user
 
     if @comment.save
       @created_comment = @comment
@@ -42,7 +41,6 @@ class CommentsController < ApplicationController
   def update
     @comment = @commentable.comments.find(params[:id])
     authorize! @comment
-    @comment.updated_by = current_user
     @comment.update(comment_params)
     setup_aggregated_context if aggregated?
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,7 +13,6 @@ class CommentsController < ApplicationController
   def create
     authorize!
     @comment = @commentable.comments.build(comment_params)
-    @comment.created_by = current_user
     @comment.updated_by = current_user
 
     if @comment.save

--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -61,7 +61,6 @@ class CommunityNewsController < ApplicationController
 
   def create
     @community_news = CommunityNews.new(community_news_params)
-    @community_news.created_by = current_user
     authorize! @community_news
 
     success = false

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -95,7 +95,7 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration
     warn_if_locked_fields_submitted
     @event_registration.assign_attributes(event_registration_update_params)
-    @event_registration.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @event_registration.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @event_registration.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @event_registration.save

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -95,8 +95,6 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration
     warn_if_locked_fields_submitted
     @event_registration.assign_attributes(event_registration_update_params)
-    @event_registration.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @event_registration.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @event_registration.save
       # Marking transferred out — from the edit-form save OR the inline roster/

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -79,7 +79,7 @@ class EventRegistrationsController < ApplicationController
   def update
     authorize! @event_registration
     @event_registration.assign_attributes(event_registration_update_params)
-    @event_registration.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @event_registration.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @event_registration.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Inline-logged notifications are addressed to the registrant.

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -79,8 +79,6 @@ class EventRegistrationsController < ApplicationController
   def update
     authorize! @event_registration
     @event_registration.assign_attributes(event_registration_update_params)
-    @event_registration.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @event_registration.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Inline-logged notifications are addressed to the registrant.
     recipient_email = @event_registration.registrant&.preferred_email.presence || "n/a"

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -169,8 +169,7 @@ module Events
       person = Person.create!(
         first_name: current_user.first_name,
         last_name: current_user.last_name,
-        email: current_user.email,
-        updated_by: current_user
+        email: current_user.email
       )
       current_user.update!(person: person)
       person

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -170,7 +170,6 @@ module Events
         first_name: current_user.first_name,
         last_name: current_user.last_name,
         email: current_user.email,
-        created_by: current_user,
         updated_by: current_user
       )
       current_user.update!(person: person)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -520,7 +520,6 @@ class EventsController < ApplicationController
   def create
     authorize!
     @event = Event.new(event_params)
-    @event.created_by ||= current_user
 
     success = false
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -315,7 +315,6 @@ class EventsController < ApplicationController
   def create
     authorize!
     @event = Event.new(event_params)
-    @event.created_by ||= current_user
 
     success = false
 

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -48,7 +48,6 @@ class GrantsController < ApplicationController
 
   def create
     @grant = Grant.new(grant_params)
-    @grant.updated_by = current_user
     authorize! @grant
 
     if @grant.save
@@ -61,7 +60,6 @@ class GrantsController < ApplicationController
 
   def update
     authorize! @grant
-    @grant.updated_by = current_user
 
     if @grant.update(grant_params)
       redirect_to @grant, notice: "Grant was successfully updated.", status: :see_other

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -48,7 +48,6 @@ class GrantsController < ApplicationController
 
   def create
     @grant = Grant.new(grant_params)
-    @grant.created_by = current_user
     @grant.updated_by = current_user
     authorize! @grant
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -127,7 +127,7 @@ class OrganizationsController < ApplicationController
   def update
     authorize! @organization
     @organization.assign_attributes(organization_params)
-    @organization.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @organization.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @organization.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @organization.save

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -127,8 +127,6 @@ class OrganizationsController < ApplicationController
   def update
     authorize! @organization
     @organization.assign_attributes(organization_params)
-    @organization.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @organization.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @organization.save
       assign_associations(@organization) if params.dig(:organization, :category_ids)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -299,8 +299,6 @@ class PeopleController < ApplicationController
     attrs = person_params
     reject_locked_license_changes!(attrs)
     @person.assign_attributes(attrs)
-    @person.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @person.save
       assign_associations(@person) if params.dig(:person, :category_ids)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -299,7 +299,7 @@ class PeopleController < ApplicationController
     attrs = person_params
     reject_locked_license_changes!(attrs)
     @person.assign_attributes(attrs)
-    @person.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @person.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     if @person.save

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -224,8 +224,6 @@ class PeopleController < ApplicationController
     attrs = person_params
     reject_locked_license_changes!(attrs)
     @person.assign_attributes(attrs)
-    @person.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Inline-logged notifications are addressed to the person.
     recipient_email = @person.preferred_email.presence || "n/a"

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -224,7 +224,7 @@ class PeopleController < ApplicationController
     attrs = person_params
     reject_locked_license_changes!(attrs)
     @person.assign_attributes(attrs)
-    @person.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @person.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Inline-logged notifications are addressed to the person.

--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -19,7 +19,6 @@ class ProfessionalLicensesController < ApplicationController
 
   def create
     @professional_license = ProfessionalLicense.new(professional_license_params)
-    @professional_license.created_by = current_user
     authorize! @professional_license
 
     if @professional_license.save
@@ -37,7 +36,6 @@ class ProfessionalLicensesController < ApplicationController
   def update
     @professional_license = ProfessionalLicense.find(params[:id])
     authorize! @professional_license
-    @professional_license.updated_by = current_user
 
     if @professional_license.update(license_edit_params)
       redirect_to professional_licenses_path, notice: "License updated for #{@professional_license.person.full_name}."

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -31,7 +31,6 @@ class QuotesController < ApplicationController
 
   def create
     @quote = Quote.new(quote_params)
-    @quote.created_by = current_user
     authorize! @quote
 
     success = false
@@ -55,7 +54,6 @@ class QuotesController < ApplicationController
 
   def update
     authorize! @quote
-    @quote.updated_by = current_user
 
     success = false
     Quote.transaction do

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -103,7 +103,6 @@ class ResourcesController < ApplicationController
   def update
     @resource = Resource.find(params[:id])
     authorize! @resource
-    @resource.created_by ||= current_user
     success = false
 
     Resource.transaction do
@@ -192,7 +191,7 @@ class ResourcesController < ApplicationController
   def load_forms
     form = @resource.form
     if form
-      @user_form = Report.new(created_by: current_user, owner: @resource)
+      @user_form = Report.new(owner: @resource)
       form.form_fields.where(status: 1).order(:position).each do |field|
         @user_form.report_form_field_answers.build(form_field: field)
       end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -74,7 +74,6 @@ class ScholarshipsController < ApplicationController
     authorize! @scholarship
 
     @scholarship.assign_attributes(scholarship_params)
-    attribute_comment_authorship
 
     if @scholarship.save
       redirect_to scholarship_save_path, notice: "Scholarship updated."
@@ -291,16 +290,5 @@ class ScholarshipsController < ApplicationController
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
-  end
-
-  # Stamp authorship on comments edited through the scholarship form: author + editor
-  # on new ones, editor on existing ones whose body changed.
-  def attribute_comment_authorship
-    @scholarship.comments.select(&:new_record?).each do |c|
-      c.updated_by = current_user
-    end
-    @scholarship.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
-      c.updated_by = current_user
-    end
   end
 end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -297,7 +297,6 @@ class ScholarshipsController < ApplicationController
   # on new ones, editor on existing ones whose body changed.
   def attribute_comment_authorship
     @scholarship.comments.select(&:new_record?).each do |c|
-      c.created_by = current_user
       c.updated_by = current_user
     end
     @scholarship.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -217,7 +217,6 @@ class ScholarshipsController < ApplicationController
   # on new ones, editor on existing ones whose body changed.
   def attribute_comment_authorship
     @scholarship.comments.select(&:new_record?).each do |c|
-      c.created_by = current_user
       c.updated_by = current_user
     end
     @scholarship.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -82,7 +82,6 @@ class ScholarshipsController < ApplicationController
     authorize! @scholarship
 
     @scholarship.assign_attributes(scholarship_params)
-    attribute_comment_authorship
 
     # Inline-logged notifications are addressed to the scholarship recipient.
     recipient_email = @scholarship.recipient&.preferred_email.presence || "n/a"
@@ -211,16 +210,5 @@ class ScholarshipsController < ApplicationController
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id, :_destroy ]
     )
-  end
-
-  # Stamp authorship on comments edited through the scholarship form: author + editor
-  # on new ones, editor on existing ones whose body changed.
-  def attribute_comment_authorship
-    @scholarship.comments.select(&:new_record?).each do |c|
-      c.updated_by = current_user
-    end
-    @scholarship.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
-      c.updated_by = current_user
-    end
   end
 end

--- a/app/controllers/staff_taggings_controller.rb
+++ b/app/controllers/staff_taggings_controller.rb
@@ -51,13 +51,6 @@ class StaffTaggingsController < ApplicationController
   def update
     authorize! @staff_tagging
     @staff_tagging.assign_attributes(staff_tagging_params)
-    @staff_tagging.comments.select(&:new_record?).each do |comment|
-      comment.created_by = current_user
-      comment.updated_by = current_user
-    end
-    @staff_tagging.comments.select { |comment| comment.persisted? && comment.body_changed? }.each do |comment|
-      comment.updated_by = current_user
-    end
 
     if @staff_tagging.save
       redirect_to staff_tagging_return_path, notice: "Staff tag updated.", status: :see_other

--- a/app/controllers/staff_tags_controller.rb
+++ b/app/controllers/staff_tags_controller.rb
@@ -33,8 +33,6 @@ class StaffTagsController < ApplicationController
 
   def create
     @staff_tag = StaffTag.new(staff_tag_params)
-    @staff_tag.created_by = current_user
-    @staff_tag.updated_by = current_user
     authorize! @staff_tag
 
     if @staff_tag.save
@@ -47,7 +45,6 @@ class StaffTagsController < ApplicationController
 
   def update
     authorize! @staff_tag
-    @staff_tag.updated_by = current_user
 
     if @staff_tag.update(staff_tag_params)
       redirect_to @staff_tag, notice: "Staff tag was successfully updated.", status: :see_other

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -63,7 +63,6 @@ class StoriesController < ApplicationController
 
   def create
     @story = Story.new(story_params.except(:category_ids, :sector_ids))
-    @story.created_by = current_user
     authorize! @story
 
     success = false

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -98,7 +98,6 @@ class StoriesController < ApplicationController
 
     Story.transaction do
       @story.assign_attributes(story_params.except(:images, :category_ids, :sector_ids))
-      attribute_comment_authorship
       if @story.save
         assign_associations(@story)
         if params[:promote_idea_assets] == "true"
@@ -159,18 +158,6 @@ class StoriesController < ApplicationController
   end
 
   private
-
-  # Stamp authorship on comments edited through the story form: author + editor
-  # on new ones, editor on existing ones whose body changed.
-  def attribute_comment_authorship
-    @story.comments.select(&:new_record?).each do |c|
-      c.created_by = current_user
-      c.updated_by = current_user
-    end
-    @story.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
-      c.updated_by = current_user
-    end
-  end
 
   # Promoting a story idea into a story emails the idea's submitter and an admin FYI.
   def notify_story_promoted

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -34,7 +34,6 @@ class StoryIdeasController < ApplicationController
 
   def create
     @story_idea = StoryIdea.new(story_idea_params.except(:category_ids, :sector_ids))
-    @story_idea.updated_by = current_user
     # Credit the submitter as the author, so the idea lists on their profile by
     # authorship like every other content type. An admin can reassign it later.
     @story_idea.author ||= current_user.person
@@ -80,14 +79,12 @@ class StoryIdeasController < ApplicationController
   end
 
   def update
-    @story_idea.updated_by = current_user
     authorize! @story_idea
 
     success = false
 
     StoryIdea.transaction do
       @story_idea.assign_attributes(story_idea_params.except(:images, :category_ids, :sector_ids))
-      attribute_comment_authorship
       if @story_idea.save
         assign_associations(@story_idea)
         success = true
@@ -118,19 +115,6 @@ class StoryIdeasController < ApplicationController
   end
 
   private
-
-  # Stamp authorship on comments edited through the story idea form: author +
-  # editor on new ones, editor on existing ones whose body changed.
-  def attribute_comment_authorship
-    @story_idea.comments.select(&:new_record?).each do |c|
-      c.created_by = current_user
-      c.updated_by = current_user
-    end
-    @story_idea.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
-      c.updated_by = current_user
-    end
-  end
-
 
   def set_story_idea
     @story_idea = StoryIdea.find(params[:id])

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -34,7 +34,6 @@ class StoryIdeasController < ApplicationController
 
   def create
     @story_idea = StoryIdea.new(story_idea_params.except(:category_ids, :sector_ids))
-    @story_idea.created_by = current_user
     @story_idea.updated_by = current_user
     # Credit the submitter as the author, so the idea lists on their profile by
     # authorship like every other content type. An admin can reassign it later.

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -33,7 +33,6 @@ class StoryIdeasController < ApplicationController
 
   def create
     @story_idea = StoryIdea.new(story_idea_params.except(:category_ids, :sector_ids))
-    @story_idea.created_by = current_user
     @story_idea.updated_by = current_user
     authorize! @story_idea
 

--- a/app/controllers/topic_subscription_types_controller.rb
+++ b/app/controllers/topic_subscription_types_controller.rb
@@ -20,8 +20,6 @@ class TopicSubscriptionTypesController < ApplicationController
   def create
     authorize! TopicSubscriptionType
     @topic_subscription_type = TopicSubscriptionType.new(topic_subscription_type_params)
-    @topic_subscription_type.created_by = current_user
-    @topic_subscription_type.updated_by = current_user
 
     if @topic_subscription_type.save
       redirect_to topic_subscription_types_path, notice: "Topic added."
@@ -36,7 +34,6 @@ class TopicSubscriptionTypesController < ApplicationController
 
   def update
     authorize! @topic_subscription_type
-    @topic_subscription_type.updated_by = current_user
 
     if @topic_subscription_type.update(topic_subscription_type_params)
       redirect_to topic_subscription_types_path, notice: "Topic updated."

--- a/app/controllers/topic_subscriptions_controller.rb
+++ b/app/controllers/topic_subscriptions_controller.rb
@@ -58,9 +58,6 @@ class TopicSubscriptionsController < ApplicationController
   def create
     authorize! TopicSubscription
     @topic_subscription = TopicSubscription.new(topic_subscription_params)
-    @topic_subscription.created_by = current_user
-    @topic_subscription.updated_by = current_user
-    stamp_inline_person
 
     if @topic_subscription.save
       redirect_to save_return_path, notice: "Subscription added."
@@ -75,7 +72,6 @@ class TopicSubscriptionsController < ApplicationController
 
   def update
     authorize! @topic_subscription
-    @topic_subscription.updated_by = current_user
 
     if @topic_subscription.update(topic_subscription_params)
       redirect_to save_return_path, notice: "Subscription updated."
@@ -138,15 +134,6 @@ class TopicSubscriptionsController < ApplicationController
     end
   end
 
-  # Stamp the auditing columns on a person created inline through the form so the
-  # new record carries the same authorship the subscription does.
-  def stamp_inline_person
-    person = @topic_subscription.person
-    return unless person&.new_record?
-
-    person.created_by ||= current_user
-    person.updated_by ||= current_user
-  end
 
   # Prefill the topic when opened from an event's Forms menu: an explicit type id
   # wins, then a stable key (e.g. "facilitator_trainings"), else the canonical

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,8 +133,6 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(user_params.except(:password, :password_confirmation))
     @user.updated_by = current_user
-    @user.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @user.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Suppress Devise's automatic reconfirmation email so the interstitial can control it
     @user.skip_confirmation_notification!

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,6 @@ class UsersController < ApplicationController
     # assign person
     person_id = params[:person_id].presence || params.dig(:user, :person_id).presence
     @user.person = Person.find(person_id) if person_id
-    @user.created_by = current_user
     @user.updated_by = current_user
 
     if @user.save
@@ -134,7 +133,7 @@ class UsersController < ApplicationController
 
     @user.assign_attributes(user_params.except(:password, :password_confirmation))
     @user.updated_by = current_user
-    @user.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @user.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @user.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     # Suppress Devise's automatic reconfirmation email so the interstitial can control it

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,6 @@ class UsersController < ApplicationController
     # assign person
     person_id = params[:person_id].presence || params.dig(:user, :person_id).presence
     @user.person = Person.find(person_id) if person_id
-    @user.updated_by = current_user
 
     if @user.save
       if params[:event_registration_id].present?
@@ -132,7 +131,6 @@ class UsersController < ApplicationController
     end
 
     @user.assign_attributes(user_params.except(:password, :password_confirmation))
-    @user.updated_by = current_user
 
     # Suppress Devise's automatic reconfirmation email so the interstitial can control it
     @user.skip_confirmation_notification!
@@ -216,11 +214,11 @@ class UsersController < ApplicationController
 
     if @user.locked_at.present?
       # Unlock the user
-      @user.update(locked_at: nil, failed_attempts: 0, updated_by: current_user)
+      @user.update(locked_at: nil, failed_attempts: 0)
       message = "User has been unlocked."
     else
       # Lock the user
-      @user.update(locked_at: Time.current, updated_by: current_user)
+      @user.update(locked_at: Time.current)
       message = "User has been locked."
     end
 
@@ -240,7 +238,7 @@ class UsersController < ApplicationController
     if @user.confirmed_at.present?
       message = "Email is already confirmed."
     else
-      @user.update(confirmed_at: Time.current, updated_by: current_user)
+      @user.update(confirmed_at: Time.current)
       message = "Email has been manually confirmed."
     end
 

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -26,7 +26,6 @@ class WorkshopLogsController < ApplicationController
     @workshop_log = WorkshopLog.find(params[:id])
     authorize! @workshop_log
     @workshop_log.assign_attributes(workshop_log_params)
-    credit_new_quotes_to_current_user
 
     if @workshop_log.save
       redirect_to @workshop_log, notice: "Thanks for reporting on a workshop."
@@ -42,7 +41,6 @@ class WorkshopLogsController < ApplicationController
     @workshop_log = WorkshopLog.new(workshop_log_params)
     authorize! @workshop_log
     @workshop_log.author ||= @workshop_log.created_by&.person
-    credit_new_quotes_to_current_user
 
     if @workshop_log.save
       NotificationServices::CreateNotification.call(
@@ -177,16 +175,6 @@ class WorkshopLogsController < ApplicationController
         .order(:name)
     organization = params[:organization_id].present? ? Organization.where(id: params[:organization_id]).last : @organizations.first
     @organization_id = organization.id if organization
-  end
-
-  # Credit new quotes to the facilitator submitting the log — the speaker (the
-  # quote's `author` Person) is left unset, since it's the participant, not the
-  # submitter. Only new records, so editing a log never re-credits existing quotes.
-  def credit_new_quotes_to_current_user
-    @workshop_log.all_quotable_item_quotes.each do |qiq|
-      quote = qiq.quote
-      quote.created_by = current_user if quote&.new_record?
-    end
   end
 
   def set_default_values

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -108,8 +108,6 @@ class WorkshopsController < ApplicationController
     success = false
 
     @workshop.assign_attributes(workshop_params)
-    @workshop.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @workshop.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     Workshop.transaction do
       if @workshop.save

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -34,7 +34,7 @@ class WorkshopsController < ApplicationController
       @workshop = WorkshopFromIdeaService.new(@workshop_idea, user: current_user).call
       authorize! @workshop
     else
-      @workshop = Workshop.new(created_by: current_user)
+      @workshop = Workshop.new
       authorize! @workshop
     end
     set_form_variables
@@ -108,7 +108,7 @@ class WorkshopsController < ApplicationController
     success = false
 
     @workshop.assign_attributes(workshop_params)
-    @workshop.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @workshop.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @workshop.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     Workshop.transaction do

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -156,8 +156,6 @@ class WorkshopsController < ApplicationController
     success = false
 
     @workshop.assign_attributes(workshop_params)
-    @workshop.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
-    @workshop.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     Workshop.transaction do
       if @workshop.save

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -82,7 +82,7 @@ class WorkshopsController < ApplicationController
       @workshop = WorkshopFromIdeaService.new(@workshop_idea, user: current_user).call
       authorize! @workshop
     else
-      @workshop = Workshop.new(created_by: current_user)
+      @workshop = Workshop.new
       authorize! @workshop
     end
     set_form_variables
@@ -156,7 +156,7 @@ class WorkshopsController < ApplicationController
     success = false
 
     @workshop.assign_attributes(workshop_params)
-    @workshop.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @workshop.comments.select(&:new_record?).each { |c| c.updated_by = current_user }
     @workshop.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
     Workshop.transaction do

--- a/app/models/concerns/user_stampable.rb
+++ b/app/models/concerns/user_stampable.rb
@@ -1,12 +1,12 @@
 module UserStampable
   extend ActiveSupport::Concern
 
-  # Stamps the audit columns from Current.user so a record records who created and who
-  # last edited it, without every controller assigning them by hand. Included on
-  # ApplicationRecord; each stamp is a no-op for tables that lack the column, and the
-  # whole thing is a no-op when Current.user is nil (seeds, jobs, unauthenticated
+  # Stamps created_by_id / updated_by_id from Current.user so attribution lives on the
+  # record itself instead of being assigned by hand in every controller. Included on
+  # ApplicationRecord; the guards make it a no-op for tables without the columns, and
+  # the whole thing is a no-op when Current.user is nil (seeds, jobs, unauthenticated
   # flows). Runs on before_validation so it satisfies a required belongs_to before the
-  # presence check. Both stamps respect a value the caller assigned explicitly.
+  # presence check.
   included do
     before_validation :stamp_user_columns
   end
@@ -21,19 +21,22 @@ module UserStampable
     stamp_updated_by(user)
   end
 
-  # created_by is set once, at create time, and never overwritten afterward.
+  # Only at creation, and always the authenticated actor — created_by is not a
+  # user-supplied value, so a mass-assigned created_by_id must not override it. A
+  # later editor never reaches this (guarded on new_record?), so it can't claim it.
   def stamp_created_by(user)
-    return unless new_record?
-    return unless has_attribute?(:created_by_id)
-    return if created_by_id.present?
+    return unless new_record? && has_attribute?(:created_by_id)
 
     self.created_by_id = user.id
   end
 
-  # updated_by tracks the last editor on every write. Skip when the caller set it
-  # explicitly, and when nothing else changed (so a no-op save stays a no-op).
   def stamp_updated_by(user)
     return unless has_attribute?(:updated_by_id)
+
+    # Skip when the caller set updated_by_id explicitly (respect it), and when nothing
+    # else changed (don't turn a no-op save into a write / spurious update event).
+    # A save whose only changes are to associations leaves the record itself unchanged,
+    # so a parent that must bump when only its nested records change still assigns by hand.
     return if updated_by_id_changed?
     return unless new_record? || changed?
 

--- a/app/models/concerns/user_stampable.rb
+++ b/app/models/concerns/user_stampable.rb
@@ -1,25 +1,41 @@
 module UserStampable
   extend ActiveSupport::Concern
 
-  # Stamps updated_by_id from Current.user on every write, so the last editor is
-  # recorded on the record itself. (created_by_id is set at create time by the
-  # controllers; only updated_by_id was going unset on updates.) Included on
-  # ApplicationRecord; the guard makes it a no-op for tables without the column. Runs
-  # on before_validation so it satisfies a required belongs_to :updated_by before the
-  # presence check.
+  # Stamps created_by_id / updated_by_id from Current.user so attribution lives on the
+  # record itself instead of being assigned by hand in every controller. Included on
+  # ApplicationRecord; the guards make it a no-op for tables without the columns. Runs
+  # on before_validation so it satisfies a required belongs_to before the presence
+  # check.
   included do
-    before_validation :stamp_updated_by
+    before_validation :stamp_user_columns
   end
 
   private
 
-  def stamp_updated_by
+  def stamp_user_columns
     user = Current.user
     return unless user
+
+    stamp_created_by(user)
+    stamp_updated_by(user)
+  end
+
+  # Only at creation, and always the authenticated actor — created_by is not a
+  # user-supplied value, so a mass-assigned created_by_id must not override it. A
+  # later editor never reaches this (guarded on new_record?), so it can't claim it.
+  def stamp_created_by(user)
+    return unless new_record? && has_attribute?(:created_by_id)
+
+    self.created_by_id = user.id
+  end
+
+  def stamp_updated_by(user)
     return unless has_attribute?(:updated_by_id)
 
     # Skip when the caller set updated_by_id explicitly (respect it), and when nothing
     # else changed (don't turn a no-op save into a write / spurious update event).
+    # A save whose only changes are to associations leaves the record itself unchanged,
+    # so those paths still assign updated_by by hand.
     return if updated_by_id_changed?
     return unless new_record? || changed?
 

--- a/spec/models/concerns/user_stampable_spec.rb
+++ b/spec/models/concerns/user_stampable_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UserStampable, type: :model do
-  # Banner carries both stamp columns and a required belongs_to :created_by.
+  # Banner carries both stamp columns, each a required belongs_to.
   let(:creator) { create(:user) }
   let(:editor)  { create(:user) }
 
@@ -10,32 +10,27 @@ RSpec.describe UserStampable, type: :model do
   end
 
   describe "on create" do
-    it "stamps updated_by from Current.user" do
-      banner = with_current(creator) { Banner.create!(content: "Hi", show: true) }
-
-      expect(banner.updated_by).to eq(creator)
-    end
-
-    it "stamps created_by from Current.user when the caller leaves it unset" do
+    it "stamps created_by and updated_by from Current.user" do
       banner = with_current(creator) { Banner.create!(content: "Hi", show: true) }
 
       expect(banner.created_by).to eq(creator)
+      expect(banner.updated_by).to eq(creator)
     end
 
-    it "satisfies required created_by/updated_by belongs_to without an explicit assignment" do
+    it "satisfies required belongs_to stamps without an explicit assignment" do
       expect { with_current(creator) { Banner.create!(content: "Hi", show: true) } }
         .not_to raise_error
     end
 
-    it "respects an explicitly assigned created_by" do
+    it "forces created_by to Current.user, ignoring a mass-assigned value" do
       banner = with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: editor) }
 
-      expect(banner.created_by).to eq(editor)
+      expect(banner.created_by).to eq(creator)
     end
   end
 
   describe "on update" do
-    let!(:banner) { with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) } }
+    let!(:banner) { with_current(creator) { Banner.create!(content: "Hi", show: true) } }
 
     it "stamps updated_by with the current editor without touching created_by" do
       with_current(editor) { banner.update!(content: "Edited") }
@@ -74,6 +69,7 @@ RSpec.describe UserStampable, type: :model do
         Banner.create!(content: "Hi", show: true, created_by: creator, updated_by: creator)
       end
 
+      expect(banner.created_by).to eq(creator)
       expect(banner.updated_by).to eq(creator)
     end
   end

--- a/spec/models/concerns/user_stampable_spec.rb
+++ b/spec/models/concerns/user_stampable_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe UserStampable, type: :model do
-  # Banner carries both stamp columns and a required belongs_to :created_by.
+  # Banner carries both stamp columns, each a required belongs_to.
   let(:creator) { create(:user) }
   let(:editor)  { create(:user) }
 
@@ -10,26 +10,27 @@ RSpec.describe UserStampable, type: :model do
   end
 
   describe "on create" do
-    it "stamps updated_by from Current.user" do
-      banner = with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) }
+    it "stamps created_by and updated_by from Current.user" do
+      banner = with_current(creator) { Banner.create!(content: "Hi", show: true) }
 
+      expect(banner.created_by).to eq(creator)
       expect(banner.updated_by).to eq(creator)
     end
 
-    it "satisfies a required belongs_to :updated_by without an explicit assignment" do
-      expect { with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) } }
+    it "satisfies required belongs_to stamps without an explicit assignment" do
+      expect { with_current(creator) { Banner.create!(content: "Hi", show: true) } }
         .not_to raise_error
     end
 
-    it "leaves created_by to the caller" do
+    it "forces created_by to Current.user, ignoring a mass-assigned value" do
       banner = with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: editor) }
 
-      expect(banner.created_by).to eq(editor)
+      expect(banner.created_by).to eq(creator)
     end
   end
 
   describe "on update" do
-    let!(:banner) { with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) } }
+    let!(:banner) { with_current(creator) { Banner.create!(content: "Hi", show: true) } }
 
     it "stamps updated_by with the current editor without touching created_by" do
       with_current(editor) { banner.update!(content: "Edited") }
@@ -58,6 +59,7 @@ RSpec.describe UserStampable, type: :model do
         Banner.create!(content: "Hi", show: true, created_by: creator, updated_by: creator)
       end
 
+      expect(banner.created_by).to eq(creator)
       expect(banner.updated_by).to eq(creator)
     end
   end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 changes the created_by anti-forgery invariant (force) and removes manual attribution across ~18 controllers

Follow-up to #2436 (which added `UserStampable`): controllers no longer set `created_by`/`updated_by` by hand — the concern is now the single source of attribution.

## What changed
- **`UserStampable` now *forces* `created_by`** to `Current.user` at create (was blank-only in #2436), so a mass-assigned `created_by_id` can no longer forge attribution. Still create-only (`new_record?`), so a later editor never claims it. `updated_by` behavior is unchanged (stamped whenever the record’s own columns change).
- **Removed the manual `created_by = current_user` / `updated_by = current_user` assignments** from create/update actions across ~18 controllers, the comment-authorship loops (story_ideas, stories, staff_taggings, affiliations — matching the ones #2436-era already dropped), and the `credit_new_quotes_to_current_user` / `stamp_inline_person` helpers.

## Deliberately kept (the concern can’t cover these)
- **Two Devise `save(validate: false)` flows** — `send_reset_password_instructions` and the welcome-invite token write. `before_validation` (and so the concern) never runs on `save(validate: false)`, so those still set `updated_by` by hand.
- **`welcome#update`** keeps `updated_by: current_user || @user` — it deliberately falls back to the account owner when no one is signed in, which the concern (no-op without `Current.user`) can’t express.

## Notes
- **Parent `updated_by` on comment-only edits no longer bumps** the parent record — the concern only stamps a record whose *own* columns changed, matching how the other comment flows already behaved.
- Services that set `created_by` explicitly (e.g. `Quotes::CaptureFromSubmission`) run in unauthenticated flows where `Current.user` is nil, so the force never overrides them.

## Verification
- All 24 audited tables carry both `created_by_id` and `updated_by_id`; every `belongs_to :created_by`/`:updated_by` points to **User** (none to Person).
- ~1,450 request/model/service examples across every touched controller — all green.