### PR TITLE
Add attendance stats to the event dashboard

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -90,8 +90,13 @@ class EventsController < ApplicationController
   def registrants
     authorize! @event, to: :registrants?
     @event = @event.decorate
+    # contact_methods (phone) and affiliations (org names) are read only by the
+    # CSV export, so skip them on the HTML roster to avoid eager-loading data the
+    # page never uses (Bullet: AVOID eager loading).
+    registrant_includes = [ :user, { avatar_attachment: :blob } ]
+    registrant_includes += [ :contact_methods, { affiliations: :organization } ] if request.format.csv?
     scope = @event.event_registrations
-      .includes(:comments, :organizations, :allocations, :scholarships, { continuing_education_registrations: [ :professional_license, :allocations ] }, registrant: [ :user, :contact_methods, { avatar_attachment: :blob }, { affiliations: :organization } ])
+      .includes(:comments, :organizations, :allocations, :scholarships, { continuing_education_registrations: [ :professional_license, :allocations ] }, registrant: registrant_includes)
       .joins(:registrant)
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
     scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -28,6 +28,18 @@ class EventRegistration < ApplicationRecord
   INACTIVE_STATUSES = %w[ cancelled no_show transferred_out ].freeze
   ATTENDANCE_STATUSES = (ACTIVE_STATUSES + INACTIVE_STATUSES).freeze
 
+  # Human labels for each attendance status — the single source of truth for
+  # status display (badges, filters, the dashboard breakdown).
+  ATTENDANCE_STATUS_LABELS = {
+    "registered" => "Registered",
+    "attended" => "Attended",
+    "incomplete_attendance" => "Incomplete attendance",
+    "transferred_in" => "Transferred in",
+    "cancelled" => "Cancelled",
+    "no_show" => "No show",
+    "transferred_out" => "Transferred out"
+  }.freeze
+
   # Manual onboarding checklist steps shown on the event's Onboarding tab. Each is
   # an audited boolean (stored as a row in event_registration_checklist_completions,
   # capturing who completed it and when). The keys double as the param/column keys
@@ -501,16 +513,7 @@ class EventRegistration < ApplicationRecord
 
   def attendance_status_label
     return "—" if status.blank?
-    case status
-    when "registered" then "Registered"
-    when "attended" then "Attended"
-    when "incomplete_attendance" then "Incomplete attendance"
-    when "cancelled" then "Cancelled"
-    when "no_show" then "No show"
-    when "transferred_in" then "Transferred in"
-    when "transferred_out" then "Transferred out"
-    else status.humanize
-    end
+    ATTENDANCE_STATUS_LABELS.fetch(status, status.humanize)
   end
 
   # The completion record for a checklist step, or nil. Reads from the loaded

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -343,7 +343,9 @@ class EventRegistration < ApplicationRecord
   end
 
   def scholarship?
-    scholarships.exists?
+    # any? (not exists?) so a preloaded :scholarships association is reused
+    # instead of firing a per-row query on the registrants roster.
+    scholarships.any?
   end
 
   # Noun phrase distinguishing a scholarship-requested registration from a

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -68,11 +68,12 @@ class EventDashboard
     attendance_outcome_count.positive?
   end
 
-  # Fraction (0.0–1.0) of expected attendees who showed up, or nil when no
-  # outcome has been recorded yet. Incomplete attendance counts as showing up.
+  # Fraction (0.0–1.0) of recorded attendees who fully attended, or nil when no
+  # outcome has been recorded yet. Only a full attendance counts toward the rate —
+  # incomplete attendance and no-shows both count against it.
   def attendance_rate
     return nil unless attendance_recorded?
-    (attended_count + incomplete_attendance_count).fdiv(attendance_outcome_count)
+    attended_count.fdiv(attendance_outcome_count)
   end
 
   # Registrants (Person records, name-sorted) with the given attendance

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -50,6 +50,10 @@ class EventDashboard
     registration_status_counts.fetch("no_show", 0)
   end
 
+  def cancelled_count
+    registration_status_counts.fetch("cancelled", 0)
+  end
+
   # Active registrations still awaiting an outcome — registered or transferred
   # in, but not yet marked attended / incomplete / no-show.
   def attendance_pending_count
@@ -57,10 +61,17 @@ class EventDashboard
       registration_status_counts.fetch("transferred_in", 0)
   end
 
-  # Registrations with an attendance outcome on record — the denominator for the
-  # attendance rate.
+  # Registrations with an attendance outcome on record (attended / incomplete /
+  # no-show).
   def attendance_outcome_count
     attended_count + incomplete_attendance_count + no_show_count
+  end
+
+  # Everyone expected at the event: active registrants (see #registrant_count)
+  # plus recorded no-shows. Cancellations and transfers out withdrew, so they're
+  # excluded. This is the denominator for the attendance rate.
+  def expected_attendee_count
+    registrant_count + no_show_count
   end
 
   # True once any attendance outcome has been recorded.
@@ -68,12 +79,14 @@ class EventDashboard
     attendance_outcome_count.positive?
   end
 
-  # Fraction (0.0–1.0) of recorded attendees who fully attended, or nil when no
-  # outcome has been recorded yet. Only a full attendance counts toward the rate —
-  # incomplete attendance and no-shows both count against it.
+  # Fraction (0.0–1.0) of everyone expected who fully attended, or nil when no
+  # outcome has been recorded yet. Only a full attendance counts in the
+  # numerator; the denominator is every registrant (#expected_attendee_count),
+  # so no-shows and not-yet-recorded registrants both pull the rate down.
   def attendance_rate
     return nil unless attendance_recorded?
-    attended_count.fdiv(attendance_outcome_count)
+    return nil if expected_attendee_count.zero?
+    attended_count.fdiv(expected_attendee_count)
   end
 
   # Registrants (Person records, name-sorted) with the given attendance

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -381,6 +381,13 @@ class EventDashboard
     end
   end
 
+  # Registrant (Person) ids whose organization(s) carried the given program
+  # status (:new / :ongoing / :reinstated) as of the event — drill target for
+  # the organizations card's program-status subtitle.
+  def program_status_registrant_ids(status)
+    program_statuses_by_registrant.select { |_, statuses| statuses.include?(status) }.keys
+  end
+
   # Organization ids per registrant (Person id) — the inverse of
   # organization_registrant_ids_by_org.
   def organization_ids_by_registrant
@@ -457,17 +464,6 @@ class EventDashboard
     @sectors ||= Sector.where(id: registrant_sector_ids).order(:name)
   end
 
-  # Counts of distinct sectors named as a primary vs an additional sector, for
-  # the sectors card subtitle. These overlap (a sector can be primary for one
-  # registrant and additional for another), so they don't sum to #sectors.size.
-  def primary_sector_count
-    primary_sector_ids.size
-  end
-
-  def additional_sector_count
-    additional_sector_ids.size
-  end
-
   # Sectors registrants named as their single primary sector (the
   # registration dropdown), ordered for the "Primary sector" chart.
   def primary_sectors
@@ -514,6 +510,19 @@ class EventDashboard
 
   def additional_sector_count
     additional_sector_ids.size
+  end
+
+  # Registrant (Person) ids who named a primary sector, and those who tagged a
+  # sector without naming it primary — drill targets for the sectors subtitle.
+  # A registrant can appear in both when their additional sectors differ from
+  # their primary one.
+  def primary_sector_registrant_ids
+    primary_sector_rows.map(&:first).uniq
+  end
+
+  def additional_sector_registrant_ids
+    primary_pairs = primary_sector_rows.to_set
+    registrant_sector_pairs.reject { |pair| primary_pairs.include?(pair) }.map(&:first).uniq
   end
 
   # Free-text "Other" sectors registrants typed, kept as OtherResponse records

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -28,6 +28,60 @@ class EventDashboard
     @registrants ||= people_sorted(registrant_ids)
   end
 
+  # --- Attendance ------------------------------------------------------------
+  # Attendance outcomes are recorded per registration (see
+  # EventRegistration#status). Before the event happens everyone is still
+  # "registered", so there's nothing meaningful to show until an outcome lands.
+
+  # Every registration status for this event, counted in one query.
+  def registration_status_counts
+    @registration_status_counts ||= event.event_registrations.group(:status).count
+  end
+
+  def attended_count
+    registration_status_counts.fetch("attended", 0)
+  end
+
+  def incomplete_attendance_count
+    registration_status_counts.fetch("incomplete_attendance", 0)
+  end
+
+  def no_show_count
+    registration_status_counts.fetch("no_show", 0)
+  end
+
+  # Active registrations still awaiting an outcome — registered or transferred
+  # in, but not yet marked attended / incomplete / no-show.
+  def attendance_pending_count
+    registration_status_counts.fetch("registered", 0) +
+      registration_status_counts.fetch("transferred_in", 0)
+  end
+
+  # Registrations with an attendance outcome on record — the denominator for the
+  # attendance rate.
+  def attendance_outcome_count
+    attended_count + incomplete_attendance_count + no_show_count
+  end
+
+  # True once any attendance outcome has been recorded.
+  def attendance_recorded?
+    attendance_outcome_count.positive?
+  end
+
+  # Fraction (0.0–1.0) of expected attendees who showed up, or nil when no
+  # outcome has been recorded yet. Incomplete attendance counts as showing up.
+  def attendance_rate
+    return nil unless attendance_recorded?
+    (attended_count + incomplete_attendance_count).fdiv(attendance_outcome_count)
+  end
+
+  # Registrants (Person records, name-sorted) with the given attendance
+  # status(es), for drilling into an attendance row's list.
+  def attendance_registrants(*statuses)
+    ids = statuses.flat_map { |status| registrant_ids_by_status.fetch(status, []) }
+    people_sorted(ids)
+  end
+
   def scholarship_total_cents
     scholarships.sum(:amount_cents)
   end
