### PR TITLE
Return to highlighted roster row after saving a registration

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -92,7 +92,7 @@ class EventRegistrationsController < ApplicationController
         format.turbo_stream
         format.html {
           case params[:return_to]
-          when "registrants" then redirect_to registrants_event_path(@event_registration.event), notice: notice, status: :see_other
+          when "registrants" then redirect_to helpers.registrants_event_row_path(@event_registration.event, @event_registration.id), notice: notice, status: :see_other
           when "index" then redirect_to event_registrations_path, notice: notice, status: :see_other
           when "ticket" then redirect_to registration_ticket_path(@event_registration.slug), notice: notice, status: :see_other
           when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event), notice: notice, status: :see_other
@@ -101,7 +101,7 @@ class EventRegistrationsController < ApplicationController
             # No explicit origin: keep admins in the management context (the
             # roster) rather than dropping them on the public registration show.
             if allowed_to?(:manage?, with: EventRegistrationPolicy)
-              redirect_to registrants_event_path(@event_registration.event), notice: notice, status: :see_other
+              redirect_to helpers.registrants_event_row_path(@event_registration.event, @event_registration.id), notice: notice, status: :see_other
             else
               redirect_to registration_ticket_path(@event_registration.slug), notice: notice, status: :see_other
             end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -324,9 +324,12 @@ RSpec.describe "EventRegistrations", type: :request do
         patch event_registration_path(existing_registration),
               params: { event_registration: { event_id: new_event.id } }
 
-        # No explicit return_to: admins land back on the management roster, not
-        # the public registration show.
-        expect(response).to redirect_to(registrants_event_path(new_event))
+        # No explicit return_to: admins land back on the management roster,
+        # scrolled to and highlighting the row they just edited, not the public
+        # registration show.
+        expect(response).to redirect_to(
+          registrants_event_path(new_event, anchor: "registrant-row-#{existing_registration.id}", highlight: existing_registration.id)
+        )
         expect(existing_registration.reload.event_id).to eq(new_event.id)
       end
 

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "Event registration edit page", type: :system do
 
       click_on "Save changes"
 
-      expect(page).to have_current_path(registrants_event_path(event))
+      expect(page).to have_current_path(registrants_event_path(event, highlight: registration.id))
       expect(registration.reload.shoutout).to be(true)
       expect(registration.registrant.reload.shoutout_text).to eq("Grateful to bring art to the survivors we serve.")
     end
@@ -198,7 +198,7 @@ RSpec.describe "Event registration edit page", type: :system do
       check "Day 2", allow_label_click: true
       click_on "Save changes"
 
-      expect(page).to have_current_path(registrants_event_path(event))
+      expect(page).to have_current_path(registrants_event_path(event, highlight: registration.id))
       expect(registration.reload.completed_day_1).to be(true)
       expect(registration.completed_day_2).to be(true)
     end
@@ -221,7 +221,7 @@ RSpec.describe "Event registration edit page", type: :system do
       click_on "Save changes"
 
       # Wait for the save round-trip to land before reading the database.
-      expect(page).to have_current_path(registrants_event_path(event))
+      expect(page).to have_current_path(registrants_event_path(event, highlight: registration.id))
       expect(registration.reload.status).to eq("attended")
       expect(registration.completed_day_count).to eq(3)
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two-line redirect change in the update action + spec update

### What is the goal of this PR and why is this important?
- Saving a registration from the edit page dropped admins on the plain registrants roster, losing their place.
- Now it returns to the roster **scrolled to and highlighting the row just edited**, matching onboarding's back-behavior and the edit page's own eyebrow.

### How did you approach the change?
- `update` now redirects to `registrants_event_row_path` (adds `anchor` + `highlight`) for the `registrants` return_to case and the no-`return_to` admin fallback, instead of the plain `registrants_event_path`.
- Applies to all roster-bound saves, not just comment edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)