### PR TITLE
Add event participation report + Events statistics hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ end
 
 - `EventDashboard` — Aggregates per-event dashboard metrics (registrant/org/sector/state/county counts, scholarship totals, payment received/outstanding/total)
 - `EventRevenueReport` — Cross-event revenue report grouped by calendar year (money in vs org subsidy vs net, projected CE, chart series) for the CEO revenue page
+- `EventParticipationReport` — Cross-event participation report grouped by calendar year (unique people trained vs attended seats vs per-status outcome counts, chart series) for the events participation page; sibling of `EventRevenueReport`
+- `ReportPeriods` — Shared module (included by `EventRevenueReport` and `EventParticipationReport`) resolving the reporting-hub period toggle (this year / last year / all time) to a metric scope + label for the summary cards
 - `ScholarshipApplication` — Gathers one person's scholarship-application answers for an event by field across all their submissions, so answers surface whether captured on a dedicated scholarship form, an embedded registration section, or the registration submission itself (used by the scholarship edit page and the public submission view)
 - `WorkshopSearchService` — Complex filtering, sorting, pagination with ActionPolicy
 - `WorkshopFromIdeaService` — Converts WorkshopIdea to Workshop with asset migration

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -12,6 +12,7 @@ class EventRegistrationsController < ApplicationController
     @event_registrations_count = filtered.size
     @event_registrations = filtered.includes(registrant: [ :user, { avatar_attachment: :blob } ], event: :event_forms).paginate(page: params[:page], per_page: per_page)
     @events = Event.order(start_date: :desc)