@@ -734,6 +788,16 @@ class EventDashboard
 
   def registrant_ids
     @registrant_ids ||= active_registrations.pluck(:registrant_id)
+  end
+
+  # Registrant (Person) ids grouped by registration status, for the attendance
+  # breakdown drill-downs.
+  def registrant_ids_by_status
+    @registrant_ids_by_status ||= event.event_registrations
+      .pluck(:status, :registrant_id)
+      .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(status, registrant_id), map|
+        map[status] << registrant_id
+      end
   end
 
   # Facilitator status for one represented organization, used by the

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -38,33 +38,23 @@ class EventDashboard
     @registration_status_counts ||= event.event_registrations.group(:status).count
   end
 
-  def attended_count
-    registration_status_counts.fetch("attended", 0)
+  # Count of registrations in a single status.
+  def attendance_count_for(status)
+    registration_status_counts.fetch(status.to_s, 0)
   end
 
-  def incomplete_attendance_count
-    registration_status_counts.fetch("incomplete_attendance", 0)
+  def attended_count
+    attendance_count_for("attended")
   end
 
   def no_show_count
-    registration_status_counts.fetch("no_show", 0)
-  end
-
-  def cancelled_count
-    registration_status_counts.fetch("cancelled", 0)
-  end
-
-  # Active registrations still awaiting an outcome — registered or transferred
-  # in, but not yet marked attended / incomplete / no-show.
-  def attendance_pending_count
-    registration_status_counts.fetch("registered", 0) +
-      registration_status_counts.fetch("transferred_in", 0)
+    attendance_count_for("no_show")
   end
 
   # Registrations with an attendance outcome on record (attended / incomplete /
   # no-show).
   def attendance_outcome_count
-    attended_count + incomplete_attendance_count + no_show_count
+    attended_count + attendance_count_for("incomplete_attendance") + no_show_count
   end
 
   # Everyone expected at the event: active registrants (see #registrant_count)

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -457,6 +457,17 @@ class EventDashboard
     @sectors ||= Sector.where(id: registrant_sector_ids).order(:name)
   end
 
+  # Counts of distinct sectors named as a primary vs an additional sector, for
+  # the sectors card subtitle. These overlap (a sector can be primary for one
+  # registrant and additional for another), so they don't sum to #sectors.size.
+  def primary_sector_count
+    primary_sector_ids.size
+  end
+
+  def additional_sector_count
+    additional_sector_ids.size
+  end
+
   # Sectors registrants named as their single primary sector (the
   # registration dropdown), ordered for the "Primary sector" chart.
   def primary_sectors

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -381,13 +381,6 @@ class EventDashboard
     end
   end
 
-  # Registrant (Person) ids whose organization(s) carried the given program
-  # status (:new / :ongoing / :reinstated) as of the event — drill target for
-  # the organizations card's program-status subtitle.
-  def program_status_registrant_ids(status)
-    program_statuses_by_registrant.select { |_, statuses| statuses.include?(status) }.keys
-  end
-
   # Organization ids per registrant (Person id) — the inverse of
   # organization_registrant_ids_by_org.
   def organization_ids_by_registrant

--- a/app/views/events/_attendance_stat_row.html.erb
+++ b/app/views/events/_attendance_stat_row.html.erb
@@ -29,9 +29,11 @@
       <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
         <% registrants.each do |registrant| %>
           <li>
-            <%= link_to registrant.name, registrants_event_path(@event, registrant_ids: registrant.id),
+            <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                  class: "block truncate min-w-0 hover:underline" %>
+                  class: "group/row flex items-center rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+              <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/events/_attendance_stat_row.html.erb
+++ b/app/views/events/_attendance_stat_row.html.erb
@@ -1,0 +1,45 @@
+<%#
+  Expandable attendance breakdown sub-row (e.g. Attended / No show). Reads as
+  "[icon] [count] [label] … [chevron]"; the summary toggles the registrant list,
+  and the jump link (outside the toggle, to the right of the chevron) drills into
+  the manage list filtered to this status.
+
+  Locals:
+    label:       row label (e.g. "Attended")
+    icon:        Font Awesome icon name (e.g. "fa-circle-check")
+    count:       registrant count for the row
+    registrants: Person records to list when expanded
+    filter_path: manage path filtered to this row's registrants
+    icon_color:  optional icon color class (defaults to neutral gray)
+%>
+<%
+  icon_color = local_assigns.fetch(:icon_color, "text-gray-400")
+%>
+<div class="flex items-start gap-1.5">
+  <details class="group/row flex-1 min-w-0">
+    <summary class="flex items-center justify-between gap-2 rounded px-1 -mx-1 py-1 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden hover:bg-gray-50">
+      <span class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+        <i class="fa-solid <%= icon %> <%= icon_color %>"></i>
+        <span class="font-semibold tabular-nums text-gray-700"><%= count %></span>
+        <%= label %>
+      </span>
+      <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 transition-transform group-open/row:rotate-180"></i>
+    </summary>
+    <% if registrants.any? %>
+      <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
+        <% registrants.each do |registrant| %>
+          <li>
+            <%= link_to registrant.name, registrants_event_path(@event, registrant_ids: registrant.id),
+                  title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
+                  class: "block truncate min-w-0 hover:underline" %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="mt-1 mb-1 ml-5 text-xs text-gray-400">None</p>
+    <% end %>
+  </details>
+  <%= link_to filter_path, class: "shrink-0 flex h-7 items-center text-gray-300 hover:text-gray-500", title: "View #{label.downcase} registrants" do %>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
+  <% end %>
+</div>

--- a/app/views/events/_attendance_stat_row.html.erb
+++ b/app/views/events/_attendance_stat_row.html.erb
@@ -31,8 +31,9 @@
           <li>
             <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                  class: "group/rowlink flex items-center rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+                  class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
               <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white shrink-0 group-hover/rowlink:text-gray-500"></i>
             <% end %>
           </li>
         <% end %>

--- a/app/views/events/_attendance_stat_row.html.erb
+++ b/app/views/events/_attendance_stat_row.html.erb
@@ -31,8 +31,8 @@
           <li>
             <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                  class: "group/row flex items-center rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
-              <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
+                  class: "group/rowlink flex items-center rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+              <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/events/_attendance_stat_row.html.erb
+++ b/app/views/events/_attendance_stat_row.html.erb
@@ -18,12 +18,12 @@
 <div class="flex items-start gap-1.5">
   <details class="group/row flex-1 min-w-0">
     <summary class="flex items-center justify-between gap-2 rounded px-1 -mx-1 py-1 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden hover:bg-gray-50">
-      <span class="flex items-center gap-1.5 text-xs font-medium text-gray-500">
-        <i class="fa-solid <%= icon %> <%= icon_color %>"></i>
-        <span class="font-semibold tabular-nums text-gray-700"><%= count %></span>
-        <%= label %>
+      <span class="flex items-center gap-1.5 min-w-0 text-xs font-medium text-gray-500">
+        <i class="fa-solid <%= icon %> <%= icon_color %> shrink-0"></i>
+        <span class="font-semibold tabular-nums text-gray-700 shrink-0"><%= count %></span>
+        <span class="truncate min-w-0" title="<%= label %>"><%= label %></span>
       </span>
-      <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 transition-transform group-open/row:rotate-180"></i>
+      <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 shrink-0 transition-transform group-open/row:rotate-180"></i>
     </summary>
     <% if registrants.any? %>
       <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">

--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -49,9 +49,12 @@
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
                   class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
               <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
-              <% if person_cents %>
-                <span class="shrink-0 tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
-              <% end %>
+              <span class="flex items-center gap-2 shrink-0">
+                <% if person_cents %>
+                  <span class="tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
+                <% end %>
+                <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover/rowlink:text-gray-500"></i>
+              </span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -47,8 +47,8 @@
           <li>
             <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                  class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
-              <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
+                  class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+              <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
               <% if person_cents %>
                 <span class="shrink-0 tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
               <% end %>

--- a/app/views/events/_dashboard_money_row.html.erb
+++ b/app/views/events/_dashboard_money_row.html.erb
@@ -43,13 +43,15 @@
     <% if registrants.any? %>
       <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
         <% registrants.each do |registrant| %>
