### PR TITLE
HOLD: Gate person deletion on associated records

### DIFF
--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -88,6 +88,10 @@ class PersonDecorator < ApplicationDecorator
   # has rather than a generic catch-all.
   DELETION_BLOCKER_LABELS = {
     user_account: "a user account",
+    workshop_logs: "authored workshop logs",
+    story_ideas: "authored story ideas",
+    workshop_ideas: "authored workshop ideas",
+    workshop_variation_ideas: "authored workshop variation ideas",
     affiliations: "organization affiliations",
     stories: "authored stories",
     workshops: "authored workshops",

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -83,6 +83,20 @@ class PersonDecorator < ApplicationDecorator
     end
   end
 
+  # Human-readable explanation of why the Delete button is unavailable, or nil
+  # when the person is deletable. Mirrors the model's deletable? checks so the
+  # edit form can tell an admin exactly what's holding the record in place.
+  def deletion_blocked_reason
+    return if deletable?
+
+    reasons = []
+    reasons << "a linked user account" if user.present?
+    reasons << "organization affiliations" if affiliations.exists?
+    reasons << "authored content (stories, workshops, news, or resources)" if authored_content?
+    reasons << "financial records (payments, scholarships, or grants)" if financial_records?
+    "Can't be deleted — this person has #{reasons.to_sentence}."
+  end
+
   def affiliated_since_date
     # Compute in Ruby from the (eager-loaded) association so list pages that
     # preload affiliations don't fire a MIN(start_date) query per row.

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -83,18 +83,31 @@ class PersonDecorator < ApplicationDecorator
     end
   end
 
-  # Human-readable explanation of why the Delete button is unavailable, or nil
-  # when the person is deletable. Mirrors the model's deletable? checks so the
-  # edit form can tell an admin exactly what's holding the record in place.
-  def deletion_blocked_reason
-    return if deletable?
+  # Label shown for each deletion-blocker key (see Person#deletion_blockers), so
+  # the "Can't be deleted" notice names the actual kinds of records the person
+  # has rather than a generic catch-all.
+  DELETION_BLOCKER_LABELS = {
+    user_account: "a user account",
+    affiliations: "organization affiliations",
+    stories: "authored stories",
+    workshops: "authored workshops",
+    workshop_variations: "authored workshop variations",
+    community_news: "authored community news",
+    resources: "authored resources",
+    payments: "payments",
+    scholarships: "scholarships",
+    grants: "grants",
+    paid_event_registrations: "event registrations with payments",
+    event_staffing: "event staff assignments"
+  }.freeze
 
-    reasons = []
-    reasons << "a linked user account" if user.present?
-    reasons << "organization affiliations" if affiliations.exists?
-    reasons << "authored content (stories, workshops, news, or resources)" if authored_content?
-    reasons << "financial records (payments, scholarships, or grants)" if financial_records?
-    "Can't be deleted — this person has #{reasons.to_sentence}."
+  # Human-readable explanation of why the Delete button is unavailable, or nil
+  # when the person is deletable — naming each kind of record that's blocking it.
+  def deletion_blocked_reason
+    labels = deletion_blockers.map { |key| DELETION_BLOCKER_LABELS.fetch(key) }
+    return if labels.empty?
+
+    "Can't be deleted — this person has #{labels.to_sentence}."
   end
 
   def affiliated_since_date

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -97,8 +97,9 @@ class PersonDecorator < ApplicationDecorator
     payments: "payments",
     scholarships: "scholarships",
     grants: "grants",
-    paid_event_registrations: "event registrations with payments",
-    event_staffing: "event staff assignments"
+    event_registrations: "event registrations",
+    event_staffing: "event staff assignments",
+    form_submissions: "form submissions"
   }.freeze
 
   # Human-readable explanation of why the Delete button is unavailable, or nil

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -328,31 +328,30 @@ class Person < ApplicationRecord
     age_range_categorizable_items.sort_by { |item| [ item.category&.position || 0, item.category&.name.to_s ] }
   end
 
