### PR TITLE
Link registrant org chip to its profile with an edit pencil

### DIFF
--- a/app/frontend/javascript/controllers/org_toggle_controller.js
+++ b/app/frontend/javascript/controllers/org_toggle_controller.js
@@ -55,7 +55,14 @@ export default class extends Controller {
     // Clone the pending-chip template (amber until saved). Keeping the markup in
     // the view means Tailwind reliably compiles its variants.
     const chip = this.templateTarget.content.firstElementChild.cloneNode(true)
-    chip.querySelector("input").value = orgId
+    const checkbox = chip.querySelector("input")
+    checkbox.value = orgId
+    // Unique id so the × label's `for` toggles this chip's checkbox — the checkbox
+    // is the peer that drives the linked/removal styling on the name and the ×.
+    const id = `org_chip_${orgId}`
+    checkbox.id = id
+    chip.querySelector("[data-org-toggle-remove]").htmlFor = id
+
     const nameLink = chip.querySelector("[data-org-toggle-name]")
     nameLink.textContent = orgName
     // Point the name at the org profile (standard REST path) so it matches the

--- a/app/frontend/javascript/controllers/org_toggle_controller.js
+++ b/app/frontend/javascript/controllers/org_toggle_controller.js
@@ -54,11 +54,15 @@ export default class extends Controller {
 
     // Clone the pending-chip template (amber until saved). Keeping the markup in
     // the view means Tailwind reliably compiles its variants.
-    const label = this.templateTarget.content.firstElementChild.cloneNode(true)
-    label.querySelector("input").value = orgId
-    label.querySelector("[data-org-toggle-name]").textContent = orgName
+    const chip = this.templateTarget.content.firstElementChild.cloneNode(true)
+    chip.querySelector("input").value = orgId
+    const nameLink = chip.querySelector("[data-org-toggle-name]")
+    nameLink.textContent = orgName
+    // Point the name at the org profile (standard REST path) so it matches the
+    // server-rendered chips, which link to organization_path.
+    if (nameLink.tagName === "A") nameLink.href = `/organizations/${orgId}`
 
-    this.chipsTarget.appendChild(label)
+    this.chipsTarget.appendChild(chip)
 
     // Show the section if it was hidden, and drop the empty-state hint.
     this.chipsTarget.closest("[data-org-toggle-target='section']")?.classList.remove("hidden")

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -173,30 +173,25 @@
             <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:organizations, f.object.organizations.any?) %>">
               <i class="fa-solid fa-building"></i>
             </span>
-            <%# Keep "Registration-linked" intact on line one (no break at the hyphen) and
-                let "organizations" wrap to line two in the narrow card header. %>
-            <h2 class="min-w-0 text-sm font-semibold text-gray-700"><span class="whitespace-nowrap">Registration-linked</span> organizations</h2>
+            <h2 class="min-w-0 text-sm font-semibold text-gray-700">Linked organizations</h2>
           </div>
 
           <div class="flex flex-1 flex-col p-4">
-            <%# Nudge the chips up by the org card's extra header line (its title wraps
-                to two lines) so the first chip's top lines up with the scholarship
-                card's "$100". %>
-            <div class="-mt-2" data-org-toggle-target="section" <%= "hidden" unless f.object.organizations.any? %>>
+            <div data-org-toggle-target="section" <%= "hidden" unless f.object.organizations.any? %>>
               <div class="flex flex-wrap gap-1.5" data-org-toggle-target="chips">
+                <%# Matched pair (like the registrants roster): the org name as a grey
+                    rounded-md rectangle linking to the org profile (same emerald hover
+                    as the roster), plus a separate × toggle that marks the org for
+                    removal — it goes red, and the org is unlinked on save. %>
+                <% org_btn_classes = "inline-flex items-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition bg-gray-50 text-gray-500 border-gray-200 hover:shadow-sm #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)} hover:text-emerald-800 hover:border-emerald-300" %>
                 <% f.object.organizations.sort_by(&:name).each do |org| %>
