### PR TITLE
Use dashboard gauge icon on registration-row event card

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -84,7 +84,7 @@ module EventHelper
     )
   end
 
-  def event_show_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false)
+  def event_show_button(event, truncate_at: nil, subtitle: nil, data: {}, path: nil, compact: false, icon: "fa-calendar-days")
     bg = DomainTheme.bg_class_for(:events, intensity: 50)
     hover_bg = DomainTheme.bg_class_for(:events, intensity: 50, hover: true)
     text = DomainTheme.text_class_for(:events)
@@ -104,7 +104,7 @@ module EventHelper
                     overflow-hidden" do
       event = event.decorate if event.respond_to?(:decorate)
 
-      icon_tag = content_tag(:i, "", class: "fa-solid fa-calendar-days shrink-0 #{icon_size} #{DomainTheme.text_class_for(:events)}")
+      icon_tag = content_tag(:i, "", class: "fa-solid #{icon} shrink-0 #{icon_size} #{DomainTheme.text_class_for(:events)}")
 
       display_name = truncate_at ? truncate(event.name.to_s, length: truncate_at) : event.name.to_s
 

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -68,6 +68,7 @@
                           <%= event_show_button(event_registration.event,
                                 truncate_at: 50,
                                 compact: true,
+                                icon: "fa-gauge",
                                 path: dashboard_event_path(event_registration.event),
                                 subtitle: event_registration.event.decorate.short_date_range) %>
                         </td>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only icon swap, no logic change

### What is the goal of this PR and why is this important?
- The per-row event card on the event registrations index links to the event **dashboard**, but showed a calendar icon.
- Swap it to a gauge icon so the affordance matches the destination.

### How did you approach the change?
- Added an optional `icon:` param to `event_show_button` (defaults to `fa-calendar-days`).
- Pass `icon: "fa-gauge"` only on the row card; the filtered-event header card (links to the event show page) keeps the calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)