### PR TITLE
Gate public event forms on the public-registration flag

### DIFF
--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -2,6 +2,7 @@ module Events
   class BulkPaymentFormSubmissionsController < ApplicationController
     skip_before_action :authenticate_user!, only: [ :new, :create, :show, :ticket, :resend_confirmation ]
     before_action :set_event, only: [ :new, :create, :show ]
+    before_action :ensure_public_or_authenticated, only: [ :new, :create ]
     before_action :set_form, only: [ :new, :create ]
 
     def new
@@ -116,6 +117,14 @@ module Events
       unless @form
         redirect_to event_path(@event), alert: "#{Form::BULK_PAYMENT_PUBLIC_NAME} form is not available for this event."
       end
+    end
+
+    # Anonymous visitors may only reach the public bulk-payment form when public
+    # registration is enabled; signed-in users (and admins) always may. Mirrors
+    # Events::PublicRegistrationPolicy for the registration/scholarship forms.
+    def ensure_public_or_authenticated
+      return if current_user.present? || @event.public_registration_enabled?
+      redirect_to event_path(@event), alert: "#{Form::BULK_PAYMENT_PUBLIC_NAME} form is not open for public submissions."
     end
 
     def validate_required_fields

--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -2,7 +2,6 @@ module Events
   class BulkPaymentFormSubmissionsController < ApplicationController
     skip_before_action :authenticate_user!, only: [ :new, :create, :show, :ticket, :resend_confirmation ]
     before_action :set_event, only: [ :new, :create, :show ]
-    before_action :ensure_public_or_authenticated, only: [ :new, :create ]
     before_action :set_form, only: [ :new, :create ]
 
     def new
@@ -117,14 +116,6 @@ module Events
       unless @form
         redirect_to event_path(@event), alert: "#{Form::BULK_PAYMENT_PUBLIC_NAME} form is not available for this event."
       end
-    end
-
-    # Anonymous visitors may only reach the public bulk-payment form when public
-    # registration is enabled; signed-in users (and admins) always may. Mirrors
-    # Events::PublicRegistrationPolicy for the registration/scholarship forms.
-    def ensure_public_or_authenticated
-      return if current_user.present? || @event.public_registration_enabled?
-      redirect_to event_path(@event), alert: "#{Form::BULK_PAYMENT_PUBLIC_NAME} form is not open for public submissions."
     end
 
     def validate_required_fields

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -5,7 +5,7 @@ module Events
     before_action :ensure_registerable, only: [ :new, :create ]
 
     def new
-      authorize! :public_registration, to: :new?
+      authorize! @event, to: :new?, with: Events::PublicRegistrationPolicy
 
       @registration_form = registration_form
       unless @registration_form
@@ -21,7 +21,7 @@ module Events
     end
 
     def create
-      authorize! :public_registration, to: :create?
+      authorize! @event, to: :create?, with: Events::PublicRegistrationPolicy
 
       if params[:public_registration][:website_url].present?
         redirect_to new_event_public_registration_path(@event)

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -5,7 +5,7 @@ module Events
     before_action :ensure_registerable, only: [ :new, :create ]
 
     def new
-      authorize! @event, to: :new?, with: Events::PublicRegistrationPolicy
+      authorize! :public_registration, to: :new?
 
       @registration_form = registration_form
       unless @registration_form
@@ -21,7 +21,7 @@ module Events
     end
 
     def create
-      authorize! @event, to: :create?, with: Events::PublicRegistrationPolicy
+      authorize! :public_registration, to: :create?
 
       if params[:public_registration][:website_url].present?
         redirect_to new_event_public_registration_path(@event)

--- a/app/policies/events/public_registration_policy.rb
+++ b/app/policies/events/public_registration_policy.rb
@@ -1,10 +1,15 @@
 class Events::PublicRegistrationPolicy < ApplicationPolicy
+  # Anonymous visitors may only reach the public registration/scholarship form
+  # when public registration is enabled for the event. Signed-in users (and
+  # admins, who are always signed in) may always reach it — mirroring the
+  # register button, which shows for any signed-in user on a registerable event.
+  # `record` is the event (authorized via `authorize! @event, with: self`).
   def new?
-    true
+    admin? || record.public_registration_enabled? || authenticated?
   end
 
   def create?
-    true
+    new?
   end
 
   def show?

--- a/app/policies/events/public_registration_policy.rb
+++ b/app/policies/events/public_registration_policy.rb
@@ -1,15 +1,10 @@
 class Events::PublicRegistrationPolicy < ApplicationPolicy
-  # Anonymous visitors may only reach the public registration/scholarship form
-  # when public registration is enabled for the event. Signed-in users (and
-  # admins, who are always signed in) may always reach it — mirroring the
-  # register button, which shows for any signed-in user on a registerable event.
-  # `record` is the event (authorized via `authorize! @event, with: self`).
   def new?
-    admin? || record.public_registration_enabled? || authenticated?
+    true
   end
 
   def create?
-    new?
+    true
   end
 
   def show?

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -352,7 +352,7 @@
               </div>
 
               <div>
