### PR TITLE
Add high-profile flag to organizations

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -221,7 +221,7 @@ class OrganizationsController < ApplicationController
     params.require(:organization).permit(
       :name, :description, :start_date, :end_date, :mission_vision_values,
       :agency_type, :agency_type_other, :filemaker_code, :logo, :notes, :email, :website_url,
-      :organization_status_id, :location_id, :windows_type_id,
+      :organization_status_id, :location_id, :windows_type_id, :high_profile,
       :profile_show_sectors, :profile_show_age_ranges, :profile_show_email, :profile_show_phone,
       :profile_show_website, :profile_show_description, :profile_show_workshops,
       :profile_show_stories, :profile_show_events_registered, :profile_show_workshop_logs,

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -56,6 +56,18 @@ class OrganizationDecorator < ApplicationDecorator
     Organization::AGENCY_TYPE_OTHER
   end
 
+  # Star marking a high-profile organization, shown next to the org name on list
+  # pages (event dashboard, background reporting). Nil for ordinary orgs so it
+  # renders nothing.
+  def high_profile_icon
+    return unless object.high_profile?
+
+    h.content_tag(:i, "",
+                  class: "fa-solid fa-star shrink-0 text-amber-400",
+                  title: "High-profile organization",
+                  "aria-hidden": true)
+  end
+
   def detail(length: nil)
     length ? description&.truncate(length) : description
   end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -63,7 +63,7 @@ class OrganizationDecorator < ApplicationDecorator
     return unless object.high_profile?
 
     h.content_tag(:i, "",
-                  class: "fa-solid fa-star shrink-0 text-amber-400",
+                  class: "fa-solid fa-gem shrink-0 text-purple-600",
                   title: "High-profile organization",
                   "aria-hidden": true)
   end

--- a/app/views/events/_organization_row.html.erb
+++ b/app/views/events/_organization_row.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </span>
     <% if row[:high_profile] %>
-      <i class="fa-solid fa-star text-amber-400 mr-1 align-middle" title="High-profile organization" aria-hidden="true"></i>
+      <i class="fa-solid fa-gem text-purple-600 mr-1 align-middle" title="High-profile organization" aria-hidden="true"></i>
     <% end %>
     <%= link_to row[:name], row[:path], class: "group-hover:underline align-middle" %>
   </td>

--- a/app/views/events/_organization_row.html.erb
+++ b/app/views/events/_organization_row.html.erb
@@ -1,5 +1,5 @@
-<%# One row of the Organizations breakdown. Locals: row (a { name:, count:,
-    scholarship_count:, path: } hash) and total (registrant sum, for the %). The
+<%# One row of the Organizations breakdown. Locals: row (a { name:, high_profile:,
+    count:, scholarship_count:, path: } hash) and total (registrant sum, for the %). The
     leading grad-cap sits in a fixed-width slot so scholarship-org names line up
     with the (empty-slot, indented) non-scholarship ones. The hover jump-link
     arrow sits after the percentage, matching the other breakdown cards. %>
@@ -13,6 +13,9 @@
            title="<%= pluralize(row[:scholarship_count], "scholarship recipient") %>" aria-hidden="true"></i>
       <% end %>
     </span>
+    <% if row[:high_profile] %>
+      <i class="fa-solid fa-star text-amber-400 mr-1 align-middle" title="High-profile organization" aria-hidden="true"></i>
+    <% end %>
     <%= link_to row[:name], row[:path], class: "group-hover:underline align-middle" %>
   </td>
   <td class="py-1 pl-3 text-right text-gray-500 tabular-nums whitespace-nowrap">

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -197,7 +197,7 @@
                   <%= mobile_label.("Organization") %>
                   <div class="min-w-0 flex-1 break-words">
                     <% if person_orgs.any? %>
-                      <% person_orgs.each_with_index do |org, i| %><%= ", " if i.positive? %><%= link_to org.name, organization_path(org), class: "hover:underline", onclick: "event.stopPropagation()" %><% end %>
+                      <% person_orgs.each_with_index do |org, i| %><%= ", " if i.positive? %><%= org.decorate.high_profile_icon %><%= link_to org.name, organization_path(org), class: "hover:underline", onclick: "event.stopPropagation()" %><% end %>
                     <% else %>
                       <span class="text-gray-300">—</span>
                     <% end %>
@@ -291,6 +291,7 @@
       filtered registrant list. %>
   <% org_rows = @dashboard.organizations.map { |o|
        { name: o.name,
+         high_profile: o.high_profile?,
          count: @dashboard.organization_counts.fetch(o.id, 0),
          scholarship_count: @dashboard.scholarship_recipient_count_by_org.fetch(o.id, 0),
          path: background_return_path(registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(o.id, []).to_a.join("-")), "all-organizations") }

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -350,6 +350,7 @@
                 <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0", title: "Registrants from #{organization.name}" do %>
                   <span class="flex items-center gap-1.5 min-w-0">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
