### PR TITLE
Fix dev seed crash from self-referential EventRegistration constant

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -603,7 +603,7 @@ class EventRegistration < ApplicationRecord
   def generate_slug
     loop do
       self.slug = SecureRandom.urlsafe_base64(16)
-      break unless EventRegistration.exists?(slug: slug)
+      break unless self.class.exists?(slug: slug)
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line model fix for a Zeitwerk constant-resolution gotcha; no behavior change

### What is the goal of this PR and why is this important?
- `db:seed:dev` aborted at "Creating Event Staff" with `NameError: uninitialized constant EventRegistration::EventRegistration`.
- Referencing `EventRegistration` lexically inside its own class body makes Zeitwerk resolve the nested `EventRegistration::EventRegistration` and raise instead of falling through to the top-level constant.

### How did you approach the change?
- `EventRegistration#generate_slug` now uses `self.class.exists?(slug:)` — sidesteps the constant lookup entirely and respects subclasses.
- Verified end-to-end: recreated the workspace DB and ran `db:seed:dev` to completion (exit 0).