-          <li class="flex items-center justify-between gap-2">
-            <%= link_to registrant.name, registrants_event_path(@event, registrant_ids: registrant.id),
+          <% person_cents = amounts_by_registrant_id&.[](registrant.id) %>
+          <li>
+            <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                   title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                  class: "truncate min-w-0 hover:underline" %>
-            <% person_cents = amounts_by_registrant_id&.[](registrant.id) %>
-            <% if person_cents %>
-              <span class="shrink-0 tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
+                  class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+              <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
+              <% if person_cents %>
+                <span class="shrink-0 tabular-nums text-gray-500"><%= dollars_from_cents(person_cents) %></span>
+              <% end %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/events/_headcount_header.html.erb
+++ b/app/views/events/_headcount_header.html.erb
@@ -1,0 +1,20 @@
+<%#
+  Clickable headcount-card title: [domain icon] [count] [label] [jump icon].
+  The whole title links to `path`; on hover the text underlines and the
+  otherwise-white jump icon appears.
+
+  Locals:
+    color_key: DomainTheme key for the card's colour (e.g. :people)
+    icon:      Font Awesome icon name for the domain (e.g. "fa-users")
+    count:     the headline count
+    label:     the card label (e.g. "Registrants")
+    path:      where the title links
+%>
+<h3 class="min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(color_key, intensity: 700) %>">
+  <%= link_to path, class: "group/header flex items-center gap-1.5 min-w-0 hover:underline" do %>
+    <i class="fa-solid <%= icon %> text-xs <%= DomainTheme.text_class_for(color_key, intensity: 600) %>"></i>
+    <span class="tabular-nums shrink-0"><%= count %></span>
+    <span class="truncate"><%= label %></span>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white shrink-0 group-hover/header:text-gray-500"></i>
+  <% end %>
+</h3>

--- a/app/views/events/_headcount_header.html.erb
+++ b/app/views/events/_headcount_header.html.erb
@@ -15,6 +15,8 @@
     <i class="fa-solid <%= icon %> text-xs <%= DomainTheme.text_class_for(color_key, intensity: 600) %>"></i>
     <span class="tabular-nums shrink-0"><%= count %></span>
     <span class="truncate"><%= label %></span>
-    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white shrink-0 group-hover/header:text-gray-500"></i>
+    <%# Hidden (not just white) so it claims no space until hover — the label keeps
+        its full width, then truncates to make room for the icon on hover. %>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-500 shrink-0 hidden group-hover/header:inline-block"></i>
   <% end %>
 </h3>

--- a/app/views/events/_headcount_header.html.erb
+++ b/app/views/events/_headcount_header.html.erb
@@ -15,8 +15,12 @@
     <i class="fa-solid <%= icon %> text-xs <%= DomainTheme.text_class_for(color_key, intensity: 600) %>"></i>
     <span class="tabular-nums shrink-0"><%= count %></span>
     <span class="truncate"><%= label %></span>
-    <%# Hidden (not just white) so it claims no space until hover — the label keeps
-        its full width, then truncates to make room for the icon on hover. %>
-    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-500 shrink-0 hidden group-hover/header:inline-block"></i>
+    <%# Toggle the wrapper span's display, not the icon's: Font Awesome forces
+        display on the <i>, so `hidden` on the icon itself has no effect. Hidden
+        (claims no space) until hover, so the label keeps its full width and only
+        truncates to make room for the icon on hover. %>
+    <span class="hidden group-hover/header:inline-block shrink-0">
+      <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-500"></i>
+    </span>
   <% end %>
 </h3>

--- a/app/views/events/_stat_link.html.erb
+++ b/app/views/events/_stat_link.html.erb
@@ -1,0 +1,6 @@
+<%# One subtitle stat. Clickable when `count` is positive; on hover the text underlines and the otherwise-white jump icon appears. Locals: label, path, count. -%>
+<% if count.positive? -%>
+<%= link_to path, class: "group/stat inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= label %> <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover/stat:text-gray-500"></i><% end %>
+<% else -%>
+<span><%= label %></span>
+<% end -%>

--- a/app/views/events/_stat_link.html.erb
+++ b/app/views/events/_stat_link.html.erb
@@ -1,6 +1,2 @@
-<%# One subtitle stat. Clickable when `count` is positive; on hover the text underlines and the otherwise-white jump icon appears. Locals: label, path, count. -%>
-<% if count.positive? -%>
+<%# One subtitle stat, always clickable. On hover the text underlines and the otherwise-white jump icon appears. Locals: label, path. -%>
 <%= link_to path, class: "group/stat inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= label %> <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover/stat:text-gray-500"></i><% end %>
-<% else -%>
-<span><%= label %></span>
-<% end -%>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -253,8 +253,8 @@
   <% end %>
 
   <%# Headcount cards — each expands to reveal its full list %>
-  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
+  <div class="grid grid-cols-2 lg:grid-cols-8 gap-3 sm:gap-4">
+    <details class="group/card lg:col-span-2 bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
@@ -285,7 +285,60 @@
       </div>
     </details>
 