-                  <label class="inline-flex items-center gap-1 px-4 py-1 rounded-full text-xs border cursor-pointer transition-colors bg-red-50 border-red-200 text-red-400 line-through has-[:checked]:bg-emerald-50 has-[:checked]:border-emerald-200 has-[:checked]:text-emerald-800 has-[:checked]:no-underline">
-                    <input
-                      type="checkbox"
-                      name="event_registration[organization_ids][]"
-                      value="<%= org.id %>"
-                      checked
-                      class="sr-only"
-                    >
-
-                    <span><%= org.name %></span>
-                    <span class="text-xs opacity-50">&times;</span>
-                  </label>
+                  <span class="inline-flex items-center gap-1">
+                    <%= link_to org.name, organization_path(org), title: org.name, class: org_btn_classes, data: { turbo_frame: "_top" } %>
+                    <label class="inline-flex items-center cursor-pointer" title="Remove from this registration">
+                      <input type="checkbox" name="event_registration[organization_ids][]" value="<%= org.id %>" checked class="peer sr-only">
+                      <span class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-gray-50 peer-checked:border-gray-200 peer-checked:text-gray-400">&times;</span>
+                    </label>
+                  </span>
                 <% end %>
               </div>
             </div>
@@ -219,11 +214,13 @@
             <%# Pending-chip template cloned by org_toggle_controller when adding. Kept in
                 the markup (not a JS string) so Tailwind always compiles the amber variants. %>
             <template data-org-toggle-target="template">
-              <label title="Pending — saved when you save the form" class="inline-flex items-center gap-1 px-4 py-1 rounded-full text-xs border cursor-pointer transition-colors bg-red-50 border-red-200 text-red-400 line-through has-[:checked]:bg-amber-50 has-[:checked]:border-amber-200 has-[:checked]:text-amber-800 has-[:checked]:no-underline">
-                <input type="checkbox" name="event_registration[organization_ids][]" value="" checked class="sr-only">
-                <span data-org-toggle-name></span>
-                <span class="text-xs opacity-50">&times;</span>
-              </label>
+              <span class="inline-flex items-center gap-1">
+                <a href="#" data-org-toggle-name title="Pending — saved when you save the form" data-turbo-frame="_top" class="inline-flex items-center whitespace-nowrap rounded-md border px-3 py-0.5 text-xs font-medium transition bg-amber-50 border-amber-200 text-amber-800 hover:shadow-sm hover:bg-amber-100 hover:border-amber-300"></a>
+                <label class="inline-flex items-center cursor-pointer" title="Remove from this registration">
+                  <input type="checkbox" name="event_registration[organization_ids][]" value="" checked class="peer sr-only">
+                  <span class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-amber-50 peer-checked:border-amber-200 peer-checked:text-amber-500">&times;</span>
+                </label>
+              </span>
             </template>
 
             <div data-org-toggle-target="addForm" class="mt-3 hidden <%= "border-t border-gray-100 pt-4" if f.object.organizations.any? %>">

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(event_registration, data: { turbo: false }) do |f| %>
+<%= simple_form_for(event_registration, data: { turbo: false, controller: "dirty-form" }) do |f| %>
   <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
   <%= render "shared/errors", resource: event_registration if event_registration.errors.any? %>
 
