### PR TITLE
Link registrant name to registration edit

### DIFF
--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -143,7 +143,8 @@
         <% ce_col = @ce_eligible %>
         <% extra_cols = (payment_col ? 1 : 0) + (ce_col ? 1 : 0) %>
         <%# Column order: Name, Organization, [CE status], Scholarship, [Payment],
-            Confirmed (hidden), Attendance, Date registered, Status, Edit (far right). %>
+            Confirmed (hidden), Attendance, Date registered, Status, Edit (far right).
+            The Name button also links to editing the registration. %>
         <% ce_index = 2 %>
         <% scholarship_index = ce_col ? 3 : 2 %>
         <% payment_index = scholarship_index + 1 %>
@@ -206,8 +207,18 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
+                    <% reg_edit_classes = "group flex flex-col justify-center w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 shadow-sm leading-tight overflow-hidden" %>
+                    <% display_email = person.preferred_email if show_email %>
                     <div class="w-60 min-w-0">
-                      <%= person_profile_button(person, truncate_at: 30, subtitle: (person.preferred_email if show_email), data: { turbo_frame: "_top" }, path_params: { return_to: "registrants", event_id: @event.id }, compact: true) %>
+                      <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
+                                  title: [ person.name, display_email ].compact_blank.join(" — "),
+                                  class: reg_edit_classes,
+                                  data: { turbo_frame: "_top", turbo_prefetch: false } do %>
+                        <span class="font-semibold text-xs <%= DomainTheme.text_class_for(:event_registrations) %> truncate"><%= truncate(person.name.to_s, length: 30) %></span>
+                        <% if display_email.present? %>
+                          <!--email_off--><span class="text-xs text-gray-500 font-normal truncate"><%= display_email %></span><!--email_on-->
+                        <% end %>
+                      <% end %>
                     </div>
 
                     <% form_show_params = registration.slug.present? ? { reg: registration.slug } : { person_id: person.id } %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only change to the registrants roster (name link target + styling); no shared-helper changes

## What
- On the event registrants roster, the **name button now opens the registration editor** (`edit_event_registration_path`) instead of the person's profile card.
- Restyled it to read as a registration action: **event-registrations (teal) theme** instead of the person/participant theme, and **no avatar/photo**.
- The far-right **Edit** column stays as a secondary affordance.

## Why
- Editing the registration is the far more common action from this roster, so making the name a direct link there saves a step. The distinct color and dropped photo signal it edits the registration, not the person profile.

## Notes
- Built inline in the view (single-use) — `person_profile_button` is unchanged.
- The registrants roster was the only source of the person-profile "Back to registrants" eyebrow; that eyebrow is now unused from here but harmless and still covered by its request spec — left in place.