+    @event_years = Event.where.not(start_date: nil).distinct.pluck(Arel.sql("YEAR(start_date)")).sort.reverse
     @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
     @filtered_event = Event.find_by(id: params[:event_id]) if params[:event_id].present?
     @selected_registrant = Person.find_by(id: params[:registrant_id]) if params[:registrant_id].present?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,7 @@ class EventsController < ApplicationController
   skip_before_action :authenticate_user!, only: [ :index, :show, :staff ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
   before_action :set_event, only: %i[ show edit update destroy preview dashboard sample_ticket background registrants onboarding staff edit_staff update_staff recipients preview_reminder confirm_reminder send_reminder copy_registration_form ]
+  before_action :set_report_filters, only: %i[ revenue participation statistics ]
 
   def index
     authorize!
@@ -17,14 +18,32 @@ class EventsController < ApplicationController
     track_view(@event)
   end
 
-  # Cross-event revenue report across every paid event (those that charge a
-  # registration fee). The KPI strip leads with the year of the event the CEO
-  # navigated from (when arriving from a dashboard), otherwise the current year.
+  # Cross-event revenue report over paid events, grouped by year. Shares the
+  # event-type + time-period filters with the participation report, and leads the
+  # KPI strip with the year of the event navigated from (when arriving from a
+  # dashboard), otherwise the current year.
   def revenue
     authorize!
-    @events = Event.paid.order(start_date: :desc).map(&:decorate)
-    origin_event = Event.find_by(id: params[:event_id]) if params[:event_id].present?
-    @report = EventRevenueReport.new(@events, featured_year: origin_event&.start_date&.year)
+    events, selected_year = filtered_report_events(Event.paid)
+    @report = EventRevenueReport.new(events, featured_year: selected_year || @filter_event&.start_date&.year)
+  end
+
+  # Cross-event participation report: how many people completed each training,
+  # grouped by year. Scopes to all events by default, narrowable to facilitator
+  # trainings, and to a single year via the ahoy-style time-period select.
+  def participation
+    authorize!
+    events, selected_year = filtered_report_events(Event.all)
+    @report = EventParticipationReport.new(events, featured_year: selected_year)
+  end
+
+  # Events statistics hub: the revenue and participation report summaries side by
+  # side, each linking to its full report.
+  def statistics
+    authorize!
+    @period = params[:period].presence_in(%w[ this_year last_year all_time ]) || "this_year"
+    @revenue_report = EventRevenueReport.new(report_events(Event.paid))
+    @participation_report = EventParticipationReport.new(report_events(Event.all))
   end
 
   def new
@@ -427,6 +446,56 @@ class EventsController < ApplicationController
       params[:reg].present? ? registration_staff_path(params[:reg]) : staff_event_path(@event)
     else staff_event_path(@event)
     end
+  end
+
+  # Shared filter state for the revenue/participation/statistics report pages: the
+  # event-type and specific-event filters, plus the event list for the Event
+  # dropdown.
+  def set_report_filters
+    @event_type = params[:event_type].presence_in(%w[ trainings other ])
+    @filter_event = Event.find_by(id: params[:event_id]) if params[:event_id].present?
+    # The revenue report only covers paid events, so its Event dropdown lists only
+    # those; the others list every event.
+    dropdown_scope = action_name == "revenue" ? Event.paid : Event.all
+    @filter_events = dropdown_scope.order(start_date: :desc)
+  end
+
+  # Applies the shared report filters (event type, specific event) plus a
+  # calendar-year time period to `base` (the report's unfiltered relation, e.g.
+  # Event.paid or Event.all). Sets @year_options and @time_period for the filter
+  # form, and returns the decorated events plus the selected year (nil for "all
+  # time").
+  def filtered_report_events(base)
+    base = scoped_report_base(base)
+    @year_options = base.where.not(start_date: nil)
+      .distinct
+      .pluck(Arel.sql("YEAR(start_date)"))
+      .sort
+      .reverse
+    @time_period = params[:time_period].presence || "all_time"
+    selected_year = selected_report_year(@time_period)
+    events = selected_year ? base.in_year(selected_year) : base
+    [ events.order(start_date: :desc).map(&:decorate), selected_year ]
+  end
+
+  # Decorated events for a report, scoped by the shared filters, newest first.
+  def report_events(base)
+    scoped_report_base(base).order(start_date: :desc).map(&:decorate)
+  end
+
+  # Narrows `base` by the event-type and specific-event filters.
+  def scoped_report_base(base)
+    base = base.facilitator_trainings if @event_type == "trainings"
+    base = base.where(facilitator_training: false) if @event_type == "other"
+    base = base.where(id: @filter_event.id) if @filter_event
+    base
+  end
+
+  # The calendar year a report is scoped to: the current year for "this_year", a
+  # specific year for a "2025"-style value, or nil for "all_time".
+  def selected_report_year(time_period)
+    return Date.current.year if time_period == "this_year"
+    Integer(time_period, exception: false)
   end
 
   # The registrations the admin checked on the recipient picker, narrowed to those

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -29,7 +29,7 @@ module AdminCardsHelper
       custom_card("Portal activity", admin_activities_counts_path, icon: "📊"),
       custom_card("Bookmarks tally", tally_bookmarks_path, icon: "🔖"),
       model_card(:quotes, icon: "💬", intensity: 100),
-      custom_card("Events revenue", revenue_events_path, icon: "📊", color: :blue),
+      custom_card("Events statistics", statistics_events_path, icon: "📊", color: :blue),
       model_card(:scholarships, icon: "🎓"),
       model_card(:notifications, icon: "🔔", title: t("communications.title")),
       model_card(:story_ideas, icon: "✍🏾️", intensity: 100),

--- a/app/helpers/event_participation_helper.rb
+++ b/app/helpers/event_participation_helper.rb
@@ -1,0 +1,13 @@
+module EventParticipationHelper
+  # A small, neutral year-over-year change indicator for a headcount, e.g.
+  # "▲ 12" / "▼ 3". Direction only, uncoloured. Returns nil when there's no prior
+  # period or no change.
+  def participation_delta(current_count, prior_count)
+    return nil if prior_count.nil?
+    delta = current_count - prior_count
+    return nil if delta.zero?
+    arrow = delta.positive? ? "▲" : "▼"
+    content_tag(:span, "#{arrow} #{number_with_delimiter(delta.abs)}",
+                class: "text-xs text-gray-400 tabular-nums")
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -93,4 +93,51 @@ module EventsHelper
       entries[attr] = attr == "days" ? "Attendance days" : column[:label]
     end
   end
+
+  # The statistics hub and the full revenue/participation reports share the
+  # event-type and specific-event filters directly, but express the time window
+  # differently: the hub's `period` select offers this_year/last_year/all_time,
+  # while the reports use `time_period` where a specific window is the calendar
+  # year "YYYY". These helpers translate a page's active filters into the query
+  # params for its cross-link so filters carry across — and back — between the
+  # summaries' "Full report" links and the reports' "Events statistics" eyebrow.
+
+  # Statistics hub filters → full report query params.
+  def statistics_to_report_params
+    {
+      return_to: params[:return_to],
+      event_type: params[:event_type].presence,
+      event_id: params[:event_id].presence,
+      time_period: statistics_period_to_time_period(@period)
+    }.compact
+  end
+
+  # Full report filters → statistics hub query params.
+  def report_to_statistics_params
+    {
+      return_to: params[:return_to],
+      event_type: params[:event_type].presence,
+      event_id: params[:event_id].presence,
+      period: time_period_to_statistics_period(@time_period)
+    }.compact
+  end
+
+  # "last_year" becomes the prior calendar year (reports name specific years
+  # "YYYY"); this_year/all_time pass through unchanged.
+  def statistics_period_to_time_period(period)
+    return (Date.current.year - 1).to_s if period == "last_year"
+    period
+  end
+
+  # Inverse: the prior year maps back to "last_year", the current year to
+  # "this_year"; any other specific year has no hub equivalent, so fall back to
+  # "all_time".
+  def time_period_to_statistics_period(time_period)
+    case time_period
+    when "this_year", "all_time" then time_period
+    when (Date.current.year - 1).to_s then "last_year"
+    when Date.current.year.to_s then "this_year"
+    else "all_time"
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -91,6 +91,8 @@ class Event < ApplicationRecord
   scope :facilitator_trainings, -> { where(facilitator_training: true) }
   # Events that charge a registration fee (cost_cents may be nil for free ones).
   scope :paid, -> { where("cost_cents > 0") }
+  # Events whose start date falls in the given calendar year.
+  scope :in_year, ->(year) { where(start_date: Date.new(year).all_year) }
 
   def self.search_by_params(params)
     stories = is_a?(ActiveRecord::Relation) ? self : all

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -186,6 +186,11 @@ class Event < ApplicationRecord
     "(#{ start_text }) #{ name }"
   end
 
+  # Like time_title but date only — no time or parens — for filter dropdowns.
+  def date_title
+    start_date ? "#{start_date.to_date.iso8601} — #{name}" : name
+  end
+
   def full_name
     "#{ name } (#{ start_text })"
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -91,8 +91,10 @@ class Event < ApplicationRecord
   scope :facilitator_trainings, -> { where(facilitator_training: true) }
   # Events that charge a registration fee (cost_cents may be nil for free ones).
   scope :paid, -> { where("cost_cents > 0") }
-  # Events whose start date falls in the given calendar year.
-  scope :in_year, ->(year) { where(start_date: Date.new(year).all_year) }
+  # Events whose start date falls in the given calendar year. Keyed off the year
+  # of start_date directly — a date range would miss same-day times on Dec 31,
+  # since start_date is a datetime and the range's upper bound is midnight.
+  scope :in_year, ->(year) { where("YEAR(start_date) = ?", year.to_i) }
 
   def self.search_by_params(params)
     stories = is_a?(ActiveRecord::Relation) ? self : all

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -27,6 +27,9 @@ class EventRegistration < ApplicationRecord
   ACTIVE_STATUSES = %w[ registered attended incomplete_attendance transferred_in ].freeze
   INACTIVE_STATUSES = %w[ cancelled no_show transferred_out ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
+  # Attendance outcomes surfaced as their own participation buckets; every other
+  # status falls into "other" (registered, transfers, cancellations).
+  NAMED_OUTCOME_STATUSES = %w[ attended incomplete_attendance no_show ].freeze
 
   # Human labels for each attendance status — the single source of truth for
   # status display (badges, filters, the dashboard breakdown).
@@ -70,7 +73,9 @@ class EventRegistration < ApplicationRecord
   scope :inactive, -> { where(status: INACTIVE_STATUSES) }
   scope :attended, -> { where(status: "attended") }
   scope :registrant_ids, ->(ids) { where(registrant_id: ids.to_s.split("-").map(&:to_i)) }
-  scope :attendance_status, ->(status) { where(status: status) }
+  scope :attendance_status, ->(status) {
+    status == "other" ? where.not(status: NAMED_OUTCOME_STATUSES) : where(status: status)
+  }
   # Registrations on facilitator-training events ("trainings") vs everything else
   # ("other"); any other value is a no-op so "all events" passes through.
   scope :event_type, ->(type) {

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -85,6 +85,9 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
+  # Registrations whose event falls in the given calendar year. Uses a subquery
+  # (via Event.in_year) so it composes with the other filters without extra joins.
+  scope :in_event_year, ->(year) { where(event_id: Event.in_year(year.to_i)) }
   scope :registrant_state, ->(state) {
     joins(registrant: :addresses)
       .where(addresses: { inactive: false, state: state })
@@ -288,6 +291,9 @@ class EventRegistration < ApplicationRecord
     end
     if params[:event_type].present?
       registrations = registrations.event_type(params[:event_type])
+    end
+    if params[:event_year].present?
+      registrations = registrations.in_event_year(params[:event_year])
     end
     registrations
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -71,6 +71,15 @@ class EventRegistration < ApplicationRecord
   scope :attended, -> { where(status: "attended") }
   scope :registrant_ids, ->(ids) { where(registrant_id: ids.to_s.split("-").map(&:to_i)) }
   scope :attendance_status, ->(status) { where(status: status) }
+  # Registrations on facilitator-training events ("trainings") vs everything else
+  # ("other"); any other value is a no-op so "all events" passes through.
+  scope :event_type, ->(type) {
+    case type
+    when "trainings" then joins(:event).where(events: { facilitator_training: true })
+    when "other" then joins(:event).where(events: { facilitator_training: false })
+    else all
+    end
+  }
   scope :registrant_state, ->(state) {
     joins(registrant: :addresses)
       .where(addresses: { inactive: false, state: state })
@@ -268,6 +277,12 @@ class EventRegistration < ApplicationRecord
     end
     if params[:ce_status].present?
       registrations = registrations.ce_status(params[:ce_status])
+    end
+    if params[:attendance_status].present?
+      registrations = registrations.attendance_status(params[:attendance_status])
+    end
+    if params[:event_type].present?
+      registrations = registrations.event_type(params[:event_type])
     end
     registrations
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -19,6 +19,18 @@ class EventPolicy < ApplicationPolicy
     admin?
   end
 
+  # The cross-event participation report aggregates attendance across every
+  # event, so it's admin-only like the revenue report.
+  def participation?
+    admin?
+  end
+
+  # The events statistics hub gathers the cross-event report summaries, so it's
+  # admin-only like the reports it links to.
+  def statistics?
+    admin?
+  end
+
   def show?
     return true if admin?
 

--- a/app/services/event_participation_report.rb
+++ b/app/services/event_participation_report.rb
@@ -140,22 +140,32 @@ class EventParticipationReport
   end
 
   # The reach of the scoped registrants: how many distinct organizations,
-  # sectors, states and countries they span, for a given calendar year (nil =
-  # every year in scope). Read "via registrants", like the event dashboard's
-  # breakdown cards.
-  Demographics = Struct.new(:organizations, :sectors, :states, :countries, keyword_init: true)
+  # sectors, states, countries and cities they span, for a given calendar year
+  # (nil = every year in scope). Read "via registrants", like the event
+  # dashboard's breakdown cards. States/countries come from registrant addresses;
+  # cities come from the linked organizations' addresses.
+  Demographics = Struct.new(:organizations, :sectors, :states, :countries, :cities, keyword_init: true)
 
   def demographics(year: nil)
     registrations = active_registrations(year: year)
     person_ids = registrations.distinct.pluck(:registrant_id)
+    organization_ids = EventRegistrationOrganization
+      .where(event_registration_id: registrations.select(:id))
+      .distinct
+      .pluck(:organization_id)
     addresses = Address.active
       .where(addressable_type: "Person", addressable_id: person_ids)
       .pluck(:state, :country)
     Demographics.new(
-      organizations: EventRegistrationOrganization.where(event_registration_id: registrations.select(:id)).distinct.count(:organization_id),
+      organizations: organization_ids.size,
       sectors: SectorableItem.where(sectorable_type: "Person", sectorable_id: person_ids).distinct.count(:sector_id),
       states: addresses.map(&:first).reject(&:blank?).uniq.size,
-      countries: addresses.map(&:last).reject(&:blank?).uniq.size
+      countries: addresses.map(&:last).reject(&:blank?).uniq.size,
+      cities: Address.active
+        .where(addressable_type: "Organization", addressable_id: organization_ids)
+        .where.not(city: [ nil, "" ])
+        .distinct
+        .count(:city)
     )
   end
 

--- a/app/services/event_participation_report.rb
+++ b/app/services/event_participation_report.rb
@@ -27,8 +27,9 @@ class EventParticipationReport
   STATUSES = STATUS_LABELS.keys.freeze
   # The outcomes with no headline card/column of their own (registered, transfers,
   # cancellations). With attended, partial and no-show they total the registration
-  # count, so the four buckets read across to Registrations.
-  OTHER_STATUSES = (STATUSES - %w[ attended incomplete_attendance no_show ]).freeze
+  # count, so the four buckets read across to Registrations. Matches the
+  # registrants index "other" attendance filter.
+  OTHER_STATUSES = (STATUSES - EventRegistration::NAMED_OUTCOME_STATUSES).freeze
 
   # Per-event outcome counts. Unique people equals attended seats here: the
   # [registrant_id, event_id] uniqueness index means a person holds one

--- a/app/services/event_participation_report.rb
+++ b/app/services/event_participation_report.rb
@@ -1,0 +1,256 @@
+# Participation report: how many people completed each training, grouped by
+# calendar year for an over-time view and annual-report figures. The sibling of
+# EventRevenueReport — same year-grouped shape, but counting people instead of
+# dollars.
+#
+# "Completed" = fully attended (EventRegistration status "attended"). The
+# headline is UNIQUE PEOPLE (distinct registrants), because a person who attends
+# two trainings in a year is one person we trained, not two. Seats (attended
+# registration count) are additive and shown alongside when they differ, which
+# is exactly where repeat attendees show up.
+#
+# The status detail (attended, partial/1-day, no-show, etc.) is a per-status
+# registration count — each registration has exactly one status, so those sum
+# cleanly and reconcile to total registrations.
+class EventParticipationReport
+  # Registration outcomes in display order — left to right across the per-event
+  # detail row (attended first, then the rest of the attendance detail).
+  STATUS_LABELS = {
+    "attended" => "Attended",
+    "registered" => "Registered",
+    "transferred_in" => "Transferred in",
+    "cancelled" => "Cancelled",
+    "incomplete_attendance" => "Partial (1-day)",
+    "no_show" => "No show",
+    "transferred_out" => "Transferred out"
+  }.freeze
+  STATUSES = STATUS_LABELS.keys.freeze
+  # The outcomes with no headline card/column of their own (registered, transfers,
+  # cancellations). With attended, partial and no-show they total the registration
+  # count, so the four buckets read across to Registrations.
+  OTHER_STATUSES = (STATUSES - %w[ attended incomplete_attendance no_show ]).freeze
+
+  # Per-event outcome counts. Unique people equals attended seats here: the
+  # [registrant_id, event_id] uniqueness index means a person holds one
+  # registration per event, so people and seats only diverge once aggregated
+  # across events (a year subtotal or the grand total).
+  Row = Struct.new(:event, :status_counts, keyword_init: true) do
+    def year
+      event.start_date&.year
+    end
+
+    def count_for(status)
+      status_counts.fetch(status, 0)
+    end
+
+    def attended_seats
+      count_for("attended")
+    end
+    alias_method :unique_people, :attended_seats
+
+    def total_registrations
+      STATUSES.sum { |status| count_for(status) }
+    end
+
+    def count_other
+      OTHER_STATUSES.sum { |status| count_for(status) }
+    end
+  end
+
+  # Additive figures — seats and per-status counts — so a year subtotal or the
+  # grand total is a plain sum over rows. Unique people is deliberately NOT here:
+  # people don't add across events, so each level computes its own distinct count.
+  module Aggregates
+    def attended_seats
+      rows.sum(&:attended_seats)
+    end
+
+    def count_for(status)
+      rows.sum { |row| row.count_for(status) }
+    end
+
+    def total_registrations
+      rows.sum(&:total_registrations)
+    end
+
+    def count_other
+      rows.sum(&:count_other)
+    end
+  end
+
+  # One calendar year of events, with its rows, additive subtotals, and its own
+  # distinct-people count (passed in — it can't be summed from the rows).
+  YearGroup = Struct.new(:year, :rows, :unique_people, :in_progress, keyword_init: true) do
+    include Aggregates
+  end
+
+  include Aggregates
+  include ReportPeriods
+
+  def initialize(events, current_year: Date.current.year, featured_year: nil)
+    @events = events.to_a
+    @current_year = current_year
+    @featured_year_value = featured_year || current_year
+  end
+
+  def rows
+    @rows ||= @events.map do |event|
+      Row.new(event: event, status_counts: status_counts_by_event.fetch(event.id, {}))
+    end
+  end
+
+  def any?
+    rows.any?
+  end
+
+  # Calendar-year groups, newest first, each with a subtotal. Events without a
+  # start date fall under a nil year that sorts last.
+  def years
+    @years ||= rows
+      .group_by(&:year)
+      .map do |year, year_rows|
+        YearGroup.new(
+          year: year,
+          rows: year_rows,
+          unique_people: unique_people_by_year.fetch(year, 0),
+          in_progress: year == @current_year
+        )
+      end
+      .sort_by { |group| [ group.year ? 0 : 1, -(group.year || 0) ] }
+  end
+
+  # Distinct people who attended across every event in scope. Its own query, not
+  # a sum of the year subtotals, because people aren't additive across years.
+  def unique_people
+    @unique_people ||= unique_attended_people
+  end
+
+  # The year whose figures lead the KPI strip: the filtered/navigated-from year,
+  # else the current year, falling back to the most recent year present.
+  def featured_year
+    years_by_value[@featured_year_value] || years.first
+  end
+
+  # The most recent year-group strictly older than the featured one, for a
+  # year-over-year delta. Nil when there's nothing older to compare against.
+  def prior_year
+    return nil unless featured_year&.year
+    years.find { |group| group.year && group.year < featured_year.year }
+  end
+
+  # The reach of the scoped registrants: how many distinct organizations,
+  # sectors, states and countries they span, for a given calendar year (nil =
+  # every year in scope). Read "via registrants", like the event dashboard's
+  # breakdown cards.
+  Demographics = Struct.new(:organizations, :sectors, :states, :countries, keyword_init: true)
+
+  def demographics(year: nil)
+    registrations = active_registrations(year: year)
+    person_ids = registrations.distinct.pluck(:registrant_id)
+    addresses = Address.active
+      .where(addressable_type: "Person", addressable_id: person_ids)
+      .pluck(:state, :country)
+    Demographics.new(
+      organizations: EventRegistrationOrganization.where(event_registration_id: registrations.select(:id)).distinct.count(:organization_id),
+      sectors: SectorableItem.where(sectorable_type: "Person", sectorable_id: person_ids).distinct.count(:sector_id),
+      states: addresses.map(&:first).reject(&:blank?).uniq.size,
+      countries: addresses.map(&:last).reject(&:blank?).uniq.size
+    )
+  end
+
+  # Distinct attended people split by whether the event is a facilitator
+  # training, for a given calendar year (nil = every year in scope). Someone who
+  # attends both a training and a non-training in the period is counted in each
+  # bucket, so the two can sum to more than the combined unique_people total.
+  def training_split(year: nil)
+    {
+      trainings: unique_attended_people(year: year, trainings: true),
+      non_trainings: unique_attended_people(year: year, trainings: false)
+    }
+  end
+
+  # Registration counts split by whether the event is a facilitator training, for
+  # a given calendar year (nil = every year in scope). Registrations are
+  # additive, so this is a plain sum over the already-loaded rows.
+  def registrations_split(year: nil)
+    scoped = year ? rows.select { |row| row.year == year } : rows
+    trainings, non_trainings = scoped.partition { |row| row.event.facilitator_training? }
+    {
+      trainings: trainings.sum(&:total_registrations),
+      non_trainings: non_trainings.sum(&:total_registrations)
+    }
+  end
+
+  # Stacked-column attendance-outcome series by year, oldest to newest — seats
+  # (registration counts, one consistent unit) so the columns stack honestly.
+  def chart_series
+    ascending = years.reject { |group| group.year.nil? }.reverse
+    {
+      "Attended" => "attended",
+      "Partial (1-day)" => "incomplete_attendance",
+      "No show" => "no_show"
+    }.map do |name, status|
+      { name: name, data: ascending.map { |group| [ group.year.to_s, group.count_for(status) ] } }
+    end
+  end
+
+  private
+
+  # A zeroed year group for a period with no events, so the summary card renders
+  # 0 rather than blank.
+  def empty_year_group(year)
+    YearGroup.new(year: year, rows: [], unique_people: 0, in_progress: false)
+  end
+
+  # Active registrations among the scoped events, optionally narrowed to a
+  # calendar year — the people counted in the demographics breakdown.
+  def active_registrations(year: nil)
+    scope = EventRegistration.active.where(event_id: event_ids)
+    scope = scope.joins(:event).where("YEAR(events.start_date) = ?", year) if year
+    scope
+  end
+
+  # Distinct attended registrants among the scoped events, optionally narrowed to
+  # a calendar year and/or facilitator-training status.
+  def unique_attended_people(year: nil, trainings: nil)
+    scope = EventRegistration.attended.where(event_id: event_ids)
+    if year || !trainings.nil?
+      scope = scope.joins(:event)
+      scope = scope.where("YEAR(events.start_date) = ?", year) if year
+      scope = scope.where(events: { facilitator_training: trainings }) unless trainings.nil?
+    end
+    scope.distinct.count(:registrant_id)
+  end
+
+  def event_ids
+    @event_ids ||= @events.map(&:id)
+  end
+
+  def years_by_value
+    @years_by_value ||= years.index_by(&:year)
+  end
+
+  # { event_id => { status => count } } from one grouped query, so no per-event
+  # round trip and no Ruby readiness pass.
+  def status_counts_by_event
+    @status_counts_by_event ||= EventRegistration
+      .where(event_id: event_ids)
+      .group(:event_id, :status)
+      .count
+      .each_with_object({}) do |((event_id, status), count), map|
+        (map[event_id] ||= {})[status] = count
+      end
+  end
+
+  # { year => distinct attended people } in one grouped distinct query. A nil
+  # start date extracts to a nil year, matching the "Undated" row group.
+  def unique_people_by_year
+    @unique_people_by_year ||= EventRegistration.attended
+      .joins(:event)
+      .where(event_id: event_ids)
+      .group(Arel.sql("YEAR(events.start_date)"))
+      .distinct
+      .count(:registrant_id)
+      .transform_keys { |year| year&.to_i }
+  end
+end

--- a/app/services/event_revenue_report.rb
+++ b/app/services/event_revenue_report.rb
@@ -80,6 +80,7 @@ class EventRevenueReport
   end
 
   include Summable
+  include ReportPeriods
 
   def initialize(events, current_year: Date.current.year, featured_year: nil)
     @events = events
@@ -134,6 +135,12 @@ class EventRevenueReport
   end
 
   private
+
+  # A zeroed year group for a period with no events, so the summary card renders
+  # $0 rather than blank.
+  def empty_year_group(year)
+    YearGroup.new(year: year, rows: [], in_progress: false)
+  end
 
   def years_by_value
     @years_by_value ||= years.index_by(&:year)

--- a/app/services/money_formatter.rb
+++ b/app/services/money_formatter.rb
@@ -20,22 +20,24 @@ class MoneyFormatter
   end
 
   # Abbreviated for tight UI like the grant picker: plain under $1k ("$750"),
-  # "k" for thousands ("$12.5k"), "m" for millions ("$1.2m"). One decimal place,
-  # trailing .0 dropped. Lossy on purpose — use dollars_from_cents for exact values.
-  def self.compact_from_cents(cents)
+  # "k" for thousands ("$12.5k"), "m" for millions ("$1.2m"). Rounds to `precision`
+  # decimal places (default 1), trailing .0 dropped, so precision: 0 gives whole
+  # units ("$15k"). Lossy on purpose — use dollars_from_cents for exact values.
+  def self.compact_from_cents(cents, precision: 1)
     amount = cents.to_i.to_d / 100
     if amount >= 1_000_000
-      "$#{trim_decimal(amount / 1_000_000)}m"
+      "$#{trim_decimal(amount / 1_000_000, precision)}m"
     elsif amount >= 1_000
-      "$#{trim_decimal(amount / 1_000)}k"
+      "$#{trim_decimal(amount / 1_000, precision)}k"
     else
       "$#{amount.to_i}"
     end
   end
 
-  def self.trim_decimal(value)
-    rounded = value.round(1)
-    rounded.frac.zero? ? rounded.to_i.to_s : rounded.to_s("F")
+  def self.trim_decimal(value, precision = 1)
+    # BigDecimal#round(0) returns an Integer, higher precisions a BigDecimal.
+    rounded = value.round(precision)
+    rounded.to_i == rounded ? rounded.to_i.to_s : rounded.to_s("F")
   end
   private_class_method :trim_decimal
 end

--- a/app/services/report_periods.rb
+++ b/app/services/report_periods.rb
@@ -1,0 +1,28 @@
+# Resolves the statistics-hub period toggle ("this_year" | "last_year" |
+# "all_time") to a metric scope + display label for a report's summary card.
+# Included by EventRevenueReport and EventParticipationReport, which each supply
+# an empty_year_group for a year that has no events (so the card shows zeros).
+module ReportPeriods
+  # A resolved period: the label to show, the calendar year (nil for all time),
+  # and the object the summary card reads its figures from — a YearGroup for a
+  # single year, or the report itself for all time.
+  PeriodScope = Struct.new(:label, :year, :metrics, keyword_init: true)
+
+  def period_scope(period, current_year: @current_year)
+    case period
+    when "all_time"
+      PeriodScope.new(label: "All time", year: nil, metrics: self)
+    when "last_year"
+      year_period(current_year - 1)
+    else
+      year_period(current_year)
+    end
+  end
+
+  private
+
+  def year_period(year)
+    metrics = years.find { |group| group.year == year } || empty_year_group(year)
+    PeriodScope.new(label: year.to_s, year: year, metrics: metrics)
+  end
+end

--- a/app/views/event_registrations/_search_boxes.html.erb
+++ b/app/views/event_registrations/_search_boxes.html.erb
@@ -52,6 +52,15 @@
                              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
                      onchange: "this.form.submit();" %>
     </div>
+    <div class="w-full md:flex-1">
+      <%= label_tag :event_year, "Year", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :event_year,
+                     options_for_select(@event_years.map { |year| [ year.to_s, year ] }, params[:event_year].presence&.to_i),
+                     include_blank: "All years",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                     onchange: "this.form.submit();" %>
+    </div>
     <!-- Clear filters -->
     <div class="w-full md:w-auto flex justify-end"><%= link_to 'Clear filters', event_registrations_path,
                   class: "btn btn-utility-outline",

--- a/app/views/event_registrations/_search_boxes.html.erb
+++ b/app/views/event_registrations/_search_boxes.html.erb
@@ -10,6 +10,15 @@
                      onchange: "this.form.submit();" %>
     </div>
     <div class="w-full md:flex-1">
+      <%= label_tag :event_type, "Event type", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :event_type,
+                     options_for_select([ [ "Trainings", "trainings" ], [ "Other", "other" ] ], params[:event_type]),
+                     include_blank: "All events",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                     onchange: "this.form.submit();" %>
+    </div>
+    <div class="w-full md:flex-1">
       <%= label_tag :registrant_id, "Registrant", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :registrant_id,
                      options_for_select(
@@ -30,6 +39,15 @@
       <%= select_tag :organization_id,
                      options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),
                      include_blank: "All organizations",
+                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
+                             focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                     onchange: "this.form.submit();" %>
+    </div>
+    <div class="w-full md:flex-1">
+      <%= label_tag :attendance_status, "Attendance", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= select_tag :attendance_status,
+                     options_for_select(EventRegistration::ATTENDANCE_STATUSES.map { |status| [ status.humanize, status ] }, params[:attendance_status]),
+                     include_blank: "All statuses",
                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
                              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
                      onchange: "this.form.submit();" %>

--- a/app/views/event_registrations/_search_boxes.html.erb
+++ b/app/views/event_registrations/_search_boxes.html.erb
@@ -46,7 +46,7 @@
     <div class="w-full md:flex-1">
       <%= label_tag :attendance_status, "Attendance", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= select_tag :attendance_status,
-                     options_for_select(EventRegistration::ATTENDANCE_STATUSES.map { |status| [ status.humanize, status ] }, params[:attendance_status]),
+                     options_for_select(EventRegistration::ATTENDANCE_STATUSES.map { |status| [ status.humanize, status ] } + [ [ "Other (registered, transfers, cancellations)", "other" ] ], params[:attendance_status]),
                      include_blank: "All statuses",
                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
                              focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -7,6 +7,10 @@
               <%= EventRegistration.model_name.human.pluralize %> (<%= @event_registrations_count %>)
             </h1>
             <div class="flex gap-2">
+              <% if @filtered_event %>
+                <%= link_to "#{@filtered_event.decorate.compact_label} event dashboard", dashboard_event_path(@filtered_event),
+                            class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+              <% end %>
               <%= link_to "Events", events_path,
                           class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
               <% if params[:admin] == "true" %>

--- a/app/views/events/_event_filter.html.erb
+++ b/app/views/events/_event_filter.html.erb
@@ -4,8 +4,8 @@
 <div class="flex flex-col gap-1">
   <label class="text-xs font-medium text-gray-600" for="event_id">Event</label>
   <%= select_tag :event_id,
-        options_from_collection_for_select(@filter_events, :id, :time_title, params[:event_id].to_i),
+        options_from_collection_for_select(@filter_events, :id, :date_title, params[:event_id].to_i),
         include_blank: local_assigns.fetch(:all_label, "All events"),
-        class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+        class: "max-w-[13rem] px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
         onchange: "this.form.submit()" %>
 </div>

--- a/app/views/events/_event_filter.html.erb
+++ b/app/views/events/_event_filter.html.erb
@@ -1,0 +1,10 @@
+<%# Specific-event filter shared by the revenue/participation/statistics report
+    forms. Scopes the report(s) to the chosen event. %>
+<div class="flex flex-col gap-1">
+  <label class="text-xs font-medium text-gray-600" for="event_id">Event</label>
+  <%= select_tag :event_id,
+        options_from_collection_for_select(@filter_events, :id, :time_title, params[:event_id].to_i),
+        include_blank: "All events",
+        class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+        onchange: "this.form.submit()" %>
+</div>

--- a/app/views/events/_event_filter.html.erb
+++ b/app/views/events/_event_filter.html.erb
@@ -1,10 +1,11 @@
 <%# Specific-event filter shared by the revenue/participation/statistics report
-    forms. Scopes the report(s) to the chosen event. %>
+    forms. Scopes the report(s) to the chosen event. `all_label` overrides the
+    blank option (revenue lists paid events only). %>
 <div class="flex flex-col gap-1">
   <label class="text-xs font-medium text-gray-600" for="event_id">Event</label>
   <%= select_tag :event_id,
         options_from_collection_for_select(@filter_events, :id, :time_title, params[:event_id].to_i),
-        include_blank: "All events",
+        include_blank: local_assigns.fetch(:all_label, "All events"),
         class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
         onchange: "this.form.submit()" %>
 </div>

--- a/app/views/events/_event_type_filter.html.erb
+++ b/app/views/events/_event_type_filter.html.erb
@@ -1,10 +1,11 @@
 <%# Event-type filter (all events / trainings / other) shared by the
-    revenue/participation/statistics report forms. %>
+    revenue/participation/statistics report forms. `all_label` overrides the
+    blank option (revenue lists paid events only). %>
 <div class="flex flex-col gap-1">
   <label class="text-xs font-medium text-gray-600" for="event_type">Event type</label>
   <%= select_tag :event_type,
         options_for_select([ [ "Trainings", "trainings" ], [ "Other", "other" ] ], @event_type),
-        include_blank: "All events",
+        include_blank: local_assigns.fetch(:all_label, "All events"),
         class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
         onchange: "this.form.submit()" %>
 </div>

--- a/app/views/events/_event_type_filter.html.erb
+++ b/app/views/events/_event_type_filter.html.erb
@@ -1,0 +1,10 @@
+<%# Event-type filter (all events / trainings / other) shared by the
+    revenue/participation/statistics report forms. %>
+<div class="flex flex-col gap-1">
+  <label class="text-xs font-medium text-gray-600" for="event_type">Event type</label>
+  <%= select_tag :event_type,
+        options_for_select([ [ "Trainings", "trainings" ], [ "Other", "other" ] ], @event_type),
+        include_blank: "All events",
+        class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+        onchange: "this.form.submit()" %>
+</div>

--- a/app/views/events/_participation_kpi.html.erb
+++ b/app/views/events/_participation_kpi.html.erb
@@ -1,0 +1,16 @@
+<% note = local_assigns[:note] %>
+<% card_class = local_assigns.fetch(:card_class, "border-gray-200 bg-white") %>
+<% href = local_assigns[:href] %>
+<% tag = href ? :a : :div %>
+<%= content_tag tag, href: href,
+      class: class_names("block rounded-xl border p-4", card_class, "transition-shadow hover:shadow-md" => href.present?) do %>
+  <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= label %></div>
+  <div class="mt-1 text-2xl font-bold tabular-nums <%= value_class %>"><%= number_with_delimiter(value) %></div>
+  <% if note %>
+    <div class="text-xs italic text-gray-400 whitespace-nowrap">(<%= note %>)</div>
+  <% end %>
+  <% delta = participation_delta(value, local_assigns[:prior]) %>
+  <% if delta %>
+    <div class="mt-1 flex items-center gap-1.5"><%= delta %><span class="text-xs text-gray-400">vs <%= local_assigns[:prior_year] %></span></div>
+  <% end %>
+<% end %>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -35,8 +35,8 @@
       </div>
     </div>
     <%# Reach of the scoped registrants, like the dashboard's breakdown cards. %>
-    <div class="grid grid-cols-4 gap-2 mb-4">
-      <% [ [ "Orgs", reach.organizations ], [ "Sectors", reach.sectors ], [ "States", reach.states ], [ "Countries", reach.countries ] ].each do |label, value| %>
+    <div class="grid grid-cols-5 gap-2 mb-4">
+      <% [ [ "Orgs", reach.organizations ], [ "Sectors", reach.sectors ], [ "Cities", reach.cities ], [ "States", reach.states ], [ "Countries", reach.countries ] ].each do |label, value| %>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-2 text-center">
           <div class="text-lg font-bold tabular-nums text-gray-900"><%= number_with_delimiter(value) %></div>
           <div class="text-xs text-gray-500"><%= label %></div>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -20,8 +20,8 @@
         <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= number_with_delimiter(metrics.unique_people) %></div>
         <%# Each side links to the attended registrants of that event type. %>
         <div class="mt-1 text-xs text-gray-500 tabular-nums">
-          <%= link_to "#{number_with_delimiter(people[:trainings])} trainings", event_registrations_path(event_type: "trainings", attendance_status: "attended"), class: "hover:underline" %>
-          · <%= link_to "#{number_with_delimiter(people[:non_trainings])} other", event_registrations_path(event_type: "other", attendance_status: "attended"), class: "hover:underline" %>
+          <%= link_to "#{number_with_delimiter(people[:trainings])} trainings", event_registrations_path(event_type: "trainings", attendance_status: "attended", event_year: period.year), class: "hover:underline" %>
+          · <%= link_to "#{number_with_delimiter(people[:non_trainings])} other", event_registrations_path(event_type: "other", attendance_status: "attended", event_year: period.year), class: "hover:underline" %>
         </div>
       </div>
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
@@ -29,8 +29,8 @@
         <div class="mt-1 text-xl font-bold tabular-nums text-gray-900"><%= number_with_delimiter(metrics.total_registrations) %></div>
         <%# Each side links to all registrants of that event type. %>
         <div class="mt-1 text-xs text-gray-500 tabular-nums">
-          <%= link_to "#{number_with_delimiter(registrations[:trainings])} trainings", event_registrations_path(event_type: "trainings"), class: "hover:underline" %>
-          · <%= link_to "#{number_with_delimiter(registrations[:non_trainings])} other", event_registrations_path(event_type: "other"), class: "hover:underline" %>
+          <%= link_to "#{number_with_delimiter(registrations[:trainings])} trainings", event_registrations_path(event_type: "trainings", event_year: period.year), class: "hover:underline" %>
+          · <%= link_to "#{number_with_delimiter(registrations[:non_trainings])} other", event_registrations_path(event_type: "other", event_year: period.year), class: "hover:underline" %>
         </div>
       </div>
     </div>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -1,0 +1,54 @@
+<%# Compact participation headline for the statistics hub, linking to the full
+    report. Expects `report` (an EventParticipationReport) and `period` (its
+    resolved PeriodScope: #label, #year and #metrics). %>
+<div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+  <div class="flex items-center justify-between mb-4">
+    <h3 class="text-base font-semibold text-gray-900">Participation</h3>
+    <%= link_to "Full report →", participation_events_path(return_to: params[:return_to]),
+          class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+  </div>
+
+  <% if report.any? %>
+    <% metrics = period.metrics %>
+    <% people = report.training_split(year: period.year) %>
+    <% registrations = report.registrations_split(year: period.year) %>
+    <% reach = report.demographics(year: period.year) %>
+    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2"><%= period.label %></div>
+    <div class="grid grid-cols-2 gap-3 mb-4">
+      <div class="rounded-lg border border-blue-200 bg-blue-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">People attended</div>
+        <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= number_with_delimiter(metrics.unique_people) %></div>
+        <%# Each side links to the attended registrants of that event type. %>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums">
+          <%= link_to "#{number_with_delimiter(people[:trainings])} trainings", event_registrations_path(event_type: "trainings", attendance_status: "attended"), class: "hover:underline" %>
+          · <%= link_to "#{number_with_delimiter(people[:non_trainings])} other", event_registrations_path(event_type: "other", attendance_status: "attended"), class: "hover:underline" %>
+        </div>
+      </div>
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Registrations</div>
+        <div class="mt-1 text-xl font-bold tabular-nums text-gray-900"><%= number_with_delimiter(metrics.total_registrations) %></div>
+        <%# Each side links to all registrants of that event type. %>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums">
+          <%= link_to "#{number_with_delimiter(registrations[:trainings])} trainings", event_registrations_path(event_type: "trainings"), class: "hover:underline" %>
+          · <%= link_to "#{number_with_delimiter(registrations[:non_trainings])} other", event_registrations_path(event_type: "other"), class: "hover:underline" %>
+        </div>
+      </div>
+    </div>
+    <%# Reach of the scoped registrants, like the dashboard's breakdown cards. %>
+    <div class="grid grid-cols-4 gap-2 mb-4">
+      <% [ [ "Orgs", reach.organizations ], [ "Sectors", reach.sectors ], [ "States", reach.states ], [ "Countries", reach.countries ] ].each do |label, value| %>
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-2 text-center">
+          <div class="text-lg font-bold tabular-nums text-gray-900"><%= number_with_delimiter(value) %></div>
+          <div class="text-xs text-gray-500"><%= label %></div>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-auto">
+      <%= column_chart report.chart_series, stacked: true, thousands: ",",
+            colors: [ "#2563eb", "#d97706", "#dc2626" ], height: "120px", legend: false,
+            library: { borderRadius: 3 } %>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 my-auto">No attendance recorded yet.</p>
+  <% end %>
+</div>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -4,7 +4,7 @@
 <div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
   <div class="flex items-center justify-between mb-4">
     <h3 class="text-base font-semibold text-gray-900">Participation</h3>
-    <%= link_to "Full report →", participation_events_path(return_to: params[:return_to]),
+    <%= link_to "Full report →", participation_events_path(statistics_to_report_params),
           class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
   </div>
 

--- a/app/views/events/_revenue_summary.html.erb
+++ b/app/views/events/_revenue_summary.html.erb
@@ -20,7 +20,7 @@
         <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fees collected</div>
         <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= dollars_from_cents(metrics.fees_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums">
-          <%= dollars_from_cents(metrics.registration_payments_cents) %> registration · <%= dollars_from_cents(ce_collected_cents) %> CE
+          <%= MoneyFormatter.compact_from_cents(metrics.registration_payments_cents, precision: 0) %> registration · <%= MoneyFormatter.compact_from_cents(ce_collected_cents, precision: 0) %> CE
         </div>
       </div>
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">

--- a/app/views/events/_revenue_summary.html.erb
+++ b/app/views/events/_revenue_summary.html.erb
@@ -4,7 +4,7 @@
 <div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
   <div class="flex items-center justify-between mb-4">
     <h3 class="text-base font-semibold text-gray-900">Revenue</h3>
-    <%= link_to "Full report →", revenue_events_path(return_to: params[:return_to]),
+    <%= link_to "Full report →", revenue_events_path(statistics_to_report_params),
           class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
   </div>
 
@@ -20,13 +20,23 @@
         <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fees collected</div>
         <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= dollars_from_cents(metrics.fees_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums">
-          <%= MoneyFormatter.compact_from_cents(metrics.registration_payments_cents, precision: 0) %> registration · <%= MoneyFormatter.compact_from_cents(ce_collected_cents, precision: 0) %> CE
+          <%= MoneyFormatter.compact_from_cents(metrics.registration_payments_cents, precision: 0) %> registration + <%= MoneyFormatter.compact_from_cents(ce_collected_cents, precision: 0) %> CE
         </div>
       </div>
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
         <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Net</div>
         <div class="mt-1 text-xl font-bold tabular-nums <%= metrics.net_cents.negative? ? "text-rose-700" : "text-gray-900" %>"><%= signed_dollars_from_cents(metrics.net_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= net_parts.join(" ") %></div>
+      </div>
+      <div class="rounded-lg border border-orange-200 bg-orange-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Outstanding</div>
+        <div class="mt-1 text-xl font-bold tabular-nums text-orange-600"><%= dollars_from_cents(metrics.outstanding_cents) %></div>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums">registration + CE owed</div>
+      </div>
+      <div class="rounded-lg border border-green-300 bg-green-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Total expected</div>
+        <div class="mt-1 text-xl font-bold tabular-nums text-gray-900"><%= dollars_from_cents(metrics.total_expected_cents) %></div>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums">net once all paid</div>
       </div>
     </div>
     <div class="mt-auto">

--- a/app/views/events/_revenue_summary.html.erb
+++ b/app/views/events/_revenue_summary.html.erb
@@ -1,0 +1,40 @@
+<%# Compact revenue headline for the statistics hub, linking to the full report.
+    Expects `report` (an EventRevenueReport) and `period` (its resolved
+    PeriodScope: #label, #year and #metrics). %>
+<div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+  <div class="flex items-center justify-between mb-4">
+    <h3 class="text-base font-semibold text-gray-900">Revenue</h3>
+    <%= link_to "Full report →", revenue_events_path(return_to: params[:return_to]),
+          class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+  </div>
+
+  <% if report.any? %>
+    <% metrics = period.metrics %>
+    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2"><%= period.label %></div>
+    <% ce_collected_cents = metrics.fees_cents - metrics.registration_payments_cents %>
+    <% net_parts = [ "Fees" ]
+       net_parts << "+ #{MoneyFormatter.compact_from_cents(metrics.funded_scholarship_cents, precision: 0)} scholarships" if metrics.funded_scholarship_cents.positive?
+       net_parts << "− #{MoneyFormatter.compact_from_cents(metrics.org_subsidy_cents, precision: 0)} subsidy" %>
+    <div class="grid grid-cols-2 gap-3 mb-4">
+      <div class="rounded-lg border border-blue-200 bg-blue-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fees collected</div>
+        <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= dollars_from_cents(metrics.fees_cents) %></div>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums">
+          <%= dollars_from_cents(metrics.registration_payments_cents) %> registration · <%= dollars_from_cents(ce_collected_cents) %> CE
+        </div>
+      </div>
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Net</div>
+        <div class="mt-1 text-xl font-bold tabular-nums <%= metrics.net_cents.negative? ? "text-rose-700" : "text-gray-900" %>"><%= signed_dollars_from_cents(metrics.net_cents) %></div>
+        <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= net_parts.join(" ") %></div>
+      </div>
+    </div>
+    <div class="mt-auto">
+      <%= column_chart report.chart_series, stacked: true, prefix: "$", thousands: ",",
+            colors: [ "#2563eb", "#c026d3", "#dc2626" ], height: "120px", legend: false,
+            library: { borderRadius: 3 } %>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 my-auto">No paid events yet.</p>
+  <% end %>
+</div>

--- a/app/views/events/_time_period_filter.html.erb
+++ b/app/views/events/_time_period_filter.html.erb
@@ -1,0 +1,11 @@
+<%# Calendar-year time-period filter shared by the revenue and participation
+    report forms (all time / this year / a specific year). The statistics hub
+    uses its own this-year/last-year/all-time period select. %>
+<div class="flex flex-col gap-1">
+  <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
+  <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
+  <%= select_tag :time_period,
+        options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),
+        class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+        onchange: "this.form.submit()" %>
+</div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -253,8 +253,17 @@
   <% end %>
 
   <%# Headcount cards — each expands to reveal its full list. One row of five on
-      large screens, wrapping to three then two as the viewport narrows. %>
-  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[minmax(0,4fr)_minmax(0,4fr)_minmax(0,5fr)_minmax(0,4fr)_minmax(0,3fr)] gap-3 sm:gap-4">
+      large screens (Organizations widest, States narrowest), wrapping to three
+      then two as the viewport narrows. The lg proportional widths are set by the
+      scoped rule below rather than an arbitrary Tailwind class
+      (lg:grid-cols-[minmax(0,4fr)_…]), which this project's Vite/Tailwind build
+      silently drops from the compiled CSS. %>
+  <style>
+    @media (min-width: 1024px) {
+      .event-headcount-cards { grid-template-columns: minmax(0, 4fr) minmax(0, 4fr) minmax(0, 5fr) minmax(0, 4fr) minmax(0, 3fr); }
+    }
+  </style>
+  <div class="event-headcount-cards grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,10 +14,10 @@
       </div>
       <div class="text-right text-end">
         <% if allowed_to?(:new?, Event) %>
-          <div class="admin-only bg-blue-100 flex flex-wrap justify-end gap-2">
-            <%= link_to "Revenue report",
-                        revenue_events_path,
-                        class: "whitespace-nowrap btn btn-secondary-outline" %>
+          <div class="admin-only bg-blue-100 flex flex-wrap items-center justify-end gap-4">
+            <%= link_to "Events statistics",
+                        statistics_events_path(return_to: "events"),
+                        class: "whitespace-nowrap text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
             <%= link_to "New event",
                         new_event_path,
                         class: "whitespace-nowrap btn btn-secondary-outline" %>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -55,23 +55,23 @@
                 value_class: "text-blue-700", card_class: "border-blue-300 bg-blue-100",
                 note: featured.attended_seats == featured.unique_people ? "fully attended" : "#{number_with_delimiter(featured.attended_seats)} seats",
                 prior: prior&.unique_people, prior_year: prior&.year,
-                href: event_registrations_path(attendance_status: "attended") %>
+                href: event_registrations_path(attendance_status: "attended", event_year: featured.year) %>
           <%= render "participation_kpi", label: "Partial (1-day)", value: featured.count_for("incomplete_attendance"),
                 value_class: "text-amber-700", card_class: "border-amber-300 bg-amber-50", note: "some days only",
                 prior: prior&.count_for("incomplete_attendance"), prior_year: prior&.year,
-                href: event_registrations_path(attendance_status: "incomplete_attendance") %>
+                href: event_registrations_path(attendance_status: "incomplete_attendance", event_year: featured.year) %>
           <%= render "participation_kpi", label: "No show", value: featured.count_for("no_show"),
                 value_class: "text-red-600", card_class: "border-red-300 bg-red-50", note: "registered, absent",
                 prior: prior&.count_for("no_show"), prior_year: prior&.year,
-                href: event_registrations_path(attendance_status: "no_show") %>
+                href: event_registrations_path(attendance_status: "no_show", event_year: featured.year) %>
           <%= render "participation_kpi", label: "Other", value: featured.count_other,
                 value_class: "text-purple-700", card_class: "border-purple-300 bg-purple-50", note: "registered, transfers, cancels",
                 prior: prior&.count_other, prior_year: prior&.year,
-                href: event_registrations_path(attendance_status: "other") %>
+                href: event_registrations_path(attendance_status: "other", event_year: featured.year) %>
           <%= render "participation_kpi", label: "Registrations", value: featured.total_registrations,
                 value_class: "text-gray-900", card_class: "border-gray-300 bg-gray-50", note: "all outcomes",
                 prior: prior&.total_registrations, prior_year: prior&.year,
-                href: event_registrations_path %>
+                href: event_registrations_path(event_year: featured.year) %>
         </div>
       </section>
 

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -1,0 +1,202 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% content_for(:full_width, true) %>
+
+<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+    <div class="mb-6">
+      <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]),
+              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <% else %>
+        <%= link_to "← Events statistics", statistics_events_path(return_to: params[:return_to]),
+              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <% end %>
+    </div>
+
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-gray-900">Events participation</h1>
+      <p class="text-gray-600 mt-1">
+        People who completed each training by year — counted as unique people, not seats.
+      </p>
+    </div>
+
+    <%# Ahoy-style filters — event, time period and event type — each
+        auto-submitting a GET form so the report reshapes on change. %>
+    <%= form_with url: participation_events_path, method: :get, local: true,
+          class: "flex flex-wrap items-end gap-4 mb-8" do %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
+      <%= render "event_filter" %>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
+        <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
+        <%= select_tag :time_period,
+              options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),
+              class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+              onchange: "this.form.submit()" %>
+      </div>
+      <%= render "event_type_filter" %>
+    <% end %>
+
+    <% if @report.any? %>
+      <% featured = @report.featured_year %>
+      <% prior = @report.prior_year %>
+
+      <%# Headline figures for the featured year: unique people fully attended,
+          with seats broken out when repeat attendees make them differ. %>
+      <section class="mb-8">
+        <div class="flex items-baseline gap-2 mb-3">
+          <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500"><%= featured.year || "All events" %></h2>
+          <% if featured.in_progress %>
+            <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded px-1.5 py-0.5">In progress</span>
+          <% end %>
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <%= render "participation_kpi", label: "People attended", value: featured.unique_people,
+                value_class: "text-blue-700", card_class: "border-blue-300 bg-blue-100",
+                note: featured.attended_seats == featured.unique_people ? "fully attended" : "#{number_with_delimiter(featured.attended_seats)} seats",
+                prior: prior&.unique_people, prior_year: prior&.year,
+                href: event_registrations_path(attendance_status: "attended") %>
+          <%= render "participation_kpi", label: "Partial (1-day)", value: featured.count_for("incomplete_attendance"),
+                value_class: "text-amber-700", card_class: "border-amber-300 bg-amber-50", note: "some days only",
+                prior: prior&.count_for("incomplete_attendance"), prior_year: prior&.year,
+                href: event_registrations_path(attendance_status: "incomplete_attendance") %>
+          <%= render "participation_kpi", label: "No show", value: featured.count_for("no_show"),
+                value_class: "text-red-600", card_class: "border-red-300 bg-red-50", note: "registered, absent",
+                prior: prior&.count_for("no_show"), prior_year: prior&.year,
+                href: event_registrations_path(attendance_status: "no_show") %>
+          <%= render "participation_kpi", label: "Other", value: featured.count_other,
+                value_class: "text-purple-700", card_class: "border-purple-300 bg-purple-50", note: "registered, transfers, cancels",
+                prior: prior&.count_other, prior_year: prior&.year %>
+          <%= render "participation_kpi", label: "Registrations", value: featured.total_registrations,
+                value_class: "text-gray-900", card_class: "border-gray-300 bg-gray-50", note: "all outcomes",
+                prior: prior&.total_registrations, prior_year: prior&.year,
+                href: event_registrations_path %>
+        </div>
+      </section>
+
+      <%# Attendance outcomes by year: attended / partial / no-show seats, one
+          stacked column per year. %>
+      <section class="mb-8">
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Attendance by year</h2>
+        <div class="rounded-xl border border-gray-200 bg-white p-4">
+          <%= column_chart @report.chart_series, stacked: true, thousands: ",",
+                colors: [ "#2563eb", "#d97706", "#dc2626" ], height: "260px", library: { borderRadius: 4 } %>
+        </div>
+      </section>
+
+      <%# Per-event detail, grouped by year. Each year leads with its subtotal;
+          each event expands to the full status breakdown. Shared column template
+          (--part-cols) keeps every row aligned. %>
+      <section data-controller="toggle-details" style="--part-cols: minmax(11rem, 1.8fr) repeat(5, minmax(5rem, 1fr))">
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500">By event</h2>
+          <button type="button" data-toggle-details-target="toggleBtn" data-action="toggle-details#toggleAll"
+                  class="text-xs font-medium <%= DomainTheme.text_class_for(:events, intensity: 700) %> hover:underline">
+            Expand all
+          </button>
+        </div>
+
+        <div class="grid items-center gap-x-3 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500"
+             style="grid-template-columns: var(--part-cols)">
+          <div>Event</div>
+          <div class="text-right">Attended</div>
+          <div class="text-right">Partial</div>
+          <div class="text-right">No show</div>
+          <div class="text-right">Other</div>
+          <div class="text-right">Registrations</div>
+        </div>
+
+        <% @report.years.each do |group| %>
+          <details class="group/year mb-4" open>
+            <summary class="grid items-center gap-x-3 px-3 py-2 bg-gray-100 border border-gray-200 rounded-lg group-open/year:rounded-b-none text-sm font-semibold text-gray-900 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:bg-gray-200"
+                     style="grid-template-columns: var(--part-cols)">
+              <div class="flex items-center gap-2">
+                <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform group-open/year:rotate-180"></i>
+                <span class="text-base"><%= group.year || "Undated" %></span>
+                <% if group.in_progress %>
+                  <span class="text-xs font-medium text-amber-700 bg-amber-100 rounded px-1.5 py-0.5">In progress</span>
+                <% end %>
+              </div>
+              <div class="text-right tabular-nums">
+                <%= number_with_delimiter(group.unique_people) %>
+                <% if group.attended_seats != group.unique_people %>
+                  <span class="text-xs font-normal text-gray-400">(<%= number_with_delimiter(group.attended_seats) %> seats)</span>
+                <% end %>
+              </div>
+              <div class="text-right tabular-nums text-amber-700"><%= number_with_delimiter(group.count_for("incomplete_attendance")) %></div>
+              <div class="text-right tabular-nums text-red-600"><%= number_with_delimiter(group.count_for("no_show")) %></div>
+              <div class="text-right tabular-nums text-purple-700"><%= number_with_delimiter(group.count_other) %></div>
+              <div class="text-right tabular-nums text-gray-500"><%= number_with_delimiter(group.total_registrations) %></div>
+            </summary>
+
+            <div class="border-x border-b border-gray-200 rounded-b-lg divide-y divide-gray-100 bg-white">
+              <% group.rows.each do |row| %>
+                <details class="group/card">
+                  <summary class="grid items-center gap-x-3 px-3 py-2.5 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:bg-gray-50"
+                           style="grid-template-columns: var(--part-cols)">
+                    <div class="min-w-0">
+                      <div class="flex items-center gap-2">
+                        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform group-open/card:rotate-180"></i>
+                        <span class="font-medium text-gray-900 truncate" title="<%= row.event.title %>"><%= row.event.compact_label %></span>
+                      </div>
+                      <div class="text-xs text-gray-500 pl-5"><%= row.event.date_range %></div>
+                    </div>
+                    <div class="text-right tabular-nums text-gray-900"><%= number_with_delimiter(row.attended_seats) %></div>
+                    <div class="text-right tabular-nums text-amber-700"><%= number_with_delimiter(row.count_for("incomplete_attendance")) %></div>
+                    <div class="text-right tabular-nums text-red-600"><%= number_with_delimiter(row.count_for("no_show")) %></div>
+                    <div class="text-right tabular-nums text-purple-700"><%= number_with_delimiter(row.count_other) %></div>
+                    <div class="text-right tabular-nums text-gray-500"><%= number_with_delimiter(row.total_registrations) %></div>
+                  </summary>
+                  <div class="px-3 pb-3 pl-8 bg-gray-50">
+                    <%# Each outcome links to this event's registrants filtered to that status.
+                        Inline grid-template-columns (like the revenue table) so all seven
+                        outcomes sit in one row without relying on a generated grid-cols-7. %>
+                    <div class="grid gap-x-4 gap-y-2 text-sm py-2"
+                         style="grid-template-columns: repeat(7, minmax(0, 1fr))">
+                      <% EventParticipationReport::STATUS_LABELS.each do |status, label| %>
+                        <%= link_to event_registrations_path(event_id: row.event.id, attendance_status: status),
+                              class: "flex items-baseline justify-between gap-2 rounded px-1 -mx-1 hover:bg-white transition-colors" do %>
+                          <span class="text-gray-500 whitespace-nowrap"><%= label %></span>
+                          <span class="tabular-nums text-gray-800"><%= number_with_delimiter(row.count_for(status)) %></span>
+                        <% end %>
+                      <% end %>
+                    </div>
+                    <%= link_to "Open event dashboard →", dashboard_event_path(row.event),
+                          class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+                  </div>
+                </details>
+              <% end %>
+            </div>
+          </details>
+        <% end %>
+
+        <div class="grid items-center gap-x-3 px-3 py-3 mt-2 bg-gray-200 border border-gray-300 rounded-lg text-base font-bold text-gray-900"
+             style="grid-template-columns: var(--part-cols)">
+          <div class="uppercase tracking-wide text-xs text-gray-600">All years</div>
+          <div class="text-right tabular-nums">
+            <%= number_with_delimiter(@report.unique_people) %>
+            <% if @report.attended_seats != @report.unique_people %>
+              <span class="text-xs font-normal text-gray-500">(<%= number_with_delimiter(@report.attended_seats) %> seats)</span>
+            <% end %>
+          </div>
+          <div class="text-right tabular-nums text-amber-700"><%= number_with_delimiter(@report.count_for("incomplete_attendance")) %></div>
+          <div class="text-right tabular-nums text-red-600"><%= number_with_delimiter(@report.count_for("no_show")) %></div>
+          <div class="text-right tabular-nums text-purple-700"><%= number_with_delimiter(@report.count_other) %></div>
+          <div class="text-right tabular-nums text-gray-700"><%= number_with_delimiter(@report.total_registrations) %></div>
+        </div>
+
+        <p class="mt-3 text-xs text-gray-500">
+          <span class="font-medium">Attended</span> = fully attended (all event days). The headline counts
+          <span class="font-medium">unique people</span>; <span class="font-medium">seats</span> counts attended registrations,
+          so they differ when someone completes more than one training in the period.
+          <span class="font-medium">Partial</span> = attended some but not all days.
+          Expand an event for the full outcome breakdown (transfers, cancellations, no-shows).
+        </p>
+      </section>
+    <% else %>
+      <div class="text-center py-12 text-gray-500">
+        No events match this filter yet — once trainings run and attendance is recorded, you'll see participation by year here.
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -16,7 +16,7 @@
     <div class="mb-6">
       <h1 class="text-2xl font-semibold text-gray-900">Events participation</h1>
       <p class="text-gray-600 mt-1">
-        People who completed each training by year — counted as unique people, not seats.
+        People who attended each event by year — counted as unique people, not seats.
       </p>
     </div>
 
@@ -66,7 +66,8 @@
                 href: event_registrations_path(attendance_status: "no_show") %>
           <%= render "participation_kpi", label: "Other", value: featured.count_other,
                 value_class: "text-purple-700", card_class: "border-purple-300 bg-purple-50", note: "registered, transfers, cancels",
-                prior: prior&.count_other, prior_year: prior&.year %>
+                prior: prior&.count_other, prior_year: prior&.year,
+                href: event_registrations_path(attendance_status: "other") %>
           <%= render "participation_kpi", label: "Registrations", value: featured.total_registrations,
                 value_class: "text-gray-900", card_class: "border-gray-300 bg-gray-50", note: "all outcomes",
                 prior: prior&.total_registrations, prior_year: prior&.year,

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -20,21 +20,14 @@
       </p>
     </div>
 
-    <%# Ahoy-style filters — event, time period and event type — each
+    <%# Ahoy-style filters — time period, event type and event — each
         auto-submitting a GET form so the report reshapes on change. %>
     <%= form_with url: participation_events_path, method: :get, local: true,
           class: "flex flex-wrap items-end gap-4 mb-8" do %>
       <%= hidden_field_tag :return_to, params[:return_to] %>
-      <%= render "event_filter" %>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
-        <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
-        <%= select_tag :time_period,
-              options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),
-              class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
-              onchange: "this.form.submit()" %>
-      </div>
+      <%= render "time_period_filter" %>
       <%= render "event_type_filter" %>
+      <%= render "event_filter" %>
     <% end %>
 
     <% if @report.any? %>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -5,11 +5,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]),
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% else %>
-        <%= link_to "← Events statistics", statistics_events_path(return_to: params[:return_to]),
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Events statistics", statistics_events_path(report_to_statistics_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% end %>
     </div>
 

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -20,21 +20,14 @@
       </p>
     </div>
 
-    <%# Ahoy-style filters shared with the participation report — event, time
-        period and event type — each auto-submitting a GET form. %>
+    <%# Ahoy-style filters shared with the participation report — time period,
+        event type and event — each auto-submitting a GET form. %>
     <%= form_with url: revenue_events_path, method: :get, local: true,
           class: "flex flex-wrap items-end gap-4 mb-8" do %>
       <%= hidden_field_tag :return_to, params[:return_to] %>
-      <%= render "event_filter", all_label: "All paid events" %>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
-        <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
-        <%= select_tag :time_period,
-              options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),
-              class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
-              onchange: "this.form.submit()" %>
-      </div>
+      <%= render "time_period_filter" %>
       <%= render "event_type_filter", all_label: "All paid events" %>
+      <%= render "event_filter", all_label: "All paid events" %>
     <% end %>
 
     <% if @report.any? %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -25,7 +25,7 @@
     <%= form_with url: revenue_events_path, method: :get, local: true,
           class: "flex flex-wrap items-end gap-4 mb-8" do %>
       <%= hidden_field_tag :return_to, params[:return_to] %>
-      <%= render "event_filter" %>
+      <%= render "event_filter", all_label: "All paid events" %>
       <div class="flex flex-col gap-1">
         <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
         <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
@@ -34,7 +34,7 @@
               class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
               onchange: "this.form.submit()" %>
       </div>
-      <%= render "event_type_filter" %>
+      <%= render "event_type_filter", all_label: "All paid events" %>
     <% end %>
 
     <% if @report.any? %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -8,17 +8,34 @@
         <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]),
               class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
       <% else %>