@@ -181,16 +181,20 @@
               <div class="flex flex-wrap gap-1.5" data-org-toggle-target="chips">
                 <%# Matched pair (like the registrants roster): the org name as a grey
                     rounded-md rectangle linking to the org profile (same emerald hover
-                    as the roster), plus a separate × toggle that marks the org for
-                    removal — it goes red, and the org is unlinked on save. %>
-                <% org_btn_classes = "inline-flex items-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition bg-gray-50 text-gray-500 border-gray-200 hover:shadow-sm #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)} hover:text-emerald-800 hover:border-emerald-300" %>
+                    as the roster), plus a separate × toggle. The checkbox is the peer, so
+                    unchecking it (clicking ×) turns the name red + line-through and the ×
+                    red; the org is unlinked on save. The × is a <label for> rather than
+                    wrapping the checkbox so the name link stays a plain profile link. %>
+                <%# Emerald hover is scoped to the linked (checked) state so a to-be-removed
+                    chip stays red on hover. %>
+                <% org_name_classes = "inline-flex items-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition bg-red-50 border-red-200 text-red-500 line-through peer-checked:bg-gray-50 peer-checked:border-gray-200 peer-checked:text-gray-500 peer-checked:no-underline peer-checked:hover:bg-emerald-200 peer-checked:hover:text-emerald-800 peer-checked:hover:border-emerald-300 peer-checked:hover:shadow-sm" %>
+                <% remove_classes = "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none cursor-pointer transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-gray-50 peer-checked:border-gray-200 peer-checked:text-gray-400" %>
                 <% f.object.organizations.sort_by(&:name).each do |org| %>
                   <span class="inline-flex items-center gap-1">
-                    <%= link_to org.name, organization_path(org), title: org.name, class: org_btn_classes, data: { turbo_frame: "_top" } %>
-                    <label class="inline-flex items-center cursor-pointer" title="Remove from this registration">
-                      <input type="checkbox" name="event_registration[organization_ids][]" value="<%= org.id %>" checked class="peer sr-only">
-                      <span class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-gray-50 peer-checked:border-gray-200 peer-checked:text-gray-400">&times;</span>
-                    </label>
+                    <input type="checkbox" id="org_chip_<%= org.id %>" name="event_registration[organization_ids][]" value="<%= org.id %>" checked class="peer sr-only">
+                    <%# Warn before leaving to the profile if the form has unsaved edits. %>
+                    <%= link_to org.name, organization_path(org), title: org.name, class: org_name_classes, data: { turbo_frame: "_top", action: "dirty-form#confirmCancel" } %>
+                    <label for="org_chip_<%= org.id %>" title="Remove from this registration" class="<%= remove_classes %>">&times;</label>
                   </span>
                 <% end %>
               </div>
@@ -215,11 +219,9 @@
                 the markup (not a JS string) so Tailwind always compiles the amber variants. %>
             <template data-org-toggle-target="template">
               <span class="inline-flex items-center gap-1">
-                <a href="#" data-org-toggle-name title="Pending — saved when you save the form" data-turbo-frame="_top" class="inline-flex items-center whitespace-nowrap rounded-md border px-3 py-0.5 text-xs font-medium transition bg-amber-50 border-amber-200 text-amber-800 hover:shadow-sm hover:bg-amber-100 hover:border-amber-300"></a>
-                <label class="inline-flex items-center cursor-pointer" title="Remove from this registration">
-                  <input type="checkbox" name="event_registration[organization_ids][]" value="" checked class="peer sr-only">
-                  <span class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-amber-50 peer-checked:border-amber-200 peer-checked:text-amber-500">&times;</span>
-                </label>
+                <input type="checkbox" name="event_registration[organization_ids][]" value="" checked class="peer sr-only">
+                <a href="#" data-org-toggle-name title="Pending — saved when you save the form" data-turbo-frame="_top" data-action="dirty-form#confirmCancel" class="inline-flex items-center whitespace-nowrap rounded-md border px-3 py-0.5 text-xs font-medium transition bg-red-50 border-red-200 text-red-500 line-through peer-checked:bg-amber-50 peer-checked:border-amber-200 peer-checked:text-amber-800 peer-checked:no-underline peer-checked:hover:bg-amber-100 peer-checked:hover:border-amber-300 peer-checked:hover:shadow-sm"></a>
+                <label data-org-toggle-remove title="Remove from this registration" class="inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs leading-none cursor-pointer transition-colors bg-red-100 border-red-300 text-red-600 peer-checked:bg-amber-50 peer-checked:border-amber-200 peer-checked:text-amber-500">&times;</label>
               </span>
             </template>
 

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
     <div class="flex items-start justify-between gap-3 mb-2">
