### PR TITLE
Gate videoconference details solely on the callout drip date

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -88,8 +88,10 @@ class EventDecorator < ApplicationDecorator
   # `show_videoconference_details` controls whether the join link/ID/passcode are
   # carried into the calendar entry. Callers with a registration pass that
   # registrant's gate (date + paid/intends); the default falls back to the
-  # event-level date gate for registration-less contexts.
-  def calendar_links(show_videoconference_details: object.videoconference_details_visible?)
+  # event-level date gate for registration-less contexts. `re_add_url` is the
+  # viewer's personalized ticket URL, appended to the gated re-download note so
+  # the saved entry links back to where they can regenerate it.
+  def calendar_links(show_videoconference_details: object.videoconference_details_visible?, re_add_url: nil)
     start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
     end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
     title_encoded = ERB::Util.url_encode(object.title)
@@ -131,7 +133,7 @@ class EventDecorator < ApplicationDecorator
       if show_videoconference_details
         videoconference_calendar_details
       elsif object.videoconference_url.present?
-        videoconference_calendar_pending_note
+        videoconference_calendar_pending_note(re_add_url: re_add_url)
       end
     description = [ vc_details, base_description ].compact_blank.join("\n\n")
 
@@ -189,20 +191,22 @@ class EventDecorator < ApplicationDecorator
   end
 
   # The note shown while the viewer's videoconference details are still gated: the
-  # entry they save now won't carry the join link, so tell them to re-download the
-  # event from the Portal once it unlocks. Plain-text form for the calendar entry
-  # (#calendar_links); a calendar description can't hold a link. The hover uses
+  # entry they save now won't carry the join link, so tell them to re-download it
+  # from the Portal once it unlocks. Plain-text form for the calendar entry
+  # (#calendar_links); a calendar description can't hold a link, so `re_add_url`
+  # (the viewer's ticket URL) is appended as plain text when given. The hover uses
   # the _html form below. Both share the reveal-date phrasing so they stay in sync.
-  def videoconference_calendar_pending_note
-    "The videoconference join link isn't in this calendar entry yet. " \
-      "Re-download the event from the Portal #{videoconference_pending_reveal_phrase} to include it."
+  def videoconference_calendar_pending_note(re_add_url: nil)
+    note = "The videoconference join link isn't in this calendar entry yet. " \
+      "Re-download it from the Portal #{videoconference_pending_reveal_phrase} to include it."
+    re_add_url.present? ? "#{note}\n#{re_add_url}" : note
   end
 
   # HTML form of #videoconference_calendar_pending_note for the on-page hover, with
-  # the "Re-download the event from the Portal" phrase linked to `portal_url` — the
-  # page whose add-to-calendar buttons regenerate the entry once the link unlocks.
+  # the "Re-download it from the Portal" phrase linked to `portal_url` — the page
+  # whose add-to-calendar buttons regenerate the entry once the link unlocks.
   def videoconference_calendar_pending_note_html(portal_url)
-    link = h.link_to("Re-download the event from the Portal", portal_url, class: "underline font-medium")
+    link = h.link_to("Re-download it from the Portal", portal_url, class: "underline font-medium")
     h.safe_join([
       "The videoconference join link isn't in this calendar entry yet. ",
       link,

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -124,8 +124,15 @@ class EventDecorator < ApplicationDecorator
 
     # Carry the join link, meeting ID/code, and passcode into the calendar entry
     # so registrants have everything they need to connect straight from the event
-    # — but only once the details may be shared (date + paid/intends).
-    vc_details = videoconference_calendar_details if show_videoconference_details
+    # — but only once the details may be shared (date + paid/intends). While they
+    # are still gated, leave a note in the entry so a viewer who saves it now
+    # knows to re-add the event once the link unlocks.
+    vc_details =
+      if show_videoconference_details
+        videoconference_calendar_details
+      elsif object.videoconference_url.present?
+        videoconference_calendar_pending_note
+      end
     description = [ vc_details, base_description ].compact_blank.join("\n\n")
 
     desc_encoded     = ERB::Util.url_encode(description)
@@ -179,6 +186,16 @@ class EventDecorator < ApplicationDecorator
       ],
       " "
     )
+  end
+
+  # The note shown while the viewer's videoconference details are still gated: the
+  # calendar entry (or on-page hover) they save now won't carry the join link, so
+  # tell them when to re-add the event to get it. Shared by #calendar_links and
+  # the videoconference_calendar_notice partial so both stay in sync.
+  def videoconference_calendar_pending_note
+    reveal = object.videoconference_details_available_from
+    when_text = reveal.present? ? "on #{reveal.to_date.strftime("%B %-d, %Y")}" : "once the link is available"
+    "The videoconference join link isn't in this calendar entry yet. Add the event again #{when_text} to include it."
   end
 
   # True when the event spans more than one calendar day in the viewer's time

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -189,13 +189,25 @@ class EventDecorator < ApplicationDecorator
   end
 
   # The note shown while the viewer's videoconference details are still gated: the
-  # calendar entry (or on-page hover) they save now won't carry the join link, so
-  # tell them when to re-add the event to get it. Shared by #calendar_links and
-  # the videoconference_calendar_notice partial so both stay in sync.
+  # entry they save now won't carry the join link, so tell them to re-download the
+  # event from the Portal once it unlocks. Plain-text form for the calendar entry
+  # (#calendar_links); a calendar description can't hold a link. The hover uses
+  # the _html form below. Both share the reveal-date phrasing so they stay in sync.
   def videoconference_calendar_pending_note
-    reveal = object.videoconference_details_available_from
-    when_text = reveal.present? ? "on #{reveal.to_date.strftime("%B %-d, %Y")}" : "once the link is available"
-    "The videoconference join link isn't in this calendar entry yet. Add the event again #{when_text} to include it."
+    "The videoconference join link isn't in this calendar entry yet. " \
+      "Re-download the event from the Portal #{videoconference_pending_reveal_phrase} to include it."
+  end
+
+  # HTML form of #videoconference_calendar_pending_note for the on-page hover, with
+  # the "Re-download the event from the Portal" phrase linked to `portal_url` — the
+  # page whose add-to-calendar buttons regenerate the entry once the link unlocks.
+  def videoconference_calendar_pending_note_html(portal_url)
+    link = h.link_to("Re-download the event from the Portal", portal_url, class: "underline font-medium")
+    h.safe_join([
+      "The videoconference join link isn't in this calendar entry yet. ",
+      link,
+      " #{videoconference_pending_reveal_phrase} to include it."
+    ])
   end
 
   # True when the event spans more than one calendar day in the viewer's time
@@ -365,6 +377,13 @@ class EventDecorator < ApplicationDecorator
   end
 
   private
+
+  # "on <date>" when the details unlock on a known drip date, else a generic
+  # phrase. Shared by the plain-text and HTML pending-note forms.
+  def videoconference_pending_reveal_phrase
+    reveal = object.videoconference_details_available_from
+    reveal.present? ? "on #{reveal.to_date.strftime("%B %-d, %Y")}" : "once the link is available"
+  end
 
   # The videoconference connection block (join link, meeting ID/code, passcode)
   # as plain text for embedding in calendar entries. Nil when there's no link.

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -90,8 +90,10 @@ class EventDecorator < ApplicationDecorator
   # registrant's gate (date + paid/intends); the default falls back to the
   # event-level date gate for registration-less contexts. `re_add_url` is the
   # viewer's personalized ticket URL, appended to the gated re-download note so
