### PR TITLE
Recipients: mute chips, link age chips + registration, group by funder

### DIFF
--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -170,6 +170,33 @@ class EventDashboard
       .sort_by(&:name)
   end
 
+  # Label for the "no scholarship record yet" bucket in the funder grouping —
+  # applicants who requested a scholarship but haven't been awarded one.
+  FUNDER_NONE_LABEL = "No scholarship yet".freeze
+
+  # Label for scholarships awarded without a parent grant (comped directly).
+  FUNDER_UNFUNDED_LABEL = "Unfunded".freeze
+
+  # One funder bucket for the recipients page "group by funder" view: the funder
+  # name, the donor record behind it (an Organization or Person — nil for the
+  # unfunded / no-scholarship buckets), that donor's "City, State", and the
+  # applicants in the bucket.
+  FunderGroup = Struct.new(:name, :donor, :location, :people, keyword_init: true) do
+    def count = people.size
+  end
+
+  # Scholarship applicants bucketed by their scholarship's funder (the grant's
+  # donor), as ordered FunderGroups — alphabetical by funder with the "Unfunded"
+  # and "No scholarship yet" buckets pinned last. Grants from the same donor
+  # share a bucket. People within a group keep #scholarship_applicants'
+  # display-name order.
+  def scholarship_applicants_by_funder
+    @scholarship_applicants_by_funder ||= scholarship_applicants
+      .group_by { |person| funder_key_for(person) }
+      .map { |_key, people| build_applicant_funder_group(people) }
+      .sort_by { |group| funder_group_sort_key(group.name) }
+  end
+
   # Scholarship-application answers for this event's applicants, keyed by Person
   # id and de-duplicated to one answer per question. The scholarship section may
   # be captured on the registration submission (registered with scholarship
@@ -1021,6 +1048,52 @@ class EventDashboard
 
   def scholarship_applicant_ids
     @scholarship_applicant_ids ||= active_registrations.where(scholarship_requested: true).pluck(:registrant_id)
+  end
+
+  # Grouping key for an applicant's funder: the donor identity when the
+  # scholarship is drawn from a grant (so a donor's grants share a bucket), else
+  # the unfunded / no-scholarship bucket.
+  def funder_key_for(person)
+    scholarship = scholarship_by_recipient[person.id]
+    return :none unless scholarship
+    donor = scholarship.grant&.donor
+    return :unfunded unless donor
+    [ donor.class.name, donor.id ]
+  end
+
+  # Builds a FunderGroup from a bucket of applicants that share a funder, reading
+  # the funder name, donor, and location from any member's scholarship (they're
+  # identical across the bucket).
+  def build_applicant_funder_group(people)
+    scholarship = scholarship_by_recipient[people.first.id]
+    grant = scholarship&.grant
+    donor = grant&.donor
+    name = if scholarship.nil?
+      FUNDER_NONE_LABEL
+    else
+      grant&.funder_name.presence || FUNDER_UNFUNDED_LABEL
+    end
+    FunderGroup.new(name: name, donor: donor, location: donor_location(donor), people: people)
+  end
+
+  # "City, State" from the donor's first active address — works for either an
+  # Organization or a Person funder (both are addressable). Nil when the donor
+  # has no address or isn't addressable.
+  def donor_location(donor)
+    return unless donor.respond_to?(:addresses)
+    address = donor.addresses.active.first
+    return unless address
+    [ address.city, address.state ].compact_blank.join(", ").presence
+  end
+
+  # Alphabetical by funder, with the unfunded and no-scholarship buckets last.
+  def funder_group_sort_key(label)
+    pinned = case label
+    when FUNDER_UNFUNDED_LABEL then 1
+    when FUNDER_NONE_LABEL then 2
+    else 0
+    end
+    [ pinned, label.to_s.downcase ]
   end
 
   # Registrant (Person) ids behind active registrations that opted into a