-    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
+    <%# Attendance — outcomes recorded per registrant once the event has happened %>
+    <details class="group/card lg:col-span-2 rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> bg-white p-4 shadow-sm">
+      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+            <i class="fa-solid fa-user-check"></i>
+            <span>Attendance</span>
+          </div>
+          <%= link_to registrants_event_path(@event),
+                class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
+                title: "View all registrants" do %>
+            <i class="fa-solid fa-users text-gray-400"></i>
+            <%= pluralize(@dashboard.registrant_count, "registrant") %>
+          <% end %>
+        </div>
+        <div class="mt-2 flex items-center justify-between gap-2">
+          <p class="break-words">
+            <% if @dashboard.attendance_recorded? %>
+              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= @dashboard.attended_count %></span>
+              <span class="text-xs text-gray-500">attended (<%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
+            <% else %>
+              <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
+              <span class="text-xs text-gray-500">Not yet recorded</span>
+            <% end %>
+          </p>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
+        </div>
+      </summary>
+
+      <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
+        <%# One row per attendance status. Icon/colour are presentation config;
+            labels come from EventRegistration::ATTENDANCE_STATUS_LABELS. %>
+        <% [
+             [ "attended", "fa-circle-check", "text-green-600" ],
+             [ "incomplete_attendance", "fa-circle-half-stroke", "text-amber-500" ],
+             [ "no_show", "fa-circle-xmark", "text-red-500" ],
+             [ "registered", "fa-hourglass-half", nil ],
+             [ "transferred_in", "fa-arrow-right-to-bracket", nil ],
+             [ "transferred_out", "fa-arrow-right-from-bracket", nil ],
+             [ "cancelled", "fa-ban", nil ]
+           ].each do |status, icon, active_color| %>
+          <% count = @dashboard.attendance_count_for(status) %>
+          <%= render "attendance_stat_row",
+                label: EventRegistration::ATTENDANCE_STATUS_LABELS.fetch(status),
+                icon: icon,
+                icon_color: (count.positive? && active_color) || "text-gray-400",
+                count: count,
+                registrants: @dashboard.attendance_registrants(status),
+                filter_path: registrants_event_path(@event, attendance_status: status) %>
+        <% end %>
+      </div>
+    </details>
+
+    <details class="group/card lg:col-span-2 bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
@@ -383,61 +436,6 @@
           </ul>
         <% else %>
           <p class="text-sm text-gray-400">None yet</p>
-        <% end %>
-      </div>
-    </details>
-  </div>
-
-  <%# Attendance — outcomes recorded per registrant once the event has happened %>
-  <div class="mt-6">
-    <details class="group/card rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> bg-white p-4 shadow-sm">
-      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
-        <div class="flex items-center justify-between gap-2">
-          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-            <i class="fa-solid fa-user-check"></i>
-            <span>Attendance</span>
-          </div>
-          <%= link_to registrants_event_path(@event),
-                class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                title: "View all registrants" do %>
-            <i class="fa-solid fa-users text-gray-400"></i>
-            <%= pluralize(@dashboard.registrant_count, "registrant") %>
-          <% end %>
-        </div>
-        <div class="mt-2 flex items-center justify-between gap-2">
-          <p class="break-words">
-            <% if @dashboard.attendance_recorded? %>
-              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= @dashboard.attended_count %></span>
-              <span class="text-xs text-gray-500">attended (<%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
-            <% else %>
-              <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
-              <span class="text-xs text-gray-500">Not yet recorded</span>
-            <% end %>
-          </p>
-          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
-        </div>
-      </summary>
-
-      <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
-        <%# One row per attendance status. Icon/colour are presentation config;
-            labels come from EventRegistration::ATTENDANCE_STATUS_LABELS. %>
-        <% [
-             [ "attended", "fa-circle-check", "text-green-600" ],
-             [ "incomplete_attendance", "fa-circle-half-stroke", "text-amber-500" ],
-             [ "no_show", "fa-circle-xmark", "text-red-500" ],
-             [ "registered", "fa-hourglass-half", nil ],
-             [ "transferred_in", "fa-arrow-right-to-bracket", nil ],
-             [ "transferred_out", "fa-arrow-right-from-bracket", nil ],
-             [ "cancelled", "fa-ban", nil ]
-           ].each do |status, icon, active_color| %>
-          <% count = @dashboard.attendance_count_for(status) %>
-          <%= render "attendance_stat_row",
-                label: EventRegistration::ATTENDANCE_STATUS_LABELS.fetch(status),
-                icon: icon,
-                icon_color: (count.positive? && active_color) || "text-gray-400",
-                count: count,
-                registrants: @dashboard.attendance_registrants(status),
-                filter_path: registrants_event_path(@event, attendance_status: status) %>
         <% end %>
       </div>
     </details>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -278,7 +278,7 @@
                       title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
                       class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
                   <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
-                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 shrink-0 group-hover/rowlink:text-gray-500"></i>
+                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white shrink-0 group-hover/rowlink:text-gray-500"></i>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -267,7 +267,7 @@
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">Active registrations<% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.inactive_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.registrant_count %> active <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.inactive_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>
@@ -351,15 +351,15 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.organizations.each do |organization| %>
               <li class="flex items-center gap-1.5">
-                <%= link_to organization_path(organization), class: "#{DomainTheme.text_class_for(:organizations, intensity: 600)} hover:#{DomainTheme.text_class_for(:organizations, intensity: 800)} shrink-0", title: "View #{organization.name} profile" do %>
-                  <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-                <% end %>
                 <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
                   <span class="flex items-center gap-1.5 min-w-0">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
                     <span class="truncate min-w-0"><%= organization.name %></span>
                   </span>
                   <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
+                <% end %>
+                <%= link_to organization_path(organization), class: "shrink-0 flex h-7 items-center text-gray-300 hover:text-gray-500", title: "View #{organization.name} profile" do %>
+                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
                 <% end %>
               </li>
             <% end %>
@@ -389,9 +389,12 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.sectors.each do |sector| %>
               <li>
-                <%= link_to registrants_event_path(@event, sector: sector.id), class: "flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
+                <%= link_to registrants_event_path(@event, sector: sector.id), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
                   <span class="truncate min-w-0"><%= sector.name %></span>
-                  <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
+                  <span class="flex items-center gap-2 shrink-0">
+                    <span class="text-xs text-gray-500"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>
+                  </span>
                 <% end %>
               </li>
             <% end %>
@@ -421,9 +424,12 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.states.each do |state| %>
               <li>
-                <%= link_to registrants_event_path(@event, state: state), class: "flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+                <%= link_to registrants_event_path(@event, state: state), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
                   <span><%= state %></span>
-                  <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.state_counts.fetch(state, 0) %></span>
+                  <span class="flex items-center gap-2 shrink-0">
+                    <span class="text-xs text-gray-500"><%= @dashboard.state_counts.fetch(state, 0) %></span>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>
+                  </span>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -318,10 +318,10 @@
              [ "attended", "fa-circle-check", "text-green-600" ],
              [ "incomplete_attendance", "fa-circle-half-stroke", "text-amber-500" ],
              [ "no_show", "fa-circle-xmark", "text-red-500" ],
-             [ "registered", "fa-hourglass-half", nil ],
+             [ "cancelled", "fa-ban", nil ],
              [ "transferred_in", "fa-arrow-right-to-bracket", nil ],
              [ "transferred_out", "fa-arrow-right-from-bracket", nil ],
-             [ "cancelled", "fa-ban", nil ]
+             [ "registered", "fa-hourglass-half", nil ]
            ].each do |status, icon, active_color| %>
           <% count = @dashboard.attendance_count_for(status) %>
           <%= render "attendance_stat_row",

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -263,7 +263,7 @@
                 path: registrants_event_path(@event, status_filter: "active") %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.registrant_count, label: "#{@dashboard.registrant_count} active", path: registrants_event_path(@event, status_filter: "active") %><% if @dashboard.inactive_registration_count.positive? %> · <%= render "stat_link", count: @dashboard.inactive_registration_count, label: "#{@dashboard.inactive_registration_count} inactive", path: registrants_event_path(@event, status_filter: "inactive") %><% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{@dashboard.registrant_count} active", path: registrants_event_path(@event, status_filter: "active") %><% if @dashboard.inactive_registration_count.positive? %> · <%= render "stat_link", label: "#{@dashboard.inactive_registration_count} inactive", path: registrants_event_path(@event, status_filter: "inactive") %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>
@@ -294,7 +294,7 @@
                 path: registrants_event_path(@event, attendance_status: "attended") %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.attendance_recorded? %><%= render "stat_link", count: @dashboard.expected_attendee_count, label: "#{number_to_percentage(@dashboard.attendance_rate * 100, precision: 0)} of #{pluralize(@dashboard.expected_attendee_count, "registrant")}", path: registrants_event_path(@event) %><% else %>Not yet recorded<% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.attendance_recorded? %><%= render "stat_link", label: "#{number_to_percentage(@dashboard.attendance_rate * 100, precision: 0)} of #{pluralize(@dashboard.expected_attendee_count, "registrant")}", path: registrants_event_path(@event) %><% else %>Not yet recorded<% end %></p>
       </summary>
 
       <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
@@ -330,21 +330,21 @@
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <% program_counts = @dashboard.program_status_counts %>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: program_counts[:new], label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:new).join("-").presence || "0") %> · <%= render "stat_link", count: program_counts[:ongoing], label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:ongoing).join("-").presence || "0") %> · <%= render "stat_link", count: program_counts[:reinstated], label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:reinstated).join("-").presence || "0") %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:new).join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:ongoing).join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:reinstated).join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.organizations.any? %>
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.organizations.each do |organization| %>
-              <li class="flex items-center gap-1.5">
-                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "group/rowlink flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
+              <li class="group/rowlink flex items-center gap-1.5 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50">
+                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0", title: "Registrants from #{organization.name}" do %>
                   <span class="flex items-center gap-1.5 min-w-0">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
                     <span class="truncate min-w-0 group-hover/rowlink:underline"><%= organization.name %></span>
                   </span>
                   <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
                 <% end %>
-                <%= link_to organization_path(organization), class: "shrink-0 flex h-7 items-center text-gray-300 hover:text-gray-500", title: "View #{organization.name} profile" do %>
+                <%= link_to organization_path(organization), class: "shrink-0 flex h-7 items-center text-white group-hover/rowlink:text-gray-500", title: "View #{organization.name} profile" do %>
                   <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i>
                 <% end %>
               </li>
@@ -364,7 +364,7 @@
                 path: registrants_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.primary_sector_count, label: "#{@dashboard.primary_sector_count} primary", path: registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids.join("-").presence || "0") %> · <%= render "stat_link", count: @dashboard.additional_sector_count, label: "#{@dashboard.additional_sector_count} additional", path: registrants_event_path(@event, registrant_ids: @dashboard.additional_sector_registrant_ids.join("-").presence || "0") %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{@dashboard.primary_sector_count} primary", path: registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids.join("-").presence || "0") %> · <%= render "stat_link", label: "#{@dashboard.additional_sector_count} additional", path: registrants_event_path(@event, registrant_ids: @dashboard.additional_sector_registrant_ids.join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.sectors.any? %>
@@ -375,7 +375,7 @@
                   <span class="truncate min-w-0 group-hover/rowlink:underline"><%= sector.name %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
-                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/rowlink:text-gray-500"></i>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover/rowlink:text-gray-500"></i>
                   </span>
                 <% end %>
               </li>
@@ -395,7 +395,7 @@
                 path: registrants_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.countries.size, label: pluralize(@dashboard.countries.size, "country"), path: registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-").presence || "0") %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: pluralize(@dashboard.countries.size, "country"), path: registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.states.any? %>
@@ -406,7 +406,7 @@
                   <span class="group-hover/rowlink:underline"><%= state %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.state_counts.fetch(state, 0) %></span>
-                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/rowlink:text-gray-500"></i>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover/rowlink:text-gray-500"></i>
                   </span>
                 <% end %>
               </li>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -254,7 +254,7 @@
 
   <%# Headcount cards — each expands to reveal its full list. One row of five on
       large screens, wrapping to three then two as the viewport narrows. %>
-  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4">
+  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-[minmax(0,4fr)_minmax(0,4fr)_minmax(0,5fr)_minmax(0,4fr)_minmax(0,3fr)] gap-3 sm:gap-4">
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -347,7 +347,8 @@
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">Via registrants</p>
+        <% program_counts = @dashboard.program_status_counts %>
+        <p class="text-xs text-gray-500 mt-1"><%= program_counts[:new] %> new · <%= program_counts[:ongoing] %> ongoing · <%= program_counts[:reinstated] %> reinstated</p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.organizations.any? %>
@@ -385,7 +386,7 @@
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">Via registrants</p>
+        <p class="text-xs text-gray-500 mt-1"><%= @dashboard.primary_sector_count %> primary · <%= @dashboard.additional_sector_count %> additional</p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.sectors.any? %>
@@ -420,7 +421,7 @@
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">Via registrants</p>
+        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.countries.any? %><%= link_to registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= pluralize(@dashboard.countries.size, "country") %> <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% else %><%= pluralize(@dashboard.countries.size, "country") %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.states.any? %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -276,9 +276,9 @@
               <li>
                 <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                       title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                      class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
-                  <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
-                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 shrink-0 group-hover/row:text-gray-500"></i>
+                      class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+                  <span class="truncate min-w-0 group-hover/rowlink:underline"><%= registrant.name %></span>
+                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 shrink-0 group-hover/rowlink:text-gray-500"></i>
                 <% end %>
               </li>
             <% end %>