-        <%= link_to "← Events", events_path,
+        <%= link_to "← Events statistics", statistics_events_path(return_to: params[:return_to]),
               class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
       <% end %>
     </div>
 
     <div class="mb-8">
-      <h1 class="text-2xl font-semibold text-gray-900">Event revenue</h1>
+      <h1 class="text-2xl font-semibold text-gray-900">Events revenue</h1>
       <p class="text-gray-600 mt-1">
         Program revenue by year — money in, what the org subsidized from its own funds, and the net.
       </p>
     </div>
+
+    <%# Ahoy-style filters shared with the participation report — event, time
+        period and event type — each auto-submitting a GET form. %>
+    <%= form_with url: revenue_events_path, method: :get, local: true,
+          class: "flex flex-wrap items-end gap-4 mb-8" do %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
+      <%= render "event_filter" %>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-gray-600" for="time_period">Time period</label>
+        <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
+        <%= select_tag :time_period,
+              options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),
+              class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+              onchange: "this.form.submit()" %>
+      </div>
+      <%= render "event_type_filter" %>
+    <% end %>
 
     <% if @report.any? %>
       <% featured = @report.featured_year %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -5,11 +5,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]),
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% else %>
-        <%= link_to "← Events statistics", statistics_events_path(return_to: params[:return_to]),
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Events statistics", statistics_events_path(report_to_statistics_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% end %>
     </div>
 