-                <label class="flex items-center gap-2 cursor-pointer"><%= f.check_box :autoshow_registration_details %><span class="text-sm font-medium text-gray-700">Show event details on registration page</span></label>
+                <label class="flex items-center gap-2 cursor-pointer"><%= f.check_box :autoshow_registration_details %><span class="text-sm font-medium text-gray-700">Show event details at top of registration form</span></label>
                 <p class="text-xs text-gray-500 mt-1">Add an at-a-glance list of dates, time, platform/location, fee, and deadline above the registration form. Pulled from this event's details.</p>
 
                 <div class="mt-2 space-y-2 pl-6">

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -15,20 +15,15 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%# Menu wording and which links appear both key off the event's form settings:
-        - Links open the public-facing form pages. When public registration is on,
-          each is prefixed "Public …" to signal it's exposed to anonymous visitors.
-        - Registration link: shown when a registration form is selected AND that
-          form page is actually reachable by someone — i.e. public registration is
-          on (anonymous use it) OR one-click is off (signed-in users use it). When
-          one-click is on and public registration is off, nobody hits the form page
-          (signed-in users register in one click; anonymous are blocked), so hide it.
-        - Scholarship / bulk payment only make sense once there's a fee, so also
-          gate them on the event having a cost. %>
+    <%# Links open the public-facing form pages, gated by the event's form
+        settings. When public registration is on, each label is prefixed
+        "Public …" to signal it's the publicly-exposed form. Scholarship and bulk
+        payment only make sense once there's a fee, so they also require the event
+        to have a cost. %>
     <% has_cost = @event.cost_cents.to_i.positive? %>
     <% public_form = @event.public_registration_enabled? %>
     <% form_label = ->(name) { public_form ? "Public #{name} form" : "#{name.capitalize} form" } %>
-    <% show_registration = @event.registration_form.present? && (public_form || !@event.signed_in_one_click_enabled?) %>
+    <% show_registration = @event.registration_form.present? %>
     <% show_scholarship = @event.scholarship_form.present? && has_cost %>
     <% show_bulk_payment = @event.bulk_payment_form.present? && has_cost %>
     <% if @event.registration_form.present? || @event.scholarship_form || @event.bulk_payment_form %>

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -15,14 +15,19 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <% if @event.event_forms.registration.exists? || @event.scholarship_form || @event.bulk_payment_form %>
-      <% if @event.event_forms.registration.exists? %>
-        <%= link_to "Registration form", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <%# Scholarship and bulk payment only make sense once there's a fee, so gate
+        their links on the event having a cost. The public-registration flag only
+        governs how the registration page is advertised (not access to any of
+        these forms), so it just tweaks the registration link's wording. %>
+    <% has_cost = @event.cost_cents.to_i.positive? %>
+    <% if @event.registration_form.present? || @event.scholarship_form || @event.bulk_payment_form %>
+      <% if @event.registration_form.present? %>
+        <%= link_to @event.public_registration_enabled? ? "Public registration form" : "Registration form", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
-      <% if @event.scholarship_form %>
+      <% if @event.scholarship_form && has_cost %>
         <%= link_to "Scholarship form", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
-      <% if @event.bulk_payment_form %>
+      <% if @event.bulk_payment_form && has_cost %>
         <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -1,5 +1,5 @@
-<% button_label = local_assigns.fetch(:button_label, "Form actions") %>
-<% manage_label = local_assigns.fetch(:manage_label, "Change form settings") %>
+<% button_label = local_assigns.fetch(:button_label, "Forms") %>
+<% manage_label = local_assigns.fetch(:manage_label, "Edit form settings") %>
 <% sample_return_to = local_assigns.fetch(:sample_return_to, "registrants") %>
 <% dropdown_id = "form-actions-menu-#{SecureRandom.hex(4)}" %>
 <% item_class = "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
@@ -17,10 +17,10 @@
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
     <% if @event.event_forms.registration.exists? || @event.scholarship_form || @event.bulk_payment_form %>
       <% if @event.event_forms.registration.exists? %>
-        <%= link_to "Public registration", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+        <%= link_to "Registration form", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <% if @event.scholarship_form %>
-        <%= link_to "Scholarship version", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+        <%= link_to "Scholarship form", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <% if @event.bulk_payment_form %>
         <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -15,15 +15,20 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%# Links open the public-facing form pages, gated by the event's form
-        settings. When public registration is on, each label is prefixed
-        "Public …" to signal it's the publicly-exposed form. Scholarship and bulk
-        payment only make sense once there's a fee, so they also require the event
-        to have a cost. %>
+    <%# Menu wording and which links appear both key off the event's form settings:
+        - Links open the public-facing form pages. When public registration is on,
+          each is prefixed "Public …" to signal it's exposed to anonymous visitors.
+        - Registration link: shown when a registration form is selected AND that
+          form page is actually reachable by someone — i.e. public registration is
+          on (anonymous use it) OR one-click is off (signed-in users use it). When
+          one-click is on and public registration is off, nobody hits the form page
+          (signed-in users register in one click; anonymous are blocked), so hide it.
+        - Scholarship / bulk payment only make sense once there's a fee, so also
+          gate them on the event having a cost. %>
     <% has_cost = @event.cost_cents.to_i.positive? %>
     <% public_form = @event.public_registration_enabled? %>
     <% form_label = ->(name) { public_form ? "Public #{name} form" : "#{name.capitalize} form" } %>
