### PR TITLE
Hide Register button on ended events in events index

### DIFF
--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -60,11 +60,6 @@
       <% end %>
     <% elsif event.ended? %>
       <span class="text-sm text-gray-500 italic">Event ended</span>
-      <% if allowed_to?(:manage?, event) %>
-        <%= button_to "Register",
-                    event_registrant_registration_path(event_id: event),
-                    class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-      <% end %>
     <% elsif !event.published? %>
       <span class="admin-only bg-blue-100 p-1 text-sm text-gray-500 italic">Not published</span>
     <% elsif event.registerable? %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only removal of one button branch in the index card

### What is the goal of this PR and why is this important?
- Registration is closed once an event has ended, but the events index card still showed an admin-only "Register" button for ended events — misleading, since registration isn't available anymore.

### How did you approach the change?
- Removed the admin Register button from the `event.ended?` branch in `app/views/events/_card.html.erb`. Ended events now show only "Event ended", matching the other closed-registration paths on the card.