### PR TITLE
Report real CE payments in the dashboard, revenue report, and CSVs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~80 files |
-| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~30 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display) | ~40 files |
 | `app/jobs/` | SolidQueue background jobs | 4 files |
 | `app/models/concerns/` | Shared model modules | 16 concerns |
 
@@ -186,7 +186,8 @@ end
 ### Business Logic
 
 - `EventDashboard` — Aggregates per-event dashboard metrics (registrant/org/sector/state/county counts, scholarship totals, payment received/outstanding/total)
-- `EventRevenueReport` — Cross-event revenue report grouped by calendar year (money in vs org subsidy vs net, projected CE, chart series) for the CEO revenue page
+- `EventRevenueReport` — Cross-event revenue report grouped by calendar year (money in vs org subsidy vs net, CE fees, chart series) for the CEO revenue page
+- `EventRevenueFigures` — Batch-loads the per-event money components `EventRevenueReport` rows are built from (registration payments/outstanding, funded/unfunded scholarships, discounts, CE paid/outstanding) in a fixed number of grouped queries; mirrors the `EventDashboard` definitions
 - `EventParticipationReport` — Cross-event participation report grouped by calendar year (unique people trained vs attended seats vs per-status outcome counts, chart series) for the events participation page; sibling of `EventRevenueReport`
 - `ReportPeriods` — Shared module (included by `EventRevenueReport` and `EventParticipationReport`) resolving the reporting-hub period toggle (this year / last year / all time) to a metric scope + label for the summary cards
 - `ScholarshipApplication` — Gathers one person's scholarship-application answers for an event by field across all their submissions, so answers surface whether captured on a dedicated scholarship form, an embedded registration section, or the registration submission itself (used by the scholarship edit page and the public submission view)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,12 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Dollar cell for a CSV export: the money helper's formatting when there's an
+  # amount, blank when there's nothing (so empty cells read cleanly).
+  def csv_dollars(cents)
+    cents.positive? ? helpers.dollars_from_cents(cents) : ""
+  end
+
   def after_sign_out_path_for(resource_or_scope)
     if params[:reset_password].present? # needed for custom "log out and reset it" flow
       new_user_password_path

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -368,10 +368,10 @@ class EventRegistrationsController < ApplicationController
           er.scholarships.completed.any? ? "Yes" : "No",
           cost_required ? er.payment_status_label : "",
           er.intends_to_pay? ? "Yes" : "No",
-          total_cents.positive? ? format("%.2f", total_cents / 100.0) : "",
+          csv_dollars(total_cents),
           er.ce_registered? ? er.ce_status_label.to_s : "",
-          er.ce_amount_paid_cents.positive? ? helpers.dollars_from_cents(er.ce_amount_paid_cents) : "",
-          er.ce_amount_due_cents.positive? ? helpers.dollars_from_cents(er.ce_amount_due_cents) : ""
+          csv_dollars(er.ce_amount_paid_cents),
+          csv_dollars(er.ce_amount_due_cents)
         ]
       end
     end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -10,7 +10,11 @@ class EventRegistrationsController < ApplicationController
     base_scope = authorized_scope(EventRegistration.all)
     filtered = base_scope.search_by_params(params)
     @event_registrations_count = filtered.size
-    @event_registrations = filtered.includes(registrant: [ :user, { avatar_attachment: :blob } ], event: :event_forms).paginate(page: params[:page], per_page: per_page)
+    includes = [ { registrant: [ :user, { avatar_attachment: :blob } ] }, { event: :event_forms } ]
+    # The scholarship/payment/CE cells are CSV-only, so preload what they read
+    # (per-row queries otherwise) without eager-loading it for the HTML index.
+    includes += [ :allocations, :scholarships, { continuing_education_registrations: [ :professional_license, :allocations ] } ] if request.format.csv?
+    @event_registrations = filtered.includes(includes).paginate(page: params[:page], per_page: per_page)
     @events = Event.order(start_date: :desc)
     @event_years = Event.where.not(start_date: nil).distinct.pluck(Arel.sql("YEAR(start_date)")).sort.reverse
     @organizations = authorized_scope(Organization.all, as: :affiliated).order(:name)
@@ -365,7 +369,7 @@ class EventRegistrationsController < ApplicationController
           e&.title.to_s,
           er.attendance_status_label,
           er.scholarships.any? ? "Yes" : "No",
-          er.scholarships.completed.any? ? "Yes" : "No",
+          er.scholarships.any?(&:tasks_completed?) ? "Yes" : "No",
           cost_required ? er.payment_status_label : "",
           er.intends_to_pay? ? "Yes" : "No",
           csv_dollars(total_cents),

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -10,9 +10,11 @@ class EventRegistrationsController < ApplicationController
     base_scope = authorized_scope(EventRegistration.all)
     filtered = base_scope.search_by_params(params)
     @event_registrations_count = filtered.size
-    includes = [ { registrant: [ :user, { avatar_attachment: :blob } ] }, { event: :event_forms } ]
-    # The scholarship/payment/CE cells are CSV-only, so preload what they read
-    # (per-row queries otherwise) without eager-loading it for the HTML index.
+    registrant_includes = [ :user, { avatar_attachment: :blob } ]
+    # The phone/scholarship/payment/CE cells are CSV-only, so preload what they
+    # read (per-row queries otherwise) without eager-loading it for the HTML index.
+    registrant_includes << :contact_methods if request.format.csv?
+    includes = [ { registrant: registrant_includes }, { event: :event_forms } ]
     includes += [ :allocations, :scholarships, { continuing_education_registrations: [ :professional_license, :allocations ] } ] if request.format.csv?
     @event_registrations = filtered.includes(includes).paginate(page: params[:page], per_page: per_page)
     @events = Event.order(start_date: :desc)

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -351,7 +351,7 @@ class EventRegistrationsController < ApplicationController
 
   def csv_export(registrations)
     CSV.generate(headers: true) do |csv|
-      csv << [ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total" ]
+      csv << [ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total", "CE status", "CE paid", "CE due" ]
       registrations.find_each do |er|
         r = er.registrant
         e = er.event
@@ -368,7 +368,10 @@ class EventRegistrationsController < ApplicationController
           er.scholarships.completed.any? ? "Yes" : "No",
           cost_required ? er.payment_status_label : "",
           er.intends_to_pay? ? "Yes" : "No",
-          total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
+          total_cents.positive? ? format("%.2f", total_cents / 100.0) : "",
+          er.ce_registered? ? er.ce_status_label.to_s : "",
+          er.ce_amount_paid_cents.positive? ? helpers.dollars_from_cents(er.ce_amount_paid_cents) : "",
+          er.ce_amount_due_cents.positive? ? helpers.dollars_from_cents(er.ce_amount_due_cents) : ""
         ]
       end
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -173,7 +173,7 @@ class EventsController < ApplicationController
     authorize! @event, to: :registrants?
     @event = @event.decorate
     scope = @event.event_registrations
-      .includes(:checklist_completions, :organizations, :allocations, :scholarships, :comments, { continuing_education_registrations: :professional_license }, registrant: [ :user, { affiliations: :organization } ])
+      .includes(:checklist_completions, :organizations, :allocations, :scholarships, :comments, { continuing_education_registrations: [ :professional_license, :allocations ] }, registrant: [ :user, { affiliations: :organization } ])
       .joins(:registrant)
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
 
@@ -553,7 +553,7 @@ class EventsController < ApplicationController
       person.phone_number.presence || "",
       org_names.presence || "",
       registration.scholarships.any? ? "Yes" : "No",
-      registration.scholarships.completed.any? ? "Yes" : "No",
+      registration.scholarships.any?(&:tasks_completed?) ? "Yes" : "No",
       payment_status,
       registration.intends_to_pay? ? "Yes" : "No",
       payment_total
@@ -608,7 +608,7 @@ class EventsController < ApplicationController
       row << helpers.dollars_from_cents(registration.payments_sum)
     end
     row << registration.fee_note.to_s
-    row << (registration.discount_sum.positive? ? helpers.dollars_from_cents(registration.discount_sum) : "")
+    row << csv_dollars(registration.discount_sum)
     row << (scholarship ? helpers.dollars_from_cents(scholarship.amount_cents) : "")
     row << (scholarship ? (scholarship.grant&.name.presence || "Unfunded") : "")
     row << onboarding_scholarship_tasks_csv(registration)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -529,7 +529,7 @@ class EventsController < ApplicationController
     cost_required = @event.cost_cents.to_i > 0
     include_ce = @event.ce_eligible?
     headers = [ "First name", "Last name", "Email", "Phone", "Organization", "Scholarship recipient", "Scholarship tasks completed", "Payment status", "Intends to pay", "Payment total" ]
-    headers << "CE status" if include_ce
+    headers += [ "CE status", "CE paid", "CE due" ] if include_ce
     CSV.generate(headers: headers, write_headers: true) do |csv_out|
       @event_registrations.each do |registration|
         csv_out << event_registration_csv_row(registration, cost_required, include_ce)
@@ -558,8 +558,18 @@ class EventsController < ApplicationController
       registration.intends_to_pay? ? "Yes" : "No",
       payment_total
     ]