--- a/app/views/events/statistics.html.erb
+++ b/app/views/events/statistics.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% content_for(:full_width, true) %>
+
+<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+    <div class="mb-6">
+      <% if params[:return_to] == "events" %>
+        <%= link_to "← Events", events_path,
+              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <% else %>
+        <%= link_to "← Admin home", admin_path,
+              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <% end %>
+    </div>
+
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-gray-900">Events statistics</h1>
+      <p class="text-gray-600 mt-1">
+        Revenue and participation at a glance — open a full report for the year-by-year detail.
+      </p>
+    </div>
+
+    <%# Filters driving both summary cards — event, time period and event type —
+        matching the filter selects on the full revenue and participation reports. %>
+    <%= form_with url: statistics_events_path, method: :get, local: true,
+          class: "flex flex-wrap items-end gap-4 mb-6" do %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
+      <%= render "event_filter" %>
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-gray-600" for="period">Time period</label>
+        <%= select_tag :period,
+              options_for_select([ [ "This year", "this_year" ], [ "Last year", "last_year" ], [ "All time", "all_time" ] ], @period),
+              class: "px-3 py-2 rounded-md border-gray-300 shadow-sm text-sm text-gray-700",
+              onchange: "this.form.submit()" %>
+      </div>
+      <%= render "event_type_filter" %>
+    <% end %>
+
+    <div class="flex flex-col md:flex-row gap-6">
+      <div class="flex-1 min-w-0">
+        <%= render "events/revenue_summary", report: @revenue_report, period: @revenue_report.period_scope(@period) %>
+      </div>
+      <div class="flex-1 min-w-0">
+        <%= render "events/participation_summary", report: @participation_report, period: @participation_report.period_scope(@period) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/events/statistics.html.erb
+++ b/app/views/events/statistics.html.erb
@@ -5,11 +5,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if params[:return_to] == "events" %>
-        <%= link_to "← Events", events_path,
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% else %>
-        <%= link_to "← Admin home", admin_path,
-              class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+        <%= link_to "← Admin home", admin_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
       <% end %>
     </div>
 

