### PR TITLE
Rename grant application deadline to funds allocation deadline

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -139,7 +139,7 @@ class GrantsController < ApplicationController
   def grant_params
     params.require(:grant).permit(
       :name, :description, :amount_dollars, :amount_cents, :donor_sgid,
-      :application_deadline, :funds_received_on, :eligibility_criteria, :tasks
+      :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks
     )
   end
 end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -11,8 +11,8 @@ class GrantDecorator < ApplicationDecorator
     h.dollars_from_cents(object.remaining_cents)
   end
 
-  def application_deadline
-    object.application_deadline&.strftime("%B %-d, %Y") || "—"
+  def funds_allocation_deadline
+    object.funds_allocation_deadline&.strftime("%B %-d, %Y") || "—"
   end
 
   def funds_received_on

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -12,7 +12,7 @@ class Grant < ApplicationRecord
   validates :donor_type, inclusion: { in: DONOR_TYPES }
   validate :amount_covers_scholarships_already_issued
 
-  scope :by_deadline, -> { order(Arel.sql("application_deadline IS NULL, application_deadline ASC")) }
+  scope :by_deadline, -> { order(Arel.sql("funds_allocation_deadline IS NULL, funds_allocation_deadline ASC")) }
 
   # Total scholarship draws against a grant, as a correlated subquery. Used by the
   # funds scopes so they stay flat WHERE clauses — no GROUP BY/HAVING, which would

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -41,11 +41,12 @@
     </div>
 
     <div>
-      <%= f.input :application_deadline,
+      <%= f.input :funds_allocation_deadline,
+                  label: "Funds allocation deadline",
                   as: :string,
                   input_html: {
                     type: "date",
-                    value: @grant.application_deadline&.strftime("%Y-%m-%d"),
+                    value: @grant.funds_allocation_deadline&.strftime("%Y-%m-%d"),
                     class: "w-full sm:w-1/2 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
                   } %>
     </div>

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -30,6 +30,6 @@
       <span class="text-gray-400">0</span>
     <% end %>
   </td>
-  <td class="px-4 py-3.5 align-middle text-sm text-gray-700 whitespace-nowrap" data-sort-value="<%= grant.object.application_deadline&.iso8601 %>"><%= grant.application_deadline %></td>
+  <td class="px-4 py-3.5 align-middle text-sm text-gray-700 whitespace-nowrap" data-sort-value="<%= grant.object.funds_allocation_deadline&.iso8601 %>"><%= grant.funds_allocation_deadline %></td>
   <td class="px-4 py-3.5 align-middle text-right text-sm"><%= link_to "Edit", edit_grant_path(grant), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
 </tr>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -49,8 +49,8 @@
   <div class="bg-white rounded-lg shadow p-5">
     <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <div>
-        <dt class="text-sm font-medium text-gray-500">Application deadline</dt>
-        <dd class="mt-1 text-sm text-gray-900"><%= grant.application_deadline %></dd>
+        <dt class="text-sm font-medium text-gray-500">Funds allocation deadline</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= grant.funds_allocation_deadline %></dd>
       </div>
       <div>
         <dt class="text-sm font-medium text-gray-500">Funds received on</dt>

--- a/db/migrate/20260730012644_rename_grant_application_deadline_to_funds_allocation_deadline.rb
+++ b/db/migrate/20260730012644_rename_grant_application_deadline_to_funds_allocation_deadline.rb
@@ -1,0 +1,9 @@
+class RenameGrantApplicationDeadlineToFundsAllocationDeadline < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :grants, :application_deadline, :funds_allocation_deadline
+  end
+
+  def down
+    rename_column :grants, :funds_allocation_deadline, :application_deadline
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_020406) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_012644) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -682,13 +682,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_020406) do
 
   create_table "grants", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "amount_cents", default: 0, null: false
-    t.date "application_deadline"
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.text "description"
     t.bigint "donor_id", null: false
     t.string "donor_type", null: false
     t.text "eligibility_criteria"
+    t.date "funds_allocation_deadline"
     t.date "funds_received_on"
     t.string "name", null: false
     t.text "tasks"

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -86,7 +86,7 @@ grants = grant_plans.filter_map do |(name, donor_type, donor_name, amount_cents,
   grant = Grant.find_or_create_by!(name: name) do |g|
     g.donor = donor
     g.amount_cents = amount_cents
-    g.application_deadline = Date.current + 30
+    g.funds_allocation_deadline = Date.current + 30
     g.funds_received_on = Date.current - 30
     g.eligibility_criteria = eligibility
     g.tasks = tasks
@@ -477,7 +477,7 @@ if anchor_grant && recipient_orgs.any?
   sibling = Grant.find_or_create_by!(name: "#{anchor_grant.name} (2026)") do |g|
     g.donor = anchor_grant.donor
     g.amount_cents = 600_000
-    g.application_deadline = Date.current + 60
+    g.funds_allocation_deadline = Date.current + 60
     g.funds_received_on = Date.current - 10
     g.eligibility_criteria = anchor_grant.eligibility_criteria
     g.tasks = anchor_grant.tasks

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { "Healing Arts Scholarship Fund" }
     amount_cents { 500_000 }
     association :donor, factory: :organization
-    application_deadline { Date.current + 30 }
+    funds_allocation_deadline { Date.current + 30 }
     funds_received_on { Date.current - 7 }
     eligibility_criteria { "Must be a current facilitator\nMust serve a partner organization" }
     tasks { "Submit application form\nComplete intake interview" }

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "/grants", type: :request do
       name: "Healing Arts Grant",
       amount_dollars: "5000",
       donor_sgid: organization.to_signed_global_id.to_s,
-      application_deadline: "2026-12-31",
+      funds_allocation_deadline: "2026-12-31",
       eligibility_criteria: "Must be a facilitator",
       tasks: "Submit application"
     }


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 data-transforming column rename (migration) affecting model, controller, decorator, views, seeds

### What is the goal of this PR and why is this important?
- The grant date tracks when awarded funds must be **allocated/spent by**, not an application cutoff — there's no fixed date for grantees to apply.
- Renames column `grants.application_deadline` → `funds_allocation_deadline` and the UI label to match what's tracked.

### How did you approach the change?
- Reversible `rename_column` migration (explicit `up`/`down`).
- Updated model scope, controller param, decorator method, grant views, factory, request spec, and dev seeds.

### Anything else to add?
- Data-transforming rename — needs to run on deployed environments.
- Grant specs pass (66 examples, 0 failures).