### PR TITLE
Replace org Windows-audience dropdown with age-range chip picker

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -212,9 +212,13 @@ class OrganizationsController < ApplicationController
 
     # The category types this form edits via category_ids — the profile-specific
     # types shown below (workshop settings). assign_associations preserves taggings
-    # of any other type (age ranges included, handled by nested attributes), so
-    # saving the form can't drop an organization's other category connections.
-    @managed_category_type_ids = @org_categories_grouped.map { |type, _| type.id }
+    # of any other type, so saving the form can't drop an organization's other
+    # category connections. AgeRange is excluded even when an admin has marked it
+    # profile_specific: the form never renders age checkboxes, so claiming it here
+    # would delete the taggings the chip picker saves as nested attributes.
+    @managed_category_type_ids = @org_categories_grouped
+      .reject { |type, _| type.name == AgeGroupTaggable::AGE_RANGE_CATEGORY_TYPE }
+      .map { |type, _| type.id }
   end
 
   def set_index_variables
@@ -260,7 +264,10 @@ class OrganizationsController < ApplicationController
       :profile_show_sectors, :profile_show_age_ranges, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,
       :profile_show_stories, :profile_show_events_registered, :profile_show_workshop_logs,
-      category_ids: [],
+      # category_ids is deliberately NOT permitted (people_controller does the same):
+      # assign_associations reads it raw after the save. Mass-assigning it here would
+      # replace the whole categories collection mid-assign, deleting the age-range
+      # taggings the nested attributes below are editing.
       sectorable_items_attributes: [
         :id,
         :sector_id,

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -201,6 +201,20 @@ class OrganizationsController < ApplicationController
       .group_by(&:category_type)
       .select { |type, _| type&.profile_specific? }
       .sort_by { |type, _| type&.name.to_s.downcase }
+
+    # Age ranges edit as their own sectors-style cocoon chip picker (AgeRange
+    # isn't a profile_specific type, so it never appears in @org_categories_grouped).
+    # Tagged via age_range_categorizable_items nested attributes, not category_ids.
+    @age_range_type = CategoryType.find_by(name: AgeGroupTaggable::AGE_RANGE_CATEGORY_TYPE)
+    age_ranges = @age_range_type ? @age_range_type.categories.published.order(:position, :name) : Category.none
+    @age_ranges_collection = age_ranges.pluck(:name, :id)
+    @current_age_range_category_ids = @organization.age_range_categorizable_items.map(&:category_id)
+
+    # The category types this form edits via category_ids — the profile-specific
+    # types shown below (workshop settings). assign_associations preserves taggings
+    # of any other type (age ranges included, handled by nested attributes), so
+    # saving the form can't drop an organization's other category connections.
+    @managed_category_type_ids = @org_categories_grouped.map { |type, _| type.id }
   end
 
   def set_index_variables
@@ -242,7 +256,7 @@ class OrganizationsController < ApplicationController
     params.require(:organization).permit(
       :name, :description, :start_date, :end_date, :mission_vision_values,
       :organization_type, :organization_type_other, :filemaker_code, :logo, :notes, :email, :website_url,
-      :organization_status_id, :location_id, :windows_type_id, :high_profile, :parent_id,
+      :organization_status_id, :location_id, :high_profile, :parent_id,
       :profile_show_sectors, :profile_show_age_ranges, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,
       :profile_show_stories, :profile_show_events_registered, :profile_show_workshop_logs,
@@ -252,6 +266,7 @@ class OrganizationsController < ApplicationController
         :sector_id,
         :_destroy
       ],
+      age_range_categorizable_items_attributes: [ :id, :category_id, :is_primary, :_destroy ],
       affiliations_attributes: [
         :id,
         :person_id,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -474,9 +474,13 @@ class PeopleController < ApplicationController
 
     # The category types this form edits via category_ids — the profile-specific
     # types shown below (workshop settings). assign_associations preserves taggings
-    # of any other type (age ranges included, handled by nested attributes), so
-    # saving the form can't drop a person's other category connections.
-    @managed_category_type_ids = @person_categories_grouped.map { |type, _| type.id }
+    # of any other type, so saving the form can't drop a person's other category
+    # connections. AgeRange is excluded even when an admin has marked it
+    # profile_specific: the form never renders age checkboxes, so claiming it here
+    # would delete the taggings the chip picker saves as nested attributes.
+    @managed_category_type_ids = @person_categories_grouped
+      .reject { |type, _| type.name == AgeGroupTaggable::AGE_RANGE_CATEGORY_TYPE }
+      .map { |type, _| type.id }
 
     @staff_tags_collection = StaffTag.published.ordered.pluck(:name, :id)
     @current_staff_tag_ids = @person.staff_tag_ids

--- a/app/models/concerns/age_group_taggable.rb
+++ b/app/models/concerns/age_group_taggable.rb
@@ -8,6 +8,30 @@ module AgeGroupTaggable
 
   AGE_RANGE_CATEGORY_TYPE = "AgeRange"
 
+  included do
+    # Age ranges edit through cocoon nested fields like sectors — a scoped view of
+    # categorizable_items (AgeRange categories only) so the form's add/remove and
+    # primary toggle round-trip as nested attributes; the is_primary flag splits
+    # primary vs additional. The Person and Organization chip editors are identical.
+    has_many :age_range_categorizable_items,
+             -> { joins(category: :category_type).where(category_types: { name: AGE_RANGE_CATEGORY_TYPE }) },
+             class_name: "CategorizableItem", as: :categorizable, inverse_of: :categorizable
+    accepts_nested_attributes_for :age_range_categorizable_items, allow_destroy: true,
+                                  reject_if: proc { |attrs| attrs["category_id"].blank? }
+    # The picker can submit the same age range twice (two new rows), which the
+    # CategorizableItem uniqueness validation can't catch — both are unsaved, so
+    # both INSERT and hit the DB unique index. Collapse duplicates before validation.
+    before_validation :dedupe_age_range_items
+  end
+
+  # The age-range nested items in category position order for the cocoon chip
+  # editor. Reads the same association the form's nested attributes build into, so
+  # unsaved picks survive a failed save (and aren't primary-first — starring
+  # shouldn't reshuffle them). Display surfaces lead with the primary instead.
+  def age_range_items_ordered
+    age_range_categorizable_items.sort_by { |item| [ item.category&.position || 0, item.category&.name.to_s ] }
+  end
+
   # AgeRange categories tagged on this record, split by the primary flag and
   # returned in display order. Filters the categorizable_items association in
   # Ruby (like the sectors index does with sectorable_items) so the result rides
@@ -52,6 +76,22 @@ module AgeGroupTaggable
   end
 
   private
+
+  # Keep one tagging per age-range category. Prefer the persisted row, fold any
+  # duplicate's primary flag onto the keeper, and drop the extras (destroy if
+  # persisted, otherwise remove from the unsaved set).
+  def dedupe_age_range_items
+    live = age_range_categorizable_items.reject(&:marked_for_destruction?)
+    live.group_by(&:category_id).each_value do |items|
+      next if items.size <= 1
+
+      keeper = items.find(&:persisted?) || items.first
+      keeper.is_primary = true if items.any?(&:is_primary?)
+      (items - [ keeper ]).each do |dup|
+        dup.persisted? ? dup.mark_for_destruction : age_range_categorizable_items.delete(dup)
+      end
+    end
+  end
 
   def age_range_categories(primary:)
     categorizable_items

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -119,19 +119,8 @@ class Person < ApplicationRecord
   accepts_nested_attributes_for :contact_methods, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :sectorable_items, allow_destroy: true,
                                 reject_if: proc { |attrs| attrs["sector_id"].blank? }
-  # Age ranges edit through cocoon nested fields like sectors. A scoped view of
-  # categorizable_items (AgeRange categories only) so the form's add/remove and
-  # primary toggle round-trip as nested attributes — the is_primary flag splits
-  # primary vs additional, no separate primary_age_category_ids param needed.
-  has_many :age_range_categorizable_items,
-           -> { joins(category: :category_type).where(category_types: { name: AgeGroupTaggable::AGE_RANGE_CATEGORY_TYPE }) },
-           class_name: "CategorizableItem", as: :categorizable, inverse_of: :categorizable
-  accepts_nested_attributes_for :age_range_categorizable_items, allow_destroy: true,
-                                reject_if: proc { |attrs| attrs["category_id"].blank? }
-  # The picker can submit the same age range twice (two new rows), which the
-  # CategorizableItem uniqueness validation can't catch — both are unsaved, so
-  # both INSERT and hit the DB unique index. Collapse duplicates before validation.
-  before_validation :dedupe_age_range_items
+  # The age-range chip editor (age_range_categorizable_items nested attributes,
+  # dedupe, ordering) is shared with Organization via AgeGroupTaggable.
   accepts_nested_attributes_for :user, update_only: true
   accepts_nested_attributes_for :affiliations, allow_destroy: true,
     reject_if: proc { |attrs| attrs["organization_id"].blank? }
@@ -529,39 +518,17 @@ class Person < ApplicationRecord
     other_form_responses(OTHER_WORKSHOP_SETTING_IDENTIFIERS)
   end
 
-  # The age-range nested items in category position order for the cocoon chip
-  # editor. Reads the same association the form's nested attributes build into, so
-  # unsaved picks survive a failed save (and aren't primary-first — starring
-  # shouldn't reshuffle them). Display surfaces lead with the primary instead.
-  def age_range_items_ordered
-    age_range_categorizable_items.sort_by { |item| [ item.category&.position || 0, item.category&.name.to_s ] }
-  end
-
   private
 
   # Count the in-memory set (not a DB query): nested attributes build the items in
-  # one transaction, so a row-level check would see none persisted yet.
+  # one transaction, so a row-level check would see none persisted yet. Person-only:
+  # organizations aggregate several members' primary age groups (see AgeGroupTaggable),
+  # so their own tags don't carry this single-primary rule.
   def at_most_one_primary_age_range
     primary_count = age_range_categorizable_items.reject(&:marked_for_destruction?).count(&:is_primary?)
     return if primary_count <= 1
 
     errors.add(:base, "Only one age range can be marked as primary")
-  end
-
-  # Keep one tagging per age-range category. Prefer the persisted row, fold any
-  # duplicate's primary flag onto the keeper, and drop the extras (destroy if
-  # persisted, otherwise remove from the unsaved set).
-  def dedupe_age_range_items
-    live = age_range_categorizable_items.reject(&:marked_for_destruction?)
-    live.group_by(&:category_id).each_value do |items|
-      next if items.size <= 1
-
-      keeper = items.find(&:persisted?) || items.first
-      keeper.is_primary = true if items.any?(&:is_primary?)
-      (items - [ keeper ]).each do |dup|
-        dup.persisted? ? dup.mark_for_destruction : age_range_categorizable_items.delete(dup)
-      end
-    end
   end
 
   def other_form_responses(identifiers)

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -53,8 +53,8 @@
         <% end %>
       </div>
 
-      <!-- Sectors & Windows audience -->
-      <div class="grid grid-cols-1 items-start gap-4 md:grid-cols-[3fr_1fr]">
+      <!-- Sectors & Age ranges -->
+      <div class="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
         <div class="form-group space-y-4">
           <div class="mb-2 font-semibold text-gray-700">
             Sectors
@@ -79,15 +79,32 @@
           </div>
         </div>
 
-        <div>
-          <%= f.association :windows_type,
-                            label: "Windows audience",
-                            include_blank: true,
-                            required: false,
-                            input_html: {
-                              class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
-                            } %>
-        </div>
+        <!-- Age ranges (same cocoon chip picker as the person form) -->
+        <% if @age_ranges_collection.present? %>
+          <div class="form-group flex flex-col">
+            <div class="mb-2 font-semibold text-gray-700">
+              Age ranges
+            </div>
+            <div class="flex flex-1 flex-wrap content-start items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm"
+                 data-controller="primary-tag"
+                 data-primary-tag-primary-class="border-amber-300 bg-amber-50"
+                 data-primary-tag-default-class="border-gray-300 bg-white">
+              <% age_owner = f.object.respond_to?(:object) ? f.object.object : f.object %>
+              <%= f.simple_fields_for :age_range_categorizable_items, age_owner.age_range_items_ordered do |afi| %>
+                <%= render "shared/age_range_item_fields", f: afi %>
+              <% end %>
+
+              <%= link_to_add_association "➕ Add age range",
+                                          f,
+                                          :age_range_categorizable_items,
+                                          partial: "shared/age_range_item_fields",
+                                          render_options: {
+                                            locals: { collection: (@age_ranges_collection || [])
+                                              .reject { |_, id| (@current_age_range_category_ids || []).include?(id) } } },
+                                          class: "btn btn-secondary-outline" %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
 
@@ -98,26 +115,29 @@
     </div>
   </div>
 
-  <!-- Profile-specific Categories (e.g. Workshop Settings) -->
-  <% if @org_categories_grouped.present? %>
-    <% primary_age_ids = @organization.primary_age_category_ids %>
+  <%# Tells the controller which category types this form edits via category_ids
+      (workshop settings); saving replaces only those and preserves any other type
+      the form never shows (age ranges, edited as nested attributes above). Always
+      submit the blank keys so unchecking every box still posts them. %>
+  <%= hidden_field_tag "organization[category_ids][]", "" %>
+  <%= hidden_field_tag "organization[managed_category_type_ids][]", "" %>
+  <% (@managed_category_type_ids || []).each do |type_id| %>
+    <%= hidden_field_tag "organization[managed_category_type_ids][]", type_id %>
+  <% end %>
+
+  <!-- Profile-specific Categories (other than age ranges, e.g. Workshop Settings) -->
+  <% other_category_types = (@org_categories_grouped || {}).reject { |type, _| type.name == "AgeRange" } %>
+  <% if other_category_types.present? %>
     <div class="form-group mb-8 space-y-4">
-      <%# Ensures the primary-age param is always submitted so unchecking every
-          toggle clears the primary flags. %>
-      <%= hidden_field_tag "organization[primary_age_category_ids][]", "" %>
-      <% @org_categories_grouped.each do |type, cats| %>
-        <% is_age = type.name == "AgeRange" %>
+      <% other_category_types.each do |type, cats| %>
         <div class="mb-2 font-semibold text-gray-700"><%= type.display_label %></div>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-          <% if is_age %>
-            <p class="mb-3 text-sm text-gray-500">Check every age group served, then mark the primary ones.</p>
-          <% end %>
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "organization", category: category,
                          checked: @organization.category_ids.include?(category.id),
-                         is_age: is_age,
-                         primary_checked: is_age && primary_age_ids.include?(category.id) %>
+                         is_age: false,
+                         primary_checked: false %>
             <% end %>
           </div>
         </div>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -101,7 +101,7 @@
                                           render_options: {
                                             locals: { collection: (@age_ranges_collection || [])
                                               .reject { |_, id| (@current_age_range_category_ids || []).include?(id) } } },
-                                          class: "btn btn-secondary-outline" %>
+                                          class: button_classes(:secondary_outline) %>
             </div>
           </div>
         <% end %>
@@ -135,9 +135,7 @@
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "organization", category: category,
-                         checked: @organization.category_ids.include?(category.id),
-                         is_age: false,
-                         primary_checked: false %>
+                         checked: @organization.category_ids.include?(category.id) %>
             <% end %>
           </div>
         </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -235,9 +235,7 @@
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "person", category: category,
-                         checked: @person.category_ids.include?(category.id),
-                         is_age: false,
-                         primary_checked: false %>
+                         checked: @person.category_ids.include?(category.id) %>
             <% end %>
           </div>
         </div>

--- a/app/views/shared/_category_checkbox.html.erb
+++ b/app/views/shared/_category_checkbox.html.erb
@@ -1,9 +1,6 @@
 <%# A profile-specific category checkbox shared by the person and organization
-    edit forms. param_key is "person" or "organization". For AgeRange categories
-    (is_age), it also renders a "Primary" toggle that submits
-    [param_key][primary_age_category_ids][] so the tagging is split into the
-    primary vs additional age groups served. The primary toggle sits outside the
-    membership label so the two checkboxes never toggle each other. %>
+    edit forms. param_key is "person" or "organization". AgeRange categories are
+    edited by the cocoon chip picker instead, so they never reach this partial. %>
 <% id = "#{param_key}_category_ids_#{category.id}" %>
 <div class="flex w-auto min-w-[180px] items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
   <label for="<%= id %>" class="flex cursor-pointer items-center gap-2">
@@ -13,19 +10,6 @@
                       checked,
                       id: id,
                       class: "h-4 w-4 text-blue-600 rounded" %>
-    <span class="text-sm whitespace-nowrap text-gray-700"><%= is_age ? category.decorate.age_group_label : category.name %></span>
+    <span class="text-sm whitespace-nowrap text-gray-700"><%= category.name %></span>
   </label>
-  <% if is_age %>
-    <% primary_id = "#{param_key}_primary_age_#{category.id}" %>
-    <label for="<%= primary_id %>"
-           class="ml-auto flex cursor-pointer items-center gap-1 text-xs text-gray-500"
-           title="Mark as a primary age group served">
-      <%= check_box_tag "#{param_key}[primary_age_category_ids][]",
-                        category.id,
-                        primary_checked,
-                        id: primary_id,
-                        class: "h-3.5 w-3.5 text-amber-600 rounded" %>
-      Primary
-    </label>
-  <% end %>
 </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3277,3 +3277,16 @@
     menu — with a back link (to Admin home, or to Forms) at the top of each.
   action_path: "/forms"
   pr_number: 2506
+
+- name: "Age-range editor on the organization form"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-09-01
+  action_path: "/organizations"
+  pr_number: 2039
+  summary: >-
+    Pick an organization's primary and additional age ranges with the same chip
+    editor the person form uses, replacing the old single-choice Windows audience
+    dropdown.
+  pro_tips:
+    - "Star one chip to mark it the primary age range served; the rest stay additional."

--- a/spec/requests/organizations_age_ranges_spec.rb
+++ b/spec/requests/organizations_age_ranges_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "Organization age ranges", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let!(:organization_status) { create(:organization_status, name: "Active") }
+  let(:organization) { create(:organization, organization_status: organization_status) }
+
+  # AgeGroupTaggable matches the type by the exact name "AgeRange".
+  let(:age_type) { create(:category_type, :published, name: "AgeRange") }
+  # Created in order so the positioned gem assigns positions children < teens < adults.
+  let!(:children) { create(:category, :published, category_type: age_type, name: "Children (0-12)") }
+  let!(:teens) { create(:category, :published, category_type: age_type, name: "Teens (13-17)") }
+  let!(:adults) { create(:category, :published, category_type: age_type, name: "Adults (18+)") }
+
+  # A profile-specific category the form edits via category_ids (workshop settings).
+  let(:workshop_type) { create(:category_type, :published, name: "WorkshopEnvironment", profile_specific: true) }
+  let!(:in_person) { create(:category, :published, category_type: workshop_type, name: "In person") }
+
+  before { sign_in admin }
+
+  # Age ranges save as age_range_categorizable_items nested attributes (the cocoon
+  # chip picker), not category_ids — mirroring the person form.
+  def update_org(age_items:, category_ids: [ "" ])
+    patch organization_path(organization), params: {
+      organization: {
+        name: organization.name,
+        organization_status_id: organization_status.id,
+        category_ids: category_ids,
+        managed_category_type_ids: [ workshop_type.id ],
+        age_range_categorizable_items_attributes: age_items
+      }
+    }
+  end
+
+  describe "edit form" do
+    it "renders the cocoon age-range chip picker, not the windows dropdown" do
+      get edit_organization_path(organization)
+
+      expect(response.body).to include("primary-tag")
+      expect(response.body).to include("Add age range")
+      expect(response.body).to include("Children (0-12)")
+      expect(response.body).not_to include("organization[windows_type_id]")
+    end
+  end
+
+  describe "saving age ranges" do
+    it "tags the selected age ranges and marks the chosen one primary" do
+      update_org(age_items: [
+        { category_id: children.id, is_primary: "1" },
+        { category_id: adults.id, is_primary: "0" }
+      ])
+
+      organization.reload
+      expect(organization.primary_age_groups).to contain_exactly(children)
+      expect(organization.additional_age_groups).to contain_exactly(adults)
+    end
+
+    it "removes an age range via _destroy" do
+      organization.categories << children
+      item = organization.categorizable_items.find_by(category: children)
+
+      update_org(age_items: [ { id: item.id, category_id: children.id, _destroy: "1" } ])
+
+      organization.reload
+      expect(organization.primary_age_groups).to be_empty
+      expect(organization.additional_age_groups).to be_empty
+    end
+
+    it "dedupes duplicate selections instead of raising RecordNotUnique" do
+      expect {
+        update_org(age_items: [
+          { category_id: children.id, is_primary: "0" },
+          { category_id: children.id, is_primary: "1" }
+        ])
+      }.not_to raise_error
+
+      organization.reload
+      expect(organization.categorizable_items.where(category: children).count).to eq(1)
+      expect(organization.primary_age_groups).to contain_exactly(children)
+    end
+  end
+
+  describe "preserving non-AgeRange category connections" do
+    it "keeps the organization's workshop-setting taggings when saving age ranges" do
+      organization.categories << in_person
+
+      update_org(age_items: [ { category_id: children.id, is_primary: "1" } ],
+                 category_ids: [ "", in_person.id.to_s ])
+
+      organization.reload
+      expect(organization.categories).to include(in_person)
+      expect(organization.primary_age_groups).to contain_exactly(children)
+    end
+  end
+end

--- a/spec/requests/organizations_age_ranges_spec.rb
+++ b/spec/requests/organizations_age_ranges_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe "Organization age ranges", type: :request do
 
   # Age ranges save as age_range_categorizable_items nested attributes (the cocoon
   # chip picker), not category_ids — mirroring the person form.
-  def update_org(age_items:, category_ids: [ "" ])
+  def update_org(age_items:, category_ids: [ "" ], managed_type_ids: [ workshop_type.id ])
     patch organization_path(organization), params: {
       organization: {
         name: organization.name,
         organization_status_id: organization_status.id,
         category_ids: category_ids,
-        managed_category_type_ids: [ workshop_type.id ],
+        managed_category_type_ids: managed_type_ids,
         age_range_categorizable_items_attributes: age_items
       }
     }
@@ -90,6 +90,57 @@ RSpec.describe "Organization age ranges", type: :request do
       organization.reload
       expect(organization.categories).to include(in_person)
       expect(organization.primary_age_groups).to contain_exactly(children)
+    end
+
+    # An admin can flag the AgeRange type profile_specific in /category_types. The
+    # form renders no age checkboxes either way, so the type has to stay out of
+    # managed_category_type_ids — otherwise assign_associations sees an empty
+    # selection for a managed type and deletes what the chip picker just saved.
+    it "keeps the age ranges when an admin has marked the AgeRange type profile_specific" do
+      age_type.update!(profile_specific: true)
+      organization.age_range_categorizable_items.create!(category: children, is_primary: false)
+
+      get edit_organization_path(organization)
+      managed_type_ids = Nokogiri::HTML(response.body)
+        .css("input[name='organization[managed_category_type_ids][]']")
+        .filter_map { |input| input["value"].presence }
+      expect(managed_type_ids).not_to include(age_type.id.to_s)
+
+      update_org(age_items: [
+        { id: organization.age_range_categorizable_items.first.id, category_id: children.id, is_primary: "0" },
+        { category_id: teens.id, is_primary: "1" }
+      ], managed_type_ids: managed_type_ids)
+
+      organization.reload
+      expect(organization.primary_age_groups).to contain_exactly(teens)
+      expect(organization.additional_age_groups).to contain_exactly(children)
+    end
+  end
+
+  # The form posts every existing chip back as a nested row alongside category_ids.
+  # If category_ids were mass-assigned it would replace the whole categories
+  # collection mid-assign, deleting those rows before their nested attributes are
+  # applied — the resubmitted ids then point at nothing and the save 404s.
+  describe "re-saving the form with existing age ranges" do
+    it "round-trips the already-tagged age ranges" do
+      organization.age_range_categorizable_items.create!(category: children, is_primary: true)
+      item = organization.age_range_categorizable_items.first
+      organization.categories << in_person
+
+      patch organization_path(organization), params: {
+        organization: {
+          name: organization.name,
+          organization_status_id: organization_status.id,
+          age_range_categorizable_items_attributes: { "0" => { id: item.id, category_id: children.id, is_primary: "1" } },
+          category_ids: [ "", in_person.id.to_s ],
+          managed_category_type_ids: [ "", workshop_type.id.to_s ]
+        }
+      }
+
+      expect(response).to have_http_status(:see_other)
+      organization.reload
+      expect(organization.primary_age_groups).to contain_exactly(children)
+      expect(organization.categories).to include(in_person)
     end
   end
 end

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -27,12 +27,21 @@ RSpec.describe "organizations/edit", type: :view do
   it "renders the edit organization form" do
     render
     assert_select "form[action=?][method=?]", organization_path(organization), "post" do
-      assert_select "select[name=?]", "organization[windows_type_id]"
-
       assert_select "textarea[name=?]", "organization[name]"
 
       assert_select "textarea[name=?]", "organization[description]"
     end
+    # The Windows audience dropdown was replaced by the age-range chip picker.
+    assert_select "select[name=?]", "organization[windows_type_id]", false
+  end
+
+  it "renders the cocoon age-range chip picker instead of the windows dropdown" do
+    assign(:age_ranges_collection, [ [ "Children (0-12)", 1 ], [ "Adults (18+)", 2 ] ])
+    assign(:current_age_range_category_ids, [])
+    render
+    expect(rendered).to include("primary-tag")
+    expect(rendered).to include("Add age range")
+    expect(rendered).to include("Children (0-12)")
   end
 
   describe "status select visibility" do

--- a/spec/views/organizations/new.html.erb_spec.rb
+++ b/spec/views/organizations/new.html.erb_spec.rb
@@ -8,16 +8,25 @@ RSpec.describe "organizations/new", type: :view do
     assign(:organization, Organization.new)
     allow(view).to receive(:current_user).and_return(admin)
     allow(view).to receive(:allowed_to?).and_return(true)
-    render
   end
 
   it "renders new organization form" do
+    render
     assert_select "form[action=?][method=?]", organizations_path, "post" do
-      assert_select "select[name=?]", "organization[windows_type_id]"
-
       assert_select "textarea[name=?]", "organization[name]"
 
       assert_select "textarea[name=?]", "organization[description]"
     end
+    # The Windows audience dropdown was replaced by the age-range chip picker.
+    assert_select "select[name=?]", "organization[windows_type_id]", false
+  end
+
+  it "renders the cocoon age-range chip picker instead of the windows dropdown" do
+    assign(:age_ranges_collection, [ [ "Children (0-12)", 1 ], [ "Adults (18+)", 2 ] ])
+    assign(:current_age_range_category_ids, [])
+    render
+    expect(rendered).to include("primary-tag")
+    expect(rendered).to include("Add age range")
+    expect(rendered).to include("Children (0-12)")
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 strong-params + category-assignment change that could silently drop taggings

Organizations now pick age ranges with the same chip picker people use, instead of the single-choice "Windows audience" dropdown — so an org can record every age group it serves and star the primary one.

### The swap
- Replaces the `windows_type_id` dropdown on the org form with the cocoon age-range chip picker; the param is dropped since no other org flow writes it (the column and its reads elsewhere are untouched).
- Shared chip mechanics (`age_range_categorizable_items`, dedupe, ordering) moved into `AgeGroupTaggable`, which Person and Organization both already include.
- The single-primary validation stays Person-only — orgs aggregate several members' primary age groups.

### Two save bugs this had to fix
- **`category_ids` can't be mass-assigned.** `organization_params` permitted it, so `assign_attributes` replaced the whole categories collection *before* the nested age rows were applied — wiping existing age chips, and 404ing the save because the resubmitted row ids pointed at deleted rows. `people_controller` already keeps it out of strong params and reads it raw in `assign_associations`; org now matches.
- **AgeRange is excluded from `managed_category_type_ids`.** Neither form renders age checkboxes, so if an admin flags that type `profile_specific` in `/category_types`, `assign_associations` would see an empty selection for a "managed" type and delete what the picker just saved. Fixed in both controllers.

### Also
- `shared/_category_checkbox` loses its age branch — both callers passed `is_age: false`.
- Features & tips entry added.