### PR TITLE
Align event report title rows and unify page headers

### DIFF
--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -39,22 +39,26 @@
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :background %>
   </div>
-  <div class="flex justify-end gap-3 mb-6 print:hidden">
-    <button onclick="window.print();" class="btn btn-utility-outline">
-      <i class="fa-solid fa-print"></i> Print
-    </button>
-  </div>
+  <%# Title block with the Print button pinned top-right so it shares the title's
+      vertical band instead of stacking above it. On mobile it sits in its own
+      right-aligned row above the centered title to avoid overlapping it. %>
+  <div class="relative mb-8">
+    <div class="flex justify-end gap-3 mb-4 sm:mb-0 sm:absolute sm:right-0 sm:top-0 print:hidden">
+      <button onclick="window.print();" class="btn btn-utility-outline">
+        <i class="fa-solid fa-print"></i> Print
+      </button>
+    </div>
 
-  <%# Title block %>
-  <div class="text-center mb-8">
-    <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
-    <% if @event.start_date.present? %>
-      <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
-    <% end %>
-    <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
-      Get to know the registrants
-    </h1>
+    <div class="text-center">
+      <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
+      <% if @event.start_date.present? %>
+        <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+      <% end %>
+      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+        <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
+        Get to know the registrants
+      </h1>
+    </div>
   </div>
 
   <%# ---- At-a-glance counts — one compact "stat bar" of metrics; each segment

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -9,33 +9,33 @@
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
-  <div class="flex justify-end gap-3 mb-6 print:hidden">
-    <button onclick="window.print();" class="btn btn-utility-outline">
-      <i class="fa-solid fa-print"></i> Print
-    </button>
-  </div>
-
-  <%# Forms dropdown — sits top-right below the sub-nav, holding the public form
-      links, the sample-ticket preview, and "Edit form settings" (the Edit-event
-      form settings section). %>
-  <% if allowed_to?(:edit?, @event) %>
-    <div class="flex justify-end mb-6">
-      <%= render "form_actions_menu", sample_return_to: "dashboard" %>
+  <%# Title block with the action buttons pinned top-right so they share the
+      title's vertical band instead of stacking above it. Forms holds the public
+      form links, sample-ticket preview, and "Edit form settings"; it only shows
+      to editors. On mobile the buttons sit in their own right-aligned row above
+      the centered title to avoid overlapping it. %>
+  <div class="relative mb-8">
+    <div class="flex justify-end gap-3 mb-4 sm:mb-0 sm:absolute sm:right-0 sm:top-0 print:hidden">
+      <% if allowed_to?(:edit?, @event) %>
+        <%= render "form_actions_menu", sample_return_to: "dashboard" %>
+      <% end %>
+      <button onclick="window.print();" class="btn btn-utility-outline">
+        <i class="fa-solid fa-print"></i> Print
+      </button>
     </div>
-  <% end %>
 
-  <%# Centered title block %>
-  <div class="text-center mb-8">
-    <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
-    <% if @event.start_date.present? %>
-      <p class="text-sm text-gray-500 mt-1">
-        <%= @event.date_range %>
-      </p>
-    <% end %>
-    <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-chart-simple <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
-      Dashboard
-    </h1>
+    <div class="text-center">
+      <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
+      <% if @event.start_date.present? %>
+        <p class="text-sm text-gray-500 mt-1">
+          <%= @event.date_range %>
+        </p>
+      <% end %>
+      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+        <i class="fa-solid fa-chart-simple <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
+        Dashboard
+      </h1>
+    </div>
   </div>
 
   <%# Money cards (paid events only) — shown first %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -14,29 +14,33 @@
     <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: :scholarships %>
   </div>
-  <div class="flex justify-end gap-3 mb-6 print:hidden">
-    <% if allowed_to?(:index?, Grant) %>
-      <%= link_to grants_path, target: "_blank", rel: "noopener", class: "btn btn-utility-outline" do %>
-        <i class="fa-solid fa-hand-holding-dollar"></i> Grants
-        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+  <%# Title block with the Grants / Print buttons pinned top-right so they share
+      the title's vertical band instead of stacking above it. On mobile they sit
+      in their own right-aligned row above the centered title to avoid overlap. %>
+  <div class="relative mb-8">
+    <div class="flex justify-end gap-3 mb-4 sm:mb-0 sm:absolute sm:right-0 sm:top-0 print:hidden">
+      <% if allowed_to?(:index?, Grant) %>
+        <%= link_to grants_path, target: "_blank", rel: "noopener", class: "btn btn-utility-outline" do %>
+          <i class="fa-solid fa-hand-holding-dollar"></i> Grants
+          <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+        <% end %>
       <% end %>
-    <% end %>
-    <button onclick="window.print();" class="btn btn-utility-outline">
-      <i class="fa-solid fa-print"></i> Print
-    </button>
-  </div>
+      <button onclick="window.print();" class="btn btn-utility-outline">
+        <i class="fa-solid fa-print"></i> Print
+      </button>
+    </div>
 