-      <h1 class="text-2xl font-bold text-gray-900">Organizations &amp; affiliations</h1>
+      <h1 class="text-2xl font-bold text-gray-900">Linked organizations &amp; affiliations</h1>
       <%= link_to edit_affiliations_path, data: { turbo_frame: "_top" },
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700 shrink-0 mt-1.5" do %>
         Edit <%= @person.first_name.presence || @person.full_name %>'s affiliations

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -286,14 +286,24 @@
                   <% editor_path = link_organization_event_registration_path(registration, return_to: "registrants") %>
                   <% pill_classes = "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
                   <div class="flex flex-wrap gap-1.5">
+                    <%# Same grey style as the "None" chip below, but a rectangle
+                        (rounded-md) instead of a pill, and with the organization
+                        (emerald) hover color. %>
+                    <% org_btn_classes = "inline-flex items-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition bg-gray-50 text-gray-500 border-gray-200 hover:shadow-sm #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)} hover:text-emerald-800 hover:border-emerald-300" %>
                     <% linked_orgs.each do |org| %>
-                      <%= link_to editor_path,
-                                  title: org.name,
-                                  class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
-                                  data: { turbo_frame: "_top" } do %>
-                        <span><%= truncate(org.name, length: 31) %></span>
-                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
-                      <% end %>
+                      <span class="inline-flex items-center gap-1">
+                        <%= link_to truncate(org.name, length: 31),
+                                    organization_path(org),
+                                    title: org.name,
+                                    class: org_btn_classes,
+                                    data: { turbo_frame: "_top" } %>
+                        <%= link_to editor_path,
+                                    title: "Edit linked organizations",
+                                    class: "inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-600",
+                                    data: { turbo_frame: "_top" } do %>
+                          <i class="fa-solid fa-pencil text-[0.7rem]"></i>
+                        <% end %>
+                      </span>
                     <% end %>
                     <% if needs_linking %>
                       <%= link_to editor_path,
@@ -309,7 +319,7 @@
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span>None</span>
-                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
+                        <i class="fa-solid fa-pencil text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                   </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -297,13 +297,19 @@
                                     title: org.name,
                                     class: org_btn_classes,
                                     data: { turbo_frame: "_top" } %>
-                        <%# Same chip styling as the "None" chip (padding, colors, hover),
-                            just a rounded-md rectangle to pair with the org button. %>
+                        <%# Same chip as "None" below, but for a linked org only the icon
+                            shows. A zero-width invisible copy of the word carries the
+                            text-xs line height so the chip keeps the same height (vertical
+                            padding around the icon) without reserving the word's width.
+                            gap-1.5 is dropped from pill_classes so the collapsed span adds
+                            no horizontal gap. %>
+                        <% icon_only_pill = pill_classes.sub("gap-1.5 ", "") %>
                         <%= link_to editor_path,
                                     title: "Edit linked organizations",
-                                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm bg-gray-50 text-gray-500 border-gray-200",
+                                    class: "#{icon_only_pill} bg-gray-50 text-gray-500 border-gray-200",
                                     data: { turbo_frame: "_top" } do %>
-                          <i class="fa-solid fa-pencil text-[0.7rem]"></i>
+                          <span class="invisible w-0 min-w-0 overflow-hidden">None</span>
+                          <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                         <% end %>
                       </span>
                     <% end %>
@@ -321,7 +327,7 @@
                                   class: "#{pill_classes} bg-gray-50 text-gray-500 border-gray-200",
                                   data: { turbo_frame: "_top" } do %>
                         <span>None</span>
-                        <i class="fa-solid fa-pencil text-[0.6rem] opacity-70"></i>
+                        <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] opacity-70"></i>
                       <% end %>
                     <% end %>
                   </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -297,9 +297,11 @@
                                     title: org.name,
                                     class: org_btn_classes,
                                     data: { turbo_frame: "_top" } %>
