### PR TITLE
Collapse chevron + expand/collapse-all for callout editor

### DIFF
--- a/app/decorators/registration_ticket_callout_decorator.rb
+++ b/app/decorators/registration_ticket_callout_decorator.rb
@@ -11,6 +11,16 @@ class RegistrationTicketCalloutDecorator < ApplicationDecorator
     "Won't show on the ticket — #{gap}" if gap
   end
 
+  # For the editor's collapsed callout header: the config change the admin must
+  # make for this built-in to appear on the ticket (e.g. "set an event cost above
+  # $0"), or nil when it's already set up (or it's a custom callout with no config
+  # dependency). Shown regardless of published state so admins see the requirement
+  # before publishing. Shares BuiltinCalloutCards.config_gap_action.
+  def config_action_hint
+    return unless builtin?
+    BuiltinCalloutCards.config_gap_action(event, builtin_key)
+  end
+
   # This callout's linked resources as cards, in display order, each reading its
   # subtitle from the materialized join row and linking to the resource's own
   # page. Shared by every surface that lists a callout's resources (the handouts

--- a/app/decorators/registration_ticket_callout_decorator.rb
+++ b/app/decorators/registration_ticket_callout_decorator.rb
@@ -1,22 +1,10 @@
 class RegistrationTicketCalloutDecorator < ApplicationDecorator
-  # For the editor's amber warning badge: when this published built-in callout can
-  # never reach the ticket because the event isn't configured for it (free event →
-  # no payment card, no scholarship form → no scholarship card, no CE hours → no CE
-  # card, no videoconference link → no videoconference card), the reason to show;
-  # nil when it will show (or it's hidden/custom). Shares BuiltinCalloutCards.config_gap
-  # so the badge and the ticket guard can't drift.
-  def ticket_suppression_reason
-    return unless published? && builtin?
-    gap = BuiltinCalloutCards.config_gap(event, builtin_key)
-    "Won't show on the ticket — #{gap}" if gap
-  end
-
   # For the editor's collapsed callout header: the config change the admin must
   # make for this built-in to appear on the ticket (e.g. "set an event cost above
   # $0"), or nil when it's already set up (or it's a custom callout with no config
   # dependency). Shown regardless of published state so admins see the requirement
   # before publishing. Shares BuiltinCalloutCards.config_gap_action.
-  def config_action_hint
+  def config_suppression_hint
     return unless builtin?
     BuiltinCalloutCards.config_gap_action(event, builtin_key)
   end

--- a/app/frontend/javascript/controllers/expandable_card_controller.js
+++ b/app/frontend/javascript/controllers/expandable_card_controller.js
@@ -20,6 +20,26 @@ export default class extends Controller {
     this.expandedValue = false
   }
 