--- a/app/views/events/statistics.html.erb
+++ b/app/views/events/statistics.html.erb
@@ -20,12 +20,11 @@
       </p>
     </div>
 
-    <%# Filters driving both summary cards — event, time period and event type —
+    <%# Filters driving both summary cards — time period, event type and event —
         matching the filter selects on the full revenue and participation reports. %>
     <%= form_with url: statistics_events_path, method: :get, local: true,
           class: "flex flex-wrap items-end gap-4 mb-6" do %>
       <%= hidden_field_tag :return_to, params[:return_to] %>
-      <%= render "event_filter" %>
       <div class="flex flex-col gap-1">
         <label class="text-xs font-medium text-gray-600" for="period">Time period</label>
         <%= select_tag :period,
@@ -34,6 +33,7 @@
               onchange: "this.form.submit()" %>
       </div>
       <%= render "event_type_filter" %>
+      <%= render "event_filter" %>
     <% end %>
 
     <div class="flex flex-col md:flex-row gap-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,8 @@ Rails.application.routes.draw do
   resources :events do
     collection do
       get :revenue
+      get :participation
+      get :statistics
     end
     member do
       get :dashboard

--- a/config/vite.json
+++ b/config/vite.json
@@ -1,7 +1,12 @@
 {
   "all": {
     "sourceCodeDir": "app/frontend",
-    "watchAdditionalPaths": []
+    "watchAdditionalPaths": [
+      "app/views/**/*",
+      "app/helpers/**/*.rb",
+      "app/decorators/**/*.rb",
+      "app/presenters/**/*.rb"
+    ]
   },
   "development": {
     "autoBuild": true,

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#date_title" do
+    it "labels the event by date and title, without the time or parens" do
+      event = build(:event, title: "Youth Creativity Day", start_date: Time.zone.local(2026, 9, 14, 14, 9))
+      expect(event.date_title).to eq("2026-09-14 — Youth Creativity Day")
+    end
+  end
+
   describe "#ended?" do
     it "returns true when end_date is in the past" do
       event = build(:event, end_date: 1.day.ago)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe ".in_year" do
+    it "matches events by the calendar year of their start date" do
+      in_year = create(:event, start_date: Time.zone.parse("2025-06-01 09:00"))
+      other_year = create(:event, start_date: Time.zone.parse("2024-06-01 09:00"))
+      expect(Event.in_year(2025)).to include(in_year)
+      expect(Event.in_year(2025)).not_to include(other_year)
+    end
+
+    it "includes a same-day start time on Dec 31 (not just midnight)" do
+      nye = create(:event, start_date: Time.zone.parse("2025-12-31 09:00"))
+      expect(Event.in_year(2025)).to include(nye)
+    end
+  end
+
   describe "#ended?" do
     it "returns true when end_date is in the past" do
       event = build(:event, end_date: 1.day.ago)

--- a/spec/requests/admin/home_spec.rb
+++ b/spec/requests/admin/home_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe "Admin::Home", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "links to the event revenue report and still surfaces payments" do
+    it "links to events statistics and still surfaces payments" do
       get admin_path
-      expect(response.body).to include("Events revenue")
-      expect(response.body).to include(revenue_events_path)
+      expect(response.body).to include("Events statistics")
+      expect(response.body).to include(statistics_events_path)
       expect(response.body).to include("Payments")
     end
   end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).not_to include(attended.registrant.first_name)
       end
 
+      it "filters registrations by event year" do
+        this_year = create(:event_registration, event: create(:event, start_date: Date.new(2026, 5, 1)))
+        last_year = create(:event_registration, event: create(:event, start_date: Date.new(2025, 5, 1)))
+
+        get event_registrations_path(event_year: 2026)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(this_year.registrant.first_name)
+        expect(response.body).not_to include(last_year.registrant.first_name)
+      end
+
       it "filters registrations by event type" do
         training_reg = create(:event_registration, event: create(:event, facilitator_training: true))
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).not_to include(existing_registration.registrant.first_name)
       end
 
