### PR TITLE
Aggregated per-person comments + global comments index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,12 @@ This codebase (Rails 8.1)
 
 | Directory | Purpose | Count |
 |---|---|---|
-| `app/controllers/` | Rails controllers (admin/, events/) | ~77 files |
+| `app/controllers/` | Rails controllers (admin/, events/) | ~78 files |
 | `app/views/` | ERB templates | ~632 files |
 | `app/decorators/` | Draper decorators for view logic | ~40 files |
 | `app/policies/` | ActionPolicy authorization rules | ~55 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~29 files |
+| `app/helpers/` | View helpers | ~31 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 
@@ -71,7 +71,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose |
 |---|---|
 | `app/frontend/entrypoints/` | Vite entry points (application.js, application.css) |
-| `app/frontend/javascript/controllers/` | Stimulus controllers (76) |
+| `app/frontend/javascript/controllers/` | Stimulus controllers (75) |
 | `app/frontend/javascript/rhino/` | Rich text editor customizations (mentions, grid) |
 | `app/frontend/stylesheets/` | Tailwind CSS and component styles |
 
@@ -123,7 +123,7 @@ This codebase (Rails 8.1)
 - **Bookmarks** (`bookmarkable`): Workshop, Event, Resource, etc.
 - **Grant donor** (`donor`): Organization, Person
 - **Assets** (`owner`): Workshop, Story, Resource, Report, etc.
-- **Comments** (`commentable`): User, Person, Organization, etc.
+- **Comments** (`commentable`): Person, User, EventRegistration, Scholarship, ContinuingEducationRegistration, TopicSubscription, Organization, Workshop
 - **Categorizable/Sectorable** items: Workshop, Story, Resource, etc.
 - **Forms** (`owner`): Resource, Report, etc.
 
@@ -152,7 +152,7 @@ This codebase (Rails 8.1)
 ### Namespaces
 
 - **Root level** (~58 controllers): Workshops, stories, resources, events, people, organizations, registration ticket callouts, etc.
-- **`admin/`**: HomeController, AnalyticsController, AhoyActivitiesController
+- **`admin/`**: HomeController, AnalyticsController, AhoyActivitiesController, CommentsController (global comments index at `/admin/comments` with search + remote person/event filters)
 - **`events/`**: Registrations sub-resource (create/destroy + slug-based show at `/registration/:slug`)
 - **Devise overrides**: Registrations, Confirmations, Passwords
 
@@ -204,6 +204,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `WorkshopVariationFromIdeaService` — Variation creation from ideas
 - `TaggingSearchService` — Search and filter tagging data
 - `PersonFromUserService` — Create Person from User account