+  // Match the expanded state to a checkbox's checked state (e.g. a "Published"
+  // toggle that expands on check, collapses on uncheck). The chevron can still
+  // override afterward.
+  syncToCheckbox(event) {
+    this.expandedValue = event.target.checked
+  }
+
+  // Toggle from a click anywhere on the card chrome, but ignore clicks inside the
+  // expanded editor body so interacting with its fields doesn't collapse it.
+  toggleFromRow(event) {
+    if (this.hasBodyTarget && this.bodyTarget.contains(event.target)) return
+    this.toggle()
+  }
+
+  // Let a nested control (e.g. the Published toggle) handle its own click without
+  // bubbling up to the card-level toggle.
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+
   expandedValueChanged() {
     this.bodyTarget.classList.toggle("hidden", !this.expandedValue)
     if (this.hasIconTarget) {

--- a/app/frontend/javascript/controllers/expandable_cards_controller.js
+++ b/app/frontend/javascript/controllers/expandable_cards_controller.js
@@ -14,10 +14,13 @@ export default class extends Controller {
 
   toggleAll() {
     this.expandedValue = !this.expandedValue
+    this.dispatch(this.expandedValue ? "expandAll" : "collapseAll")
   }
 
+  // Only syncs the button's own label/icon. The expand/collapse broadcast lives
+  // in toggleAll so it fires solely on an explicit click — not on connect, which
+  // would otherwise force every card open regardless of its own initial state.
   expandedValueChanged() {
-    this.dispatch(this.expandedValue ? "expandAll" : "collapseAll")
     if (this.hasLabelTarget) {
       this.labelTarget.textContent = this.expandedValue ? "Collapse all" : "Expand all"
     }

--- a/app/services/builtin_callout_cards.rb
+++ b/app/services/builtin_callout_cards.rb
@@ -92,6 +92,20 @@ class BuiltinCalloutCards
     end
   end
 
+  # Action-oriented companion to #config_gap for the editor: what the admin must
+  # configure for this built-in to reach the ticket, or nil when the event is
+  # already set up for it (or the built-in has no config dependency). Mirrors
+  # #config_gap's conditions so the two can't drift.
+  def self.config_gap_action(event, builtin_key)
+    return unless config_gap(event, builtin_key)
+    {
+      "payment" => "set an event cost above $0",
+      "scholarship" => "add a scholarship form under form settings",
+      "ce_hours" => "set CE hours above 0 under form settings",
+      "videoconference" => "add a videoconference link"
+    }[builtin_key]
+  end
+
   # `preview: true` is the sample ticket: it bypasses the config gaps so an admin
   # can preview (and click through) a published built-in card even before the
   # event carries the config it depends on (a cost, a scholarship form, CE hours).

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -642,15 +642,25 @@
           <% end %>
         </div>
 
-        <div
-          id="registration_ticket_callouts_list"
-          class="space-y-3"
-          data-controller="sortable"
-          data-sortable-url-value="<%= @event.persisted? ? event_registration_ticket_callout_path(@event, ":id") : "" %>"
-        >
-          <%= f.fields_for :registration_ticket_callouts do |rts| %>
-            <%= render "events/registration_ticket_callout_fields", f: rts, event_f: f %>
-          <% end %>
+        <div data-controller="expandable-cards">
+          <div class="flex justify-end mb-3">
+            <button type="button" data-action="expandable-cards#toggleAll"
+                    class="inline-flex items-center gap-2 text-sm font-medium text-purple-700 hover:text-purple-900">
+              <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-cards-target="icon"></i>
+              <span data-expandable-cards-target="label">Collapse all</span>
+            </button>
+          </div>
+
+          <div
+            id="registration_ticket_callouts_list"
+            class="space-y-3"
+            data-controller="sortable"
+            data-sortable-url-value="<%= @event.persisted? ? event_registration_ticket_callout_path(@event, ":id") : "" %>"
+          >
+            <%= f.fields_for :registration_ticket_callouts do |rts| %>
+              <%= render "events/registration_ticket_callout_fields", f: rts, event_f: f %>
+            <% end %>
+          </div>
         </div>
 
         <div class="mt-3">

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -11,7 +11,7 @@
 <div
   class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-colors cursor-pointer select-none"
   data-controller="callout-preview expandable-card"
-  data-action="click->expandable-card#toggleFromRow"
+  data-action="click->expandable-card#toggleFromRow expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse"
   data-expandable-card-expanded-value="<%= f.object.published? %>"
   data-callout-preview-themes-value="<%= DomainTheme.swatches.to_json %>"
   data-callout-preview-defaults-value="<%= RegistrationTicketCallout::DEFAULT_COLORS.to_json %>"
@@ -71,13 +71,13 @@
 
       <span class="text-gray-800 font-medium truncate max-w-xs" title="<%= f.object.title %>"><%= f.object.title %></span>
 
-      <%# Warns when this published built-in is set up but the event isn't
-          configured for it, so it still won't reach the ticket (free event → no
-          payment card, no scholarship form / CE hours → no scholarship / CE card). %>
-      <% if (suppression_reason = f.object.decorate.ticket_suppression_reason) %>
+      <%# Names the config the event is missing for this built-in (a cost, a
+          scholarship form, CE hours, a videoconference link) so admins know what
+          to change for it to reach the ticket. Shown regardless of published state. %>
+      <% if (config_hint = f.object.decorate.config_action_hint) %>
         <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 shrink-0">
           <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
-          <%= suppression_reason %>
+          Won't show unless you <%= config_hint %>
         </span>
       <% end %>
     </div>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -74,7 +74,7 @@
       <%# Names the config the event is missing for this built-in (a cost, a
           scholarship form, CE hours, a videoconference link) so admins know what
           to change for it to reach the ticket. Shown regardless of published state. %>
-      <% if (config_hint = f.object.decorate.config_action_hint) %>
+      <% if (config_hint = f.object.decorate.config_suppression_hint) %>
         <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 shrink-0">
           <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
           Won't show unless you <%= config_hint %>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -5,9 +5,14 @@
 %>
 <% event_f = local_assigns[:event_f] %>
 
+<%# Clicking anywhere on the card chrome toggles collapse (cursor-pointer signals
+    it); `toggleFromRow` ignores clicks inside the expanded editor body, and the
+    chevron + Published cluster stops propagation so those keep their own clicks. %>
 <div