+      it "filters registrations to 'other' outcomes (not attended/partial/no-show)" do
+        cancelled = create(:event_registration, status: "cancelled")
+        attended = create(:event_registration, status: "attended")
+
+        get event_registrations_path(attendance_status: "other")
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(cancelled.registrant.first_name)
+        expect(response.body).to include(existing_registration.registrant.first_name) # registered
+        expect(response.body).not_to include(attended.registrant.first_name)
+      end
+
       it "filters registrations by event type" do
         training_reg = create(:event_registration, event: create(:event, facilitator_training: true))
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response).to have_http_status(:success)
       end
 
+      it "links to the selected event's dashboard when one is filtered" do
+        event.update!(abbreviation: "TAC261")
+        get event_registrations_path(event_id: event.id)
+        expect(response.body).to include("TAC261 event dashboard")
+        expect(response.body).to include(dashboard_event_path(event))
+      end
+
+      it "shows no event-dashboard link with no event filtered" do
+        get event_registrations_path
+        expect(response.body).not_to include("event dashboard")
+      end
+
       it "filters registrations by organization_id" do
         organization = create(:organization)
         matching_reg = create(:event_registration)
@@ -42,6 +54,24 @@ RSpec.describe "EventRegistrations", type: :request do
         get event_registrations_path(ce_status: "needs_license")
         expect(response).to have_http_status(:success)
         expect(response.body).to include(needs_license.registrant.first_name)
