### PR TITLE
Load grant donor via remote-select instead of loading all people/orgs

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -37,13 +37,11 @@ class GrantsController < ApplicationController
   def new
     @grant = Grant.new
     authorize! @grant
-    set_form_variables
   end
 
   def edit
     authorize! @grant
     set_scholarships
-    set_form_variables
   end
 
   def create
@@ -55,7 +53,6 @@ class GrantsController < ApplicationController
     if @grant.save
       redirect_to @grant, notice: "Grant was successfully created."
     else
-      set_form_variables
       render :new, status: :unprocessable_content
     end
   end
@@ -68,7 +65,6 @@ class GrantsController < ApplicationController
       redirect_to @grant, notice: "Grant was successfully updated.", status: :see_other
     else
       set_scholarships
-      set_form_variables
       render :edit, status: :unprocessable_content
     end
   end
@@ -81,13 +77,6 @@ class GrantsController < ApplicationController
     else
       redirect_to @grant, alert: "Can't delete a grant that has associated scholarships. Remove its scholarships first.", status: :see_other
     end
-  end
-
-  def set_form_variables
-    @donor_options = {
-      "Organizations" => Organization.order(:name).map { |o| [ o.name, o.to_signed_global_id.to_s ] },
-      "People" => Person.order(:last_name, :first_name).map { |p| [ p.full_name, p.to_signed_global_id.to_s ] }
-    }
   end
 
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,19 +1,14 @@
 class SearchController < ApplicationController
   skip_before_action :preload_current_user_associations, raise: false
 
-  # Virtual "models" that search people and organizations together. Both search
-  # the same two tables; they differ only in result order. The payer /
-  # additional-designation pickers on the payment form list people first; the
-  # grant donor picker lists organizations first (organizations are the more
-  # common donor).
-  COMPOUND_MODELS = {
-    "person_or_organization" => [ Person, Organization ],
-    "organization_or_person" => [ Organization, Person ]
-  }.freeze
+  # Virtual "model" that searches people and organizations together for the
+  # compound payer / donor pickers. The optional `order` param picks which kind
+  # is listed first ("organization" → organizations first; anything else →
+  # people first) — both search the same two tables.
+  COMPOUND_MODEL = "person_or_organization".freeze
 
   def index
-    compound_classes = COMPOUND_MODELS[params[:model]]
-    return render json: compound_results(compound_classes) if compound_classes
+    return render json: compound_results if params[:model] == COMPOUND_MODEL
 
     model_class = allowed_model(params[:model])
     unless model_class
@@ -46,9 +41,10 @@ class SearchController < ApplicationController
 
   private
 
-  # Search each model in turn and concatenate, preserving the given class order
-  # so the caller controls which kind is listed first.
-  def compound_results(model_classes)
+  # Search people and organizations, concatenating in the order the caller
+  # asked for so each picker can lead with its most common kind.
+  def compound_results
+    model_classes = params[:order] == "organization" ? [ Organization, Person ] : [ Person, Organization ]
     model_classes.each { |klass| authorize! klass, to: :search? }
 
     query = params[:q].to_s.strip

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,12 +1,19 @@
 class SearchController < ApplicationController
   skip_before_action :preload_current_user_associations, raise: false
 
-  # Virtual "model" that searches people and organizations together, used by the
-  # compound payer / additional-designation pickers on the payment form.
-  COMPOUND_PAYER_MODEL = "person_or_organization".freeze
+  # Virtual "models" that search people and organizations together. Both search
+  # the same two tables; they differ only in result order. The payer /
+  # additional-designation pickers on the payment form list people first; the
+  # grant donor picker lists organizations first (organizations are the more
+  # common donor).
+  COMPOUND_MODELS = {
+    "person_or_organization" => [ Person, Organization ],
+    "organization_or_person" => [ Organization, Person ]
+  }.freeze
 
   def index
-    return render json: compound_payer_results if params[:model] == COMPOUND_PAYER_MODEL
+    compound_classes = COMPOUND_MODELS[params[:model]]
+    return render json: compound_results(compound_classes) if compound_classes
 
     model_class = allowed_model(params[:model])
     unless model_class