-  # the saved entry links back to where they can regenerate it.
-  def calendar_links(show_videoconference_details: object.videoconference_details_visible?, re_add_url: nil)
+  # the saved entry links back to where they can regenerate it. `payment_pending`
+  # (caller-supplied, per registrant) lets the gated note name the payment
+  # condition alongside — or instead of — the drip date.
+  def calendar_links(show_videoconference_details: object.videoconference_details_visible?, re_add_url: nil, payment_pending: false)
     start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
     end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
     title_encoded = ERB::Util.url_encode(object.title)
@@ -133,7 +135,7 @@ class EventDecorator < ApplicationDecorator
       if show_videoconference_details
         videoconference_calendar_details
       elsif object.videoconference_url.present?
-        videoconference_calendar_pending_note(re_add_url: re_add_url)
+        videoconference_calendar_pending_note(re_add_url: re_add_url, payment_pending: payment_pending)
       end
     description = [ vc_details, base_description ].compact_blank.join("\n\n")
 
@@ -196,21 +198,21 @@ class EventDecorator < ApplicationDecorator
   # (#calendar_links); a calendar description can't hold a link, so `re_add_url`
   # (the viewer's ticket URL) is appended as plain text when given. The hover uses
   # the _html form below. Both share the reveal-date phrasing so they stay in sync.
-  def videoconference_calendar_pending_note(re_add_url: nil)
+  def videoconference_calendar_pending_note(re_add_url: nil, payment_pending: false)
     note = "The videoconference join link isn't in this calendar entry yet. " \
-      "Re-download it from the Portal #{videoconference_pending_reveal_phrase} to include it."
+      "Re-download it from the Portal #{videoconference_pending_reveal_phrase(payment_pending: payment_pending)} to include it."
     re_add_url.present? ? "#{note}\n#{re_add_url}" : note
   end
 
   # HTML form of #videoconference_calendar_pending_note for the on-page hover, with
   # the "Re-download it from the Portal" phrase linked to `portal_url` — the page
   # whose add-to-calendar buttons regenerate the entry once the link unlocks.
-  def videoconference_calendar_pending_note_html(portal_url)
+  def videoconference_calendar_pending_note_html(portal_url, payment_pending: false)
     link = h.link_to("Re-download it from the Portal", portal_url, class: "underline font-medium")
     h.safe_join([
       "The videoconference join link isn't in this calendar entry yet. ",
       link,
-      " #{videoconference_pending_reveal_phrase} to include it."
+      " #{videoconference_pending_reveal_phrase(payment_pending: payment_pending)} to include it."
     ])
   end
 
@@ -382,11 +384,24 @@ class EventDecorator < ApplicationDecorator
 
   private
 
-  # "on <date>" when the details unlock on a known drip date, else a generic
-  # phrase. Shared by the plain-text and HTML pending-note forms.
-  def videoconference_pending_reveal_phrase
+  # Describes what's still gating the details, naming only the conditions that are
+  # actually pending: the payment condition (caller-supplied, since it's per
+  # registrant) and/or the drip date — and the date only while it's genuinely in
+  # the future, never a date that has already passed. Shared by the plain-text and
+  # HTML pending-note forms.
+  def videoconference_pending_reveal_phrase(payment_pending: false)
     reveal = object.videoconference_details_available_from
-    reveal.present? ? "on #{reveal.to_date.strftime("%B %-d, %Y")}" : "once the link is available"
+    date_clause = "on #{reveal.to_date.strftime("%B %-d, %Y")}" if reveal.present? && Time.current < reveal
+
+    if payment_pending && date_clause
+      "once your payment is on file and the link unlocks #{date_clause}"
+    elsif payment_pending
+      "once your payment is on file"
+    elsif date_clause
+      date_clause
+    else
+      "once the link is available"
+    end
   end
 
   # The videoconference connection block (join link, meeting ID/code, passcode)

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -88,11 +88,8 @@ class EventDecorator < ApplicationDecorator
   # `show_videoconference_details` controls whether the join link/ID/passcode are
   # carried into the calendar entry. Callers with a registration pass that
   # registrant's gate (date + paid/intends); the default falls back to the
-  # event-level date gate for registration-less contexts. `re_add_url` is the
-  # viewer's personalized ticket URL, appended to the gated re-download note so
-  # the saved entry links back to where they can regenerate it. `payment_pending`
-  # (caller-supplied, per registrant) lets the gated note name the payment
-  # condition alongside — or instead of — the drip date.
+  # event-level date gate for registration-less contexts. `re_add_url` and
+  # `payment_pending` (per registrant) feed the gated re-download note (see below).
   def calendar_links(show_videoconference_details: object.videoconference_details_visible?, re_add_url: nil, payment_pending: false)
     start_time   = object.start_date.utc.strftime("%Y%m%dT%H%M%SZ")
     end_time     = object.end_date.utc.strftime("%Y%m%dT%H%M%SZ")
@@ -128,9 +125,7 @@ class EventDecorator < ApplicationDecorator
 
     # Carry the join link, meeting ID/code, and passcode into the calendar entry
     # so registrants have everything they need to connect straight from the event
-    # — but only once the details may be shared (date + paid/intends). While they
-    # are still gated, leave a note in the entry so a viewer who saves it now
-    # knows to re-add the event once the link unlocks.
+    # — but only once the details may be shared (date + paid/intends).
     vc_details =
       if show_videoconference_details
         videoconference_calendar_details
@@ -192,21 +187,16 @@ class EventDecorator < ApplicationDecorator
     )
   end
 
-  # The note shown while the viewer's videoconference details are still gated: the
-  # entry they save now won't carry the join link, so tell them to re-download it
-  # from the Portal once it unlocks. Plain-text form for the calendar entry
-  # (#calendar_links); a calendar description can't hold a link, so `re_add_url`
-  # (the viewer's ticket URL) is appended as plain text when given. The hover uses
-  # the _html form below. Both share the reveal-date phrasing so they stay in sync.
+  # The note left in a gated calendar entry, telling the viewer to re-download from
+  # the Portal once the link unlocks. A calendar description can't hold a link, so
+  # `re_add_url` is appended as plain text; the _html form links it for the hover.
   def videoconference_calendar_pending_note(re_add_url: nil, payment_pending: false)
     note = "The videoconference join link isn't in this calendar entry yet. " \
       "Re-download it from the Portal #{videoconference_pending_reveal_phrase(payment_pending: payment_pending)} to include it."
     re_add_url.present? ? "#{note}\n#{re_add_url}" : note
   end
 