-  # True only when removing this person would neither cascade-destroy nor orphan
-  # any associated record. Gates PersonPolicy#destroy?; the decorator's
-  # deletion_blocked_reason turns a false result into a human explanation.
+  # Keys for each kind of record that deleting this person would cascade-destroy
+  # or orphan — the things worth keeping (identity, authored content, financial
+  # and event history), not disposable profile detail like addresses or tags.
+  # Empty means the person is safe to delete. Gates PersonPolicy#destroy?; the
+  # decorator maps each key to the label shown in the "Can't be deleted" notice.
+  def deletion_blockers
+    blockers = []
+    blockers << :user_account if user.present?
+    blockers << :affiliations if affiliations.exists?
+    blockers << :stories if stories_as_author.exists? || stories_as_spotlighted_facilitator.exists?
+    blockers << :workshops if workshops_as_author.exists?
+    blockers << :workshop_variations if workshop_variations_as_author.exists?
+    blockers << :community_news if community_news_as_author.exists?
+    blockers << :resources if resources_as_author.exists?
+    blockers << :payments if payments.exists?
+    blockers << :scholarships if scholarships.exists?
+    blockers << :grants if grants.exists?
+    blockers << :paid_event_registrations if event_registrations.joins(:allocations).exists?
+    blockers << :event_staffing if event_staffs.exists?
+    blockers
+  end
+
   def deletable?
-    user.blank? &&
-      !affiliations.exists? &&
-      !authored_content? &&
-      !financial_records?
-  end
-
-  # Content this person is credited on. These associations are
-  # dependent: :restrict_with_error, so they'd have to be reassigned first.
-  def authored_content?
-    stories_as_spotlighted_facilitator.exists? ||
-      stories_as_author.exists? ||
-      workshop_variations_as_author.exists? ||
-      workshops_as_author.exists? ||
-      community_news_as_author.exists? ||
-      resources_as_author.exists?
-  end
-
-  # Money tied to this person as payer, scholarship recipient, or grant donor.
-  # Deleting the person would erase this financial history, so it blocks deletion.
-  def financial_records?
-    payments.exists? || scholarships.exists? || grants.exists?
+    deletion_blockers.empty?
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -345,8 +345,9 @@ class Person < ApplicationRecord
     blockers << :payments if payments.exists?
     blockers << :scholarships if scholarships.exists?
     blockers << :grants if grants.exists?
-    blockers << :paid_event_registrations if event_registrations.joins(:allocations).exists?
+    blockers << :event_registrations if event_registrations.exists?
     blockers << :event_staffing if event_staffs.exists?
+    blockers << :form_submissions if form_submissions.exists?
     blockers
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,6 +38,7 @@ class Person < ApplicationRecord
   has_many :event_staffs, dependent: :destroy
   has_many :scholarships, foreign_key: :recipient_id, dependent: :destroy
   has_many :grants, as: :donor, dependent: :destroy
+  has_many :payments, dependent: :restrict_with_error
   has_many :events, through: :event_registrations
   has_many :staffed_events, through: :event_staffs, source: :event
   has_many :categories, through: :categorizable_items
@@ -325,6 +326,33 @@ class Person < ApplicationRecord
   # shouldn't reshuffle them). Display surfaces lead with the primary instead.
   def age_range_items_ordered
     age_range_categorizable_items.sort_by { |item| [ item.category&.position || 0, item.category&.name.to_s ] }
+  end
+
+  # True only when removing this person would neither cascade-destroy nor orphan
+  # any associated record. Gates PersonPolicy#destroy?; the decorator's
+  # deletion_blocked_reason turns a false result into a human explanation.
+  def deletable?
+    user.blank? &&
+      !affiliations.exists? &&
+      !authored_content? &&
+      !financial_records?
+  end
+
+  # Content this person is credited on. These associations are
+  # dependent: :restrict_with_error, so they'd have to be reassigned first.
+  def authored_content?
+    stories_as_spotlighted_facilitator.exists? ||
+      stories_as_author.exists? ||
+      workshop_variations_as_author.exists? ||
+      workshops_as_author.exists? ||
+      community_news_as_author.exists? ||
+      resources_as_author.exists?
+  end
+
+  # Money tied to this person as payer, scholarship recipient, or grant donor.
+  # Deleting the person would erase this financial history, so it blocks deletion.
+  def financial_records?
+    payments.exists? || scholarships.exists? || grants.exists?
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -335,7 +335,13 @@ class Person < ApplicationRecord
   # decorator maps each key to the label shown in the "Can't be deleted" notice.
   def deletion_blockers
     blockers = []