+                    <%= organization.decorate.high_profile_icon %>
                     <span class="truncate min-w-0 group-hover/rowlink:underline"><%= organization.name %></span>
                   </span>
                   <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -153,9 +153,10 @@
                     input_html: {
                       class: "rounded-md border-gray-300 bg-blue-100 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                     } %>
+        <% high_profile_gem = tag.i(class: "fa-solid fa-gem text-purple-600", aria: { hidden: true }) %>
         <%= f.input :high_profile,
-                    label: "High profile",
-                    hint: "Shows a star next to the org on dashboards and reports" %>
+                    label: "High profile #{high_profile_gem}".html_safe,
+                    hint: "Shows a #{high_profile_gem} next to the org on dashboards and reports".html_safe %>
       </div>
     <% end %>
 

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -155,7 +155,7 @@
                     } %>
         <% high_profile_gem = tag.i(class: "fa-solid fa-gem text-purple-600", aria: { hidden: true }) %>
         <%= f.input :high_profile,
-                    label: "High profile #{high_profile_gem}".html_safe,
+                    label: "High profile",
                     hint: "Shows a #{high_profile_gem} next to the org on dashboards and reports".html_safe %>
       </div>
     <% end %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -153,6 +153,9 @@
                     input_html: {
                       class: "rounded-md border-gray-300 bg-blue-100 shadow-sm focus:ring-blue-500 focus:border-blue-500"
                     } %>
+        <%= f.input :high_profile,
+                    label: "High profile",
+                    hint: "Shows a star next to the org on dashboards and reports" %>
       </div>
     <% end %>
 

--- a/db/migrate/20260804002438_add_high_profile_to_organizations.rb
+++ b/db/migrate/20260804002438_add_high_profile_to_organizations.rb
@@ -1,0 +1,13 @@
+class AddHighProfileToOrganizations < ActiveRecord::Migration[8.0]
+  # Internal flag marking an organization as high-profile — surfaced with a star
+  # next to the org name on list pages (event dashboard, background reporting) so
+  # staff can spot notable programs at a glance. Defaults false.
+  def up
+    return if column_exists?(:organizations, :high_profile)
+    add_column :organizations, :high_profile, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :organizations, :high_profile, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_160043) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_002438) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -808,6 +808,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_160043) do
     t.string "email"
     t.date "end_date"
     t.string "filemaker_code"
+    t.boolean "high_profile", default: false, null: false
     t.string "internal_id"
     t.boolean "legacy", default: false
     t.integer "legacy_id"

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe OrganizationDecorator do
     it "renders a starred marker with a tooltip when the org is high-profile" do
       organization = create(:organization, high_profile: true)
       icon = Capybara.string(organization.decorate.high_profile_icon)
-      expect(icon).to have_css("i.fa-star[title='High-profile organization']")
+      expect(icon).to have_css("i.fa-gem[title='High-profile organization']")
     end
 
     it "is nil for an ordinary organization" do

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe OrganizationDecorator do
     end
   end
 
+  describe "#high_profile_icon" do
+    it "renders a starred marker with a tooltip when the org is high-profile" do
+      organization = create(:organization, high_profile: true)
+      icon = Capybara.string(organization.decorate.high_profile_icon)
+      expect(icon).to have_css("i.fa-star[title='High-profile organization']")
+    end
+
+    it "is nil for an ordinary organization" do
+      organization = create(:organization, high_profile: false)
+      expect(organization.decorate.high_profile_icon).to be_nil
+    end
+  end
+
   describe "#facilitator_status_as_of" do
     let(:organization) { create(:organization) }
     let(:person) { create(:person) }

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -255,6 +255,12 @@ RSpec.describe "/organizations", type: :request do
         patch organization_url(organization), params: { organization: new_attributes }
         expect(response).to redirect_to(organization_url(organization))
       end
+
+      it "updates the high_profile flag" do
+        organization = Organization.create!(valid_attributes)
+        patch organization_url(organization), params: { organization: { high_profile: "1" } }
+        expect(organization.reload.high_profile).to be(true)
+      end
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small boolean column + a gem icon in three org-name lists

### What is the goal of this PR and why is this important?
- Lets staff mark notable organizations as **high-profile** and spot them at a glance in event contexts.

### How did you approach the change?
- New `organizations.high_profile` boolean (default false), permitted in `organization_params`, set from the **admin-only** area of the org edit form.
- `OrganizationDecorator#high_profile_icon` renders a purple **gem** (tooltip "High-profile organization"); shown next to the org name on the **event dashboard** org card, the **background** registrant roster, and the **All organizations** breakdown row.
- Used a gem rather than a star since a star already means "primary" elsewhere (primary sector/age group).

### Anything else to add?
- Named it `high_profile` (already-prominent) rather than `high_potential` (likely-to-grow) — say the word if you'd prefer the latter.

### Screenshots
_Pending — will add a shot of the dashboard gem + the edit-form toggle._