-    <% show_registration = @event.registration_form.present? %>
+    <% show_registration = @event.registration_form.present? && (public_form || !@event.signed_in_one_click_enabled?) %>
     <% show_scholarship = @event.scholarship_form.present? && has_cost %>
     <% show_bulk_payment = @event.bulk_payment_form.present? && has_cost %>
     <% if @event.registration_form.present? || @event.scholarship_form || @event.bulk_payment_form %>

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -15,20 +15,31 @@
   <div id="<%= dropdown_id %>"
        data-dropdown-target="content"
        class="hidden absolute right-0 z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[180px]">
-    <%# Scholarship and bulk payment only make sense once there's a fee, so gate
-        their links on the event having a cost. The public-registration flag only
-        governs how the registration page is advertised (not access to any of
-        these forms), so it just tweaks the registration link's wording. %>
+    <%# Menu wording and which links appear both key off the event's form settings:
+        - Links open the public-facing form pages. When public registration is on,
+          each is prefixed "Public …" to signal it's exposed to anonymous visitors.
+        - Registration link: shown when a registration form is selected AND that
+          form page is actually reachable by someone — i.e. public registration is
+          on (anonymous use it) OR one-click is off (signed-in users use it). When
+          one-click is on and public registration is off, nobody hits the form page
+          (signed-in users register in one click; anonymous are blocked), so hide it.
+        - Scholarship / bulk payment only make sense once there's a fee, so also
+          gate them on the event having a cost. %>
     <% has_cost = @event.cost_cents.to_i.positive? %>
+    <% public_form = @event.public_registration_enabled? %>
+    <% form_label = ->(name) { public_form ? "Public #{name} form" : "#{name.capitalize} form" } %>
+    <% show_registration = @event.registration_form.present? && (public_form || !@event.signed_in_one_click_enabled?) %>
+    <% show_scholarship = @event.scholarship_form.present? && has_cost %>
+    <% show_bulk_payment = @event.bulk_payment_form.present? && has_cost %>
     <% if @event.registration_form.present? || @event.scholarship_form || @event.bulk_payment_form %>
-      <% if @event.registration_form.present? %>
-        <%= link_to @event.public_registration_enabled? ? "Public registration form" : "Registration form", new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+      <% if show_registration %>
+        <%= link_to form_label.call("registration"), new_event_public_registration_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
-      <% if @event.scholarship_form && has_cost %>
-        <%= link_to "Scholarship form", new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+      <% if show_scholarship %>
+        <%= link_to form_label.call("scholarship"), new_event_public_registration_path(@event, scholarship_requested: true), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
-      <% if @event.bulk_payment_form && has_cost %>
-        <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+      <% if show_bulk_payment %>
+        <%= link_to form_label.call("bulk payment"), new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>
       <%= link_to manage_label, edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>

--- a/app/views/events/_form_actions_menu.html.erb
+++ b/app/views/events/_form_actions_menu.html.erb
@@ -1,3 +1,6 @@
+<% button_label = local_assigns.fetch(:button_label, "Form actions") %>
+<% manage_label = local_assigns.fetch(:manage_label, "Change form settings") %>
+<% sample_return_to = local_assigns.fetch(:sample_return_to, "registrants") %>
 <% dropdown_id = "form-actions-menu-#{SecureRandom.hex(4)}" %>
 <% item_class = "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
 <div data-controller="dropdown" class="relative">
@@ -5,7 +8,7 @@
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
           class="btn btn-utility-outline">
-    <span>Form actions</span>
+    <span><%= button_label %></span>
     <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
   </button>
 
@@ -23,11 +26,11 @@
         <%= link_to "Bulk payment form", new_event_bulk_payment_path(@event), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
       <% end %>
       <div class="my-1 border-t border-gray-100"></div>
-      <%= link_to "Change form settings", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
+      <%= link_to manage_label, edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% else %>
       <%= link_to "Enable forms", edit_event_path(@event, anchor: "registration_form_section"), class: item_class %>
     <% end %>
     <div class="my-1 border-t border-gray-100"></div>
-    <%= link_to "Sample ticket", sample_ticket_event_path(@event, return_to: "registrants"), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
+    <%= link_to "Sample ticket", sample_ticket_event_path(@event, return_to: sample_return_to), class: item_class, target: "_blank", rel: "noopener noreferrer" %>
   </div>
 </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -11,7 +11,7 @@
       form settings section). %>
   <% if allowed_to?(:edit?, @event) %>
     <div class="flex justify-end mb-6">