--- a/app/views/events/_recipient_card.html.erb
+++ b/app/views/events/_recipient_card.html.erb
@@ -1,0 +1,176 @@
+<%# One scholarship recipient's card for the recipients roster. Rendered both in
+    the flat, name-ordered list and under each funder header in the "group by
+    funder" view, so the markup lives here once.
+    Locals: person, dashboard (EventDashboard), answers_by_applicant,
+    header_answers, event_date, grouped (optional — hides the redundant
+    "Funded by" line when the roster is already grouped under a funder header). %>
+<% grouped = local_assigns.fetch(:grouped, false) %>
+<% participant_slug = dashboard.registration_slug_by_registrant[person.id] %>
+<% answers = (answers_by_applicant[person.id] || []).reject { |a| a.form_field&.field_identifier == "scholarship_eligibility" } %>
+<% header = header_answers[person.id] || {} %>
+<% sector_answer = header[EventDashboard::HEADER_SECTOR_KEY] %>
+<% age_group_answer = header["primary_age_group"] %>
+<%# Prefer the registrant's form answers; fall back to their profile data. %>
+<% sector_text = resolve_answer_text(sector_answer&.form_field, sector_answer&.submitted_answer).presence || person.sectors.map(&:name).join(", ").presence %>
+<% age_group_text = resolve_answer_text(age_group_answer&.form_field, age_group_answer&.submitted_answer).presence || person.categories.select { |c| c.category_type&.name == "AgeRange" }.map(&:name).join(", ").presence %>
+<%# The affiliation active at the time of the event, excluding facilitator roles. %>
+<% recipient_affiliations = person.affiliations.select { |a|
+     !a.facilitator? &&
+     (event_date.blank? || ((a.start_date.nil? || a.start_date <= event_date) && (a.end_date.nil? || a.end_date >= event_date)))
+   } %>
+
+<div id="<%= "participant-#{participant_slug}" if participant_slug %>"
+     class="scroll-mt-24 bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm overflow-hidden break-inside-avoid"
+     data-controller="expandable-card"
+     data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse">
+  <%# Recipient header — avatar + name, with title/org beneath the name and the
+      Serves / Ages meta strip in two fixed-width columns parallel to the name.
+      Calm palette: neutral name/org links, with the sector / age chips muted so
+      they don't shout on this scholarship page. %>
+  <% dp = person.decorate %>
+  <%# Primary sector first (rendered as a crowned chip), then the additional
+      sectors alphabetically. %>
+  <% sectorable_items = person.sectorable_items_primary_first %>
+  <% has_sectors = sectorable_items.any? %>
+  <%# Primary age groups first (starred chips), then the additional ones —
+      matching the sector chips above. Falls back to the form answer / profile
+      text only when the person carries no tagged age groups. %>
+  <% primary_age_groups = person.primary_age_groups.to_a %>
+  <% additional_age_groups = person.additional_age_groups.to_a %>
+  <% has_age_groups = primary_age_groups.any? || additional_age_groups.any? %>
+  <div class="relative px-5 py-4 pr-12 <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:scholarships) %>">
+    <button type="button" data-action="expandable-card#toggle"
+            aria-label="Toggle <%= person.name %> application"
+            class="absolute top-3 right-3 p-1 text-gray-400 hover:<%= DomainTheme.text_class_for(:scholarships) %> print:hidden">
+      <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-card-target="icon"></i>
+    </button>
+
+    <div class="flex items-start gap-3 min-w-0">
+      <% if dp.avatar.present? %>
+        <%= image_tag dp.avatar.variant(:thumbnail),
+                      class: "w-10 h-10 rounded-full object-cover border border-gray-200 shrink-0" %>
+      <% else %>
+        <span class="w-10 h-10 rounded-full flex items-center justify-center bg-gray-100 text-gray-500 font-bold border border-gray-200 shrink-0"><%= person.name.to_s.first&.upcase %></span>
+      <% end %>
+
+      <div class="min-w-0 flex-1 flex flex-wrap items-start gap-x-8 gap-y-3">
+        <%# Name with title / organization beneath. Fixed width on wide screens so
+            the Serves / Ages columns start at a consistent left edge across rows
+            instead of a jagged one. A ticket link at the right of the name jumps
+            to the person's registration (new tab). %>
+        <div class="min-w-0 xl:w-72 xl:shrink-0">
+          <div class="flex items-center gap-2">
+            <%= link_to person.name, person_path(person), data: { turbo_frame: "_top" },
+                        class: "text-lg font-bold text-gray-900 hover:underline" %>
+            <% if participant_slug %>
+              <%= link_to registration_ticket_path(participant_slug), target: "_blank", rel: "noopener",
+                          title: "View #{person.name}'s registration",
+                          class: "shrink-0 inline-flex items-center gap-1 text-sm text-gray-400 hover:text-gray-600" do %>
+                <i class="fa-solid fa-ticket"></i>
+                <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+              <% end %>
+            <% end %>
+          </div>
+          <% recipient_affiliations.each do |affiliation| %>
+            <div class="text-sm text-gray-600 leading-tight">
+              <% if affiliation.organization %>
+                <% if allowed_to?(:show?, affiliation.organization) %>
+                  <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
+                              data: { turbo_frame: "_top" },
+                              class: "font-medium text-gray-700 hover:text-gray-900 hover:underline" %>
+                <% else %>
+                  <span class="font-medium text-gray-700"><%= affiliation.organization.name %></span>
+                <% end %>
+              <% end %>
+              <% if affiliation.organization && affiliation.title.present? %><span class="text-gray-300">·</span><% end %>
+              <% if affiliation.title.present? %><span><%= affiliation.title %></span><% end %>
+            </div>
+          <% end %>
+        </div>
+
+        <%# Serves / Ages — two fixed-width columns so each label starts at a
+            consistent x across rows and its chips wrap within its own column
+            instead of pushing the next column out of alignment. %>
+        <% if has_sectors || sector_text.present? %>
+          <div class="flex flex-wrap items-center gap-2 xl:w-[28rem] xl:shrink-0">
+            <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
+            <% if has_sectors %>
+              <% sectorable_items.each do |si| %>
+                <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary?, muted: true %>
+              <% end %>
+            <% else %>
+              <span class="text-sm text-gray-600"><%= sector_text %></span>
+            <% end %>
+          </div>
+        <% end %>
+        <% if has_age_groups || age_group_text.present? %>
+          <div class="flex flex-wrap items-center gap-2 xl:w-[27rem] xl:shrink-0">
+            <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
+            <% if has_age_groups %>
+              <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups, muted: true %>
+            <% else %>
+              <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-600"><%= age_group_text %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <%# Scholarship status — awarded amount + tasks-completed state. Hidden
+      until toggled on (page-wide) so it doesn't crowd the application;
+      stays visible regardless of the card's expand/collapse state. %>
+  <% scholarship = dashboard.scholarship_by_recipient[person.id] %>
+  <% if scholarship %>
+    <div class="px-5 py-3 border-b <%= DomainTheme.border_class_for(:scholarships) %> bg-gray-50"
+         data-scholarship-status-toggle-target="status">
+      <div class="flex flex-wrap items-center gap-3">
+        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Scholarship</span>
+        <span class="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-900">
+          <i class="fa-solid fa-sack-dollar text-gray-400"></i>
+          <%= dollars_from_cents(scholarship.amount_cents) %>
+        </span>
+        <% if !grouped && scholarship.grant&.funder_name.present? %>
+          <% if allowed_to?(:show?, scholarship.grant) %>
+            <%= link_to grant_path(scholarship.grant), target: "_blank", rel: "noopener",
+                        class: "inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-800 hover:underline" do %>
+              <i class="fa-solid fa-hand-holding-heart text-gray-400"></i>
+              Funded by <%= scholarship.grant.funder_name %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+            <% end %>
+          <% else %>
+            <span class="inline-flex items-center gap-1.5 text-sm text-gray-600">
+              <i class="fa-solid fa-hand-holding-heart text-gray-400"></i>
+              Funded by <%= scholarship.grant.funder_name %>
+            </span>
+          <% end %>
+        <% end %>
+        <%= render "scholarships/tasks_status", scholarship: scholarship %>
+        <% if allowed_to?(:edit?, scholarship) %>
+          <%= link_to edit_scholarship_path(scholarship, return_to: "recipients", participant: participant_slug),
+                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                      target: "_blank", rel: "noopener" do %>
+            Edit
+            <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%# Scholarship application answers %>
+  <div class="px-5 py-4 print:block" data-expandable-card-target="body">
+    <% if answers.any? %>
+      <dl class="space-y-4">
+        <% answers.each do |answer| %>
+          <div>
+            <dt class="text-sm font-semibold text-gray-800"><%= display_question_label(answer.form_field, answer) %></dt>
+            <dd class="mt-1 text-sm text-gray-700 whitespace-pre-line"><%= resolve_answer_text(answer.form_field, answer.submitted_answer) %></dd>
+          </div>
+        <% end %>
+      </dl>
+    <% else %>
+      <p class="text-sm text-gray-400 italic">No scholarship application answers on file.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -52,7 +52,8 @@
   <% if @dashboard.scholarship_applicants.any? %>
     <div data-controller="expandable-cards scholarship-status-toggle"
          data-scholarship-status-toggle-shown-value="true">
