### PR TITLE
Event background/dashboard: topic columns + equal-height cards, All age groups, program-status chart, print button; clearer registrant org labels

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -44,6 +44,11 @@ class FormField < ApplicationRecord
     "additional_age_group" => "AgeRange"
   }.freeze
 
+  # Both age group fields (the single-select "primary" and the multi-select
+  # "additional"), backing the "All age groups" breakdown. The "primary_age_group"
+  # field alone backs the "Primary age group" chart.
+  AGE_GROUP_FIELD_IDENTIFIERS = %w[primary_age_group additional_age_group].freeze
+
   # The payment-method field. Its answer options ("Credit card (now)", etc.) are
   # wired to Stripe charge logic in the controllers, so they must not be edited
   # casually from the form builder — the editor shows them read-only unless the

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -496,6 +496,35 @@ class EventDashboard
       .transform_values { |rows| rows.map(&:first).uniq }
   end
 
+  # Every age group (primary + additional) served, read from registrants'
+  # answers to BOTH the "primary_age_group" and "additional_age_group"
+  # registration questions, backing the "All age groups" chart. The
+  # "Primary age group" chart instead uses #age_groups / #age_group_counts,
+  # which read only the primary question.
+  def all_age_groups
+    @all_age_groups ||= Category.age_ranges
+      .where(id: all_age_group_counts.keys)
+      .ordered_by_position_and_name
+  end
+
+  # Distinct registrant count per age-group category across both age group
+  # questions, deduped per [ registrant, category ]. Keyed by Category id, so it
+  # pairs with all_age_groups for the view.
+  def all_age_group_counts
+    @all_age_group_counts ||= all_age_group_answer_rows
+      .group_by(&:last)
+      .transform_values { |rows| rows.map(&:first).uniq.size }
+  end
+
+  # Registrant ids per age-group category across both questions, keyed by
+  # Category id — the people behind each "All age groups" row, for drilling into
+  # the matching registrant list.
+  def all_age_group_registrant_ids_by_category
+    @all_age_group_registrant_ids_by_category ||= all_age_group_answer_rows
+      .group_by(&:last)
+      .transform_values { |rows| rows.map(&:first).uniq }
+  end
+
   # US states only — international registrants' regions (e.g. provinces) are
   # excluded so the States breakdown reflects domestic residents.
   def states
@@ -886,19 +915,29 @@ class EventDashboard
   end
 
   # [ person_id, age_group_category_id ] for every AgeRange selection in active
-  # registrants' "primary_age_group" registration answers. The answer text is a
-  # ", "-joined list of category ids (the checkbox values); non-numeric tokens
-  # (legacy free text) are ignored. Deduped per [ person, category ].
+  # registrants' "primary_age_group" registration answers. Deduped per
+  # [ person, category ].
   def age_group_answer_rows
-    @age_group_answer_rows ||= compute_age_group_answer_rows
+    @age_group_answer_rows ||= age_group_rows_for(%w[primary_age_group])
   end
 
-  def compute_age_group_answer_rows
-    field = registration_form_field("primary_age_group")
-    return [] unless field
+  # Same, but across BOTH the primary and additional age group questions —
+  # the union backing the "All age groups" breakdown.
+  def all_age_group_answer_rows
+    @all_age_group_answer_rows ||= age_group_rows_for(FormField::AGE_GROUP_FIELD_IDENTIFIERS)
+  end
+
+  # [ person_id, age_group_category_id ] rows for the registration fields with
+  # the given identifier(s). Each answer text is a ", "-joined list of category
+  # ids (the checkbox values); non-numeric tokens (legacy free text) are ignored.
+  # Deduped per [ person, category ], so a category chosen in more than one field
+  # counts once.
+  def age_group_rows_for(identifiers)
+    field_ids = registration_form_field_ids(identifiers)
+    return [] if field_ids.empty?
 
     FormAnswer
-      .where(form_field_id: field.id)
+      .where(form_field_id: field_ids)
       .joins(:form_submission)
       .where(form_submissions: { person_id: registrant_ids })
       .pluck(Arel.sql("form_submissions.person_id"), :submitted_answer)
@@ -972,6 +1011,13 @@ class EventDashboard
     @registration_form_fields ||= {}
     return @registration_form_fields[identifier] if @registration_form_fields.key?(identifier)
     @registration_form_fields[identifier] = event.registration_form&.form_fields&.find_by(field_identifier: identifier)
