### PR TITLE
Document ActionPolicy rule inference in AI files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ When changing a model or controller, check whether these related files need upda
 - Prefer POROs over concerns when possible
 - **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
+- **Don't pass `to:` to `authorize!` when the rule matches the controller action** — ActionPolicy infers the rule from the action name (`create` → `create?`, `update` → `update?`), so `authorize! @record` in the `update` action already checks `update?`. Only pass `to:` when checking a *different* rule than the current action (e.g. `authorize! @scholarship, to: :update?` from a non-`update` action, or `authorize! :workshop, to: :summary?`).
 - **Comment only when the reason isn't obvious from the code** — don't restate what the code already says. When a comment is warranted (a non-obvious why, a gotcha), keep it brief and clear. **Keep it to one line** unless the logic is genuinely complex and can't be inferred from the code plus domain knowledge that the comment needs to capture — only then let it run longer.
 
 ## RuboCop (rubocop-rails-omakase)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,17 @@ class ApplicationController < ActionController::Base
   verify_authorized                    # ActionPolicy enforcement
 
   # Common helpers:
-  # authorize! @record               — check policy
+  # authorize! @record               — check policy (rule inferred from the action name)
+  # authorize! @record, to: :other?  — only when checking a rule ≠ the current action
   # authorized_scope(Model.all)      — filtered relation
   # @record.decorate                 — Draper decorator
 end
 ```
+
+`authorize!` infers the rule from the controller action (`create` → `create?`, `update` →
+`update?`), so `authorize! @record` in the `update` action already checks `update?`. Pass `to:`
+only to check a *different* rule (e.g. `authorize! @scholarship, to: :update?` from a non-`update`
+action, or `authorize! :workshop, to: :summary?`).
 
 ### Controller Concerns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ When changing a model or controller, check whether these related files need upda
 - Prefer POROs over concerns when possible
 - **Prefer decorators (Draper, app/decorators/) over view helpers for model-specific presentation** — when display logic is "about a record" (labels, badges, formatted attributes, status pills), put it on that model's decorator and call `record.decorate.thing`. Reserve `app/helpers/` for generic, cross-model view utilities that aren't tied to one model. Decorators keep presentation testable and out of ERB.
 - Use `after_commit` instead of `after_save` for side effects
+- **Don't pass `to:` to `authorize!` when the rule matches the controller action** — ActionPolicy infers the rule from the action name (`create` → `create?`, `update` → `update?`), so `authorize! @record` in the `update` action already checks `update?`. Only pass `to:` when checking a *different* rule than the current action (e.g. `authorize! @scholarship, to: :update?` from a non-`update` action, or `authorize! :workshop, to: :summary?`).
 - **Comment only when the reason isn't obvious from the code** — don't restate what the code already says. When a comment is warranted (a non-obvious why, a gotcha), keep it brief and clear. **Keep it to one line** unless the logic is genuinely complex and can't be inferred from the code plus domain knowledge that the comment needs to capture — only then let it run longer.
 
 ## RuboCop (rubocop-rails-omakase)


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 docs-only change to AI instruction files

### What is the goal of this PR and why is this important?
- `authorize!` infers the policy rule from the controller action (`update` → `update?`), so `to:` is redundant when it just restates the current action.
- Codify this so agents/Copilot stop adding needless `to: :action?` arguments and only use `to:` for a *different* rule.

### How did you approach the change?
- Added a Code Style bullet to `CLAUDE.md` and mirrored it in `.github/copilot-instructions.md`.
- Clarified the same in the `AGENTS.md` Base Controller Pattern helper comments + note.