### PR TITLE
Cap choropleth color scale above the second-highest count

### DIFF
--- a/app/frontend/javascript/controllers/us_map_chart_controller.js
+++ b/app/frontend/javascript/controllers/us_map_chart_controller.js
@@ -49,6 +49,12 @@ export default class extends Controller {
       return counts[abbrByStateName[name]] ?? counts[name] ?? 0
     }
 
+    // Adjust bc one over-represented state (e.g. CA) left every other state near-white.
+    const values = states.map(valueFor)
+    const highest = Math.max(0, ...values)
+    const secondHighest = Math.max(0, ...values.filter(v => v < highest))
+    const colorScaleMax = Math.max(1, Math.ceil((secondHighest || highest) * 1.4))
+
     this.chart = new Chart(this.canvasTarget, {
       type: "choropleth",
       data: {
@@ -75,6 +81,8 @@ export default class extends Controller {
           projection: { axis: "x", projection: "albersUsa" },
           color: {
             axis: "x",
+            min: 0,
+            max: colorScaleMax,
             quantize: 5,
             interpolate: rampTo(this.colorValue),
             legend: { position: "bottom-right", align: "bottom" }

--- a/app/frontend/javascript/controllers/world_map_chart_controller.js
+++ b/app/frontend/javascript/controllers/world_map_chart_controller.js
@@ -47,6 +47,12 @@ export default class extends Controller {
       return countsByName[name] ?? countsByName[aliasByAtlasName[name]] ?? 0
     }
 
+    // Adjust bc one over-represented country (e.g. US) left every other country near-white.
+    const values = countries.map(valueFor)
+    const highest = Math.max(0, ...values)
+    const secondHighest = Math.max(0, ...values.filter(v => v < highest))
+    const colorScaleMax = Math.max(1, Math.ceil((secondHighest || highest) * 1.4))
+
     this.chart = new Chart(this.canvasTarget, {
       type: "choropleth",
       data: {
@@ -73,6 +79,8 @@ export default class extends Controller {
           projection: { axis: "x", projection: "equalEarth" },
           color: {
             axis: "x",
+            min: 0,
+            max: colorScaleMax,
             quantize: 5,
             interpolate: rampTo(this.colorValue),
             legend: { position: "bottom-right", align: "bottom" }

--- a/app/frontend/javascript/lib/color_ramp.js
+++ b/app/frontend/javascript/lib/color_ramp.js
@@ -5,7 +5,9 @@ export function rampTo(base) {
   const from = [ 241, 245, 249 ] // slate-100 floor for the lowest counts
   const to = hexToRgb(base)
   return (t) => {
-    const channels = from.map((value, i) => Math.round(value + (to[i] - value) * t))
+    // Clamp so out-of-range values pin to the base color instead of extrapolating past it.
+    const clamped = t < 0 ? 0 : t > 1 ? 1 : t
+    const channels = from.map((value, i) => Math.round(value + (to[i] - value) * clamped))
     return `rgb(${channels[0]}, ${channels[1]}, ${channels[2]})`
   }
 }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, self-contained JS: color-scale capping on the two choropleth controllers

### What & why
On the event background dashboard's **States** and **Countries** maps, a single over-represented region (e.g. CA in a CA-heavy dataset) washed out the linear 0→max color ramp, leaving every other region near-white (Montana with 3 looked the same as a state with 0).

### How
- `us_map_chart_controller.js` / `world_map_chart_controller.js`: cap the color scale just above the **second-highest** count (`ceil(secondHighest × 1.4)`, `min: 0`), so the lone outlier pins to the darkest shade (clamped) while everyone else spreads across a real gradient below it.
- `color_ramp.js`: clamp `t` to `[0,1]` so capped values pin to the base color instead of extrapolating past it into out-of-range channels.
- Tooltips and the ranked list below each map keep **exact counts** — only the color scale is capped, not the data.