### PR TITLE
Registrant name pill: ticket icon + pending email-change warning

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -101,6 +101,13 @@ module EventHelper
                     overflow-hidden" do
       event = event.decorate if event.respond_to?(:decorate)
 
+      icon_tag = content_tag(:span,
+                             content_tag(:i, "", class: "fa-solid fa-calendar-days"),
+                             class: "flex h-10 w-10 shrink-0 items-center justify-center rounded-full
+                                     border #{DomainTheme.border_class_for(:events)}
+                                     #{DomainTheme.bg_class_for(:events, intensity: 200)}
+                                     #{DomainTheme.text_class_for(:events, intensity: 700)} shadow-sm")
+
       display_name = truncate_at ? truncate(event.name.to_s, length: truncate_at) : event.name.to_s
 
       name = content_tag(
@@ -122,7 +129,7 @@ module EventHelper
         class: "flex flex-col leading-tight text-left min-w-0"
       )
 
-      text_block
+      icon_tag + text_block
     end
   end
 

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -84,50 +84,41 @@ module EventHelper
     )
   end
 
-  def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil)
+  def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false)
     bg = DomainTheme.bg_class_for(:events, intensity: 100)
     hover_bg = DomainTheme.bg_class_for(:events, intensity: 100, hover: true)
     text = DomainTheme.text_class_for(:events)
     border = DomainTheme.border_class_for(:events)
 
+    padding = compact ? "px-2 py-1" : "px-4 py-2"
+    name_size = compact ? "text-xs" : "text-sm"
+    icon_size = compact ? "text-sm" : "text-lg"
+
     link_to path || event_path(event),
             data: data,
-            style: "min-height: 3.5rem;",
             class: "group relative flex items-center gap-2
-                    w-full px-4 py-2
+                    w-full #{padding}
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
                     font-medium shadow-sm leading-none
                     overflow-hidden" do
       event = event.decorate if event.respond_to?(:decorate)
 
-      icon_tag = content_tag(:span,
-                             content_tag(:i, "", class: "fa-solid fa-calendar-days"),
-                             class: "flex h-10 w-10 shrink-0 items-center justify-center rounded-full
-                                     border #{DomainTheme.border_class_for(:events)}
-                                     #{DomainTheme.bg_class_for(:events, intensity: 200)}
-                                     #{DomainTheme.text_class_for(:events, intensity: 700)} shadow-sm")
+      icon_tag = content_tag(:i, "", class: "fa-solid fa-calendar-days shrink-0 #{icon_size} #{DomainTheme.text_class_for(:events)}")
 
       display_name = truncate_at ? truncate(event.name.to_s, length: truncate_at) : event.name.to_s
 
-      name = content_tag(
-        :span,
-        display_name,
-        title: event.name.to_s,
-        class: "font-semibold #{text} truncate"
-      )
+      name = content_tag(:span, display_name, title: event.name.to_s, class: "font-semibold #{name_size} #{text} truncate")
 
-      subtitle_tag = if subtitle.present?
-        content_tag(:span, subtitle, class: "text-xs text-gray-500 font-normal truncate")
-      else
-        "".html_safe
+      # Title and date on one line, separated by a dot; the title truncates while
+      # the date stays whole.
+      parts = [ name ]
+      if subtitle.present?
+        parts << content_tag(:span, "·", class: "shrink-0 text-gray-400")
+        parts << content_tag(:span, subtitle, class: "shrink-0 #{name_size} text-gray-500 font-normal whitespace-nowrap")
       end
 
-      text_block = content_tag(
-        :div,
-        name + subtitle_tag,
-        class: "flex flex-col leading-tight text-left min-w-0"
-      )
+      text_block = content_tag(:div, safe_join(parts), class: "flex items-baseline gap-1.5 leading-none text-left min-w-0")
 
       icon_tag + text_block
     end

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -84,7 +84,7 @@ module EventHelper
     )
   end
 