@@ -39,17 +46,17 @@ class SearchController < ApplicationController
 
   private
 
-  def compound_payer_results
-    authorize! Person, to: :search?
-    authorize! Organization, to: :search?
+  # Search each model in turn and concatenate, preserving the given class order
+  # so the caller controls which kind is listed first.
+  def compound_results(model_classes)
+    model_classes.each { |klass| authorize! klass, to: :search? }
 
     query = params[:q].to_s.strip
     return [] if query.blank?
 
-    records = authorized_scope(Organization.remote_search(query)).limit(25).to_a +
-      authorized_scope(Person.remote_search(query)).limit(25).to_a
-
-    records.map(&:compound_search_label)
+    model_classes
+      .flat_map { |klass| authorized_scope(klass.remote_search(query)).limit(25).to_a }
+      .map(&:compound_search_label)
   end
 
   def allowed_model(model_param)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -46,8 +46,8 @@ class SearchController < ApplicationController
     query = params[:q].to_s.strip
     return [] if query.blank?
 
-    records = authorized_scope(Person.remote_search(query)).limit(25).to_a +
-      authorized_scope(Organization.remote_search(query)).limit(25).to_a
+    records = authorized_scope(Organization.remote_search(query)).limit(25).to_a +
+      authorized_scope(Person.remote_search(query)).limit(25).to_a
 
     records.map(&:compound_search_label)
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,9 +2,7 @@ class SearchController < ApplicationController
   skip_before_action :preload_current_user_associations, raise: false
 
   # Virtual "model" that searches people and organizations together for the
-  # compound payer / donor pickers. The optional `order` param picks which kind
-  # is listed first ("organization" → organizations first; anything else →
-  # people first) — both search the same two tables.
+  # compound payer / donor pickers, listing organizations first.
   COMPOUND_MODEL = "person_or_organization".freeze
 
   def index
@@ -41,18 +39,19 @@ class SearchController < ApplicationController
 
   private
 
-  # Search people and organizations, concatenating in the order the caller
-  # asked for so each picker can lead with its most common kind.
+  # Search people and organizations, listing organizations first (the more
+  # common donor/payer).
   def compound_results
-    model_classes = params[:order] == "organization" ? [ Organization, Person ] : [ Person, Organization ]
-    model_classes.each { |klass| authorize! klass, to: :search? }
+    authorize! Organization, to: :search?
+    authorize! Person, to: :search?
 
     query = params[:q].to_s.strip
     return [] if query.blank?
 
