### PR TITLE
Remove redundant Sample ticket link from event dashboard

### DIFF
--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -55,14 +55,6 @@
         <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
       <% end %>
     <% end %>
-
-    <%# Admin-only preview of the registration ticket with every option enabled. %>
-    <%= link_to sample_ticket_event_path(@event), target: "_blank", rel: "noopener noreferrer",
-          class: "#{link_base} border-gray-200 text-gray-700 hover:border-gray-300 hover:bg-gray-50" do %>
-      <i class="fa-solid fa-ticket text-gray-500"></i>
-      Sample ticket
-      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
-    <% end %>
   </div>
 
   <%# Money cards (paid events only) — shown first %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only: removes one duplicate link, no logic changes

## Summary
- Removed the "Sample ticket" link from the event dashboard.
- Same admin preview is still reachable from the edit event page's callouts section (and the registrants action menu) — both hit the identical `sample_ticket_event_path` → `EventsController#sample_ticket`.

## Why
- The dashboard button was a duplicate of an existing entry point.

## Tests
- None needed. The `sample_ticket` request/view specs cover the controller action and the edit-page link, both unchanged. No spec referenced the dashboard link.