+  end
+
+  # Ids of the registration form fields matching any of the given identifier(s) —
+  # for questions that can span more than one field (e.g. the primary + additional
+  # age group fields). Returns [] when the event has no registration form.
+  def registration_form_field_ids(identifiers)
+    event.registration_form&.form_fields&.where(field_identifier: identifiers)&.ids || []
   end
 
   # State abbreviation for a US address, otherwise the country's ISO 3-letter

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -302,6 +302,19 @@ class EventDashboard
     @program_status_by_organization ||= organizations.to_h { |organization| [ organization.id, program_status_for(organization) ] }
   end
 
+  # Registrant ids grouped by their organization's program status
+  # (:new / :ongoing / :reinstated) — the people behind each program-status
+  # slice, for drilling into the matching registrant list. A registrant lands in
+  # a status if any of their represented orgs has it, so the buckets can overlap
+  # (a registrant with a new and an ongoing org appears under both).
+  def program_status_registrant_ids
+    @program_status_registrant_ids ||= program_status_by_organization
+      .each_with_object({ new: [], ongoing: [], reinstated: [] }) do |(organization_id, status), map|
+        map[status].concat(organization_registrant_ids_by_org.fetch(organization_id, []).to_a)
+      end
+      .transform_values(&:uniq)
+  end
+
   # Distinct program statuses for each registrant's organization(s), keyed by
   # Person id — for the registrant roster's program-status column.
   def program_statuses_by_registrant

--- a/app/views/events/_breakdown_card.html.erb
+++ b/app/views/events/_breakdown_card.html.erb
@@ -49,20 +49,24 @@
       <tbody>
         <% data.each_with_index do |(label, count), i| %>
           <% path = row_paths[label] %>
-          <tr class="border-t border-gray-100 <%= "hover:bg-gray-50 cursor-pointer transition-colors" if path %>"
+          <tr class="border-t border-gray-100 <%= "group hover:bg-gray-50 cursor-pointer transition-colors" if path %>"
               <% if path %>onclick="window.location='<%= path %>'"<% end %>>
             <td class="py-1 text-gray-700">
               <% if chart == :pie %>
                 <span class="inline-block w-3 h-3 rounded-sm mr-2 align-middle" style="background-color: <%= palette[i % palette.size] %>"></span>
               <% end %>
               <% if path %>
-                <%= link_to label, path, class: "hover:underline" %>
+                <%= link_to label, path, class: "group-hover:underline" %>
               <% else %>
                 <%= label %>
               <% end %>
             </td>
             <td class="py-1 text-right text-gray-500 tabular-nums whitespace-nowrap">
-              <%= count %><span class="text-gray-400"> · <%= total.zero? ? 0 : (count * 100.0 / total).round(1) %>%</span>
+              <span class="group-hover:underline"><%= count %><span class="text-gray-400"> · <%= total.zero? ? 0 : (count * 100.0 / total).round(1) %>%</span></span>
+              <%# Jump-link affordance: invisible (white) until the row is hovered, matching the dashboard rows. %>
+              <% if path %>
+                <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-white group-hover:text-gray-400 ml-1 align-middle" aria-hidden="true"></i>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -21,7 +21,7 @@
         <%# On by default — Organization shows unless the admin hides it. %>
         <label class="inline-flex items-center gap-2 cursor-pointer select-none"
                data-controller="column-toggle" data-column-toggle-group-value="organization">
-          <span class="text-sm text-gray-500">Organization</span>
+          <span class="text-sm text-gray-500">Linked organization</span>
 
           <input
             type="checkbox"
@@ -161,7 +161,7 @@
                 </span>
               </th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none" data-column-toggle-col="organization">
-                <%= render "shared/sortable_header", label: "Organization", index: 1 %>
+                <%= render "shared/sortable_header", label: "Linked organization", index: 1 %>
               </th>
 
               <% if ce_col %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -160,7 +160,9 @@
                   <%= render "shared/sortable_header", label: "Last", index: 0, key: "last" %>
                 </span>
               </th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none" data-column-toggle-col="organization">
+              <%# Extra left padding lines the header up with the org pill's text (the
+                  pill is inset from the cell edge by its own px-3), not the cell edge. %>
+              <th class="pl-7 pr-4 py-2 text-left text-sm font-semibold text-gray-700 w-full" aria-sort="none" data-column-toggle-col="organization">
                 <%= render "shared/sortable_header", label: "Linked organization", index: 1 %>
               </th>
 

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -56,7 +56,7 @@
 
     <%= render "events/filter_select", param: :org_status, label: "Organization linking",
           options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