-      <%= render "form_actions_menu", button_label: "Forms", manage_label: "Edit form settings", sample_return_to: "dashboard" %>
+      <%= render "form_actions_menu", sample_return_to: "dashboard" %>
     </div>
   <% end %>
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -6,6 +6,15 @@
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
 
+  <%# Forms dropdown — sits top-right below the sub-nav, holding the public form
+      links, the sample-ticket preview, and "Manage forms" (the Edit-event form
+      settings section). %>
+  <% if allowed_to?(:edit?, @event) %>
+    <div class="flex justify-end mb-6">
+      <%= render "form_actions_menu", button_label: "Forms", manage_label: "Manage forms", sample_return_to: "dashboard" %>
+    </div>
+  <% end %>
+
   <%# Centered title block %>
   <div class="text-center mb-8">
     <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
@@ -18,43 +27,6 @@
       <i class="fa-solid fa-chart-simple text-blue-600"></i>
       Dashboard
     </h1>
-  </div>
-
-  <%# Quick links: registration forms and bulk payment. Each form link is gated by
-      its event setting — registration on an associated registration form, scholarship
-      on that form plus the "Enable scholarship application" checkbox (which is what
-      creates the scholarship event_form). The scholarship link points at the public
-      registration page, so it also needs the registration form or it dead-ends there.
-      Bulk payment is gated on the event having a bulk payment form.
-      Links open in a new tab. %>
-  <% link_base = "inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm transition-colors" %>
-  <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-8">
-    <% if @event.event_forms.registration.exists? %>
-      <%= link_to new_event_public_registration_path(@event), target: "_blank", rel: "noopener noreferrer",
-            class: "#{link_base} #{DomainTheme.border_class_for(:events, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:events, intensity: 300)} hover:bg-gray-50" do %>
-        <i class="fa-solid fa-clipboard-list <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
-        Public registration form
-        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
-      <% end %>
-    <% end %>
-
-    <% if @event.event_forms.registration.exists? && @event.scholarship_form %>
-      <%= link_to new_event_public_registration_path(@event, scholarship_requested: true), target: "_blank", rel: "noopener noreferrer",
-            class: "#{link_base} #{DomainTheme.border_class_for(:scholarships, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:scholarships, intensity: 300)} hover:bg-gray-50" do %>
-        <i class="fa-solid fa-graduation-cap <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>"></i>
-        Scholarship form
-        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
-      <% end %>
-    <% end %>
-
-    <% if @event.bulk_payment_form %>
-      <%= link_to new_event_bulk_payment_path(@event), target: "_blank", rel: "noopener noreferrer",
-            class: "#{link_base} #{DomainTheme.border_class_for(:payments, intensity: 200)} text-gray-700 hover:#{DomainTheme.border_class_for(:payments, intensity: 300)} hover:bg-gray-50" do %>
-        <i class="fa-solid fa-money-check-dollar <%= DomainTheme.text_class_for(:payments, intensity: 600) %>"></i>
-        Bulk payment form
-        <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
-      <% end %>
-    <% end %>
   </div>
 
   <%# Money cards (paid events only) — shown first %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -7,11 +7,11 @@
   </div>
 
   <%# Forms dropdown — sits top-right below the sub-nav, holding the public form
-      links, the sample-ticket preview, and "Manage forms" (the Edit-event form
-      settings section). %>
+      links, the sample-ticket preview, and "Edit form settings" (the Edit-event
+      form settings section). %>
   <% if allowed_to?(:edit?, @event) %>
     <div class="flex justify-end mb-6">
-      <%= render "form_actions_menu", button_label: "Forms", manage_label: "Manage forms", sample_return_to: "dashboard" %>
+      <%= render "form_actions_menu", button_label: "Forms", manage_label: "Edit form settings", sample_return_to: "dashboard" %>
     </div>
   <% end %>
 

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<%# Eyebrow returns the admin to wherever they opened the preview from. The
-    Form actions menu lives on the registrants page; the dashboard has its own
-    quick link. Default to the dashboard when the origin is absent/unknown. %>
+<%# Eyebrow returns the admin to wherever they opened the preview from — the
+    Forms menu (shared by the dashboard and registrants page) passes the origin
+    via return_to. Default to the dashboard when the origin is absent/unknown. %>
 <% case params[:return_to]
    when "registrants" %>
   <% back_label = "← Registrants" %>

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -25,10 +25,6 @@ FactoryBot.define do
       publicly_visible { true }
     end
 
-    trait :publicly_registerable do
-      public_registration_enabled { true }
-    end
-
     trait :publicly_featured do
       publicly_featured { true }
     end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       publicly_visible { true }
     end
 
+    trait :publicly_registerable do
+      public_registration_enabled { true }
+    end
+
     trait :publicly_featured do
       publicly_featured { true }
     end

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -77,38 +77,6 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
     end
   end
 