-  # HTML form of #videoconference_calendar_pending_note for the on-page hover, with
-  # the "Re-download it from the Portal" phrase linked to `portal_url` — the page
-  # whose add-to-calendar buttons regenerate the entry once the link unlocks.
+  # HTML form of the note for the hover, linking the re-download phrase to `portal_url`.
   def videoconference_calendar_pending_note_html(portal_url, payment_pending: false)
     link = h.link_to("Re-download it from the Portal", portal_url, class: "underline font-medium")
     h.safe_join([
@@ -384,11 +374,8 @@ class EventDecorator < ApplicationDecorator
 
   private
 
-  # Describes what's still gating the details, naming only the conditions that are
-  # actually pending: the payment condition (caller-supplied, since it's per
-  # registrant) and/or the drip date — and the date only while it's genuinely in
-  # the future, never a date that has already passed. Shared by the plain-text and
-  # HTML pending-note forms.
+  # The pending-condition clause: names payment and/or the drip date, the date only
+  # while it's still in the future (never one that has already passed).
   def videoconference_pending_reveal_phrase(payment_pending: false)
     reveal = object.videoconference_details_available_from
     date_clause = "on #{reveal.to_date.strftime("%B %-d, %Y")}" if reveal.present? && Time.current < reveal

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -149,11 +149,8 @@ class Event < ApplicationRecord
     now >= start_date - VIDEOCONFERENCE_JOIN_BUFFER && now <= end_date + VIDEOCONFERENCE_JOIN_BUFFER
   end
 
-  # When the videoconference connection details unlock: the drip date on the
-  # materialized videoconference callout (admin-editable, seeded to a week before
-  # the start). Only gates once that callout exists — with no callout, or a
-  # callout whose drip date was cleared, there's nothing to wait on and the
-  # details are available immediately (see below).
+  # The drip date on the materialized videoconference callout — nil when there's no
+  # callout or its date was cleared, in which case the details unlock immediately.
   def videoconference_details_available_from
     return @videoconference_details_available_from if defined?(@videoconference_details_available_from)
     @videoconference_details_available_from =

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,12 +7,6 @@ class Event < ApplicationRecord
   # link is available to paid registrants.
   VIDEOCONFERENCE_JOIN_BUFFER = 30.minutes
 
-  # How far ahead of the start the videoconference connection details (join link,
-  # meeting ID, passcode) may be shared. Kept hidden until then so the link isn't
-  # exposed — on the ticket, the videoconference page, or in calendar entries —
-  # more than a week in advance.
-  VIDEOCONFERENCE_DETAILS_LEAD = 7.days
-
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
@@ -155,20 +149,15 @@ class Event < ApplicationRecord
     now >= start_date - VIDEOCONFERENCE_JOIN_BUFFER && now <= end_date + VIDEOCONFERENCE_JOIN_BUFFER
   end
 
-  # When the videoconference connection details unlock. Driven by the drip date on
-  # the materialized videoconference callout (admin-editable), falling back to
-  # VIDEOCONFERENCE_DETAILS_LEAD before the start for events that haven't
-  # materialized the built-in callouts. nil when there's no date to gate on — a
-  # materialized callout whose drip date was cleared, or an event with no start
-  # date — in which case the details are available immediately (see below).
+  # When the videoconference connection details unlock: the drip date on the
+  # materialized videoconference callout (admin-editable, seeded to a week before
+  # the start). Only gates once that callout exists — with no callout, or a
+  # callout whose drip date was cleared, there's nothing to wait on and the
+  # details are available immediately (see below).
   def videoconference_details_available_from
     return @videoconference_details_available_from if defined?(@videoconference_details_available_from)
     @videoconference_details_available_from =
-      if (callout = registration_ticket_callouts.builtin.find_by(builtin_key: "videoconference"))
-        callout.display_from
-      elsif start_date
-        start_date - VIDEOCONFERENCE_DETAILS_LEAD
-      end
+      registration_ticket_callouts.builtin.find_by(builtin_key: "videoconference")&.display_from
   end
 
   # Whether the videoconference connection details may be revealed yet. A drip

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -261,8 +261,8 @@ class BuiltinCallouts
         icon_class: "fa-solid fa-video",
         color_class: "blue",
         hidden: ->(_event) { true },
-        # Drips onto the ticket a week before the event starts, replacing the old
-        # hard-coded "one week prior" rule with a stored, editable date.
+        # Drips the connection details onto the ticket a week before the event
+        # starts. Stored and admin-editable per event.
         display_from: ->(event) { event.start_date - 7.days if event.start_date }
       },
       {

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -261,8 +261,7 @@ class BuiltinCallouts
         icon_class: "fa-solid fa-video",
         color_class: "blue",
         hidden: ->(_event) { true },
-        # Drips the connection details onto the ticket a week before the event
-        # starts. Stored and admin-editable per event.
+        # Default drip date; admins can edit it per event afterward.
         display_from: ->(event) { event.start_date - 7.days if event.start_date }
       },
       {

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -206,7 +206,7 @@
             <%= render "events/videoconference_calendar_notice", event: event_registration.event, registration: event_registration %>
           </div>
 
-          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?, re_add_url: registration_ticket_url(event_registration.slug)) %></div>
+          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?, re_add_url: registration_videoconference_url(event_registration.slug), payment_pending: !event_registration.payment_access_granted?) %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -206,7 +206,7 @@
             <%= render "events/videoconference_calendar_notice", event: event_registration.event, registration: event_registration %>
           </div>
 
-          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?) %></div>
+          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?, re_add_url: registration_ticket_url(event_registration.slug)) %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -66,7 +66,8 @@
         </p>
         <%= render "events/videoconference_calendar_notice", event: event, registration: calendar_registration %>
       </div>
-      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?) %></div>
+      <% calendar_re_add_url = calendar_registration ? registration_ticket_url(calendar_registration.slug) : event_url(event) %>
+      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?, re_add_url: calendar_re_add_url) %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -66,8 +66,8 @@
         </p>
         <%= render "events/videoconference_calendar_notice", event: event, registration: calendar_registration %>
       </div>
-      <% calendar_re_add_url = calendar_registration ? registration_ticket_url(calendar_registration.slug) : event_url(event) %>
-      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?, re_add_url: calendar_re_add_url) %></div>
+      <% calendar_re_add_url = calendar_registration ? registration_videoconference_url(calendar_registration.slug) : event_url(event) %>
+      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?, re_add_url: calendar_re_add_url, payment_pending: calendar_registration ? !calendar_registration.payment_access_granted? : false) %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/_videoconference_calendar_notice.html.erb
+++ b/app/views/events/_videoconference_calendar_notice.html.erb
@@ -6,11 +6,12 @@
     event's own drip gate is used. %>
 <% visible = registration ? registration.videoconference_details_visible? : event.videoconference_details_visible? %>
 <% if event.videoconference_url.present? && !visible %>
-  <% decorated = event.respond_to?(:videoconference_calendar_pending_note) ? event : event.decorate %>
+  <% decorated = event.respond_to?(:videoconference_calendar_pending_note_html) ? event : event.decorate %>
+  <% portal_url = registration ? registration_ticket_path(registration.slug) : event_path(event) %>
   <span class="relative group cursor-help inline-flex">
     <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
-    <span class="hidden group-hover:block absolute z-50 left-1/2 -translate-x-1/2 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal normal-case tracking-normal font-normal text-left">
-      <%= decorated.videoconference_calendar_pending_note %>
+    <span class="hidden group-hover:block absolute z-50 left-1/2 -translate-x-1/2 bottom-full bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal normal-case tracking-normal font-normal text-left">
+      <%= decorated.videoconference_calendar_pending_note_html(portal_url) %>
     </span>
   </span>
 <% end %>