+- `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page
 - `BulkInviteService` — Bulk send welcome instructions and reset created_at for users
 - `FormBuilderService` — Builds configurable forms from composable sections with per-field visibility
 - `ModelDeduper` — Deduplication logic
@@ -257,7 +258,7 @@ All inherit from `ApplicationDecorator` which provides:
 - `display_image` — selects primary/gallery/downloadable asset intelligently
 - `link_target` — polymorphic path generation
 
-Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator, GrantDecorator, ScholarshipDecorator (derives the scholarship index's program/location/training/status columns).
+Key decorators: WorkshopDecorator, StoryDecorator, ResourceDecorator, PersonDecorator, OrganizationDecorator, UserDecorator, EventDecorator, ReportDecorator, GrantDecorator, ScholarshipDecorator (derives the scholarship index's program/location/training/status columns), CommentDecorator (source chip label/link/theme + author + timestamp for the aggregated person-comments feed).
 
 ## Policies (ActionPolicy)
 

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  # Global, admin-only index of every comment in the system, with the same search
+  # boxes as a person's aggregated feed plus remote person/event filters. Distinct
+  # from the nested CommentsController, which manages one record's comments.
+  class CommentsController < ApplicationController
+    def index
+      authorize! Comment, to: :index?, with: CommentPolicy
+
+      base = Comment.all
+      if turbo_frame_request?
+        filtered = base.search_by_params(params).includes(:commentable, :created_by, :updated_by).newest_first
+        @total_count = base.count
+        @count_display = filtered.count == @total_count ? @total_count : "#{filtered.count}/#{@total_count}"
+        @comments = filtered.paginate(page: params[:page], per_page: 25)
+        render :comments_results
+      else
+        @total_count = base.count
+      end
+    end
+  end
+end

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -3,6 +3,8 @@ module Admin
   # boxes as a person's aggregated feed plus remote person/event filters. Distinct
   # from the nested CommentsController, which manages one record's comments.
   class CommentsController < ApplicationController
+    include AhoyTracking
+
     def index
       authorize! Comment, to: :index?, with: CommentPolicy
 
@@ -15,6 +17,7 @@ module Admin
         render :comments_results
       else
         @total_count = base.count
+        track_view("comments", { page: "index" })
       end
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,6 +17,8 @@ class CommentsController < ApplicationController
     @comment.updated_by = current_user
 
     if @comment.save
+      @created_comment = @comment
+      setup_aggregated_context if aggregated?
       @comment = @commentable.comments.build
       @comments = @commentable.comments.newest_first.paginate(page: 1, per_page: 10)
       respond_to do |format|
@@ -36,6 +38,7 @@ class CommentsController < ApplicationController
     authorize! @comment
     @comment.updated_by = current_user
     @comment.update(comment_params)
+    setup_aggregated_context if aggregated?
 
     respond_to do |format|
       format.turbo_stream
@@ -45,8 +48,28 @@ class CommentsController < ApplicationController
 
   private
 
+  # The aggregated person-comments page posts from a composer that spans many
+  # commentables, so it flags itself and names the person whose feed to refresh.
+  # `for_person_id` (not `person_id`) is used deliberately so set_commentable
+  # still resolves the real commentable from the route rather than the person.
+  def aggregated?
+    params[:aggregated].present?
+  end
+
+  def setup_aggregated_context
+    return if params[:for_person_id].blank?
+    @aggregator_person = Person.find(params[:for_person_id]).decorate
+    @comment_targets = helpers.person_comment_targets(@aggregator_person)
+  end
+
   def set_commentable
-    if params[:person_id]
+    # The aggregated composer files against many records, so it submits the
+    # chosen record as a signed GlobalID rather than a per-target route. Signed,
+    # so the type/id can't be tampered with.
+    if params[:commentable_sgid].present?
+      @commentable = GlobalID::Locator.locate_signed(params[:commentable_sgid])
+      redirect_to(root_path, alert: "Invalid commentable resource") unless @commentable
+    elsif params[:person_id]
       @commentable = Person.find(params[:person_id])
     elsif params[:user_id]
       @commentable = User.find(params[:user_id])
@@ -54,6 +77,12 @@ class CommentsController < ApplicationController
       @commentable = Organization.find(params[:organization_id])
     elsif params[:event_registration_id]
       @commentable = EventRegistration.find(params[:event_registration_id])
+    elsif params[:scholarship_id]
+      @commentable = Scholarship.find(params[:scholarship_id])
+    elsif params[:continuing_education_registration_id]
+      @commentable = ContinuingEducationRegistration.find(params[:continuing_education_registration_id])
+    elsif params[:topic_subscription_id]
+      @commentable = TopicSubscription.find(params[:topic_subscription_id])
     elsif params[:workshop_id]
       @commentable = Workshop.find(params[:workshop_id])
     else

--- a/app/controllers/continuing_education_registrations_controller.rb
+++ b/app/controllers/continuing_education_registrations_controller.rb
@@ -91,5 +91,9 @@ class ContinuingEducationRegistrationsController < ApplicationController
     ce_registration.hours = params.dig(:continuing_education_registration, :hours)
     cost = params.dig(:continuing_education_registration, :cost_dollars)
     ce_registration.cost_cents = (cost.to_d * 100).round if cost.present?
+
+    comments = params.fetch(:continuing_education_registration, {})
+      .permit(comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ])[:comments_attributes]
+    ce_registration.comments_attributes = comments if comments.present?
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,6 +1,6 @@
 class PeopleController < ApplicationController
   include AhoyTracking, TagAssignable
-  before_action :set_person, only: %i[ show edit update destroy workshop_logs checkout bio ]
+  before_action :set_person, only: %i[ show edit update destroy workshop_logs checkout bio all_comments ]
 
   def index
     authorize!
@@ -84,6 +84,30 @@ class PeopleController < ApplicationController
         @affiliations = @person.affiliations.active.includes(organization: :logo_attachment).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/affiliations", locals: { person: @person, affiliations: @affiliations }
       end
+    end
+  end
+
+  # Every comment connected to this person — their profile plus the records that
+  # hang off them (registrations, scholarships, CE registrations, user account) —
+  # in one newest-first feed you can add to and edit in place. Staff-only, since
+  # comments are internal notes (CommentPolicy#manage? = admin).
+  def all_comments
+    authorize! @person, to: :manage?, with: CommentPolicy
+    @person = @person.decorate
+
+    base = PersonCommentAggregator.new(@person).comments
+
+    if turbo_frame_request?
+      filtered = base.search_by_params(params)
+      @total_count = base.count
+      @count_display = filtered.count == @total_count ? @total_count : "#{filtered.count}/#{@total_count}"
+      @comments = filtered.paginate(page: params[:page], per_page: 20)
+      render :person_comments_results
+    else
+      @total_count = base.count
+      @flagged_count = base.flagged.count
+      @new_comment = Comment.new
+      @comment_targets = helpers.person_comment_targets(@person)
     end
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -108,6 +108,7 @@ class PeopleController < ApplicationController
       @flagged_count = base.flagged.count
       @new_comment = Comment.new
       @comment_targets = helpers.person_comment_targets(@person)
+      track_view("person_all_comments", { person_id: @person.id })
     end
   end
 

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -1,0 +1,44 @@
+class CommentDecorator < ApplicationDecorator
+  delegate_all
+
+  # Human-readable label for the record this comment was left on, used as the
+  # source chip on the aggregated person-comments feed. Shared with the composer's
+  # target picker via CommentsHelper so the two never drift.
+  def source_label
+    h.commentable_label(commentable)
+  end
+
+  # Where the source chip links to — the record's admin page.
+  def source_path
+    case commentable
+    when Person then h.person_path(commentable)
+    when User then h.user_path(commentable)
+    when EventRegistration then h.edit_event_registration_path(commentable)
+    when Scholarship then h.scholarship_path(commentable)
+    when ContinuingEducationRegistration then h.edit_continuing_education_registration_path(commentable)
+    when TopicSubscription then h.edit_topic_subscription_path(commentable)
+    end
+  end
+
+  # DomainTheme key driving the chip's colour, so each source type reads
+  # distinctly in the feed.
+  def source_theme
+    case commentable
+    when Person then :people
+    when User then :users
+    when EventRegistration then :event_registrations
+    when Scholarship then :scholarships
+    when ContinuingEducationRegistration then :continuing_education
+    when TopicSubscription then :topic_subscriptions
+    else :comments
+    end
+  end
+
+  def author_name
+    (updated_by || created_by)&.full_name || "System"
+  end
+
+  def timestamp
+    created_at.strftime("%-m/%-d/%Y %-I:%M %p")
+  end
+end

--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -83,6 +83,13 @@ export default class extends Controller {
       });
     this.element.reset();
 
+    // TomSelect (remote-select) renders its own UI and ignores selectedIndex and
+    // form.reset(), so clear each enhanced control explicitly. Silent clear avoids
+    // a redundant submit before the one below.
+    this.element.querySelectorAll("select").forEach((select) => {
+      if (select.tomselect) select.tomselect.clear(true);
+    });
+
     if (this.hasSearchTypeSelectOutlet) {
       this.searchTypeSelectOutlets.forEach((controller) => {
         controller.toggle({ target: { value: "" } });

--- a/app/frontend/javascript/controllers/index.js
+++ b/app/frontend/javascript/controllers/index.js
@@ -102,6 +102,9 @@ application.register("grant-select", GrantSelectController)
 import InactiveToggleController from "./inactive_toggle_controller"
 application.register("inactive-toggle", InactiveToggleController)
 
+import NavigateSelectController from "./navigate_select_controller"
+application.register("navigate-select", NavigateSelectController)
+
 import OptimisticBookmarkController from "./optimistic_bookmark_controller"
 application.register("optimistic-bookmark", OptimisticBookmarkController)
 

--- a/app/frontend/javascript/controllers/navigate_select_controller.js
+++ b/app/frontend/javascript/controllers/navigate_select_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="navigate-select"
+//
+// Navigates to a per-record page when a picker's selection changes — pairs with
+// remote-select for "search a record, jump to its page" controls (e.g. jumping
+// from one person's comments page to another's). The destination comes from
+// urlTemplate with "__ID__" replaced by the selected value.
+export default class extends Controller {
+  static values = { urlTemplate: String };
+
+  navigate(event) {
+    const id = event.target.value;
+    if (id) window.location.href = this.urlTemplateValue.replace("__ID__", id);
+  }
+}

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -83,6 +83,7 @@ module AdminCardsHelper
       custom_card("Payments", payments_path, icon: "💳", color: :sky, intensity: 100),
       custom_card("Story shares", story_shares_path, icon: "🔗", color: :sky, intensity: 100),
       custom_card("Bookmarks", bookmarks_path, icon: "🔖", color: :sky, intensity: 100),
+      custom_card("Comments", admin_comments_path, icon: "💬", color: :sky, intensity: 100),
       disabled_card("Affiliations", icon: "🤝"),
       disabled_card("Reports", icon: "📄"),
       disabled_card("Discounts", icon: "💲"),

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,35 @@
+module CommentsHelper
+  # Human-readable label for a commentable record, used for both the aggregated
+  # composer's target picker and each feed row's source chip so the two never
+  # drift. For event-bound records we spell out the event and its date so a
+  # scholarship/registration reads as a concrete thing rather than an opaque id.
+  def commentable_label(record)
+    case record
+    when Person then "Profile"
+    when User then "User account"
+    when EventRegistration then "Registration · #{event_label(record.event)}"
+    when Scholarship then scholarship_label(record)
+    when ContinuingEducationRegistration then "CE · #{event_label(record.event_registration.event)}"
+    when TopicSubscription then "Subscription · #{record.topic_label}"
+    else record.class.name.underscore.humanize
+    end
+  end
+
+  private
+
+  def event_label(event)
+    return "—" unless event
+    [ event.title, event.start_date&.strftime("%b %-d, %Y") ].compact_blank.join(" · ")
+  end
+
+  def scholarship_label(scholarship)
+    allocatable = scholarship.allocation&.allocatable
+    event =
+      case allocatable
+      when EventRegistration then allocatable.event
+      when ContinuingEducationRegistration then allocatable.event_registration&.event
+      end
+    return "Scholarship ##{scholarship.id}" unless event
+    "Scholarship · #{event_label(event)}"
+  end
+end

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -1,0 +1,20 @@
+module PeopleHelper
+  # Targets a new comment can be attached to from the aggregated person-comments
+  # page: the person's own profile, their login account, and each of their
+  # registrations, scholarships, and CE registrations. Each entry carries a
+  # signed GlobalID the composer submits so the controller can resolve (and
+  # trust) the commentable without threading a route per target.
+  def person_comment_targets(person)
+    records = [ person.object ]
+    records << person.user if person.user
+    records.concat(person.event_registrations.includes(:event).order("events.start_date DESC").references(:events))
+    records.concat(person.scholarships.includes(allocation: :allocatable).order(created_at: :desc))
+    records.concat(
+      ContinuingEducationRegistration.where(event_registration_id: person.event_registrations.ids)
+        .includes(event_registration: :event)
+    )
+    records.concat(person.topic_subscriptions.includes(:topic_subscription_type).newest_first)
+
+    records.map { |record| { label: commentable_label(record), sgid: record.to_sgid.to_s } }
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,4 +10,67 @@ class Comment < ApplicationRecord
 
   scope :newest_first, -> { order(created_at: :desc) }
   scope :flagged, -> { where(flagged: true) }
+
+  # Body/topic keyword match.
+  scope :matching, ->(term) {
+    pattern = "%#{sanitize_sql_like(term.to_s.strip.downcase)}%"
+    where("LOWER(comments.body) LIKE :pattern OR LOWER(comments.topic) LIKE :pattern", pattern: pattern)
+  }
+
+  # Comments a given staff user created or last edited — the author filter picks
+  # a specific user via the remote-select (which searches by person name/email).
+  scope :authored_by_user, ->(user_id) {
+    where("comments.created_by_id = :id OR comments.updated_by_id = :id", id: user_id)
+  }
+
+  scope :created_on_or_after, ->(value) {
+    date = parse_date(value)
+    date ? where("comments.created_at >= ?", date.beginning_of_day) : all
+  }
+
+  scope :created_on_or_before, ->(value) {
+    date = parse_date(value)
+    date ? where("comments.created_at <= ?", date.end_of_day) : all
+  }
+
+  # Every comment connected to a person (profile, registrations, scholarships, CE
+  # registrations, user account) — reuses the aggregator so this and the person
+  # page stay in lockstep.
+  scope :for_person, ->(person_id) {
+    person = Person.find_by(id: person_id)
+    next none unless person
+    where(id: PersonCommentAggregator.new(person).comments.select(:id))
+  }
+
+  # Every comment connected to an event: its registrations, their CE
+  # registrations, and the scholarships allocated to those registrations.
+  scope :for_event, ->(event_id) {
+    registration_ids = EventRegistration.where(event_id: event_id).ids
+    next none if registration_ids.empty?
+    ce_ids = ContinuingEducationRegistration.where(event_registration_id: registration_ids).ids
+    scholarship_ids = Scholarship.joins(:allocation)
+      .where(allocations: { allocatable_type: "EventRegistration", allocatable_id: registration_ids }).ids
+    where(commentable_type: "EventRegistration", commentable_id: registration_ids)
+      .or(where(commentable_type: "ContinuingEducationRegistration", commentable_id: ce_ids))
+      .or(where(commentable_type: "Scholarship", commentable_id: scholarship_ids))
+  }
+
+  def self.search_by_params(params)
+    scope = is_a?(ActiveRecord::Relation) ? self : all
+    scope = scope.where(commentable_type: params[:source]) if params[:source].present?
+    scope = scope.flagged if params[:flagged] == "1"
+    scope = scope.matching(params[:query]) if params[:query].present?
+    scope = scope.authored_by_user(params[:author_id]) if params[:author_id].present?
+    scope = scope.created_on_or_after(params[:from]) if params[:from].present?
+    scope = scope.created_on_or_before(params[:to]) if params[:to].present?
+    scope = scope.for_person(params[:person_id]) if params[:person_id].present?
+    scope = scope.for_event(params[:event_id]) if params[:event_id].present?
+    scope
+  end
+
+  def self.parse_date(value)
+    Date.iso8601(value.to_s)
+  rescue ArgumentError
+    nil
+  end
 end

--- a/app/models/continuing_education_registration.rb
+++ b/app/models/continuing_education_registration.rb
@@ -18,6 +18,15 @@ class ContinuingEducationRegistration < ApplicationRecord
 
   has_many :allocations, as: :allocatable, dependent: :destroy
   has_many :payments, through: :allocations, source: :source, source_type: "Payment"
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+
+  # Virtual sub-fields for the edit form's license inputs. The controller reads
+  # them from params and routes them through #assign_license; declared here so the
+  # form builder can bind to them (SimpleForm reads the object when a field's
+  # value is nil, e.g. a blank expiry on a placeholder license).
+  attr_accessor :license_kind, :license_number, :license_issuing_state, :license_expires_on
 
   before_validation :default_from_event, on: :create
 

--- a/app/services/person_comment_aggregator.rb
+++ b/app/services/person_comment_aggregator.rb
@@ -1,0 +1,57 @@
+# Gathers every comment connected to a person into a single newest-first feed —
+# their own profile comments plus the comments left on the records that hang off
+# them: event registrations, scholarships, CE registrations, and their login
+# account. Returns one ActiveRecord::Relation of Comment so callers can filter,
+# paginate, and preload uniformly. Payments carry no comments, so they never
+# appear here.
+class PersonCommentAggregator
+  # commentable_type => class, in the order sources are surfaced. Kept as strings
+  # so the query never has to instantiate the classes.
+  SOURCE_TYPES = %w[ Person EventRegistration Scholarship ContinuingEducationRegistration TopicSubscription User ].freeze
+
+  def initialize(person)
+    @person = person
+  end
+
+  def comments
+    scopes = [
+      scope_for("Person", [ @person.id ]),
+      scope_for("EventRegistration", registration_ids),
+      scope_for("Scholarship", scholarship_ids),
+      scope_for("ContinuingEducationRegistration", ce_registration_ids),
+      scope_for("TopicSubscription", topic_subscription_ids),
+      scope_for("User", user_ids)
+    ]
+    scopes.reduce { |combined, scope| combined.or(scope) }
+      .includes(:commentable, :created_by, :updated_by)
+      .newest_first
+  end
+
+  private
+
+  attr_reader :person
+
+  def scope_for(type, ids)
+    Comment.where(commentable_type: type, commentable_id: ids)
+  end
+
+  def registration_ids
+    @registration_ids ||= person.event_registrations.ids
+  end
+
+  def scholarship_ids
+    person.scholarships.ids
+  end
+
+  def ce_registration_ids
+    ContinuingEducationRegistration.where(event_registration_id: registration_ids).ids
+  end
+
+  def topic_subscription_ids
+    person.topic_subscriptions.ids
+  end
+
+  def user_ids
+    person.user ? [ person.user.id ] : []
+  end
+end

--- a/app/views/admin/comments/comments_results.html.erb
+++ b/app/views/admin/comments/comments_results.html.erb
@@ -1,0 +1,8 @@
+<%= turbo_frame_tag "comments_results" do %>
+  <div class="border-t border-gray-100 pt-4 mb-3">
+    <h2 class="text-sm font-semibold text-gray-700">Comments <span class="font-normal text-gray-400">· <%= @count_display %> shown</span></h2>
+  </div>
+  <%= render "comments/feed",
+             comments: @comments,
+             pagination_params: params.slice(:source, :query, :author_id, :from, :to, :flagged, :person_id, :event_id).permit! %>
+<% end %>

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -1,0 +1,34 @@
+<% content_for(:page_bg_class, "admin-only bg-white") %>
+<div class="mb-3">
+  <%= link_to admin_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
+  <% end %>
+</div>
+
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <div class="<%= DomainTheme.bg_class_for(:comments, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:comments) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <i class="fa-solid fa-comments <%= DomainTheme.text_class_for(:comments, intensity: 700) %>"></i>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> uppercase tracking-wide">Comments</span>
+    </div>
+  </div>
+
+  <div class="p-4 sm:p-8 space-y-6">
+    <div class="flex flex-wrap items-baseline justify-between gap-2">
+      <h1 class="text-2xl font-semibold text-gray-900">All comments</h1>
+      <p class="text-sm text-gray-500"><%= pluralize(@total_count, "comment") %></p>
+    </div>
+
+    <%= render "comments/search_boxes",
+               url: admin_comments_path,
+               clear_path: admin_comments_path,
+               frame: "comments_results",
+               show_person: true,
+               show_event: true %>
+
+    <% result_src = admin_comments_path + "?" + request.query_string %>
+    <%= turbo_frame_tag "comments_results", src: result_src, data: { turbo: "temporary" } do %>
+      <div class="py-6 text-center text-sm text-gray-400">Loading comments…</div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/_aggregated_comment.html.erb
+++ b/app/views/comments/_aggregated_comment.html.erb
@@ -1,0 +1,57 @@
+<%# One row in an aggregated comment feed. `comment` is a decorated Comment;
+    `person` (optional) is the person whose feed this is — passed so the edit form
+    can report back which feed to refresh. View/edit states flip via the
+    edit-toggle Stimulus controller; saving posts to the comment's own commentable
+    route and the response replaces this row. %>
+<% person = local_assigns.fetch(:person, nil) %>
+<div id="<%= dom_id(comment.object) %>"
+     data-controller="edit-toggle"
+     class="rounded-lg border <%= comment.flagged? ? "border-orange-200 bg-orange-50" : "border-gray-200 bg-white" %> p-4 shadow-sm">
+  <div data-edit-toggle-target="view">
+    <div class="flex items-start justify-between gap-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <%= link_to comment.source_label, comment.source_path,
+              class: "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium #{DomainTheme.border_class_for(comment.source_theme)} #{DomainTheme.bg_class_for(comment.source_theme, intensity: 100)} #{DomainTheme.text_class_for(comment.source_theme, intensity: 800)}" %>
+        <% if comment.topic.present? %>
+          <span class="text-xs font-bold uppercase tracking-wide text-gray-500"><%= comment.topic %></span>
+        <% end %>
+      </div>
+      <div class="flex shrink-0 items-center gap-3">
+        <%= render "comments/flag_toggle", commentable: comment.commentable, comment: comment.object %>
+        <button type="button" data-action="edit-toggle#toggle"
+                class="text-xs text-gray-500 hover:text-gray-700">
+          <i class="fa-solid fa-pen text-[0.65rem]"></i> Edit
+        </button>
+      </div>
+    </div>
+    <div class="mt-2 text-sm text-gray-900"><%= simple_format(comment.body) %></div>
+    <div class="mt-2 text-xs text-gray-400"><%= comment.author_name %> · <%= comment.timestamp %></div>
+  </div>
+
+  <div data-edit-toggle-target="edit" class="hidden">
+    <%= simple_form_for comment.object,
+                        url: polymorphic_path([ comment.commentable, comment.object ]), method: :patch do |f| %>
+      <%= hidden_field_tag :aggregated, 1 %>
+      <% if person %><%= hidden_field_tag :for_person_id, person.id %><% end %>
+      <div class="flex items-start gap-x-2">
+        <%= f.input_field :topic,
+                          placeholder: "Topic",
+                          class: "w-1/3 shrink-0 bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+        <%= f.input_field :body,
+                          as: :text,
+                          rows: 3,
+                          required: true,
+                          class: "grow bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      </div>
+      <div class="mt-3 flex items-center gap-x-3">
+        <%= f.submit "Save", class: "btn btn-secondary-outline" %>
+        <button type="button" data-action="edit-toggle#toggle" class="text-sm text-gray-500 hover:text-gray-700">Cancel</button>
+        <label class="inline-flex items-center cursor-pointer select-none" title="Flag this note for follow-up">
+          <%= f.check_box :flagged, class: "peer sr-only" %>
+          <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+          <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flag</span>
+        </label>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/_composer.html.erb
+++ b/app/views/comments/_composer.html.erb
@@ -1,0 +1,41 @@
+<%# Add-a-note composer for the aggregated person-comments page. One static form:
+    the "Add a note to…" picker submits the chosen record's signed GlobalID
+    (commentable_sgid), which the controller resolves — no JS needed to repoint
+    the action. `for_person_id` tells the controller whose feed to refresh. %>
+<div id="aggregated_comment_composer"
+     class="rounded-lg border <%= DomainTheme.border_class_for(:comments) %> <%= DomainTheme.bg_class_for(:comments, intensity: 50) %> p-4 shadow-sm">
+  <%= simple_form_for comment, url: person_comments_path(person) do |f| %>
+    <%= hidden_field_tag :aggregated, 1 %>
+    <%= hidden_field_tag :for_person_id, person.id %>
+
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
+      <div class="sm:w-1/3 shrink-0">
+        <label class="block text-xs font-semibold text-gray-600 mb-1" for="commentable_sgid">Add a note to</label>
+        <%= select_tag :commentable_sgid,
+                       options_for_select(comment_targets.map { |target| [ target[:label], target[:sgid] ] }),
+                       class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+        <%= f.input_field :topic,
+                          placeholder: "Topic (optional)",
+                          class: "mt-2 w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      </div>
+      <div class="grow">
+        <label class="block text-xs font-semibold text-gray-600 mb-1" for="comment_body">Comment</label>
+        <%= f.input_field :body,
+                          as: :text,
+                          rows: 3,
+                          required: true,
+                          placeholder: "Type your comment",
+                          class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      </div>
+    </div>
+
+    <div class="mt-3 flex items-center gap-x-3">
+      <%= f.submit "Add comment", class: "btn btn-secondary-outline" %>
+      <label class="inline-flex items-center cursor-pointer select-none" title="Flag this note for follow-up">
+        <%= f.check_box :flagged, class: "peer sr-only" %>
+        <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+        <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flag</span>
+      </label>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/_feed.html.erb
+++ b/app/views/comments/_feed.html.erb
@@ -1,0 +1,19 @@
+<%# Shared list of aggregated comment rows + pagination, used by both the person
+    all_comments frame and the global comments index frame.
+    Locals: comments. Optional: person (edit-in-place context), pagination_params. %>
+<% person = local_assigns.fetch(:person, nil) %>
+<% pagination_params = local_assigns.fetch(:pagination_params, {}) %>
+<div id="aggregated_comments_list" class="space-y-3">
+  <% if comments.any? %>
+    <% comments.each do |comment| %>
+      <%= render "comments/aggregated_comment", comment: comment.decorate, person: person %>
+    <% end %>
+  <% else %>
+    <div id="aggregated_comments_empty" class="py-6 text-center text-sm text-gray-500">No comments found.</div>
+  <% end %>
+</div>
+<% if comments.total_pages > 1 %>
+  <div class="mt-4 flex justify-center">
+    <%= tailwind_paginate comments, params: pagination_params %>
+  </div>
+<% end %>

--- a/app/views/comments/_search_boxes.html.erb
+++ b/app/views/comments/_search_boxes.html.erb
@@ -54,28 +54,6 @@
                        onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <% if show_person %>
-      <div class="min-w-[200px]">
-        <label for="person_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Person</label>
-        <%= select_tag :person_id,
-                       options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
-                       include_blank: true, prompt: "Search for a person",
-                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                       data: { controller: "remote-select", remote_select_model_value: "person" } %>
-      </div>
-    <% end %>
-
-    <% if show_event %>
-      <div class="min-w-[200px]">
-        <label for="event_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Event</label>
-        <%= select_tag :event_id,
-                       options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.title, event.id ] }, params[:event_id]),
-                       include_blank: true, prompt: "Search for an event",
-                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
-                       data: { controller: "remote-select", remote_select_model_value: "event" } %>
-      </div>
-    <% end %>
-
     <div class="pb-1">
       <label class="inline-flex items-center cursor-pointer select-none" title="Flagged for follow-up">
         <%= check_box_tag :flagged, "1", params[:flagged] == "1", class: "peer sr-only", onchange: "this.form.requestSubmit()" %>
@@ -88,4 +66,30 @@
       <%= link_to "Clear", clear_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
     </div>
   </div>
+
+  <% if show_person || show_event %>
+    <div class="flex flex-wrap items-end gap-4">
+      <% if show_person %>
+        <div class="min-w-[200px]">
+          <label for="person_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Person</label>
+          <%= select_tag :person_id,
+                         options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
+                         include_blank: true, prompt: "Search for a person",
+                         class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                         data: { controller: "remote-select", remote_select_model_value: "person" } %>
+        </div>
+      <% end %>
+
+      <% if show_event %>
+        <div class="min-w-[200px]">
+          <label for="event_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Event</label>
+          <%= select_tag :event_id,
+                         options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.title, event.id ] }, params[:event_id]),
+                         include_blank: true, prompt: "Search for an event",
+                         class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                         data: { controller: "remote-select", remote_select_model_value: "event" } %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/comments/_search_boxes.html.erb
+++ b/app/views/comments/_search_boxes.html.erb
@@ -1,0 +1,91 @@
+<%# Shared filter/search bar for the comment feeds. Auto-submits into `frame`
+    (collection Stimulus) so results swap in place with no page jump.
+    Locals: url, frame, clear_path. Optional: show_person / show_event (global
+    index only). %>
+<% show_person = local_assigns.fetch(:show_person, false) %>
+<% show_event = local_assigns.fetch(:show_event, false) %>
+<% source_options = [ [ "All sources", "" ], [ "Profile", "Person" ], [ "Registrations", "EventRegistration" ], [ "Scholarships", "Scholarship" ], [ "CE registrations", "ContinuingEducationRegistration" ], [ "Subscriptions", "TopicSubscription" ], [ "User account", "User" ], [ "Organizations", "Organization" ], [ "Workshops", "Workshop" ] ] %>
+<%= form_with url: url, method: :get,
+              data: { controller: "collection", turbo_frame: frame },
+              html: { autocomplete: "off" }, class: "bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3" do |f| %>
+  <div class="flex items-center gap-2 text-gray-600">
+    <i class="fa-solid fa-filter text-xs"></i>
+    <span class="text-xs font-semibold uppercase tracking-wide">Filter</span>
+  </div>
+  <div class="flex flex-wrap items-end gap-3">
+    <div class="grow min-w-[150px]">
+      <label for="query" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Keyword</label>
+      <div class="relative">
+        <%= f.text_field :query, value: params[:query],
+                         placeholder: "Body or topic…",
+                         class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 pr-10 focus:ring-blue-500 focus:border-blue-500",
+                         oninput: "this.form.requestSubmit()" %>
+        <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"><i class="fa fa-search"></i></button>
+      </div>
+    </div>
+
+    <div class="grow min-w-[150px]">
+      <label for="author_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Author</label>
+      <%= select_tag :author_id,
+                     options_for_select(User.where(id: params[:author_id]).map { |user| [ user.full_name_with_email, user.id ] }, params[:author_id]),
+                     include_blank: true, prompt: "Search staff by name",
+                     class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                     data: { controller: "remote-select", remote_select_model_value: "user" } %>
+    </div>
+
+    <div class="w-36">
+      <label for="source" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Type</label>
+      <%= f.select :source, options_for_select(source_options, params[:source]), {},
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                   onchange: "this.form.requestSubmit()" %>
+    </div>
+
+    <div class="w-36">
+      <label for="from" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">From</label>
+      <%= f.date_field :from, value: params[:from],
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                       onchange: "this.form.requestSubmit()" %>
+    </div>
+
+    <div class="w-36">
+      <label for="to" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">To</label>
+      <%= f.date_field :to, value: params[:to],
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                       onchange: "this.form.requestSubmit()" %>
+    </div>
+
+    <% if show_person %>
+      <div class="min-w-[200px]">
+        <label for="person_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Person</label>
+        <%= select_tag :person_id,
+                       options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
+                       include_blank: true, prompt: "Search for a person",
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                       data: { controller: "remote-select", remote_select_model_value: "person" } %>
+      </div>
+    <% end %>
+
+    <% if show_event %>
+      <div class="min-w-[200px]">
+        <label for="event_id" class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1">Event</label>
+        <%= select_tag :event_id,
+                       options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.title, event.id ] }, params[:event_id]),
+                       include_blank: true, prompt: "Search for an event",
+                       class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                       data: { controller: "remote-select", remote_select_model_value: "event" } %>
+      </div>
+    <% end %>
+
+    <div class="pb-1">
+      <label class="inline-flex items-center cursor-pointer select-none" title="Flagged for follow-up">
+        <%= check_box_tag :flagged, "1", params[:flagged] == "1", class: "peer sr-only", onchange: "this.form.requestSubmit()" %>
+        <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+        <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flagged</span>
+      </label>
+    </div>
+
+    <div class="pb-1">
+      <%= link_to "Clear", clear_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,7 +1,20 @@
-<%= turbo_stream.replace "comment_form" do %>
-  <%= render "comments/form", commentable: @commentable %>
-<% end %>
+<% if @aggregator_person %>
+  <%= turbo_stream.prepend "aggregated_comments_list" do %>
+    <%= render "comments/aggregated_comment", comment: @created_comment.decorate, person: @aggregator_person %>
+  <% end %>
+  <%= turbo_stream.replace "aggregated_comment_composer" do %>
+    <%= render "comments/composer",
+               person: @aggregator_person,
+               comment: Comment.new,
+               comment_targets: @comment_targets %>
+  <% end %>
+  <%= turbo_stream.remove "aggregated_comments_empty" %>
+<% else %>
+  <%= turbo_stream.replace "comment_form" do %>
+    <%= render "comments/form", commentable: @commentable %>
+  <% end %>
 
-<%= turbo_stream.replace "comments_list" do %>
-  <%= render "comments/list", commentable: @commentable, comments: @comments %>
+  <%= turbo_stream.replace "comments_list" do %>
+    <%= render "comments/list", commentable: @commentable, comments: @comments %>
+  <% end %>
 <% end %>

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -1,3 +1,9 @@
-<%= turbo_stream.replace dom_id(@comment, :flag) do %>
-  <%= render "comments/flag_toggle", commentable: @commentable, comment: @comment %>
+<% if params[:aggregated] %>
+  <%= turbo_stream.replace dom_id(@comment) do %>
+    <%= render "comments/aggregated_comment", comment: @comment.decorate, person: @aggregator_person %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace dom_id(@comment, :flag) do %>
+    <%= render "comments/flag_toggle", commentable: @commentable, comment: @comment %>
+  <% end %>
 <% end %>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -30,10 +30,56 @@
              person: registration.registrant %>
 
   <div class="space-y-6">
-    <%= form_with model: @ce_registration, url: continuing_education_registration_path(@ce_registration, return_to: params[:return_to].presence),
-          method: :patch, id: "ce_registration_form", data: { turbo: false } do |f| %>
+    <%= simple_form_for @ce_registration, url: continuing_education_registration_path(@ce_registration, return_to: params[:return_to].presence),
+          html: { id: "ce_registration_form", data: { turbo: false } } do |f| %>
       <%= render "details_section", f: f, license: license, ce_registration: @ce_registration, event: registration.event %>
       <%= render "payment_history", ce_registration: @ce_registration %>
+
+      <%# ---- Comments (saved with the CE registration, like the other forms) ---- %>
+      <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
+        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
+            <i class="fa-solid fa-comments"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">CE comments</h2>
+          <% if registration.registrant %>
+            <%= link_to all_comments_person_path(registration.registrant),
+                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                        target: "_blank", rel: "noopener" do %>
+              View all
+              <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
+          <div id="comment-list" class="space-y-4">
+            <%= f.simple_fields_for :comments do |cf| %>
+              <%= render "comments/comment_fields", f: cf %>
+            <% end %>
+          </div>
+
+          <div data-paginated-fields-target="nav"></div>
+
+          <div class="flex items-center justify-between gap-2">
+            <%= link_to_add_association f, :comments,
+                  partial: "comments/comment_fields",
+                  data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
+                  class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+              <i class="fa-solid fa-plus text-[0.6rem]"></i>
+              Add comment
+            <% end %>
+
+            <button type="button"
+                    class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                    data-action="edit-toggle#toggle">
+              <i class="fa-solid fa-pen text-[0.6rem]"></i>
+              <span data-edit-toggle-target="editLabel">Edit comments</span>
+              <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
+            </button>
+          </div>
+        </div>
+      </section>
     <% end %>
 
     <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -282,11 +282,13 @@
             <i class="fa-solid fa-message"></i>
           </span>
           <h2 class="text-sm font-semibold text-gray-700">Registration comments</h2>
-          <%= link_to event_registration_comments_path(f.object),
-                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
-                      target: "_blank", rel: "noopener" do %>
-            View all
-            <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+          <% if f.object.registrant %>
+            <%= link_to all_comments_person_path(f.object.registrant),
+                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                        target: "_blank", rel: "noopener" do %>
+              View all
+              <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -533,32 +533,47 @@
 
     <!-- Comments -->
     <% if allowed_to?(:manage?, Comment) %>
-      <div class="admin-only bg-blue-100 form-group space-y-4" id="comments-section">
-        <div class="font-semibold text-gray-700 mb-2">Comments</div>
+      <section class="overflow-hidden rounded-xl border border-blue-200 bg-white shadow-sm"
+               id="comments-section"
+               data-controller="paginated-fields edit-toggle"
+               data-paginated-fields-per-page-value="5">
+        <div class="admin-only bg-blue-100 flex items-center gap-3 border-b border-blue-200 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white text-blue-600">
+            <i class="fa-solid fa-comments"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
+          <% if @person.persisted? %>
+            <%= link_to all_comments_person_path(@person),
+                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                        target: "_blank", rel: "noopener" do %>
+              View all
+              <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+            <% end %>
+          <% end %>
+        </div>
 
-        <div class="admin-only bg-blue-100 rounded-lg border border-gray-200 p-4 mb-4 shadow-sm"
-            data-controller="paginated-fields edit-toggle"
-            data-paginated-fields-per-page-value="5">
+        <div class="space-y-3 p-4">
           <%= f.simple_fields_for :comments do |cf| %>
             <%= render "comments/comment_fields", f: cf %>
           <% end %>
 
           <div data-paginated-fields-target="nav"></div>
 
-          <button type="button"
-                  class="text-sm text-gray-400 hover:text-blue-600 underline cursor-pointer whitespace-nowrap"
-                  style="float:right"
-                  data-action="edit-toggle#toggle">
-            <span data-edit-toggle-target="editLabel">Edit Comments</span>
-            <span data-edit-toggle-target="viewLabel" class="hidden">Done Editing</span>
-          </button>
-          <%= link_to_add_association "➕ Add Comment",
-                                      f,
-                                      :comments,
-                                      partial: "comments/comment_fields",
-                                      class: "btn btn-secondary-outline" %>
+          <div class="flex items-center justify-between gap-2">
+            <%= link_to_add_association "➕ Add Comment",
+                                        f,
+                                        :comments,
+                                        partial: "comments/comment_fields",
+                                        class: "btn btn-secondary-outline" %>
+            <button type="button"
+                    class="text-sm text-gray-400 hover:text-blue-600 underline cursor-pointer whitespace-nowrap"
+                    data-action="edit-toggle#toggle">
+              <span data-edit-toggle-target="editLabel">Edit Comments</span>
+              <span data-edit-toggle-target="viewLabel" class="hidden">Done Editing</span>
+            </button>
+          </div>
         </div>
-      </div>
+      </section>
     <% end %>
   <% end %>
 

--- a/app/views/people/all_comments.html.erb
+++ b/app/views/people/all_comments.html.erb
@@ -1,0 +1,49 @@
+<% content_for(:page_bg_class, "admin-only bg-white") %>
+<div class="mb-3">
+  <%= link_to person_path(@person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> Back to <%= @person.full_name %>
+  <% end %>
+</div>
+
+<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+  <div class="<%= DomainTheme.bg_class_for(:comments, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:comments) %> px-8 py-3">
+    <div class="flex items-center gap-2">
+      <i class="fa-solid fa-comments <%= DomainTheme.text_class_for(:comments, intensity: 700) %>"></i>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> uppercase tracking-wide">All comments</span>
+    </div>
+  </div>
+
+  <div class="p-4 sm:p-8 space-y-6">
+    <div class="flex flex-wrap items-baseline justify-between gap-2">
+      <h1 class="text-2xl font-semibold text-gray-900"><%= @person.full_name %></h1>
+      <p class="text-sm text-gray-500">
+        <%= pluralize(@total_count, "comment") %><% if @flagged_count.positive? %> · <span class="font-medium text-orange-600"><%= @flagged_count %> flagged</span><% end %>
+      </p>
+    </div>
+
+    <%# Jump straight to another person's comments page. %>
+    <div class="flex items-center gap-2">
+      <label for="jump_person_id" class="text-xs font-semibold uppercase tracking-wide text-gray-500 whitespace-nowrap">Another person's comments</label>
+      <%= select_tag :jump_person_id, options_for_select([]),
+                     include_blank: true, prompt: "Search people…",
+                     class: "min-w-[240px] bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                     data: { controller: "remote-select navigate-select",
+                             remote_select_model_value: "person",
+                             remote_select_exclude_value: @person.id,
+                             navigate_select_url_template_value: all_comments_person_path("__ID__"),
+                             action: "change->navigate-select#navigate" } %>
+    </div>
+
+    <%= render "comments/composer", person: @person, comment: @new_comment, comment_targets: @comment_targets %>
+
+    <%= render "comments/search_boxes",
+               url: all_comments_person_path(@person),
+               clear_path: all_comments_person_path(@person),
+               frame: "person_comments_results" %>
+
+    <% result_src = all_comments_person_path(@person) + "?" + request.query_string %>
+    <%= turbo_frame_tag "person_comments_results", src: result_src, data: { turbo: "temporary" } do %>
+      <div class="py-6 text-center text-sm text-gray-400">Loading comments…</div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/people/person_comments_results.html.erb
+++ b/app/views/people/person_comments_results.html.erb
@@ -1,0 +1,9 @@
+<%= turbo_frame_tag "person_comments_results" do %>
+  <div class="border-t border-gray-100 pt-4 mb-3">
+    <h2 class="text-sm font-semibold text-gray-700">Comments <span class="font-normal text-gray-400">· <%= @count_display %> shown</span></h2>
+  </div>
+  <%= render "comments/feed",
+             comments: @comments,
+             person: @person,
+             pagination_params: params.slice(:source, :query, :author_id, :from, :to, :flagged).permit! %>
+<% end %>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -204,6 +204,14 @@
         <i class="fa-solid fa-comments"></i>
       </span>
       <h2 class="text-sm font-semibold text-gray-700">Scholarship comments</h2>
+      <% if f.object.recipient %>
+        <%= link_to all_comments_person_path(f.object.recipient),
+                    class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                    target: "_blank", rel: "noopener" do %>
+          View all
+          <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+        <% end %>
+      <% end %>
     </div>
 
     <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">

--- a/app/views/topic_subscriptions/_form.html.erb
+++ b/app/views/topic_subscriptions/_form.html.erb
@@ -95,6 +95,14 @@
         <i class="fa-solid fa-comments"></i>
       </span>
       <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
+      <% if @topic_subscription.person %>
+        <%= link_to all_comments_person_path(@topic_subscription.person),
+                    class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                    target: "_blank", rel: "noopener" do %>
+          View all
+          <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+        <% end %>
+      <% end %>
     </div>
 
     <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -132,7 +132,17 @@
   <% if f.object.persisted? %>
     <!-- Comments -->
     <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6" id="comments-section">
-      <h4 class="text-sm font-semibold uppercase text-gray-700 mb-4">Comments</h4>
+      <div class="flex items-center mb-4">
+        <h4 class="text-sm font-semibold uppercase text-gray-700">Comments</h4>
+        <% if f.object.person %>
+          <%= link_to all_comments_person_path(f.object.person),
+                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                      target: "_blank", rel: "noopener" do %>
+            View all
+            <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+          <% end %>
+        <% end %>
+      </div>
 
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm"
            data-controller="paginated-fields edit-toggle"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     get "activities/charts",         to: "ahoy_activities#charts", as: "activities_charts"
     get "activities/counts",         to: "analytics#index", as: "activities_counts"
     post "activities/counts/print",  to: "analytics#print", as: "analytics_print"
+    resources :comments, only: [ :index ]
   end
 
   resources :banners
@@ -115,6 +116,7 @@ Rails.application.routes.draw do
       patch :unsubscribe
       patch :resubscribe
     end
+    resources :comments, only: [ :index, :create, :update ]
   end
   resources :topic_subscription_types, except: [ :show ] do
     member do
@@ -134,9 +136,11 @@ Rails.application.routes.draw do
   resources :grants
   resources :scholarships, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     member { patch :toggle_tasks }
+    resources :comments, only: [ :index, :create, :update ]
   end
   resources :continuing_education_registrations, only: [ :new, :create, :edit, :update, :destroy ] do
     member { patch :toggle_certificate }
+    resources :comments, only: [ :index, :create, :update ]
   end
   resources :discounts, only: [ :create, :show, :destroy ] do
     collection do
@@ -194,6 +198,7 @@ Rails.application.routes.draw do
       get :workshop_logs
       get :checkout
       get :bio
+      get :all_comments
     end
     resources :comments, only: [ :index, :create, :update ]
   end

--- a/spec/decorators/comment_decorator_spec.rb
+++ b/spec/decorators/comment_decorator_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe CommentDecorator do
+  describe "#source_label" do
+    it "labels a profile comment" do
+      comment = create(:comment, commentable: create(:person))
+      expect(comment.decorate.source_label).to eq("Profile")
+    end
+
+    it "labels a user-account comment" do
+      comment = create(:comment, commentable: create(:user))
+      expect(comment.decorate.source_label).to eq("User account")
+    end
+
+    it "labels a registration comment with the event title" do
+      registration = create(:event_registration)
+      comment = create(:comment, commentable: registration)
+      expect(comment.decorate.source_label).to include("Registration ·", registration.event.title)
+    end
+
+    it "labels an unallocated scholarship comment with its id" do
+      scholarship = create(:scholarship)
+      comment = create(:comment, commentable: scholarship)
+      expect(comment.decorate.source_label).to eq("Scholarship ##{scholarship.id}")
+    end
+
+    it "labels an allocated scholarship comment with its event" do
+      registration = create(:event_registration)
+      scholarship = create(:scholarship, recipient: registration.registrant)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 0)
+      comment = create(:comment, commentable: scholarship)
+      expect(Comment.find(comment.id).decorate.source_label).to include("Scholarship ·", registration.event.title)
+    end
+
+    it "labels a CE registration comment with the event title" do
+      ce = create(:continuing_education_registration)
+      comment = create(:comment, commentable: ce)
+      expect(comment.decorate.source_label).to include("CE ·", ce.event_registration.event.title)
+    end
+
+    it "labels a topic subscription comment with its topic" do
+      subscription = create(:topic_subscription)
+      comment = create(:comment, commentable: subscription)
+      expect(comment.decorate.source_label).to include("Subscription ·", subscription.topic_label)
+    end
+  end
+
+  describe "#source_path" do
+    it "points a profile comment at the person page" do
+      person = create(:person)
+      comment = create(:comment, commentable: person)
+      expect(comment.decorate.source_path).to eq(Rails.application.routes.url_helpers.person_path(person))
+    end
+  end
+
+  describe "#source_theme" do
+    it "returns the scholarships theme for a scholarship comment" do
+      comment = create(:comment, commentable: create(:scholarship))
+      expect(comment.decorate.source_theme).to eq(:scholarships)
+    end
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -21,5 +21,13 @@ FactoryBot.define do
     trait :for_workshop do
       association :commentable, factory: :workshop
     end
+
+    trait :for_scholarship do
+      association :commentable, factory: :scholarship
+    end
+
+    trait :for_continuing_education_registration do
+      association :commentable, factory: :continuing_education_registration
+    end
   end
 end

--- a/spec/models/comment_search_spec.rb
+++ b/spec/models/comment_search_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Comment, "search scopes" do
+  describe ".matching" do
+    it "matches body or topic case-insensitively" do
+      body_hit = create(:comment, body: "Called the FAMILY", topic: "x")
+      topic_hit = create(:comment, body: "x", topic: "Family outreach")
+      miss = create(:comment, body: "nothing", topic: "here")
+
+      expect(Comment.matching("family")).to include(body_hit, topic_hit)
+      expect(Comment.matching("family")).not_to include(miss)
+    end
+  end
+
+  describe ".authored_by_user" do
+    it "matches comments the user created or last edited" do
+      author = create(:user, :admin)
+      created = create(:comment, created_by: author, updated_by: create(:user))
+      edited = create(:comment, created_by: create(:user), updated_by: author)
+      miss = create(:comment)
+
+      expect(Comment.authored_by_user(author.id)).to include(created, edited)
+      expect(Comment.authored_by_user(author.id)).not_to include(miss)
+    end
+  end
+
+  describe "date range" do
+    it "filters created_on_or_after / created_on_or_before" do
+      old = create(:comment, created_at: "2026-01-01 09:00")
+      recent = create(:comment, created_at: "2026-06-01 09:00")
+
+      expect(Comment.created_on_or_after("2026-05-01")).to include(recent)
+      expect(Comment.created_on_or_after("2026-05-01")).not_to include(old)
+      expect(Comment.created_on_or_before("2026-05-01")).to include(old)
+      expect(Comment.created_on_or_before("2026-05-01")).not_to include(recent)
+    end
+
+    it "ignores an unparseable date" do
+      comment = create(:comment)
+      expect(Comment.created_on_or_after("not-a-date")).to include(comment)
+    end
+  end
+
+  describe ".for_event" do
+    it "gathers registration, CE, and scholarship comments for the event" do
+      registration = create(:event_registration)
+      reg_comment = create(:comment, commentable: registration)
+      ce = create(:continuing_education_registration, event_registration: registration)
+      ce_comment = create(:comment, commentable: ce)
+      scholarship = create(:scholarship, recipient: registration.registrant)
+      create(:allocation, source: scholarship, allocatable: registration, amount: 0)
+      schol_comment = create(:comment, commentable: scholarship)
+
+      other = create(:comment, commentable: create(:event_registration))
+
+      result = Comment.for_event(registration.event_id)
+      expect(result).to include(reg_comment, ce_comment, schol_comment)
+      expect(result).not_to include(other)
+    end
+  end
+end

--- a/spec/models/continuing_education_registration_spec.rb
+++ b/spec/models/continuing_education_registration_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe ContinuingEducationRegistration, type: :model do
+  describe "comments" do
+    it "is commentable and destroys its comments when removed" do
+      ce_reg = create(:continuing_education_registration)
+      comment = create(:comment, commentable: ce_reg)
+
+      expect(ce_reg.comments).to include(comment)
+      expect { ce_reg.destroy }.to change(Comment, :count).by(-1)
+    end
+  end
+
   describe "validations" do
     it "rejects a license that belongs to someone other than the registrant" do
       registration = create(:event_registration)

--- a/spec/requests/admin_comments_spec.rb
+++ b/spec/requests/admin_comments_spec.rb
@@ -54,5 +54,17 @@ RSpec.describe "Admin comments index", type: :request do
       get admin_comments_path
       expect(response).to redirect_to(root_path)
     end
+
+    it "tracks a view event on the full page" do
+      sign_in admin
+      expect(Analytics::AhoyTracker).to receive(:track_event).with(anything, "view.comments", { page: "index" })
+      get admin_comments_path
+    end
+
+    it "does not track on the results frame request" do
+      sign_in admin
+      expect(Analytics::AhoyTracker).not_to receive(:track_event)
+      get admin_comments_path, headers: frame_headers
+    end
   end
 end

--- a/spec/requests/admin_comments_spec.rb
+++ b/spec/requests/admin_comments_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Admin comments index", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:frame_headers) { { "Turbo-Frame" => "comments_results" } }
+
+  describe "GET /admin/comments" do
+    it "renders the page shell with search boxes including person and event filters" do
+      sign_in admin
+      get admin_comments_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("comments_results")
+      expect(response.body).to include("person_id", "event_id")
+    end
+
+    it "lists every comment in the results frame" do
+      sign_in admin
+      create(:comment, commentable: create(:person), body: "One")
+      create(:comment, commentable: create(:workshop), body: "Two")
+
+      get admin_comments_path, headers: frame_headers
+
+      expect(response.body).to include("One", "Two")
+    end
+
+    it "filters to comments connected to a person" do
+      sign_in admin
+      target = create(:person)
+      registration = create(:event_registration, registrant: target)
+      create(:comment, commentable: registration, body: "Target registration note")
+      create(:comment, commentable: create(:person), body: "Unrelated note")
+
+      get admin_comments_path(person_id: target.id), headers: frame_headers
+
+      expect(response.body).to include("Target registration note")
+      expect(response.body).not_to include("Unrelated note")
+    end
+
+    it "filters to comments connected to an event" do
+      sign_in admin
+      registration = create(:event_registration)
+      create(:comment, commentable: registration, body: "Event note")
+      create(:comment, commentable: create(:event_registration), body: "Other event note")
+
+      get admin_comments_path(event_id: registration.event_id), headers: frame_headers
+
+      expect(response.body).to include("Event note")
+      expect(response.body).not_to include("Other event note")
+    end
+
+    it "forbids non-admins" do
+      sign_in create(:user)
+      get admin_comments_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
         issuing_state: "CA", expires_on: Date.new(2027, 1, 31))
     end
 
+    it "renders a comments box on the edit page" do
+      get edit_continuing_education_registration_path(ce_registration)
+      expect(response.body).to include("CE comments")
+      expect(response.body).to include("comment-list")
+    end
+
+    it "saves a comment added on the CE form (with the record)" do
+      expect {
+        patch continuing_education_registration_path(ce_registration),
+              params: { continuing_education_registration: {
+                hours: "6", cost_dollars: "120", license_kind: "LMFT", license_number: "555",
+                comments_attributes: { "0" => { body: "Verified license by phone" } }
+              } }
+      }.to change(ce_registration.comments, :count).by(1)
+
+      expect(ce_registration.comments.last.body).to eq("Verified license by phone")
+    end
+
     it "edits the same license in place when correcting a typo (no new record)" do
       license = create(:professional_license, person: registration.registrant, kind: "LCSW", number: "11223")
       ce_registration.update!(professional_license: license)

--- a/spec/requests/people_all_comments_spec.rb
+++ b/spec/requests/people_all_comments_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe "Person aggregated comments", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+  let(:frame_headers) { { "Turbo-Frame" => "person_comments_results" } }
+
+  describe "GET /people/:id/all_comments" do
+    before { sign_in admin }
+
+    it "renders the page shell with the composer and search boxes" do
+      get all_comments_person_path(person)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("All comments")
+      expect(response.body).to include("aggregated_comment_composer")
+      expect(response.body).to include("person_comments_results")
+    end
+
+    it "shows comments from the person, their registrations, scholarships, CE, and user account in the results frame" do
+      create(:comment, commentable: person, body: "Profile note")
+
+      registration = create(:event_registration, registrant: person)
+      create(:comment, commentable: registration, body: "Registration note")
+
+      scholarship = create(:scholarship, recipient: person)
+      create(:comment, commentable: scholarship, body: "Scholarship note")
+
+      ce = create(:continuing_education_registration, event_registration: registration)
+      create(:comment, commentable: ce, body: "CE note")
+
+      create(:comment, commentable: person.user, body: "Account note")
+
+      get all_comments_person_path(person), headers: frame_headers
+
+      expect(response.body).to include("Profile note", "Registration note", "Scholarship note", "CE note", "Account note")
+    end
+
+    it "filters to a single source" do
+      create(:comment, commentable: person, body: "Profile note")
+      registration = create(:event_registration, registrant: person)
+      create(:comment, commentable: registration, body: "Registration note")
+
+      get all_comments_person_path(person, source: "EventRegistration"), headers: frame_headers
+
+      expect(response.body).to include("Registration note")
+      expect(response.body).not_to include("Profile note")
+    end
+
+    it "filters by keyword across body and topic" do
+      create(:comment, commentable: person, body: "Called the family", topic: "Outreach")
+      create(:comment, commentable: person, body: "Sent the packet", topic: "Mailing")
+
+      get all_comments_person_path(person, query: "family"), headers: frame_headers
+
+      expect(response.body).to include("Called the family")
+      expect(response.body).not_to include("Sent the packet")
+    end
+
+    it "filters by author" do
+      author = create(:user, :admin, first_name: "Zelda", last_name: "Vance")
+      create(:comment, commentable: person, body: "By Zelda", created_by: author, updated_by: author)
+      create(:comment, commentable: person, body: "By someone else")
+
+      get all_comments_person_path(person, author_id: author.id), headers: frame_headers
+
+      expect(response.body).to include("By Zelda")
+      expect(response.body).not_to include("By someone else")
+    end
+
+    it "filters to flagged only" do
+      create(:comment, commentable: person, body: "Plain note")
+      create(:comment, :flagged, commentable: person, body: "Flagged note")
+
+      get all_comments_person_path(person, flagged: "1"), headers: frame_headers
+
+      expect(response.body).to include("Flagged note")
+      expect(response.body).not_to include("Plain note")
+    end
+  end
+
+  describe "authorization" do
+    it "forbids non-admins" do
+      sign_in create(:user)
+      get all_comments_person_path(person)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "adding a comment from the aggregated composer" do
+    before { sign_in admin }
+
+    it "files a note against the record named by the composer's signed GlobalID and prepends it to the feed" do
+      scholarship = create(:scholarship, recipient: person)
+
+      expect {
+        post person_comments_path(person),
+             params: { aggregated: "1", for_person_id: person.id,
+                       commentable_sgid: scholarship.to_sgid.to_s, comment: { body: "Scholarship follow-up" } },
+             as: :turbo_stream
+      }.to change(scholarship.comments, :count).by(1)
+
+      expect(response.body).to include("aggregated_comments_list")
+      expect(response.body).to include("Scholarship follow-up")
+    end
+
+    it "files a note against a CE registration named by a signed GlobalID" do
+      registration = create(:event_registration, registrant: person)
+      ce = create(:continuing_education_registration, event_registration: registration)
+
+      expect {
+        post person_comments_path(person),
+             params: { aggregated: "1", for_person_id: person.id,
+                       commentable_sgid: ce.to_sgid.to_s, comment: { body: "CE follow-up" } },
+             as: :turbo_stream
+      }.to change(ce.comments, :count).by(1)
+    end
+  end
+
+  describe "editing a comment inline from the aggregated feed" do
+    before { sign_in admin }
+
+    it "updates the body and re-renders the row" do
+      comment = create(:comment, commentable: person, body: "Original")
+
+      patch person_comment_path(person, comment),
+            params: { aggregated: "1", for_person_id: person.id, comment: { body: "Edited" } },
+            as: :turbo_stream
+
+      expect(comment.reload.body).to eq("Edited")
+      expect(response.body).to include("Edited")
+    end
+  end
+end

--- a/spec/requests/people_all_comments_spec.rb
+++ b/spec/requests/people_all_comments_spec.rb
@@ -79,6 +79,21 @@ RSpec.describe "Person aggregated comments", type: :request do
     end
   end
 
+  describe "Ahoy tracking" do
+    before { sign_in admin }
+
+    it "tracks a distinct view event on the full page" do
+      expect(Analytics::AhoyTracker).to receive(:track_event)
+        .with(anything, "view.person_all_comments", hash_including(person_id: person.id))
+      get all_comments_person_path(person)
+    end
+
+    it "does not track on the results frame request" do
+      expect(Analytics::AhoyTracker).not_to receive(:track_event)
+      get all_comments_person_path(person), headers: frame_headers
+    end
+  end
+
   describe "authorization" do
     it "forbids non-admins" do
       sign_in create(:user)

--- a/spec/services/person_comment_aggregator_spec.rb
+++ b/spec/services/person_comment_aggregator_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe PersonCommentAggregator do
+  subject(:aggregator) { described_class.new(person) }
+
+  let(:person) { create(:person) }
+
+  describe "#comments" do
+    it "gathers comments from the person, their registrations, scholarships, CE registrations, and user account" do
+      profile_comment = create(:comment, commentable: person)
+
+      registration = create(:event_registration, registrant: person)
+      registration_comment = create(:comment, commentable: registration)
+
+      scholarship = create(:scholarship, recipient: person)
+      scholarship_comment = create(:comment, commentable: scholarship)
+
+      ce_registration = create(:continuing_education_registration, event_registration: registration)
+      ce_comment = create(:comment, commentable: ce_registration)
+
+      subscription = create(:topic_subscription, person: person)
+      subscription_comment = create(:comment, commentable: subscription)
+
+      user_comment = create(:comment, commentable: person.user)
+
+      expect(aggregator.comments).to contain_exactly(
+        profile_comment, registration_comment, scholarship_comment, ce_comment, subscription_comment, user_comment
+      )
+    end
+
+    it "excludes comments left on unrelated records" do
+      other_person = create(:person)
+      create(:comment, commentable: other_person)
+      mine = create(:comment, commentable: person)
+
+      expect(aggregator.comments).to contain_exactly(mine)
+    end
+
+    it "returns comments newest first" do
+      older = create(:comment, commentable: person, created_at: 2.days.ago)
+      newer = create(:comment, commentable: person, created_at: 1.hour.ago)
+
+      expect(aggregator.comments.to_a).to eq([ newer, older ])
+    end
+
+    it "returns an empty relation when the person has no comments and no user" do
+      person_without_user = create(:person, user: nil)
+
+      expect(described_class.new(person_without_user).comments).to be_empty
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/other_responses/index.html.erb"         => "admin-only bg-blue-100",
     "app/views/banners/index.html.erb"                 => "admin-only bg-blue-100",
     "app/views/comments/index.html.erb"                => "admin-only bg-blue-100",
+    "app/views/people/all_comments.html.erb"           => "admin-only bg-white",
+    "app/views/admin/comments/index.html.erb"          => "admin-only bg-white",
     "app/views/bookmarks/index.html.erb"               => "admin-only bg-blue-100",
     "app/views/categories/index.html.erb"              => "admin-only bg-blue-100",
     "app/views/category_types/index.html.erb"          => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new admin pages, shared CommentsController create/update branch, new commentable model/routes, search scopes

> **Stacked on #2098** (topic-subscription comments) — merge #2098 first; this PR is based on that branch and will retarget to `main` automatically once #2098 merges.

### What is the goal of this PR and why is this important?
- Comments lived per-record with no rollup. This adds **/people/:id/all_comments** (admin-only): one searchable, newest-first feed of every comment connected to a person, each tagged with a linked source chip, with an inline composer + in-place editing, and a picker to jump to another person's comments.
- Adds a **global admin comments index** (/admin/comments, linked from admin home) with the same search boxes + remote person/event filters.

### How did you approach the change?
- `PersonCommentAggregator` unions comments across profile + registrations + scholarships + CE + topic subscriptions + user account.
- Makes `ContinuingEducationRegistration` commentable; adds nested comment routes + `set_commentable` branches for scholarships, CE, and topic subscriptions (for the feed's inline edit). Payments stay non-commentable.
- Reuses `CommentsController#create`/`#update` via an `aggregated` flag; the composer posts the chosen record as a signed GlobalID resolved server-side (no JS action-swapping).
- Feed + global index use the lazy Turbo-frame filter pattern: keyword (body/topic), author (user remote-select), type, date range, flagged; person/event remote search on the global index.
- `CommentsHelper#commentable_label` + `CommentDecorator` give each row/source its label, link, and theme. "View all" links from every record's comment box to the person's report.

### Anything else to add?
- New specs: aggregator, decorator, comment search scopes, CE-commentable model, and request specs for the person page + global index.