-    row << registration.ce_status_label.to_s if include_ce
+    if include_ce
+      row << registration.ce_status_label.to_s
+      row << ce_dollars(registration.ce_amount_paid_cents)
+      row << ce_dollars(registration.ce_amount_due_cents)
+    end
     row
+  end
+
+  # CE dollar cell for a CSV: the money helper's formatting when there's an
+  # amount, blank when there's nothing (so empty cells read cleanly).
+  def ce_dollars(cents)
+    cents.positive? ? helpers.dollars_from_cents(cents) : ""
   end
 
   def onboarding_csv_string
@@ -571,7 +581,7 @@ class EventsController < ApplicationController
     headers += [ "Payment status", "Fees due", "Paid amount" ] if cost_required
     headers << "Fee note"
     headers += [ "Discounted amount", "Scholarship amount", "Scholarship grant", "Scholarship tasks completed" ]
-    headers += [ "CE requested", "CE hours", "CE amount", "CE license" ] if include_ce
+    headers += [ "CE requested", "CE hours", "CE amount", "CE paid", "CE due", "CE license" ] if include_ce
     headers += EventRegistration::CHECKLIST_STEPS.values
     headers += [ "Portal user status", "Portal access" ]
     headers += (1..day_count).map { |day| "Day #{day}" }
@@ -612,7 +622,9 @@ class EventsController < ApplicationController
       ce_hours = registration.ce_hours_total
       row << (registration.ce_registered? ? "Yes" : "No")
       row << (ce_hours.positive? ? helpers.plain_number(ce_hours) : "")
-      row << (registration.ce_amount_owed_cents.positive? ? helpers.dollars_from_cents(registration.ce_amount_owed_cents) : "")
+      row << ce_dollars(registration.ce_amount_owed_cents)
+      row << ce_dollars(registration.ce_amount_paid_cents)
+      row << ce_dollars(registration.ce_amount_due_cents)
       row << registration.ce_license_numbers.join("; ")
     end
     EventRegistration::CHECKLIST_STEPS.each_key do |step|

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -544,7 +544,7 @@ class EventsController < ApplicationController
       .map(&:organization).compact.uniq
     org_names = orgs.map(&:name).join("; ")
     total_cents = registration.allocations_sum
-    payment_total = total_cents.positive? ? format("%.2f", total_cents / 100.0) : ""
+    payment_total = csv_dollars(total_cents)
     payment_status = cost_required ? registration.payment_status_label : ""
     row = [
       person.first_name,
@@ -560,16 +560,10 @@ class EventsController < ApplicationController
     ]
     if include_ce
       row << registration.ce_status_label.to_s
-      row << ce_dollars(registration.ce_amount_paid_cents)
-      row << ce_dollars(registration.ce_amount_due_cents)
+      row << csv_dollars(registration.ce_amount_paid_cents)
+      row << csv_dollars(registration.ce_amount_due_cents)
     end
     row
-  end
-
-  # CE dollar cell for a CSV: the money helper's formatting when there's an
-  # amount, blank when there's nothing (so empty cells read cleanly).
-  def ce_dollars(cents)
-    cents.positive? ? helpers.dollars_from_cents(cents) : ""
   end
 
   def onboarding_csv_string
@@ -622,9 +616,9 @@ class EventsController < ApplicationController
       ce_hours = registration.ce_hours_total
       row << (registration.ce_registered? ? "Yes" : "No")
       row << (ce_hours.positive? ? helpers.plain_number(ce_hours) : "")
-      row << ce_dollars(registration.ce_amount_owed_cents)
-      row << ce_dollars(registration.ce_amount_paid_cents)
-      row << ce_dollars(registration.ce_amount_due_cents)
+      row << csv_dollars(registration.ce_amount_owed_cents)
+      row << csv_dollars(registration.ce_amount_paid_cents)
+      row << csv_dollars(registration.ce_amount_due_cents)
       row << registration.ce_license_numbers.join("; ")
     end
     EventRegistration::CHECKLIST_STEPS.each_key do |step|

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -175,7 +175,8 @@ class EventRegistration < ApplicationRecord
   # Filter by CE state. All derived (no stored CE status): payment (requested/paid)
   # is computed from allocations vs cost like the registration's own payment state;
   # issued/not_issued read the certificate delivery; needs_license is a CE