--- a/app/views/events/_videoconference_calendar_notice.html.erb
+++ b/app/views/events/_videoconference_calendar_notice.html.erb
@@ -7,11 +7,12 @@
 <% visible = registration ? registration.videoconference_details_visible? : event.videoconference_details_visible? %>
 <% if event.videoconference_url.present? && !visible %>
   <% decorated = event.respond_to?(:videoconference_calendar_pending_note_html) ? event : event.decorate %>
-  <% portal_url = registration ? registration_ticket_path(registration.slug) : event_path(event) %>
+  <% portal_url = registration ? registration_videoconference_path(registration.slug) : event_path(event) %>
+  <% payment_pending = registration ? !registration.payment_access_granted? : false %>
   <span class="relative group cursor-help inline-flex">
     <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
     <span class="hidden group-hover:block absolute z-50 left-1/2 -translate-x-1/2 bottom-full bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal normal-case tracking-normal font-normal text-left">
-      <%= decorated.videoconference_calendar_pending_note_html(portal_url) %>
+      <%= decorated.videoconference_calendar_pending_note_html(portal_url, payment_pending: payment_pending) %>
     </span>
   </span>
 <% end %>

--- a/app/views/events/_videoconference_calendar_notice.html.erb
+++ b/app/views/events/_videoconference_calendar_notice.html.erb
@@ -6,11 +6,11 @@
     event's own drip gate is used. %>
 <% visible = registration ? registration.videoconference_details_visible? : event.videoconference_details_visible? %>
 <% if event.videoconference_url.present? && !visible %>
-  <% reveal = event.videoconference_details_available_from %>
+  <% decorated = event.respond_to?(:videoconference_calendar_pending_note) ? event : event.decorate %>
   <span class="relative group cursor-help inline-flex">
     <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
     <span class="hidden group-hover:block absolute z-50 left-1/2 -translate-x-1/2 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal normal-case tracking-normal font-normal text-left">
-      The videoconference join link isn't in this calendar entry yet. Add the event again <%= reveal.present? ? "on #{reveal.to_date.strftime('%B %-d, %Y')}" : "once the link is available" %> to include it.
+      <%= decorated.videoconference_calendar_pending_note %>
     </span>
   </span>
 <% end %>

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -43,7 +43,7 @@
         <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Add to your calendar</p>
         <%= render "events/videoconference_calendar_notice", event: @event, registration: @event_registration %>
       </div>
-      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?, re_add_url: registration_ticket_url(@event_registration.slug)) %></div>
+      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?, re_add_url: registration_videoconference_url(@event_registration.slug), payment_pending: !@event_registration.payment_access_granted?) %></div>
     </div>
   </div>
 <% end %>

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -43,7 +43,7 @@
         <p class="text-xs font-medium uppercase tracking-wide text-gray-400">Add to your calendar</p>
         <%= render "events/videoconference_calendar_notice", event: @event, registration: @event_registration %>
       </div>
-      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?) %></div>
+      <div class="flex flex-wrap gap-1 items-center text-sm text-blue-600 font-medium"><%= @event.calendar_links(show_videoconference_details: @event_registration.videoconference_details_visible?, re_add_url: registration_ticket_url(@event_registration.slug)) %></div>
     </div>
   </div>
 <% end %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -316,11 +316,9 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
   hint_registration_cost: "due within 3 weeks of registration"
 )
 
-# Any event with a videoconference link should show its videoconference callout
-# card on the ticket — the card is the doorway to the videoconference page, which
-# gates the actual join details (payment + drip date) on its own. So publish it
-# and keep it un-gated (it must stay reachable before payment). force-set on
-# re-seed, mirroring the videoconference-settings refresh above.
+# Show the videoconference callout card on any event with a link: it's the doorway
+# to the videoconference page, which gates the join details itself, so it must stay
+# reachable (un-gated) before payment. force-set on re-seed.
 Event.where.not(videoconference_url: [ nil, "" ]).find_each do |vc_event|
   vc_event.registration_ticket_callouts
           .find_by(builtin_key: "videoconference")

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -316,6 +316,17 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
   hint_registration_cost: "due within 3 weeks of registration"
 )
 
+# Any event with a videoconference link should show its videoconference callout
+# card on the ticket — the card is the doorway to the videoconference page, which
+# gates the actual join details (payment + drip date) on its own. So publish it
+# and keep it un-gated (it must stay reachable before payment). force-set on
+# re-seed, mirroring the videoconference-settings refresh above.
+Event.where.not(videoconference_url: [ nil, "" ]).find_each do |vc_event|
+  vc_event.registration_ticket_callouts
+          .find_by(builtin_key: "videoconference")
+          &.update!(hidden: false, payment_access_gated: false)
+end
+
 # Seed the "Before you attend" details — the materials/art-supply info that used to
 # live in a long confirmation email and that registrants routinely missed. Shown on
 # its own ticket-linked page (and via the prominent amber call-out on the ticket).

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -316,13 +316,13 @@ Event.find_by(title: "AWBW Facilitator Training")&.update!(
   hint_registration_cost: "due within 3 weeks of registration"
 )
 
-# Show the videoconference callout card on any event with a link: it's the doorway
-# to the videoconference page, which gates the join details itself, so it must stay
-# reachable (un-gated) before payment. force-set on re-seed.
+# Un-gate a published videoconference callout on events that have a link, so its
+# card stays reachable before payment (it's the doorway to the videoconference
+# page, which gates the join details itself). Only when already published — don't
+# force-publish an opted-out callout. force-set on re-seed.
 Event.where.not(videoconference_url: [ nil, "" ]).find_each do |vc_event|
-  vc_event.registration_ticket_callouts
-          .find_by(builtin_key: "videoconference")
-          &.update!(hidden: false, payment_access_gated: false)
+  vc = vc_event.registration_ticket_callouts.find_by(builtin_key: "videoconference")
+  vc.update!(payment_access_gated: false) if vc&.published?
 end
 
 # Seed the "Before you attend" details — the materials/art-supply info that used to

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -261,7 +261,6 @@ RSpec.describe EventDecorator do
       doc = Nokogiri::HTML.fragment(decorated.calendar_links)
       hrefs = doc.css("a").map { |a| a["href"] }
 
-      # Every provider link still renders; none carry a join URL or meeting details.
       expect(hrefs.size).to eq(5)
       hrefs.each do |href|
         expect(href).not_to include("Join on")

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -270,6 +270,59 @@ RSpec.describe EventDecorator do
       end
     end
 
