### PR TITLE
Add "New communication" button + create flow to the communications index

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -17,6 +17,36 @@ class NotificationsController < ApplicationController
     end
   end
 
+  def new
+    authorize! Notification, to: :new?
+    @notification = Notification.new
+  end
+
+  # Log a communication by hand against a person — mirrors the nested
+  # notifications flow (people_controller#update): the picked person is the
+  # noticeable and supplies the recipient_email; the model fills in the
+  # manual_log defaults (kind, recipient_role, notification_type, delivered_at).
+  def create
+    authorize! Notification, to: :create?
+
+    @person = Person.find_by(id: params[:person_id])
+    @notification = Notification.new(notification_params)
+    @notification.sender = current_user
+
+    if @person
+      @notification.noticeable = @person
+      @notification.recipient_email = @person.communications_email.presence || "n/a"
+    else
+      @notification.errors.add(:base, "Select a person to log this communication against")
+    end
+
+    if @person && @notification.save
+      redirect_to notifications_path, notice: "Communication logged."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def show
     authorize! @notification
   end
@@ -61,6 +91,6 @@ class NotificationsController < ApplicationController
   end
 
   def notification_params
-    params.require(:notification).permit(:responded)
+    params.require(:notification).permit(:responded, :channel, :email_subject, :email_body_text)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -109,6 +109,10 @@ class Notification < ApplicationRecord
   validates :recipient_email, presence: true
   validates :notification_type, presence: true
   validates :channel, inclusion: { in: CHANNELS }, allow_nil: true
+  # A hand-logged communication must carry a subject (it's the line shown to the
+  # user); the nested flow drops blank-subject rows via reject_if, so this only
+  # bites the standalone "New communication" form.
+  validates :email_subject, presence: true, if: :manual_log?
 
   # A manually logged communication (created inline, e.g. from the registration
   # edit page) records a contact that already happened — fill in the sensible

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -9,6 +9,14 @@ class NotificationPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  def new?
+    admin?
+  end
+
+  def create?
+    admin?
+  end
+
   def update?
     admin?
   end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,8 +2,15 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex justify-between items-center mb-6">
         <section class="w-full">
-          <div class="flex flex-col items-start mb-4">
+          <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
             <h1 class="text-3xl font-bold text-gray-900 my-2"><%= t("communications.title") %></h1>