-      <%# Title shares a row with the controls (show/hide scholarship status, expand/collapse all) %>
+      <%# Title shares a row with the controls (show/hide scholarship status,
+          group by funder, expand/collapse all). %>
       <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
         <h2 class="text-xl font-bold flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
           <i class="fa-solid fa-user-graduate"></i>
@@ -71,6 +72,19 @@
             </span>
             <span>Show scholarship status</span>
           </button>
+          <%# Group the roster by funder (the scholarship's grant donor), with a
+              header per funder — or return to the flat, name-ordered list. %>
+          <% if params[:group_by] == "funder" %>
+            <%= link_to recipients_event_path(@event),
+                        class: "inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800" do %>
+              <i class="fa-solid fa-layer-group"></i> Ungroup
+            <% end %>
+          <% else %>
+            <%= link_to recipients_event_path(@event, group_by: "funder"),
+                        class: "inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800" do %>
+              <i class="fa-solid fa-layer-group"></i> Group by funder
+            <% end %>
+          <% end %>
           <%# Expand / collapse all %>
           <button type="button" data-action="expandable-cards#toggleAll"
                   class="inline-flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> hover:<%= DomainTheme.text_class_for(:scholarships) %>">
@@ -80,169 +94,49 @@
         </div>
       </div>
 
