### PR TITLE
Fix people index N+1 and email obfuscation gap

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -8,7 +8,7 @@ class PeopleController < ApplicationController
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
       base_scope = authorized_scope(Person.includes(
-        :avatar_attachment,
+        { avatar_attachment: :blob },
         :user,
         sectorable_items: :sector,
         affiliations: :organization,

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -29,7 +29,7 @@
                   <% else %>
                     <span class="font-semibold"><%= person.name %></span>
                     <% if show_email && person.preferred_email.present? %>
-                      <div class="text-xs text-gray-500"><%= person.preferred_email %></div>
+                      <div class="text-xs text-gray-500"><!--email_off--><%= person.preferred_email %><!--email_on--></div>
                     <% end %>
                   <% end %>
                 </td>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two small, contained fixes to the people index (controller preload + one view branch)

## What
- Preload the avatar **blob** on the people index (`{ avatar_attachment: :blob }`) so rendering `person.avatar.variant(:thumbnail)` in `person_profile_button` doesn't fire a blob query per row. Only the `index` action was missing this — every other people-list controller (and this controller's own `update`) already preloads the blob.
- Wrap the people-index fallback email (viewer not allowed to `:show?` the person) in Cloudflare `<!--email_off-->`/`<!--email_on-->` markers, matching the primary `person_profile_button` branch, so it can't render as the `[email protected]` obfuscation placeholder.

## Why
- The avatar variant needs the blob; without it the index N+1s on ActiveStorage blobs.
- The fallback branch was the one email on the page not opted out of Cloudflare obfuscation.