-  def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false)
+  def event_show_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false)
     bg = DomainTheme.bg_class_for(:events, intensity: 50)
     hover_bg = DomainTheme.bg_class_for(:events, intensity: 50, hover: true)
     text = DomainTheme.text_class_for(:events)

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -85,8 +85,8 @@ module EventHelper
   end
 
   def event_profile_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false)
-    bg = DomainTheme.bg_class_for(:events, intensity: 100)
-    hover_bg = DomainTheme.bg_class_for(:events, intensity: 100, hover: true)
+    bg = DomainTheme.bg_class_for(:events, intensity: 50)
+    hover_bg = DomainTheme.bg_class_for(:events, intensity: 50, hover: true)
     text = DomainTheme.text_class_for(:events)
     border = DomainTheme.border_class_for(:events)
 

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -80,7 +80,7 @@
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
                                     class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
                           <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.text_class_for(:event_registrations, intensity: 700)} shadow-sm">
-                            <i class="fa-solid fa-clipboard-list"></i>
+                            <i class="fa-solid fa-user-pen"></i>
                           </span>
                           <span class="truncate font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
                         <% end %>

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -78,11 +78,11 @@
                       <!-- Actions -->
                       <td class="px-4 py-2 align-top">
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
-                                    class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
-                          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.text_class_for(:event_registrations, intensity: 700)} shadow-sm">
+                                    class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
+                          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full #{DomainTheme.bg_class_for(:event_registrations, intensity: 600)} text-white shadow-sm">
                             <i class="fa-solid fa-user-pen"></i>
                           </span>
-                          <span class="truncate font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
+                          <span class="truncate text-sm font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
                         <% end %>
                       </td>
                     </tr>

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -79,7 +79,7 @@
                       <!-- Actions -->
                       <td class="px-3 py-1 align-middle">
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
-                                    class: "group relative flex items-center gap-2 w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
+                                    class: "group relative flex items-center gap-2 w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
                           <i class="fa-solid fa-user-pen shrink-0 text-sm <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
                           <span class="truncate text-xs font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
                         <% end %>

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -28,7 +28,7 @@
           <% if @filtered_event %>
             <div class="mb-4">
               <%= event_profile_button(@filtered_event,
-                    subtitle: @filtered_event.decorate.times(display_day: true, display_date: true, inline: true)) %>
+                    subtitle: @filtered_event.decorate.short_date_range) %>
             </div>
           <% end %>
 
@@ -53,9 +53,9 @@
                 <tbody class="divide-y divide-gray-200">
                   <% @event_registrations.each do |event_registration| %>
                     <tr id="<%= dom_id(event_registration) %>" class="hover:bg-gray-50 transition-colors duration-150">
-                      <td class="px-4 py-2 text-sm text-gray-800 align-top">
+                      <td class="px-3 py-1 text-sm text-gray-800 align-middle">
                         <div class="flex items-center gap-2">
-                          <%= person_profile_button(event_registration.registrant) %>
+                          <%= person_profile_button(event_registration.registrant, compact: true) %>
                           <% if submitted_pairs.include?([ event_registration.registrant_id, event_registration.event_id ]) %>
                             <i class="fa-solid fa-file-lines text-green-600 shrink-0" title="Completed registration form"></i>
                           <% elsif events_with_forms.include?(event_registration.event_id) %>
@@ -64,25 +64,24 @@
                         </div>
                       </td>
                       <% unless @filtered_event %>
-                        <td class="px-4 py-2 text-sm text-gray-800 min-w-[50ch]">
+                        <td class="px-3 py-1 text-sm text-gray-800 align-middle min-w-[50ch]">
                           <%= event_profile_button(event_registration.event,
                                 truncate_at: 50,
+                                compact: true,
                                 path: dashboard_event_path(event_registration.event),
-                                subtitle: event_registration.event.decorate.times(display_day: true, display_date: true, inline: true)) %>
+                                subtitle: event_registration.event.decorate.short_date_range) %>
                         </td>
                       <% end %>
-                      <td class="px-4 pb-2 text-sm text-gray-800 align-top" style="padding-top: 1.25rem;">
+                      <td class="px-3 py-1 text-sm text-gray-800 align-middle whitespace-nowrap">
                         <%= event_registration.created_at.strftime("%B %d, %Y") %>
                       </td>
 
                       <!-- Actions -->
