### PR TITLE
Show communications admin-only blue only where non-admins can view

### DIFF
--- a/app/views/notifications/_communications.html.erb
+++ b/app/views/notifications/_communications.html.erb
@@ -13,6 +13,11 @@
 <% email = record.communications_email %>
 <% notifications = email.present? ? Notification.email(email).order(created_at: :desc) : Notification.none %>
 <% admin = allowed_to?(:index?, with: NotificationPolicy) %>
+<%# On a page non-admins can view (the person profile), admin-only content is
+    marked with the app's `admin-only bg-blue-100` wash so it reads as privileged.
+    On admin-only pages (event registration, scholarship) everything is admin-only
+    already, so callers leave this off and it renders plainly. %>
+<% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
 <% new_notifications = record.notifications.select(&:new_record?) %>
 <%# `record` may be a Draper decorator here, so read the model name via
     `model_name` (delegated to the underlying class) rather than `class.name`,
@@ -48,18 +53,18 @@
         <% notifications.each do |notification| %>
           <% if editable_notifications.include?(notification) %>
             <%= f.simple_fields_for :notifications, own_notifications_by_id.fetch(notification.id, notification) do |nf| %>
-              <%= render "notifications/notification_fields", f: nf, record: record %>
+              <%= render "notifications/notification_fields", f: nf, record: record, mark_admin_only: mark_admin_only %>
             <% end %>
           <% else %>
             <div data-paginated-fields-target="item">
-              <%= render "notifications/notification_row", notification: notification, admin: admin %>
+              <%= render "notifications/notification_row", notification: notification, admin: admin, mark_admin_only: mark_admin_only %>
             </div>
           <% end %>
         <% end %>
         <% if admin %>
           <%# New, unsaved entries — re-rendered here on validation error. %>
           <%= f.simple_fields_for :notifications, new_notifications do |nf| %>
-            <%= render "notifications/notification_fields", f: nf, record: record %>
+            <%= render "notifications/notification_fields", f: nf, record: record, mark_admin_only: mark_admin_only %>
           <% end %>
         <% end %>
       </div>
@@ -71,19 +76,23 @@
     <% end %>
 
     <% if admin %>
-      <div class="admin-only mt-3 flex items-center justify-between gap-2 rounded-md bg-blue-100 px-3 py-2">
+      <%# Blue admin-only wash only where non-admins share the page; a plain gray
+          hover otherwise, matching the org-show admin-only linked text. %>
+      <% admin_button_marker = mark_admin_only ? "admin-only bg-blue-100" : "hover:bg-gray-100" %>
+      <% admin_button_class = "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:text-gray-700 cursor-pointer #{admin_button_marker}" %>
+      <div class="mt-3 flex items-center justify-between gap-2">
         <%= link_to_add_association f, :notifications,
               partial: "notifications/notification_fields",
-              render_options: { locals: { record: record } },
+              render_options: { locals: { record: record, mark_admin_only: mark_admin_only } },
               data: { association_insertion_node: "##{list_id}", association_insertion_method: "append" },
-              class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+              class: admin_button_class do %>
           <i class="fa-solid fa-plus text-[0.6rem]"></i>
           <%= t("communications.add") %>
         <% end %>
 
         <% if editable_notifications.any? %>
           <button type="button"
-                  class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                  class="<%= admin_button_class %>"
                   data-action="edit-toggle#toggle">
             <i class="fa-solid fa-pen text-[0.6rem]"></i>
             <span data-edit-toggle-target="editLabel"><%= t("communications.edit") %></span>

--- a/app/views/notifications/_notification_fields.html.erb
+++ b/app/views/notifications/_notification_fields.html.erb
@@ -7,6 +7,7 @@
     notifications box. The sender defaults to whoever logs it. ---- %>
 <% channel_default = Notification::MANUAL_CHANNELS.include?(f.object.channel) ? f.object.channel : "email" %>
 <% record = local_assigns[:record] %>
+<% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
 <div class="nested-fields" data-paginated-fields-target="item">
   <%# Record this communication against its parent (the "Record" column in the
       notifications index) — e.g. an event registration or a person. %>
@@ -21,7 +22,7 @@
   <% if f.object.persisted? %>
     <%= f.hidden_field :id %>
     <div data-edit-toggle-target="view">
-      <%= render "notifications/notification_row", notification: f.object, admin: true %>
+      <%= render "notifications/notification_row", notification: f.object, admin: true, mark_admin_only: mark_admin_only %>
     </div>
     <div class="hidden rounded-md border border-amber-200 bg-amber-50 p-3" data-edit-toggle-target="edit">
       <%= render "notifications/notification_form", f: f, channel_default: channel_default %>