-    blockers << :user_account if user.present?
+    if user.present?
+      blockers << :user_account
+      blockers << :workshop_logs if user.workshop_logs.exists?
+      blockers << :story_ideas if user.story_ideas_as_creator.exists?
+      blockers << :workshop_ideas if user.workshop_ideas_as_creator.exists?
+      blockers << :workshop_variation_ideas if user.workshop_variation_ideas_creator.exists?
+    end
     blockers << :affiliations if affiliations.exists?
     blockers << :stories if stories_as_author.exists? || stories_as_spotlighted_facilitator.exists?
     blockers << :workshops if workshops_as_author.exists?

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -30,7 +30,7 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def destroy?
-    admin? && record.persisted? && !has_associated_data?
+    admin? && record.persisted? && record.deletable?
   end
 
   def search?
@@ -50,16 +50,5 @@ class PersonPolicy < ApplicationPolicy
   def owner?
     return false unless authenticated?
     record.user == user
-  end
-
-  def has_associated_data?
-    record.user.present? ||
-      record.affiliations.exists? ||
-      record.stories_as_spotlighted_facilitator.exists? ||
-      record.stories_as_author.exists? ||
-      record.workshop_variations_as_author.exists? ||
-      record.workshops_as_author.exists? ||
-      record.community_news_as_author.exists? ||
-      record.resources_as_author.exists?
   end
 end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -566,6 +566,11 @@
     <% if allowed_to?(:destroy?, f.object) %>
       <%= link_to "Delete", @person, class: "btn btn-danger-outline",
                   data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } %>
+    <% elsif f.object.persisted? %>
+      <span class="inline-flex max-w-md items-start gap-2 text-sm text-gray-500">
+        <i class="fa-solid fa-circle-info mt-0.5 shrink-0 text-gray-400"></i>
+        <%= f.object.decorate.deletion_blocked_reason %>
+      </span>
     <% end %>
 
     <%= link_to "Cancel", people_path, class: "btn btn-secondary-outline",

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -52,4 +52,28 @@ RSpec.describe PersonDecorator do
       expect(person.decorate.affiliated_since_date).to be_nil
     end
   end
+
+  describe "#deletion_blocked_reason" do
+    it "is nil when the person has no blocking associations" do
+      person = create(:person, user: nil)
+
+      expect(person.decorate.deletion_blocked_reason).to be_nil
+    end
+
+    it "names financial records when the person has payments" do
+      person = create(:person, user: nil)
+      create(:payment, person: person)
+
+      expect(person.decorate.deletion_blocked_reason)
+        .to eq("Can't be deleted — this person has financial records (payments, scholarships, or grants).")
+    end
+
+    it "names a linked user account and financial records together" do
+      person = create(:person)
+      create(:scholarship, recipient: person)
+
+      expect(person.decorate.deletion_blocked_reason)
+        .to eq("Can't be deleted — this person has a linked user account and financial records (payments, scholarships, or grants).")
+    end
+  end
 end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -77,13 +77,21 @@ RSpec.describe PersonDecorator do
         .to eq("Can't be deleted — this person has event registrations and form submissions.")
     end
 
-    it "names each kind of blocking record the person actually has" do
+    it "names authored records owned through the person's user" do
       person = create(:person)
+      create(:workshop_log, created_by: person.user)
+
+      expect(person.decorate.deletion_blocked_reason)
+        .to eq("Can't be deleted — this person has a user account and authored workshop logs.")
+    end
+
+    it "names each kind of blocking record the person actually has" do
+      person = create(:person, user: nil)
       create(:scholarship, recipient: person)
       create(:grant, donor: person)
 
       expect(person.decorate.deletion_blocked_reason)