-      <div class="space-y-6">
-      <% @dashboard.scholarship_applicants.each do |person| %>
-        <% participant_slug = @dashboard.registration_slug_by_registrant[person.id] %>
-        <% answers = (answers_by_applicant[person.id] || []).reject { |a| a.form_field&.field_identifier == "scholarship_eligibility" } %>
-        <% header = header_answers[person.id] || {} %>
-        <% sector_answer = header[EventDashboard::HEADER_SECTOR_KEY] %>
-        <% age_group_answer = header["primary_age_group"] %>
-        <%# Prefer the registrant's form answers; fall back to their profile data. %>
-        <% sector_text = resolve_answer_text(sector_answer&.form_field, sector_answer&.submitted_answer).presence || person.sectors.map(&:name).join(", ").presence %>
-        <% age_group_text = resolve_answer_text(age_group_answer&.form_field, age_group_answer&.submitted_answer).presence || person.categories.select { |c| c.category_type&.name == "AgeRange" }.map(&:name).join(", ").presence %>
-        <%# The affiliation active at the time of the event, excluding facilitator roles. %>
-        <% recipient_affiliations = person.affiliations.select { |a|
-             !a.facilitator? &&
-             (event_date.blank? || ((a.start_date.nil? || a.start_date <= event_date) && (a.end_date.nil? || a.end_date >= event_date)))
-           } %>
-
-        <div id="<%= "participant-#{participant_slug}" if participant_slug %>"
-             class="scroll-mt-24 bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm overflow-hidden break-inside-avoid"
-             data-controller="expandable-card"
-             data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse">
-          <%# Recipient header — avatar + name, with title/org beneath the name and
-              the Serves / Ages meta strip set parallel to the name (the space under
-              the avatar stays blank). Calm palette: neutral name/org links, with
-              the sector chips as the single accent. %>
-          <% dp = person.decorate %>
-          <%# Primary sector first (rendered as a darker-green crowned chip),
-              then the additional sectors alphabetically. %>
-          <% sectorable_items = person.sectorable_items_primary_first %>
-          <% has_sectors = sectorable_items.any? %>
-          <%# Primary age groups first (starred amber chips), then the additional
-              ones — matching the sector chips above. Falls back to the form
-              answer / profile text only when the person carries no tagged age
-              groups. %>
-          <% primary_age_groups = person.primary_age_groups.to_a %>
-          <% additional_age_groups = person.additional_age_groups.to_a %>
-          <% has_age_groups = primary_age_groups.any? || additional_age_groups.any? %>
-          <div class="relative px-5 py-4 pr-12 <%= DomainTheme.bg_class_for(:scholarships, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:scholarships) %>">
-            <button type="button" data-action="expandable-card#toggle"
-                    aria-label="Toggle <%= person.name %> application"
-                    class="absolute top-3 right-3 p-1 text-gray-400 hover:<%= DomainTheme.text_class_for(:scholarships) %> print:hidden">
-              <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-card-target="icon"></i>
-            </button>
-
-            <div class="flex items-start gap-3 min-w-0">
-              <% if dp.avatar.present? %>
-                <%= image_tag dp.avatar.variant(:thumbnail),
-                              class: "w-10 h-10 rounded-full object-cover border border-gray-200 shrink-0" %>
-              <% else %>
-                <span class="w-10 h-10 rounded-full flex items-center justify-center bg-gray-100 text-gray-500 font-bold border border-gray-200 shrink-0"><%= person.name.to_s.first&.upcase %></span>
-              <% end %>
-
-              <div class="min-w-0 flex-1 flex flex-wrap items-start gap-x-8 gap-y-3">
-                <%# Name with title / organization beneath. Fixed width on wide
-                    screens so the Serves / Ages columns start at a consistent left
-                    edge across rows instead of a jagged one. %>
-                <div class="min-w-0 xl:w-72 xl:shrink-0">
-                  <%= link_to person.name, person_path(person), data: { turbo_frame: "_top" },
-                              class: "text-lg font-bold text-gray-900 hover:underline" %>
-                  <% recipient_affiliations.each do |affiliation| %>
-                    <div class="text-sm text-gray-600 leading-tight">
-                      <% if affiliation.organization %>
-                        <% if allowed_to?(:show?, affiliation.organization) %>
-                          <%= link_to affiliation.organization.name, organization_path(affiliation.organization),
-                                      data: { turbo_frame: "_top" },
-                                      class: "font-medium text-gray-700 hover:text-gray-900 hover:underline" %>
-                        <% else %>
-                          <span class="font-medium text-gray-700"><%= affiliation.organization.name %></span>
-                        <% end %>
-                      <% end %>
-                      <% if affiliation.organization && affiliation.title.present? %><span class="text-gray-300">·</span><% end %>
-                      <% if affiliation.title.present? %><span><%= affiliation.title %></span><% end %>
-                    </div>
-                  <% end %>
-                </div>
-
-                <%# Serves / Ages — two fixed-width columns so each label starts at
-                    a consistent x across rows and its chips wrap within its own
-                    column instead of pushing the next column out of alignment. %>
-                <% if has_sectors || sector_text.present? %>
-                  <div class="flex flex-wrap items-center gap-2 xl:w-[28rem] xl:shrink-0">
-                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
-                    <% if has_sectors %>
-                      <% sectorable_items.each do |si| %>
-                        <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
-                      <% end %>
-                    <% else %>
-                      <span class="text-sm text-gray-600"><%= sector_text %></span>
-                    <% end %>
-                  </div>
-                <% end %>
-                <% if has_age_groups || age_group_text.present? %>
-                  <div class="flex flex-wrap items-center gap-2 xl:w-[27rem] xl:shrink-0">
-                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
-                    <% if has_age_groups %>
-                      <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
-                    <% else %>
-                      <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-600"><%= age_group_text %></span>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-          </div>
-
-          <%# Scholarship status — awarded amount + tasks-completed state. Hidden
-              until toggled on (page-wide) so it doesn't crowd the application;
-              stays visible regardless of the card's expand/collapse state. %>
-          <% scholarship = @dashboard.scholarship_by_recipient[person.id] %>
-          <% if scholarship %>
-            <div class="px-5 py-3 border-b <%= DomainTheme.border_class_for(:scholarships) %> bg-gray-50"
-                 data-scholarship-status-toggle-target="status">
-              <div class="flex flex-wrap items-center gap-3">
-                <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Scholarship</span>
-                <span class="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-900">
-                  <i class="fa-solid fa-sack-dollar text-gray-400"></i>
-                  <%= dollars_from_cents(scholarship.amount_cents) %>
-                </span>
-                <% if scholarship.grant&.funder_name.present? %>
-                  <% if allowed_to?(:show?, scholarship.grant) %>
-                    <%= link_to grant_path(scholarship.grant), target: "_blank", rel: "noopener",
-                                class: "inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-800 hover:underline" do %>
-                      <i class="fa-solid fa-hand-holding-heart text-gray-400"></i>
-                      Funded by <%= scholarship.grant.funder_name %>
-                      <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+      <% card_locals = { dashboard: @dashboard, answers_by_applicant: answers_by_applicant,
+                         header_answers: header_answers, event_date: event_date } %>
+      <% if params[:group_by] == "funder" %>
+        <div class="space-y-8">
+          <% @dashboard.scholarship_applicants_by_funder.each do |group| %>
+            <section class="break-inside-avoid">
+              <%# Bold, dark-fuchsia funder band so each group's header stands out.
+                  The funder name links to the donor's profile (org or person). %>
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-fuchsia-800 px-4 py-2.5 mb-4 text-white">
+                <i class="fa-solid fa-hand-holding-heart text-fuchsia-200"></i>
+                <h2 class="text-lg font-bold tracking-tight">
+                  <% if group.donor && allowed_to?(:show?, group.donor) %>
+                    <%= link_to polymorphic_path(group.donor), data: { turbo_frame: "_top" },
+                                class: "inline-flex items-center gap-1.5 hover:underline" do %>
+                      <%= group.name %>
+                      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-fuchsia-200"></i>
                     <% end %>
                   <% else %>