-  # Anonymous visitors may only reach the public bulk-payment form when public
-  # registration is enabled; signed-in users and admins always may. (The parent
-  # `before` signs in an admin, so sign out to exercise the anonymous path.)
-  describe "access control by public registration setting" do
-    it "redirects an anonymous visitor when public registration is disabled" do
-      sign_out admin
-      get new_event_bulk_payment_path(event)
-      expect(response).to redirect_to(event_path(event))
-    end
-
-    it "rejects an anonymous create when public registration is disabled" do
-      sign_out admin
-      post_bulk_payment("this answer easily has plenty of words")
-      expect(response).to redirect_to(event_path(event))
-    end
-
-    it "allows an anonymous visitor when public registration is enabled" do
-      sign_out admin
-      public_event = create(:event, :publicly_registerable, cost_cents: 0)
-      EventForm.create!(event: public_event, form: create(:form), role: "bulk_payment")
-
-      get new_event_bulk_payment_path(public_event)
-
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "allows a signed-in admin when public registration is disabled" do
-      get new_event_bulk_payment_path(event)
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
   describe "POST create with credit card payment" do
     let(:admin) { create(:user, :admin, :with_person) }
     let(:event) { create(:event, cost_cents: 15_00) }
@@ -165,8 +133,6 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
   end
 
   describe "GET new with the seeded bulk payment form" do
-    # Public registration must be on for the signed-out (anonymous) view.
-    let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
     let(:seeded_form) do
       FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
     end

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -77,6 +77,38 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
     end
   end
 
+  # Anonymous visitors may only reach the public bulk-payment form when public
+  # registration is enabled; signed-in users and admins always may. (The parent
+  # `before` signs in an admin, so sign out to exercise the anonymous path.)
+  describe "access control by public registration setting" do
+    it "redirects an anonymous visitor when public registration is disabled" do
+      sign_out admin
+      get new_event_bulk_payment_path(event)
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "rejects an anonymous create when public registration is disabled" do
+      sign_out admin
+      post_bulk_payment("this answer easily has plenty of words")
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "allows an anonymous visitor when public registration is enabled" do
+      sign_out admin
+      public_event = create(:event, :publicly_registerable, cost_cents: 0)
+      EventForm.create!(event: public_event, form: create(:form), role: "bulk_payment")
+
+      get new_event_bulk_payment_path(public_event)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "allows a signed-in admin when public registration is disabled" do
+      get new_event_bulk_payment_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "POST create with credit card payment" do
     let(:admin) { create(:user, :admin, :with_person) }
     let(:event) { create(:event, cost_cents: 15_00) }
@@ -133,6 +165,8 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
   end
 
   describe "GET new with the seeded bulk payment form" do
+    # Public registration must be on for the signed-out (anonymous) view.
+    let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
     let(:seeded_form) do
       FormBuilderService.new(name: "Bulk Payment", sections: %i[bulk_payment], role: "bulk_payment").call
     end

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -14,7 +14,7 @@ require "rails_helper"
 #     and form-submission show pages.
 RSpec.describe "Events::PublicRegistrations professional fields", type: :request do
   let(:admin) { create(:user, :admin) }
-  let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
+  let(:event) { create(:event, cost_cents: 0) }
 
   # An AgeRange type (profile-specific so the person edit form lists it) with the
   # published ranges plus an unpublished range that must never be offered.

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -14,7 +14,7 @@ require "rails_helper"
 #     and form-submission show pages.
 RSpec.describe "Events::PublicRegistrations professional fields", type: :request do
   let(:admin) { create(:user, :admin) }
-  let(:event) { create(:event, cost_cents: 0) }
+  let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
 
   # An AgeRange type (profile-specific so the person edit form lists it) with the
   # published ranges plus an unpublished range that must never be offered.

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Events::PublicRegistrations", type: :request do
   # A guest registering on a free event so we exercise the bare create path
   # without payment or auth.