-        .to eq("Can't be deleted — this person has a user account, scholarships, and grants.")
+        .to eq("Can't be deleted — this person has scholarships and grants.")
     end
   end
 end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -60,20 +60,30 @@ RSpec.describe PersonDecorator do
       expect(person.decorate.deletion_blocked_reason).to be_nil
     end
 
-    it "names financial records when the person has payments" do
+    it "names payments when the person has them" do
       person = create(:person, user: nil)
       create(:payment, person: person)
 
       expect(person.decorate.deletion_blocked_reason)
-        .to eq("Can't be deleted — this person has financial records (payments, scholarships, or grants).")
+        .to eq("Can't be deleted — this person has payments.")
     end
 
-    it "names a linked user account and financial records together" do
-      person = create(:person)
-      create(:scholarship, recipient: person)
+    it "names event registrations with payments" do
+      person = create(:person, user: nil)
+      registration = create(:event_registration, registrant: person)
+      create(:allocation, allocatable: registration)
 
       expect(person.decorate.deletion_blocked_reason)
-        .to eq("Can't be deleted — this person has a linked user account and financial records (payments, scholarships, or grants).")
+        .to eq("Can't be deleted — this person has event registrations with payments.")
+    end
+
+    it "names each kind of blocking record the person actually has" do
+      person = create(:person)
+      create(:scholarship, recipient: person)
+      create(:grant, donor: person)
+
+      expect(person.decorate.deletion_blocked_reason)
+        .to eq("Can't be deleted — this person has a user account, scholarships, and grants.")
     end
   end
 end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe PersonDecorator do
         .to eq("Can't be deleted — this person has payments.")
     end
 
-    it "names event registrations with payments" do
+    it "names event registrations and form submissions" do
       person = create(:person, user: nil)
-      registration = create(:event_registration, registrant: person)
-      create(:allocation, allocatable: registration)
+      create(:event_registration, registrant: person)
+      create(:form_submission, person: person)
 
       expect(person.decorate.deletion_blocked_reason)
-        .to eq("Can't be deleted — this person has event registrations with payments.")
+        .to eq("Can't be deleted — this person has event registrations and form submissions.")
     end
 
     it "names each kind of blocking record the person actually has" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -554,19 +554,25 @@ RSpec.describe Person, "scholarship index helpers" do
       expect(person).not_to be_deletable
     end
 
-    it "is false when the person has an event registration with a payment" do
+    it "is false when the person has an event registration" do
       person = create(:person, user: nil)
-      registration = create(:event_registration, registrant: person)
-      create(:allocation, allocatable: registration)
+      create(:event_registration, registrant: person)
 
       expect(person).not_to be_deletable
     end
 
-    it "is true when the person has only an unpaid event registration" do
+    it "is false when the person has staffed an event" do
       person = create(:person, user: nil)
-      create(:event_registration, registrant: person)
+      create(:event_staff, person: person)
 
-      expect(person).to be_deletable
+      expect(person).not_to be_deletable
+    end
+
+    it "is false when the person has a form submission" do
+      person = create(:person, user: nil)
+      create(:form_submission, person: person)
+
+      expect(person).not_to be_deletable
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -523,4 +523,35 @@ RSpec.describe Person, "scholarship index helpers" do
       expect(person.completed_facilitator_trainings).to contain_exactly(training)
     end
   end
+
+  describe "#deletable?" do
+    it "is true for a person with no user, affiliations, content, or financial records" do
+      expect(create(:person, user: nil)).to be_deletable
+    end
+
+    it "is false when the person has a linked user account" do
+      expect(create(:person)).not_to be_deletable
+    end
+
+    it "is false when the person has payments" do
+      person = create(:person, user: nil)
+      create(:payment, person: person)
+
+      expect(person).not_to be_deletable
+    end
+
+    it "is false when the person is a scholarship recipient" do
+      person = create(:person, user: nil)
+      create(:scholarship, recipient: person)
+
+      expect(person).not_to be_deletable
+    end
+
+    it "is false when the person is a grant donor" do
+      person = create(:person, user: nil)
+      create(:grant, donor: person)
+
+      expect(person).not_to be_deletable
+    end
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -553,5 +553,20 @@ RSpec.describe Person, "scholarship index helpers" do
 
       expect(person).not_to be_deletable
     end