-                    <span class="inline-flex items-center gap-1.5 text-sm text-gray-600">
-                      <i class="fa-solid fa-hand-holding-heart text-gray-400"></i>
-                      Funded by <%= scholarship.grant.funder_name %>
-                    </span>
+                    <%= group.name %>
                   <% end %>
+                </h2>
+                <% if group.location.present? %>
+                  <span class="inline-flex items-center gap-1 text-sm text-fuchsia-100">
+                    <i class="fa-solid fa-location-dot text-xs text-fuchsia-200"></i><%= group.location %>
+                  </span>
                 <% end %>
-                <%= render "scholarships/tasks_status", scholarship: scholarship %>
-                <% if allowed_to?(:edit?, scholarship) %>
-                  <%= link_to edit_scholarship_path(scholarship, return_to: "recipients", participant: participant_slug),
-                              class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
-                              target: "_blank", rel: "noopener" do %>
-                    Edit
-                    <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
-                  <% end %>
+                <span class="ml-auto text-sm font-medium text-fuchsia-100"><%= pluralize(group.count, "recipient") %></span>
+              </div>
+              <div class="space-y-6">
+                <% group.people.each do |person| %>
+                  <%= render "events/recipient_card", card_locals.merge(person: person, grouped: true) %>
                 <% end %>
               </div>