@@ -354,10 +354,10 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.organizations.each do |organization| %>
               <li class="flex items-center gap-1.5">
-                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "group/row flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
+                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "group/rowlink flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
                   <span class="flex items-center gap-1.5 min-w-0">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
-                    <span class="truncate min-w-0 group-hover/row:underline"><%= organization.name %></span>
+                    <span class="truncate min-w-0 group-hover/rowlink:underline"><%= organization.name %></span>
                   </span>
                   <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
                 <% end %>
@@ -392,11 +392,11 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.sectors.each do |sector| %>
               <li>
-                <%= link_to registrants_event_path(@event, sector: sector.id), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
-                  <span class="truncate min-w-0 group-hover/row:underline"><%= sector.name %></span>
+                <%= link_to registrants_event_path(@event, sector: sector.id), class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
+                  <span class="truncate min-w-0 group-hover/rowlink:underline"><%= sector.name %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
-                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/rowlink:text-gray-500"></i>
                   </span>
                 <% end %>
               </li>
@@ -427,11 +427,11 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.states.each do |state| %>
               <li>
-                <%= link_to registrants_event_path(@event, state: state), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
-                  <span class="group-hover/row:underline"><%= state %></span>
+                <%= link_to registrants_event_path(@event, state: state), class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+                  <span class="group-hover/rowlink:underline"><%= state %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.state_counts.fetch(state, 0) %></span>
-                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>
+                    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/rowlink:text-gray-500"></i>
                   </span>
                 <% end %>
               </li>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -258,16 +258,12 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
-            <i class="fa-solid fa-users text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
-            <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.registrant_count, registrants_event_path(@event, status_filter: "active"), class: "hover:underline" %>
-            </span>
-            <span class="truncate">Registrants</span>
-          </h3>
+          <%= render "headcount_header", color_key: :people, icon: "fa-users",
+                count: @dashboard.registrant_count, label: "Registrants",
+                path: registrants_event_path(@event, status_filter: "active") %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= link_to registrants_event_path(@event, status_filter: "active"), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.registrant_count %> active <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, status_filter: "inactive"), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.registrant_count, label: "#{@dashboard.registrant_count} active", path: registrants_event_path(@event, status_filter: "active") %><% if @dashboard.inactive_registration_count.positive? %> · <%= render "stat_link", count: @dashboard.inactive_registration_count, label: "#{@dashboard.inactive_registration_count} inactive", path: registrants_event_path(@event, status_filter: "inactive") %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>
@@ -293,22 +289,12 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %>">
-            <i class="fa-solid fa-user-check text-xs <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %>"></i>
-            <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.attended_count, registrants_event_path(@event, attendance_status: "attended"), class: "hover:underline" %>
-            </span>
-            <span class="truncate">Attended</span>
-          </h3>
+          <%= render "headcount_header", color_key: :event_registrations, icon: "fa-user-check",
+                count: @dashboard.attended_count, label: "Attended",
+                path: registrants_event_path(@event, attendance_status: "attended") %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1">
-          <% if @dashboard.attendance_recorded? %>
-            <%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>
-          <% else %>
-            Not yet recorded
-          <% end %>
-        </p>
+        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.attendance_recorded? %><%= render "stat_link", count: @dashboard.expected_attendee_count, label: "#{number_to_percentage(@dashboard.attendance_rate * 100, precision: 0)} of #{pluralize(@dashboard.expected_attendee_count, "registrant")}", path: registrants_event_path(@event) %><% else %>Not yet recorded<% end %></p>
       </summary>
 
       <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
@@ -338,17 +324,13 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
-            <i class="fa-solid fa-building text-xs <%= DomainTheme.text_class_for(:organizations, intensity: 600) %>"></i>
-            <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.organization_count, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids.join("-")), class: "hover:underline" %>
-            </span>
-            <span class="truncate">Organizations</span>
-          </h3>
+          <%= render "headcount_header", color_key: :organizations, icon: "fa-building",
+                count: @dashboard.organization_count, label: "Organizations",
+                path: registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <% program_counts = @dashboard.program_status_counts %>
-        <p class="text-xs text-gray-500 mt-1"><%= program_counts[:new] %> new · <%= program_counts[:ongoing] %> ongoing · <%= program_counts[:reinstated] %> reinstated</p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: program_counts[:new], label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:new).join("-").presence || "0") %> · <%= render "stat_link", count: program_counts[:ongoing], label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:ongoing).join("-").presence || "0") %> · <%= render "stat_link", count: program_counts[:reinstated], label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:reinstated).join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.organizations.any? %>
@@ -377,16 +359,12 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
-            <i class="fa-solid fa-layer-group text-xs <%= DomainTheme.text_class_for(:sectors, intensity: 600) %>"></i>
-            <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.sectors.size, registrants_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")), class: "hover:underline" %>
-            </span>
-            <span class="truncate">Sectors</span>
-          </h3>
+          <%= render "headcount_header", color_key: :sectors, icon: "fa-layer-group",
+                count: @dashboard.sectors.size, label: "Sectors",
+                path: registrants_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= @dashboard.primary_sector_count %> primary · <%= @dashboard.additional_sector_count %> additional</p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.primary_sector_count, label: "#{@dashboard.primary_sector_count} primary", path: registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids.join("-").presence || "0") %> · <%= render "stat_link", count: @dashboard.additional_sector_count, label: "#{@dashboard.additional_sector_count} additional", path: registrants_event_path(@event, registrant_ids: @dashboard.additional_sector_registrant_ids.join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.sectors.any? %>
@@ -412,16 +390,12 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">
-            <i class="fa-solid fa-location-dot text-xs <%= DomainTheme.text_class_for(:addresses, intensity: 600) %>"></i>
-            <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.states.size, registrants_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")), class: "hover:underline" %>
-            </span>
-            <span class="truncate">States</span>
-          </h3>
+          <%= render "headcount_header", color_key: :addresses, icon: "fa-location-dot",
+                count: @dashboard.states.size, label: "States",
+                path: registrants_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.countries.any? %><%= link_to registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= pluralize(@dashboard.countries.size, "country") %> <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% else %><%= pluralize(@dashboard.countries.size, "country") %><% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", count: @dashboard.countries.size, label: pluralize(@dashboard.countries.size, "country"), path: registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.states.any? %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -408,7 +408,7 @@
           <p class="break-words">
             <% if @dashboard.attendance_recorded? %>
               <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %></span>
-              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count + @dashboard.incomplete_attendance_count %> of <%= @dashboard.attendance_outcome_count %> recorded)</span>
+              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count %> of <%= @dashboard.attendance_outcome_count %> recorded)</span>
             <% else %>
               <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
               <span class="text-xs text-gray-500">Not yet recorded</span>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -407,8 +407,8 @@
         <div class="mt-2 flex items-center justify-between gap-2">
           <p class="break-words">
             <% if @dashboard.attendance_recorded? %>
-              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %></span>
-              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
+              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= @dashboard.attended_count %></span>
+              <span class="text-xs text-gray-500">attended (<%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
             <% else %>
               <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
               <span class="text-xs text-gray-500">Not yet recorded</span>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -408,7 +408,7 @@
           <p class="break-words">
             <% if @dashboard.attendance_recorded? %>
               <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %></span>
-              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count %> of <%= @dashboard.attendance_outcome_count %> recorded)</span>
+              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
             <% else %>
               <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
               <span class="text-xs text-gray-500">Not yet recorded</span>
@@ -438,6 +438,11 @@
               count: @dashboard.attendance_pending_count,
               registrants: @dashboard.attendance_registrants("registered", "transferred_in"),
               filter_path: registrants_event_path(@event, registrant_ids: @dashboard.attendance_registrants("registered", "transferred_in").map(&:id).join("-").presence || "0") %>
+        <%= render "attendance_stat_row", label: "Cancelled", icon: "fa-ban",
+              icon_color: @dashboard.cancelled_count.positive? ? "text-gray-500" : "text-gray-400",
+              count: @dashboard.cancelled_count,
+              registrants: @dashboard.attendance_registrants("cancelled"),
+              filter_path: registrants_event_path(@event, attendance_status: "cancelled") %>
       </div>
     </details>
   </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -294,7 +294,7 @@
                 path: registrants_event_path(@event, attendance_status: "attended") %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.attendance_recorded? %><%= render "stat_link", label: "#{number_to_percentage(@dashboard.attendance_rate * 100, precision: 0)} of #{pluralize(@dashboard.expected_attendee_count, "registrant")}", path: registrants_event_path(@event) %><% else %>Not yet recorded<% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><% if @dashboard.attendance_recorded? %><%= render "stat_link", label: "#{number_to_percentage(@dashboard.attendance_rate * 100, precision: 0)} of #{pluralize(@dashboard.expected_attendee_count, "registrant")}", path: registrants_event_path(@event, attendance_status: "attended") %><% else %>Not yet recorded<% end %></p>
       </summary>
 
       <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -239,13 +239,13 @@
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.cont_ed_paid_cents,
                   count: @dashboard.cont_ed_paid_count, registrants: @dashboard.cont_ed_paid_registrants,