+        expect(response.body).not_to include(existing_registration.registrant.first_name)
+      end
+
+      it "filters registrations by attendance status" do
+        no_show = create(:event_registration, status: "no_show")
+
+        get event_registrations_path(attendance_status: "no_show")
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(no_show.registrant.first_name)
+        expect(response.body).not_to include(existing_registration.registrant.first_name)
+      end
+
+      it "filters registrations by event type" do
+        training_reg = create(:event_registration, event: create(:event, facilitator_training: true))
+
+        get event_registrations_path(event_type: "trainings")
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(training_reg.registrant.first_name)
         expect(response.body).not_to include(existing_registration.registrant.first_name)
       end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Events", type: :request do
         sign_in admin
         get revenue_events_path
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Event revenue")
+        expect(response.body).to include("Events revenue")
         expect(response.body).to include("Revenue by year")
         expect(response.body).to include("Fees collected")
         expect(response.body).to include("TAC 261")
@@ -162,11 +162,48 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include('title="TAC 261"')
       end
 
+      # The Event dropdown lists every (paid) event, so the report rows are
+      # identified by their per-event dashboard link rather than the title.
+      it "narrows to facilitator trainings by event type" do
+        sign_in admin
+        get revenue_events_path(event_type: "trainings")
+        expect(response.body).to include(dashboard_event_path(paid_training))
+        expect(response.body).not_to include(dashboard_event_path(paid_webinar))
+      end
+
+      it "narrows to non-trainings by event type" do
+        sign_in admin
+        get revenue_events_path(event_type: "other")
+        expect(response.body).to include(dashboard_event_path(paid_webinar))
+        expect(response.body).not_to include(dashboard_event_path(paid_training))
+      end
+
+      it "narrows to a single selected event" do
+        sign_in admin
+        get revenue_events_path(event_id: paid_training.id)
+        expect(response.body).to include(dashboard_event_path(paid_training))
+        expect(response.body).not_to include(dashboard_event_path(paid_webinar))
+      end
+
+      it "narrows to a single calendar year" do
+        sign_in admin
+        get revenue_events_path(time_period: "2025")
+        expect(response.body).to include(dashboard_event_path(paid_webinar))
+        expect(response.body).not_to include(dashboard_event_path(paid_training))
+      end
+
       it "returns to the originating event's dashboard when arrived from it" do
         sign_in admin
         get revenue_events_path(return_to: "dashboard", event_id: paid_training.id)
         expect(response.body).to include(dashboard_event_path(paid_training))
         expect(response.body).to include("← Dashboard")
+      end
+
+      it "carries the statistics origin back through the eyebrow" do
+        sign_in admin
+        get revenue_events_path(return_to: "events")
+        expect(response.body).to include("← Events statistics")
+        expect(response.body).to include(statistics_events_path(return_to: "events"))
       end
     end
 
@@ -174,6 +211,128 @@ RSpec.describe "Events", type: :request do
       it "redirects" do
         sign_in user
         get revenue_events_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "GET /participation" do
+    let!(:training_2026) { create(:event, title: "TAC 261", facilitator_training: true, start_date: Date.new(2026, 5, 1)) }
+    let!(:webinar_2025) { create(:event, title: "Open webinar", facilitator_training: false, start_date: Date.new(2025, 5, 1)) }
+
+    before do
+      create(:event_registration, event: training_2026, status: "attended")
+      create(:event_registration, event: training_2026, status: "no_show")
+      create(:event_registration, event: webinar_2025, status: "attended")
+    end
+
+    context "as admin" do
+      it "lists every event grouped by year by default" do
+        sign_in admin
+        get participation_events_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Events participation")
+        expect(response.body).to include("Attendance by year")
+        expect(response.body).to include("TAC 261")
+        expect(response.body).to include("Open webinar")
+        expect(response.body).to include("2026", "2025")
+      end
+
+      # The Event dropdown lists every event, so the report rows are identified by
+      # their per-event dashboard link rather than the title.
+      it "narrows to facilitator trainings by event type" do
+        sign_in admin
+        get participation_events_path(event_type: "trainings")
+        expect(response.body).to include(dashboard_event_path(training_2026))
+        expect(response.body).not_to include(dashboard_event_path(webinar_2025))
+      end
+
+      it "narrows to non-trainings by event type" do
+        sign_in admin
+        get participation_events_path(event_type: "other")
+        expect(response.body).to include(dashboard_event_path(webinar_2025))
+        expect(response.body).not_to include(dashboard_event_path(training_2026))
+      end
+
+      it "narrows to a single selected event" do
+        sign_in admin
+        get participation_events_path(event_id: training_2026.id)
+        expect(response.body).to include(dashboard_event_path(training_2026))
+        expect(response.body).not_to include(dashboard_event_path(webinar_2025))
+      end
+
+      it "narrows to a single calendar year" do
+        sign_in admin
+        get participation_events_path(time_period: "2025")
+        expect(response.body).to include(dashboard_event_path(webinar_2025))
+        expect(response.body).not_to include(dashboard_event_path(training_2026))
+      end
+
+      it "carries the statistics origin back through the eyebrow and the filter form" do
+        sign_in admin
+        get participation_events_path(return_to: "events")
+        expect(response.body).to include("← Events statistics")
+        expect(response.body).to include(statistics_events_path(return_to: "events"))
+        expect(response.body).to match(/<input[^>]*name="return_to"[^>]*value="events"/)
+      end
+    end
+
+    context "as non-admin" do
+      it "redirects" do
+        sign_in user
+        get participation_events_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "GET /statistics" do
+    let!(:training) { create(:event, facilitator_training: true, cost_cents: 10_000, start_date: Date.current) }
+
+    before { create(:event_registration, event: training, status: "attended") }
+
+    context "as admin" do
+      it "shows the revenue and participation summaries side by side" do
+        sign_in admin
+        get statistics_events_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Events statistics")
+        expect(response.body).to include("Revenue")
+        expect(response.body).to include("Participation")
+        expect(response.body).to include("People attended")
+        expect(response.body).to match(/\d+ trainings/)
+        expect(response.body).to match(/\d+ other/)
+        # The trainings/other split links into the filtered registrants index.
+        expect(response.body).to include("event_type=trainings", "attendance_status=attended")
+        expect(response.body).to include(revenue_events_path, participation_events_path)
+      end
+
+      it "toggles the summary figures to all time via the period select" do
+        sign_in admin
+        get statistics_events_path(period: "all_time")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("All time")
+        expect(response.body).to match(/<select[^>]*name="period"/)
+      end
+
+      it "returns to the admin home by default" do
+        sign_in admin
+        get statistics_events_path
+        expect(response.body).to include("← Admin home")
+      end
+
+      it "returns to the events index when arrived from it" do
+        sign_in admin
+        get statistics_events_path(return_to: "events")
+        expect(response.body).to include("← Events")
+        expect(response.body).to include(events_path)
+      end
+    end
+
+    context "as non-admin" do
+      it "redirects" do
+        sign_in user
+        get statistics_events_path
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -199,11 +199,13 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("← Dashboard")
       end
 
-      it "carries the statistics origin back through the eyebrow" do
+      it "carries the statistics origin and active filters back through the eyebrow" do
         sign_in admin
-        get revenue_events_path(return_to: "events")
+        get revenue_events_path(return_to: "events", event_type: "trainings", event_id: paid_training.id)
         expect(response.body).to include("← Events statistics")
-        expect(response.body).to include(statistics_events_path(return_to: "events"))
+        expect(response.body).to include(
+          CGI.escapeHTML(statistics_events_path(return_to: "events", event_type: "trainings", event_id: paid_training.id, period: "all_time"))
+        )
       end
     end
 
@@ -268,11 +270,13 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include(dashboard_event_path(training_2026))
       end
 
-      it "carries the statistics origin back through the eyebrow and the filter form" do
+      it "carries the statistics origin and active filters back through the eyebrow and the filter form" do
         sign_in admin
-        get participation_events_path(return_to: "events")
+        get participation_events_path(return_to: "events", event_type: "trainings", event_id: training_2026.id)
         expect(response.body).to include("← Events statistics")
-        expect(response.body).to include(statistics_events_path(return_to: "events"))
+        expect(response.body).to include(
+          CGI.escapeHTML(statistics_events_path(return_to: "events", event_type: "trainings", event_id: training_2026.id, period: "all_time"))
+        )
         expect(response.body).to match(/<input[^>]*name="return_to"[^>]*value="events"/)
       end
     end
@@ -305,6 +309,13 @@ RSpec.describe "Events", type: :request do
         # The trainings/other split links into the filtered registrants index.
         expect(response.body).to include("event_type=trainings", "attendance_status=attended")
         expect(response.body).to include(revenue_events_path, participation_events_path)
+      end
+
+      it "carries the active filters into the full report links" do
+        sign_in admin
+        get statistics_events_path(period: "all_time", event_type: "trainings")
+        expect(response.body).to include(CGI.escapeHTML(revenue_events_path(event_type: "trainings", time_period: "all_time")))
+        expect(response.body).to include(CGI.escapeHTML(participation_events_path(event_type: "trainings", time_period: "all_time")))
       end
 
       it "toggles the summary figures to all time via the period select" do

