### PR TITLE
Break table sort ties by the server's initial row order

### DIFF
--- a/app/frontend/javascript/controllers/table_sort_controller.js
+++ b/app/frontend/javascript/controllers/table_sort_controller.js
@@ -13,13 +13,18 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["body", "header"]
 
+  connect() {
+    // The server base order tie breaks every sort.
+    this.initialRows = Array.from(this.bodyTarget.rows)
+  }
+
   sort(event) {
     const header = event.currentTarget
     const index = Number(header.dataset.sortIndex)
     const key = header.dataset.sortKey
     const ascending = header.dataset.sortDirection !== "asc"
 
-    const rows = Array.from(this.bodyTarget.rows)
+    const rows = [ ...this.initialRows ]
     rows.sort((a, b) => this.compare(a, b, index, key) * (ascending ? 1 : -1))
     rows.forEach((row) => this.bodyTarget.appendChild(row))
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two-line change to the shared table-sort controller

### What & why
`table-sort` reorders table rows client-side. Sorting by a non-name column (status, sector, scholarship, …) should keep equal rows grouped by the server's default order (typically name) — instead of leaving them in whatever the previous sort produced.

### How
Capture the server-rendered row order on `connect()` and start every sort from that snapshot. `Array#sort` is stable, so ties keep the initial (name) order automatically — the server ordering becomes the secondary sort with no explicit tiebreak logic, and it holds across chained sorts.

Applies to every `data-controller="table-sort"` table (grants, event registrants/onboarding results, background roster).