-                  filter_path: registrants_event_path(@event, registrant_ids: @dashboard.cont_ed_paid_registrants.map(&:id).join("-").presence || "0") %>
+                  filter_path: registrants_event_path(@event, ce_status: "paid") %>
             <%= render "dashboard_money_row", label: "Due", icon: "fa-hourglass-half",
                   icon_color: @dashboard.cont_ed_unpaid_count.positive? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.cont_ed_unpaid_count.positive? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.cont_ed_outstanding_cents,
                   count: @dashboard.cont_ed_unpaid_count, registrants: @dashboard.cont_ed_unpaid_registrants,
-                  filter_path: registrants_event_path(@event, registrant_ids: @dashboard.cont_ed_unpaid_registrants.map(&:id).join("-").presence || "0") %>
+                  filter_path: registrants_event_path(@event, ce_status: "requested") %>
           </div>
         </details>
       </div>
@@ -261,13 +261,13 @@
           <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
             <i class="fa-solid fa-users text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
-              <%= link_to @dashboard.registrant_count, registrants_event_path(@event, registrant_ids: @dashboard.registrants.map(&:id).join("-")), class: "hover:underline" %>
+              <%= link_to @dashboard.registrant_count, registrants_event_path(@event, status_filter: "active"), class: "hover:underline" %>
             </span>
             <span class="truncate">Registrants</span>
           </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.registrant_count %> active <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.inactive_registrant_ids.join("-")), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
+        <p class="text-xs text-gray-500 mt-1"><%= link_to registrants_event_path(@event, status_filter: "active"), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.registrant_count %> active <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% if @dashboard.inactive_registration_count.positive? %> · <%= link_to registrants_event_path(@event, status_filter: "inactive"), class: "inline-flex items-center gap-1 no-underline hover:underline hover:text-gray-700" do %><%= @dashboard.inactive_registration_count %> inactive <i class="fa-solid fa-arrow-up-right-from-square text-[10px]"></i><% end %><% end %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -387,5 +387,59 @@
       </div>
     </details>
   </div>
+
+  <%# Attendance — outcomes recorded per registrant once the event has happened %>
+  <div class="mt-6">
+    <details class="group/card rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> bg-white p-4 shadow-sm">
+      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+            <i class="fa-solid fa-user-check"></i>
+            <span>Attendance</span>
+          </div>
+          <%= link_to registrants_event_path(@event),
+                class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
+                title: "View all registrants" do %>
+            <i class="fa-solid fa-users text-gray-400"></i>
+            <%= pluralize(@dashboard.registrant_count, "registrant") %>
+          <% end %>
+        </div>
+        <div class="mt-2 flex items-center justify-between gap-2">
+          <p class="break-words">
+            <% if @dashboard.attendance_recorded? %>
+              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %></span>
+              <span class="text-xs text-gray-500">attended (<%= @dashboard.attended_count + @dashboard.incomplete_attendance_count %> of <%= @dashboard.attendance_outcome_count %> recorded)</span>
+            <% else %>
+              <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
+              <span class="text-xs text-gray-500">Not yet recorded</span>
+            <% end %>
+          </p>
+          <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
+        </div>
+      </summary>
+
+      <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
+        <%= render "attendance_stat_row", label: "Attended", icon: "fa-circle-check",
+              icon_color: @dashboard.attended_count.positive? ? "text-green-600" : "text-gray-400",
+              count: @dashboard.attended_count,
+              registrants: @dashboard.attendance_registrants("attended"),
+              filter_path: registrants_event_path(@event, attendance_status: "attended") %>
+        <%= render "attendance_stat_row", label: "Incomplete attendance", icon: "fa-circle-half-stroke",
+              icon_color: @dashboard.incomplete_attendance_count.positive? ? "text-amber-500" : "text-gray-400",
+              count: @dashboard.incomplete_attendance_count,
+              registrants: @dashboard.attendance_registrants("incomplete_attendance"),
+              filter_path: registrants_event_path(@event, attendance_status: "incomplete_attendance") %>
+        <%= render "attendance_stat_row", label: "No show", icon: "fa-circle-xmark",
+              icon_color: @dashboard.no_show_count.positive? ? "text-red-500" : "text-gray-400",
+              count: @dashboard.no_show_count,
+              registrants: @dashboard.attendance_registrants("no_show"),
+              filter_path: registrants_event_path(@event, attendance_status: "no_show") %>
+        <%= render "attendance_stat_row", label: "Not recorded", icon: "fa-hourglass-half",
+              count: @dashboard.attendance_pending_count,
+              registrants: @dashboard.attendance_registrants("registered", "transferred_in"),
+              filter_path: registrants_event_path(@event, registrant_ids: @dashboard.attendance_registrants("registered", "transferred_in").map(&:id).join("-").presence || "0") %>
+      </div>
+    </details>
+  </div>
 </div>
 </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -274,9 +274,12 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.registrants.each do |registrant| %>
               <li>
-                <%= link_to registrant.name, registrants_event_path(@event, registrant_ids: registrant.id),
+                <%= link_to registrants_event_path(@event, registrant_ids: registrant.id),
                       title: [ registrant.name, *@dashboard.organization_names_by_registrant[registrant.id] ].join(" · "),
-                      class: "block truncate rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" %>
+                      class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+                  <span class="truncate min-w-0 group-hover/row:underline"><%= registrant.name %></span>
+                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 shrink-0 group-hover/row:text-gray-500"></i>
+                <% end %>
               </li>
             <% end %>
           </ul>
@@ -351,10 +354,10 @@
           <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
             <% @dashboard.organizations.each do |organization| %>
               <li class="flex items-center gap-1.5">
-                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
+                <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "group/row flex items-center justify-between gap-2 flex-1 min-w-0 rounded px-1 py-0.5 hover:bg-gray-50", title: "Registrants from #{organization.name}" do %>
                   <span class="flex items-center gap-1.5 min-w-0">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
-                    <span class="truncate min-w-0"><%= organization.name %></span>
+                    <span class="truncate min-w-0 group-hover/row:underline"><%= organization.name %></span>
                   </span>
                   <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
                 <% end %>
@@ -390,7 +393,7 @@
             <% @dashboard.sectors.each do |sector| %>
               <li>
                 <%= link_to registrants_event_path(@event, sector: sector.id), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
-                  <span class="truncate min-w-0"><%= sector.name %></span>
+                  <span class="truncate min-w-0 group-hover/row:underline"><%= sector.name %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
                     <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>
@@ -425,7 +428,7 @@
             <% @dashboard.states.each do |state| %>
               <li>
                 <%= link_to registrants_event_path(@event, state: state), class: "group/row flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
-                  <span><%= state %></span>
+                  <span class="group-hover/row:underline"><%= state %></span>
                   <span class="flex items-center gap-2 shrink-0">
                     <span class="text-xs text-gray-500"><%= @dashboard.state_counts.fetch(state, 0) %></span>
                     <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-300 group-hover/row:text-gray-500"></i>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -252,12 +252,13 @@
     </div>
   <% end %>
 
-  <%# Headcount cards — each expands to reveal its full list %>
-  <div class="grid grid-cols-2 lg:grid-cols-8 gap-3 sm:gap-4">
-    <details class="group/card lg:col-span-2 bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
+  <%# Headcount cards — each expands to reveal its full list. One row of five on
+      large screens, wrapping to three then two as the viewport narrows. %>
+  <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:people, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:people, intensity: 700) %>">
             <i class="fa-solid fa-users text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.registrant_count, registrants_event_path(@event, registrant_ids: @dashboard.registrants.map(&:id).join("-")), class: "hover:underline" %>
@@ -285,33 +286,26 @@
       </div>
     </details>
 
-    <%# Attendance — outcomes recorded per registrant once the event has happened %>
-    <details class="group/card lg:col-span-2 rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> bg-white p-4 shadow-sm">
+    <%# Attendance — attendance outcomes, styled like the sibling headcount cards %>
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:event_registrations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
-            <i class="fa-solid fa-user-check"></i>
-            <span>Attendance</span>
-          </div>
-          <%= link_to registrants_event_path(@event),
-                class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                title: "View all registrants" do %>
-            <i class="fa-solid fa-users text-gray-400"></i>
-            <%= pluralize(@dashboard.registrant_count, "registrant") %>
-          <% end %>
-        </div>
-        <div class="mt-2 flex items-center justify-between gap-2">
-          <p class="break-words">
-            <% if @dashboard.attendance_recorded? %>
-              <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %> tabular-nums"><%= @dashboard.attended_count %></span>
-              <span class="text-xs text-gray-500">attended (<%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>)</span>
-            <% else %>
-              <span class="text-2xl sm:text-3xl font-bold text-gray-400 tabular-nums">—</span>
-              <span class="text-xs text-gray-500">Not yet recorded</span>
-            <% end %>
-          </p>
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:event_registrations, intensity: 700) %>">
+            <i class="fa-solid fa-user-check text-xs <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %>"></i>
+            <span class="tabular-nums shrink-0">
+              <%= link_to @dashboard.attended_count, registrants_event_path(@event, attendance_status: "attended"), class: "hover:underline" %>
+            </span>
+            <span class="truncate">Attended</span>
+          </h3>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
+        <p class="text-xs text-gray-500 mt-1">
+          <% if @dashboard.attendance_recorded? %>
+            <%= number_to_percentage(@dashboard.attendance_rate * 100, precision: 0) %> of <%= pluralize(@dashboard.expected_attendee_count, "registrant") %>
+          <% else %>
+            Not yet recorded
+          <% end %>
+        </p>
       </summary>
 
       <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