-  class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-colors"
-  data-controller="callout-preview"
+  class="nested-fields registration-ticket-callout-fields flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition-colors cursor-pointer select-none"
+  data-controller="callout-preview expandable-card"
+  data-action="click->expandable-card#toggleFromRow"
+  data-expandable-card-expanded-value="<%= f.object.published? %>"
   data-callout-preview-themes-value="<%= DomainTheme.swatches.to_json %>"
   data-callout-preview-defaults-value="<%= RegistrationTicketCallout::DEFAULT_COLORS.to_json %>"
   <% if f.object.persisted? %>
@@ -28,24 +33,38 @@
       <%= f.hidden_field :builtin_key %>
     <% end %>
     <%#
-      Published toggle, pinned to the card's top-right corner. The checkbox is
-      kept as a bare sibling *before* the content div below so the
-      `peer-checked:block` reveal still works — only its visual position is moved
-      (via absolute), not its DOM order. For the same reason the label is a
-      separate `for`-linked element rather than wrapping the input (wrapping it
-      would stop it being a sibling of the content div and break the reveal).
+      Top-right controls, pinned to the card's corner: a chevron that
+      collapses/expands this callout's editor (via expandable-card) and, to its
+      right, the Published toggle. Collapse is independent of Published, so a
+      published callout can still be collapsed.
     %>
-    <%= f.label :published, "Published", class: "absolute top-0 right-6 text-sm font-medium text-gray-600 cursor-pointer select-none" %>
-    <%= f.check_box :published, class: "peer rounded border-gray-300 text-purple-600 absolute top-0.5 right-0" %>
+    <div class="absolute top-0 right-0 flex items-center gap-3"
+         data-action="click->expandable-card#stopPropagation">
+      <button type="button"
+              class="leading-none text-gray-400 hover:text-gray-600"
+              data-action="expandable-card#toggle"
+              aria-label="Collapse or expand callout details">
+        <i class="fa-solid fa-chevron-down text-xs transition-transform <%= "rotate-180" if f.object.published? %>" data-expandable-card-target="icon"></i>
+      </button>
+
+      <%# Toggling Published expands (checked) or collapses (unchecked) the editor;
+          the chevron can then override that state independently. %>
+      <label class="flex items-center gap-2 text-sm font-medium text-gray-600 cursor-pointer select-none">
+        Published
+        <%= f.check_box :published, class: "rounded border-gray-300 text-purple-600",
+              data: { action: "change->expandable-card#syncToCheckbox" } %>
+      </label>
+    </div>
 
     <%#
       Always-visible header row: identifies the callout even when its editor is
       collapsed. Holds the built-in badge, title, and default-status text on the
-      left; `pr-24` reserves the top-right gutter so nothing runs under the
-      Published toggle pinned there.
+      left; `pr-32` reserves the top-right gutter so nothing runs under the
+      chevron + Published controls pinned there. Toggling is handled by the card
+      root (see above), so this row needs no click handler of its own.
     %>
 