-  let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
+  let(:event) { create(:event, cost_cents: 0) }
   let(:form) { create(:form) }
   let!(:essay_field) do
     create(:form_field, form: form, answer_type: :free_form_input_paragraph,
@@ -15,51 +15,6 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
   def post_registration(answer)
     post event_public_registration_path(event),
          params: { public_registration: { form_fields: { essay_field.id.to_s => answer } } }
-  end
-
-  # Anonymous visitors may only reach the public registration/scholarship form
-  # when public registration is enabled; signed-in users and admins always may.
-  describe "access control by public registration setting" do
-    let(:admin) { create(:user, :admin) }
-    let(:visitor) { create(:user, :with_person) }
-
-    context "when public registration is disabled" do
-      let(:event) { create(:event, cost_cents: 0) }
-
-      it "redirects an anonymous visitor from the registration form" do
-        get new_event_public_registration_path(event)
-        expect(response).to redirect_to(root_path)
-      end
-
-      it "redirects an anonymous visitor from the scholarship form" do
-        get new_event_public_registration_path(event, scholarship_requested: true)
-        expect(response).to redirect_to(root_path)
-      end
-
-      it "rejects an anonymous create" do
-        post_registration("this answer easily has plenty of words")
-        expect(response).to redirect_to(root_path)
-      end
-
-      it "allows a signed-in user" do
-        sign_in visitor
-        get new_event_public_registration_path(event)
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "allows an admin" do
-        sign_in admin
-        get new_event_public_registration_path(event)
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "when public registration is enabled" do
-      it "allows an anonymous visitor to the registration form" do
-        get new_event_public_registration_path(event)
-        expect(response).to have_http_status(:ok)
-      end
-    end
   end
 
   describe "POST create with a minimum word count" do
@@ -615,7 +570,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
   describe "GET new payment method options" do
     # A paid event so the payment section is not stripped from the form.
-    let(:event) { create(:event, :publicly_registerable, cost_cents: 150_00) }
+    let(:event) { create(:event, cost_cents: 150_00) }
     let!(:payment_method_field) do
       field = create(:form_field, form: form, answer_type: :single_select_radio,
                      field_identifier: "payment_method", name: "Payment method",

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Events::PublicRegistrations", type: :request do
   # A guest registering on a free event so we exercise the bare create path
   # without payment or auth.
-  let(:event) { create(:event, cost_cents: 0) }
+  let(:event) { create(:event, :publicly_registerable, cost_cents: 0) }
   let(:form) { create(:form) }
   let!(:essay_field) do
     create(:form_field, form: form, answer_type: :free_form_input_paragraph,
@@ -15,6 +15,51 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
   def post_registration(answer)
     post event_public_registration_path(event),
          params: { public_registration: { form_fields: { essay_field.id.to_s => answer } } }
+  end
+
+  # Anonymous visitors may only reach the public registration/scholarship form
+  # when public registration is enabled; signed-in users and admins always may.
+  describe "access control by public registration setting" do
+    let(:admin) { create(:user, :admin) }
+    let(:visitor) { create(:user, :with_person) }
+
+    context "when public registration is disabled" do
+      let(:event) { create(:event, cost_cents: 0) }
+
+      it "redirects an anonymous visitor from the registration form" do
+        get new_event_public_registration_path(event)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "redirects an anonymous visitor from the scholarship form" do
+        get new_event_public_registration_path(event, scholarship_requested: true)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "rejects an anonymous create" do
+        post_registration("this answer easily has plenty of words")
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "allows a signed-in user" do
+        sign_in visitor
+        get new_event_public_registration_path(event)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "allows an admin" do
+        sign_in admin
+        get new_event_public_registration_path(event)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when public registration is enabled" do
+      it "allows an anonymous visitor to the registration form" do
+        get new_event_public_registration_path(event)
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "POST create with a minimum word count" do
@@ -570,7 +615,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
   describe "GET new payment method options" do
     # A paid event so the payment section is not stripped from the form.
-    let(:event) { create(:event, cost_cents: 150_00) }
+    let(:event) { create(:event, :publicly_registerable, cost_cents: 150_00) }
     let!(:payment_method_field) do
       field = create(:form_field, form: form, answer_type: :single_select_radio,
                      field_identifier: "payment_method", name: "Payment method",

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1614,51 +1614,98 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include(bulk_payments_event_path(event))
       end
 
-      it "renders a Forms menu with an Edit form settings link to the edit form-settings section" do
-        create(:event_form, event: event, form: create(:form), role: "registration")
+      # The Forms dropdown (app/views/events/_form_actions_menu.html.erb) shows a
+      # link per public-facing form, gated by the event's form settings, and
+      # prefixes each label with "Public" when public registration is enabled.
+      describe "Forms dropdown" do
+        it "renders the menu with an Edit form settings link to the edit form-settings section" do
+          create(:event_form, event: event, form: create(:form), role: "registration")
 
-        get dashboard_event_path(event)
+          get dashboard_event_path(event)
 
-        expect(response.body).to include("Forms")
-        expect(response.body).to include("Edit form settings")
-        expect(response.body).to include(edit_event_path(event, anchor: "registration_form_section"))
-      end
+          expect(response.body).to include("Forms")
+          expect(response.body).to include("Edit form settings")
+          expect(response.body).to include(edit_event_path(event, anchor: "registration_form_section"))
+        end
 
-      it "shows the registration link only when a registration form is selected" do
-        get dashboard_event_path(event)
-        expect(response.body).not_to include("Registration form")
+        context "registration link" do
+          it "is hidden when no registration form is selected" do
+            get dashboard_event_path(event)
+            expect(response.body).not_to include("Registration form")
+            expect(response.body).not_to include("Public registration form")
+          end
 
-        create(:event_form, event: event, form: create(:form), role: "registration")
-        get dashboard_event_path(event)
-        expect(response.body).to include("Registration form")
-      end
+          it "shows 'Registration form' when a form is selected and public registration is off" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
 
-      it "prefixes the registration link with Public when public registration is enabled" do
-        create(:event_form, event: event, form: create(:form), role: "registration")
+            get dashboard_event_path(event)
 
-        get dashboard_event_path(event)
-        expect(response.body).not_to include("Public registration form")
+            expect(response.body).to include("Registration form")
+            expect(response.body).not_to include("Public registration form")
+          end
 
-        event.update!(public_registration_enabled: true)
-        get dashboard_event_path(event)
-        expect(response.body).to include("Public registration form")
-      end
+          it "shows 'Public registration form' when public registration is enabled" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(public_registration_enabled: true)
 
-      it "shows scholarship and bulk payment links only when the event has a cost" do
-        create(:event_form, event: event, form: create(:form), role: "scholarship")
-        create(:event_form, event: event, form: create(:form), role: "bulk_payment")
+            get dashboard_event_path(event)
 
-        free_event = create(:event, cost_cents: 0)
-        create(:event_form, event: free_event, form: create(:form), role: "scholarship")
-        create(:event_form, event: free_event, form: create(:form), role: "bulk_payment")
+            expect(response.body).to include("Public registration form")
+          end
 
-        get dashboard_event_path(free_event)
-        expect(response.body).not_to include("Scholarship form")
-        expect(response.body).not_to include("Bulk payment form")
+          it "is hidden when one-click is on and public registration is off (nobody uses the form page)" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(signed_in_one_click_enabled: true)
 
-        get dashboard_event_path(event)
-        expect(response.body).to include("Scholarship form")
-        expect(response.body).to include("Bulk payment form")
+            get dashboard_event_path(event)
+
+            expect(response.body).not_to include("Registration form")
+          end
+
+          it "is shown when one-click is on but public registration is enabled (anonymous still use it)" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(signed_in_one_click_enabled: true, public_registration_enabled: true)
+
+            get dashboard_event_path(event)
+
+            expect(response.body).to include("Public registration form")
+          end
+        end
+
+        context "scholarship and bulk payment links" do
+          before do
+            create(:event_form, event: event, form: create(:form), role: "scholarship")
+            create(:event_form, event: event, form: create(:form), role: "bulk_payment")
+          end
+
+          it "shows them on a paid event" do
+            get dashboard_event_path(event)
+
+            expect(response.body).to include("Scholarship form")
+            expect(response.body).to include("Bulk payment form")
+          end
+
+          it "hides them on a free event" do
+            free_event = create(:event, cost_cents: 0)
+            create(:event_form, event: free_event, form: create(:form), role: "scholarship")
+            create(:event_form, event: free_event, form: create(:form), role: "bulk_payment")
+
+            get dashboard_event_path(free_event)
+
+            expect(response.body).not_to include("Scholarship form")
+            expect(response.body).not_to include("Bulk payment form")
+          end
+
+          it "prefixes them with Public when public registration is enabled" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(public_registration_enabled: true)
+
+            get dashboard_event_path(event)
+
+            expect(response.body).to include("Public scholarship form")
+            expect(response.body).to include("Public bulk payment form")
+          end
+        end
       end
     end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1613,6 +1613,16 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Bulk payments")
         expect(response.body).to include(bulk_payments_event_path(event))
       end
+
+      it "renders a Forms menu with a Manage forms link to the edit form-settings section" do
+        create(:event_form, event: event, form: create(:form), role: "registration")
+
+        get dashboard_event_path(event)
+
+        expect(response.body).to include("Forms")
+        expect(response.body).to include("Manage forms")
+        expect(response.body).to include(edit_event_path(event, anchor: "registration_form_section"))
+      end
     end
 
     context "as non-admin non-owner" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1623,6 +1623,43 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Edit form settings")
         expect(response.body).to include(edit_event_path(event, anchor: "registration_form_section"))
       end
+
+      it "shows the registration link only when a registration form is selected" do
+        get dashboard_event_path(event)
+        expect(response.body).not_to include("Registration form")
+
+        create(:event_form, event: event, form: create(:form), role: "registration")
+        get dashboard_event_path(event)
+        expect(response.body).to include("Registration form")
+      end
+
+      it "prefixes the registration link with Public when public registration is enabled" do
+        create(:event_form, event: event, form: create(:form), role: "registration")
+
+        get dashboard_event_path(event)
+        expect(response.body).not_to include("Public registration form")
+
+        event.update!(public_registration_enabled: true)
+        get dashboard_event_path(event)
+        expect(response.body).to include("Public registration form")
+      end
+
+      it "shows scholarship and bulk payment links only when the event has a cost" do
+        create(:event_form, event: event, form: create(:form), role: "scholarship")
+        create(:event_form, event: event, form: create(:form), role: "bulk_payment")
+
+        free_event = create(:event, cost_cents: 0)
+        create(:event_form, event: free_event, form: create(:form), role: "scholarship")
+        create(:event_form, event: free_event, form: create(:form), role: "bulk_payment")
+
+        get dashboard_event_path(free_event)
+        expect(response.body).not_to include("Scholarship form")
+        expect(response.body).not_to include("Bulk payment form")
+
+        get dashboard_event_path(event)
+        expect(response.body).to include("Scholarship form")
+        expect(response.body).to include("Bulk payment form")
+      end
     end
 
     context "as non-admin non-owner" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1652,6 +1652,24 @@ RSpec.describe "Events", type: :request do
 
             expect(response.body).to include("Public registration form")
           end
+
+          it "is hidden when one-click is on and public registration is off (nobody uses the form page)" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(signed_in_one_click_enabled: true)
+
+            get dashboard_event_path(event)
+
+            expect(response.body).not_to include("Registration form")
+          end
+
+          it "is shown when one-click is on but public registration is enabled (anonymous still use it)" do
+            create(:event_form, event: event, form: create(:form), role: "registration")
+            event.update!(signed_in_one_click_enabled: true, public_registration_enabled: true)
+
+            get dashboard_event_path(event)
+
+            expect(response.body).to include("Public registration form")
+          end
         end
 
         context "scholarship and bulk payment links" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1652,24 +1652,6 @@ RSpec.describe "Events", type: :request do
 
             expect(response.body).to include("Public registration form")
           end
-
-          it "is hidden when one-click is on and public registration is off (nobody uses the form page)" do
-            create(:event_form, event: event, form: create(:form), role: "registration")
-            event.update!(signed_in_one_click_enabled: true)
-
-            get dashboard_event_path(event)
-
-            expect(response.body).not_to include("Registration form")
-          end
-
-          it "is shown when one-click is on but public registration is enabled (anonymous still use it)" do
-            create(:event_form, event: event, form: create(:form), role: "registration")
-            event.update!(signed_in_one_click_enabled: true, public_registration_enabled: true)
-
-            get dashboard_event_path(event)
-
-            expect(response.body).to include("Public registration form")
-          end
         end
 
         context "scholarship and bulk payment links" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1614,13 +1614,13 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include(bulk_payments_event_path(event))
       end
 
-      it "renders a Forms menu with a Manage forms link to the edit form-settings section" do
+      it "renders a Forms menu with an Edit form settings link to the edit form-settings section" do
         create(:event_form, event: event, form: create(:form), role: "registration")
 
         get dashboard_event_path(event)
 
         expect(response.body).to include("Forms")
-        expect(response.body).to include("Manage forms")
+        expect(response.body).to include("Edit form settings")
         expect(response.body).to include(edit_event_path(event, anchor: "registration_form_section"))
       end
     end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -8,7 +8,7 @@ require "rails_helper"
 # questions the dev seeds attach, so the DOM matches what registrants really see.
 RSpec.describe "Public form submissions", type: :system do
   let(:event) do
-    create(:event, :published, :publicly_visible,
+    create(:event, :published, :publicly_visible, :publicly_registerable,
            title: "AWBW Facilitator Training",
            cost_cents: 150_000,
            start_date: 10.days.from_now.change(hour: 9),

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -8,7 +8,7 @@ require "rails_helper"
 # questions the dev seeds attach, so the DOM matches what registrants really see.
 RSpec.describe "Public form submissions", type: :system do
   let(:event) do
-    create(:event, :published, :publicly_visible, :publicly_registerable,
+    create(:event, :published, :publicly_visible,
            title: "AWBW Facilitator Training",
            cost_cents: 150_000,
            start_date: 10.days.from_now.change(hour: 9),

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Public registration new page", type: :system do
       :event,
       :published,
       :publicly_visible,
-      :publicly_registerable,
       title: "My Event",
       start_date: 2.days.from_now.change(hour: 10),
       end_date: 2.days.from_now.change(hour: 12)

--- a/spec/system/public_registration_new_spec.rb
+++ b/spec/system/public_registration_new_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Public registration new page", type: :system do
       :event,
       :published,
       :publicly_visible,
+      :publicly_registerable,
       title: "My Event",
       start_date: 2.days.from_now.change(hour: 10),
       end_date: 2.days.from_now.change(hour: 12)


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 behavior change — anonymous access to public forms now depends on the public-registration flag

> ⚠️ Stacked on #2046 (Forms dropdown). Base is `maebeale/forms-dropdown-dashboard`; review/merge that first, then this rebases onto main.

### What is the goal of this PR and why is this important?
- Make the **public-registration flag actually gate access** to the public forms. Today the register button only *advertises* registration to anonymous visitors when the flag is on, but the form URLs are reachable directly regardless — this closes that gap.
- Anonymous visitors may reach the registration, scholarship, and bulk-payment forms **only when public registration is enabled**; signed-in users and admins always may (matches the existing register-button logic, so signed-in registration on flag-off events is unaffected).

### How did you approach the change?
- `Events::PublicRegistrationPolicy#new?/create?` → `admin? || public_registration_enabled? || authenticated?` (covers registration + scholarship — same controller; `authorize! @event, with: …` so the policy sees the event).
- `BulkPaymentFormSubmissionsController` gets an equivalent `before_action`.
- Forms dropdown: hide the registration link when one-click is on and public registration is off (nobody reaches the form page then).
- Adds a `:publicly_registerable` factory trait; existing anonymous specs use it, plus new access-control + one-click specs.

### Anything else to add?
- Behavior change: a direct URL to these forms on a flag-off event now redirects an anonymous visitor (to root for registration/scholarship, to the event for bulk payment).