+    describe "the pending re-add note (join link present but gated)" do
+      it "embeds a dated note telling the viewer to re-add the event once the link unlocks" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 23.days.from_now)
+        event.reload
+        reveal = event.videoconference_details_available_from.to_date.strftime("%B %-d, %Y")
+
+        apple = Nokogiri::HTML.fragment(event.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
+        expect(apple["href"]).to include("Add the event again on #{reveal} to include it")
+        expect(apple["href"]).not_to include("88285411273")
+      end
+
+      it "uses a generic re-add note when there's no unlock date to name (payment gate)" do
+        event = create(:event,
+                        start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+
+        apple = Nokogiri::HTML.fragment(event.decorate.calendar_links(show_videoconference_details: false))
+                  .css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("Add the event again once the link is available to include it")
+      end
+
+      it "drops the note once the details are visible — the real join link takes its place" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 1.day.ago)
+
+        apple = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
+        expect(apple["href"]).not_to include("Add the event again")
+      end
+
+      it "adds no note when the event has no videoconference URL, even while gated" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: nil)
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 23.days.from_now)
+
+        hrefs = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").map { |a| a["href"] }
+        hrefs.each { |href| expect(href).not_to include("Add the event again") }
+      end
+    end
+
     # The reveal date is the admin-editable drip date (display_from) on the
     # built-in videoconference callout. These drive that gate directly.
     context "with a materialized videoconference callout (admin drip date gate)" do

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
 
         expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
-        expect(apple["href"]).to include("Add the event again on #{reveal} to include it")
+        expect(apple["href"]).to include("Re-download the event from the Portal on #{reveal} to include it")
         expect(apple["href"]).not_to include("88285411273")
       end
 
@@ -295,7 +295,7 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.decorate.calendar_links(show_videoconference_details: false))
                   .css("a").find { |a| a.text == "Apple" }
 
-        expect(apple["href"]).to include("Add the event again once the link is available to include it")
+        expect(apple["href"]).to include("Re-download the event from the Portal once the link is available to include it")
       end
 
       it "drops the note once the details are visible — the real join link takes its place" do
@@ -308,7 +308,7 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
 
         expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
-        expect(apple["href"]).not_to include("Add the event again")
+        expect(apple["href"]).not_to include("Re-download the event from the Portal")
       end
 
       it "adds no note when the event has no videoconference URL, even while gated" do
@@ -319,7 +319,24 @@ RSpec.describe EventDecorator do
                                               display_from: 23.days.from_now)
 
         hrefs = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").map { |a| a["href"] }
-        hrefs.each { |href| expect(href).not_to include("Add the event again") }
+        hrefs.each { |href| expect(href).not_to include("Re-download the event from the Portal") }
+      end
+
+      it "links the re-download phrase to the given Portal URL in the HTML note" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 23.days.from_now)
+        event.reload
+        reveal = event.videoconference_details_available_from.to_date.strftime("%B %-d, %Y")
+
+        doc = Nokogiri::HTML.fragment(event.decorate.videoconference_calendar_pending_note_html("/registration/abc/ticket"))
+        link = doc.at_css("a")
+
+        expect(link.text).to eq("Re-download the event from the Portal")
+        expect(link["href"]).to eq("/registration/abc/ticket")
+        expect(doc.text).to include("on #{reveal} to include it")
       end
     end
 

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -283,8 +283,23 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
 
         expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
-        expect(apple["href"]).to include("Re-download the event from the Portal on #{reveal} to include it")
+        expect(apple["href"]).to include("Re-download it from the Portal on #{reveal} to include it")
         expect(apple["href"]).not_to include("88285411273")
+      end
+
+      it "appends the viewer's personalized ticket URL to the gated calendar entry" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 23.days.from_now)
+
+        apple = Nokogiri::HTML.fragment(
+          event.reload.decorate.calendar_links(re_add_url: "https://portal.example/registration/abc/ticket")
+        ).css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("Re-download it from the Portal")
+        expect(apple["href"]).to include("https://portal.example/registration/abc/ticket")
       end
 
       it "uses a generic re-add note when there's no unlock date to name (payment gate)" do
@@ -295,7 +310,7 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.decorate.calendar_links(show_videoconference_details: false))
                   .css("a").find { |a| a.text == "Apple" }
 
-        expect(apple["href"]).to include("Re-download the event from the Portal once the link is available to include it")
+        expect(apple["href"]).to include("Re-download it from the Portal once the link is available to include it")
       end
 
       it "drops the note once the details are visible — the real join link takes its place" do
@@ -308,7 +323,7 @@ RSpec.describe EventDecorator do
         apple = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").find { |a| a.text == "Apple" }
 
         expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
-        expect(apple["href"]).not_to include("Re-download the event from the Portal")
+        expect(apple["href"]).not_to include("Re-download it from the Portal")
       end
 
       it "adds no note when the event has no videoconference URL, even while gated" do
@@ -319,7 +334,7 @@ RSpec.describe EventDecorator do
                                               display_from: 23.days.from_now)
 
         hrefs = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").map { |a| a["href"] }
-        hrefs.each { |href| expect(href).not_to include("Re-download the event from the Portal") }
+        hrefs.each { |href| expect(href).not_to include("Re-download it from the Portal") }
       end
 
       it "links the re-download phrase to the given Portal URL in the HTML note" do
@@ -334,7 +349,7 @@ RSpec.describe EventDecorator do
         doc = Nokogiri::HTML.fragment(event.decorate.videoconference_calendar_pending_note_html("/registration/abc/ticket"))
         link = doc.at_css("a")
 
-        expect(link.text).to eq("Re-download the event from the Portal")
+        expect(link.text).to eq("Re-download it from the Portal")
         expect(link["href"]).to eq("/registration/abc/ticket")
         expect(doc.text).to include("on #{reveal} to include it")
       end

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -313,7 +313,9 @@ RSpec.describe EventDecorator do
         expect(apple["href"]).to include("Re-download it from the Portal once the link is available to include it")
       end
 
-      it "names the payment condition — not a past drip date — when payment is the only blocker" do
+      it "names only payment — not a passed drip date — when both gates were set but the date has passed" do
+        # A drip date exists but is already in the past (date gate satisfied),
+        # leaving payment as the only remaining blocker.
         event = create(:event,
                         start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
                         videoconference_url: "https://awbw.zoom.us/j/88285411273")

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe EventDecorator do
         expect(apple["href"]).not_to include("88285411273")
       end
 
-      it "appends the viewer's personalized ticket URL to the gated calendar entry" do
+      it "appends the viewer's personalized re-download URL to the gated calendar entry" do
         event = create(:event,
                         start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
                         videoconference_url: "https://awbw.zoom.us/j/88285411273")
@@ -302,7 +302,7 @@ RSpec.describe EventDecorator do
         expect(apple["href"]).to include("https://portal.example/registration/abc/ticket")
       end
 
-      it "uses a generic re-add note when there's no unlock date to name (payment gate)" do
+      it "uses a generic note when neither payment nor a drip date can be named" do
         event = create(:event,
                         start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
                         videoconference_url: "https://awbw.zoom.us/j/88285411273")
@@ -311,6 +311,40 @@ RSpec.describe EventDecorator do
                   .css("a").find { |a| a.text == "Apple" }
 
         expect(apple["href"]).to include("Re-download it from the Portal once the link is available to include it")