--- a/spec/services/event_participation_report_spec.rb
+++ b/spec/services/event_participation_report_spec.rb
@@ -1,0 +1,229 @@
+require "rails_helper"
+
+RSpec.describe EventParticipationReport do
+  describe "per-event outcome counts" do
+    subject(:report) { described_class.new([ event ]) }
+
+    let(:event) { create(:event) }
+
+    before do
+      create(:event_registration, event: event, status: "attended")
+      create(:event_registration, event: event, status: "attended")
+      create(:event_registration, event: event, status: "incomplete_attendance")
+      create(:event_registration, event: event, status: "no_show")
+      create(:event_registration, event: event, status: "cancelled")
+      create(:event_registration, event: event, status: "registered")
+    end
+
+    let(:row) { report.rows.first }
+
+    it "counts each outcome by status" do
+      expect(row.attended_seats).to eq(2)
+      expect(row.count_for("incomplete_attendance")).to eq(1)
+      expect(row.count_for("no_show")).to eq(1)
+      expect(row.count_for("cancelled")).to eq(1)
+      expect(row.count_for("registered")).to eq(1)
+      expect(row.count_for("transferred_out")).to eq(0)
+    end
+
+    it "totals every registration regardless of outcome" do
+      expect(row.total_registrations).to eq(6)
+    end
+
+    it "buckets the remaining outcomes into 'other' so the four sum to registrations" do
+      expect(row.count_other).to eq(2) # registered + cancelled
+      buckets = row.attended_seats + row.count_for("incomplete_attendance") + row.count_for("no_show") + row.count_other
+      expect(buckets).to eq(row.total_registrations)
+    end
+
+    it "treats attended seats as unique people for a single event" do
+      expect(row.unique_people).to eq(row.attended_seats)
+    end
+  end
+
+  describe "unique people vs seats across events" do
+    let(:person) { create(:person) }
+    let(:event_a) { create(:event, start_date: Date.new(2026, 3, 1)) }
+    let(:event_b) { create(:event, start_date: Date.new(2026, 6, 1)) }
+
+    subject(:report) { described_class.new([ event_a, event_b ], current_year: 2026) }
+
+    before do
+      # The same person completes both trainings in 2026: two attended seats,
+      # but one person trained.
+      create(:event_registration, event: event_a, registrant: person, status: "attended")
+      create(:event_registration, event: event_b, registrant: person, status: "attended")
+      create(:event_registration, event: event_b, status: "attended")
+    end
+
+    it "sums attended seats additively" do
+      expect(report.attended_seats).to eq(3)
+    end
+
+    it "counts unique people distinctly, not by summing rows" do
+      expect(report.unique_people).to eq(2)
+    end
+
+    it "counts unique people per year distinctly in the subtotal" do
+      year = report.years.first
+      expect(year.year).to eq(2026)
+      expect(year.attended_seats).to eq(3)
+      expect(year.unique_people).to eq(2)
+    end
+  end
+
+  describe "#training_split" do
+    let(:person_both) { create(:person) }
+    let(:training) { create(:event, facilitator_training: true, start_date: Date.new(2026, 4, 1)) }
+    let(:webinar) { create(:event, facilitator_training: false, start_date: Date.new(2026, 4, 1)) }
+
+    subject(:report) { described_class.new([ training, webinar ], current_year: 2026) }
+
+    before do
+      # person_both attends a training and a non-training; two others attend one each.
+      create(:event_registration, event: training, registrant: person_both, status: "attended")
+      create(:event_registration, event: webinar, registrant: person_both, status: "attended")
+      create(:event_registration, event: training, status: "attended")
+      create(:event_registration, event: webinar, status: "attended")
+    end
+
+    it "counts distinct attendees on each side, counting cross-attenders in both" do
+      split = report.training_split
+      expect(split[:trainings]).to eq(2)
+      expect(split[:non_trainings]).to eq(2)
+      # Only three distinct people overall — the cross-attender is in both buckets.
+      expect(report.unique_people).to eq(3)
+    end
+
+    it "narrows the split to a calendar year" do
+      older = create(:event, facilitator_training: true, start_date: Date.new(2025, 4, 1))
+      create(:event_registration, event: older, status: "attended")
+      scoped = described_class.new([ training, webinar, older ], current_year: 2026)
+
+      expect(scoped.training_split[:trainings]).to eq(3)
+      expect(scoped.training_split(year: 2026)[:trainings]).to eq(2)
+    end
+  end
+
+  describe "#registrations_split" do
+    let(:training) { create(:event, facilitator_training: true, start_date: Date.new(2026, 4, 1)) }
+    let(:webinar) { create(:event, facilitator_training: false, start_date: Date.new(2026, 4, 1)) }
+
+    subject(:report) { described_class.new([ training, webinar ], current_year: 2026) }
+
+    before do
+      create(:event_registration, event: training, status: "attended")
+      create(:event_registration, event: training, status: "no_show")
+      create(:event_registration, event: webinar, status: "registered")
+    end
+
+    it "sums every registration on each side regardless of outcome" do
+      split = report.registrations_split
+      expect(split[:trainings]).to eq(2)
+      expect(split[:non_trainings]).to eq(1)
+    end
+  end
+
+  describe "#demographics" do
+    let(:event) { create(:event, start_date: Date.new(2026, 5, 1)) }
+    let(:person) { create(:person) }
+
+    subject(:report) { described_class.new([ event ], current_year: 2026) }
+
+    before do
+      registration = create(:event_registration, event: event, registrant: person, status: "attended")
+      create(:event_registration_organization, event_registration: registration, organization: create(:organization))
+      create(:sectorable_item, sectorable: person, sector: create(:sector))
+      create(:address, addressable: person, state: "CA", country: "US")
+    end
+
+    it "counts distinct orgs, sectors, states and countries via registrants" do
+      reach = report.demographics
+      expect(reach.organizations).to eq(1)
+      expect(reach.sectors).to eq(1)
+      expect(reach.states).to eq(1)
+      expect(reach.countries).to eq(1)
+    end
+  end
+
+  describe "#period_scope" do
+    let(:this_year) { create(:event, start_date: Date.new(2026, 5, 1)) }
+    let(:last_year) { create(:event, start_date: Date.new(2025, 5, 1)) }
+
+    subject(:report) { described_class.new([ this_year, last_year ], current_year: 2026) }
+
+    before do
+      create(:event_registration, event: this_year, status: "attended")
+      create(:event_registration, event: last_year, status: "attended")
+      create(:event_registration, event: last_year, status: "attended")
+    end
+
+    it "resolves this year to the current year's group" do
+      period = report.period_scope("this_year")
+      expect(period.label).to eq("2026")
+      expect(period.year).to eq(2026)
+      expect(period.metrics.unique_people).to eq(1)
+    end
+
+    it "resolves last year to the prior year's group" do
+      period = report.period_scope("last_year")
+      expect(period.label).to eq("2025")
+      expect(period.metrics.unique_people).to eq(2)
+    end
+
+    it "resolves all time to the whole report" do
+      period = report.period_scope("all_time")
+      expect(period.label).to eq("All time")
+      expect(period.year).to be_nil
+      expect(period.metrics).to eq(report)
+      expect(period.metrics.unique_people).to eq(3)
+    end
+
+    it "yields a zeroed group for a year with no events" do
+      period = report.period_scope("this_year", current_year: 2030)
+      expect(period.label).to eq("2030")
+      expect(period.metrics.unique_people).to eq(0)
+      expect(period.metrics.total_registrations).to eq(0)
+    end
+  end
+
+  describe "grouping over time" do
+    let(:e2024) { create(:event, start_date: Date.new(2024, 5, 1)) }
+    let(:e2025) { create(:event, start_date: Date.new(2025, 5, 1)) }
+    let(:e2026) { create(:event, start_date: Date.new(2026, 5, 1)) }
+
+    subject(:report) { described_class.new([ e2026, e2024, e2025 ], current_year: 2026) }
+
+    it "groups events by calendar year, newest first, flagging the current year" do
+      expect(report.years.map(&:year)).to eq([ 2026, 2025, 2024 ])
+      expect(report.years.first.in_progress).to be(true)
+      expect(report.years.last.in_progress).to be(false)
+    end
+
+    it "features the current year by default, with the next older year as prior" do
+      expect(report.featured_year.year).to eq(2026)
+      expect(report.prior_year.year).to eq(2025)
+    end
+
+    it "features an explicit year when given" do
+      scoped = described_class.new([ e2026, e2024, e2025 ], current_year: 2026, featured_year: 2024)
+      expect(scoped.featured_year.year).to eq(2024)
+      expect(scoped.prior_year).to be_nil
+    end
+
+    it "builds an oldest-to-newest stacked series: attended, partial, no show" do
+      series = report.chart_series
+      expect(series.map { |s| s[:name] }).to eq([ "Attended", "Partial (1-day)", "No show" ])
+      expect(series.first[:data].map(&:first)).to eq(%w[2024 2025 2026])
+    end
+  end
+
+  describe "an empty report" do
+    subject(:report) { described_class.new([]) }
+
+    it "has no rows and reports zero people" do
+      expect(report.any?).to be(false)
+      expect(report.unique_people).to eq(0)
+    end
+  end
+end

--- a/spec/services/event_participation_report_spec.rb
+++ b/spec/services/event_participation_report_spec.rb
@@ -130,11 +130,14 @@ RSpec.describe EventParticipationReport do
 
     subject(:report) { described_class.new([ event ], current_year: 2026) }
 
+    let(:organization) { create(:organization) }
+
     before do
       registration = create(:event_registration, event: event, registrant: person, status: "attended")
-      create(:event_registration_organization, event_registration: registration, organization: create(:organization))
+      create(:event_registration_organization, event_registration: registration, organization: organization)
       create(:sectorable_item, sectorable: person, sector: create(:sector))
       create(:address, addressable: person, state: "CA", country: "US")
+      create(:address, addressable: organization, city: "Los Angeles")
     end
 
     it "counts distinct orgs, sectors, states and countries via registrants" do
@@ -143,6 +146,10 @@ RSpec.describe EventParticipationReport do
       expect(reach.sectors).to eq(1)
       expect(reach.states).to eq(1)
       expect(reach.countries).to eq(1)
+    end
+
+    it "counts distinct cities from the linked organizations' addresses" do
+      expect(report.demographics.cities).to eq(1)
     end
   end
 

--- a/spec/services/money_formatter_spec.rb
+++ b/spec/services/money_formatter_spec.rb
@@ -43,9 +43,12 @@ RSpec.describe MoneyFormatter do
       expect(described_class.compact_from_cents(120_000_000)).to eq("$1.2m")
     end
 
-    it "rounds to whole units at precision 0" do
+    it "rounds to whole units at precision 0 — rounding, not flooring" do
       expect(described_class.compact_from_cents(1_517_000, precision: 0)).to eq("$15k")
       expect(described_class.compact_from_cents(420_000, precision: 0)).to eq("$4k")
+      # $15,700 rounds up to $16k (a floor would give $15k).
+      expect(described_class.compact_from_cents(1_570_000, precision: 0)).to eq("$16k")
+      expect(described_class.compact_from_cents(1_540_000, precision: 0)).to eq("$15k")
     end
   end
 end

--- a/spec/services/money_formatter_spec.rb
+++ b/spec/services/money_formatter_spec.rb
@@ -42,5 +42,10 @@ RSpec.describe MoneyFormatter do
       expect(described_class.compact_from_cents(1_000_000)).to eq("$10k")
       expect(described_class.compact_from_cents(120_000_000)).to eq("$1.2m")
     end
+
+    it "rounds to whole units at precision 0" do
+      expect(described_class.compact_from_cents(1_517_000, precision: 0)).to eq("$15k")
+      expect(described_class.compact_from_cents(420_000, precision: 0)).to eq("$4k")
+    end
   end
 end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -114,6 +114,8 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/registrants.html.erb"         => "admin-only bg-blue-100",
     "app/views/events/onboarding.html.erb"             => "admin-only bg-blue-100",
     "app/views/events/revenue.html.erb"                => "admin-only bg-blue-100",
+    "app/views/events/participation.html.erb"          => "admin-only bg-blue-100",
+    "app/views/events/statistics.html.erb"              => "admin-only bg-blue-100",
     "app/views/events/preview_reminder.html.erb"       => "admin-only bg-blue-100",
     "app/views/events/confirm_reminder.html.erb"       => "admin-only bg-blue-100",
     "app/views/event_registrations/index.html.erb"     => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new cross-event report services, an admin statistics hub, filters, and registrants drill-down across many pages

### What is the goal of this PR and why is this important?
- Adds an **Event participation** report: how many people attended (fully attended) across events, grouped by year — the people-side sibling of the revenue report.
- Adds an **Events statistics** hub linked from admin home, showing the revenue + participation summaries side by side.

### How did you approach the change?
- **`EventParticipationReport`** service (sibling of `EventRevenueReport`): year-grouped, two grouped SQL queries. **Unique people is non-additive** — each level runs its own `COUNT(DISTINCT registrant_id)`; seats/status counts are additive.
- **Participation full page**: KPI strip (People attended / Partial / No show / **Other** / Registrations — the four outcome buckets reconcile to Registrations) + stacked chart + by-event table with a per-event 7-status breakdown that links into the filtered registrants index.
- **Events statistics hub** (`statistics` action, admin-only): revenue + participation summary cards with a **This year / Last year / All time** period select (shared `ReportPeriods` module). Participation card shows trainings-vs-other splits (clickable) and a registrant **reach** row (orgs / sectors / states / countries).
- **Shared filters** across revenue / participation / statistics: **Event** (specific event), **Time period**, **Event type** (All events / Trainings / Other), extracted into shared partials + `set_report_filters`.
- **Registrants index**: new **Event type** and **Attendance** filters; a "<abbr> event dashboard" link when an event is filtered.
- Net breakdown reads "Fees + $Xk scholarships − $Yk subsidy" (compact); `MoneyFormatter.compact_from_cents` gains a `precision` option.

### Anything else to add?
- Reports default to **all events**; narrow with the Event / Event type / Time period filters.
- Trainings + Other people-splits can exceed the total (a cross-attender counts in both buckets, since unique people aren't additive); registration/outcome splits sum exactly.
- Screenshots to add for the statistics hub, participation page, and registrants filters.