-    <div class="flex items-center gap-x-3 pr-24 text-sm">
+    <div class="flex items-center gap-x-3 pr-32 text-sm">
       <% if f.object.builtin? %>
         <span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 shrink-0">Built in</span>
       <% end %>
@@ -63,9 +82,11 @@
       <% end %>
     </div>
 
-    <%# Editable content — hidden when the Published checkbox is unchecked.
-        `mt-5` keeps the preview card clear of the Published toggle above it. %>
-    <div class="hidden peer-checked:block space-y-3 mt-5">
+    <%# Editable content — collapsed/expanded by the chevron above (expandable-card
+        toggles `hidden`). Defaults open when published, closed otherwise; render
+        the matching initial state to avoid a flash before the controller connects.
+        `mt-5` keeps the preview card clear of the controls above it. %>
+    <div class="<%= "hidden" unless f.object.published? %> space-y-3 mt-5 cursor-auto select-auto" data-expandable-card-target="body">
       <%#
         Live preview of how this callout appears on the ticket — the same card
         registrants see (icon, title, subtitle, themed color). Seeded from the

--- a/spec/decorators/registration_ticket_callout_decorator_spec.rb
+++ b/spec/decorators/registration_ticket_callout_decorator_spec.rb
@@ -67,4 +67,31 @@ RSpec.describe RegistrationTicketCalloutDecorator, type: :decorator do
       expect(callout.decorate.ticket_suppression_reason).to be_nil
     end
   end
+
+  describe "#config_action_hint" do
+    def builtin_callout(builtin_key, event:, hidden: true)
+      create(:registration_ticket_callout, event:, builtin_key:, hidden:,
+             title: builtin_key.humanize)
+    end
+
+    it "names the config change even when the callout is unpublished" do
+      callout = builtin_callout("payment", event: create(:event, cost_cents: 0), hidden: true)
+      expect(callout.decorate.config_action_hint).to eq("set an event cost above $0")
+    end
+
+    it "names setting CE hours for a CE callout on an event that offers none" do
+      callout = builtin_callout("ce_hours", event: create(:event, ce_hours_offered: nil))
+      expect(callout.decorate.config_action_hint).to eq("set CE hours above 0 under form settings")
+    end
+
+    it "is nil once the event is configured for the callout" do
+      callout = builtin_callout("payment", event: create(:event, cost_cents: 5_000))
+      expect(callout.decorate.config_action_hint).to be_nil
+    end
+
+    it "is nil for a custom (non-built-in) callout" do
+      callout = create(:registration_ticket_callout, builtin_key: nil)
+      expect(callout.decorate.config_action_hint).to be_nil
+    end
+  end
 end

--- a/spec/decorators/registration_ticket_callout_decorator_spec.rb
+++ b/spec/decorators/registration_ticket_callout_decorator_spec.rb
@@ -26,49 +26,7 @@ RSpec.describe RegistrationTicketCalloutDecorator, type: :decorator do
     end
   end
 