+
+    it "is false when the person has an event registration with a payment" do
+      person = create(:person, user: nil)
+      registration = create(:event_registration, registrant: person)
+      create(:allocation, allocatable: registration)
+
+      expect(person).not_to be_deletable
+    end
+
+    it "is true when the person has only an unpaid event registration" do
+      person = create(:person, user: nil)
+      create(:event_registration, registrant: person)
+
+      expect(person).to be_deletable
+    end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -574,5 +574,12 @@ RSpec.describe Person, "scholarship index helpers" do
 
       expect(person).not_to be_deletable
     end
+
+    it "is false when the person's user authored workshop logs or ideas" do
+      person = create(:person)
+      create(:workshop_log, created_by: person.user)
+
+      expect(person).not_to be_deletable
+    end
   end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -258,6 +258,22 @@ RSpec.describe PersonPolicy, type: :policy do
       end
     end
 
+    context "when person has an event registration with a payment" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        registration = create(:event_registration, registrant: person)
+        create(:allocation, allocatable: registration)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
     context "when person has no associated data" do
       let(:admin) { create(:user, :admin) }
       let(:person) { create(:person, user: nil) }

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -212,6 +212,62 @@ RSpec.describe PersonPolicy, type: :policy do
         expect(policy).not_to be_allowed_to(:destroy?)
       end
     end
+
+    context "when person has payments" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:payment, person: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
+    context "when person has scholarships" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:scholarship, recipient: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
+    context "when person has grants" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:grant, donor: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
+    context "when person has no associated data" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      it "is allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).to be_allowed_to(:destroy?)
+      end
+    end
   end
 
   describe "relation_scope" do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -258,13 +258,42 @@ RSpec.describe PersonPolicy, type: :policy do
       end
     end
 
-    context "when person has an event registration with a payment" do
+    context "when person has an event registration" do
       let(:admin) { create(:user, :admin) }
       let(:person) { create(:person, user: nil) }
 
       before do
-        registration = create(:event_registration, registrant: person)
-        create(:allocation, allocatable: registration)
+        create(:event_registration, registrant: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
+    context "when person has staffed an event" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:event_staff, person: person)
+      end
+
+      it "is not allowed" do
+        policy = policy_for(record: person, user: admin)
+
+        expect(policy).not_to be_allowed_to(:destroy?)
+      end
+    end
+
+    context "when person has a form submission" do
+      let(:admin) { create(:user, :admin) }
+      let(:person) { create(:person, user: nil) }
+
+      before do
+        create(:form_submission, person: person)
       end
 
       it "is not allowed" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained gating change on one policy/model/decorator + a form branch

### What is the goal of this PR and why is this important?
- A person could be deleted while still holding records worth keeping — the destroy gate only checked user / affiliations / authored content, ignoring money and event history entirely. Deleting cascade-destroyed or orphaned that data. The Delete button is meant only for cleaning up person records with no real associations.

### How did you approach the change?
- `Person#deletion_blockers` is the single source of truth — a keyed list of every record kind that blocks deletion: user account, user-authored workshop logs / story ideas / workshop ideas / workshop variation ideas, affiliations, authored stories/workshops/workshop variations/community news/resources, payments, scholarships, grants, event registrations, event staff assignments, and form submissions. `deletable?` is just "no blockers".
- `PersonPolicy#destroy?` delegates to it (dropped the policy-local `has_associated_data?`).
- `PersonDecorator#deletion_blocked_reason` maps those keys to labels, so the edit form names the **actual** kinds the person has — e.g. "Can't be deleted — this person has a user account, authored workshop logs, and event registrations." — instead of silently hiding the Delete button.
- Added `has_many :payments` (`restrict_with_error` backstop).

### Anything else to add?
- The workshop-log/idea records hang off the person's **user** (created_by), so they only appear on a person who already has a user account — they add specificity to the notice.
- **Still deletable (disposable profile detail only):** addresses, contact methods, tags/sectors, bookmarks, comments, notifications, professional licenses, avatar.
- Specs cover policy, model, and decorator (per-kind + combined messages).