+      end
+
+      it "names the payment condition — not a past drip date — when payment is the only blocker" do
+        event = create(:event,
+                        start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 1.day.ago)
+        event.reload
+        past_date = event.videoconference_details_available_from.to_date.strftime("%B %-d, %Y")
+
+        apple = Nokogiri::HTML.fragment(
+          event.decorate.calendar_links(show_videoconference_details: false, payment_pending: true)
+        ).css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("Re-download it from the Portal once your payment is on file to include it")
+        expect(apple["href"]).not_to include(past_date)
+        expect(apple["href"]).not_to include("unlocks on")
+      end
+
+      it "names both conditions when payment and the drip date are pending" do
+        event = create(:event,
+                        start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273")
+        create(:registration_ticket_callout, event: event, builtin_key: "videoconference",
+                                              display_from: 23.days.from_now)
+        event.reload
+        reveal = event.videoconference_details_available_from.to_date.strftime("%B %-d, %Y")
+
+        apple = Nokogiri::HTML.fragment(
+          event.decorate.calendar_links(show_videoconference_details: false, payment_pending: true)
+        ).css("a").find { |a| a.text == "Apple" }
+
+        expect(apple["href"]).to include("once your payment is on file and the link unlocks on #{reveal} to include it")
       end
 
       it "drops the note once the details are visible — the real join link takes its place" do

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -216,14 +216,16 @@ RSpec.describe EventDecorator do
       expect(apple["href"]).to include("DESCRIPTION:Bring a friend!")
     end
 
-    it "embeds the join link, meeting ID, and passcode within a week of the event" do
+    it "embeds the join link, meeting ID, and passcode once the details are visible" do
       event = create(:event,
                       start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours,
                       videoconference_url: "https://awbw.zoom.us/j/88285411273",
                       videoconference_passcode: "secret123")
-      decorated = event.decorate
+      create(:registration_ticket_callout, event: event,
+                                            builtin_key: "videoconference",
+                                            display_from: 1.day.ago)
 
-      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      doc = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links)
       apple = doc.css("a").find { |a| a.text == "Apple" }
 
       expect(apple["href"]).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
@@ -231,19 +233,95 @@ RSpec.describe EventDecorator do
       expect(apple["href"]).to include("Passcode: secret123")
     end
 
-    it "omits the join link, meeting ID, and passcode more than a week out" do
+    it "omits the join link from every calendar link when details are gated for the registrant (payment gate)" do
+      # Within the date window (details would otherwise be visible), but the
+      # caller passes false — the per-registration payment gate hasn't opened.
       event = create(:event,
-                      start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours,
+                      start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
                       videoconference_url: "https://awbw.zoom.us/j/88285411273",
                       videoconference_passcode: "secret123")
       decorated = event.decorate
 
-      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
-      apple = doc.css("a").find { |a| a.text == "Apple" }
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links(show_videoconference_details: false))
+      hrefs = doc.css("a").map { |a| a["href"] }
 
-      expect(apple["href"]).not_to include("88285411273")
-      expect(apple["href"]).not_to include("Meeting ID")
-      expect(apple["href"]).not_to include("secret123")
+      hrefs.each do |href|
+        expect(href).not_to include("88285411273")
+        expect(href).not_to include("secret123")
+        expect(href).not_to include("awbw.zoom.us")
+      end
+    end
+
+    it "does not leak a join link in any calendar link when the event has no videoconference URL" do
+      event = create(:event,
+                      start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
+                      videoconference_url: nil)
+      decorated = event.decorate
+
+      doc = Nokogiri::HTML.fragment(decorated.calendar_links)
+      hrefs = doc.css("a").map { |a| a["href"] }
+
+      # Every provider link still renders; none carry a join URL or meeting details.
+      expect(hrefs.size).to eq(5)
+      hrefs.each do |href|
+        expect(href).not_to include("Join on")
+        expect(href).not_to include("Meeting ID")
+        expect(href).not_to include("zoom.us")
+      end
+    end
+
+    # The reveal date is the admin-editable drip date (display_from) on the
+    # built-in videoconference callout. These drive that gate directly.
+    context "with a materialized videoconference callout (admin drip date gate)" do
+      def zoom_details_visible_in_all_links?(decorated)
+        hrefs = Nokogiri::HTML.fragment(decorated.calendar_links).css("a").map { |a| a["href"] }
+        hrefs.all? { |href| href.include?("88285411273") }
+      end
+
+      it "embeds the join link in every calendar link once the drip date has passed, even months out" do
+        event = create(:event,
+                        start_date: 90.days.from_now, end_date: 90.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                        videoconference_passcode: "secret123")
+        create(:registration_ticket_callout, event: event,
+                                              builtin_key: "videoconference",
+                                              display_from: 1.day.ago)
+
+        expect(zoom_details_visible_in_all_links?(event.reload.decorate)).to be(true)
+      end
+
+      it "omits the join link from every calendar link while the drip date is still in the future, even days out" do
+        # Close to the start (3 days out) but the drip date hasn't arrived, so
+        # the details must stay withheld regardless of proximity.
+        event = create(:event,
+                        start_date: 3.days.from_now, end_date: 3.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                        videoconference_passcode: "secret123")
+        create(:registration_ticket_callout, event: event,
+                                              builtin_key: "videoconference",
+                                              display_from: 1.day.from_now)
+
+        hrefs = Nokogiri::HTML.fragment(event.reload.decorate.calendar_links).css("a").map { |a| a["href"] }
+        # Guard against a change that only wires the gate into some providers:
+        # the join link and passcode must be absent from all of them.
+        hrefs.each do |href|
+          expect(href).not_to include("88285411273")
+          expect(href).not_to include("secret123")
+          expect(href).not_to include("awbw.zoom.us")
+        end
+      end
+
+      it "embeds the join link immediately when the drip date is blank (no gate), even months out" do
+        event = create(:event,
+                        start_date: 90.days.from_now, end_date: 90.days.from_now + 2.hours,
+                        videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                        videoconference_passcode: "secret123")
+        create(:registration_ticket_callout, event: event,
+                                              builtin_key: "videoconference",
+                                              display_from: nil)
+
+        expect(zoom_details_visible_in_all_links?(event.reload.decorate)).to be(true)
+      end
     end
   end
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -638,25 +638,27 @@ RSpec.describe EventRegistration, type: :model do
   describe "#videoconference_details_visible?" do
     let(:user) { create(:user, :with_person) }
 