-  describe "#ticket_suppression_reason" do
-    def builtin_callout(builtin_key, event:, hidden: false)
-      create(:registration_ticket_callout, event:, builtin_key:, hidden:,
-             title: builtin_key.humanize)
-    end
-
-    it "warns when a published payment callout is on a free event" do
-      callout = builtin_callout("payment", event: create(:event, cost_cents: 0))
-      expect(callout.decorate.ticket_suppression_reason).to eq("Won't show on the ticket — this event is free")
-    end
-
-    it "warns when a published scholarship callout's event has no scholarship form" do
-      callout = builtin_callout("scholarship", event: create(:event))
-      expect(callout.decorate.ticket_suppression_reason).to include("no scholarship form")
-    end
-
-    it "warns when a published CE callout's event offers no CE hours" do
-      callout = builtin_callout("ce_hours", event: create(:event, ce_hours_offered: nil))
-      expect(callout.decorate.ticket_suppression_reason).to include("offers no CE hours")
-    end
-
-    it "warns when a published videoconference callout's event has no join link" do
-      callout = builtin_callout("videoconference", event: create(:event, videoconference_url: nil))
-      expect(callout.decorate.ticket_suppression_reason).to include("no videoconference link")
-    end
-
-    it "is nil when the event is configured for the callout" do
-      callout = builtin_callout("payment", event: create(:event, cost_cents: 5_000))
-      expect(callout.decorate.ticket_suppression_reason).to be_nil
-    end
-
-    it "is nil when the callout is unpublished" do
-      callout = builtin_callout("payment", event: create(:event, cost_cents: 0), hidden: true)
-      expect(callout.decorate.ticket_suppression_reason).to be_nil
-    end
-
-    it "is nil for a custom (non-built-in) callout" do
-      callout = create(:registration_ticket_callout, builtin_key: nil, hidden: false)
-      expect(callout.decorate.ticket_suppression_reason).to be_nil
-    end
-  end
-
-  describe "#config_action_hint" do
+  describe "#config_suppression_hint" do
     def builtin_callout(builtin_key, event:, hidden: true)
       create(:registration_ticket_callout, event:, builtin_key:, hidden:,
              title: builtin_key.humanize)
@@ -76,22 +34,22 @@ RSpec.describe RegistrationTicketCalloutDecorator, type: :decorator do
 
     it "names the config change even when the callout is unpublished" do
       callout = builtin_callout("payment", event: create(:event, cost_cents: 0), hidden: true)
-      expect(callout.decorate.config_action_hint).to eq("set an event cost above $0")
+      expect(callout.decorate.config_suppression_hint).to eq("set an event cost above $0")
     end
 
     it "names setting CE hours for a CE callout on an event that offers none" do
       callout = builtin_callout("ce_hours", event: create(:event, ce_hours_offered: nil))
-      expect(callout.decorate.config_action_hint).to eq("set CE hours above 0 under form settings")
+      expect(callout.decorate.config_suppression_hint).to eq("set CE hours above 0 under form settings")
     end
 
     it "is nil once the event is configured for the callout" do
       callout = builtin_callout("payment", event: create(:event, cost_cents: 5_000))
-      expect(callout.decorate.config_action_hint).to be_nil
+      expect(callout.decorate.config_suppression_hint).to be_nil
     end
 
     it "is nil for a custom (non-built-in) callout" do
       callout = create(:registration_ticket_callout, builtin_key: nil)
-      expect(callout.decorate.config_action_hint).to be_nil
+      expect(callout.decorate.config_suppression_hint).to be_nil
     end
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view + Stimulus changes plus a small decorator/service tweak, no data migrations

### Goal
Let admins collapse a callout's editor independently of Published, and expand/collapse all callouts at once. Previously the editor was revealed only by the Published checkbox (CSS `peer` trick), so a published callout was always expanded with no way to collapse it.

### Approach
- Reuse the `expandable-card` controller (as on `recipients.html.erb`) for per-card collapse, replacing the `hidden peer-checked:block` mechanism.
- Chevron toggle in the title row (left of Published), rotating with state; the whole card chrome is clickable (`toggleFromRow` ignores clicks inside the expanded body; the chevron/Published cluster stops propagation — no double-toggle).
- Published checkbox `change` drives expand/collapse; the chevron can override.
- Added an "Expand all / Collapse all" control above the list (`expandable-cards`). Its broadcast now fires only on explicit toggle, not on connect, so each card keeps its own published-based initial state on load.
- Editor header now shows an action hint ("Won't show unless you set an event cost above $0") from `config_action_hint`, regardless of published state, so admins see the config requirement before publishing.

### Notes
- `expandable_card_controller.js`: added `syncToCheckbox` / `toggleFromRow` / `stopPropagation` (additive; safe for its other caller).
- `expandable_cards_controller.js`: moved the expand/collapse broadcast into `toggleAll` (recipients unaffected — its cards already start expanded).
- Collapsed fields stay in the DOM (`hidden`), so they still submit.