-            </div>
+            </section>
           <% end %>
-
-          <%# Scholarship application answers %>
-          <div class="px-5 py-4 print:block" data-expandable-card-target="body">
-            <% if answers.any? %>
-              <dl class="space-y-4">
-                <% answers.each do |answer| %>
-                  <div>
-                    <dt class="text-sm font-semibold text-gray-800"><%= display_question_label(answer.form_field, answer) %></dt>
-                    <dd class="mt-1 text-sm text-gray-700 whitespace-pre-line"><%= resolve_answer_text(answer.form_field, answer.submitted_answer) %></dd>
-                  </div>
-                <% end %>
-              </dl>
-            <% else %>
-              <p class="text-sm text-gray-400 italic">No scholarship application answers on file.</p>
-            <% end %>
-          </div>
+        </div>
+      <% else %>
+        <div class="space-y-6">
+          <% @dashboard.scholarship_applicants.each do |person| %>
+            <%= render "events/recipient_card", card_locals.merge(person: person) %>
+          <% end %>
         </div>
       <% end %>
-      </div>
     </div>
   <% else %>
     <div class="text-center py-12 text-gray-500">

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -15,6 +15,11 @@
 <% compact ||= false %>
 <% chip_size = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
 
+<%# Muted renders the chip in a calm neutral grey instead of the loud lime, for
+    pages where the sector isn't the focus (e.g. the scholarship recipients
+    roster). The star stays as the only accent. %>
+<% muted ||= false %>
+
 <%# Tags hidden from the public (unpublished) are only ever shown to admins, so
     they read as a muted grey chip with an eye-slash icon — the same "hidden" cue
     used on password fields — to flag at a glance what the public can't see. %>
@@ -39,6 +44,12 @@
      bg_color = "bg-gray-100"
      bg_hover_color = "bg-gray-200"
      text_color = "text-gray-500"
+     border_class = "border-gray-200"
+     border_hover_class = "border-gray-300"
+   elsif muted
+     bg_color = is_primary ? "bg-gray-100" : "bg-gray-50"
+     bg_hover_color = is_primary ? "bg-gray-200" : "bg-gray-100"
+     text_color = is_primary ? "text-gray-700" : "text-gray-500"
      border_class = "border-gray-200"
      border_hover_class = "border-gray-300"
    end %>

