### PR TITLE
Add "View all" link to the CE payments and allocations card

### DIFF
--- a/app/views/continuing_education_registrations/_payment_history.html.erb
+++ b/app/views/continuing_education_registrations/_payment_history.html.erb
@@ -9,6 +9,12 @@
       <i class="fa-solid fa-dollar-sign"></i>
     </span>
     <h2 class="text-sm font-semibold text-gray-700">CE payments and allocations</h2>
+    <%= link_to allocations_path(allocatable_sgid: ce_registration.to_sgid.to_s, return_to: "ce_registration"),
+                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                target: "_blank", rel: "noopener" do %>
+      View all
+      <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+    <% end %>
   </div>
 
   <div class="p-4">

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
       expect(response.body).to include("Edit CE registration")
     end
 
+    it "offers a 'View all' link to this registration's allocations from the CE payments card" do
+      get edit_continuing_education_registration_path(ce_registration)
+      # sgid carries an expiry, so match the allocations href without pinning it.
+      expect(response.body).to match(%r{/allocations\?[^"]*return_to=ce_registration"[^>]*>\s*View all})
+    end
+
     it "updates hours, cost, and fills the placeholder license type, number, state + expiry in place" do
       license = ce_registration.professional_license
       patch continuing_education_registration_path(ce_registration),


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup: one header link mirroring the registration card, plus a request-spec assertion

### What is the goal of this PR and why is this important?
- The "CE payments and allocations" card mirrors the "Registration payments and allocations" card, but its header was missing the **View all** link the registration card has — so there was no header-level entry point to a CE registration's full allocations list.

### How did you approach the change?
- Added the CE-specific header **View all** link, scoped to the CE registration (`allocatable_sgid` + `return_to: "ce_registration"`) so the allocations page's eyebrow returns to the CE edit page.
- Omitted the registration card's `after:inset-0` stretch overlay — the CE card's amount subcards are already links, so a full-card overlay would sit on top of them.
- No controller/route/index changes: `AllocationsController#index` and the allocations index view already handle a `ContinuingEducationRegistration` allocatable.
- Added a request-spec assertion that the CE edit page renders the link.