-          selected: params[:org_status], blank: "All linkings", field_class: field_class %>
+          selected: params[:org_status], blank: "Any linking", field_class: field_class %>
 
     <%= render "events/filter_select", param: :comment_status, label: "Comments",
           options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -54,7 +54,7 @@
           options: [ [ "Not ready", "not_ready" ], [ "Ready", "ready" ], [ "Certificate pending", "certificate_due" ], [ "Completed", "completed" ] ],
           selected: params[:readiness], blank: "All statuses", field_class: field_class %>
 
-    <%= render "events/filter_select", param: :org_status, label: "Organization",
+    <%= render "events/filter_select", param: :org_status, label: "Organization linking",
           options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
           selected: params[:org_status], blank: "All organizations", field_class: field_class %>
 

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -56,7 +56,7 @@
 
     <%= render "events/filter_select", param: :org_status, label: "Organization linking",
           options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
-          selected: params[:org_status], blank: "All organizations", field_class: field_class %>
+          selected: params[:org_status], blank: "All linkings", field_class: field_class %>
 
     <%= render "events/filter_select", param: :comment_status, label: "Comments",
           options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -260,9 +260,9 @@
     <% if org_data.any? %>
       <div class="flex flex-col gap-6 lg:grid lg:grid-rows-subgrid lg:row-span-2">
         <% if program_status_data.any? %>
-          <%= render "breakdown_card", title: "Program status", data: program_status_data, chart: :pie, palette: program_status_palette, row_paths: program_status_paths %>
+          <%= render "breakdown_card", title: "Organization/program status", data: program_status_data, chart: :pie, palette: program_status_palette, row_paths: program_status_paths %>
         <% end %>
-        <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
+        <%= render "breakdown_card", title: "All organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
       </div>
     <% end %>
     <%# --- Remaining breakdowns flow below row 1 --- %>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -226,10 +226,13 @@
   <% program_status_paths = @dashboard.program_status_registrant_ids.to_h { |status, ids| [ status.to_s.titleize, registrants_event_path(@event, registrant_ids: ids.join("-")) ] } %>
   <%# States and countries use the addresses theme color (slate) for their map ramps. %>
   <% addresses_color = "#475569" %>
+  <%# On lg the three topic columns share row tracks via subgrid, so the primary
+      cards (row 1) line up in height with each other and the "all"/org cards
+      (row 2) line up with each other — across all three columns. %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
     <%# Col 1: sectors — primary on top, all sectors stacked below. %>
     <% if primary_sector_data.any? || sector_data.any? %>
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-6 lg:grid lg:grid-rows-subgrid lg:row-span-2">
         <% if primary_sector_data.any? %>
           <%= render "breakdown_card", title: "Primary sector", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
         <% end %>
@@ -241,7 +244,7 @@
     <%# Col 2: age groups — primary on top, all age groups stacked below. Primary
         always shows (no-data box when empty); "All age groups" (primary +
         additional questions) appears only when someone answered either. %>
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-6 lg:grid lg:grid-rows-subgrid lg:row-span-2">
       <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
                                    empty_message: "No age group responses from registration answers yet.", row_paths: age_group_paths %>
       <% if all_age_group_data.any? %>
@@ -251,7 +254,7 @@
     <%# Col 3: organizations — program-status breakdown (new/ongoing/reinstated)
         charted on top, the full org list below. %>
     <% if org_data.any? %>
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-6 lg:grid lg:grid-rows-subgrid lg:row-span-2">
         <% if program_status_data.any? %>
           <%= render "breakdown_card", title: "Program status", data: program_status_data, chart: :pie, palette: program_status_palette, row_paths: program_status_paths %>
         <% end %>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -48,7 +48,7 @@
       <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
     <% end %>
     <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-users-viewfinder <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %>"></i>
+      <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
       Get to know the registrants
     </h1>
   </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -31,12 +31,12 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-2 print:hidden">
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :background %>
   </div>