--- a/app/views/notifications/_notification_row.html.erb
+++ b/app/views/notifications/_notification_row.html.erb
@@ -1,12 +1,14 @@
 <%# ---- Read-only display of one communication: channel icon + subject (always
     visible), then the body. The body of a hand-noted communication (any channel
-    but "autoemail") is an internal staff note — admin-only, shown with the
-    admin-only blue styling and hidden from non-admins (no inline text, nothing
-    in the hover title). An automated ("autoemail") message is the recipient's
-    own email, so its body stays visible to everyone. Pass admin: false for a
-    non-admin viewer. Shared by the notifications box and the view mode of an
-    editable communication. ---- %>
+    but "autoemail") is an internal staff note — admin-only, hidden from non-admins
+    (no inline text, nothing in the hover title). On a page non-admins can view,
+    pass mark_admin_only: true to give the body the `admin-only bg-blue-100` wash;
+    on admin-only pages it renders plainly. An automated ("autoemail") message is
+    the recipient's own email, so its body stays visible to everyone. Pass admin:
+    false for a non-admin viewer. Shared by the notifications box and the view mode
+    of an editable communication. ---- %>
 <% admin = local_assigns.fetch(:admin, true) %>
+<% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
 <% body_admin_only = notification.channel != "autoemail" %>
 <% show_body = admin || !body_admin_only %>
 <% subject = notification.email_subject.presence || notification.kind.to_s.humanize %>
@@ -21,9 +23,12 @@
     <%= notification.decorate.channel_icon %>
     <span class="font-semibold text-gray-900"><%= subject %></span>
     <% if body.present? %>
-      <% if body_admin_only %>
-        <%# Internal staff note — admin-only, marked with the admin-only blue styling. Only the body is hoverable. %>
+      <% if body_admin_only && mark_admin_only %>
+        <%# Internal staff note on a page non-admins can view — flag it admin-only. %>
         <span class="admin-only bg-blue-100 rounded px-1 text-gray-700" title="<%= body %>"><%= body %></span>
+      <% elsif body_admin_only %>
+        <%# Internal staff note on an admin-only page — rendered plainly like a comment. %>
+        <span class="text-gray-900" title="<%= body %>"><%= body %></span>
       <% else %>
         <span class="text-gray-500" title="<%= body %>"><%= body %></span>
       <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -528,7 +528,7 @@
   <% if f.object.persisted? %>
     <%# Communications — subjects are visible to the person; the body and the
         add/edit controls are admin-only (gated inside the partial). %>
-    <%= render "notifications/communications", f: f,
+    <%= render "notifications/communications", f: f, mark_admin_only: true,
           title_key: "communications.title", none_key: "communications.none_for_person" %>
 
     <!-- Comments -->

--- a/spec/views/notifications/_notification_row.html.erb_spec.rb
+++ b/spec/views/notifications/_notification_row.html.erb_spec.rb
@@ -17,10 +17,18 @@ RSpec.describe "notifications/_notification_row", type: :view do
     expect(rendered).to include("Called them")
   end
 
-  it "shows a hand-noted body only to admins, with the admin-only blue styling" do
-    render partial: "notifications/notification_row", locals: { notification: hand_noted, admin: true }
+  it "flags a hand-noted body with the admin-only blue wash when mark_admin_only is set" do
+    render partial: "notifications/notification_row",
+           locals: { notification: hand_noted, admin: true, mark_admin_only: true }
 
     expect(rendered).to have_css("span.admin-only.bg-blue-100", text: "Left a voicemail about the deadline")
+  end
+
+  it "renders a hand-noted body plainly (no blue) on an admin-only page" do
+    render partial: "notifications/notification_row", locals: { notification: hand_noted, admin: true }
+
+    expect(rendered).to include("Left a voicemail about the deadline")
+    expect(rendered).not_to have_css("span.bg-blue-100")
   end
 
   it "hides a hand-noted body from non-admins (no inline text, nothing to hover)" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view-logic change gating a styling wash behind a flag across three callers

### What is the goal of this PR and why is this important?
The `notifications/communications` partial is shared by three pages: the **person profile** (`people/_form`, viewable by non-admins), and the admin-only **event-registration** and **scholarship** edit forms. The `admin-only bg-blue-100` wash only means something where non-admins share the page — on admin-only pages everything is privileged already, so the blue just read as noise on the edit-registration page.

### How did you approach the change?
- Added a `mark_admin_only` flag (default `false`) to the communications chain (`_communications` → `_notification_fields` → `_notification_row`).
- Passed `mark_admin_only: true` only from the person profile; the two admin-only callers keep the default and render plainly (staff-note body like a comment, gray-hover buttons).
- When set, the staff-note body and the add/edit buttons get the `admin-only bg-blue-100` wash, matching the org-show admin-only linked-text convention.
- Buttons remain inside `<% if admin %>`, so non-admins never see them once the person profile is ungated.

### Anything else to add?
Prep for ungating the communications box on the person profile. Updated the `_notification_row` view spec to cover both modes.