### PR TITLE
Swap invoice button for ticket button on bulk payments cards

### DIFF
--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -46,11 +46,13 @@
         Submission - ID: <%= submission.id %>
       <% end %>
 
-      <%= link_to event_invoice_path(@event, submission_id: submission.id, return_to: "bulk_payments"),
-                  title: "View invoice",
-                  class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
-        <i class="fa-solid fa-file-invoice-dollar text-xs"></i>
-        Invoice
+      <% if submission.slug.present? %>
+        <%= link_to bulk_payment_ticket_path(submission.slug, return_to: "bulk_payments", expand: submission.id),
+                    title: "View ticket",
+                    class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
+          <i class="fa-solid fa-ticket text-xs"></i>
+          Ticket
+        <% end %>
       <% end %>
     </div>
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup swap of one per-card button

## What
On each bulk payments index card, the per-submission **Invoice** button is now a **Ticket** button (→ `bulk_payment_ticket_path`).

## Why
- Admins reviewing bulk payments usually want the payer-facing ticket (allocations, confirmation resend) rather than the raw invoice.
- Guarded on `submission.slug` presence — the ticket route is slug-keyed, so legacy slugless submissions simply don't render the button.
- Carries `return_to: "bulk_payments"` + `expand` so the ticket eyebrow returns to the originating, re-expanded card.

The page-header "Blank invoice" (event-level) button is unchanged.