--- a/app/views/shared/_age_group_tags.html.erb
+++ b/app/views/shared/_age_group_tags.html.erb
@@ -1,20 +1,37 @@
-<%# Age-group chips, themed in lime to match the sector chips. Primary groups lead
-    with an amber star on a darker lime chip; additional groups follow in a lighter
-    lime. `primary` and `additional` are arrays of Category records. `compact`
-    shrinks the chips for dense table cells. %>
+<%# Age-group chips. Each links to the taggings page filtered to that category —
+    the same drill-in the sector chips offer (sectors/_tagging_label) — so the two
+    rows behave alike. Primary groups lead with an amber star on a darker chip;
+    additional groups follow lighter. `primary` and `additional` are arrays of
+    Category records. `compact` shrinks the chips for dense table cells. `muted`
+    swaps the lime theme for a calm neutral grey on pages where the tags aren't
+    the focus (e.g. the scholarship recipients roster). %>
 <% primary ||= [] %>
 <% additional ||= [] %>
 <% compact = local_assigns.fetch(:compact, false) %>
+<% muted = local_assigns.fetch(:muted, false) %>
 <% padding = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
+<% if muted
+     primary_classes = "border-gray-200 bg-gray-100 text-gray-700 hover:border-gray-300 hover:bg-gray-200"
+     additional_classes = "border-gray-200 bg-gray-50 text-gray-500 hover:border-gray-300 hover:bg-gray-100"
+   else
+     primary_classes = "border-lime-300 bg-lime-100 text-lime-800 hover:border-lime-400 hover:bg-lime-200"
+     additional_classes = "border-lime-300 bg-lime-50 text-gray-500 hover:border-lime-400 hover:bg-lime-100"
+   end %>
 <div class="flex flex-wrap gap-1.5">
   <% primary.each do |category| %>