+            <% if allowed_to?(:new?, with: NotificationPolicy) %>
+              <%= link_to new_notification_path,
+                          class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700" do %>
+                <i class="fa-solid fa-plus text-xs"></i>
+                <%= t("communications.new") %>
+              <% end %>
+            <% end %>
           </div>
 
           <%= render "search_boxes" %>

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -1,0 +1,66 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+  <%= link_to t("communications.back_link"), notifications_path,
+              class: "text-sm text-blue-600 hover:underline" %>
+
+  <h1 class="mt-3 mb-1 text-2xl font-semibold text-gray-900"><%= t("communications.new") %></h1>
+  <p class="mb-5 text-sm text-gray-500">
+    Log a communication you had with a person by hand (a call, text, or email sent outside the portal).
+  </p>
+
+  <div class="bg-white rounded-lg p-6">
+    <%= simple_form_for @notification, url: notifications_path do |f| %>
+      <%= render "shared/errors", resource: @notification if @notification.errors.any? %>
+
+      <div class="space-y-5">
+        <div>
+          <% person_label = @person&.remote_search_label %>
+          <label for="person_id" class="block text-sm font-medium text-gray-700 mb-1">Person</label>
+          <%= select_tag "person_id",
+                options_for_select(person_label ? [ [ person_label[:label], @person.id ] ] : [], @person&.id),
+                include_blank: "Search people by name or email",
+                data: { controller: "remote-select", remote_select_model_value: "person" },
+                class: "w-full bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+          <p class="mt-1 text-xs text-gray-500">The communication is logged against this person and their email.</p>
+        </div>
+
+        <div>
+          <span class="block text-sm font-medium text-gray-700 mb-1">From</span>
+          <span class="inline-flex items-center gap-2 rounded bg-sky-100 px-2 py-1 text-sm text-sky-800">
+            <i class="fa-solid fa-user text-xs"></i><%= current_user.full_name %>
+          </span>
+          <p class="mt-1 text-xs text-gray-500">You are recorded as the sender.</p>
+        </div>
+
+        <div>
+          <%= f.input :channel,
+                      collection: Notification::MANUAL_CHANNELS.map { |c| [ c.titleize, c ] },
+                      selected: @notification.channel.presence || "email",
+                      include_blank: false,
+                      label: "Channel",
+                      input_html: { class: "w-full sm:w-1/3 bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
+
+        <div>
+          <%= f.input :email_subject, as: :text, required: true,
+                      label: "Subject (visible to user)",
+                      input_html: { rows: 2, placeholder: "Topic or subject line",
+                                    class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
+
+        <div>
+          <%= f.input :email_body_text, as: :text,
+                      label: "Body (internal staff note, hidden from user)",
+                      input_html: { rows: 4, placeholder: "What happened? (e.g. left voicemail, sent reminder)",
+                                    class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
+      </div>
+
+      <div class="mt-6 flex items-center justify-end gap-3">
+        <%= link_to "Cancel", notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= f.button :submit, t("communications.new"),
+                     class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     back_link: "← Back to communications"
     empty: "No communications found."
     add: "Add communication"
+    new: "New communication"
     edit: "Edit communications"
     done_editing: "Done editing"
     resent: "Communication has been resent successfully."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,7 @@ Rails.application.routes.draw do
       post :curate
     end
   end
-  resources :notifications, only: [ :index, :show, :update ] do
+  resources :notifications, only: [ :index, :new, :create, :show, :update ] do
     member do
       post :resend
     end

--- a/spec/policies/notification_policy_spec.rb
+++ b/spec/policies/notification_policy_spec.rb
@@ -50,6 +50,29 @@ RSpec.describe NotificationPolicy, type: :policy do
     end
   end
 
+  describe "#new? and #create?" do
+    context "with admin user" do
+      subject { policy_for(user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:new?) }
+      it { is_expected.to be_allowed_to(:create?) }
+    end
+
+    context "with regular user" do
+      subject { policy_for(user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:new?) }
+      it { is_expected.not_to be_allowed_to(:create?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:new?) }
+      it { is_expected.not_to be_allowed_to(:create?) }
+    end
+  end
+
   describe "#update?" do
     context "with admin user" do
       subject { policy_for(record: notification, user: admin_user) }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -122,6 +122,108 @@ RSpec.describe "Notifications", type: :request do
     end
   end
 
+  describe "GET /notifications/new" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the new communication form" do
+        get new_notification_path
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include("New communication")
+        expect(response.body).to include("Search people by name or email")
+      end
+    end
+
+    context "as a regular user" do
+      before { sign_in regular_user }
+
+      it "is not authorized" do
+        get new_notification_path
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as a guest" do
+      it "redirects to sign in" do
+        get new_notification_path
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /notifications" do
+    let(:person) { create(:person, email: "logged@example.com") }
+    let(:valid_params) do
+      {
+        person_id: person.id,
+        notification: {
+          channel: "phone",
+          email_subject: "Called about registration",
+          email_body_text: "Left a voicemail."
+        }
+      }
+    end
+
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "logs a manual communication against the person, attributed to the sender" do
+        expect {
+          post notifications_path, params: valid_params
+        }.to change(Notification, :count).by(1)
+
+        notification = Notification.last
+        expect(notification.noticeable).to eq(person)
+        expect(notification.recipient_email).to eq(person.communications_email)
+        expect(notification.sender).to eq(admin)
+        expect(notification.channel).to eq("phone")
+        expect(notification.email_subject).to eq("Called about registration")
+        expect(notification.kind).to eq("manual_log")
+        expect(response).to redirect_to(notifications_path)
+      end
+
+      it "re-renders with an error when no person is selected" do
+        expect {
+          post notifications_path, params: valid_params.except(:person_id)
+        }.not_to change(Notification, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("Select a person")
+      end
+
+      it "re-renders when the subject is blank" do
+        expect {
+          post notifications_path, params: valid_params.deep_merge(notification: { email_subject: "" })
+        }.not_to change(Notification, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "as a regular user" do
+      before { sign_in regular_user }
+
+      it "is not authorized and creates nothing" do
+        expect {
+          post notifications_path, params: valid_params
+        }.not_to change(Notification, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "as a guest" do
+      it "redirects to sign in" do
+        post notifications_path, params: valid_params
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
   describe "GET /notifications/:id" do
     let(:fyi)          { create(:notification, kind: "contact_us_fyi") }
     let(:user_confirm) { create(:notification, kind: "contact_us") }

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/forms/index.html.erb"                   => "admin-only bg-blue-100",
     "app/views/forms/show.html.erb"                    => "admin-only bg-blue-100",
     "app/views/notifications/index.html.erb"           => "admin-only bg-blue-100",
+    "app/views/notifications/new.html.erb"             => "admin-only bg-blue-100",
     "app/views/organization_statuses/index.html.erb"   => "admin-only bg-blue-100",
     "app/views/quotes/index.html.erb"                  => "admin-only bg-blue-100",
     "app/views/sectors/index.html.erb"                 => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new admin CRUD action reusing the nested manual-log flow; adds one scoped model validation

## Why
- Communications could only be logged nested inside a person / event registration / scholarship form. Admins wanted to log one directly from the **Communications** index.

## What
- **New communication** button on the notifications index (admin-only) → `new`/`create` actions + routes + policy (`new?`/`create?`).
- The form picks a **person** via the existing remote-select search; that person becomes the `noticeable` and supplies `recipient_email` — mirroring `people_controller#update`. Sender is the current admin; the model fills the `manual_log` defaults.
- Added `validates :email_subject, presence: true, if: :manual_log?` — the nested flow drops blank-subject rows via `reject_if`, which doesn't apply to a standalone create, so this backstops it. Non-manual notifications and nested blanks are unaffected.

## Notes
- Scoped the "about" record to **Person** (the only noticeable with a search endpoint + email). Event-registration / scholarship logging stays in their own nested forms.
- Request + policy specs cover the happy path, no-person / blank-subject errors, and admin/non-admin/guest auth. Verified the nested people/event-registration/scholarship flows still pass with the new validation.