-  # registration sitting on a placeholder license.
+  # registration sitting on a placeholder license. "registered" adds no condition
+  # of its own — the EXISTS alone means "signed up for CE, whatever its state".
   scope :ce_status, ->(value) {
     paid_sql = <<~SQL.squish
       COALESCE((SELECT SUM(a.amount) FROM allocations a
@@ -184,6 +185,7 @@ class EventRegistration < ApplicationRecord
     SQL
     condition =
       case value
+      when "registered" then "TRUE"
       when "needs_license" then "pl.number IS NULL"
       when "paid" then paid_sql
       when "requested" then "NOT (#{paid_sql})"

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -478,6 +478,12 @@ class EventRegistration < ApplicationRecord
     continuing_education_registrations.sum { |c| c.remaining_cost }
   end
 
+  # CE cash collected across this registration's CE registrations (payments only,
+  # excluding discounts) — the CE analogue of payments_sum, for revenue reporting.
+  def ce_amount_paid_cents
+    continuing_education_registrations.sum { |c| c.payments_sum }
+  end
+
   # True only when every CE registration has a known license number on file.
   def ce_license_provided?
     return false unless ce_registered?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -239,14 +239,18 @@ class Person < ApplicationRecord
     organizations.pluck(:id)
   end
 
+  # The primary active phone, or the first one on file. Reads the loaded
+  # contact_methods when a caller has preloaded it (rosters, CSV exports), so a
+  # page or export of people doesn't pay a query per row.
   def phone_number
-    primary_phone = contact_methods.find_by(primary: true, inactive: false, kind: :phone)
-    return primary_phone.value if primary_phone.present?
+    phones =
+      if contact_methods.loaded?
+        contact_methods.to_a.select { |method| method.phone? && !method.inactive? }
+      else
+        contact_methods.where(kind: :phone, inactive: false).to_a
+      end
 
-    first_phone = contact_methods.where(kind: :phone, inactive: false).first
-    return first_phone.value if first_phone.present?
-
-    nil
+    (phones.find(&:primary?) || phones.first)&.value
   end
 
   def has_liasion_position_for?(organization_id)

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -103,12 +103,6 @@ class EventDashboard
     scholarships.where(grant_id: nil).sum(:amount_cents)
   end
 
-  # Registration cost waived via discounts — money the org gives up from its own
-  # pocket (like an unfunded scholarship).
-  def discount_cents
-    registration_allocations.where(source_type: "Discount").sum(:amount)
-  end
-
   def scholarship_recipient_count
     scholarships.distinct.count(:recipient_id)
   end

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -326,18 +326,57 @@ class EventDashboard
     @unpaid_registrants ||= people_sorted(registrants_for(active_registration_ids - paid_registration_ids))
   end
 
-  # Continuing-education fee: a flat per-registrant add-on. Not yet implemented —
-  # the fee amount and per-registration paid/outstanding tracking will arrive
-  # with a future migration. Stubbed to zero so the dashboard renders the
-  # section without depending on columns that don't exist yet.
-  def cont_ed_fee_cents = 0
-  def cont_ed_total_cents = 0
-  def cont_ed_paid_count = 0
-  def cont_ed_unpaid_count = 0
-  def cont_ed_paid_cents = 0
-  def cont_ed_outstanding_cents = 0
-  def cont_ed_paid_registrants = []
-  def cont_ed_unpaid_registrants = []
+  # --- Continuing-education fees ---------------------------------------------
+  # CE is billed per ContinuingEducationRegistration (its own cost_cents),
+  # separate from the registration fee. These mirror the registration-fee
+  # methods above: paid is CE cash collected, outstanding is CE cost still owed
+  # after every allocation, and the total (paid + outstanding) is the CE addend
+  # in the grand total. Scoped to CE registrations tied to an active event
+  # registration, so cancelled registrants' CE is ignored like their fees.
+
+  # CE cash collected across this event's active CE registrations.
+  def cont_ed_paid_cents
+    ce_payment_allocated_by_ce_registration.values.sum
+  end
+
+  # CE cost still owed after every allocation (payments and discounts), floored
+  # per registration at zero.
+  def cont_ed_outstanding_cents
+    ce_registrations.sum { |ce_registration| ce_due_cents(ce_registration) }
+  end
+
+  # CE fee revenue: collected plus outstanding. Mirrors registration_subtotal_cents,
+  # so the CE card's Paid + Due sub-rows reconcile with this headline.
+  def cont_ed_total_cents
+    cont_ed_paid_cents + cont_ed_outstanding_cents
+  end
+
+  # Registrants whose CE balance is fully covered vs those still owing.
+  def cont_ed_paid_count
+    ce_paid_registrant_ids.size
+  end
+
+  def cont_ed_unpaid_count
+    ce_unpaid_registrant_ids.size
+  end
+
+  def cont_ed_paid_registrants
+    @cont_ed_paid_registrants ||= people_sorted(ce_paid_registrant_ids)
+  end
+
+  def cont_ed_unpaid_registrants
+    @cont_ed_unpaid_registrants ||= people_sorted(ce_unpaid_registrant_ids)
+  end
+
+  # Per-registrant CE cash collected / still owed, keyed by Person id — the
+  # per-person figures on the CE card's Paid / Due rows. Each sums to its total.
+  def cont_ed_paid_by_registrant
+    @cont_ed_paid_by_registrant ||= ce_cents_by_registrant { |ce_registration| ce_paid_cents(ce_registration) }
+  end
+
+  def cont_ed_due_by_registrant
+    @cont_ed_due_by_registrant ||= ce_cents_by_registrant { |ce_registration| ce_due_cents(ce_registration) }
+  end
 
   def free?
     event.cost_cents.to_i <= 0
@@ -502,14 +541,9 @@ class EventDashboard
   # First continuing-education registration per registrant (Person id), for the
   # roster's CE column: its icon links to editing this record when present.
   def ce_registration_by_registrant
-    @ce_registration_by_registrant ||= begin
-      registrant_by_registration = active_registrations.to_h { |registration| [ registration.id, registration.registrant_id ] }
-      ContinuingEducationRegistration
-        .where(event_registration_id: active_registration_ids)
-        .each_with_object({}) do |ce_registration, map|
-          registrant_id = registrant_by_registration[ce_registration.event_registration_id]
-          map[registrant_id] ||= ce_registration if registrant_id
-        end
+    @ce_registration_by_registrant ||= ce_registrations.each_with_object({}) do |ce_registration, map|
+      registrant_id = registrant_id_by_registration[ce_registration.event_registration_id]
+      map[registrant_id] ||= ce_registration if registrant_id
     end
   end
 
@@ -990,6 +1024,67 @@ class EventDashboard
 
   def allocated_by_registration
     @allocated_by_registration ||= registration_allocations.group(:allocatable_id).sum(:amount)
+  end
+
+  # Active continuing-education registrations for this event: those tied to an
+  # active event registration. The basis for every CE money figure and for the
+  # CE registrant counts / pie.
+  def ce_registrations
+    @ce_registrations ||= ContinuingEducationRegistration
+      .where(event_registration_id: active_registration_ids)
+      .to_a
+  end
+
+  def ce_allocations
+    Allocation.where(allocatable_type: "ContinuingEducationRegistration", allocatable_id: ce_registrations.map(&:id))
+  end
+
+  # Allocations against this event's CE registrations, grouped by CE registration
+  # id: all sources (for outstanding) and payments only (for collected).
+  def ce_allocated_by_ce_registration
+    @ce_allocated_by_ce_registration ||= ce_allocations.group(:allocatable_id).sum(:amount)
+  end
+
+  def ce_payment_allocated_by_ce_registration
+    @ce_payment_allocated_by_ce_registration ||= ce_allocations
+      .where(source_type: "Payment")
+      .group(:allocatable_id)
+      .sum(:amount)
+  end
+
+  # CE cash collected on one CE registration (payment allocations only).
+  def ce_paid_cents(ce_registration)
+    ce_payment_allocated_by_ce_registration.fetch(ce_registration.id, 0)
+  end
+
+  # CE cost still owed on one CE registration after every allocation, floored at zero.
+  def ce_due_cents(ce_registration)
+    [ ce_registration.cost_cents.to_i - ce_allocated_by_ce_registration.fetch(ce_registration.id, 0), 0 ].max
+  end
+
+  # Registrant (Person) ids with at least one CE registration still owing.
+  def ce_unpaid_registrant_ids
+    @ce_unpaid_registrant_ids ||= ce_registrations
+      .select { |ce_registration| ce_due_cents(ce_registration).positive? }
+      .filter_map { |ce_registration| registrant_id_by_registration[ce_registration.event_registration_id] }
+      .uniq
+  end
+
+  # Registrants with CE whose whole CE balance is covered — everyone with CE
+  # minus those with any unpaid CE registration.
+  def ce_paid_registrant_ids
+    @ce_paid_registrant_ids ||= ce_registrant_ids - ce_unpaid_registrant_ids
+  end
+
+  # Roll a per-CE-registration cents figure (from the block) up to a
+  # { Person id => cents } hash, dropping zeros.
+  def ce_cents_by_registrant
+    ce_registrations.each_with_object(Hash.new(0)) do |ce_registration, map|
+      registrant_id = registrant_id_by_registration[ce_registration.event_registration_id]
+      next unless registrant_id
+      cents = yield(ce_registration)
+      map[registrant_id] += cents if cents.positive?
+    end
   end
 
   # Payments tied to this event's bulk payment form submissions. Scoped by the

--- a/app/services/event_revenue_figures.rb
+++ b/app/services/event_revenue_figures.rb
@@ -1,0 +1,126 @@
+# Per-event money components for the revenue report, loaded for every event at
+# once in a fixed number of grouped queries instead of an EventDashboard (and its
+# ~8 queries) per event.
+#
+# The definitions mirror EventDashboard's — active registrations only, cost net of
+# every allocation and floored at zero, payment allocations for cash collected —
+# so a row in the report and that event's dashboard can't disagree. A parity spec
+# holds the two together.
+#
+# One definition is broader than the dashboard's: discounts cover CE registrations
+# too, not just event registrations. CE cost is only ever paid, discounted, or
+# owed, so counting CE discounts as org subsidy is what keeps a discounted CE fee
+# from vanishing from the report entirely.
+class EventRevenueFigures
+  Figures = Struct.new(
+    :registration_payments_cents,
+    :registration_outstanding_cents,
+    :funded_scholarship_cents,
+    :unfunded_scholarship_cents,
+    :discount_cents,
+    :ce_paid_cents,
+    :ce_outstanding_cents,
+    keyword_init: true
+  )
+
+  EMPTY = Figures.new(
+    registration_payments_cents: 0,
+    registration_outstanding_cents: 0,
+    funded_scholarship_cents: 0,
+    unfunded_scholarship_cents: 0,
+    discount_cents: 0,
+    ce_paid_cents: 0,
+    ce_outstanding_cents: 0
+  ).freeze
+
+  def initialize(events)
+    @events = events.to_a
+  end
+
+  def for(event)
+    figures_by_event_id.fetch(event.id, EMPTY)
+  end
+
+  private
+
+  def figures_by_event_id
+    @figures_by_event_id ||= @events.to_h { |event| [ event.id, build(event) ] }
+  end
+
+  def build(event)
+    registration_ids = registration_ids_by_event.fetch(event.id, [])
+    cost_cents = event.cost_cents.to_i
+    ce_rows = registration_ids.flat_map { |id| ce_rows_by_registration.fetch(id, []) }
+    scholarships = registration_ids.flat_map { |id| scholarship_rows_by_registration.fetch(id, []) }
+
+    Figures.new(
+      registration_payments_cents: registration_ids.sum { |id| registration_allocations[[ id, "Payment" ]].to_i },
+      registration_outstanding_cents: registration_ids.sum { |id| [ cost_cents - registration_allocated_total[id], 0 ].max },
+      funded_scholarship_cents: scholarships.sum { |grant_id, amount_cents| grant_id ? amount_cents : 0 },
+      unfunded_scholarship_cents: scholarships.sum { |grant_id, amount_cents| grant_id ? 0 : amount_cents },
+      discount_cents: registration_ids.sum { |id| registration_allocations[[ id, "Discount" ]].to_i } +
+        ce_rows.sum { |ce_id, _cost| ce_allocations[[ ce_id, "Discount" ]].to_i },
+      ce_paid_cents: ce_rows.sum { |ce_id, _cost| ce_allocations[[ ce_id, "Payment" ]].to_i },
+      ce_outstanding_cents: ce_rows.sum { |ce_id, cost| [ cost.to_i - ce_allocated_total[ce_id], 0 ].max }
+    )
+  end
+
+  # { event_id => [ registration_id, ... ] } across every event in the report.
+  def registration_ids_by_event
+    @registration_ids_by_event ||= EventRegistration
+      .active
+      .where(event_id: @events.map(&:id))
+      .pluck(:event_id, :id)
+      .each_with_object({}) { |(event_id, id), map| (map[event_id] ||= []) << id }
+  end
+
+  def registration_ids
+    @registration_ids ||= registration_ids_by_event.values.flatten
+  end
+
+  # { registration_id => [ [ ce_registration_id, cost_cents ], ... ] }.
+  def ce_rows_by_registration
+    @ce_rows_by_registration ||= ContinuingEducationRegistration
+      .where(event_registration_id: registration_ids)
+      .pluck(:event_registration_id, :id, :cost_cents)
+      .each_with_object({}) { |(registration_id, id, cost), map| (map[registration_id] ||= []) << [ id, cost ] }
+  end
+
+  # { registration_id => [ [ grant_id, amount_cents ], ... ] }.
+  def scholarship_rows_by_registration
+    @scholarship_rows_by_registration ||= Scholarship
+      .joins(:allocation)
+      .where(allocations: { allocatable_type: "EventRegistration", allocatable_id: registration_ids })
+      .pluck(Arel.sql("allocations.allocatable_id"), :grant_id, :amount_cents)
+      .each_with_object({}) { |(registration_id, grant_id, amount), map| (map[registration_id] ||= []) << [ grant_id, amount ] }
+  end
+
+  # { [ allocatable_id, source_type ] => cents } for each allocatable kind, plus
+  # the same sums collapsed to { allocatable_id => cents } across every source.
+  def registration_allocations
+    @registration_allocations ||= allocation_sums("EventRegistration", registration_ids)
+  end
+
+  def ce_allocations
+    @ce_allocations ||= allocation_sums("ContinuingEducationRegistration", ce_rows_by_registration.values.flatten(1).map(&:first))
+  end
+
+  def registration_allocated_total
+    @registration_allocated_total ||= totals_by_allocatable(registration_allocations)
+  end
+
+  def ce_allocated_total
+    @ce_allocated_total ||= totals_by_allocatable(ce_allocations)
+  end
+
+  def allocation_sums(allocatable_type, allocatable_ids)
+    Allocation
+      .where(allocatable_type: allocatable_type, allocatable_id: allocatable_ids)
+      .group(:allocatable_id, :source_type)
+      .sum(:amount)
+  end
+
+  def totals_by_allocatable(sums)
+    sums.each_with_object(Hash.new(0)) { |((id, _source_type), amount), map| map[id] += amount }
+  end
+end

--- a/app/services/event_revenue_report.rb
+++ b/app/services/event_revenue_report.rb
@@ -2,37 +2,35 @@
 # org subsidized from its own pocket, and the net — per event, grouped by
 # calendar year for an over-time view and annual-report figures.
 #
-# Money in   = registration payments collected + projected CE + grant-funded
-#              scholarships (grant money the org received).
+# Money in   = registration payments collected + CE payments collected +
+#              grant-funded scholarships (grant money the org received).
 # Org subsidy = unfunded scholarships + discounts (cost the org absorbs).
 # Net         = money in - org subsidy.
 #
-# Projected CE is the CE fees owed across active registrants (each CE
-# registration's own cost), flagged in the UI. It's counted in money in (and
-# therefore net) per the report's definition, and treated as outstanding — CE
-# payments collected aren't netted out here yet.
+# CE fees are billed per ContinuingEducationRegistration. CE cash collected
+# counts as fees (money in); CE cost still owed counts as outstanding. Both come
+# from EventDashboard so the per-event figures agree with the event dashboard.
 class EventRevenueReport
   # Raw per-event component figures, with the bucket totals derived from them.
   Row = Struct.new(
     :event,
     :registration_payments_cents,
-    :ce_projected_cents,
+    :ce_paid_cents,
+    :ce_outstanding_cents,
     :funded_scholarship_cents,
     :unfunded_scholarship_cents,
     :discount_cents,
     :registration_outstanding_cents,
     keyword_init: true
   ) do
-    # Fees actually collected: registration payments plus CE paid. CE payments
-    # aren't netted here yet, so the CE portion is $0 today.
+    # Fees actually collected: registration payments plus CE cash collected.
     def fees_cents
-      registration_payments_cents
+      registration_payments_cents + ce_paid_cents
     end
 
-    # Fees still owed: unpaid registration cost plus projected CE (none of which
-    # is collected yet).
+    # Fees still owed: unpaid registration cost plus CE cost not yet collected.
     def outstanding_cents
-      registration_outstanding_cents + ce_projected_cents
+      registration_outstanding_cents + ce_outstanding_cents
     end
 
     # Money that's in or counted toward revenue: collected fees plus grant-funded
@@ -63,7 +61,7 @@ class EventRevenueReport
   # The figures that get summed — raw components plus derived buckets — so a year
   # subtotal or the grand total is just a sum over rows.
   SUMMABLE = %i[
-    registration_payments_cents ce_projected_cents funded_scholarship_cents
+    registration_payments_cents ce_paid_cents ce_outstanding_cents funded_scholarship_cents
     unfunded_scholarship_cents discount_cents registration_outstanding_cents
     fees_cents outstanding_cents money_in_cents org_subsidy_cents net_cents total_expected_cents
   ].freeze
@@ -151,22 +149,13 @@ class EventRevenueReport
     Row.new(
       event: event,
       registration_payments_cents: dashboard.received_cents,
-      ce_projected_cents: ce_projected_cents_for(event),
+      ce_paid_cents: dashboard.cont_ed_paid_cents,
+      ce_outstanding_cents: dashboard.cont_ed_outstanding_cents,
       funded_scholarship_cents: dashboard.funded_scholarship_cents,
       unfunded_scholarship_cents: dashboard.unfunded_scholarship_cents,
       discount_cents: dashboard.discount_cents,
       registration_outstanding_cents: dashboard.outstanding_cents
     )
-  end
-
-  # Projected CE revenue: the CE fees owed across this event's active registrants
-  # — each ContinuingEducationRegistration's own cost. Treated as outstanding, not
-  # netted against any CE payments collected.
-  def ce_projected_cents_for(event)
-    ContinuingEducationRegistration
-      .joins(:event_registration)
-      .where(event_registrations: { event_id: event.id, status: EventRegistration::ACTIVE_STATUSES })
-      .sum(:cost_cents)
   end
 
   def to_dollars(cents)

--- a/app/services/event_revenue_report.rb
+++ b/app/services/event_revenue_report.rb
@@ -8,8 +8,10 @@
 # Net         = money in - org subsidy.
 #
 # CE fees are billed per ContinuingEducationRegistration. CE cash collected
-# counts as fees (money in); CE cost still owed counts as outstanding. Both come
-# from EventDashboard so the per-event figures agree with the event dashboard.
+# counts as fees (money in), CE cost still owed counts as outstanding, and a CE
+# discount is org subsidy like any other. Every component comes from
+# EventRevenueFigures, which loads them for all events at once and mirrors the
+# EventDashboard definitions so a row agrees with that event's dashboard.
 class EventRevenueReport
   # Raw per-event component figures, with the bucket totals derived from them.
   Row = Struct.new(
@@ -87,7 +89,10 @@ class EventRevenueReport
   end
 
   def rows
-    @rows ||= @events.map { |event| build_row(event) }
+    @rows ||= begin
+      figures = EventRevenueFigures.new(@events)
+      @events.map { |event| build_row(event, figures.for(event)) }
+    end
   end
 
   def any?
@@ -144,17 +149,16 @@ class EventRevenueReport
     @years_by_value ||= years.index_by(&:year)
   end
 
-  def build_row(event)
-    dashboard = EventDashboard.new(event)
+  def build_row(event, figures)
     Row.new(
       event: event,
-      registration_payments_cents: dashboard.received_cents,
-      ce_paid_cents: dashboard.cont_ed_paid_cents,
-      ce_outstanding_cents: dashboard.cont_ed_outstanding_cents,
-      funded_scholarship_cents: dashboard.funded_scholarship_cents,
-      unfunded_scholarship_cents: dashboard.unfunded_scholarship_cents,
-      discount_cents: dashboard.discount_cents,
-      registration_outstanding_cents: dashboard.outstanding_cents
+      registration_payments_cents: figures.registration_payments_cents,
+      ce_paid_cents: figures.ce_paid_cents,
+      ce_outstanding_cents: figures.ce_outstanding_cents,
+      funded_scholarship_cents: figures.funded_scholarship_cents,
+      unfunded_scholarship_cents: figures.unfunded_scholarship_cents,
+      discount_cents: figures.discount_cents,
+      registration_outstanding_cents: figures.registration_outstanding_cents
     )
   end
 

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -36,7 +36,7 @@
 
     <% if @ce_eligible %>
       <%= render "events/filter_select", param: :ce_status, label: "CE status",
-            options: [ [ "Needs license", "needs_license" ], [ "Requested", "requested" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
+            options: [ [ "Registered for CE", "registered" ], [ "Needs license", "needs_license" ], [ "Requested", "requested" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
             selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
     <% end %>
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -38,8 +38,10 @@
     </div>
   </div>
 
-  <%# Money cards (paid events only) — shown first %>
-  <% if @dashboard.free? %>
+  <%# Money cards — shown first. Hidden only when there's genuinely no money:
+      free registration AND no CE fees or scholarships (a free event can still
+      charge for CE). %>
+  <% if @dashboard.free? && @dashboard.cont_ed_total_cents.zero? && @dashboard.scholarship_total_cents.zero? %>
     <div class="bg-white rounded-xl border border-gray-200 p-4 text-center text-sm text-gray-500 mb-4">
       <i class="fa-solid fa-tag text-gray-400 mr-1"></i> Free event — no payments or scholarships
     </div>
@@ -221,9 +223,9 @@
               </div>
               <%= link_to registrants_event_path(@event),
                     class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
-                    title: "View all registrants" do %>
+                    title: "View registrants with continuing education" do %>
                 <i class="fa-solid fa-users text-gray-400"></i>
-                <%= pluralize(@dashboard.registrant_count, "registrant") %>
+                <%= pluralize(@dashboard.ce_registrant_count, "registrant") %>
               <% end %>
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
@@ -239,12 +241,14 @@
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.cont_ed_paid_cents,
                   count: @dashboard.cont_ed_paid_count, registrants: @dashboard.cont_ed_paid_registrants,
+                  amounts_by_registrant_id: @dashboard.cont_ed_paid_by_registrant,
                   filter_path: registrants_event_path(@event, ce_status: "paid") %>
             <%= render "dashboard_money_row", label: "Due", icon: "fa-hourglass-half",
                   icon_color: @dashboard.cont_ed_unpaid_count.positive? ? "text-white" : "text-gray-400",
                   icon_bg: @dashboard.cont_ed_unpaid_count.positive? ? "bg-orange-500" : nil,
                   amount_cents: @dashboard.cont_ed_outstanding_cents,
                   count: @dashboard.cont_ed_unpaid_count, registrants: @dashboard.cont_ed_unpaid_registrants,
+                  amounts_by_registrant_id: @dashboard.cont_ed_due_by_registrant,
                   filter_path: registrants_event_path(@event, ce_status: "requested") %>
           </div>
         </details>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -91,7 +91,7 @@
                 <p class="hidden lg:block text-xs text-gray-500">Scholarships</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
-              <%= link_to registrants_event_path(@event), class: "#{addend_class.call(:continuing_education)} whitespace-nowrap", title: "Manage registrants" do %>
+              <%= link_to registrants_event_path(@event, ce_status: "registered"), class: "#{addend_class.call(:continuing_education)} whitespace-nowrap", title: "View registrants with continuing education" do %>
                 <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></p>
                 <p class="hidden lg:block text-xs text-gray-500">CE fees</p>
               <% end %>
@@ -221,7 +221,7 @@
                 <i class="fa-solid fa-award"></i>
                 <span>CE fees</span>
               </div>
-              <%= link_to registrants_event_path(@event),
+              <%= link_to registrants_event_path(@event, ce_status: "registered"),
                     class: "inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:border-gray-300 hover:text-gray-800 transition-colors",
                     title: "View registrants with continuing education" do %>
                 <i class="fa-solid fa-users text-gray-400"></i>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -135,11 +135,12 @@
                     <dl class="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm py-2">
                       <% columns = [
                            [ [ "Registration payments", row.registration_payments_cents, "text-gray-800" ],
-                             [ "Projected CE*", row.ce_projected_cents, ce_class ] ],
+                             [ "CE paid", row.ce_paid_cents, ce_class ] ],
                            [ [ "Funded scholarships", row.funded_scholarship_cents, "text-gray-800" ],
-                             [ "Unfunded scholarships", row.unfunded_scholarship_cents, "text-gray-800" ] ],
-                           [ [ "Discounts", row.discount_cents, "text-gray-800" ],
-                             [ "Registration owed", row.registration_outstanding_cents, "text-orange-600" ] ]
+                             [ "Unfunded scholarships", row.unfunded_scholarship_cents, "text-gray-800" ],
+                             [ "Discounts", row.discount_cents, "text-gray-800" ] ],
+                           [ [ "Registration owed", row.registration_outstanding_cents, "text-orange-600" ],
+                             [ "CE owed", row.ce_outstanding_cents, "text-orange-600" ] ]
                          ] %>
                       <% columns.each do |pair| %>
                         <div class="space-y-1.5">
@@ -178,8 +179,6 @@
           <span class="font-medium">Outstanding</span> = registration + CE still owed.
           <span class="font-medium">Net</span> = fees collected + scholarships − org subsidy.
           <span class="font-medium">Total expected</span> = net once all outstanding is paid.
-          <br>
-          * Outstanding includes projected CE — the CE fees owed by active registrants — not yet netted against CE payments collected.
         </p>
       </section>
     <% else %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -51,7 +51,7 @@
           <%= render "revenue_kpi", label: "Org subsidy", value: dollars_from_cents(featured.org_subsidy_cents),
                 value_class: "text-red-600", card_class: "border-red-300 bg-red-50", note: "discounts + unfunded", cents: featured.org_subsidy_cents,
                 prior_cents: prior&.org_subsidy_cents, prior_year: prior&.year %>
-          <%= render "revenue_kpi", label: "Outstanding*", value: dollars_from_cents(featured.outstanding_cents),
+          <%= render "revenue_kpi", label: "Outstanding", value: dollars_from_cents(featured.outstanding_cents),
                 value_class: "text-orange-600", card_class: "border-orange-300 bg-orange-50", note: "reg + CE owed", cents: featured.outstanding_cents,
                 prior_cents: prior&.outstanding_cents, prior_year: prior&.year %>
           <%= render "revenue_kpi", label: "Net", value: signed_dollars_from_cents(featured.net_cents),
@@ -90,7 +90,7 @@
           <div class="text-right">Fees collected</div>
           <div class="text-right">Scholarships</div>
           <div class="text-right">Org subsidy</div>
-          <div class="text-right">Outstanding*</div>
+          <div class="text-right">Outstanding</div>
           <div class="text-right">Total expected</div>
         </div>
 

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -353,6 +353,12 @@ RSpec.describe EventRegistration, type: :model do
       end
       let!(:no_ce) { create(:event_registration, event: event) }
 
+      it "maps 'registered' to everyone signed up for CE, whatever its state" do
+        results = EventRegistration.ce_status("registered")
+        expect(results).to include(paid_ce, requested_ce, needs_license_ce, issued_ce)
+        expect(results).not_to include(no_ce)
+      end
+
       it "maps 'needs_license' to CE on a placeholder license" do
         results = EventRegistration.ce_status("needs_license")
         expect(results).to include(needs_license_ce)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -267,6 +267,43 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe "#phone_number" do
+    let(:person) { create(:person) }
+
+    def add_phone(value, primary: false, inactive: false, kind: "phone")
+      ContactMethod.create!(contactable: person, kind: kind, value: value, primary: primary, inactive: inactive)
+    end
+
+    # The same answer whether the caller preloaded contact_methods or not — the
+    # loaded branch exists only to spare a query per row on rosters and exports.
+    def phone_numbers
+      [ person.reload.phone_number, Person.includes(:contact_methods).find(person.id).phone_number ]
+    end
+
+    it "returns nil with no phone on file" do
+      add_phone("nope", kind: "sms")
+      expect(phone_numbers).to all(be_nil)
+    end
+
+    it "prefers the primary phone over the others" do
+      add_phone("555-0001")
+      add_phone("555-0002", primary: true)
+      expect(phone_numbers).to all(eq("555-0002"))
+    end
+
+    it "falls back to the first phone when none is primary" do
+      add_phone("555-0001")
+      add_phone("555-0002")
+      expect(phone_numbers).to all(eq("555-0001"))
+    end
+
+    it "ignores inactive phones, including an inactive primary" do
+      add_phone("555-0001", primary: true, inactive: true)
+      add_phone("555-0002")
+      expect(phone_numbers).to all(eq("555-0002"))
+    end
+  end
+
   describe "#primary_organization" do
     let(:person) { create(:person) }
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -130,6 +130,31 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(data_rows).to include(expected_row)
       end
 
+      # The CE, scholarship, payment and phone cells each used to query per row;
+      # they're preloaded for the CSV only, so the export stays flat.
+      it "exports without querying per registration" do
+        add_registration = lambda do
+          registration = create(:event_registration, event: event, registrant: create(:person))
+          ce = create(:continuing_education_registration, event_registration: registration, cost_cents: 5_000)
+          create(:allocation, source: create(:payment, amount_cents: 2_000, amount_cents_remaining: 2_000),
+                              allocatable: ce, amount: 2_000)
+          ContactMethod.create!(contactable: registration.registrant, kind: "phone", value: "555-0100")
+        end
+        query_count = lambda do
+          count = 0
+          counter = ->(_name, _start, _finish, _id, payload) { count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/) }
+          ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { get event_registrations_path(format: :csv) }
+          count
+        end
+
+        add_registration.call
+        get event_registrations_path(format: :csv) # warm up: the first request of a session also loads the signed-in user
+        baseline = query_count.call
+        3.times { add_registration.call }
+
+        expect(query_count.call).to eq(baseline)
+      end
+
       context "registration form icon" do
         let(:reg_form) { create(:form, :standalone, name: "Registration Form") }
         let(:person) { existing_registration.registrant }

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "EventRegistrations", type: :request do
 
         rows = CSV.parse(response.body)
         expect(rows.size).to be >= 1
-        expect(rows.first).to eq([ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total" ])
+        expect(rows.first).to eq([ "First name", "Last name", "Email", "Phone", "Event", "Status", "Scholarship", "Scholarship completed", "Payment status", "Intends to pay", "Payment total", "CE status", "CE paid", "CE due" ])
 
         data_rows = rows.drop(1)
         expect(data_rows).not_to be_empty
@@ -122,6 +122,9 @@ RSpec.describe "EventRegistrations", type: :request do
           "No",
           "Due",
           "No",
+          "",
+          "",
+          "",
           ""
         ]
         expect(data_rows).to include(expected_row)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1615,7 +1615,7 @@ RSpec.describe "Events", type: :request do
       expect(response.media_type).to eq("text/csv")
       expect(response.body).to include("First name,Last name,Email")
       expect(response.body).to include("Mailchimp")
-      expect(response.body).to include("CE requested,CE hours,CE amount,CE license")
+      expect(response.body).to include("CE requested,CE hours,CE amount,CE paid,CE due,CE license")
       expect(response.body).to include("Portal user status,Portal access")
       expect(response.body).to include("Comments,Flagged comments")
       expect(response.body).to include("Ready")
@@ -1668,6 +1668,21 @@ RSpec.describe "Events", type: :request do
 
       expect(paid_amount).to eq("$5")        # the $5 payment, NOT the $15 scholarship
       expect(scholarship_amount).to eq("$15")
+    end
+
+    it "reports CE paid and CE due from CE payments" do
+      ce = create(:continuing_education_registration, event_registration: registration, cost_cents: 6_000)
+      create(:allocation, source: create(:payment, amount_cents: 5_000, amount_cents_remaining: 5_000),
+                          allocatable: ce, amount: 5_000)
+
+      get onboarding_event_path(event, format: :csv)
+
+      rows = CSV.parse(response.body)
+      headers = rows.first
+      row = rows.find { |r| r[1] == person.last_name }
+
+      expect(row[headers.index("CE paid")]).to eq("$50")   # $50 collected
+      expect(row[headers.index("CE due")]).to eq("$10")    # $10 still owed
     end
 
     it "redirects a non-admin" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1786,6 +1786,15 @@ RSpec.describe "Events", type: :request do
         expect(page).to have_link(href: registrants_event_path(event, status_filter: "inactive"), visible: :all)
       end
 
+      it "drills the CE card into the registrants filtered to continuing education" do
+        create(:continuing_education_registration, event_registration: registration, cost_cents: 6_000)
+
+        get dashboard_event_path(event)
+
+        page = Capybara.string(response.body)
+        expect(page).to have_link(href: registrants_event_path(event, ce_status: "registered"), visible: :all)
+      end
+
       it "shows a program status badge next to each organization" do
         get dashboard_event_path(event)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe "Events", type: :request do
     target_event
   end
 
+  def query_count
+    count = 0
+    counter = ->(_name, _start, _finish, _id, payload) { count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/) }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { yield }
+    count
+  end
+
+  # A registrant carrying every column the CSV exports read per row: a phone, a
+  # partly paid CE registration, and the allocations behind the money cells.
+  def add_ce_registrant(target_event)
+    registration = create(:event_registration, event: target_event, registrant: create(:person), status: "registered")
+    ce = create(:continuing_education_registration, event_registration: registration, cost_cents: 5_000)
+    create(:allocation, source: create(:payment, amount_cents: 2_000, amount_cents_remaining: 2_000),
+                        allocatable: ce, amount: 2_000)
+    ContactMethod.create!(contactable: registration.registrant, kind: "phone", value: "555-0100")
+    registration
+  end
+
   let(:valid_params) do
     {
       event: {
@@ -1439,6 +1457,21 @@ RSpec.describe "Events", type: :request do
       get registrants_event_path(event, format: :csv)
       expect(response.body).to include("CE status")
       expect(response.body).to include("Needs license")
+    end
+
+    # Every cell the exports read is preloaded, so a bigger roster costs no more
+    # queries than a small one. Guards the CE, scholarship, payment and phone
+    # columns, each of which used to query per row.
+    %i[registrants onboarding].each do |action|
+      it "exports the #{action} CSV without querying per registrant" do
+        path = public_send(:"#{action}_event_path", event, format: :csv)
+        add_ce_registrant(event)
+        get path # warm up: the first request of a session also loads the signed-in user
+        baseline = query_count { get path }
+        3.times { add_ce_registrant(event) }
+
+        expect(query_count { get path }).to eq(baseline)
+      end
     end
   end
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -667,29 +667,81 @@ RSpec.describe EventDashboard do
     end
   end
 
-  # Continuing-education fees are stubbed to zero until the feature (and its
-  # migration) lands. The dashboard still renders the section, showing $0.
-  describe "continuing-education fees (stubbed)" do
-    let(:event) { create(:event, cost_cents: 10_000) }
+  # CE fees are billed per ContinuingEducationRegistration and flow through the
+  # generic payment/allocation system. The event is free-registration to isolate
+  # CE money (and prove CE still reports on a free event). Cancelled registrants'
+  # CE is ignored, like their registration fees.
+  describe "continuing-education fees" do
+    let(:event) { create(:event, cost_cents: 0) }
+    let(:paid_person) { create(:person) }
+    let(:partial_person) { create(:person) }
+    let(:unpaid_person) { create(:person) }
+
+    let!(:paid_reg) { create(:event_registration, event: event, registrant: paid_person, status: "registered") }
+    let!(:partial_reg) { create(:event_registration, event: event, registrant: partial_person, status: "registered") }
+    let!(:unpaid_reg) { create(:event_registration, event: event, registrant: unpaid_person, status: "registered") }
 
     before do
-      create(:event_registration, event: event, registrant: create(:person), status: "registered")
+      ce_paid = create(:continuing_education_registration, event_registration: paid_reg, cost_cents: 10_000)
+      create(:allocation, source: create(:payment, amount_cents: 10_000, amount_cents_remaining: 10_000),
+                          allocatable: ce_paid, amount: 10_000)
+
+      ce_partial = create(:continuing_education_registration, event_registration: partial_reg, cost_cents: 8_000)
+      create(:allocation, source: create(:payment, amount_cents: 3_000, amount_cents_remaining: 3_000),
+                          allocatable: ce_partial, amount: 3_000)
+
+      create(:continuing_education_registration, event_registration: unpaid_reg, cost_cents: 6_000)
+
+      cancelled = create(:event_registration, event: event, registrant: create(:person), status: "cancelled")
+      ce_cancelled = create(:continuing_education_registration, event_registration: cancelled, cost_cents: 20_000)
+      create(:allocation, source: create(:payment, amount_cents: 20_000, amount_cents_remaining: 20_000),
+                          allocatable: ce_cancelled, amount: 20_000)
     end
 
-    it "reports zero across totals, splits, and registrant lists" do
-      expect(dashboard.cont_ed_total_cents).to eq(0)
-      expect(dashboard.cont_ed_paid_cents).to eq(0)
-      expect(dashboard.cont_ed_outstanding_cents).to eq(0)
-      expect(dashboard.cont_ed_paid_count).to eq(0)
-      expect(dashboard.cont_ed_unpaid_count).to eq(0)
-      expect(dashboard.cont_ed_paid_registrants).to be_empty
-      expect(dashboard.cont_ed_unpaid_registrants).to be_empty
+    it "sums CE cash collected across active CE registrations" do
+      expect(dashboard.cont_ed_paid_cents).to eq(13_000)
     end
 
-    it "adds nothing to the grand total" do
+    it "sums CE cost still owed after allocations" do
+      expect(dashboard.cont_ed_outstanding_cents).to eq(11_000)
+    end
+
+    it "reports CE total as paid plus outstanding" do
+      expect(dashboard.cont_ed_total_cents).to eq(24_000)
+    end
+
+    it "counts registrants whose CE is fully paid vs still owing" do
+      expect(dashboard.cont_ed_paid_count).to eq(1)
+      expect(dashboard.cont_ed_unpaid_count).to eq(2)
+    end
+
+    it "lists the registrants behind each CE bucket" do
+      expect(dashboard.cont_ed_paid_registrants).to contain_exactly(paid_person)
+      expect(dashboard.cont_ed_unpaid_registrants).to contain_exactly(partial_person, unpaid_person)
+    end
+
+    it "maps each registrant to their CE paid / due amounts, reconciling with the totals" do
+      expect(dashboard.cont_ed_paid_by_registrant[paid_person.id]).to eq(10_000)
+      expect(dashboard.cont_ed_paid_by_registrant[partial_person.id]).to eq(3_000)
+      expect(dashboard.cont_ed_paid_by_registrant.values.sum).to eq(dashboard.cont_ed_paid_cents)
+
+      expect(dashboard.cont_ed_due_by_registrant[partial_person.id]).to eq(5_000)
+      expect(dashboard.cont_ed_due_by_registrant[unpaid_person.id]).to eq(6_000)
+      expect(dashboard.cont_ed_due_by_registrant.values.sum).to eq(dashboard.cont_ed_outstanding_cents)
+    end
+
+    it "counts distinct registrants with continuing education" do
+      expect(dashboard.ce_registrant_count).to eq(3)
+    end
+
+    it "adds CE fees to the grand total and cash breakdown" do
       expect(dashboard.grand_total_cents).to eq(
-        dashboard.scholarship_total_cents + dashboard.received_cents + dashboard.outstanding_cents
+        dashboard.registration_subtotal_cents + dashboard.scholarship_total_cents +
+          dashboard.cont_ed_total_cents + dashboard.unallocated_bulk_payment_cents
       )
+      expect(dashboard.grand_total_cents).to eq(24_000)
+      expect(dashboard.collected_cents).to eq(13_000)
+      expect(dashboard.due_cents).to eq(11_000)
     end
   end
 

--- a/spec/services/event_revenue_figures_spec.rb
+++ b/spec/services/event_revenue_figures_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe EventRevenueFigures do
+  # One event carrying every money shape the report reads: payments, a funded and
+  # an unfunded scholarship, a registration discount, paid / partly paid / unpaid
+  # CE, a comped CE fee, and a cancelled registration whose money must be ignored.
+  let(:event) { create(:event, cost_cents: 10_000) }
+  let(:person1) { create(:person) }
+  let(:person2) { create(:person) }
+
+  let!(:reg1) { create(:event_registration, event: event, registrant: person1, status: "registered") }
+  let!(:reg2) { create(:event_registration, event: event, registrant: person2, status: "registered") }
+
+  before do
+    create(:allocation, source: create(:payment, amount_cents: 6_000, amount_cents_remaining: 6_000),
+                        allocatable: reg1, amount: 6_000)
+    funded = create(:scholarship, recipient: person1, amount_cents: 4_000, grant: create(:grant))
+    create(:allocation, source: funded, allocatable: reg1, amount: 4_000)
+
+    create(:allocation, source: create(:payment, amount_cents: 3_000, amount_cents_remaining: 3_000),
+                        allocatable: reg2, amount: 3_000)
+    unfunded = create(:scholarship, recipient: person2, amount_cents: 2_000, grant: nil)
+    create(:allocation, source: unfunded, allocatable: reg2, amount: 2_000)
+    create(:allocation, source: create(:discount, amount_cents: 1_000), allocatable: reg2, amount: 1_000)
+
+    ce_paid = create(:continuing_education_registration, event_registration: reg1, cost_cents: 7_500)
+    create(:allocation, source: create(:payment, amount_cents: 7_500, amount_cents_remaining: 7_500),
+                        allocatable: ce_paid, amount: 7_500)
+    ce_partial = create(:continuing_education_registration, event_registration: reg2, cost_cents: 6_000)
+    create(:allocation, source: create(:payment, amount_cents: 2_000, amount_cents_remaining: 2_000),
+                        allocatable: ce_partial, amount: 2_000)
+
+    cancelled = create(:event_registration, event: event, registrant: create(:person), status: "cancelled")
+    create(:continuing_education_registration, event_registration: cancelled, cost_cents: 12_000)
+    create(:allocation, source: create(:payment, amount_cents: 5_000, amount_cents_remaining: 5_000),
+                        allocatable: cancelled, amount: 5_000)
+  end
+
+  subject(:figures) { described_class.new([ event ]).for(event) }
+
+  it "reports each money component for the event" do
+    expect(figures.registration_payments_cents).to eq(9_000)
+    expect(figures.registration_outstanding_cents).to eq(4_000)
+    expect(figures.funded_scholarship_cents).to eq(4_000)
+    expect(figures.unfunded_scholarship_cents).to eq(2_000)
+    expect(figures.discount_cents).to eq(1_000)
+    expect(figures.ce_paid_cents).to eq(9_500)
+    expect(figures.ce_outstanding_cents).to eq(4_000)
+  end
+
+  # The report and a single event's dashboard must never disagree, so the batched
+  # figures are held against the per-event service they replaced.
+  it "matches the event's dashboard" do
+    dashboard = EventDashboard.new(event)
+
+    expect(figures.registration_payments_cents).to eq(dashboard.received_cents)
+    expect(figures.registration_outstanding_cents).to eq(dashboard.outstanding_cents)
+    expect(figures.funded_scholarship_cents).to eq(dashboard.funded_scholarship_cents)
+    expect(figures.unfunded_scholarship_cents).to eq(dashboard.unfunded_scholarship_cents)
+    expect(figures.ce_paid_cents).to eq(dashboard.cont_ed_paid_cents)
+    expect(figures.ce_outstanding_cents).to eq(dashboard.cont_ed_outstanding_cents)
+  end
+
+  it "counts a comped CE fee as a discount" do
+    ce = create(:continuing_education_registration, event_registration: reg2, cost_cents: 5_000)
+    create(:allocation, source: create(:discount, amount_cents: 5_000), allocatable: ce, amount: 5_000)
+
+    expect(figures.discount_cents).to eq(6_000)
+    expect(figures.ce_outstanding_cents).to eq(4_000)
+  end
+
+  it "returns zeros for an event with no registrations" do
+    other = create(:event, cost_cents: 10_000)
+
+    expect(described_class.new([ event, other ]).for(other)).to eq(described_class::EMPTY)
+  end
+
+  it "loads every event in a fixed number of queries" do
+    events = [ event ] + Array.new(3) do
+      other = create(:event, cost_cents: 5_000)
+      registration = create(:event_registration, event: other, registrant: create(:person), status: "registered")
+      create(:continuing_education_registration, event_registration: registration, cost_cents: 1_000)
+      other
+    end
+
+    queries = 0
+    counter = ->(_name, _start, _finish, _id, payload) { queries += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/) }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      loader = described_class.new(events)
+      events.each { |e| loader.for(e) }
+    end
+
+    expect(queries).to eq(5)
+  end
+end

--- a/spec/services/event_revenue_report_spec.rb
+++ b/spec/services/event_revenue_report_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe EventRevenueReport do
       expect(row.fees_cents).to eq(9_000)
     end
 
-    it "owes registration plus projected CE as outstanding" do
+    it "owes registration plus uncollected CE as outstanding" do
       expect(row.outstanding_cents).to eq(11_500)
     end
 
@@ -107,6 +107,31 @@ RSpec.describe EventRevenueReport do
     it "counts collected CE toward money in and net" do
       expect(row.money_in_cents).to eq(5_000)
       expect(row.net_cents).to eq(5_000)
+    end
+  end
+
+  # A discounted CE fee is cost the org absorbs, same as a discounted
+  # registration fee — it must land in org subsidy rather than disappear between
+  # "collected" and "owed".
+  describe "discounted CE fees" do
+    subject(:report) { described_class.new([ event ]) }
+
+    let(:event) { create(:event, cost_cents: 0) }
+    let!(:registration) { create(:event_registration, event: event, registrant: create(:person), status: "registered") }
+    let(:row) { report.rows.first }
+
+    before do
+      # A $60 CE registration comped in full.
+      ce = create(:continuing_education_registration, event_registration: registration, cost_cents: 6_000)
+      create(:allocation, source: create(:discount, amount_cents: 6_000), allocatable: ce, amount: 6_000)
+    end
+
+    it "counts the comped CE fee as org subsidy, not as collected or owed" do
+      expect(row.discount_cents).to eq(6_000)
+      expect(row.org_subsidy_cents).to eq(6_000)
+      expect(row.ce_paid_cents).to eq(0)
+      expect(row.ce_outstanding_cents).to eq(0)
+      expect(row.net_cents).to eq(-6_000)
     end
   end
 

--- a/spec/services/event_revenue_report_spec.rb
+++ b/spec/services/event_revenue_report_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EventRevenueReport do
     end
 
     before do
-      # reg2's projected CE fee: a $75 CE registration.
+      # reg2's CE fee: a $75 CE registration with no payment — outstanding, not collected.
       create(:continuing_education_registration, event_registration: reg2, cost_cents: 7_500)
 
       # A cancelled registration whose money/CE must be ignored everywhere.
@@ -41,14 +41,15 @@ RSpec.describe EventRevenueReport do
 
     it "reports the raw components" do
       expect(row.registration_payments_cents).to eq(9_000)
-      expect(row.ce_projected_cents).to eq(7_500)
+      expect(row.ce_paid_cents).to eq(0)
+      expect(row.ce_outstanding_cents).to eq(7_500)
       expect(row.funded_scholarship_cents).to eq(4_000)
       expect(row.unfunded_scholarship_cents).to eq(2_000)
       expect(row.discount_cents).to eq(1_000)
       expect(row.registration_outstanding_cents).to eq(4_000)
     end
 
-    it "collects fees from registration payments (CE isn't collected yet)" do
+    it "collects registration payments plus CE paid (this event's CE is unpaid)" do
       expect(row.fees_cents).to eq(9_000)
     end
 
@@ -74,6 +75,38 @@ RSpec.describe EventRevenueReport do
       expect(report.org_subsidy_cents).to eq(3_000)
       expect(report.net_cents).to eq(10_000)
       expect(report.total_expected_cents).to eq(21_500)
+    end
+  end
+
+  describe "collected CE payments" do
+    subject(:report) { described_class.new([ event ]) }
+
+    # Free-registration event to isolate CE money from registration fees.
+    let(:event) { create(:event, cost_cents: 0) }
+    let(:person) { create(:person) }
+    let!(:registration) { create(:event_registration, event: event, registrant: person, status: "registered") }
+    let(:row) { report.rows.first }
+
+    before do
+      # A $60 CE registration with $50 collected: $50 is fees, $10 stays outstanding.
+      ce = create(:continuing_education_registration, event_registration: registration, cost_cents: 6_000)
+      create(:allocation, source: create(:payment, amount_cents: 5_000, amount_cents_remaining: 5_000),
+                          allocatable: ce, amount: 5_000)
+    end
+
+    it "counts CE cash collected as fees" do
+      expect(row.ce_paid_cents).to eq(5_000)
+      expect(row.fees_cents).to eq(5_000)
+    end
+
+    it "leaves only the uncollected CE balance outstanding" do
+      expect(row.ce_outstanding_cents).to eq(1_000)
+      expect(row.outstanding_cents).to eq(1_000)
+    end
+
+    it "counts collected CE toward money in and net" do
+      expect(row.money_in_cents).to eq(5_000)
+      expect(row.net_cents).to eq(5_000)
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 money aggregation logic feeding the CEO dashboard + revenue report; verify CE paid/due sums

### What is the goal of this PR and why is this important?
CE payments are a real feature now (`ContinuingEducationRegistration` + polymorphic allocations), but reporting still treated CE as unbuilt or uncollected, so CE revenue was silently under-reported.

### How did you approach the change?
- **Event dashboard** — `EventDashboard#cont_ed_*` were zero stubs, so the CE fee card, grand total, collected, due, and monies-made all showed **$0**. Implemented them from CE registrations' cost and CE allocations, mirroring the registration-fee methods: paid = CE cash collected (payment allocations), due = CE cost still owed after all allocations, total = paid + due. Added per-registrant CE paid/due maps and paid/unpaid registrant lists.
- **Revenue report** — CE was counted as *always outstanding*. CE cash collected now counts as fees / money-in / net, and drops out of outstanding once paid. A **comped CE fee counts as org subsidy** — otherwise it's neither collected nor owed and disappears from the report; CE cost is only ever paid, discounted, or owed.
- **`EventRevenueFigures`** — the report built an `EventDashboard` per event (~8 queries each). All components for every event now load in **five grouped queries**, with a parity spec holding the batched figures to the dashboard's definitions so a row can't drift from that event's dashboard.
- **CSV exports** — registration, onboarding, and cross-event registration CSVs omitted CE dollars. Added **CE paid** / **CE due** columns via a new `EventRegistration#ce_amount_paid_cents`. Normalized every CSV dollar cell (including the legacy "Payment total") through a shared `ApplicationController#csv_dollars` → `dollars_from_cents`, so a single export reads consistently (`$50`, not `50.00`). Preloaded what those cells read, and taught `Person#phone_number` to use the loaded `contact_methods` instead of querying past them. All three exports are now **flat — zero queries per row** (registrations index was 13/row), pinned by query-count specs.
- **Free events** — the dashboard no longer hides the whole money section on a free-registration event that still charges for CE.
- **CE filter** — `ce_status` gains a `registered` value ("signed up for CE, whatever its state") so the CE card's registrant chip and total actually drill into the CE roster instead of the unfiltered list.

### Anything else to add?
- Comped CE fees → org subsidy is a live accounting question: #2084
- Bulk-payment → CE allocation deferred to #2082 (needs UI work; not a small change). The bulk-payments "already allocated" figure stays registration-fee-scoped by design.
- `EventDashboard#discount_cents` removed — the revenue report was its only caller, and `EventRevenueFigures` now owns the (broader) definition.
- Tests: dashboard CE money (paid/partial/unpaid/cancelled-ignored), revenue report collected + comped CE, figures↔dashboard parity and query count, `ce_status("registered")`, and CSV CE-dollar columns.