+                        <%# Same chip styling as the "None" chip (padding, colors, hover),
+                            just a rounded-md rectangle to pair with the org button. %>
                         <%= link_to editor_path,
                                     title: "Edit linked organizations",
-                                    class: "inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-600",
+                                    class: "inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm bg-gray-50 text-gray-500 border-gray-200",
                                     data: { turbo_frame: "_top" } do %>
                           <i class="fa-solid fa-pencil text-[0.7rem]"></i>
                         <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -968,13 +968,13 @@ RSpec.describe "Events", type: :request do
         create(:form_answer, form_submission: submission, form_field: field, submitted_answer: name)
       end
 
-      it "links a linked organization to the edit page rather than its profile" do
+      it "links a linked organization chip to its profile with a pencil to the edit page" do
         create(:event_registration_organization, event_registration: registration, organization: organization)
 
         get registrants_event_path(event)
 
+        expect(response.body).to include(organization_path(organization))
         expect(response.body).to include(link_organization_event_registration_path(registration, return_to: "registrants"))
-        expect(response.body).not_to include(organization_path(organization))
       end
 
       it "shows a 'Pending' chip when a registrant submitted an org name but has no linked org" do

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe "Event registration edit page", type: :system do
     end
   end
 
+  describe "Linked organizations card" do
+    let(:organization) { create(:organization, name: "Asian Women Shelter") }
+
+    it "renders a linked organization as a profile link with a × removal toggle" do
+      create(:event_registration_organization, event_registration: registration, organization: organization)
+
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Linked organizations") do
+        expect(page).to have_link("Asian Women Shelter", href: organization_path(organization))
+        # The × is a <label for> wired to the (visually hidden) checkbox that
+        # submits the link — unchecking it marks the org for removal on save.
+        expect(page).to have_css("label[for='org_chip_#{organization.id}']")
+        expect(page).to have_field("event_registration[organization_ids][]", type: "checkbox", with: organization.id.to_s, visible: :all)
+      end
+    end
+  end
+
   describe "payment & allocation history" do
     it "shows the cost/allocated/due totals with nothing allocated" do
       sign_in(admin)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained view/JS changes across two org-linking surfaces; adds a dirty-form guard

## What
Reworks how registration-linked organizations are displayed.

**Registrants roster (`events/_registrants_results.html.erb`)**
- Linked org renders as a compact grey `rounded-md` button linking to the **org profile** (was a chip opening the editor), with an emerald hover.
- A small icon-only jump chip beside it opens the **link-organizations editor** (reuses the "None" chip styling collapsed to icon width).
- **None**/**Pending** chips unchanged; all column icons use the jump-link glyph.

**Registration form org card (`event_registrations/_form.html.erb` + `org_toggle_controller.js`)**
- Each linked org is a grey `rounded-md` rectangle linking to the org profile (same emerald hover as the roster), with a separate **× toggle**.
- The link checkbox is the peer; unchecking it (clicking ×) turns the name **red + line-through** and the × red — org is unlinked on save. The × is a `<label for>` so the name stays a plain profile link.
- Clicking the profile link runs `dirty-form#confirmCancel`, so it **warns on unsaved edits** instead of silently discarding them (form now uses `dirty-form`).
- Pending-add template matches (amber); the controller sets each cloned chip's unique id/`for` and profile href.
- Card heading "Registration-linked organizations" → **"Linked organizations"** (nudge for the old two-line title removed).

**Editor page**
- Heading renamed to **"Linked organizations & affiliations"**.

## Why
Splits the two destinations that were conflated: viewing an org's profile vs. editing/removing the link. The org name goes to the profile everywhere; the adjacent control edits/removes the link — and leaving to a profile no longer loses unsaved form edits.

## Tests
- New system spec: linked-org profile link + `for`-wired × toggle.

## Screenshots
_Roster org button + jump chip; form card org rectangle + × (linked vs. removal); dirty-form warning._