-  <%# Title block %>
-  <div class="text-center mb-8">
-    <%= link_to @event.title, edit_event_path(@event), class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
-    <% if @event.start_date.present? %>
-      <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
-    <% end %>
-    <h1 class="text-3xl font-bold mt-1 flex items-center justify-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
-      <i class="fa-solid fa-graduation-cap"></i>
-      Scholarship recipients
-    </h1>
-    <p class="text-gray-500 mt-2"><%= pluralize(@dashboard.scholarship_applicants.size, "recipient") %></p>
+    <div class="text-center">
+      <%= link_to @event.title, edit_event_path(@event), class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
+      <% if @event.start_date.present? %>
+        <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+      <% end %>
+      <h1 class="text-3xl font-bold mt-1 flex items-center justify-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+        <i class="fa-solid fa-graduation-cap"></i>
+        Scholarship recipients
+      </h1>
+      <p class="text-gray-500 mt-2"><%= pluralize(@dashboard.scholarship_applicants.size, "person") %></p>
+    </div>
   </div>
 
   <% if @dashboard.scholarship_applicants.any? %>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -10,17 +10,13 @@
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 
-  <%# Title row: heading + registrant action controls %>
-  <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
-    <div>
-      <h1 class="text-2xl font-semibold text-gray-900">
-        Registrants (<%= @active_count %>)
-      </h1>
-      <p class="text-gray-600 mt-1">
-        <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
-      </p>
-    </div>
-    <div class="flex flex-wrap items-center gap-1">
+  <%# Title block — matches the dashboard/background/scholarships report pages:
+      event eyebrow over a text-3xl heading with an icon and a count subtitle,
+      with the registrant action controls pinned top-right so they share the
+      title's vertical band. On mobile they sit in their own right-aligned row
+      above the centered title to avoid overlap. %>
+  <div class="relative mb-6">
+    <div class="flex flex-wrap items-center justify-end gap-1 mb-4 sm:mb-0 sm:absolute sm:right-0 sm:top-0">
       <% if allowed_to?(:edit?, @event) %>
         <%= render "form_actions_menu" %>
       <% end %>
@@ -28,6 +24,18 @@
       <% if allowed_to?(:new?, EventRegistration) %>
         <%= link_to "Add registrant", new_event_registration_path(event_id: @event.id, return_to: "registrants"), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
       <% end %>
+    </div>
+
+    <div class="text-center">
+      <%= link_to @event.decorate.compact_label, edit_event_path(@event), title: @event.title, class: "text-sm font-semibold text-gray-500 uppercase tracking-wide hover:text-gray-700" %>
+      <% if @event.start_date.present? %>
+        <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+      <% end %>
+      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+        <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
+        Registrants
+      </h1>
+      <p class="text-gray-500 mt-2"><%= pluralize(@active_count, "person") %></p>
     </div>
   </div>
 

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -12,25 +12,29 @@
       <%= render "events/subnav", event: @event, current: :staff %>
     <% end %>
   </div>
-  <% if allowed_to?(:edit_staff?, @event) %>
-    <div class="flex justify-end gap-3 mb-6 print:hidden">
-      <%= link_to edit_staff_event_path(@event), class: "admin-only btn btn-primary btn--small" do %>
-        <i class="fa-solid fa-pen"></i> Edit staff
-      <% end %>
-    </div>
-  <% end %>
-
   <%# Title block — matches the dashboard/background/scholarships report pages:
-      event title eyebrow over a text-3xl heading with an icon. %>
-  <div class="text-center mb-8">
-    <p class="text-sm font-semibold text-gray-500 uppercase tracking-wide"><%= @event.title %></p>
-    <% if @event.start_date.present? %>
-      <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+      event title eyebrow over a text-3xl heading with an icon, with the Edit
+      staff button pinned top-right so it shares the title's vertical band. On
+      mobile it sits in its own right-aligned row above the centered title. %>
+  <div class="relative mb-8">
+    <% if allowed_to?(:edit_staff?, @event) %>
+      <div class="flex justify-end gap-3 mb-4 sm:mb-0 sm:absolute sm:right-0 sm:top-0 print:hidden">
+        <%= link_to edit_staff_event_path(@event), class: "admin-only btn btn-primary btn--small" do %>
+          <i class="fa-solid fa-pen"></i> Edit staff
+        <% end %>
+      </div>
     <% end %>
-    <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-      <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
-      Meet the staff
-    </h1>
+
+    <div class="text-center">
+      <p class="text-sm font-semibold text-gray-500 uppercase tracking-wide"><%= @event.title %></p>
+      <% if @event.start_date.present? %>
+        <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
+      <% end %>
+      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+        <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
+        Meet the staff
+      </h1>
+    </div>
   </div>
 
   <%= render "events/staff_cards", event_staffs: @event_staffs %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -757,7 +757,7 @@ RSpec.describe "Events", type: :request do
       it "shows the active registrant count in the page heading" do
         get registrants_event_path(event)
 
-        expect(response.body).to include("Registrants (2)")
+        expect(response.body).to include("2 people")
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup/layout + copy changes across 5 event pages, no logic

### What is the goal of this PR and why is this important?
- Reclaim vertical space on the event report pages: action buttons stacked above each centered title used a full band of empty space.

### How did you approach the change?
- Pin the action buttons to the **top-right of the title's vertical band** (`sm:absolute`), with a static right-aligned row on mobile to avoid overlapping the heading — on dashboard, background, scholarships, staff, and registrants.
- Dashboard button order is now **Forms → Print**.
- Reshape the **registrants** header to match the other report pages: centered eyebrow + icon heading + count subtitle.
- Registrants & scholarships subtitles now read **"N people"** (was "N registrants" / "N recipients").

### Anything else to add?
- Markup/copy only — no controller, model, or route changes.