@@ -338,10 +332,10 @@
       </div>
     </details>
 
-    <details class="group/card lg:col-span-2 bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
+    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">
             <i class="fa-solid fa-building text-xs <%= DomainTheme.text_class_for(:organizations, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.organization_count, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids.join("-")), class: "hover:underline" %>
@@ -379,7 +373,7 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:sectors, intensity: 700) %>">
             <i class="fa-solid fa-layer-group text-xs <%= DomainTheme.text_class_for(:sectors, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.sectors.size, registrants_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")), class: "hover:underline" %>
@@ -411,7 +405,7 @@
     <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="flex items-center gap-1.5 min-w-0 text-lg sm:text-xl font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">
+          <h3 class="flex items-center gap-1.5 min-w-0 text-lg font-bold <%= DomainTheme.text_class_for(:addresses, intensity: 700) %>">
             <i class="fa-solid fa-location-dot text-xs <%= DomainTheme.text_class_for(:addresses, intensity: 600) %>"></i>
             <span class="tabular-nums shrink-0">
               <%= link_to @dashboard.states.size, registrants_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")), class: "hover:underline" %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -419,30 +419,26 @@
       </summary>
 
       <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
-        <%= render "attendance_stat_row", label: "Attended", icon: "fa-circle-check",
-              icon_color: @dashboard.attended_count.positive? ? "text-green-600" : "text-gray-400",
-              count: @dashboard.attended_count,
-              registrants: @dashboard.attendance_registrants("attended"),
-              filter_path: registrants_event_path(@event, attendance_status: "attended") %>
-        <%= render "attendance_stat_row", label: "Incomplete attendance", icon: "fa-circle-half-stroke",
-              icon_color: @dashboard.incomplete_attendance_count.positive? ? "text-amber-500" : "text-gray-400",
-              count: @dashboard.incomplete_attendance_count,
-              registrants: @dashboard.attendance_registrants("incomplete_attendance"),
-              filter_path: registrants_event_path(@event, attendance_status: "incomplete_attendance") %>
-        <%= render "attendance_stat_row", label: "No show", icon: "fa-circle-xmark",
-              icon_color: @dashboard.no_show_count.positive? ? "text-red-500" : "text-gray-400",
-              count: @dashboard.no_show_count,
-              registrants: @dashboard.attendance_registrants("no_show"),
-              filter_path: registrants_event_path(@event, attendance_status: "no_show") %>
-        <%= render "attendance_stat_row", label: "Not recorded", icon: "fa-hourglass-half",
-              count: @dashboard.attendance_pending_count,
-              registrants: @dashboard.attendance_registrants("registered", "transferred_in"),
-              filter_path: registrants_event_path(@event, registrant_ids: @dashboard.attendance_registrants("registered", "transferred_in").map(&:id).join("-").presence || "0") %>
-        <%= render "attendance_stat_row", label: "Cancelled", icon: "fa-ban",
-              icon_color: @dashboard.cancelled_count.positive? ? "text-gray-500" : "text-gray-400",
-              count: @dashboard.cancelled_count,
-              registrants: @dashboard.attendance_registrants("cancelled"),
-              filter_path: registrants_event_path(@event, attendance_status: "cancelled") %>
+        <%# One row per attendance status. Icon/colour are presentation config;
+            labels come from EventRegistration::ATTENDANCE_STATUS_LABELS. %>
+        <% [
+             [ "attended", "fa-circle-check", "text-green-600" ],
+             [ "incomplete_attendance", "fa-circle-half-stroke", "text-amber-500" ],
+             [ "no_show", "fa-circle-xmark", "text-red-500" ],
+             [ "registered", "fa-hourglass-half", nil ],
+             [ "transferred_in", "fa-arrow-right-to-bracket", nil ],
+             [ "transferred_out", "fa-arrow-right-from-bracket", nil ],
+             [ "cancelled", "fa-ban", nil ]
+           ].each do |status, icon, active_color| %>
+          <% count = @dashboard.attendance_count_for(status) %>
+          <%= render "attendance_stat_row",
+                label: EventRegistration::ATTENDANCE_STATUS_LABELS.fetch(status),
+                icon: icon,
+                icon_color: (count.positive? && active_color) || "text-gray-400",
+                count: count,
+                registrants: @dashboard.attendance_registrants(status),
+                filter_path: registrants_event_path(@event, attendance_status: status) %>
+        <% end %>
       </div>
     </details>
   </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -330,7 +330,8 @@
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <% program_counts = @dashboard.program_status_counts %>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:new).join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:ongoing).join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: @dashboard.program_status_registrant_ids(:reinstated).join("-").presence || "0") %></p>
+        <% program_status_ids = @dashboard.program_status_registrant_ids %>
+        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: program_status_ids[:new].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: program_status_ids[:ongoing].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: program_status_ids[:reinstated].join("-").presence || "0") %></p>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.organizations.any? %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -44,6 +44,10 @@
   </div>
 
   <% if @dashboard.scholarship_applicants.any? %>
+    <h2 class="text-xl font-bold mb-4 flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+      <i class="fa-solid fa-user-graduate"></i>
+      Recipients
+    </h2>
     <div data-controller="expandable-cards scholarship-status-toggle"
          data-scholarship-status-toggle-shown-value="true">
       <%# Controls — show/hide scholarship status for all recipients, and expand/collapse all %>
@@ -274,6 +278,28 @@
             </div>
           </div>
         <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%# ---- Statistics: recipient breakdowns by city + organization. The actual
+      breakdown partials (scholarship-recipient totals) land in a follow-up PR;
+      titled placeholders for now. ---- %>
+  <% if @dashboard.scholarship_applicants.any? %>
+    <div class="mt-10 break-inside-avoid">
+      <h2 class="text-xl font-bold mb-4 flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+        <i class="fa-solid fa-chart-pie"></i>
+        Statistics
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-4">
+          <h3 class="text-sm font-semibold text-gray-700 mb-3">Recipients by city</h3>
+          <p class="text-sm text-gray-400 italic text-center py-8">Coming soon</p>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-4">
+          <h3 class="text-sm font-semibold text-gray-700 mb-3">Recipients by organization</h3>
+          <p class="text-sm text-gray-400 italic text-center py-8">Coming soon</p>
+        </div>
       </div>
     </div>
   <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1699,9 +1699,10 @@ RSpec.describe "Events", type: :request do
 
         page = Capybara.string(response.body)
         expect(page).to have_text("Attendance", normalize_ws: true)
-        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "attended"), visible: :all)
-        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "no_show"), visible: :all)
-        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "cancelled"), visible: :all)
+        # Every status is its own row that drills into the roster filtered to it.
+        %w[ attended no_show registered cancelled transferred_in transferred_out incomplete_attendance ].each do |status|
+          expect(page).to have_link(href: registrants_event_path(event, attendance_status: status), visible: :all)
+        end
         # 1 attended over 3 registrants (attended + registered + no-show; the
         # cancellation is excluded) → 33%.
         expect(page).to have_text("33%", normalize_ws: true)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1699,6 +1699,7 @@ RSpec.describe "Events", type: :request do
             expect(response.body).to include("Public bulk payment form")
           end
         end
+      end
 
       it "renders the attendance breakdown with per-status drill-down links" do
         create(:event_registration, event: event, registrant: create(:person), status: "attended")

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1693,6 +1693,7 @@ RSpec.describe "Events", type: :request do
       it "renders the attendance breakdown with per-status drill-down links" do
         create(:event_registration, event: event, registrant: create(:person), status: "attended")
         create(:event_registration, event: event, registrant: create(:person), status: "no_show")
+        create(:event_registration, event: event, registrant: create(:person), status: "cancelled")
 
         get dashboard_event_path(event)
 
@@ -1700,8 +1701,10 @@ RSpec.describe "Events", type: :request do
         expect(page).to have_text("Attendance", normalize_ws: true)
         expect(page).to have_link(href: registrants_event_path(event, attendance_status: "attended"), visible: :all)
         expect(page).to have_link(href: registrants_event_path(event, attendance_status: "no_show"), visible: :all)
-        # attended + no_show recorded → 50% show rate.
-        expect(page).to have_text("50%", normalize_ws: true)
+        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "cancelled"), visible: :all)
+        # 1 attended over 3 registrants (attended + registered + no-show; the
+        # cancellation is excluded) → 33%.
+        expect(page).to have_text("33%", normalize_ws: true)
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1572,6 +1572,16 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Overview Org")
       end
 