-                      <td class="px-4 py-2 align-top">
+                      <td class="px-3 py-1 align-middle">
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
-                                    class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
-                          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 300)} #{DomainTheme.text_class_for(:event_registrations, intensity: 700)} shadow-sm">
-                            <i class="fa-solid fa-user-pen"></i>
-                          </span>
-                          <span class="truncate text-sm font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
+                                    class: "group relative flex items-center gap-2 w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
+                          <i class="fa-solid fa-user-pen shrink-0 text-sm <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
+                          <span class="truncate text-xs font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
                         <% end %>
                       </td>
                     </tr>

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -27,7 +27,7 @@
 
           <% if @filtered_event %>
             <div class="mb-4">
-              <%= event_profile_button(@filtered_event,
+              <%= event_show_button(@filtered_event,
                     subtitle: @filtered_event.decorate.short_date_range) %>
             </div>
           <% end %>
@@ -65,7 +65,7 @@
                       </td>
                       <% unless @filtered_event %>
                         <td class="px-3 py-1 text-sm text-gray-800 align-middle min-w-[50ch]">
-                          <%= event_profile_button(event_registration.event,
+                          <%= event_show_button(event_registration.event,
                                 truncate_at: 50,
                                 compact: true,
                                 path: dashboard_event_path(event_registration.event),

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -79,7 +79,7 @@
                       <td class="px-4 py-2 align-top">
                         <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
                                     class: "group relative flex items-center gap-2 w-full px-4 py-2 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 200, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
-                          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full #{DomainTheme.bg_class_for(:event_registrations, intensity: 600)} text-white shadow-sm">
+                          <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 300)} #{DomainTheme.text_class_for(:event_registrations, intensity: 700)} shadow-sm">
                             <i class="fa-solid fa-user-pen"></i>
                           </span>
                           <span class="truncate text-sm font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -216,7 +216,7 @@
                                   title: [ person.name, display_email ].compact_blank.join(" — "),
                                   class: reg_edit_classes,
                                   data: { turbo_frame: "_top", turbo_prefetch: false } do %>
-                        <i class="fa-solid fa-ticket flex-shrink-0 <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
+                        <i class="fa-solid fa-user-pen flex-shrink-0 <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
                         <div class="flex flex-col justify-center min-w-0">
                           <span class="font-semibold text-xs <%= DomainTheme.text_class_for(:event_registrations) %> truncate"><%= truncate(person.name.to_s, length: 30) %></span>
                           <% if display_email.present? %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -216,6 +216,7 @@
                                   title: [ person.name, display_email ].compact_blank.join(" — "),
                                   class: reg_edit_classes,
                                   data: { turbo_frame: "_top", turbo_prefetch: false } do %>
+                        <i class="fa-solid fa-ticket flex-shrink-0 <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
                         <div class="flex flex-col justify-center min-w-0">
                           <span class="font-semibold text-xs <%= DomainTheme.text_class_for(:event_registrations) %> truncate"><%= truncate(person.name.to_s, length: 30) %></span>
                           <% if display_email.present? %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -207,16 +207,26 @@
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
 
                   <div class="flex items-center gap-1">
-                    <% reg_edit_classes = "group flex flex-col justify-center w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 shadow-sm leading-tight overflow-hidden" %>
+                    <% reg_edit_classes = "group flex items-center gap-2 w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 shadow-sm leading-tight overflow-hidden" %>
                     <% display_email = person.preferred_email if show_email %>
+                    <%# Mirror person_profile_button: warn admins/the person of a pending email change. %>
+                    <% unconfirmed_email = person.user&.unconfirmed_email if allowed_to?(:show_email_change?, person) %>
                     <div class="w-60 min-w-0">
                       <%= link_to edit_event_registration_path(registration, return_to: "registrants"),
                                   title: [ person.name, display_email ].compact_blank.join(" — "),
                                   class: reg_edit_classes,
                                   data: { turbo_frame: "_top", turbo_prefetch: false } do %>
-                        <span class="font-semibold text-xs <%= DomainTheme.text_class_for(:event_registrations) %> truncate"><%= truncate(person.name.to_s, length: 30) %></span>
-                        <% if display_email.present? %>
-                          <!--email_off--><span class="text-xs text-gray-500 font-normal truncate"><%= display_email %></span><!--email_on-->
+                        <div class="flex flex-col justify-center min-w-0">
+                          <span class="font-semibold text-xs <%= DomainTheme.text_class_for(:event_registrations) %> truncate"><%= truncate(person.name.to_s, length: 30) %></span>
+                          <% if display_email.present? %>
+                            <!--email_off--><span class="text-xs text-gray-500 font-normal truncate"><%= display_email %></span><!--email_on-->
+                          <% end %>
+                        </div>
+                        <% if unconfirmed_email.present? %>
+                          <span class="flex-shrink-0 ml-auto text-yellow-500"
+                                title="Email change to <%= unconfirmed_email %> awaiting confirmation. Only the person and admins can see this; it is hidden from other profile visitors.">
+                            <i class="fa-solid fa-triangle-exclamation"></i>
+                          </span>
                         <% end %>
                       <% end %>
                     </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -54,7 +54,7 @@
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-        <i class="fa-solid fa-users-viewfinder text-cyan-600"></i>
+        <i class="fa-solid fa-users-viewfinder <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
         Get to know the registrants
       </h1>
     </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -54,7 +54,7 @@
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-        <i class="fa-solid fa-users-viewfinder text-blue-600"></i>
+        <i class="fa-solid fa-users-viewfinder text-cyan-600"></i>
         Get to know the registrants
       </h1>
     </div>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -54,7 +54,7 @@
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-        <i class="fa-solid fa-users-viewfinder <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
+        <i class="fa-solid fa-users-viewfinder <%= DomainTheme.text_class_for(:people, intensity: 500) %>"></i>
         Get to know the registrants
       </h1>
     </div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -35,7 +35,7 @@
       <% if @event.start_date.present? %>
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
-      <h1 class="text-3xl font-bold mt-1 flex items-center justify-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+      <h1 class="text-3xl font-bold mt-2 flex items-center justify-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
         <i class="fa-solid fa-graduation-cap"></i>
         Scholarship recipients
       </h1>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -38,7 +38,7 @@
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-        <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
+        <i class="fa-solid fa-users text-teal-800"></i>
         Registrants
       </h1>
       <p class="text-gray-500 mt-2"><%= pluralize(@active_count, "person") %></p>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -38,7 +38,7 @@
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
-        <i class="fa-solid fa-users text-teal-800"></i>
+        <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:event_registrations, intensity: 800) %>"></i>
         Registrants
       </h1>
       <p class="text-gray-500 mt-2"><%= pluralize(@active_count, "person") %></p>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small logic/markup change in one roster cell, reusing existing policy + theme

### What is the goal of this PR and why is this important?
- Linking the registrant name to the registration editor (#2057) inlined the name pill, which dropped the avatar and the pending email-change warning that `person_profile_button` shows.
- Restore the warning so admins/the person can see an unconfirmed email change from the roster, and add a leading icon so the pill reads as a *registration edit* action rather than a profile link.

### How did you approach the change?
- Reshaped the pill to a horizontal flex so the icon leads and the warning triangle trails, matching `person_profile_button`.
- Leading glyph: `fa-user-pen` in the `event_registrations` teal theme — the same icon the "Edit registration" page uses in its own header, so the button matches its destination. (Deliberately not `fa-ticket`, which is the app's ticket/cost glyph, nor a bare pencil.)
- Warning: icon + tooltip copied verbatim, gated by the same `show_email_change?` policy (admin-or-owner) rather than the roster's looser `show_email`.
- No N+1: the controller already preloads `registrant: [ :user, ... ]`.

### Anything else to add?
- The **yellow** email-change triangle is distinct from the existing **amber** duplicate-email triangle in the same cell (multiple registrants sharing an email).