-    it "is true within a week of the start for a registrant with payment access" do
+    it "is true for a paid registrant when the event details are ungated" do
       event = create(:event, cost_cents: 1099, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
       reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
       expect(reg.videoconference_details_visible?).to be true
     end
 
-    it "is false more than a week before the start" do
+    it "is false while the event's videoconference callout drip date is still in the future" do
       event = create(:event, cost_cents: 1099, start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, builtin_key: "videoconference",
+        display_from: 2.days.from_now)
       reg = create(:event_registration, event: event, registrant: user.person, intends_to_pay: true)
       expect(reg.videoconference_details_visible?).to be false
     end
 
-    it "is false within a week when the registrant lacks payment access" do
+    it "is false when the registrant lacks payment access, even with the event details ungated" do
       event = create(:event, cost_cents: 1099, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
       reg = create(:event_registration, event: event, registrant: user.person)
       expect(reg.videoconference_details_visible?).to be false
     end
 
-    it "is true within a week for a free event regardless of payment" do
+    it "is true for a free event regardless of payment" do
       event = create(:event, cost_cents: 0, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
       reg = create(:event_registration, event: event, registrant: user.person)
       expect(reg.videoconference_details_visible?).to be true

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -89,34 +89,25 @@ RSpec.describe Event, type: :model do
   end
 
   describe "#videoconference_details_visible?" do
-    it "returns true when there is no drip date to wait on (no start_date)" do
-      event = build(:event, start_date: nil)
+    it "is visible when no videoconference callout has been materialized (nothing to gate on)" do
+      event = create(:event, start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
       expect(event.videoconference_details_visible?).to be true
     end
 
-    it "returns false more than a week before the start" do
-      event = build(:event, start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
-      expect(event.videoconference_details_visible?).to be false
-    end
-
-    it "returns true within a week of the start" do
-      event = build(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
-      expect(event.videoconference_details_visible?).to be true
-    end
-
-    it "returns true once the event has started" do
-      event = build(:event, start_date: 1.hour.ago, end_date: 1.hour.from_now)
-      expect(event.videoconference_details_visible?).to be true
-    end
-
-    it "defers to the videoconference callout's drip date over the week-before default" do
+    it "is gated while the materialized callout's drip date is still in the future" do
       event = create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
       create(:registration_ticket_callout, event:, builtin_key: "videoconference",
         display_from: 2.days.from_now)
 
-      # Within the week-before default (which would be true), but before the
-      # callout's later drip date.
       expect(event.videoconference_details_visible?).to be false
+    end
+
+    it "is visible once the materialized callout's drip date has passed" do
+      event = create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, builtin_key: "videoconference",
+        display_from: 1.day.ago)
+
+      expect(event.videoconference_details_visible?).to be true
     end
 
     it "is visible immediately when the callout's drip date has been cleared" do

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(reveal_date).to be_present
       # "isn't" is HTML-escaped on the page (isn&#39;t), so match the apostrophe-free part.
       expect(response.body).to include("in this calendar entry yet")
-      expect(response.body).to include("Re-download the event from the Portal")
+      expect(response.body).to include("Re-download it from the Portal")
       expect(response.body).to include("on #{reveal_date}")
     end
   end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(reveal_date).to be_present
       # "isn't" is HTML-escaped on the page (isn&#39;t), so match the apostrophe-free part.
       expect(response.body).to include("in this calendar entry yet")
-      expect(response.body).to include("Add the event again on #{reveal_date}")
+      expect(response.body).to include("Re-download the event from the Portal")
+      expect(response.body).to include("on #{reveal_date}")
     end
   end
 

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -141,7 +141,8 @@ RSpec.describe "Events::Callouts", type: :request do
       # from the body to stay independent of the request's time zone).
       reveal_date = response.body[/Available from ([A-Z][a-z]+ \d{1,2}, \d{4})/, 1]
       expect(reveal_date).to be_present
-      expect(response.body).to include("isn't in this calendar entry yet")
+      # "isn't" is HTML-escaped on the page (isn&#39;t), so match the apostrophe-free part.
+      expect(response.body).to include("in this calendar entry yet")
       expect(response.body).to include("Add the event again on #{reveal_date}")
     end
   end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe "Events::Callouts", type: :request do
     end
 
     it "lists both unlock conditions while the details aren't visible yet" do
-      event.update!(start_date: 30.days.from_now, end_date: 30.days.from_now + 2.hours)
+      create(:registration_ticket_callout, event:, builtin_key: "videoconference",
+        display_from: 23.days.from_now)
 
       get registration_videoconference_path(registration.slug)
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -592,6 +592,10 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response).to have_http_status(:success)
       expect(response.body).to include("https://awbw.zoom.us/j/88285411273")
       expect(response.body).to include("Add to your calendar")
+      # The page passes the visible gate into #calendar_links, so the join link
+      # is embedded in the calendar entry (the "Join on <domain>: <url>" form is
+      # unique to the calendar details).
+      expect(response.body).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
     end
 
     it "shows the meeting ID parsed from the URL and the passcode" do
@@ -617,6 +621,37 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).not_to include("88285411273")
       expect(response.body).not_to include("secret123")
       expect(response.body).to include("payment is on file")
+    end
+  end
+
+  # The ticket page passes the registrant's own gate into #calendar_links, so the
+  # join link only reaches the add-to-calendar entry once the details are visible.
+  describe "GET /registration/:slug add-to-calendar videoconference gating" do
+    let(:event) do
+      create(:event, start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours,
+                     videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                     videoconference_label: "Zoom", videoconference_passcode: "secret123")
+    end
+    let!(:videoconference_callout) do
+      create(:registration_ticket_callout, event:, builtin_key: "videoconference", display_from: 1.day.ago)
+    end
+    let!(:registration) { create(:event_registration, event:, registrant: user.person, intends_to_pay: true) }
+
+    it "embeds the join link in the add-to-calendar entry once the details are visible" do
+      get registration_ticket_path(registration.slug)
+      expect(response.body).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
+    end
+
+    it "keeps the join link out of the add-to-calendar entry while the drip date is pending" do
+      videoconference_callout.update!(display_from: 1.day.from_now)
+      get registration_ticket_path(registration.slug)
+      expect(response.body).not_to include("88285411273")
+    end
+
+    it "keeps the join link out of the add-to-calendar entry until the registrant has payment access" do
+      registration.update!(intends_to_pay: false)
+      get registration_ticket_path(registration.slug)
+      expect(response.body).not_to include("88285411273")
     end
   end
 

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -613,6 +613,11 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).not_to include("secret123")
       expect(response.body).to include("unlocks once both of these are met")
       expect(response.body).to include("Available from")
+
+      # The downloadable calendar entry itself carries the re-add note (Nokogiri
+      # decodes the href attribute, so match the note text directly).
+      apple = Nokogiri::HTML.fragment(response.body).css("a").find { |a| a.text == "Apple" }
+      expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
     end
 
     it "withholds the link and credentials until the registrant has payment access" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -615,12 +615,12 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("Available from")
 
       # The downloadable calendar entry itself carries the re-download note as
-      # plain text, with the registrant's own ticket URL appended (Nokogiri
-      # decodes the href attribute, so match it directly).
+      # plain text, with the registrant's own videoconference-page URL appended
+      # (Nokogiri decodes the href attribute, so match it directly).
       apple = Nokogiri::HTML.fragment(response.body).css("a").find { |a| a.text == "Apple" }
       expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
       expect(apple["href"]).to include("Re-download it from the Portal")
-      expect(apple["href"]).to include(registration_ticket_url(registration.slug))
+      expect(apple["href"]).to include(registration_videoconference_url(registration.slug))
     end
 
     it "withholds the link and credentials until the registrant has payment access" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -614,10 +614,11 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("unlocks once both of these are met")
       expect(response.body).to include("Available from")
 
-      # The downloadable calendar entry itself carries the re-add note (Nokogiri
-      # decodes the href attribute, so match the note text directly).
+      # The downloadable calendar entry itself carries the re-download note as
+      # plain text (Nokogiri decodes the href attribute, so match it directly).
       apple = Nokogiri::HTML.fragment(response.body).css("a").find { |a| a.text == "Apple" }
       expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
+      expect(apple["href"]).to include("Re-download the event from the Portal")
     end
 
     it "withholds the link and credentials until the registrant has payment access" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -614,9 +614,7 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("unlocks once both of these are met")
       expect(response.body).to include("Available from")
 
-      # The downloadable calendar entry itself carries the re-download note as
-      # plain text, with the registrant's own videoconference-page URL appended
-      # (Nokogiri decodes the href attribute, so match it directly).
+      # Nokogiri decodes the href attribute, so match the note/URL text directly.
       apple = Nokogiri::HTML.fragment(response.body).css("a").find { |a| a.text == "Apple" }
       expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
       expect(apple["href"]).to include("Re-download it from the Portal")

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -615,10 +615,12 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("Available from")
 
       # The downloadable calendar entry itself carries the re-download note as
-      # plain text (Nokogiri decodes the href attribute, so match it directly).
+      # plain text, with the registrant's own ticket URL appended (Nokogiri
+      # decodes the href attribute, so match it directly).
       apple = Nokogiri::HTML.fragment(response.body).css("a").find { |a| a.text == "Apple" }
       expect(apple["href"]).to include("The videoconference join link isn't in this calendar entry yet")
-      expect(apple["href"]).to include("Re-download the event from the Portal")
+      expect(apple["href"]).to include("Re-download it from the Portal")
+      expect(apple["href"]).to include(registration_ticket_url(registration.slug))
     end
 
     it "withholds the link and credentials until the registrant has payment access" do

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -580,7 +580,11 @@ RSpec.describe "Events::Registrations", type: :request do
                      videoconference_url: "https://awbw.zoom.us/j/88285411273",
                      videoconference_label: "Zoom", videoconference_passcode: "secret123")
     end
-    # Within a week and intends to pay → the connection details are visible.
+    # The videoconference callout's drip date has passed and the registrant
+    # intends to pay → the connection details are visible.
+    let!(:videoconference_callout) do
+      create(:registration_ticket_callout, event:, builtin_key: "videoconference", display_from: 1.day.ago)
+    end
     let!(:registration) { create(:event_registration, event: event, registrant: user.person, intends_to_pay: true) }
 
     it "shows the join link and add-to-calendar options" do
@@ -598,8 +602,8 @@ RSpec.describe "Events::Registrations", type: :request do
       expect(response.body).to include("secret123")
     end
 
-    it "withholds the link and credentials more than a week before the event" do
-      event.update!(start_date: 8.days.from_now, end_date: 8.days.from_now + 2.hours)
+    it "withholds the link and credentials until the drip date arrives" do
+      videoconference_callout.update!(display_from: 1.day.from_now)
       get registration_videoconference_path(registration.slug)
       expect(response.body).not_to include("88285411273")
       expect(response.body).not_to include("secret123")

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -99,6 +99,39 @@ RSpec.describe "Events", type: :request do
         expect(response).to redirect_to(root_path)
       end
     end
+
+    # The registration section passes the viewer's registration gate into
+    # #calendar_links, so the join link only reaches the add-to-calendar entry
+    # once the details are visible. A free event keeps payment access open so
+    # these isolate the drip-date gate.
+    context "add-to-calendar videoconference gating for a registered viewer" do
+      let(:registrant) { create(:user, :with_person) }
+      let(:vc_event) do
+        create(:event, :published, :publicly_visible, cost_cents: 0,
+                       start_date: 6.days.from_now, end_date: 6.days.from_now + 2.hours,
+                       videoconference_url: "https://awbw.zoom.us/j/88285411273",
+                       videoconference_passcode: "secret123")
+      end
+      let!(:videoconference_callout) do
+        create(:registration_ticket_callout, event: vc_event, builtin_key: "videoconference", display_from: 1.day.ago)
+      end
+
+      before do
+        create(:event_registration, event: vc_event, registrant: registrant.person, status: "registered")
+        sign_in registrant
+      end
+
+      it "embeds the join link in the add-to-calendar entry once the details are visible" do
+        get event_path(vc_event)
+        expect(response.body).to include("Join on Zoom: https://awbw.zoom.us/j/88285411273")
+      end
+
+      it "keeps the join link out of the add-to-calendar entry while the drip date is pending" do
+        videoconference_callout.update!(display_from: 1.day.from_now)
+        get event_path(vc_event)
+        expect(response.body).not_to include("88285411273")
+      end
+    end
   end
 
   describe "GET /revenue" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 removes an orphaned model fallback, adds a condition-aware gated-calendar note, and reworks/extends the specs

### What is the goal of this PR and why is this important?
- The videoconference join link/ID/passcode must stay hidden until the viewer's details unlock. For a registrant that gate is **both** payment access **and** the built-in videoconference callout's admin-editable drip date (`display_from`) — `EventRegistration#videoconference_details_visible?` = `payment_access_granted? && event.videoconference_details_visible?`.
- `Event#videoconference_details_available_from` (the date half) still carried a `start_date - 7.days` runtime fallback for events without a materialized callout — reintroducing the exact hard-coded "one week prior" rule the drip date was meant to replace.
- A viewer who added the event to their calendar before the link unlocked got an entry with no join link and no way back — and the note that explained it only talked about the date (naming a *past* date when payment was the real blocker).

### How did you approach the change?
- Removed the fallback branch and the `VIDEOCONFERENCE_DETAILS_LEAD` constant; `videoconference_details_available_from` now reads `display_from` off the callout and nothing else. The date gate is active only when the callout is materialized (the 7-day default lives solely in `BuiltinCallouts`, which seeds `display_from`).
- While gated, the calendar entry and on-page hover name **whichever conditions are actually pending** — "once your payment is on file", "on <date>", or both — and only name a date while it's genuinely in the future (never a past one). The hover links "Re-download it from the Portal" to the viewer's **videoconference page**; the calendar entry carries the same wording as plain text with that page's URL appended so it's actionable from the calendar app. Shared via a decorator method so both stay in sync.
- Verified the join link is **never rendered in any mailer** (no mailer view or partial reaches `calendar_links` / the join link / an `.ics` attachment), so threading the URL through `calendar_links` stays web-only.
- Strengthened `#calendar_links` coverage: the join link must be absent from **all five** provider links across drip-passed / drip-future / drip-cleared / no-callout / payment-gate / no-URL cases, plus the gated-note scenarios (date-only, payment-only-without-a-past-date, both conditions, generic fallback, appended URL, note dropped once visible, no note without a URL, and the linked HTML form).
- Added **caller-level** request specs so each page that renders the add-to-calendar links — the ticket, the event show page's registration section, and the videoconference page — passes its own gate value (payment + date) and (for the videoconference page) embeds the re-download note with the URL in the downloadable entry.
- Verified live: the gated videoconference page renders the note, the hover link and appended URL both point to the videoconference page, and the wording matches the registrant's actual pending condition.

### Anything else to add?
- Behavior change: an event with a `videoconference_url` but **no** materialized callout is now ungated on the date half (details visible immediately) instead of gated by start date. In practice setting a URL goes through the event `update` path, which seeds the callout, so real events have one.