-  <div class="flex justify-end mb-6 print:hidden">
-    <button onclick="window.print();" class="text-sm text-gray-500 hover:text-gray-700">
+  <div class="flex justify-end gap-3 mb-6 print:hidden">
+    <button onclick="window.print();" class="btn btn-utility-outline">
       <i class="fa-solid fa-print"></i> Print
     </button>
   </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -29,7 +29,11 @@
 <%# Shared palette: pie slice i and its legend swatch i both use palette[i]. %>
 <% palette = %w[#3b82f6 #ef4444 #f59e0b #10b981 #6366f1 #ec4899 #14b8a6 #f97316 #8b5cf6 #84cc16 #06b6d4 #eab308 #a855f7 #22c55e #fb7185] %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<%# Opt out of the layout's max-w-7xl cap to match the wider registrants page;
+    the wrapper restores the layout's gutters at a wider bound. %>
+<% content_for(:full_width, true) %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -285,4 +289,5 @@
       <%= render "breakdown_card", title: "Settings", data: settings_data, chart: :bar, palette: palette, row_paths: settings_paths %>
     <% end %>
   </div>
+</div>
 </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -278,7 +278,7 @@
       <%= render "breakdown_card", title: "States", data: state_data, chart: :map, palette: palette, map_color: addresses_color, row_paths: state_paths %>
     <% end %>
     <% if school_district_data.any? %>
-      <%= render "breakdown_card", title: "School districts", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>
+      <%= render "breakdown_card", title: "School districts (via Address data)", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>
     <% end %>
     <%# Life experiences and settings come from registration answers; hide each
         card entirely when no one has answered those questions. %>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -10,6 +10,7 @@
 <% other_response_data = @dashboard.other_sector_response_rows.map { |text, count, _ids| [ text, count ] } %>
 <% other_response_paths = @dashboard.other_sector_response_rows.to_h { |text, _count, ids| [ text, registrants_event_path(@event, registrant_ids: ids.join("-")) ] } %>
 <% age_group_data = @dashboard.age_groups.map { |c| [ c.name, @dashboard.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
+<% all_age_group_data = @dashboard.all_age_groups.map { |c| [ c.name, @dashboard.all_age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% state_data = @dashboard.state_counts.sort_by { |_, count| -count } %>
 <% country_data = @dashboard.country_counts.sort_by { |_, count| -count } %>
 <% school_district_data = @dashboard.school_district_counts.sort_by { |_, count| -count } %>
@@ -207,37 +208,50 @@
   <% sector_paths = @dashboard.sectors.to_h { |s| [ s.name, registrants_event_path(@event, sector: s.id) ] } %>
   <% sector_paths["Other"] = registrants_event_path(@event, registrant_ids: @dashboard.other_sector_response_registrant_ids.join("-")) if @dashboard.other_sector_response_count.positive? %>
   <% age_group_paths = @dashboard.age_groups.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.age_group_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
+  <% all_age_group_paths = @dashboard.all_age_groups.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.all_age_group_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% state_paths = @dashboard.states.index_with { |state| registrants_event_path(@event, state: state) } %>
   <% country_paths = @dashboard.country_registrant_ids_by_country.transform_values { |ids| registrants_event_path(@event, registrant_ids: ids.join("-")) } %>
   <% school_district_paths = @dashboard.school_district_registrant_ids_by_district.transform_values { |ids| registrants_event_path(@event, registrant_ids: ids.join("-")) } %>
   <% life_experience_paths = @dashboard.life_experiences.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.life_experience_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% settings_paths = @dashboard.settings.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.settings_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% org_paths = @dashboard.organizations.to_h { |o| [ o.name, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(o.id, []).to_a.join("-")) ] } %>
+  <%# States and countries use the addresses theme color (slate) for their map ramps. %>
+  <% addresses_color = "#475569" %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
-    <% if primary_sector_data.any? %>
-      <%= render "breakdown_card", title: "Primary sector", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
+    <%# Col 1: sectors — primary on top, all sectors stacked below. %>
+    <% if primary_sector_data.any? || sector_data.any? %>
+      <div class="flex flex-col gap-6">
+        <% if primary_sector_data.any? %>
+          <%= render "breakdown_card", title: "Primary sector", data: primary_sector_data, chart: :pie, palette: palette, row_paths: primary_sector_paths %>
+        <% end %>
+        <% if sector_data.any? %>
+          <%= render "breakdown_card", title: "All sectors", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
+        <% end %>
+      </div>
     <% end %>
-    <% if sector_data.any? %>
-      <%= render "breakdown_card", title: "All sectors", data: sector_data, chart: :pie, palette: palette, row_paths: sector_paths %>
+    <%# Col 2: age groups — primary on top, all age groups stacked below. Primary
+        always shows (no-data box when empty); "All age groups" (primary +
+        additional questions) appears only when someone answered either. %>
+    <div class="flex flex-col gap-6">
+      <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
+                                   empty_message: "No age group responses from registration answers yet.", row_paths: age_group_paths %>
+      <% if all_age_group_data.any? %>
+        <%= render "breakdown_card", title: "All age groups", data: all_age_group_data, chart: :pie, palette: palette, row_paths: all_age_group_paths %>
+      <% end %>
+    </div>
+    <%# Col 3: organizations. %>
+    <% if org_data.any? %>
+      <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
     <% end %>
+    <%# --- Remaining breakdowns flow below row 1 --- %>
     <%# The free-text values behind the "Other" sector slice — a list, since these
         are un-curated answers a curator later promotes into real sectors. %>
     <% if other_response_data.any? %>
       <%= render "breakdown_card", title: "Other sector responses", data: other_response_data, chart: nil, palette: palette, row_paths: other_response_paths %>
     <% end %>
-    <%# States and countries use the addresses theme color (slate) for their map ramps. %>
-    <% addresses_color = "#475569" %>
-    <%# Age group and Countries are both short; stack them in one column so the pair
-        fits within the height of the taller Primary sector pie card. %>
-    <div class="flex flex-col gap-6">
-      <%# Primary age group comes from the registration "ages served" answers;
-          always show the card (with a no-data box when empty). %>
-      <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
-                                   empty_message: "No age group responses from registration answers yet.", row_paths: age_group_paths %>
-      <% if country_data.any? %>
-        <%= render "breakdown_card", title: "Countries", data: country_data, chart: :world_map, palette: palette, map_color: addresses_color, row_paths: country_paths %>
-      <% end %>
-    </div>
+    <% if country_data.any? %>
+      <%= render "breakdown_card", title: "Countries", data: country_data, chart: :world_map, palette: palette, map_color: addresses_color, row_paths: country_paths %>
+    <% end %>
     <% if state_data.any? %>
       <%= render "breakdown_card", title: "States", data: state_data, chart: :map, palette: palette, map_color: addresses_color, row_paths: state_paths %>
     <% end %>
@@ -251,9 +265,6 @@
     <% end %>
     <% if settings_data.any? %>
       <%= render "breakdown_card", title: "Settings", data: settings_data, chart: :bar, palette: palette, row_paths: settings_paths %>
-    <% end %>
-    <% if org_data.any? %>
-      <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -15,6 +15,14 @@
 <% country_data = @dashboard.country_counts.sort_by { |_, count| -count } %>
 <% school_district_data = @dashboard.school_district_counts.sort_by { |_, count| -count } %>
 <% org_data = @dashboard.organizations.map { |o| [ o.name, @dashboard.organization_counts.fetch(o.id, 0) ] }.sort_by { |_, count| -count } %>
+<%# Program-status breakdown of the represented orgs. Each status carries its own
+    swatch (green/blue/purple) matching the OrganizationDecorator badge colors, and
+    zero-count statuses drop out so data and palette stay aligned. %>
+<% program_status_rows = [ [ "New", @dashboard.program_status_counts[:new], "#22c55e" ],
+                           [ "Ongoing", @dashboard.program_status_counts[:ongoing], "#3b82f6" ],
+                           [ "Reinstated", @dashboard.program_status_counts[:reinstated], "#a855f7" ] ].select { |_, count, _| count.positive? } %>
+<% program_status_data = program_status_rows.map { |label, count, _| [ label, count ] } %>
+<% program_status_palette = program_status_rows.map { |_, _, color| color } %>
 <% life_experience_data = @dashboard.life_experiences.map { |c| [ c.name, @dashboard.life_experience_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% settings_data = @dashboard.settings.map { |c| [ c.name, @dashboard.settings_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 
@@ -215,6 +223,7 @@
   <% life_experience_paths = @dashboard.life_experiences.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.life_experience_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% settings_paths = @dashboard.settings.to_h { |c| [ c.name, registrants_event_path(@event, registrant_ids: @dashboard.settings_registrant_ids_by_category.fetch(c.id, []).join("-")) ] } %>
   <% org_paths = @dashboard.organizations.to_h { |o| [ o.name, registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(o.id, []).to_a.join("-")) ] } %>
+  <% program_status_paths = @dashboard.program_status_registrant_ids.to_h { |status, ids| [ status.to_s.titleize, registrants_event_path(@event, registrant_ids: ids.join("-")) ] } %>
   <%# States and countries use the addresses theme color (slate) for their map ramps. %>
   <% addresses_color = "#475569" %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
@@ -239,9 +248,15 @@
         <%= render "breakdown_card", title: "All age groups", data: all_age_group_data, chart: :pie, palette: palette, row_paths: all_age_group_paths %>
       <% end %>
     </div>
-    <%# Col 3: organizations. %>
+    <%# Col 3: organizations — program-status breakdown (new/ongoing/reinstated)
+        charted on top, the full org list below. %>
     <% if org_data.any? %>
-      <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
+      <div class="flex flex-col gap-6">
+        <% if program_status_data.any? %>
+          <%= render "breakdown_card", title: "Program status", data: program_status_data, chart: :pie, palette: program_status_palette, row_paths: program_status_paths %>
+        <% end %>
+        <%= render "breakdown_card", title: "Organizations", data: org_data, chart: nil, palette: palette, row_paths: org_paths %>
+      </div>
     <% end %>
     <%# --- Remaining breakdowns flow below row 1 --- %>
     <%# The free-text values behind the "Other" sector slice — a list, since these

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -48,7 +48,7 @@
       <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
     <% end %>
     <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
+      <i class="fa-solid fa-users-viewfinder <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %>"></i>
       Get to know the registrants
     </h1>
   </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -47,7 +47,7 @@
     <% if @event.start_date.present? %>
       <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
     <% end %>
-    <h1 class="text-4xl sm:text-5xl font-extrabold text-black mt-2 flex items-center justify-center gap-3">
+    <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
       <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
       Get to know the registrants
     </h1>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -1,9 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <%# Top bar: back link + actions %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+  <%# Top bar: back link + sub-nav, matching the other event pages %>
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-2 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
+  </div>
+  <div class="flex justify-end mb-6 print:hidden">
+    <button onclick="window.print();" class="text-sm text-gray-500 hover:text-gray-700">
+      <i class="fa-solid fa-print"></i> Print
+    </button>
   </div>
 
   <%# Centered title block %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-2 print:hidden">
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
-  <div class="flex justify-end mb-6 print:hidden">
-    <button onclick="window.print();" class="text-sm text-gray-500 hover:text-gray-700">
+  <div class="flex justify-end gap-3 mb-6 print:hidden">
+    <button onclick="window.print();" class="btn btn-utility-outline">
       <i class="fa-solid fa-print"></i> Print
     </button>
   </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -1,5 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<%# Opt out of the layout's max-w-7xl cap to match the wider registrants page;
+    the wrapper restores the layout's gutters at a wider bound. %>
+<% content_for(:full_width, true) %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -419,4 +423,5 @@
       </div>
     </details>
   </div>
+</div>
 </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -20,7 +20,7 @@
       </p>
     <% end %>
     <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-chart-simple text-blue-600"></i>
+      <i class="fa-solid fa-chart-simple <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
       Dashboard
     </h1>
   </div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -1,10 +1,14 @@
-<% content_for(:page_bg_class, "admin-only bg-white") %>
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
 <% answers_by_applicant = @dashboard.scholarship_answers_by_applicant %>
 <% header_answers = @dashboard.header_answers_by_applicant %>
 <% event_date = @event.start_date %>
 
-<div class="max-w-7xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<%# Opt out of the layout's max-w-7xl cap to match the wider registrants page;
+    the wrapper restores the layout's gutters at a wider bound. %>
+<% content_for(:full_width, true) %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+<div class="bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -269,4 +273,5 @@
       </div>
     </div>
   <% end %>
+</div>
 </div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -25,6 +25,9 @@
   <%# Title block %>
   <div class="text-center mb-8">
     <%= link_to @event.title, edit_event_path(@event), class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
+    <% if @event.start_date.present? %>
+      <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+    <% end %>
     <h1 class="text-3xl font-bold mt-1 flex items-center justify-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
       <i class="fa-solid fa-graduation-cap"></i>
       Scholarship recipients

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -20,6 +20,9 @@
       event title eyebrow over a text-3xl heading with an icon. %>
   <div class="text-center mb-8">
     <p class="text-sm font-semibold text-gray-500 uppercase tracking-wide"><%= @event.title %></p>
+    <% if @event.start_date.present? %>
+      <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+    <% end %>
     <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
       <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
       Meet the staff

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -21,7 +21,7 @@
   <div class="text-center mb-8">
     <p class="text-sm font-semibold text-gray-500 uppercase tracking-wide"><%= @event.title %></p>
     <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-users text-blue-600"></i>
+      <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
       Meet the staff
     </h1>
   </div>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -1,6 +1,10 @@
 <% content_for(:page_bg_class, "public") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<%# Opt out of the layout's max-w-7xl cap to match the wider registrants page;
+    the wrapper restores the layout's gutters at a wider bound. %>
+<% content_for(:full_width, true) %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
@@ -152,4 +156,5 @@
       None yet!
     </div>
   <% end %>
+</div>
 </div>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -2,23 +2,28 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-2 print:hidden">
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <% if allowed_to?(:manage?, @event) %>
       <%= render "events/subnav", event: @event, current: :staff %>
     <% end %>
   </div>
   <% if allowed_to?(:edit_staff?, @event) %>
-    <div class="flex justify-end mb-6 print:hidden">
+    <div class="flex justify-end gap-3 mb-6 print:hidden">
       <%= link_to edit_staff_event_path(@event), class: "admin-only btn btn-primary btn--small" do %>
         <i class="fa-solid fa-pen"></i> Edit staff
       <% end %>
     </div>
   <% end %>
 
-  <div class="text-center mb-10">
-    <p class="text-sm font-semibold uppercase tracking-wide <%= DomainTheme.text_class_for(:events) %>">Meet the staff</p>
-    <h1 class="text-3xl font-bold text-gray-900 mt-1"><%= @event.title %></h1>
+  <%# Title block — matches the dashboard/background/scholarships report pages:
+      event title eyebrow over a text-3xl heading with an icon. %>
+  <div class="text-center mb-8">
+    <p class="text-sm font-semibold text-gray-500 uppercase tracking-wide"><%= @event.title %></p>
+    <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+      <i class="fa-solid fa-users text-blue-600"></i>
+      Meet the staff
+    </h1>
   </div>
 
   <% if @event_staffs.any? %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1714,6 +1714,14 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to match(/\d+ new · \d+ ongoing · \d+ reinstated/)
       end
 
+      it "charts the organizations' program-status breakdown above the org list" do
+        get background_event_path(event)
+
+        expect(response.body).to include("Program status")
+        # "Background Org" is the registrant's first-facilitator program → New.
+        expect(response.body).to include("New")
+      end
+
       it "shows a program-status column in the registrant roster" do
         get background_event_path(event)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1760,6 +1760,26 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("100.0%")
       end
 
+      it "shows an all age groups breakdown spanning the primary and additional questions" do
+        registration_form = create(:form, name: "Registration")
+        create(:event_form, event: event, form: registration_form, role: "registration")
+        age_range = create(:category_type, name: "AgeRange")
+        adults = create(:category, name: "Adults", category_type: age_range)
+        teens = create(:category, name: "Teens", category_type: age_range)
+        primary_field = create(:form_field, form: registration_form, field_identifier: "primary_age_group",
+                                            answer_type: :multi_select_checkbox)
+        additional_field = create(:form_field, form: registration_form, field_identifier: "additional_age_group",
+                                               answer_type: :multi_select_checkbox)
+        submission = create(:form_submission, person: person, form: registration_form)
+        create(:form_answer, form_submission: submission, form_field: primary_field, submitted_answer: adults.id.to_s)
+        create(:form_answer, form_submission: submission, form_field: additional_field, submitted_answer: teens.id.to_s)
+
+        get background_event_path(event)
+
+        expect(response.body).to include("All age groups")
+        expect(response.body).to include("Teens")
+      end
+
       it "shows a life experiences breakdown from registrants' StoryPopulation tags" do
         story_population = create(:category_type, name: "StoryPopulation")
         experience = create(:category, name: "Veterans", category_type: story_population)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1717,7 +1717,7 @@ RSpec.describe "Events", type: :request do
       it "charts the organizations' program-status breakdown above the org list" do
         get background_event_path(event)
 
-        expect(response.body).to include("Program status")
+        expect(response.body).to include("Organization/program status")
         # "Background Org" is the registrant's first-facilitator program → New.
         expect(response.body).to include("New")
       end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe EventDashboard do
       create(:form_field, form: registration_form, field_identifier: "primary_age_group",
                           name: "Primary Age Group(s) Served", answer_type: :multi_select_checkbox)
     end
+    let(:additional_age_group_field) do
+      create(:form_field, form: registration_form, field_identifier: "additional_age_group",
+                          name: "Additional Age Group(s) Served", answer_type: :multi_select_checkbox)
+    end
 
     let!(:reg1) do
       # Affiliation exists before registration so it is captured in the snapshot.
@@ -102,6 +106,16 @@ RSpec.describe EventDashboard do
       create(:form_answer, form_field: age_group_field, submitted_answer: "#{age_group1.id}, #{age_group2.id}",
                            form_submission: create(:form_submission, person: person2, form: registration_form))
       create(:form_answer, form_field: age_group_field, submitted_answer: age_group_excluded.id.to_s,
+                           form_submission: create(:form_submission, person: cancelled_person, form: registration_form))
+
+      # Additional age group(s) served, captured as "additional_age_group" answers.
+      # person1 → Adults + Teens (Adults dupes the primary answer, so it dedupes);
+      # cancelled → Adults (ignored). This makes "All age groups" (primary +
+      # additional) differ from the primary-only breakdown.
+      create(:form_answer, form_field: additional_age_group_field,
+                           submitted_answer: "#{age_group1.id}, #{age_group2.id}",
+                           form_submission: create(:form_submission, person: person1, form: registration_form))
+      create(:form_answer, form_field: additional_age_group_field, submitted_answer: age_group1.id.to_s,
                            form_submission: create(:form_submission, person: cancelled_person, form: registration_form))
 
       # States from active registrant addresses; inactive address excluded.
@@ -359,6 +373,22 @@ RSpec.describe EventDashboard do
         map = dashboard.age_group_registrant_ids_by_category
         expect(map[age_group1.id]).to contain_exactly(person1.id, person2.id)
         expect(map[age_group2.id]).to contain_exactly(person2.id)
+      end
+    end
+
+    describe "all age groups (primary + additional registration responses)" do
+      it "returns unique age-group categories across both age group questions" do
+        expect(dashboard.all_age_groups).to contain_exactly(age_group1, age_group2)
+      end
+
+      it "counts distinct registrants per age group, deduping across both questions" do
+        expect(dashboard.all_age_group_counts).to eq(age_group1.id => 2, age_group2.id => 2)
+      end
+
+      it "maps each age group to its registrant ids across both questions" do
+        map = dashboard.all_age_group_registrant_ids_by_category
+        expect(map[age_group1.id]).to contain_exactly(person1.id, person2.id)
+        expect(map[age_group2.id]).to contain_exactly(person1.id, person2.id)
       end
     end
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -796,6 +796,14 @@ RSpec.describe EventDashboard do
       expect(statuses[reinstated_facilitator.id]).to eq([ :reinstated ])
       expect(statuses).not_to have_key(cancelled_facilitator.id)
     end
+
+    it "groups registrant ids by program status, for the breakdown drill-in" do
+      ids = dashboard.program_status_registrant_ids
+
+      expect(ids[:new]).to contain_exactly(new_facilitator.id)
+      expect(ids[:ongoing]).to contain_exactly(ongoing_facilitator.id)
+      expect(ids[:reinstated]).to contain_exactly(reinstated_facilitator.id)
+    end
   end
 
   context "program-status breakdown for non-facilitator affiliations" do

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/bulk_payments/index.html.erb"      => "admin-only bg-blue-100",
     "app/views/events/background.html.erb"             => "admin-only bg-blue-100",
     "app/views/events/edit_staff.html.erb"             => "admin-only bg-white",
-    "app/views/events/recipients.html.erb"             => "admin-only bg-white",
+    "app/views/events/recipients.html.erb"             => "admin-only bg-blue-100",
     "app/views/events/registrants.html.erb"         => "admin-only bg-blue-100",
     "app/views/events/onboarding.html.erb"             => "admin-only bg-blue-100",
     "app/views/events/revenue.html.erb"                => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 — two new EventDashboard aggregations plus layout/label/print polish across the event background, registrants, and dashboard pages

### What is the goal of this PR and why is this important?
**Event background report:**
- Row 1 regrouped into topic columns: sectors (primary/all) · age groups (primary/all) · organizations.
- New **"All age groups"** breakdown (unions `primary_age_group` + `additional_age_group`; before, only primary fed the card).
- New **"Program status" pie** above the org list (new/ongoing/reinstated), badge-colored, each slice drilling into its registrants.
- **Equal-height cards** across the three columns via CSS subgrid (lg only) — the primary row and the all/org row each line up.
- Header brought down to the **dashboard's title styling** so the two report pages match.

**Event registrants list:** org filter → **"Organization linking"** (empty state **"Any linking"**); org column (header + toggle) → **"Linked organization"**, aligned to the pill text.

**Event dashboard:** added the same **print button** the other report pages have.

### How did you approach the change?
- `EventDashboard`: `all_age_groups*` (shared `age_group_rows_for`, `FormField::AGE_GROUP_FIELD_IDENTIFIERS`) and `program_status_registrant_ids`.
- Subgrid: each topic column is `lg:grid lg:grid-rows-subgrid lg:row-span-2` sharing the parent's two row tracks.
- Specs for both new dashboard methods + request coverage of the new cards.

### Anything else to add?
- Countries/States/School-districts rows were already click-through (since #1591) — no change needed.
- Row 2 of the grid layout (states above countries) remains a deferred follow-up.