-    model_classes
-      .flat_map { |klass| authorized_scope(klass.remote_search(query)).limit(25).to_a }
-      .map(&:compound_search_label)
+    records = authorized_scope(Organization.remote_search(query)).limit(25).to_a +
+      authorized_scope(Person.remote_search(query)).limit(25).to_a
+
+    records.map(&:compound_search_label)
   end
 
   def allowed_model(model_param)

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 import TomSelect from "tom-select";
 
 export default class extends Controller {
-  static values = { model: String, exclude: String, order: String };
+  static values = { model: String, exclude: String };
 
   connect() {
     this.select = new TomSelect(this.element, {
@@ -19,9 +19,6 @@ export default class extends Controller {
 
         if (this.hasExcludeValue && this.excludeValue) {
           url += `&exclude=${encodeURIComponent(this.excludeValue)}`;
-        }
-        if (this.hasOrderValue && this.orderValue) {
-          url += `&order=${encodeURIComponent(this.orderValue)}`;
         }
         fetch(url)
           .then((r) => r.json())

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus";
 import TomSelect from "tom-select";
 
 export default class extends Controller {
-  static values = { model: String, exclude: String };
+  static values = { model: String, exclude: String, order: String };
 
   connect() {
     this.select = new TomSelect(this.element, {
@@ -19,6 +19,9 @@ export default class extends Controller {
 
         if (this.hasExcludeValue && this.excludeValue) {
           url += `&exclude=${encodeURIComponent(this.excludeValue)}`;
+        }
+        if (this.hasOrderValue && this.orderValue) {
+          url += `&order=${encodeURIComponent(this.orderValue)}`;
         }
         fetch(url)
           .then((r) => r.json())

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -19,8 +19,7 @@
                     class: "bg-white",
                     data: {
                       controller: "remote-select",
-                      remote_select_model_value: "person_or_organization",
-                      remote_select_order_value: "organization"
+                      remote_select_model_value: "person_or_organization"
                     }
                   },
                   prompt: "Search organizations and people",

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -19,7 +19,7 @@
                     class: "bg-white",
                     data: {
                       controller: "remote-select",
-                      remote_select_model_value: "person_or_organization"
+                      remote_select_model_value: "organization_or_person"
                     }
                   },
                   prompt: "Search organizations and people",

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -19,7 +19,8 @@
                     class: "bg-white",
                     data: {
                       controller: "remote-select",
-                      remote_select_model_value: "organization_or_person"
+                      remote_select_model_value: "person_or_organization",
+                      remote_select_order_value: "organization"
                     }
                   },
                   prompt: "Search organizations and people",

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -10,12 +10,21 @@
     </div>
 
     <div>
-      <%= f.label :donor_sgid, "Donor", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= select_tag "grant[donor_sgid]",
-                     grouped_options_for_select(@donor_options, @grant.donor_sgid),
-                     include_blank: "Select an organization or person",
-                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
-      <p class="mt-1 text-xs text-gray-500">The organization or person donating the funds.</p>
+      <% donor_label_data = @grant.donor&.compound_search_label %>
+      <%= f.input :donor_sgid,
+                  collection: donor_label_data ? [ [ donor_label_data[:label], donor_label_data[:id] ] ] : [],
+                  selected: donor_label_data&.dig(:id),
+                  required: true,
+                  input_html: {
+                    class: "bg-white",
+                    data: {
+                      controller: "remote-select",
+                      remote_select_model_value: "person_or_organization"
+                    }
+                  },
+                  prompt: "Search organizations and people",
+                  label: "Donor",
+                  hint: "The organization or person donating the funds." %>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/spec/requests/payer_search_spec.rb
+++ b/spec/requests/payer_search_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "Payer search (combined people + organizations)", type: :request 
       expect(resolved).to include(organization)
     end
 
+    it "lists organizations before people" do
+      get "/search/person_or_organization", params: { q: "Searchable" }
+
+      kinds = response.parsed_body.map { |row| row["label"].split(" · ").last }
+      expect(kinds.index("Organization")).to be < kinds.index("Person")
+    end
+
     it "returns an empty array for a blank query" do
       get "/search/person_or_organization", params: { q: "" }
 

--- a/spec/requests/payer_search_spec.rb
+++ b/spec/requests/payer_search_spec.rb
@@ -34,20 +34,22 @@ RSpec.describe "Payer search (combined people + organizations)", type: :request 
     end
   end
 
-  # Each compound endpoint searches the same two tables and differs only in
-  # order; the returned kinds must follow the class order declared in the
-  # controller (payer picker: people first; donor picker: organizations first).
-  describe "result ordering follows SearchController::COMPOUND_MODELS" do
+  # The `order` param controls which kind leads the combined results.
+  describe "result ordering" do
     let!(:person) { create(:person, first_name: "Searchable", last_name: "Payer") }
     let!(:organization) { create(:organization, name: "Searchable Payer Org") }
 
-    SearchController::COMPOUND_MODELS.each do |model_param, classes|
-      it "lists #{classes.map(&:name).join(', then ')} for /search/#{model_param}" do
-        get "/search/#{model_param}", params: { q: "Searchable" }
+    def result_kinds(params)
+      get "/search/person_or_organization", params: params
+      response.parsed_body.map { |row| row["label"].split(" · ").last }.uniq
+    end
 
-        kinds = response.parsed_body.map { |row| row["label"].split(" · ").last }.uniq
-        expect(kinds).to eq(classes.map { |klass| klass.model_name.human })
-      end
+    it "lists people first by default" do
+      expect(result_kinds(q: "Searchable")).to eq([ "Person", "Organization" ])
+    end
+
+    it "lists organizations first when order=organization" do
+      expect(result_kinds(q: "Searchable", order: "organization")).to eq([ "Organization", "Person" ])
     end
   end
 end

--- a/spec/requests/payer_search_spec.rb
+++ b/spec/requests/payer_search_spec.rb
@@ -26,18 +26,28 @@ RSpec.describe "Payer search (combined people + organizations)", type: :request 
       expect(resolved).to include(organization)
     end
 
-    it "lists organizations before people" do
-      get "/search/person_or_organization", params: { q: "Searchable" }
-
-      kinds = response.parsed_body.map { |row| row["label"].split(" · ").last }
-      expect(kinds.index("Organization")).to be < kinds.index("Person")
-    end
-
     it "returns an empty array for a blank query" do
       get "/search/person_or_organization", params: { q: "" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq([])
+    end
+  end
+
+  # Each compound endpoint searches the same two tables and differs only in
+  # order; the returned kinds must follow the class order declared in the
+  # controller (payer picker: people first; donor picker: organizations first).
+  describe "result ordering follows SearchController::COMPOUND_MODELS" do
+    let!(:person) { create(:person, first_name: "Searchable", last_name: "Payer") }
+    let!(:organization) { create(:organization, name: "Searchable Payer Org") }
+
+    SearchController::COMPOUND_MODELS.each do |model_param, classes|
+      it "lists #{classes.map(&:name).join(', then ')} for /search/#{model_param}" do
+        get "/search/#{model_param}", params: { q: "Searchable" }
+
+        kinds = response.parsed_body.map { |row| row["label"].split(" · ").last }.uniq
+        expect(kinds).to eq(classes.map { |klass| klass.model_name.human })
+      end
     end
   end
 end

--- a/spec/requests/payer_search_spec.rb
+++ b/spec/requests/payer_search_spec.rb
@@ -26,30 +26,18 @@ RSpec.describe "Payer search (combined people + organizations)", type: :request 
       expect(resolved).to include(organization)
     end
 
+    it "lists organizations before people" do
+      get "/search/person_or_organization", params: { q: "Searchable" }
+
+      kinds = response.parsed_body.map { |row| row["label"].split(" · ").last }.uniq
+      expect(kinds).to eq([ "Organization", "Person" ])
+    end
+
     it "returns an empty array for a blank query" do
       get "/search/person_or_organization", params: { q: "" }
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq([])
-    end
-  end
-
-  # The `order` param controls which kind leads the combined results.
-  describe "result ordering" do
-    let!(:person) { create(:person, first_name: "Searchable", last_name: "Payer") }
-    let!(:organization) { create(:organization, name: "Searchable Payer Org") }
-
-    def result_kinds(params)
-      get "/search/person_or_organization", params: params
-      response.parsed_body.map { |row| row["label"].split(" · ").last }.uniq
-    end
-
-    it "lists people first by default" do
-      expect(result_kinds(q: "Searchable")).to eq([ "Person", "Organization" ])
-    end
-
-    it "lists organizations first when order=organization" do
-      expect(result_kinds(q: "Searchable", order: "organization")).to eq([ "Organization", "Person" ])
     end
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small form/controller change reusing the existing remote-select + search pattern

Closes #1971

### What is the goal of this PR and why is this important?
- The grant form loaded **every** `Organization` and `Person` into a grouped `<select>` just to pick a donor — doesn't scale.

### How did you approach the change?
- Swapped the donor `select_tag` for the same `remote-select` pattern the payment payer picker uses (donors are searched on demand).
- Dropped `GrantsController#set_form_variables` (`@donor_options`) and its calls — no longer needed.
- `grant[donor_sgid]` already resolves via signed GlobalID, so the compound search labels drop straight in; no model changes.
- The shared `person_or_organization` search now lists **organizations before people** everywhere (both the grant donor picker and the payment payer picker).

### Anything else to add?
- Keeps the two "someone (person or org) gives money toward something" flows (grants/donor and payments/payer) consistent.