+      it "drills the active/inactive counts into the matching status filter, not a registrant_ids list" do
+        create(:event_registration, event: event, registrant: create(:person), status: "cancelled")
+
+        get dashboard_event_path(event)
+
+        page = Capybara.string(response.body)
+        expect(page).to have_link(href: registrants_event_path(event, status_filter: "active"), visible: :all)
+        expect(page).to have_link(href: registrants_event_path(event, status_filter: "inactive"), visible: :all)
+      end
+
       it "shows a program status badge next to each organization" do
         get dashboard_event_path(event)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2049,6 +2049,14 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Hide scholarship status")
       end
 
+      it "renders the Recipients and Statistics section headers with placeholder breakdowns" do
+        get recipients_event_path(event)
+
+        expect(response.body).to include("Statistics")
+        expect(response.body).to include("Recipients by city")
+        expect(response.body).to include("Recipients by organization")
+      end
+
       it "shows each recipient's awarded amount and completed tasks status" do
         event.update!(cost_cents: 50_000)
         registration = event.event_registrations.find_by(registrant: applicant)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1689,6 +1689,19 @@ RSpec.describe "Events", type: :request do
             expect(response.body).to include("Public bulk payment form")
           end
         end
+
+      it "renders the attendance breakdown with per-status drill-down links" do
+        create(:event_registration, event: event, registrant: create(:person), status: "attended")
+        create(:event_registration, event: event, registrant: create(:person), status: "no_show")
+
+        get dashboard_event_path(event)
+
+        page = Capybara.string(response.body)
+        expect(page).to have_text("Attendance", normalize_ws: true)
+        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "attended"), visible: :all)
+        expect(page).to have_link(href: registrants_event_path(event, attendance_status: "no_show"), visible: :all)
+        # attended + no_show recorded → 50% show rate.
+        expect(page).to have_text("50%", normalize_ws: true)
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1698,7 +1698,7 @@ RSpec.describe "Events", type: :request do
         get dashboard_event_path(event)
 
         page = Capybara.string(response.body)
-        expect(page).to have_text("Attendance", normalize_ws: true)
+        expect(page).to have_text("Attended", normalize_ws: true)
         # Every status is its own row that drills into the roster filtered to it.
         %w[ attended no_show registered cancelled transferred_in transferred_out incomplete_attendance ].each do |status|
           expect(page).to have_link(href: registrants_event_path(event, attendance_status: status), visible: :all)

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -943,4 +943,51 @@ RSpec.describe EventDashboard do
       expect(dashboard.unallocated_bulk_payment_cents).to eq(0)
     end
   end
+
+  describe "attendance stats" do
+    let(:event) { create(:event) }
+
+    context "with a mix of attendance outcomes" do
+      before do
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Aa"), status: "attended")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Ab"), status: "attended")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Ba"), status: "incomplete_attendance")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Ca"), status: "no_show")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Da"), status: "registered")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Ea"), status: "transferred_in")
+      end
+
+      it "counts each attendance outcome" do
+        expect(dashboard.attended_count).to eq(2)
+        expect(dashboard.incomplete_attendance_count).to eq(1)
+        expect(dashboard.no_show_count).to eq(1)
+        expect(dashboard.attendance_pending_count).to eq(2)
+      end
+
+      it "reports the recorded-outcome total and rate (incomplete counts as showing up)" do
+        expect(dashboard.attendance_recorded?).to be(true)
+        expect(dashboard.attendance_outcome_count).to eq(4)
+        expect(dashboard.attendance_rate).to eq(3.0 / 4)
+      end
+
+      it "lists the registrants behind each status" do
+        expect(dashboard.attendance_registrants("attended").map(&:first_name)).to eq(%w[ Aa Ab ])
+        expect(dashboard.attendance_registrants("no_show").map(&:first_name)).to eq(%w[ Ca ])
+        expect(dashboard.attendance_registrants("registered", "transferred_in").map(&:first_name)).to eq(%w[ Da Ea ])
+      end
+    end
+
+    context "before any outcome is recorded" do
+      before do
+        create(:event_registration, event: event, status: "registered")
+      end
+
+      it "reports nothing recorded and a nil rate" do
+        expect(dashboard.attendance_recorded?).to be(false)
+        expect(dashboard.attendance_outcome_count).to eq(0)
+        expect(dashboard.attendance_rate).to be_nil
+        expect(dashboard.attendance_pending_count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -958,12 +958,14 @@ RSpec.describe EventDashboard do
         create(:event_registration, event: event, registrant: create(:person, first_name: "Fa"), status: "cancelled")
       end
 
-      it "counts each attendance status" do
-        expect(dashboard.attended_count).to eq(2)
-        expect(dashboard.incomplete_attendance_count).to eq(1)
-        expect(dashboard.no_show_count).to eq(1)
-        expect(dashboard.attendance_pending_count).to eq(2)
-        expect(dashboard.cancelled_count).to eq(1)
+      it "counts each attendance status individually" do
+        expect(dashboard.attendance_count_for("attended")).to eq(2)
+        expect(dashboard.attendance_count_for("incomplete_attendance")).to eq(1)
+        expect(dashboard.attendance_count_for("no_show")).to eq(1)
+        expect(dashboard.attendance_count_for("registered")).to eq(1)
+        expect(dashboard.attendance_count_for("transferred_in")).to eq(1)
+        expect(dashboard.attendance_count_for("cancelled")).to eq(1)
+        expect(dashboard.attendance_count_for("transferred_out")).to eq(0)
       end
 
       it "rates full attendance over every registrant (active + no-shows, excluding cancellations)" do
@@ -992,7 +994,7 @@ RSpec.describe EventDashboard do
         expect(dashboard.attendance_recorded?).to be(false)
         expect(dashboard.attendance_outcome_count).to eq(0)
         expect(dashboard.attendance_rate).to be_nil
-        expect(dashboard.attendance_pending_count).to eq(1)
+        expect(dashboard.attendance_count_for("registered")).to eq(1)
       end
     end
   end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -964,10 +964,10 @@ RSpec.describe EventDashboard do
         expect(dashboard.attendance_pending_count).to eq(2)
       end
 
-      it "reports the recorded-outcome total and rate (incomplete counts as showing up)" do
+      it "reports the recorded-outcome total and rate (only full attendance counts toward it)" do
         expect(dashboard.attendance_recorded?).to be(true)
         expect(dashboard.attendance_outcome_count).to eq(4)
-        expect(dashboard.attendance_rate).to eq(3.0 / 4)
+        expect(dashboard.attendance_rate).to eq(2.0 / 4)
       end
 
       it "lists the registrants behind each status" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -955,25 +955,31 @@ RSpec.describe EventDashboard do
         create(:event_registration, event: event, registrant: create(:person, first_name: "Ca"), status: "no_show")
         create(:event_registration, event: event, registrant: create(:person, first_name: "Da"), status: "registered")
         create(:event_registration, event: event, registrant: create(:person, first_name: "Ea"), status: "transferred_in")
+        create(:event_registration, event: event, registrant: create(:person, first_name: "Fa"), status: "cancelled")
       end
 
-      it "counts each attendance outcome" do
+      it "counts each attendance status" do
         expect(dashboard.attended_count).to eq(2)
         expect(dashboard.incomplete_attendance_count).to eq(1)
         expect(dashboard.no_show_count).to eq(1)
         expect(dashboard.attendance_pending_count).to eq(2)
+        expect(dashboard.cancelled_count).to eq(1)
       end
 
-      it "reports the recorded-outcome total and rate (only full attendance counts toward it)" do
+      it "rates full attendance over every registrant (active + no-shows, excluding cancellations)" do
         expect(dashboard.attendance_recorded?).to be(true)
         expect(dashboard.attendance_outcome_count).to eq(4)
-        expect(dashboard.attendance_rate).to eq(2.0 / 4)
+        # 5 active registrants (attended ×2, incomplete, registered, transferred_in)
+        # + 1 no-show; the cancellation is excluded.
+        expect(dashboard.expected_attendee_count).to eq(6)
+        expect(dashboard.attendance_rate).to eq(2.0 / 6)
       end
 
       it "lists the registrants behind each status" do
         expect(dashboard.attendance_registrants("attended").map(&:first_name)).to eq(%w[ Aa Ab ])
         expect(dashboard.attendance_registrants("no_show").map(&:first_name)).to eq(%w[ Ca ])
         expect(dashboard.attendance_registrants("registered", "transferred_in").map(&:first_name)).to eq(%w[ Da Ea ])
+        expect(dashboard.attendance_registrants("cancelled").map(&:first_name)).to eq(%w[ Fa ])
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained stats logic + one new dashboard card, no data migration

### What is the goal of this PR and why is this important?
- Surfaces per-registrant attendance outcomes on the event dashboard so staff can see who showed up without leaving the page.

### How did you approach the change?
- Added attendance methods to `EventDashboard` (counts per status, recorded-outcome total, show rate, per-status registrant lists) off a single grouped query.
- Added an "Attendance" breakdown card to `dashboard.html.erb` (headline show rate + Attended / Incomplete / No show / Not recorded rows), each row expanding to its registrants and drilling into the filtered roster via the existing `attendance_status` filter.
- Extracted a count-based `_attendance_stat_row` partial (sibling of `_dashboard_money_row`).

### Anything else to add?
- Show rate = (attended + incomplete) / (attended + incomplete + no-show); nil/"Not yet recorded" until an outcome lands.