### PR TITLE
Deflake #joinable? join-window specs

### DIFF
--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -535,6 +535,10 @@ RSpec.describe EventRegistration, type: :model do
   end
 
   describe "#joinable?" do
+    # Freeze the clock so the join-window boundary cases (events placed exactly
+    # 1 minute inside the 30-minute buffer) can't flake on wall-clock drift.
+    before { freeze_time }
+
     let(:event) { create(:event, cost_cents: 1099, start_date: 1.hour.ago, end_date: 1.hour.from_now) }
     let(:user) { create(:user, :with_person) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,10 @@ ActiveJob::Base.queue_adapter = :test
 RSpec.configure do |config|
   # Gives travel method for time helpers
   config.include ActiveSupport::Testing::TimeHelpers
+  # RSpec doesn't run minitest teardown, so travel_to never auto-reverts — freeze
+  # one example and the frozen clock leaks into later specs. Always reset after
+  # each example (no-op when time wasn't traveled).
+  config.after { travel_back }
 
   # Include pagination helper globally
   config.include PaginationHelpers


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 test-only: freezes the clock in a describe block + a global travel_back safety net, no product code

### What is the goal of this PR and why is this important?
- The `EventRegistration#joinable?` join-window boundary examples place events exactly **1 minute** inside the 30-minute join buffer, so they raced wall-clock drift and could spike under CI load.

### How did you approach the change?
- `freeze_time` across the `#joinable?` describe so those boundary cases are deterministic instead of clock-dependent.
- Added a global `config.after { travel_back }` — RSpec never runs minitest teardown, so a frozen clock would otherwise leak into later specs. No-op today; required now that a spec freezes time.

### Anything else to add?
- Test-only. `event_registration_spec.rb` 142/142 green; RuboCop clean.