-    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-100 <%= padding %> font-medium text-lime-800">
-      <i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><%= category.name %>
-    </span>
+    <%= link_to taggings_path(category_names_all: category.name), title: category.name,
+                data: { turbo_frame: "_top", controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
+                class: "inline-flex items-center whitespace-nowrap rounded-md border #{padding} font-medium transition #{primary_classes}" do %>
+      <span data-tag-link-loading-target="text"><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><%= category.name %></span>
+      <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
+    <% end %>
   <% end %>
   <% additional.each do |category| %>
-    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-50 <%= padding %> font-medium text-gray-500">
-      <%= category.name %>
-    </span>
+    <%= link_to taggings_path(category_names_all: category.name), title: category.name,
+                data: { turbo_frame: "_top", controller: "tag-link-loading", action: "click->tag-link-loading#showSpinner" },
+                class: "inline-flex items-center whitespace-nowrap rounded-md border #{padding} font-medium transition #{additional_classes}" do %>
+      <span data-tag-link-loading-target="text"><%= category.name %></span>
+      <span data-tag-link-loading-target="spinner" class="hidden"><i class="fa-solid fa-spinner animate-spin" aria-hidden="true"></i></span>
+    <% end %>
   <% end %>
 </div>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2723,7 +2723,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("Pat Plain")
       end
 
-      it "renders each recipient's tagged age groups as chips, primary ones starred" do
+      it "renders each recipient's tagged age groups as muted chips linking to the taggings filter, primary ones starred" do
         age_type = create(:category_type, name: "AgeRange", published: true)
         teens = create(:category, :published, category_type: age_type, name: "13-17")
         adults = create(:category, :published, category_type: age_type, name: "18+")
@@ -2734,8 +2734,41 @@ RSpec.describe "Events", type: :request do
         page = Capybara.string(response.body)
         expect(page).to have_content("13-17")
         expect(page).to have_content("18+")
-        # The primary group leads with the starred lime chip from the shared partial.
-        expect(page).to have_css("span.text-lime-800 i.fa-star")
+        # Each age chip links to the taggings page filtered to that category, like
+        # the sector chips do.
+        expect(page).to have_css("a[href*='category_names_all=13-17']")
+        expect(page).to have_css("a[href*='category_names_all=18%2B']")
+        # The primary group leads with a starred, muted (neutral-grey) chip.
+        expect(page).to have_css("a.text-gray-700 i.fa-star")
+      end
+
+      it "links each recipient's name row to their registration ticket" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include(registration_ticket_path(registration.slug))
+      end
+
+      it "groups recipients by funder with a linked header carrying the funder's city/state, hiding the per-card funder line" do
+        registration = event.event_registrations.find_by(registrant: applicant)
+        org = create(:organization, name: "Joyful Heart Foundation")
+        create(:address, addressable: org, city: "Los Angeles", state: "CA")
+        grant = create(:grant, name: "Healing Arts Fund", donor: org, amount_cents: 100_000)
+        scholarship = create(:scholarship, recipient: applicant, grant: grant, amount_cents: 1_000)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
+
+        get recipients_event_path(event, group_by: "funder")
+
+        expect(response).to have_http_status(:ok)
+        page = Capybara.string(response.body)
+        # The funder name renders as a section header linking to the donor's profile,
+        # with its city/state alongside.
+        expect(page).to have_css("h2 a[href='#{organization_path(org)}']", text: "Joyful Heart Foundation")
+        expect(page).to have_content("Los Angeles, CA")
+        expect(response.body).to include("Ungroup")
+        # The redundant per-card "Funded by" line is dropped when grouped.
+        expect(response.body).not_to include("Funded by")
       end
 
       it "shows the org linked to its website on the left and the bold recipient name linked to their profile on the right" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -510,6 +510,36 @@ RSpec.describe EventDashboard do
       expect(map[separate_applicant.id]).to eq(EventRegistration.find_by(event: event, registrant: separate_applicant).id)
     end
 
+    describe "#scholarship_applicants_by_funder" do
+      it "buckets applicants by their scholarship's grant funder, unfunded last, carrying the donor and its city/state" do
+        embedded_reg = event.event_registrations.find_by(registrant: embedded_applicant)
+        separate_reg = event.event_registrations.find_by(registrant: separate_applicant)
+        donor = create(:organization, name: "Joyful Heart Foundation")
+        create(:address, addressable: donor, city: "Los Angeles", state: "CA")
+        grant = create(:grant, name: "Healing Arts", donor: donor, amount_cents: 100_000)
+        funded = create(:scholarship, recipient: embedded_applicant, grant: grant, amount_cents: 1_000)
+        create(:allocation, source: funded, allocatable: embedded_reg, amount: 1_000)
+        unfunded = create(:scholarship, recipient: separate_applicant, amount_cents: 1_000)
+        create(:allocation, source: unfunded, allocatable: separate_reg, amount: 1_000)
+
+        groups = dashboard.scholarship_applicants_by_funder
+
+        expect(groups.map(&:name)).to eq([ "Joyful Heart Foundation", "Unfunded" ])
+        expect(groups.first.people).to eq([ embedded_applicant ])
+        expect(groups.first.donor).to eq(donor)
+        expect(groups.first.location).to eq("Los Angeles, CA")
+        expect(groups.last.people).to eq([ separate_applicant ])
+        expect(groups.last.donor).to be_nil
+      end
+
+      it "collects applicants with no awarded scholarship under 'No scholarship yet'" do
+        groups = dashboard.scholarship_applicants_by_funder
+
+        expect(groups.map(&:name)).to eq([ "No scholarship yet" ])
+        expect(groups.first.people).to match_array([ embedded_applicant, separate_applicant ])
+      end
+    end
+
     it "gathers scholarship answers wherever they were captured, keyed by applicant" do
       answers = dashboard.scholarship_answers_by_applicant
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mostly view work, but the shared age-chip partial now links on 5 pages and there's a new dashboard grouping method

Changes to the **scholarship recipients** page (and the shared chip partials it uses):

- **Muted chips** — sector and age chips render in a calm neutral grey here (via a new `muted:` local on both partials) instead of the loud lime, so they stop pulling focus on a page that's about scholarships.
- **Age chips now filter** — they link into the taggings page (`category_names_all=`) the same way sector chips already do; previously they were plain, non-clickable spans. This applies everywhere the `shared/_age_group_tags` partial is used, matching the sector chips beside them.
- **Registration link** — a ticket icon at the right of each recipient's name opens that person's registration ticket in a new tab.
- **Group by funder** — a toggle regroups the roster under a **bold dark-fuchsia header per funder** (the scholarship's grant donor). The funder name links to the donor's profile (org or person) and shows the donor's **city/state** (from its first active address, so it works for either donor type). `Unfunded` and `No scholarship yet` are pinned last. The now-redundant per-card "Funded by" line is hidden while grouped. Backed by `EventDashboard#scholarship_applicants_by_funder`.
- **Hide-status switch** starts grey/off by default (statuses are shown to start; the switch only lights up fuchsia once you hide them).
- The recipient card markup moved into `events/_recipient_card` so the flat and grouped lists share it.

## Testing
- `EventDashboard#scholarship_applicants_by_funder` grouping/ordering + donor/location specs
- Recipients request specs: age chips link + muted, registration ticket link, funder header link + city/state, hidden per-card funder line when grouped
- Existing recipients / people / organizations / tagging-label specs still green