### PR TITLE
Make the profile the source of truth for author credit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ This codebase (Rails 8.1)
 | `app/decorators/` | Draper decorators for view logic | ~50 files |
 | `app/policies/` | ActionPolicy authorization rules | ~63 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~31 files |
+| `app/helpers/` | View helpers | ~36 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ This codebase (Rails 8.1)
 | `app/decorators/` | Draper decorators for view logic | ~50 files |
 | `app/policies/` | ActionPolicy authorization rules | ~63 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~36 files |
+| `app/helpers/` | View helpers | ~37 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ This codebase (Rails 8.1)
 |---|---|
 | `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
-| `AuthorCreditable` | Author attribution |
+| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page — it no longer drives display, except `"anonymous"`, which is always honored (anonymity is a one-way latch: profile or record can set it, neither can strip it) |
 | `Featureable` | `featured`, `publicly_featured` scopes |
 | `Mentioner` | ActionText @mention extraction and grouping |
 | `NameFilterable` | Name-based filtering |
@@ -222,6 +222,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `WorkshopSearchService` — Complex filtering, sorting, pagination with ActionPolicy
 - `WorkshopFromIdeaService` — Converts WorkshopIdea to Workshop with asset migration
 - `WorkshopVariationFromIdeaService` — Variation creation from ideas
+- `AuthorCreditDivergenceQuery` — Finds content whose stored `author_credit_preference` no longer matches the credited person's profile, grouped by person, for the admin reconciliation page. `MODEL_NAMES` doubles as the allowlist for the `type` param (never constantize a raw param)
 - `TaggingSearchService` — Search and filter tagging data
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ This codebase (Rails 8.1)
 |---|---|
 | `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
-| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page — it no longer drives display, except `"anonymous"`, which is always honored (anonymity is a one-way latch: profile or record can set it, neither can strip it) |
+| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page — it no longer drives display, except `"anonymous"`, which is always honored while set (either the profile or the record can make a credit anonymous, and neither strips the other's flag — only an admin clearing the record's snapshot on that page does) |
 | `Featureable` | `featured`, `publicly_featured` scopes |
 | `Mentioner` | ActionText @mention extraction and grouping |
 | `NameFilterable` | Name-based filtering |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `WorkshopSearchService` — Complex filtering, sorting, pagination with ActionPolicy
 - `WorkshopFromIdeaService` — Converts WorkshopIdea to Workshop with asset migration
 - `WorkshopVariationFromIdeaService` — Variation creation from ideas
-- `AuthorCreditDivergenceQuery` — Finds content whose stored `author_credit_preference` no longer matches the credited person's profile, grouped by person, for the admin reconciliation page. `MODEL_NAMES` doubles as the allowlist for the `type` param (never constantize a raw param)
+- `AuthorCreditDivergenceQuery` — Backs the admin author credit divergences page. Returns four sections: `preference` (stored snapshot no longer matches the profile, grouped by person), `legacy` (credited by a free-text column — `workshops.full_name`, `resources.legacy_author_name`), `creator` (no `author_id`, so the credit falls back to the creating user's person — idea models excluded, since that's their only credit path), and `unattributed` (nothing to credit, renders `missing_author_label`). The last three all resolve by assigning an `author_id`, the only credit path that follows a profile and links to it. `MODEL_NAMES` doubles as the allowlist for the `type` param (never constantize a raw param)
 - `TaggingSearchService` — Search and filter tagging data
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ This codebase (Rails 8.1)
 | `app/decorators/` | Draper decorators for view logic | ~50 files |
 | `app/policies/` | ActionPolicy authorization rules | ~63 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~37 files |
+| `app/helpers/` | View helpers | ~31 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 
@@ -137,7 +137,7 @@ This codebase (Rails 8.1)
 |---|---|
 | `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
-| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page — it no longer drives display, except `"anonymous"`, which is always honored while set (either the profile or the record can make a credit anonymous, and neither strips the other's flag — only an admin clearing the record's snapshot on that page does) |
+| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page. Anonymity is a one-way latch: the profile or the record can set it, neither can strip it from the other |
 | `Featureable` | `featured`, `publicly_featured` scopes |
 | `Mentioner` | ActionText @mention extraction and grouping |
 | `NameFilterable` | Name-based filtering |
@@ -222,7 +222,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `WorkshopSearchService` — Complex filtering, sorting, pagination with ActionPolicy
 - `WorkshopFromIdeaService` — Converts WorkshopIdea to Workshop with asset migration
 - `WorkshopVariationFromIdeaService` — Variation creation from ideas
-- `AuthorCreditDivergenceQuery` — Backs the admin author credit divergences page. Returns four sections: `preference` (stored snapshot no longer matches the profile, grouped by person), `legacy` (credited by a free-text column — `workshops.full_name`, `resources.legacy_author_name`), `creator` (no `author_id`, so the credit falls back to the creating user's person — idea models excluded, since that's their only credit path), and `unattributed` (nothing to credit, renders `missing_author_label`). The last three all resolve by assigning an `author_id`, the only credit path that follows a profile and links to it. `MODEL_NAMES` doubles as the allowlist for the `type` param (never constantize a raw param)
+- `AuthorCreditDivergenceQuery` — Backs the admin author credit divergences page. Four sections: `preference` (snapshot no longer matches the profile, grouped by person), `legacy` (credited by a free-text column, one group per column), `creator` (no `author_id`, so the credit falls back to the creating user's person — idea models excluded), and `unattributed` (nothing to credit). The last three resolve by assigning an `author_id`. `MODEL_NAMES` doubles as the allowlist for the `type` param — never constantize a raw param
 - `TaggingSearchService` — Search and filter tagging data
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -33,6 +33,15 @@ class AuthorCreditDivergencesController < ApplicationController
     return redirect_to(author_credit_divergences_path(filters), alert: "Unknown record type.") unless model
 
     record = model.find(params[:record_id])
+
+    # Anonymity is a one-way latch: clearing the snapshot of an item submitted
+    # anonymously would silently de-anonymize it. A deliberate re-credit still works
+    # by picking an explicit preference.
+    if params[:author_credit_preference].blank? && record.author_credit_preference == AuthorCreditable::ANONYMOUS
+      return redirect_to(author_credit_divergences_path(filters),
+                         alert: "Can't clear the consent for an item submitted anonymously — pick an explicit preference instead.")
+    end
+
     record.author_credit_preference = params[:author_credit_preference]
     record.updated_by = current_user if record.respond_to?(:updated_by=)
 

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -36,13 +36,9 @@ class AuthorCreditDivergencesController < ApplicationController
 
     record = model.find(params[:record_id])
 
-    # Anonymity is a one-way latch: clearing the snapshot of an item submitted
-    # anonymously would silently de-anonymize it. A deliberate re-credit still works
-    # by picking an explicit preference.
-    if params[:author_credit_preference].blank? && record.author_credit_preference == AuthorCreditable::ANONYMOUS
-      return render_divergence_change("Can't clear the consent for an item submitted anonymously — pick an explicit preference instead.", :alert)
-    end
-
+    # Clearing an "anonymous" snapshot hands the item back to the profile, which may
+    # well credit it. That's the point: a per-item anonymous flag is the legacy state
+    # this page exists to drain, and the person's profile is the source of truth.
     record.author_credit_preference = params[:author_credit_preference]
     record.updated_by = current_user if record.respond_to?(:updated_by=)
 

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -91,7 +91,7 @@ class AuthorCreditDivergencesController < ApplicationController
   end
 
   def person_params
-    params.require(:person).permit(:display_name_preference, :contributions_anonymous)
+    params.require(:person).permit(:display_name_preference, :anonymous_contributions)
   end
 
   # Carried through every redirect so the admin lands back on the same filtered list.

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -3,8 +3,6 @@ class AuthorCreditDivergencesController < ApplicationController
 
   FILTER_KEYS = %i[person_id type preference include_reconciled].freeze
 
-  # The full page renders only the header, filters, and an empty results frame;
-  # the frame's src request builds the divergences.
   def index
     return unless turbo_frame_request?
 
@@ -12,8 +10,7 @@ class AuthorCreditDivergencesController < ApplicationController
     render :author_credit_divergences_results
   end
 
-  # Resolve a whole person: point their profile at one preference and stamp them
-  # reconciled so a deliberate divergence stops reappearing on the worklist.
+  # Stamped reconciled so a deliberate divergence stops reappearing on the worklist.
   def update_person
     person = Person.find(params[:id])
     person.assign_attributes(person_params)
@@ -27,18 +24,16 @@ class AuthorCreditDivergencesController < ApplicationController
     end
   end
 
-  # Resolve a single item by rewriting its stored consent snapshot. Setting
-  # "anonymous" here is a live override that suppresses that item's credit alone;
-  # any other value only re-records history (see AuthorCreditable).
+  # "anonymous" here suppresses this item's credit; any other value only re-records
+  # history (see AuthorCreditable).
   def update_item
     model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
     return render_divergence_change("Unknown record type.", :alert) unless model
 
     record = model.find(params[:record_id])
 
-    # Clearing an "anonymous" snapshot hands the item back to the profile, which may
-    # well credit it. That's the point: a per-item anonymous flag is the legacy state
-    # this page exists to drain, and the person's profile is the source of truth.
+    # Clearing "anonymous" hands the item back to the profile, which may credit it —
+    # that's what this page exists to do.
     record.author_credit_preference = params[:author_credit_preference]
     record.updated_by = current_user if record.respond_to?(:updated_by=)
 
@@ -49,10 +44,8 @@ class AuthorCreditDivergencesController < ApplicationController
     end
   end
 
-  # Point a record at a real person. This is the fix for every section below the
-  # first: an author_id is the only credit path that follows the person's profile,
-  # links to it, and lists the record there. Once set, any legacy free-text name on
-  # the record stops being used.
+  # The fix for every section below the first: an author_id is the only credit path
+  # that follows a profile, links to it, and lists the record there.
   def assign_author
     model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
     return render_divergence_change("Unknown record type.", :alert) unless model
@@ -73,8 +66,7 @@ class AuthorCreditDivergencesController < ApplicationController
 
   private
 
-  # Update in place: re-render the results frame and flash over Turbo so a save
-  # doesn't flip the whole page. Falls back to a redirect for non-Turbo requests.
+  # Re-render the frame over Turbo so a save doesn't flip the whole page.
   def render_divergence_change(message, type)
     respond_to do |format|
       format.turbo_stream do
@@ -94,9 +86,8 @@ class AuthorCreditDivergencesController < ApplicationController
     params.require(:person).permit(:display_name_preference, :anonymous_contributions)
   end
 
-  # Carried through every redirect so the admin lands back on the same filtered list.
-  # The write actions deliberately name their own params `id` / `record_type` /
-  # `record_id` so a record identifier can never be mistaken for a filter.
+  # The write actions name their params `id` / `record_type` / `record_id` so a
+  # record identifier can never be mistaken for a filter.
   def filters
     params.permit(*FILTER_KEYS).to_h.compact_blank
   end

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -6,9 +6,7 @@ class AuthorCreditDivergencesController < ApplicationController
   def index
     return unless turbo_frame_request?
 
-    @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
-    @reconciled_people = Person.where.not(author_credit_reconciled_at: nil)
-                               .order(author_credit_reconciled_at: :desc)
+    load_divergences
     render :author_credit_divergences_results
   end
 
@@ -69,11 +67,17 @@ class AuthorCreditDivergencesController < ApplicationController
   private
 
   # Re-render the frame over Turbo so a save doesn't flip the whole page.
+  def load_divergences
+    @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+    @reconciled_people = Person.where.not(author_credit_reconciled_at: nil)
+                               .order(author_credit_reconciled_at: :desc)
+  end
+
   def render_divergence_change(message, type)
     respond_to do |format|
       format.turbo_stream do
         flash.now[type] = message
-        @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+        load_divergences
         render :divergence_change
       end
       format.html { redirect_to author_credit_divergences_path(filters), flash: { type => message } }

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -19,9 +19,9 @@ class AuthorCreditDivergencesController < ApplicationController
     person.updated_by = current_user
 
     if person.save
-      redirect_to author_credit_divergences_path(filters), notice: "Updated credit preferences for #{person.full_name}."
+      render_divergence_change("Updated credit preferences for #{person.full_name}.", :notice)
     else
-      redirect_to author_credit_divergences_path(filters), alert: person.errors.full_messages.to_sentence
+      render_divergence_change(person.errors.full_messages.to_sentence, :alert)
     end
   end
 
@@ -30,7 +30,7 @@ class AuthorCreditDivergencesController < ApplicationController
   # any other value only re-records history (see AuthorCreditable).
   def update_item
     model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
-    return redirect_to(author_credit_divergences_path(filters), alert: "Unknown record type.") unless model
+    return render_divergence_change("Unknown record type.", :alert) unless model
 
     record = model.find(params[:record_id])
 
@@ -38,17 +38,16 @@ class AuthorCreditDivergencesController < ApplicationController
     # anonymously would silently de-anonymize it. A deliberate re-credit still works
     # by picking an explicit preference.
     if params[:author_credit_preference].blank? && record.author_credit_preference == AuthorCreditable::ANONYMOUS
-      return redirect_to(author_credit_divergences_path(filters),
-                         alert: "Can't clear the consent for an item submitted anonymously — pick an explicit preference instead.")
+      return render_divergence_change("Can't clear the consent for an item submitted anonymously — pick an explicit preference instead.", :alert)
     end
 
     record.author_credit_preference = params[:author_credit_preference]
     record.updated_by = current_user if record.respond_to?(:updated_by=)
 
     if record.save
-      redirect_to author_credit_divergences_path(filters), notice: "Updated credit for #{model.name.underscore.humanize.downcase} ##{record.id}."
+      render_divergence_change("Updated credit for #{model.name.underscore.humanize.downcase} ##{record.id}.", :notice)
     else
-      redirect_to author_credit_divergences_path(filters), alert: record.errors.full_messages.to_sentence
+      render_divergence_change(record.errors.full_messages.to_sentence, :alert)
     end
   end
 
@@ -58,24 +57,36 @@ class AuthorCreditDivergencesController < ApplicationController
   # the record stops being used.
   def assign_author
     model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
-    return redirect_to(author_credit_divergences_path(filters), alert: "Unknown record type.") unless model
+    return render_divergence_change("Unknown record type.", :alert) unless model
 
     record = model.find(params[:record_id])
     person = Person.find_by(id: params[:author_id])
-    return redirect_to(author_credit_divergences_path(filters), alert: "Choose a person to credit.") unless person
+    return render_divergence_change("Choose a person to credit.", :alert) unless person
 
     record.author_id = person.id
     record.updated_by = current_user if record.respond_to?(:updated_by=)
 
     if record.save
-      redirect_to author_credit_divergences_path(filters),
-                  notice: "Credited #{model.name.underscore.humanize.downcase} ##{record.id} to #{person.full_name}."
+      render_divergence_change("Credited #{model.name.underscore.humanize.downcase} ##{record.id} to #{person.full_name}.", :notice)
     else
-      redirect_to author_credit_divergences_path(filters), alert: record.errors.full_messages.to_sentence
+      render_divergence_change(record.errors.full_messages.to_sentence, :alert)
     end
   end
 
   private
+
+  # Update in place: re-render the results frame and flash over Turbo so a save
+  # doesn't flip the whole page. Falls back to a redirect for non-Turbo requests.
+  def render_divergence_change(message, type)
+    respond_to do |format|
+      format.turbo_stream do
+        flash.now[type] = message
+        @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+        render :divergence_change
+      end
+      format.html { redirect_to author_credit_divergences_path(filters), flash: { type => message } }
+    end
+  end
 
   def authorize_page
     authorize! :author_credit_divergence, to: :"#{action_name}?", with: AuthorCreditDivergencePolicy

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -4,7 +4,7 @@ class AuthorCreditDivergencesController < ApplicationController
   FILTER_KEYS = %i[person_id type preference include_reconciled].freeze
 
   def index
-    @groups = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+    @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
 
     return unless turbo_frame_request?
     render :author_credit_divergences_results
@@ -38,6 +38,29 @@ class AuthorCreditDivergencesController < ApplicationController
 
     if record.save
       redirect_to author_credit_divergences_path(filters), notice: "Updated credit for #{model.name.underscore.humanize.downcase} ##{record.id}."
+    else
+      redirect_to author_credit_divergences_path(filters), alert: record.errors.full_messages.to_sentence
+    end
+  end
+
+  # Point a record at a real person. This is the fix for every section below the
+  # first: an author_id is the only credit path that follows the person's profile,
+  # links to it, and lists the record there. Once set, any legacy free-text name on
+  # the record stops being used.
+  def assign_author
+    model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
+    return redirect_to(author_credit_divergences_path(filters), alert: "Unknown record type.") unless model
+
+    record = model.find(params[:record_id])
+    person = Person.find_by(id: params[:author_id])
+    return redirect_to(author_credit_divergences_path(filters), alert: "Choose a person to credit.") unless person
+
+    record.author_id = person.id
+    record.updated_by = current_user if record.respond_to?(:updated_by=)
+
+    if record.save
+      redirect_to author_credit_divergences_path(filters),
+                  notice: "Credited #{model.name.underscore.humanize.downcase} ##{record.id} to #{person.full_name}."
     else
       redirect_to author_credit_divergences_path(filters), alert: record.errors.full_messages.to_sentence
     end

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -1,0 +1,62 @@
+class AuthorCreditDivergencesController < ApplicationController
+  before_action :authorize_page
+
+  FILTER_KEYS = %i[person_id type preference include_reconciled].freeze
+
+  def index
+    @groups = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+
+    return unless turbo_frame_request?
+    render :author_credit_divergences_results
+  end
+
+  # Resolve a whole person: point their profile at one preference and stamp them
+  # reconciled so a deliberate divergence stops reappearing on the worklist.
+  def update_person
+    person = Person.find(params[:id])
+    person.assign_attributes(person_params)
+    person.author_credit_reconciled_at = Time.current
+    person.updated_by = current_user
+
+    if person.save
+      redirect_to author_credit_divergences_path(filters), notice: "Updated credit preferences for #{person.full_name}."
+    else
+      redirect_to author_credit_divergences_path(filters), alert: person.errors.full_messages.to_sentence
+    end
+  end
+
+  # Resolve a single item by rewriting its stored consent snapshot. Setting
+  # "anonymous" here is a live override that suppresses that item's credit alone;
+  # any other value only re-records history (see AuthorCreditable).
+  def update_item
+    model = AuthorCreditDivergenceQuery.model_for(params[:record_type])
+    return redirect_to(author_credit_divergences_path(filters), alert: "Unknown record type.") unless model
+
+    record = model.find(params[:record_id])
+    record.author_credit_preference = params[:author_credit_preference]
+    record.updated_by = current_user if record.respond_to?(:updated_by=)
+
+    if record.save
+      redirect_to author_credit_divergences_path(filters), notice: "Updated credit for #{model.name.underscore.humanize.downcase} ##{record.id}."
+    else
+      redirect_to author_credit_divergences_path(filters), alert: record.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def authorize_page
+    authorize! :author_credit_divergence, to: :"#{action_name}?", with: AuthorCreditDivergencePolicy
+  end
+
+  def person_params
+    params.require(:person).permit(:display_name_preference, :contributions_anonymous)
+  end
+
+  # Carried through every redirect so the admin lands back on the same filtered list.
+  # The write actions deliberately name their own params `id` / `record_type` /
+  # `record_id` so a record identifier can never be mistaken for a filter.
+  def filters
+    params.permit(*FILTER_KEYS).to_h.compact_blank
+  end
+end

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -7,6 +7,8 @@ class AuthorCreditDivergencesController < ApplicationController
     return unless turbo_frame_request?
 
     @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
+    @reconciled_people = Person.where.not(author_credit_reconciled_at: nil)
+                               .order(author_credit_reconciled_at: :desc)
     render :author_credit_divergences_results
   end
 

--- a/app/controllers/author_credit_divergences_controller.rb
+++ b/app/controllers/author_credit_divergences_controller.rb
@@ -3,10 +3,12 @@ class AuthorCreditDivergencesController < ApplicationController
 
   FILTER_KEYS = %i[person_id type preference include_reconciled].freeze
 
+  # The full page renders only the header, filters, and an empty results frame;
+  # the frame's src request builds the divergences.
   def index
-    @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
-
     return unless turbo_frame_request?
+
+    @result = AuthorCreditDivergenceQuery.new(**filters.symbolize_keys).call
     render :author_credit_divergences_results
   end
 

--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -146,7 +146,7 @@ class CommunityNewsController < ApplicationController
       :title, :rhino_body, :published, :featured, :publicly_visible, :publicly_featured,
       :reference_url, :youtube_url,
       :organization_id,
-      :author_id, :created_by_id, :updated_by_id, :author_credit_preference,
+      :author_id, :author_credit_preference, :created_by_id, :updated_by_id,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -146,7 +146,7 @@ class CommunityNewsController < ApplicationController
       :title, :rhino_body, :published, :featured, :publicly_visible, :publicly_featured,
       :reference_url, :youtube_url,
       :organization_id,
-      :author_id, :author_credit_preference, :created_by_id, :updated_by_id,
+      :author_id, :created_by_id, :updated_by_id,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -146,7 +146,7 @@ class CommunityNewsController < ApplicationController
       :title, :rhino_body, :published, :featured, :publicly_visible, :publicly_featured,
       :reference_url, :youtube_url,
       :organization_id,
-      :author_id, :created_by_id, :updated_by_id,
+      :author_id, :created_by_id, :updated_by_id, :author_credit_preference,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -527,7 +527,6 @@ class PeopleController < ApplicationController
       :display_name_preference,
       :anonymous_contributions,
       :pronouns,
-      :profile_show_name_preference,
       :profile_is_searchable,
       :profile_show_pronouns,
       :profile_show_credentials,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -62,8 +62,7 @@ class PeopleController < ApplicationController
       when "stories"
         # Credit the person for stories they authored or were spotlighted in —
         # not ones their user merely entered (created_by is a pure audit trail).
-        # Spotlighted stories are always listed: the spotlight is a separate credit
-        # from authorship, so the anonymity flag doesn't apply to it.
+        # The spotlight is a separate credit from authorship, so anonymity doesn't apply.
         story_ids = visible_authored_content(@person.stories_as_author).pluck(:id) +
           @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
@@ -299,10 +298,8 @@ class PeopleController < ApplicationController
 
   private
 
-  # Anonymously-credited content is listed on the profile only for the person
-  # themselves and admins — showing it to anyone else would tie an "Anonymous"
-  # credit back to a name. `anonymous_contributions` anonymizes every item at once;
-  # otherwise only the items whose stored consent is "anonymous" are hidden.
+  # Showing anonymous content to anyone but the person and admins would tie an
+  # "Anonymous" credit back to a name.
   def visible_authored_content(scope)
     return scope if allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
     return scope.none if @person.anonymous_contributions?

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -306,7 +306,7 @@ class PeopleController < ApplicationController
   def visible_authored_content(scope)
     return scope if allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
     return scope.none if @person.contributions_anonymous?
-    scope.where.not(author_credit_preference: AuthorCreditable::ANONYMOUS)
+    scope.credited_openly
   end
 
   def set_person

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -2,6 +2,10 @@ class PeopleController < ApplicationController
   include AhoyTracking, TagAssignable
   before_action :set_person, only: %i[ show edit update destroy workshop_logs checkout bio all_comments ]
 
+  # The profile's "Submitted content" sections — private to the person and admins,
+  # not part of the public profile even after profile viewing opens up.
+  PRIVATE_SECTIONS = %w[ workshop_ideas story_ideas workshop_variation_ideas workshop_logs ].freeze
+
   def index
     authorize!
 
@@ -47,6 +51,11 @@ class PeopleController < ApplicationController
     if turbo_frame_request?
       per_page = params[:section] == "stories" ? 8 : 9
       section = params[:section]
+
+      # Re-authorize the private sections on the narrow owner/admin rule, so a
+      # crafted ?section= frame request can't reach them once show? is widened
+      # to let non-owners view the public profile.
+      authorize! @person, to: :own_record? if PRIVATE_SECTIONS.include?(section)
 
       case section
       when "workshops"

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -52,24 +52,26 @@ class PeopleController < ApplicationController
       when "workshops"
         # Credit the person for workshops they authored — not ones their user
         # merely created (created_by is a pure audit trail).
-        @workshops = @person.workshops_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        @workshops = visible_authored_content(@person.workshops_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshops", locals: { person: @person, workshops: @workshops }
       when "workshop_variations"
         # Credit the person for variations they authored — not ones their user
         # merely entered (created_by is a pure audit trail).
-        @workshop_variations = @person.workshop_variations_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        @workshop_variations = visible_authored_content(@person.workshop_variations_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variations", locals: { person: @person, workshop_variations: @workshop_variations }
       when "stories"
         # Credit the person for stories they authored or were spotlighted in —
         # not ones their user merely entered (created_by is a pure audit trail).
-        story_ids = @person.stories_as_author.pluck(:id) +
+        # Spotlighted stories are always listed: the spotlight is a separate credit
+        # from authorship, so the anonymity flag doesn't apply to it.
+        story_ids = visible_authored_content(@person.stories_as_author).pluck(:id) +
           @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }
       when "resources"
         # Credit the person for resources they authored — not ones their user
         # merely entered (created_by is a pure audit trail).
-        @resources = @person.resources_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        @resources = visible_authored_content(@person.resources_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/resources", locals: { person: @person, resources: @resources }
       when "events"
         @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
@@ -297,6 +299,15 @@ class PeopleController < ApplicationController
 
   private
 
+  # Anonymously-credited content is listed on the profile only for the person
+  # themselves and admins — showing it to anyone else would tie an "Anonymous"
+  # credit back to a name. `contributions_anonymous` anonymizes every item at once;
+  # otherwise only the items whose stored consent is "anonymous" are hidden.
+  def visible_authored_content(scope)
+    return scope if allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
+    return scope.none if @person.contributions_anonymous?
+    scope.where.not(author_credit_preference: AuthorCreditable::ANONYMOUS)
+  end
 
   def set_person
     @person = Person.find(params[:id])

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -301,11 +301,11 @@ class PeopleController < ApplicationController
 
   # Anonymously-credited content is listed on the profile only for the person
   # themselves and admins — showing it to anyone else would tie an "Anonymous"
-  # credit back to a name. `contributions_anonymous` anonymizes every item at once;
+  # credit back to a name. `anonymous_contributions` anonymizes every item at once;
   # otherwise only the items whose stored consent is "anonymous" are hidden.
   def visible_authored_content(scope)
     return scope if allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
-    return scope.none if @person.contributions_anonymous?
+    return scope.none if @person.anonymous_contributions?
     scope.credited_openly
   end
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -180,7 +180,7 @@ class ResourcesController < ApplicationController
     params.require(:resource).permit(
       :rhino_body, :kind, :male, :female, :title, :featured, :published, :publicly_visible, :publicly_featured,
       :hidden_from_search,
-      :agency, :author_id, :filemaker_code, :windows_type_id, :position,
+      :agency, :author_id, :author_credit_preference, :filemaker_code, :windows_type_id, :position,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       downloadable_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -180,7 +180,7 @@ class ResourcesController < ApplicationController
     params.require(:resource).permit(
       :rhino_body, :kind, :male, :female, :title, :featured, :published, :publicly_visible, :publicly_featured,
       :hidden_from_search,
-      :agency, :author_id, :author_credit_preference, :filemaker_code, :windows_type_id, :position,
+      :agency, :author_id, :filemaker_code, :windows_type_id, :position,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       downloadable_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -228,7 +228,7 @@ class StoriesController < ApplicationController
     params.require(:story).permit(
       :title, :rhino_body, :featured, :published, :publicly_visible, :publicly_featured, :youtube_url, :website_url,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
-      :author_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id,
+      :author_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -228,7 +228,7 @@ class StoriesController < ApplicationController
     params.require(:story).permit(
       :title, :rhino_body, :featured, :published, :publicly_visible, :publicly_featured, :youtube_url, :website_url,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
-      :author_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id, :author_credit_preference,
+      :author_id, :updated_by_id, :story_idea_id, :spotlighted_facilitator_id,
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -146,7 +146,7 @@ class StoryIdeasController < ApplicationController
   def story_idea_params
     params.require(:story_idea).permit(
       :title, :rhino_body, :youtube_url,
-      :permission_given,
+      :permission_given, :author_credit_preference,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
       :created_by_id, :updated_by_id,
       category_ids: [],

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -146,7 +146,7 @@ class StoryIdeasController < ApplicationController
   def story_idea_params
     params.require(:story_idea).permit(
       :title, :rhino_body, :youtube_url,
-      :permission_given, :author_credit_preference, :promoted_to_story,
+      :permission_given,
       :windows_type_id, :organization_id, :workshop_id, :external_workshop_title,
       :created_by_id, :updated_by_id,
       category_ids: [],

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -111,7 +111,7 @@ class WorkshopIdeasController < ApplicationController
   # Strong parameters
   def workshop_idea_params
     params.require(:workshop_idea).permit(
-      :title, :staff_notes, :created_by_id, :updated_by_id, :windows_type_id,
+      :title, :staff_notes, :author_credit_preference, :created_by_id, :updated_by_id, :windows_type_id,
       :time_closing, :time_creation, :time_demonstration,
       :time_hours, :time_intro, :time_minutes,
       :time_opening, :time_opening_circle, :time_warm_up,

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -111,8 +111,7 @@ class WorkshopIdeasController < ApplicationController
   # Strong parameters
   def workshop_idea_params
     params.require(:workshop_idea).permit(
-      :title, :staff_notes, :author_credit_preference,
-      :created_by_id, :updated_by_id, :windows_type_id,
+      :title, :staff_notes, :created_by_id, :updated_by_id, :windows_type_id,
       :time_closing, :time_creation, :time_demonstration,
       :time_hours, :time_intro, :time_minutes,
       :time_opening, :time_opening_circle, :time_warm_up,

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -111,7 +111,8 @@ class WorkshopIdeasController < ApplicationController
   # Strong parameters
   def workshop_idea_params
     params.require(:workshop_idea).permit(
-      :title, :staff_notes, :author_credit_preference, :created_by_id, :updated_by_id, :windows_type_id,
+      :title, :staff_notes, :author_credit_preference,
+      :created_by_id, :updated_by_id, :windows_type_id,
       :time_closing, :time_creation, :time_demonstration,
       :time_hours, :time_intro, :time_minutes,
       :time_opening, :time_opening_circle, :time_warm_up,

--- a/app/controllers/workshop_variation_ideas_controller.rb
+++ b/app/controllers/workshop_variation_ideas_controller.rb
@@ -117,7 +117,8 @@ class WorkshopVariationIdeasController < ApplicationController
   def workshop_variation_idea_params
     params.require(:workshop_variation_idea).permit(
       :name, :rhino_body, :youtube_url,
-      :permission_given, :author_credit_preference, :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
+      :permission_given, :author_credit_preference,
+      :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ]
     )

--- a/app/controllers/workshop_variation_ideas_controller.rb
+++ b/app/controllers/workshop_variation_ideas_controller.rb
@@ -117,7 +117,7 @@ class WorkshopVariationIdeasController < ApplicationController
   def workshop_variation_idea_params
     params.require(:workshop_variation_idea).permit(
       :name, :rhino_body, :youtube_url,
-      :permission_given, :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
+      :permission_given, :author_credit_preference, :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ]
     )

--- a/app/controllers/workshop_variation_ideas_controller.rb
+++ b/app/controllers/workshop_variation_ideas_controller.rb
@@ -117,8 +117,7 @@ class WorkshopVariationIdeasController < ApplicationController
   def workshop_variation_idea_params
     params.require(:workshop_variation_idea).permit(
       :name, :rhino_body, :youtube_url,
-      :permission_given, :author_credit_preference,
-      :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
+      :permission_given, :organization_id, :windows_type_id, :workshop_id, :created_by_id, :updated_by_id,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ]
     )

--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -132,8 +132,7 @@ class WorkshopVariationsController < ApplicationController
   def workshop_variation_params
     params.require(:workshop_variation).permit(
       [ :name, :rhino_body, :published, :publicly_visible, :position, :youtube_url, :author_id,
-        :organization_id, :workshop_id, :workshop_variation_idea_id, :author_credit_preference,
-        :windows_type_id,
+        :organization_id, :workshop_id, :workshop_variation_idea_id, :windows_type_id,
         primary_asset_attributes: [ :id, :file, :_destroy ],
         gallery_assets_attributes: [ :id, :file, :_destroy ]
       ]

--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -132,7 +132,7 @@ class WorkshopVariationsController < ApplicationController
   def workshop_variation_params
     params.require(:workshop_variation).permit(
       [ :name, :rhino_body, :published, :publicly_visible, :position, :youtube_url, :author_id,
-        :organization_id, :workshop_id, :workshop_variation_idea_id, :windows_type_id,
+        :organization_id, :workshop_id, :workshop_variation_idea_id, :author_credit_preference, :windows_type_id,
         primary_asset_attributes: [ :id, :file, :_destroy ],
         gallery_assets_attributes: [ :id, :file, :_destroy ]
       ]

--- a/app/controllers/workshop_variations_controller.rb
+++ b/app/controllers/workshop_variations_controller.rb
@@ -132,7 +132,8 @@ class WorkshopVariationsController < ApplicationController
   def workshop_variation_params
     params.require(:workshop_variation).permit(
       [ :name, :rhino_body, :published, :publicly_visible, :position, :youtube_url, :author_id,
-        :organization_id, :workshop_id, :workshop_variation_idea_id, :author_credit_preference, :windows_type_id,
+        :organization_id, :workshop_id, :workshop_variation_idea_id, :author_credit_preference,
+        :windows_type_id,
         primary_asset_attributes: [ :id, :file, :_destroy ],
         gallery_assets_attributes: [ :id, :file, :_destroy ]
       ]

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -226,8 +226,7 @@ class WorkshopsController < ApplicationController
   def workshop_params
     params.require(:workshop).permit(
       :title, :featured, :published,
-      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :author_credit_preference,
-      :month, :year,
+      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :month, :year,
       :publicly_visible,
       :publicly_featured,
 

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -226,7 +226,7 @@ class WorkshopsController < ApplicationController
   def workshop_params
     params.require(:workshop).permit(
       :title, :featured, :published,
-      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :month, :year,
+      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :author_credit_preference, :month, :year,
       :publicly_visible,
       :publicly_featured,
 

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -226,7 +226,8 @@ class WorkshopsController < ApplicationController
   def workshop_params
     params.require(:workshop).permit(
       :title, :featured, :published,
-      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :author_credit_preference, :month, :year,
+      :full_name, :author_id, :windows_type_id, :workshop_idea_id, :author_credit_preference,
+      :month, :year,
       :publicly_visible,
       :publicly_featured,
 

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -12,10 +12,6 @@ class ResourceDecorator < ApplicationDecorator
     kind == "Scholarship" ? "Scholar-ship" : (kind.present? ? kind.titleize : "Resource")
   end
 
-  def truncated_author
-    h.truncate author_credit, length: 20
-  end
-
   def truncated_title
     h.truncate title, length: 25
   end
@@ -34,10 +30,6 @@ class ResourceDecorator < ApplicationDecorator
 
   def breadcrumbs
     "#{type_link} >> #{title}".html_safe
-  end
-
-  def author_full_name
-    author_credit
   end
 
   def display_date

--- a/app/frontend/javascript/controllers/remote_select_controller.js
+++ b/app/frontend/javascript/controllers/remote_select_controller.js
@@ -80,7 +80,7 @@ export default class extends Controller {
         z-index: 1;
       }
       .remote-select-container .ts-control {
-        padding-left: 1.5rem !important;  /* Make room for the search icon */
+        padding-left: 2rem !important;  /* Clear the search icon so it never overlaps the placeholder or value */
       }
       .ts-control {
         border: none !important;

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -76,6 +76,7 @@ module AdminCardsHelper
   def additional_data_cards
     [
       custom_card("Allocations", allocations_path, icon: "📤", color: :sky, intensity: 100),
+      custom_card("Author credit divergences", author_credit_divergences_path, icon: "✍️", color: :sky, intensity: 100),
       disabled_card("Bulk payments", icon: "💳"),
       custom_card("Event registrations", event_registrations_path, icon: "🎟️", color: :sky, intensity: 100),
       custom_card("Features & tips", features_path, icon: "⭐", color: :sky, intensity: 100),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,14 @@ module ApplicationHelper
     end
   end
 
+  # The person an author picker should show. Only the record's own author counts —
+  # falling back to the creator would present a person nobody chose as the selected
+  # author, and saving the form would silently promote them over a legacy credit.
+  # New records still default to the current user, which is the documented behavior.
+  def author_picker_person(record)
+    record.author || (record.new_record? ? current_user&.person : nil)
+  end
+
   # Tags an admin may use in a form field name / group header that should
   # render (rather than escape) on the public form. Block + inline formatting,
   # links, line breaks, and font sizing/coloring (via <font> or inline style).

--- a/app/helpers/author_credit_divergences_helper.rb
+++ b/app/helpers/author_credit_divergences_helper.rb
@@ -4,6 +4,21 @@ module AuthorCreditDivergencesHelper
     record.try(:title).presence || record.try(:name).presence || "##{record.id}"
   end
 
+  # An empty page means "nothing left to reconcile" only when nothing is filtered
+  # out — otherwise the congratulations would be reporting on the filter.
+  def divergence_filters_applied?
+    AuthorCreditDivergencesController::FILTER_KEYS.any? { |key| params[key].present? }
+  end
+
+  # New tab rather than an eyebrow: these rows link to 8 different destinations,
+  # none of which carries a return_to today.
+  def divergence_record_link(record)
+    link_to divergence_record_title(record), polymorphic_path(record),
+            target: "_blank", rel: "noopener",
+            title: "Opens in a new tab",
+            class: "text-blue-700 hover:underline"
+  end
+
   # The suggestion is the most restrictive preference across the person's content,
   # but `anonymous` isn't a name format — it's the separate checkbox — so fall back
   # to the profile's current format when that's what was suggested.

--- a/app/helpers/author_credit_divergences_helper.rb
+++ b/app/helpers/author_credit_divergences_helper.rb
@@ -4,6 +4,15 @@ module AuthorCreditDivergencesHelper
     record.try(:title).presence || record.try(:name).presence || "##{record.id}"
   end
 
+  # Wraps plain records for the shared assign-a-person table. Sections 3 and 4 have
+  # no free-text name to guess from, so the suggestion is passed in (the creator) or
+  # omitted entirely.
+  def assignable_rows(records, suggested_author: nil)
+    records.map do |record|
+      AuthorCreditDivergenceQuery::AssignableRow.new(record: record, suggested_author: suggested_author)
+    end
+  end
+
   # An empty page means "nothing left to reconcile" only when nothing is filtered
   # out — otherwise the congratulations would be reporting on the filter.
   def divergence_filters_applied?

--- a/app/helpers/author_credit_divergences_helper.rb
+++ b/app/helpers/author_credit_divergences_helper.rb
@@ -1,0 +1,15 @@
+module AuthorCreditDivergencesHelper
+  # The 8 AuthorCreditable models label their content differently (title vs name).
+  def divergence_record_title(record)
+    record.try(:title).presence || record.try(:name).presence || "##{record.id}"
+  end
+
+  # The suggestion is the most restrictive preference across the person's content,
+  # but `anonymous` isn't a name format — it's the separate checkbox — so fall back
+  # to the profile's current format when that's what was suggested.
+  def suggested_display_name_preference(group)
+    suggested = group.suggested_preference
+    return suggested if Person::DISPLAY_NAME_PREFERENCES.include?(suggested)
+    group.person.display_name_preference.presence || "full_name"
+  end
+end

--- a/app/helpers/author_credit_divergences_helper.rb
+++ b/app/helpers/author_credit_divergences_helper.rb
@@ -1,26 +1,22 @@
 module AuthorCreditDivergencesHelper
-  # The 8 AuthorCreditable models label their content differently (title vs name).
+  # The models label their content differently (title vs name).
   def divergence_record_title(record)
     record.try(:title).presence || record.try(:name).presence || "##{record.id}"
   end
 
-  # Wraps plain records for the shared assign-a-person table. Sections 3 and 4 have
-  # no free-text name to guess from, so the suggestion is passed in (the creator) or
-  # omitted entirely.
+  # Sections 3 and 4 have no name to guess from, so any suggestion is passed in.
   def assignable_rows(records, suggested_author: nil)
     records.map do |record|
       AuthorCreditDivergenceQuery::AssignableRow.new(record: record, suggested_author: suggested_author)
     end
   end
 
-  # An empty page means "nothing left to reconcile" only when nothing is filtered
-  # out — otherwise the congratulations would be reporting on the filter.
+  # Otherwise the congratulations would be reporting on the filter.
   def divergence_filters_applied?
     AuthorCreditDivergencesController::FILTER_KEYS.any? { |key| params[key].present? }
   end
 
-  # New tab rather than an eyebrow: these rows link to 8 different destinations,
-  # none of which carries a return_to today.
+  # New tab rather than an eyebrow: 8 destinations, none carrying a return_to today.
   def divergence_record_link(record)
     link_to divergence_record_title(record), polymorphic_path(record),
             target: "_blank", rel: "noopener",
@@ -28,9 +24,7 @@ module AuthorCreditDivergencesHelper
             class: "text-blue-700 hover:underline"
   end
 
-  # The suggestion is the most restrictive preference across the person's content,
-  # but `anonymous` isn't a name format — it's the separate checkbox — so fall back
-  # to the profile's current format when that's what was suggested.
+  # `anonymous` isn't a name format — it's the separate checkbox — so fall back.
   def suggested_display_name_preference(group)
     suggested = group.suggested_preference
     return suggested if Person::DISPLAY_NAME_PREFERENCES.include?(suggested)

--- a/app/helpers/author_credit_divergences_helper.rb
+++ b/app/helpers/author_credit_divergences_helper.rb
@@ -18,7 +18,7 @@ module AuthorCreditDivergencesHelper
 
   # New tab rather than an eyebrow: 8 destinations, none carrying a return_to today.
   def divergence_record_link(record)
-    link_to divergence_record_title(record), polymorphic_path(record),
+    link_to divergence_record_title(record), edit_polymorphic_path(record),
             target: "_blank", rel: "noopener",
             title: "Opens in a new tab",
             class: "text-blue-700 hover:underline"

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -47,9 +47,11 @@ class CommunityNews < ApplicationRecord
   # SearchCop
   include SearchCop
   search_scope :search do
-    attributes :title, :published, person_first: "people.first_name", person_last: "people.last_name"
+    attributes :title, :published
 
-    scope { join_rich_texts.left_joins(:author) }
+    # Author names are deliberately not indexed here — see Story. Person-name
+    # search goes through `by_credited_person_name`, which honors the preference.
+    scope { join_rich_texts }
     attributes action_text_body: "action_text_rich_texts.plain_text_body"
   end
 

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -68,9 +68,9 @@ class CommunityNews < ApplicationRecord
       community_news = self.search(conditions)
     end
 
-    # SearchCop's free-text query covers title + body + the explicit author. Also
-    # match the credited author/legacy author/creator by name, OR-ed in via id
-    # subqueries so the extra person joins stay isolated from SearchCop's joins.
+    # SearchCop's free-text query covers title + body only. Match the credited author
+    # by name separately, OR-ed in via id subqueries so the extra person joins stay
+    # isolated from SearchCop's joins.
     if params[:query].present?
       community_news = self.where(id: community_news.select("community_news.id"))
                            .or(self.where(id: by_credited_person_name(params[:query]).select("community_news.id")))

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -32,11 +32,6 @@ class CommunityNews < ApplicationRecord
   validates :reference_url, length: { maximum: 255 }
   validates :youtube_url, length: { maximum: 255 }
 
-  # Unattributed community news is credited to the organization's staff.
-  def missing_author_label
-    "AWBW Staff"
-  end
-
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -5,9 +5,9 @@ module AuthorCreditable
   # `author_credit_preference` is retained as the record of what the submitter consented
   # to at submission time, and is human-editable only on the author credit divergences
   # page. It no longer drives display — with one exception: a stored "anonymous" is
-  # always honored, because anonymity is inherently per-item (a person may want four
-  # stories credited and the fifth not) and because nothing should be able to
-  # de-anonymize an item that was submitted anonymously.
+  # always honored while it's set, because anonymity is inherently per-item (a person
+  # may want four stories credited and the fifth not). Only an admin clearing the
+  # snapshot on that page hands the item back to the profile.
   AUTHOR_CREDIT_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only anonymous].freeze
 
   ANONYMOUS = "anonymous"
@@ -179,13 +179,16 @@ module AuthorCreditable
 
     # Arel COALESCE over every credited person alias (and legacy name column),
     # so the ORDER BY carries no interpolated SQL. Aliases and column names come
-    # from model config / column_names, never user input.
+    # from model config / column_names, never user input. Ordered author → legacy →
+    # creator to match `author_credit`, so a row sorts under the name it displays.
     def coalesced_author_arel(field, ascending)
-      parts = credited_person_aliases.map { |sql_alias| Arel::Table.new(sql_alias)[field] }
+      parts = []
+      parts << Arel::Table.new("credited_author")[field] if column_names.include?("author_id")
       parts += legacy_author_name_columns.map do |col|
         table, column = col.split(".")
         Arel::Table.new(table)[column]
       end
+      parts << Arel::Table.new("credited_creator")[field]
       node = Arel::Nodes::NamedFunction.new("COALESCE", parts)
       ascending ? node.asc : node.desc
     end

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -86,15 +86,19 @@ module AuthorCreditable
     person.present? && author_credit_preference != person.effective_author_credit_preference
   end
 
-  # Shown when there's no credited person or legacy name. Overridable per model.
+  # Shown when there's no credited person or legacy name. The portal is behind a
+  # login, so this names the org's facilitators rather than hiding behind
+  # "Anonymous", which would read as a deliberate privacy choice.
   def missing_author_label
-    "Anonymous"
+    "AWBW Facilitator"
   end
 
   def snapshot_author_credit_preference
     # Promotion services copy the originating idea's snapshot forward — keep it.
     return if author_credit_preference.present?
-    person = primary_author_person || created_by&.person
+    # Only the governing profile, so a legacy credit doesn't snapshot the profile of
+    # whoever entered it and then read as drift against it.
+    person = credit_governing_person
     self.author_credit_preference = person.effective_author_credit_preference if person
   end
 
@@ -180,7 +184,15 @@ module AuthorCreditable
         "(#{preference} = '#{value}' AND (#{expressions.map { |e| name_like(e) }.join(' OR ')}))"
       end
 
-      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
+      # A legacy name outranks the creator in the credit, so the creator's name isn't
+      # displayed on those rows and mustn't find them either.
+      gate = sql_alias == "credited_creator" ? " AND #{no_legacy_name_sql}" : ""
+      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql}#{gate} AND (#{by_preference.join(' OR ')}))"
+    end
+
+    def no_legacy_name_sql
+      return "1 = 1" if legacy_author_name_columns.empty?
+      legacy_author_name_columns.map { |col| "(#{col} IS NULL OR #{col} = '')" }.join(" AND ")
     end
 
     # No person behind a legacy name, so only the record's own anonymity applies.

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -1,15 +1,16 @@
 module AuthorCreditable
   extend ActiveSupport::Concern
 
+  # How a credit renders comes from the credited person's profile, not from the record.
+  # `author_credit_preference` is retained as the record of what the submitter consented
+  # to at submission time, and is human-editable only on the author credit divergences
+  # page. It no longer drives display — with one exception: a stored "anonymous" is
+  # always honored, because anonymity is inherently per-item (a person may want four
+  # stories credited and the fifth not) and because nothing should be able to
+  # de-anonymize an item that was submitted anonymously.
   AUTHOR_CREDIT_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only anonymous].freeze
 
-  IDEA_FORM_OPTIONS = {
-    "I would like my full name published with the story" => "full_name",
-    "I would like my first name and last initial published" => "first_name_last_initial",
-    "I would like only my first name published" => "first_name_only",
-    "I would like only my last name published" => "last_name_only",
-    "I do not want my name published with my story" => "anonymous"
-  }.freeze
+  ANONYMOUS = "anonymous"
 
   ADMIN_FORM_OPTIONS = {
     "Full name" => "full_name",
@@ -20,11 +21,9 @@ module AuthorCreditable
   }.freeze
 
   included do
-    # Admin-created records default a blank preference to full_name (in the UI and
-    # on save) — no data backfill. Public-submission models call
-    # `require_author_credit_preference` instead, to force a conscious choice.
-    attribute :author_credit_preference, :string, default: "full_name"
-    before_validation :apply_default_author_credit_preference
+    # Snapshot the credited person's profile preference on create, so the column keeps
+    # recording consent-at-submission without a human ever picking it.
+    before_create :snapshot_author_credit_preference
     validates :author_credit_preference, inclusion: { in: AUTHOR_CREDIT_PREFERENCES }, allow_blank: true
 
     # Filter to content explicitly authored by a person (belongs_to :author);
@@ -57,16 +56,15 @@ module AuthorCreditable
     nil
   end
 
-  # Display string for the credited author, honoring the credit preference.
-  # Precedence: an explicit "anonymous" preference always renders "Anonymous";
-  # then the primary author person, then the legacy free-text name, then the
+  # Display string for the credited author, formatted by that person's profile.
+  # Precedence: the primary author person, then the legacy free-text name, then the
   # creating user's person, then `missing_author_label`.
   def author_credit
-    return "Anonymous" if author_credit_preference == "anonymous"
     person = primary_author_person
-    return format_person_credit(person) if person
+    return credit_for(person) if person
     return legacy_author_name_text if legacy_author_name_text.present?
-    format_person_credit(created_by&.person)
+    creator = created_by&.person
+    creator ? credit_for(creator) : missing_author_label
   end
 
   # The person the credit should link to, or nil when the credit must not resolve
@@ -75,8 +73,23 @@ module AuthorCreditable
   # never declared authorship (and the record isn't listed on their profile
   # either). Anonymous never links.
   def author_credit_person
-    return nil if author_credit_preference == "anonymous"
-    primary_author_person
+    person = primary_author_person
+    person && !credit_anonymous?(person) ? person : nil
+  end
+
+  # Anonymity is a one-way latch: the profile can set it, the record can set it,
+  # and neither can strip it from the other.
+  def credit_anonymous?(person)
+    person.contributions_anonymous? || author_credit_preference == ANONYMOUS
+  end
+
+  # True when the stored consent snapshot no longer agrees with the credited
+  # person's current profile — surfaced as a warning on the record's form and as a
+  # row on the author credit divergences page.
+  def author_credit_diverged?
+    return false if author_credit_preference.blank?
+    person = author_person
+    person.present? && author_credit_preference != person.effective_author_credit_preference
   end
 
   # Shown when there is no credited person or legacy name. Overridable per model
@@ -85,44 +98,19 @@ module AuthorCreditable
     "Anonymous"
   end
 
-  # Default an unset preference to "full_name" (so legacy rows normalize on save,
-  # no backfill) — unless the model requires an explicit choice.
-  def apply_default_author_credit_preference
-    return if self.class.require_author_credit_preference?
-    self.author_credit_preference = "full_name" if author_credit_preference.blank?
+  def snapshot_author_credit_preference
+    # Promotion services copy the originating idea's snapshot forward — keep it.
+    return if author_credit_preference.present?
+    person = primary_author_person || created_by&.person
+    self.author_credit_preference = person.effective_author_credit_preference if person
   end
 
-  # Formats a person's name per the credit preference, falling back to
-  # `missing_author_label` when the person or the requested name part is missing.
-  private def format_person_credit(person)
-    case author_credit_preference
-    when "first_name_last_initial"
-      first = person&.first_name
-      first.present? ? "#{first} #{person.last_name&.first}." : missing_author_label
-    when "first_name_only"
-      person&.first_name.presence || missing_author_label
-    when "last_name_only"
-      person&.last_name.presence || missing_author_label
-    else # full_name — the default, and the fallback for any unknown value
-      person&.full_name.presence || missing_author_label
-    end
+  private def credit_for(person)
+    return "Anonymous" if credit_anonymous?(person)
+    person.name.presence || missing_author_label
   end
 
   class_methods do
-    # Require an explicit credit choice rather than defaulting to full_name — for
-    # public submissions where the preference is a privacy decision (the submitter
-    # must not be silently opted into publishing their full name). Used by the
-    # *_idea models.
-    def require_author_credit_preference
-      @require_author_credit_preference = true
-      attribute :author_credit_preference, :string, default: nil
-      validates :author_credit_preference, presence: true
-    end
-
-    def require_author_credit_preference?
-      @require_author_credit_preference == true
-    end
-
     # Legacy free-text columns (fully qualified, e.g. "resources.legacy_author_name")
     # that also hold an author's name. Overridden per model that has one.
     def legacy_author_name_columns
@@ -138,8 +126,8 @@ module AuthorCreditable
       sanitized = query.to_s.strip.gsub(/\s+/, "")
       return none if sanitized.blank?
 
-      clauses = credited_person_aliases.flat_map { |a| person_name_match_clauses(a) }
-      clauses += legacy_author_name_columns.map { |col| "LOWER(REPLACE(#{col}, ' ', '')) LIKE :name" }
+      clauses = credited_person_aliases.map { |a| credited_person_match_sql(a) }
+      clauses += legacy_author_name_columns.map { |col| legacy_author_name_match_sql(col) }
       joins(credited_person_join_sql).where(clauses.join(" OR "), name: "%#{sanitized}%")
     end
 
@@ -189,13 +177,40 @@ module AuthorCreditable
       ascending ? node.asc : node.desc
     end
 
-    def person_name_match_clauses(sql_alias)
-      [
-        "LOWER(REPLACE(CONCAT(#{sql_alias}.first_name, #{sql_alias}.last_name), ' ', '')) LIKE :name",
-        "LOWER(REPLACE(CONCAT(#{sql_alias}.last_name, #{sql_alias}.first_name), ' ', '')) LIKE :name",
-        "LOWER(REPLACE(#{sql_alias}.first_name, ' ', '')) LIKE :name",
-        "LOWER(REPLACE(#{sql_alias}.last_name, ' ', '')) LIKE :name"
-      ]
+    # Match only on the name parts the credit actually displays, so search can't
+    # surface what the credit hides: an anonymous credit matches nothing, a
+    # "first name only" credit isn't findable by last name, and a "first name,
+    # last initial" credit matches the initial rather than the whole last name.
+    def credited_person_match_sql(sql_alias)
+      first = "#{sql_alias}.first_name"
+      last = "#{sql_alias}.last_name"
+      preference = "COALESCE(#{sql_alias}.display_name_preference, 'full_name')"
+
+      by_preference = {
+        "full_name" => [ "CONCAT(#{first}, #{last})", "CONCAT(#{last}, #{first})", first, last ],
+        "first_name_last_initial" => [ "CONCAT(#{first}, LEFT(#{last}, 1))", first ],
+        "first_name_only" => [ first ],
+        "last_name_only" => [ last ]
+      }.map do |value, expressions|
+        "(#{preference} = '#{value}' AND (#{expressions.map { |e| name_like(e) }.join(' OR ')}))"
+      end
+
+      "(#{sql_alias}.contributions_anonymous = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
+    end
+
+    # Legacy free-text author names have no person, so only the record's own
+    # anonymity applies.
+    def legacy_author_name_match_sql(column)
+      "(#{not_anonymous_sql} AND #{name_like(column)})"
+    end
+
+    def not_anonymous_sql
+      "(#{table_name}.author_credit_preference IS NULL OR " \
+        "#{table_name}.author_credit_preference <> '#{AuthorCreditable::ANONYMOUS}')"
+    end
+
+    def name_like(expression)
+      "LOWER(REPLACE(#{expression}, ' ', '')) LIKE :name"
     end
   end
 end

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -162,13 +162,17 @@ module AuthorCreditable
     # Only an explicit author is ever credited, so search and sort reach that person
     # alone — and nobody at all on the idea models, which have no author_id.
     def credited_person_aliases
-      column_names.include?("author_id") ? [ "credited_author" ] : []
+      explicit_author? ? [ "credited_author" ] : []
     end
 
     def credited_person_join_sql
       return [] if credited_person_aliases.empty?
 
       [ "LEFT OUTER JOIN people credited_author ON credited_author.id = #{table_name}.author_id" ]
+    end
+
+    def explicit_author?
+      column_names.include?("author_id")
     end
 
     # Arel keeps interpolated SQL out of the ORDER BY. Same precedence as
@@ -202,9 +206,15 @@ module AuthorCreditable
       "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
     end
 
-    # No person behind a legacy name, so only the record's own anonymity applies.
+    # A legacy name only displays when no person author outranks it, so it's only
+    # searchable then — otherwise the person's profile governs the credit, and the
+    # stale column would surface a name that profile hides.
     def legacy_author_name_match_sql(column)
-      "(#{not_anonymous_sql} AND #{name_like(column)})"
+      "(#{no_person_author_sql} AND #{not_anonymous_sql} AND #{name_like(column)})"
+    end
+
+    def no_person_author_sql
+      explicit_author? ? "#{table_name}.author_id IS NULL" : "TRUE"
     end
 
     def not_anonymous_sql

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -93,15 +93,26 @@ module AuthorCreditable
   # Anonymity is a one-way latch: the profile can set it, the record can set it,
   # and neither can strip it from the other.
   def credit_anonymous?(person)
-    person.contributions_anonymous? || author_credit_preference == ANONYMOUS
+    person.anonymous_contributions? || author_credit_preference == ANONYMOUS
   end
 
-  # True when the stored consent snapshot no longer agrees with the credited
-  # person's current profile — surfaced as a warning on the record's form and as a
-  # row on the author credit divergences page.
+  # The person whose profile actually formats this credit. A legacy free-text name
+  # follows nobody's profile, so a legacy-credited record has no governing person even
+  # when it has a creator — those have to be matched to a real person by hand, not
+  # resolved to whoever happened to enter them.
+  def credit_governing_person
+    person = primary_author_person
+    return person if person
+    return nil if legacy_author_name_text.present?
+    created_by&.person
+  end
+
+  # True when the stored consent snapshot no longer agrees with the profile that
+  # governs this credit — surfaced as a warning on the record's form and as a row on
+  # the author credit divergences page.
   def author_credit_diverged?
     return false if author_credit_preference.blank?
-    person = author_person
+    person = credit_governing_person
     person.present? && author_credit_preference != person.effective_author_credit_preference
   end
 
@@ -211,7 +222,7 @@ module AuthorCreditable
         "(#{preference} = '#{value}' AND (#{expressions.map { |e| name_like(e) }.join(' OR ')}))"
       end
 
-      "(#{sql_alias}.contributions_anonymous = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
+      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
     end
 
     # Legacy free-text author names have no person, so only the record's own

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -52,11 +52,11 @@ module AuthorCreditable
 
   def author_credit
     # Outranks every source, including a legacy name no profile can suppress.
-    return "Anonymous" if author_credit_preference == ANONYMOUS
+    return missing_author_label if author_credit_preference == ANONYMOUS
     person = primary_author_person
     return credit_for(person) if person
     return legacy_author_name_text if legacy_author_name_text.present?
-    creator = created_by&.person
+    creator = self.class.credits_creator? ? created_by&.person : nil
     creator ? credit_for(creator) : missing_author_label
   end
 
@@ -71,12 +71,13 @@ module AuthorCreditable
     person.anonymous_contributions? || author_credit_preference == ANONYMOUS
   end
 
-  # A legacy name follows nobody's profile, so those have no governing person.
+  # A legacy name follows nobody's profile, and neither does a record that never
+  # named an author, so neither has a governing person.
   def credit_governing_person
     person = primary_author_person
     return person if person
     return nil if legacy_author_name_text.present?
-    created_by&.person
+    self.class.credits_creator? ? created_by&.person : nil
   end
 
   # Snapshot no longer agrees with the governing profile.
@@ -103,11 +104,18 @@ module AuthorCreditable
   end
 
   private def credit_for(person)
-    return "Anonymous" if credit_anonymous?(person)
+    return missing_author_label if credit_anonymous?(person)
     person.name.presence || missing_author_label
   end
 
   class_methods do
+    # Whoever entered a record didn't claim it, so a model that can name an author
+    # credits only that author. The idea models have no author_id at all, so their
+    # creator is the only credit they can carry.
+    def credits_creator?
+      !column_names.include?("author_id")
+    end
+
     # Fully-qualified legacy name columns, e.g. "resources.legacy_author_name".
     def legacy_author_name_columns
       []
@@ -136,34 +144,29 @@ module AuthorCreditable
 
     private
 
-    # Person SQL aliases in credit precedence order.
+    # The one person a credit can name — author XOR creator, never both, so search
+    # and sort can't reach a person the credit never displays.
     def credited_person_aliases
-      aliases = []
-      aliases << "credited_author" if column_names.include?("author_id")
-      aliases << "credited_creator"
-      aliases
+      credits_creator? ? [ "credited_creator" ] : [ "credited_author" ]
     end
 
     def credited_person_join_sql
-      sql = []
-      if column_names.include?("author_id")
-        sql << "LEFT OUTER JOIN people credited_author ON credited_author.id = #{table_name}.author_id"
-      end
-      sql << "LEFT OUTER JOIN users credited_creator_user ON credited_creator_user.id = #{table_name}.created_by_id"
-      sql << "LEFT OUTER JOIN people credited_creator ON credited_creator.id = credited_creator_user.person_id"
-      sql
+      return [
+        "LEFT OUTER JOIN users credited_creator_user ON credited_creator_user.id = #{table_name}.created_by_id",
+        "LEFT OUTER JOIN people credited_creator ON credited_creator.id = credited_creator_user.person_id"
+      ] if credits_creator?
+
+      [ "LEFT OUTER JOIN people credited_author ON credited_author.id = #{table_name}.author_id" ]
     end
 
-    # Arel keeps interpolated SQL out of the ORDER BY. Ordered author → legacy →
-    # creator to match `author_credit`, so a row sorts under the name it displays.
+    # Arel keeps interpolated SQL out of the ORDER BY. Same precedence as
+    # `author_credit`, so a row sorts under the name it displays.
     def coalesced_author_arel(field, ascending)
-      parts = []
-      parts << Arel::Table.new("credited_author")[field] if column_names.include?("author_id")
+      parts = credited_person_aliases.map { |sql_alias| Arel::Table.new(sql_alias)[field] }
       parts += legacy_author_name_columns.map do |col|
         table, column = col.split(".")
         Arel::Table.new(table)[column]
       end
-      parts << Arel::Table.new("credited_creator")[field]
       node = Arel::Nodes::NamedFunction.new("COALESCE", parts)
       ascending ? node.asc : node.desc
     end
@@ -184,15 +187,7 @@ module AuthorCreditable
         "(#{preference} = '#{value}' AND (#{expressions.map { |e| name_like(e) }.join(' OR ')}))"
       end
 
-      # A legacy name outranks the creator in the credit, so the creator's name isn't
-      # displayed on those rows and mustn't find them either.
-      gate = sql_alias == "credited_creator" ? " AND #{no_legacy_name_sql}" : ""
-      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql}#{gate} AND (#{by_preference.join(' OR ')}))"
-    end
-
-    def no_legacy_name_sql
-      return "1 = 1" if legacy_author_name_columns.empty?
-      legacy_author_name_columns.map { |col| "(#{col} IS NULL OR #{col} = '')" }.join(" AND ")
+      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
     end
 
     # No person behind a legacy name, so only the record's own anonymity applies.

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -8,6 +8,11 @@ module AuthorCreditable
 
   ANONYMOUS = "anonymous"
 
+  # Read through `anonymous_author_label` / `missing_author_label` from a record, so a
+  # model can override; reference the constants directly only where no record is in hand.
+  ANONYMOUS_AUTHOR_LABEL = "AWBW Facilitator".freeze
+  MISSING_AUTHOR_LABEL = "AWBW Staff".freeze
+
   ADMIN_FORM_OPTIONS = {
     "Full name" => "full_name",
     "First name, last initial" => "first_name_last_initial",
@@ -88,12 +93,12 @@ module AuthorCreditable
   # A named author who opted out of the credit — still a facilitator's content,
   # just shown without their name rather than hiding behind "Anonymous".
   def anonymous_author_label
-    "AWBW Facilitator"
+    ANONYMOUS_AUTHOR_LABEL
   end
 
   # No author at all, so the content reads as the org's own.
   def missing_author_label
-    "AWBW Staff"
+    MISSING_AUTHOR_LABEL
   end
 
   def snapshot_author_credit_preference

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -33,6 +33,13 @@ module AuthorCreditable
     # no-op when person_id is blank. Only models with an author_id column use it.
     scope :authored_by, ->(person_id) { where(author_id: person_id) if person_id.present? }
 
+    # Content whose credit isn't suppressed per item. A blank snapshot means "follow
+    # the profile", so those rows stay in — `where.not` on its own would drop them,
+    # since NULL never compares unequal in SQL.
+    scope :credited_openly, -> {
+      where(author_credit_preference: nil).or(where.not(author_credit_preference: ANONYMOUS))
+    }
+
     # Filter to content whose creating user belongs to a person. This is the only
     # authorship link the idea models have (they carry no author_id of their own),
     # and it's keyed on the person rather than a user id so it stays correct — and
@@ -63,6 +70,9 @@ module AuthorCreditable
   # Precedence: the primary author person, then the legacy free-text name, then the
   # creating user's person, then `missing_author_label`.
   def author_credit
+    # A stored "anonymous" outranks every source, including the legacy free-text
+    # name — that name belongs to no profile, so nothing else would suppress it.
+    return "Anonymous" if author_credit_preference == ANONYMOUS
     person = primary_author_person
     return credit_for(person) if person
     return legacy_author_name_text if legacy_author_name_text.present?

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -1,13 +1,8 @@
 module AuthorCreditable
   extend ActiveSupport::Concern
 
-  # How a credit renders comes from the credited person's profile, not from the record.
-  # `author_credit_preference` is retained as the record of what the submitter consented
-  # to at submission time, and is human-editable only on the author credit divergences
-  # page. It no longer drives display — with one exception: a stored "anonymous" is
-  # always honored while it's set, because anonymity is inherently per-item (a person
-  # may want four stories credited and the fifth not). Only an admin clearing the
-  # snapshot on that page hands the item back to the profile.
+  # Credits render from the credited person's profile. This column is the consent
+  # snapshot and no longer drives display, except "anonymous", which is always honored.
   AUTHOR_CREDIT_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only anonymous].freeze
 
   ANONYMOUS = "anonymous"
@@ -21,11 +16,8 @@ module AuthorCreditable
   }.freeze
 
   included do
-    # Snapshot the credited person's profile preference on create, so the column keeps
-    # recording consent-at-submission without a human ever picking it.
     before_create :snapshot_author_credit_preference
-    # A blank preference means "no per-item override, just follow the profile" — store
-    # it as nil so the divergence worklist (which excludes nil) never re-flags it.
+    # Blank means "follow the profile"; nil keeps it off the divergence worklist.
     normalizes :author_credit_preference, with: ->(value) { value.presence }
     validates :author_credit_preference, inclusion: { in: AUTHOR_CREDIT_PREFERENCES }, allow_blank: true
 
@@ -33,17 +25,13 @@ module AuthorCreditable
     # no-op when person_id is blank. Only models with an author_id column use it.
     scope :authored_by, ->(person_id) { where(author_id: person_id) if person_id.present? }
 
-    # Content whose credit isn't suppressed per item. A blank snapshot means "follow
-    # the profile", so those rows stay in — `where.not` on its own would drop them,
-    # since NULL never compares unequal in SQL.
+    # `where.not` alone would drop NULL rows, which mean "follow the profile".
     scope :credited_openly, -> {
       where(author_credit_preference: nil).or(where.not(author_credit_preference: ANONYMOUS))
     }
 
-    # Filter to content whose creating user belongs to a person. This is the only
-    # authorship link the idea models have (they carry no author_id of their own),
-    # and it's keyed on the person rather than a user id so it stays correct — and
-    # empty — for a person with no user account.
+    # The idea models' only authorship link. Keyed on person, not user, so it stays
+    # empty for a person with no account.
     scope :created_by_person, ->(person_id) { joins(:created_by).where(users: { person_id: person_id }) }
   end
 
@@ -53,25 +41,17 @@ module AuthorCreditable
     primary_author_person || created_by&.person
   end
 
-  # The credited author person that is *not* the creator fallback — the explicit
-  # author.
   def primary_author_person
     author if respond_to?(:author)
   end
 
-  # A legacy free-text author name (no linkable person), ranked between the
-  # explicit author and the creator. Overridden by models that have one
-  # (Workshop, Resource).
+  # Free-text author name with no linkable person. Overridden by Workshop, Resource.
   def legacy_author_name_text
     nil
   end
 
-  # Display string for the credited author, formatted by that person's profile.
-  # Precedence: the primary author person, then the legacy free-text name, then the
-  # creating user's person, then `missing_author_label`.
   def author_credit
-    # A stored "anonymous" outranks every source, including the legacy free-text
-    # name — that name belongs to no profile, so nothing else would suppress it.
+    # Outranks every source, including a legacy name no profile can suppress.
     return "Anonymous" if author_credit_preference == ANONYMOUS
     person = primary_author_person
     return credit_for(person) if person
@@ -80,26 +60,18 @@ module AuthorCreditable
     creator ? credit_for(creator) : missing_author_label
   end
 
-  # The person the credit should link to, or nil when the credit must not resolve
-  # to a profile. Only an explicit/legacy author links: a credit that falls back
-  # to the creating user's person is shown as plain text, because that person
-  # never declared authorship (and the record isn't listed on their profile
-  # either). Anonymous never links.
+  # Only an explicit author links — a creator fallback never declared authorship.
   def author_credit_person
     person = primary_author_person
     person && !credit_anonymous?(person) ? person : nil
   end
 
-  # Anonymity is a one-way latch: the profile can set it, the record can set it,
-  # and neither can strip it from the other.
+  # A one-way latch: either side can set it, neither can strip it from the other.
   def credit_anonymous?(person)
     person.anonymous_contributions? || author_credit_preference == ANONYMOUS
   end
 
-  # The person whose profile actually formats this credit. A legacy free-text name
-  # follows nobody's profile, so a legacy-credited record has no governing person even
-  # when it has a creator — those have to be matched to a real person by hand, not
-  # resolved to whoever happened to enter them.
+  # A legacy name follows nobody's profile, so those have no governing person.
   def credit_governing_person
     person = primary_author_person
     return person if person
@@ -107,17 +79,14 @@ module AuthorCreditable
     created_by&.person
   end
 
-  # True when the stored consent snapshot no longer agrees with the profile that
-  # governs this credit — surfaced as a warning on the record's form and as a row on
-  # the author credit divergences page.
+  # Snapshot no longer agrees with the governing profile.
   def author_credit_diverged?
     return false if author_credit_preference.blank?
     person = credit_governing_person
     person.present? && author_credit_preference != person.effective_author_credit_preference
   end
 
-  # Shown when there is no credited person or legacy name. Overridable per model
-  # (e.g. Workshop shows "Facilitator").
+  # Shown when there's no credited person or legacy name. Overridable per model.
   def missing_author_label
     "Anonymous"
   end
@@ -135,17 +104,13 @@ module AuthorCreditable
   end
 
   class_methods do
-    # Legacy free-text columns (fully qualified, e.g. "resources.legacy_author_name")
-    # that also hold an author's name. Overridden per model that has one.
+    # Fully-qualified legacy name columns, e.g. "resources.legacy_author_name".
     def legacy_author_name_columns
       []
     end
 
-    # Records whose credited author's name resembles `query`: the explicit author
-    # person, the creating user's person, plus any legacy sources the model folds
-    # in. Uses explicit LEFT JOIN aliases so it composes safely — SearchCop can't
-    # join `people` more than once, so callers OR this into full-text results via
-    # an id subquery.
+    # Explicit LEFT JOIN aliases, because SearchCop can't join `people` twice —
+    # callers OR this into full-text results via an id subquery.
     def by_credited_person_name(query)
       sanitized = query.to_s.strip.gsub(/\s+/, "")
       return none if sanitized.blank?
@@ -175,9 +140,6 @@ module AuthorCreditable
       aliases
     end
 
-    # Explicit LEFT JOINs (as raw SQL strings with unique aliases) reaching every
-    # person that can be credited, so the aliases never collide with SearchCop's
-    # or Rails' own joins.
     def credited_person_join_sql
       sql = []
       if column_names.include?("author_id")
@@ -188,9 +150,7 @@ module AuthorCreditable
       sql
     end
 
-    # Arel COALESCE over every credited person alias (and legacy name column),
-    # so the ORDER BY carries no interpolated SQL. Aliases and column names come
-    # from model config / column_names, never user input. Ordered author → legacy →
+    # Arel keeps interpolated SQL out of the ORDER BY. Ordered author → legacy →
     # creator to match `author_credit`, so a row sorts under the name it displays.
     def coalesced_author_arel(field, ascending)
       parts = []
@@ -204,10 +164,8 @@ module AuthorCreditable
       ascending ? node.asc : node.desc
     end
 
-    # Match only on the name parts the credit actually displays, so search can't
-    # surface what the credit hides: an anonymous credit matches nothing, a
-    # "first name only" credit isn't findable by last name, and a "first name,
-    # last initial" credit matches the initial rather than the whole last name.
+    # Match only the name parts the credit displays, so search can't surface what
+    # the credit hides.
     def credited_person_match_sql(sql_alias)
       first = "#{sql_alias}.first_name"
       last = "#{sql_alias}.last_name"
@@ -225,8 +183,7 @@ module AuthorCreditable
       "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
     end
 
-    # Legacy free-text author names have no person, so only the record's own
-    # anonymity applies.
+    # No person behind a legacy name, so only the record's own anonymity applies.
     def legacy_author_name_match_sql(column)
       "(#{not_anonymous_sql} AND #{name_like(column)})"
     end

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -1,8 +1,9 @@
 module AuthorCreditable
   extend ActiveSupport::Concern
 
-  # Credits render from the credited person's profile. This column is the consent
-  # snapshot and no longer drives display, except "anonymous", which is always honored.
+  # A record's stored preference is the submitter's consent snapshot. When set it
+  # wins for display (honoring what they chose at submission); otherwise the credited
+  # person's current profile decides. "anonymous" (either side) is always honored.
   AUTHOR_CREDIT_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only anonymous].freeze
 
   ANONYMOUS = "anonymous"
@@ -56,8 +57,9 @@ module AuthorCreditable
     person = primary_author_person
     return credit_for(person) if person
     return legacy_author_name_text if legacy_author_name_text.present?
-    creator = self.class.credits_creator? ? created_by&.person : nil
-    creator ? credit_for(creator) : missing_author_label
+    # Whoever entered a record didn't claim authorship, so an unattributed record
+    # falls to the generic label rather than crediting its creator.
+    missing_author_label
   end
 
   # Only an explicit author links — a creator fallback never declared authorship.
@@ -71,13 +73,10 @@ module AuthorCreditable
     person.anonymous_contributions? || author_credit_preference == ANONYMOUS
   end
 
-  # A legacy name follows nobody's profile, and neither does a record that never
-  # named an author, so neither has a governing person.
+  # Only an explicit author has a governing profile. A legacy name follows nobody's,
+  # and an unattributed record credits nobody, so neither has a governing person.
   def credit_governing_person
-    person = primary_author_person
-    return person if person
-    return nil if legacy_author_name_text.present?
-    self.class.credits_creator? ? created_by&.person : nil
+    primary_author_person
   end
 
   # Snapshot no longer agrees with the governing profile.
@@ -105,17 +104,13 @@ module AuthorCreditable
 
   private def credit_for(person)
     return missing_author_label if credit_anonymous?(person)
-    person.name.presence || missing_author_label
+    # The record's own preference wins over the person's profile; fall back to the
+    # profile when the record didn't store one.
+    preference = author_credit_preference.presence || person.display_name_preference
+    person.name_for(preference).presence || missing_author_label
   end
 
   class_methods do
-    # Whoever entered a record didn't claim it, so a model that can name an author
-    # credits only that author. The idea models have no author_id at all, so their
-    # creator is the only credit they can carry.
-    def credits_creator?
-      !column_names.include?("author_id")
-    end
-
     # Fully-qualified legacy name columns, e.g. "resources.legacy_author_name".
     def legacy_author_name_columns
       []
@@ -129,12 +124,16 @@ module AuthorCreditable
 
       clauses = credited_person_aliases.map { |a| credited_person_match_sql(a) }
       clauses += legacy_author_name_columns.map { |col| legacy_author_name_match_sql(col) }
+      return none if clauses.empty?
+
       joins(credited_person_join_sql).where(clauses.join(" OR "), name: "%#{sanitized}%")
     end
 
     # Orders by the credited author's name, matching `author_person` precedence:
     # explicit author, then any legacy sources, then the creating user's person.
     def order_by_author(direction)
+      return all if credited_person_aliases.empty? && legacy_author_name_columns.empty?
+
       ascending = direction.to_s.casecmp("asc").zero?
       # By first name then last name, matching the credit displayed by default
       # ("First Last"), so the ordering follows the visible column.
@@ -144,17 +143,14 @@ module AuthorCreditable
 
     private
 
-    # The one person a credit can name — author XOR creator, never both, so search
-    # and sort can't reach a person the credit never displays.
+    # Only an explicit author is ever credited, so search and sort reach that person
+    # alone — and nobody at all on the idea models, which have no author_id.
     def credited_person_aliases
-      credits_creator? ? [ "credited_creator" ] : [ "credited_author" ]
+      column_names.include?("author_id") ? [ "credited_author" ] : []
     end
 
     def credited_person_join_sql
-      return [
-        "LEFT OUTER JOIN users credited_creator_user ON credited_creator_user.id = #{table_name}.created_by_id",
-        "LEFT OUTER JOIN people credited_creator ON credited_creator.id = credited_creator_user.person_id"
-      ] if credits_creator?
+      return [] if credited_person_aliases.empty?
 
       [ "LEFT OUTER JOIN people credited_author ON credited_author.id = #{table_name}.author_id" ]
     end
@@ -176,7 +172,8 @@ module AuthorCreditable
     def credited_person_match_sql(sql_alias)
       first = "#{sql_alias}.first_name"
       last = "#{sql_alias}.last_name"
-      preference = "COALESCE(#{sql_alias}.display_name_preference, 'full_name')"
+      # The record's own preference wins over the profile, matching `credit_for`.
+      preference = "COALESCE(#{table_name}.author_credit_preference, #{sql_alias}.display_name_preference, 'full_name')"
 
       by_preference = {
         "full_name" => [ "CONCAT(#{first}, #{last})", "CONCAT(#{last}, #{first})", first, last ],

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -52,13 +52,12 @@ module AuthorCreditable
   end
 
   def author_credit
-    # Outranks every source, including a legacy name no profile can suppress.
-    return missing_author_label if author_credit_preference == ANONYMOUS
     person = primary_author_person
+    # credit_for suppresses an anonymous author to the facilitator label.
     return credit_for(person) if person
-    return legacy_author_name_text if legacy_author_name_text.present?
-    # Whoever entered a record didn't claim authorship, so an unattributed record
-    # falls to the generic label rather than crediting its creator.
+    # Anonymous suppresses a legacy name too; with no person behind it, nothing is left.
+    return legacy_author_name_text if legacy_author_name_text.present? && author_credit_preference != ANONYMOUS
+    # No author at all, so it reads as the org's own content.
     missing_author_label
   end
 
@@ -86,11 +85,15 @@ module AuthorCreditable
     person.present? && author_credit_preference != person.effective_author_credit_preference
   end
 
-  # Shown when there's no credited person or legacy name. The portal is behind a
-  # login, so this names the org's facilitators rather than hiding behind
-  # "Anonymous", which would read as a deliberate privacy choice.
-  def missing_author_label
+  # A named author who opted out of the credit — still a facilitator's content,
+  # just shown without their name rather than hiding behind "Anonymous".
+  def anonymous_author_label
     "AWBW Facilitator"
+  end
+
+  # No author at all, so the content reads as the org's own.
+  def missing_author_label
+    "AWBW Staff"
   end
 
   def snapshot_author_credit_preference
@@ -103,11 +106,11 @@ module AuthorCreditable
   end
 
   private def credit_for(person)
-    return missing_author_label if credit_anonymous?(person)
+    return anonymous_author_label if credit_anonymous?(person)
     # The record's own preference wins over the person's profile; fall back to the
     # profile when the record didn't store one.
     preference = author_credit_preference.presence || person.display_name_preference
-    person.name_for(preference).presence || missing_author_label
+    person.name_for(preference).presence || anonymous_author_label
   end
 
   class_methods do

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -1,9 +1,10 @@
 module AuthorCreditable
   extend ActiveSupport::Concern
 
-  # A record's stored preference is the submitter's consent snapshot. When set it
-  # wins for display (honoring what they chose at submission); otherwise the credited
-  # person's current profile decides. "anonymous" (either side) is always honored.
+  # The credited person's profile decides how a credit renders. A record's stored
+  # preference is the submitter's request, recorded at submission and surfaced on the
+  # author credit divergences page for an admin to apply to the profile — it does not
+  # drive display on its own. "anonymous" (either side) is always honored.
   AUTHOR_CREDIT_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only anonymous].freeze
 
   ANONYMOUS = "anonymous"
@@ -12,6 +13,16 @@ module AuthorCreditable
   # model can override; reference the constants directly only where no record is in hand.
   ANONYMOUS_AUTHOR_LABEL = "AWBW Facilitator".freeze
   MISSING_AUTHOR_LABEL = "AWBW Staff".freeze
+
+  # Submitter-facing wording. Blank is the default and means "follow my profile" —
+  # anything else is a request an admin applies to the profile on the divergences page.
+  SUBMITTER_FORM_OPTIONS = {
+    "My full name" => "full_name",
+    "My first name and last initial" => "first_name_last_initial",
+    "My first name only" => "first_name_only",
+    "My last name only" => "last_name_only",
+    "Don't credit me by name" => "anonymous"
+  }.freeze
 
   ADMIN_FORM_OPTIONS = {
     "Full name" => "full_name",
@@ -112,10 +123,7 @@ module AuthorCreditable
 
   private def credit_for(person)
     return anonymous_author_label if credit_anonymous?(person)
-    # The record's own preference wins over the person's profile; fall back to the
-    # profile when the record didn't store one.
-    preference = author_credit_preference.presence || person.display_name_preference
-    person.name_for(preference).presence || anonymous_author_label
+    person.name.presence || anonymous_author_label
   end
 
   class_methods do
@@ -180,8 +188,7 @@ module AuthorCreditable
     def credited_person_match_sql(sql_alias)
       first = "#{sql_alias}.first_name"
       last = "#{sql_alias}.last_name"
-      # The record's own preference wins over the profile, matching `credit_for`.
-      preference = "COALESCE(#{table_name}.author_credit_preference, #{sql_alias}.display_name_preference, 'full_name')"
+      preference = "COALESCE(#{sql_alias}.display_name_preference, 'full_name')"
 
       by_preference = {
         "full_name" => [ "CONCAT(#{first}, #{last})", "CONCAT(#{last}, #{first})", first, last ],

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -24,6 +24,9 @@ module AuthorCreditable
     # Snapshot the credited person's profile preference on create, so the column keeps
     # recording consent-at-submission without a human ever picking it.
     before_create :snapshot_author_credit_preference
+    # A blank preference means "no per-item override, just follow the profile" — store
+    # it as nil so the divergence worklist (which excludes nil) never re-flags it.
+    normalizes :author_credit_preference, with: ->(value) { value.presence }
     validates :author_credit_preference, inclusion: { in: AUTHOR_CREDIT_PREFERENCES }, allow_blank: true
 
     # Filter to content explicitly authored by a person (belongs_to :author);

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -80,6 +80,20 @@ class Person < ApplicationRecord
   CONTACT_TYPES = [ "work", "personal" ].freeze
   validates :email_type, inclusion: { in: %w[work personal] }, allow_blank: true
   validates :email_2_type, inclusion: { in: %w[work personal] }, allow_blank: true
+
+  # How this person's name is formatted wherever it appears. Anonymity is not one of
+  # these — it's the separate `contributions_anonymous` flag, because a person still
+  # has to be listed *somehow* on the people index.
+  DISPLAY_NAME_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only].freeze
+
+  DISPLAY_NAME_PREFERENCE_LABELS = {
+    "full_name" => "First and last name",
+    "first_name_last_initial" => "First name and last initial",
+    "first_name_only" => "First name only",
+    "last_name_only" => "Last name only"
+  }.freeze
+
+  validates :display_name_preference, inclusion: { in: DISPLAY_NAME_PREFERENCES }, allow_blank: true
   # Mirrors SectorsTaggable's single-primary rule for age ranges — the chip
   # editor's single-star JS is the first line of defense, this guards imports,
   # the console, and bad form posts. Person-only: organizations aggregate
@@ -215,19 +229,28 @@ class Person < ApplicationRecord
     end
   end
 
+  # The single name formatter for this person — drives the people index, the profile
+  # header, and every author credit on content they've shared.
   def name
     case display_name_preference
-    when "full_name"
-      full_name
     when "first_name_last_initial"
-      "#{first_name} #{last_name.first}"
+      initial = last_name&.first
+      initial.present? ? "#{first_name} #{initial}." : first_name.to_s
     when "first_name_only"
       first_name
     when "last_name_only"
       last_name
-    else
+    else # full_name — the default, and the fallback for any unknown value
       full_name
     end
+  end
+
+  # How this person is credited on content they've shared. Anonymity is a separate
+  # axis from the name format: it suppresses author credits without affecting how
+  # they're listed on the people index. See AuthorCreditable.
+  def effective_author_credit_preference
+    return "anonymous" if contributions_anonymous?
+    display_name_preference.presence || "full_name"
   end
 
   def full_name

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -82,7 +82,7 @@ class Person < ApplicationRecord
   validates :email_2_type, inclusion: { in: %w[work personal] }, allow_blank: true
 
   # How this person's name is formatted wherever it appears. Anonymity is not one of
-  # these — it's the separate `contributions_anonymous` flag, because a person still
+  # these — it's the separate `anonymous_contributions` flag, because a person still
   # has to be listed *somehow* on the people index.
   DISPLAY_NAME_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only].freeze
 
@@ -249,7 +249,7 @@ class Person < ApplicationRecord
   # axis from the name format: it suppresses author credits without affecting how
   # they're listed on the people index. See AuthorCreditable.
   def effective_author_credit_preference
-    return "anonymous" if contributions_anonymous?
+    return "anonymous" if anonymous_contributions?
     display_name_preference.presence || "full_name"
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -228,9 +228,16 @@ class Person < ApplicationRecord
     end
   end
 
-  # Drives the people index, the profile header, and every author credit.
+  # Drives the people index and the profile header. Author credits pass an explicit
+  # preference (the record's own, which outranks the profile) through `name_for`.
   def name
-    case display_name_preference
+    name_for(display_name_preference)
+  end
+
+  # Formats the name by a given preference rather than the profile's, so a record
+  # that stored its own credit preference can win over the profile.
+  def name_for(preference)
+    case preference
     when "first_name_last_initial"
       initial = last_name&.first
       initial.present? ? "#{first_name} #{initial}." : first_name.to_s

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -81,9 +81,8 @@ class Person < ApplicationRecord
   validates :email_type, inclusion: { in: %w[work personal] }, allow_blank: true
   validates :email_2_type, inclusion: { in: %w[work personal] }, allow_blank: true
 
-  # How this person's name is formatted wherever it appears. Anonymity is not one of
-  # these — it's the separate `anonymous_contributions` flag, because a person still
-  # has to be listed *somehow* on the people index.
+  # Anonymity isn't one of these — it's the separate `anonymous_contributions` flag,
+  # since a person still has to be listed somehow on the people index.
   DISPLAY_NAME_PREFERENCES = %w[full_name first_name_last_initial first_name_only last_name_only].freeze
 
   DISPLAY_NAME_PREFERENCE_LABELS = {
@@ -229,8 +228,7 @@ class Person < ApplicationRecord
     end
   end
 
-  # The single name formatter for this person — drives the people index, the profile
-  # header, and every author credit on content they've shared.
+  # Drives the people index, the profile header, and every author credit.
   def name
     case display_name_preference
     when "first_name_last_initial"
@@ -245,9 +243,8 @@ class Person < ApplicationRecord
     end
   end
 
-  # How this person is credited on content they've shared. Anonymity is a separate
-  # axis from the name format: it suppresses author credits without affecting how
-  # they're listed on the people index. See AuthorCreditable.
+  # Anonymity is a separate axis from the name format: it suppresses author credits
+  # without affecting how they're listed on the people index.
   def effective_author_credit_preference
     return "anonymous" if anonymous_contributions?
     display_name_preference.presence || "full_name"

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -89,11 +89,6 @@ class Resource < ApplicationRecord
     legacy_author_name
   end
 
-  # Unattributed resources are credited to the organization's staff.
-  def missing_author_label
-    "AWBW Staff"
-  end
-
   # Scopes
   scope :by_created, -> { order(created_at: :desc) }
   scope :by_featured_first, -> { order(featured: :desc, created_at: :desc) }

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -71,7 +71,10 @@ class Resource < ApplicationRecord
 
   include SearchCop
   search_scope :search do
-    attributes all: [ :title, :legacy_author_name ]
+    # The legacy author name is deliberately not indexed here. Author-name search —
+    # person or legacy column — goes through `by_credited_person_name`, which is the
+    # only path that honors the credit preference.
+    attributes all: [ :title ]
     options :all, type: :text, default: true, default_operator: :or
 
     scope { join_rich_texts }
@@ -114,8 +117,8 @@ class Resource < ApplicationRecord
   def self.search_by_params(params)
     resources = is_a?(ActiveRecord::Relation) ? self : all
     if params[:query].present?
-      # SearchCop covers title + legacy author name + body; OR in the credited
-      # author/creator person name via id subqueries (isolated person joins).
+      # SearchCop covers title + body; OR in the credited author name — person and
+      # legacy column both — via id subqueries (isolated person joins).
       by_text = resources.search(params[:query]).select("resources.id")
       by_person = resources.by_credited_person_name(params[:query]).select("resources.id")
       resources = resources.where(id: by_text).or(resources.where(id: by_person))

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -9,7 +9,7 @@ class Story < ApplicationRecord
   belongs_to :windows_type
   belongs_to :organization, optional: true
   # Display this person via `.name` (honors their display_name_preference) — a
-  # spotlight is not an author credit, so it ignores contributions_anonymous.
+  # spotlight is not an author credit, so it ignores anonymous_contributions.
   # Don't route the spotlighted name through author_credit / effective_author_credit_preference.
   belongs_to :spotlighted_facilitator, class_name: "Person",
              foreign_key: "spotlighted_facilitator_id", optional: true

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -53,10 +53,13 @@ class Story < ApplicationRecord
   search_scope :search do
     attributes all: [ :title, :published ]
     attributes :title, :published
-    attributes person_first: "people.first_name", person_last: "people.last_name"
     options :all, type: :text, default: true, default_operator: :or
 
-    scope { join_rich_texts.left_joins(created_by: :person) }
+    # Author names are deliberately not indexed here. `by_credited_person_name` is
+    # the only person-name search path, because it honors the credit preference —
+    # indexing people.first_name/last_name would let a full-text query surface a
+    # credit that renders "Anonymous".
+    scope { join_rich_texts }
     attributes action_text_body: "action_text_rich_texts.plain_text_body"
     options :action_text_body, type: :text, default: true, default_operator: :or
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -8,6 +8,9 @@ class Story < ApplicationRecord
   belongs_to :updated_by, class_name: "User"
   belongs_to :windows_type
   belongs_to :organization, optional: true
+  # Display this person via `.name` (honors their display_name_preference) — a
+  # spotlight is not an author credit, so it ignores contributions_anonymous.
+  # Don't route the spotlighted name through author_credit / effective_author_credit_preference.
   belongs_to :spotlighted_facilitator, class_name: "Person",
              foreign_key: "spotlighted_facilitator_id", optional: true
   belongs_to :author, class_name: "Person", optional: true
@@ -128,11 +131,6 @@ class Story < ApplicationRecord
   # so the shared notifications/_communications partial works across records.
   def communications_email
     author_person&.preferred_email
-  end
-
-  # Unattributed stories are credited to the facilitator who shared them.
-  def missing_author_label
-    "AWBW Facilitator"
   end
 
   def organization_name

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -1,7 +1,5 @@
 class StoryIdea < ApplicationRecord
   include AuthorCreditable
-  # Public submission: the submitter must choose how they're credited.
-  require_author_credit_preference
   include SearchCop
   search_scope :search do
     attributes :title, :body

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -202,10 +202,6 @@ class Workshop < ApplicationRecord
     "AWBW Facilitator"
   end
 
-  def author_name
-    author_person&.full_name.presence || full_name.presence
-  end
-
   def date
     if month.present? && year.present?
       Date.new(year.to_i, month.to_i).strftime("%B %Y")

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -197,11 +197,6 @@ class Workshop < ApplicationRecord
     full_name
   end
 
-  # With no credited person or legacy name, attribute to the generic facilitator.
-  def missing_author_label
-    "AWBW Facilitator"
-  end
-
   def date
     if month.present? && year.present?
       Date.new(year.to_i, month.to_i).strftime("%B %Y")

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -173,7 +173,10 @@ class Workshop < ApplicationRecord
   # Search Cop
   include SearchCop
   search_scope :search do
-    attributes all: [ :title, :full_name ] # no spanish alternatives
+    # The legacy `full_name` is deliberately not indexed here. Author-name search —
+    # person or legacy column — goes through `by_credited_person_name`, which is the
+    # only path that honors the credit preference.
+    attributes all: [ :title ] # no spanish alternatives
     options :all, type: :text, default: true, default_operator: :or
 
     attributes :title, type: :text

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -73,11 +73,16 @@ class WorkshopIdea < ApplicationRecord
 
   # Scopes
   scope :title, ->(title) { where("workshop_ideas.title like ?", "%#{ title }%") }
-  # Goes through by_credited_person_name so the filter honors the credit preference —
-  # matching users.first_name/last_name/email directly would surface ideas whose
-  # credit renders "Anonymous".
+  # An idea credits nobody — `author_credit` is always the generic label — so there is
+  # no credit for this filter to leak. It matches the submitter the pages actually show
+  # (`created_by.name`, i.e. the person), falling back to the account email.
   scope :author_name, ->(author_name) {
-    where(id: by_credited_person_name(author_name).select("workshop_ideas.id"))
+    needle = "%#{author_name.to_s.strip.downcase}%"
+    joins("INNER JOIN users ON users.id = workshop_ideas.created_by_id")
+      .joins("LEFT OUTER JOIN people ON people.id = users.person_id")
+      .where("LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
+             "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle " \
+             "OR LOWER(users.email) LIKE :needle", needle: needle)
   }
 
   def self.search(params)

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -1,7 +1,5 @@
 class WorkshopIdea < ApplicationRecord
   include AuthorCreditable
-  # Public submission: the submitter must choose how they're credited.
-  require_author_credit_preference
 
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -73,9 +73,12 @@ class WorkshopIdea < ApplicationRecord
 
   # Scopes
   scope :title, ->(title) { where("workshop_ideas.title like ?", "%#{ title }%") }
-  scope :author_name, ->(author_name) { joins(:created_by).
-    where("users.first_name like ? or users.last_name like ? or users.email like ?",
-          "%#{author_name}%", "%#{author_name}%", "%#{author_name}%") }
+  # Goes through by_credited_person_name so the filter honors the credit preference —
+  # matching users.first_name/last_name/email directly would surface ideas whose
+  # credit renders "Anonymous".
+  scope :author_name, ->(author_name) {
+    where(id: by_credited_person_name(author_name).select("workshop_ideas.id"))
+  }
 
   def self.search(params)
     results = is_a?(ActiveRecord::Relation) ? self : all

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -57,11 +57,6 @@ class WorkshopVariation < ApplicationRecord
     rhino_body.to_plain_text
   end
 
-  # Unattributed workshop variations are credited to the generic facilitator.
-  def missing_author_label
-    "AWBW Facilitator"
-  end
-
   def title
     name
   end

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -1,7 +1,5 @@
 class WorkshopVariationIdea < ApplicationRecord
   include AuthorCreditable
-  # Public submission: the submitter must choose how they're credited.
-  require_author_credit_preference
   include SearchCop
   search_scope :search do
     attributes :name, :body

--- a/app/policies/author_credit_divergence_policy.rb
+++ b/app/policies/author_credit_divergence_policy.rb
@@ -10,4 +10,8 @@ class AuthorCreditDivergencePolicy < ApplicationPolicy
   def update_item?
     admin?
   end
+
+  def assign_author?
+    admin?
+  end
 end

--- a/app/policies/author_credit_divergence_policy.rb
+++ b/app/policies/author_credit_divergence_policy.rb
@@ -1,0 +1,13 @@
+class AuthorCreditDivergencePolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
+
+  def update_person?
+    admin?
+  end
+
+  def update_item?
+    admin?
+  end
+end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -9,6 +9,13 @@ class PersonPolicy < ApplicationPolicy
     admin? || owner?
   end
 
+  # Admin, or the profile's own person. The narrow rule for owner-only content
+  # (submitted ideas, workshop logs) — kept separate from `show?` so opening
+  # `show?` up to public profile viewing later can't expose it.
+  def own_record?
+    admin? || owner?
+  end
+
   def workshop_logs?
     admin? || owner?
   end

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -2,7 +2,7 @@
 #
 #   preference   — snapshot no longer matches the profile
 #   legacy       — credited by a free-text name column, no person at all
-#   creator      — author_id blank, so the credit falls back to the creator
+#   creator      — author_id blank, credited generically, creator suggested to assign
 #   unattributed — nothing to credit at all
 #
 # Comparisons run in Ruby because they walk the author fallback chain.
@@ -75,8 +75,8 @@ class AuthorCreditDivergenceQuery
     @models ||= type ? [ self.class.model_for(type) ].compact : MODEL_NAMES.map(&:constantize)
   end
 
-  # The idea models have no author_id, so crediting through the creator is correct
-  # for them, not something to resolve.
+  # The idea models have no author_id, so they credit generically — there's no
+  # author to reconcile, so they're left out of every section.
   def authorable_models
     models.select { |model| model.column_names.include?("author_id") }
   end

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -1,22 +1,13 @@
-# Everything on the author credit divergences page: content whose credit doesn't
-# resolve cleanly through the credited person's profile.
+# Content whose credit doesn't resolve cleanly through a profile, in four sections:
 #
-# Four sections, in the order an admin should work them. The first is about a
-# preference that drifted; the other three are all forms of "this credit isn't
-# coming from an author_id", which is the only path that links to a profile and
-# lists the record on it.
-#
-#   preference   — stored consent snapshot no longer matches the profile
+#   preference   — snapshot no longer matches the profile
 #   legacy       — credited by a free-text name column, no person at all
-#   creator      — author_id is blank, so the credit falls back to the creator
-#   unattributed — nothing to credit; renders the model's missing_author_label
+#   creator      — author_id blank, so the credit falls back to the creator
+#   unattributed — nothing to credit at all
 #
-# Comparisons run in Ruby because they walk the author fallback chain. The
-# candidate sets are small: the preference column was added with no default and
-# no backfill, and the legacy columns only hold pre-person data.
+# Comparisons run in Ruby because they walk the author fallback chain.
 class AuthorCreditDivergenceQuery
-  # Every AuthorCreditable model. Doubles as the allowlist for the `type` param —
-  # never constantize a raw param.
+  # Doubles as the allowlist for the `type` param — never constantize a raw param.
   MODEL_NAMES = %w[
     Story
     StoryIdea
@@ -30,8 +21,7 @@ class AuthorCreditDivergenceQuery
 
   SECTIONS = %w[preference legacy creator unattributed].freeze
 
-  # Which preference reveals the least, for suggesting a profile value that
-  # satisfies all of a person's content.
+  # Which preference reveals the least, for suggesting one that fits all their content.
   RESTRICTIVENESS = {
     "anonymous" => 4,
     "last_name_only" => 3,
@@ -42,13 +32,11 @@ class AuthorCreditDivergenceQuery
 
   PersonGroup = Struct.new(:person, :records, :suggested_preference, keyword_init: true)
 
-  # One per legacy column, kept even when empty so the page can congratulate each
-  # field separately — clearing a column is what makes it safe to drop.
+  # Kept even when empty — clearing a column is what makes it safe to drop.
   LegacyGroup = Struct.new(:model, :column, :entries, keyword_init: true) do
     def empty? = entries.empty?
     def field = column.split(".").last
   end
-  # A row an admin can resolve by picking a person, optionally pre-guessed.
   AssignableRow = Struct.new(:record, :suggested_author, keyword_init: true)
 
   Result = Struct.new(:preference, :legacy, :creator, :unattributed, keyword_init: true) do
@@ -87,9 +75,8 @@ class AuthorCreditDivergenceQuery
     @models ||= type ? [ self.class.model_for(type) ].compact : MODEL_NAMES.map(&:constantize)
   end
 
-  # Only models that actually have an author_id can be "missing" one — the idea
-  # models have no such column, so crediting through the creator is their normal
-  # and correct behavior, not something to resolve.
+  # The idea models have no author_id, so crediting through the creator is correct
+  # for them, not something to resolve.
   def authorable_models
     models.select { |model| model.column_names.include?("author_id") }
   end
@@ -104,7 +91,6 @@ class AuthorCreditDivergenceQuery
     includes
   end
 
-  # ── Section 1: the stored snapshot drifted from the profile ────────────────
   def preference_groups
     records = models.flat_map do |model|
       scope = scoped(model).where.not(author_credit_preference: nil)
@@ -115,10 +101,7 @@ class AuthorCreditDivergenceQuery
     group_by_person(records)
   end
 
-  # ── Section 2: credited by a free-text name, with no person behind it ──────
-  # One group per legacy column, so each field can be reported (and retired)
-  # on its own. The person filter can't apply here: these records have no
-  # credited person, which is the whole problem with them.
+  # No credited person here, which is the whole problem — so no person filter.
   def legacy_groups
     groups = authorable_models.flat_map do |model|
       model.legacy_author_name_columns.map { |column| [ model, column ] }
@@ -142,9 +125,7 @@ class AuthorCreditDivergenceQuery
     end
   end
 
-  # Guess who each free-text name refers to, so an admin can confirm rather than
-  # look every one up. Matches on the whole name, or on first + last token, in one
-  # query for the whole page rather than one per row.
+  # Guess who each free-text name means, in one query for the page, not one per row.
   def suggested_authors_for(records)
     names = records.filter_map { |record| record.legacy_author_name_text.presence }.uniq
     return {} if names.empty?
@@ -160,7 +141,6 @@ class AuthorCreditDivergenceQuery
     value.to_s.downcase.gsub(/\s+/, "")
   end
 
-  # ── Section 3: author_id blank, so the credit falls back to the creator ────
   def creator_groups
     records = authorable_models.flat_map do |model|
       scoped(model)
@@ -171,7 +151,6 @@ class AuthorCreditDivergenceQuery
     group_by_person(records)
   end
 
-  # ── Section 4: nothing to credit at all ────────────────────────────────────
   def unattributed_records
     return [] if preference || person_id
 

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -41,9 +41,21 @@ class AuthorCreditDivergenceQuery
   }.freeze
 
   PersonGroup = Struct.new(:person, :records, :suggested_preference, keyword_init: true)
+
+  # One per legacy column, kept even when empty so the page can congratulate each
+  # field separately — clearing a column is what makes it safe to drop.
+  LegacyGroup = Struct.new(:model, :column, :entries, keyword_init: true) do
+    def empty? = entries.empty?
+    def field = column.split(".").last
+  end
+  # A row an admin can resolve by picking a person, optionally pre-guessed.
+  AssignableRow = Struct.new(:record, :suggested_author, keyword_init: true)
+
   Result = Struct.new(:preference, :legacy, :creator, :unattributed, keyword_init: true) do
+    def legacy_empty? = legacy.all?(&:empty?)
+
     def empty?
-      preference.empty? && legacy.empty? && creator.empty? && unattributed.empty?
+      preference.empty? && legacy_empty? && creator.empty? && unattributed.empty?
     end
   end
 
@@ -61,7 +73,7 @@ class AuthorCreditDivergenceQuery
   def call
     Result.new(
       preference: preference_groups,
-      legacy: legacy_records,
+      legacy: legacy_groups,
       creator: creator_groups,
       unattributed: unattributed_records
     )
@@ -104,15 +116,48 @@ class AuthorCreditDivergenceQuery
   end
 
   # ── Section 2: credited by a free-text name, with no person behind it ──────
-  # The person filter can't apply here: these records have no credited person,
-  # which is the whole problem with them.
-  def legacy_records
-    return [] if preference || person_id
+  # One group per legacy column, so each field can be reported (and retired)
+  # on its own. The person filter can't apply here: these records have no
+  # credited person, which is the whole problem with them.
+  def legacy_groups
+    groups = authorable_models.flat_map do |model|
+      model.legacy_author_name_columns.map { |column| [ model, column ] }
+    end
 
+    records = preference || person_id ? [] : legacy_candidates
+    suggestions = suggested_authors_for(records)
+
+    groups.map do |model, column|
+      entries = records.select { |record| record.is_a?(model) }.map do |record|
+        AssignableRow.new(record: record, suggested_author: suggestions[normalized(record.legacy_author_name_text)])
+      end
+      LegacyGroup.new(model: model, column: column, entries: entries)
+    end
+  end
+
+  def legacy_candidates
     authorable_models.flat_map do |model|
       next [] if model.legacy_author_name_columns.empty?
       sorted(scoped(model).where(author_id: nil).select { |record| record.legacy_author_name_text.present? })
     end
+  end
+
+  # Guess who each free-text name refers to, so an admin can confirm rather than
+  # look every one up. Matches on the whole name, or on first + last token, in one
+  # query for the whole page rather than one per row.
+  def suggested_authors_for(records)
+    names = records.filter_map { |record| record.legacy_author_name_text.presence }.uniq
+    return {} if names.empty?
+
+    candidates = Person.where(last_name: names.flat_map { |name| name.split(/\s+/) }.uniq)
+    by_normalized_full_name = candidates.index_by { |person| normalized(person.full_name) }
+
+    names.index_with { |name| by_normalized_full_name[normalized(name)] }
+         .transform_keys { |name| normalized(name) }
+  end
+
+  def normalized(value)
+    value.to_s.downcase.gsub(/\s+/, "")
   end
 
   # ── Section 3: author_id blank, so the credit falls back to the creator ────

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -184,7 +184,7 @@ class AuthorCreditDivergenceQuery
 
   def group_by_person(records)
     records
-      .group_by(&:author_person)
+      .group_by(&:credit_governing_person)
       .filter_map { |person, grouped| build_group(person, grouped) }
       .sort_by { |group| [ group.person.first_name.to_s.downcase, group.person.last_name.to_s.downcase ] }
   end

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -121,8 +121,8 @@ class AuthorCreditDivergenceQuery
   def legacy_candidates
     authorable_models.flat_map do |model|
       next [] if model.legacy_author_name_columns.empty?
-      sorted(scoped(model).where(author_id: nil).select { |record| record.legacy_author_name_text.present? })
-    end
+      scoped(model).where(author_id: nil).select { |record| record.legacy_author_name_text.present? }
+    end.sort_by { |record| [ record.class.name, record.legacy_author_name_text.to_s.downcase ] }
   end
 
   # Guess who each free-text name means, in one query for the page, not one per row.

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -141,6 +141,8 @@ class AuthorCreditDivergenceQuery
     value.to_s.downcase.gsub(/\s+/, "")
   end
 
+  # Grouped by the creator as a *suggestion*, not as a governing profile — the credit
+  # itself already shows the generic label, since nobody claimed these.
   def creator_groups
     records = authorable_models.flat_map do |model|
       scoped(model)
@@ -148,7 +150,7 @@ class AuthorCreditDivergenceQuery
         .select { |record| record.legacy_author_name_text.blank? && record.created_by&.person.present? }
     end
 
-    group_by_person(records)
+    group_by_person(records) { |record| record.created_by.person }
   end
 
   def unattributed_records
@@ -161,9 +163,9 @@ class AuthorCreditDivergenceQuery
     end
   end
 
-  def group_by_person(records)
+  def group_by_person(records, &grouper)
     records
-      .group_by(&:credit_governing_person)
+      .group_by(&(grouper || :credit_governing_person.to_proc))
       .filter_map { |person, grouped| build_group(person, grouped) }
       .sort_by { |group| [ group.person.first_name.to_s.downcase, group.person.last_name.to_s.downcase ] }
   end

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -1,0 +1,97 @@
+# Finds content whose stored `author_credit_preference` no longer agrees with the
+# credited person's profile, grouped by person so an admin can resolve a whole
+# person at once.
+#
+# The comparison runs in Ruby rather than SQL because it walks the author fallback
+# chain (explicit author, then the creating user's person). The candidate set is
+# small: the column was added with no default and no backfill, so most legacy rows
+# are NULL and only the *_idea tables hold a real spread.
+class AuthorCreditDivergenceQuery
+  # Every AuthorCreditable model. Doubles as the allowlist for the `type` param —
+  # never constantize a raw param.
+  MODEL_NAMES = %w[
+    Story
+    StoryIdea
+    Workshop
+    WorkshopIdea
+    WorkshopVariation
+    WorkshopVariationIdea
+    Resource
+    CommunityNews
+  ].freeze
+
+  # Which preference reveals the least, for suggesting a profile value that
+  # satisfies all of a person's items.
+  RESTRICTIVENESS = {
+    "anonymous" => 4,
+    "last_name_only" => 3,
+    "first_name_only" => 3,
+    "first_name_last_initial" => 2,
+    "full_name" => 1
+  }.freeze
+
+  Group = Struct.new(:person, :records, :suggested_preference, keyword_init: true)
+
+  def self.model_for(type)
+    MODEL_NAMES.include?(type.to_s) ? type.to_s.constantize : nil
+  end
+
+  def initialize(person_id: nil, type: nil, preference: nil, include_reconciled: false)
+    @person_id = person_id.presence
+    @type = type.presence
+    @preference = preference.presence
+    @include_reconciled = ActiveModel::Type::Boolean.new.cast(include_reconciled)
+  end
+
+  # => [Group] sorted by the person's name
+  def call
+    diverged_records
+      .group_by(&:author_person)
+      .filter_map { |person, records| build_group(person, records) }
+      .sort_by { |group| group.person.full_name.to_s.downcase }
+  end
+
+  private
+
+  attr_reader :person_id, :type, :preference, :include_reconciled
+
+  def models
+    return [ self.class.model_for(type) ].compact if type
+    MODEL_NAMES.map(&:constantize)
+  end
+
+  def diverged_records
+    models.flat_map { |model| diverged_for(model) }
+  end
+
+  # No person_id filter here — a record can be credited through `author_id` *or*
+  # through the creating user's person, so the filter has to run after the
+  # fallback chain resolves. See `build_group`.
+  def diverged_for(model)
+    scope = model.where.not(author_credit_preference: nil)
+    scope = scope.where(author_credit_preference: preference) if preference
+    scope.includes(includes_for(model)).select(&:author_credit_diverged?)
+  end
+
+  def includes_for(model)
+    includes = [ { created_by: :person } ]
+    includes << :author if model.column_names.include?("author_id")
+    includes
+  end
+
+  def build_group(person, records)
+    return nil if person.blank?
+    return nil if person_id && person.id != person_id.to_i
+    return nil if person.author_credit_reconciled_at.present? && !include_reconciled
+
+    Group.new(
+      person: person,
+      records: records.sort_by { |record| [ record.class.name, record.id ] },
+      suggested_preference: most_restrictive(records)
+    )
+  end
+
+  def most_restrictive(records)
+    records.map(&:author_credit_preference).max_by { |value| RESTRICTIVENESS.fetch(value, 0) }
+  end
+end

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -1,11 +1,19 @@
-# Finds content whose stored `author_credit_preference` no longer agrees with the
-# credited person's profile, grouped by person so an admin can resolve a whole
-# person at once.
+# Everything on the author credit divergences page: content whose credit doesn't
+# resolve cleanly through the credited person's profile.
 #
-# The comparison runs in Ruby rather than SQL because it walks the author fallback
-# chain (explicit author, then the creating user's person). The candidate set is
-# small: the column was added with no default and no backfill, so most legacy rows
-# are NULL and only the *_idea tables hold a real spread.
+# Four sections, in the order an admin should work them. The first is about a
+# preference that drifted; the other three are all forms of "this credit isn't
+# coming from an author_id", which is the only path that links to a profile and
+# lists the record on it.
+#
+#   preference   — stored consent snapshot no longer matches the profile
+#   legacy       — credited by a free-text name column, no person at all
+#   creator      — author_id is blank, so the credit falls back to the creator
+#   unattributed — nothing to credit; renders the model's missing_author_label
+#
+# Comparisons run in Ruby because they walk the author fallback chain. The
+# candidate sets are small: the preference column was added with no default and
+# no backfill, and the legacy columns only hold pre-person data.
 class AuthorCreditDivergenceQuery
   # Every AuthorCreditable model. Doubles as the allowlist for the `type` param —
   # never constantize a raw param.
@@ -20,8 +28,10 @@ class AuthorCreditDivergenceQuery
     CommunityNews
   ].freeze
 
+  SECTIONS = %w[preference legacy creator unattributed].freeze
+
   # Which preference reveals the least, for suggesting a profile value that
-  # satisfies all of a person's items.
+  # satisfies all of a person's content.
   RESTRICTIVENESS = {
     "anonymous" => 4,
     "last_name_only" => 3,
@@ -30,7 +40,12 @@ class AuthorCreditDivergenceQuery
     "full_name" => 1
   }.freeze
 
-  Group = Struct.new(:person, :records, :suggested_preference, keyword_init: true)
+  PersonGroup = Struct.new(:person, :records, :suggested_preference, keyword_init: true)
+  Result = Struct.new(:preference, :legacy, :creator, :unattributed, keyword_init: true) do
+    def empty?
+      preference.empty? && legacy.empty? && creator.empty? && unattributed.empty?
+    end
+  end
 
   def self.model_for(type)
     MODEL_NAMES.include?(type.to_s) ? type.to_s.constantize : nil
@@ -43,12 +58,13 @@ class AuthorCreditDivergenceQuery
     @include_reconciled = ActiveModel::Type::Boolean.new.cast(include_reconciled)
   end
 
-  # => [Group] sorted by the person's name
   def call
-    diverged_records
-      .group_by(&:author_person)
-      .filter_map { |person, records| build_group(person, records) }
-      .sort_by { |group| group.person.full_name.to_s.downcase }
+    Result.new(
+      preference: preference_groups,
+      legacy: legacy_records,
+      creator: creator_groups,
+      unattributed: unattributed_records
+    )
   end
 
   private
@@ -56,21 +72,18 @@ class AuthorCreditDivergenceQuery
   attr_reader :person_id, :type, :preference, :include_reconciled
 
   def models
-    return [ self.class.model_for(type) ].compact if type
-    MODEL_NAMES.map(&:constantize)
+    @models ||= type ? [ self.class.model_for(type) ].compact : MODEL_NAMES.map(&:constantize)
   end
 
-  def diverged_records
-    models.flat_map { |model| diverged_for(model) }
+  # Only models that actually have an author_id can be "missing" one — the idea
+  # models have no such column, so crediting through the creator is their normal
+  # and correct behavior, not something to resolve.
+  def authorable_models
+    models.select { |model| model.column_names.include?("author_id") }
   end
 
-  # No person_id filter here — a record can be credited through `author_id` *or*
-  # through the creating user's person, so the filter has to run after the
-  # fallback chain resolves. See `build_group`.
-  def diverged_for(model)
-    scope = model.where.not(author_credit_preference: nil)
-    scope = scope.where(author_credit_preference: preference) if preference
-    scope.includes(includes_for(model)).select(&:author_credit_diverged?)
+  def scoped(model)
+    model.includes(includes_for(model))
   end
 
   def includes_for(model)
@@ -79,19 +92,75 @@ class AuthorCreditDivergenceQuery
     includes
   end
 
+  # ── Section 1: the stored snapshot drifted from the profile ────────────────
+  def preference_groups
+    records = models.flat_map do |model|
+      scope = scoped(model).where.not(author_credit_preference: nil)
+      scope = scope.where(author_credit_preference: preference) if preference
+      scope.select(&:author_credit_diverged?)
+    end
+
+    group_by_person(records)
+  end
+
+  # ── Section 2: credited by a free-text name, with no person behind it ──────
+  # The person filter can't apply here: these records have no credited person,
+  # which is the whole problem with them.
+  def legacy_records
+    return [] if preference || person_id
+
+    authorable_models.flat_map do |model|
+      next [] if model.legacy_author_name_columns.empty?
+      sorted(scoped(model).where(author_id: nil).select { |record| record.legacy_author_name_text.present? })
+    end
+  end
+
+  # ── Section 3: author_id blank, so the credit falls back to the creator ────
+  def creator_groups
+    records = authorable_models.flat_map do |model|
+      scoped(model)
+        .where(author_id: nil)
+        .select { |record| record.legacy_author_name_text.blank? && record.created_by&.person.present? }
+    end
+
+    group_by_person(records)
+  end
+
+  # ── Section 4: nothing to credit at all ────────────────────────────────────
+  def unattributed_records
+    return [] if preference || person_id
+
+    authorable_models.flat_map do |model|
+      sorted(scoped(model)
+        .where(author_id: nil)
+        .select { |record| record.legacy_author_name_text.blank? && record.created_by&.person.blank? })
+    end
+  end
+
+  def group_by_person(records)
+    records
+      .group_by(&:author_person)
+      .filter_map { |person, grouped| build_group(person, grouped) }
+      .sort_by { |group| [ group.person.first_name.to_s.downcase, group.person.last_name.to_s.downcase ] }
+  end
+
   def build_group(person, records)
     return nil if person.blank?
-    return nil if person_id && person.id != person_id.to_i
+    return nil if person_id.present? && person.id != person_id.to_i
     return nil if person.author_credit_reconciled_at.present? && !include_reconciled
 
-    Group.new(
+    PersonGroup.new(
       person: person,
-      records: records.sort_by { |record| [ record.class.name, record.id ] },
+      records: sorted(records),
       suggested_preference: most_restrictive(records)
     )
   end
 
+  def sorted(records)
+    records.sort_by { |record| [ record.class.name, record.id ] }
+  end
+
   def most_restrictive(records)
-    records.map(&:author_credit_preference).max_by { |value| RESTRICTIVENESS.fetch(value, 0) }
+    records.map(&:author_credit_preference).compact.max_by { |value| RESTRICTIVENESS.fetch(value, 0) }
   end
 end

--- a/app/services/workshop_search_service.rb
+++ b/app/services/workshop_search_service.rb
@@ -139,8 +139,10 @@ class WorkshopSearchService
     )
     return if spaced.blank?
 
-    # Match against spaced variant (punctuation → space) and spaceless variant (punctuation + spaces removed)
-    fields = %w[workshops.title workshops.full_name action_text_rich_texts.plain_text_body]
+    # Match against spaced variant (punctuation → space) and spaceless variant (punctuation + spaces removed).
+    # The legacy `full_name` is excluded — matching it raw would surface a workshop
+    # whose credit renders anonymous, so it comes back via search_by_author_name.
+    fields = %w[workshops.title action_text_rich_texts.plain_text_body]
     conditions = fields.flat_map do |field|
       [
         "#{self.class.strip_punctuation_sql_spaced(field)} LIKE :spaced",
@@ -148,11 +150,16 @@ class WorkshopSearchService
       ]
     end.join(" OR ")
 
-    @workshops = @workshops
+    by_text = @workshops
       .joins("LEFT JOIN action_text_rich_texts ON action_text_rich_texts.record_id = workshops.id " \
              "AND action_text_rich_texts.record_type = 'Workshop'")
       .where(conditions, spaced: "%#{spaced}%", spaceless: "%#{spaceless}%")
-      .distinct
+      .select("workshops.id")
+
+    # Isolated in an id subquery so the person joins don't collide with the text joins.
+    by_person = search_by_author_name(@workshops, params[:query]).select("workshops.id")
+
+    @workshops = @workshops.where(id: by_text).or(@workshops.where(id: by_person)).distinct
   end
 
   # --- Search methods ---

--- a/app/views/author_credit_divergences/_assign_author_form.html.erb
+++ b/app/views/author_credit_divergences/_assign_author_form.html.erb
@@ -2,7 +2,6 @@
     Person to preselect, e.g. the creator on the "credited to the creator" section). %>
 <% suggested = local_assigns[:suggested] %>
 <%= form_with url: assign_author_author_credit_divergences_path, method: :patch,
-              data: { turbo_frame: "_top" },
               class: "flex items-center gap-2" do %>
   <%= hidden_field_tag :record_type, record.class.name, id: nil %>
   <%= hidden_field_tag :record_id, record.id, id: nil %>

--- a/app/views/author_credit_divergences/_assign_author_form.html.erb
+++ b/app/views/author_credit_divergences/_assign_author_form.html.erb
@@ -1,5 +1,4 @@
-<%# Point one record at a real person. Locals: record (required), suggested (optional
-    Person to preselect, e.g. the creator on the "credited to the creator" section). %>
+<%# Locals: record (required), suggested (optional Person to preselect). %>
 <% suggested = local_assigns[:suggested] %>
 <%= form_with url: assign_author_author_credit_divergences_path, method: :patch,
               class: "flex items-center gap-2" do %>

--- a/app/views/author_credit_divergences/_assign_author_form.html.erb
+++ b/app/views/author_credit_divergences/_assign_author_form.html.erb
@@ -1,0 +1,18 @@
+<%# Point one record at a real person. Locals: record (required), suggested (optional
+    Person to preselect, e.g. the creator on the "credited to the creator" section). %>
+<% suggested = local_assigns[:suggested] %>
+<%= form_with url: assign_author_author_credit_divergences_path, method: :patch,
+              data: { turbo_frame: "_top" },
+              class: "flex items-center gap-2" do %>
+  <%= hidden_field_tag :record_type, record.class.name, id: nil %>
+  <%= hidden_field_tag :record_id, record.id, id: nil %>
+  <%= render "filter_fields" %>
+  <%= select_tag :author_id,
+                 options_for_select(suggested ? [ [ suggested.full_name, suggested.id ] ] : [], suggested&.id),
+                 include_blank: "Select a person",
+                 class: "rounded-md border-gray-300 text-sm",
+                 id: nil,
+                 data: { controller: "remote-select", remote_select_model_value: "person" } %>
+  <%= submit_tag "Credit",
+                 class: "rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer" %>
+<% end %>

--- a/app/views/author_credit_divergences/_filter_fields.html.erb
+++ b/app/views/author_credit_divergences/_filter_fields.html.erb
@@ -1,0 +1,5 @@
+<%# Carries the active filters through a save so the admin lands back on the same list. %>
+<% AuthorCreditDivergencesController::FILTER_KEYS.each do |key| %>
+  <% next if params[key].blank? %>
+  <%= hidden_field_tag key, params[key], id: nil %>
+<% end %>

--- a/app/views/author_credit_divergences/_filters.html.erb
+++ b/app/views/author_credit_divergences/_filters.html.erb
@@ -1,0 +1,36 @@
+<%= form_with url: author_credit_divergences_path, method: :get,
+              data: { turbo_frame: "author_credit_divergences_results" },
+              class: "flex flex-wrap items-end gap-3 mb-6" do |f| %>
+  <div>
+    <%= f.label :type, "Content type", class: "block text-sm font-medium text-gray-700" %>
+    <%= f.select :type,
+                 options_for_select(AuthorCreditDivergenceQuery::MODEL_NAMES.map { |name| [ name.underscore.humanize, name ] }, params[:type]),
+                 { include_blank: "All types" },
+                 class: "mt-1 rounded-md border-gray-300 text-sm" %>
+  </div>
+
+  <div>
+    <%= f.label :preference, "Stored preference", class: "block text-sm font-medium text-gray-700" %>
+    <%= f.select :preference,
+                 options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, params[:preference]),
+                 { include_blank: "Any preference" },
+                 class: "mt-1 rounded-md border-gray-300 text-sm" %>
+  </div>
+
+  <div>
+    <%= f.label :person_id, "Person ID", class: "block text-sm font-medium text-gray-700" %>
+    <%= f.number_field :person_id, value: params[:person_id], placeholder: "Any person",
+                       class: "mt-1 rounded-md border-gray-300 text-sm w-32" %>
+  </div>
+
+  <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
+    <%= check_box_tag :include_reconciled, "1", params[:include_reconciled].present?,
+                      class: "rounded border-gray-300" %>
+    Include already reconciled
+  </label>
+
+  <%= f.submit "Filter", class: "rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
+  <%= link_to "Clear", author_credit_divergences_path,
+              data: { turbo_frame: "author_credit_divergences_results" },
+              class: "text-sm text-gray-600 underline pb-2" %>
+<% end %>

--- a/app/views/author_credit_divergences/_filters.html.erb
+++ b/app/views/author_credit_divergences/_filters.html.erb
@@ -1,36 +1,48 @@
-<%= form_with url: author_credit_divergences_path, method: :get,
-              data: { turbo_frame: "author_credit_divergences_results" },
-              class: "flex flex-wrap items-end gap-3 mb-6" do |f| %>
-  <div>
-    <%= f.label :type, "Content type", class: "block text-sm font-medium text-gray-700" %>
-    <%= f.select :type,
-                 options_for_select(AuthorCreditDivergenceQuery::MODEL_NAMES.map { |name| [ name.underscore.humanize, name ] }, params[:type]),
-                 { include_blank: "All types" },
-                 class: "mt-1 rounded-md border-gray-300 text-sm" %>
-  </div>
+<div class="rounded-lg border border-gray-200 bg-white shadow-sm p-4 mb-6">
+  <%# The collection controller auto-submits into the results frame, so filters
+      apply as you type/pick — no Filter button needed. %>
+  <%= form_with url: author_credit_divergences_path, method: :get,
+                data: { controller: "collection", turbo_frame: "author_credit_divergences_results" },
+                html: { autocomplete: "off" },
+                class: "flex flex-wrap items-end gap-3" do |f| %>
+    <div class="flex items-center gap-2 text-gray-600 basis-full">
+      <i class="fa-solid fa-filter text-xs"></i>
+      <span class="text-xs font-semibold uppercase tracking-wide">Filter</span>
+    </div>
 
-  <div>
-    <%= f.label :preference, "Stored preference", class: "block text-sm font-medium text-gray-700" %>
-    <%= f.select :preference,
-                 options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, params[:preference]),
-                 { include_blank: "Any preference" },
-                 class: "mt-1 rounded-md border-gray-300 text-sm" %>
-  </div>
+    <div>
+      <%= f.label :type, "Content type", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.select :type,
+                   options_for_select(AuthorCreditDivergenceQuery::MODEL_NAMES.map { |name| [ name.underscore.humanize, name ] }, params[:type]),
+                   { include_blank: "All types" },
+                   class: "mt-1 rounded-md border-gray-300 text-sm" %>
+    </div>
 
-  <div>
-    <%= f.label :person_id, "Person ID", class: "block text-sm font-medium text-gray-700" %>
-    <%= f.number_field :person_id, value: params[:person_id], placeholder: "Any person",
-                       class: "mt-1 rounded-md border-gray-300 text-sm w-32" %>
-  </div>
+    <div>
+      <%= f.label :preference, "Stored preference", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.select :preference,
+                   options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, params[:preference]),
+                   { include_blank: "Any preference" },
+                   class: "mt-1 rounded-md border-gray-300 text-sm" %>
+    </div>
 
-  <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
-    <%= check_box_tag :include_reconciled, "1", params[:include_reconciled].present?,
-                      class: "rounded border-gray-300" %>
-    Include already reconciled
-  </label>
+    <div class="w-56">
+      <%= f.label :person_id, "Person", class: "block text-sm font-medium text-gray-700" %>
+      <%= select_tag :person_id,
+                     options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
+                     include_blank: true, prompt: "Search for a person",
+                     class: "mt-1 block w-full rounded-md border-gray-300 text-sm",
+                     data: { controller: "remote-select", remote_select_model_value: "person" } %>
+    </div>
 
-  <%= f.submit "Filter", class: "rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
-  <%= link_to "Clear", author_credit_divergences_path,
-              data: { turbo_frame: "author_credit_divergences_results" },
-              class: "text-sm text-gray-600 underline pb-2" %>
-<% end %>
+    <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
+      <%= check_box_tag :include_reconciled, "1", params[:include_reconciled].present?,
+                        class: "rounded border-gray-300" %>
+      Include already reconciled
+    </label>
+
+    <%= link_to "Clear", author_credit_divergences_path,
+                data: { action: "collection#clearAndSubmit" },
+                class: "text-sm text-gray-600 underline pb-2" %>
+  <% end %>
+</div>

--- a/app/views/author_credit_divergences/_filters.html.erb
+++ b/app/views/author_credit_divergences/_filters.html.erb
@@ -1,6 +1,5 @@
 <div class="rounded-lg border border-gray-200 bg-white shadow-sm p-4 mb-6">
-  <%# The collection controller auto-submits into the results frame, so filters
-      apply as you type/pick — no Filter button needed. %>
+  <%# The collection controller auto-submits, so there's no Filter button. %>
   <%= form_with url: author_credit_divergences_path, method: :get,
                 data: { controller: "collection", turbo_frame: "author_credit_divergences_results" },
                 html: { autocomplete: "off" },

--- a/app/views/author_credit_divergences/_filters.html.erb
+++ b/app/views/author_credit_divergences/_filters.html.erb
@@ -4,45 +4,43 @@
   <%= form_with url: author_credit_divergences_path, method: :get,
                 data: { controller: "collection", turbo_frame: "author_credit_divergences_results" },
                 html: { autocomplete: "off" },
-                class: "flex flex-wrap items-end gap-3" do |f| %>
-    <div class="flex items-center gap-2 text-gray-600 basis-full">
-      <i class="fa-solid fa-filter text-xs"></i>
-      <span class="text-xs font-semibold uppercase tracking-wide">Filter</span>
-    </div>
-
-    <div>
-      <%= f.label :type, "Content type", class: "block text-sm font-medium text-gray-700" %>
+                class: "flex flex-wrap items-end gap-6" do |f| %>
+    <div class="min-w-[150px] pb-2">
+      <%= f.label :type, "Content type", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
       <%= f.select :type,
                    options_for_select(AuthorCreditDivergenceQuery::MODEL_NAMES.map { |name| [ name.underscore.humanize, name ] }, params[:type]),
                    { include_blank: "All types" },
-                   class: "mt-1 rounded-md border-gray-300 text-sm" %>
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                   onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <div>
-      <%= f.label :preference, "Stored preference", class: "block text-sm font-medium text-gray-700" %>
+    <div class="min-w-[150px] pb-2">
+      <%= f.label :preference, "Stored preference", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
       <%= f.select :preference,
                    options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, params[:preference]),
                    { include_blank: "Any preference" },
-                   class: "mt-1 rounded-md border-gray-300 text-sm" %>
+                   class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+                   onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <div class="w-56">
-      <%= f.label :person_id, "Person", class: "block text-sm font-medium text-gray-700" %>
+    <div class="min-w-[200px] pb-2">
+      <%= f.label :person_id, "Person", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
       <%= select_tag :person_id,
                      options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
                      include_blank: true, prompt: "Search for a person",
-                     class: "mt-1 block w-full rounded-md border-gray-300 text-sm",
+                     class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
                      data: { controller: "remote-select", remote_select_model_value: "person" } %>
     </div>
 
-    <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
+    <label class="flex items-center gap-2 text-sm text-gray-600 pb-4">
       <%= check_box_tag :include_reconciled, "1", params[:include_reconciled].present?,
                         class: "rounded border-gray-300" %>
       Include already reconciled
     </label>
 
-    <%= link_to "Clear", author_credit_divergences_path,
-                data: { action: "collection#clearAndSubmit" },
-                class: "text-sm text-gray-600 underline pb-2" %>
+    <div class="min-w-[120px] pb-3">
+      <%= link_to "Clear filters", author_credit_divergences_path,
+                  data: { action: "collection#clearAndSubmit" }, class: "btn btn-utility" %>
+    </div>
   <% end %>
 </div>

--- a/app/views/author_credit_divergences/_legacy_group.html.erb
+++ b/app/views/author_credit_divergences/_legacy_group.html.erb
@@ -1,0 +1,19 @@
+<%# One legacy free-text column. Reported separately from its siblings so clearing
+    a single column is a visible milestone — that's what makes it safe to drop. %>
+<div class="mb-6">
+  <h3 class="text-sm font-semibold text-gray-800 mb-2">
+    <%= group.model.name.underscore.humanize %>
+    <code class="text-xs font-normal text-gray-500"><%= group.column %></code>
+  </h3>
+
+  <% if group.empty? %>
+    <%= render "section_clear",
+          message: "No #{group.model.name.underscore.humanize.downcase} records are credited by #{group.field} any more.",
+          cleanup: "Ask your developers to remove the unused #{group.column} field." %>
+  <% else %>
+    <%= render "unlinked_table",
+          rows: group.entries,
+          name_header: "Legacy name",
+          suggestion_note: "Suggested: a person whose name matches the legacy text." %>
+  <% end %>
+</div>

--- a/app/views/author_credit_divergences/_legacy_group.html.erb
+++ b/app/views/author_credit_divergences/_legacy_group.html.erb
@@ -1,5 +1,4 @@
-<%# One legacy free-text column. Reported separately from its siblings so clearing
-    a single column is a visible milestone — that's what makes it safe to drop. %>
+<%# Reported per column: clearing one is what makes that column safe to drop. %>
 <div class="mb-6">
   <h3 class="text-sm font-semibold text-gray-800 mb-2">
     <%= group.model.name.underscore.humanize %>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -2,15 +2,9 @@
 <% highlighted = params[:highlight].to_s == person.id.to_s %>
 <div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border shadow-sm scroll-mt-4 transition-colors duration-150 <%= highlighted ? "border-yellow-400 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200 bg-white" %>">
   <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
-    <div>
-      <%= link_to person.full_name, person_path(person),
-                  target: "_blank", rel: "noopener", title: "Opens in a new tab",
-                  class: "font-semibold text-gray-900 hover:underline" %>
-      <span class="text-sm text-gray-500">
-        &mdash; profile currently credits as
-        <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %></strong>
-      </span>
-    </div>
+    <%= link_to person.full_name, person_path(person),
+                target: "_blank", rel: "noopener", title: "Opens in a new tab",
+                class: "font-semibold text-gray-900 hover:underline" %>
     <% if person.author_credit_reconciled_at.present? %>
       <%= render "shared/badge",
             label: "Reconciled #{person.author_credit_reconciled_at.strftime('%b %-d, %Y')}",
@@ -66,6 +60,17 @@
       <%= hidden_field_tag :id, person.id, id: nil %>
       <%= render "filter_fields" %>
 
+      <%# Read-only current state on the left, so the row reads current → new. Only
+          the fields to its right are applied. %>
+      <div class="pb-2">
+        <span class="block text-xs font-medium text-gray-500">Currently credits as</span>
+        <span class="mt-1 block text-sm font-medium text-gray-800">
+          <%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %>
+        </span>
+      </div>
+
+      <span class="pb-3 text-gray-400" aria-hidden="true">&rarr;</span>
+
       <div>
         <%= label_tag "person_display_name_preference_#{person.id}", "Set profile to",
                       class: "block text-xs font-medium text-gray-700" %>
@@ -74,6 +79,7 @@
                                           suggested_display_name_preference(group)),
                        id: "person_display_name_preference_#{person.id}",
                        class: "mt-1 rounded-md border-gray-300 text-sm" %>
+        <p class="mt-0.5 text-xs text-gray-500">Suggested: <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(group.suggested_preference) %></strong></p>
       </div>
 
       <div class="pb-2">
@@ -90,9 +96,6 @@
 
       <%= submit_tag "Apply to profile",
                      class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
-      <span class="basis-full text-xs text-gray-500">
-        Suggested: <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(group.suggested_preference) %></strong>
-      </span>
     <% end %>
   </div>
 </div>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -36,7 +36,6 @@
           <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
           <td class="px-4 py-2">
             <%= form_with url: update_item_author_credit_divergences_path, method: :patch,
-                          data: { turbo_frame: "_top" },
                           class: "flex items-center gap-2" do %>
               <%= hidden_field_tag :record_type, record.class.name, id: nil %>
               <%= hidden_field_tag :record_id, record.id, id: nil %>
@@ -65,7 +64,6 @@
   <%# The action lands after the supportive data above: read the content, then apply. %>
   <div class="bg-gray-50 px-4 py-3 border-t border-gray-200">
     <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
-                  data: { turbo_frame: "_top" },
                   class: "flex flex-wrap items-end gap-3" do %>
       <%= hidden_field_tag :id, person.id, id: nil %>
       <%= render "filter_fields" %>
@@ -91,9 +89,8 @@
 
       <%= submit_tag "Apply to profile",
                      class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
-      <span class="text-xs text-gray-500 pb-2">
+      <span class="basis-full text-xs text-gray-500">
         Suggested: <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(group.suggested_preference) %></strong>
-        &mdash; the most restrictive consent across <%= person.full_name %>'s content.
       </span>
     <% end %>
   </div>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -40,8 +40,7 @@
               <%= hidden_field_tag :record_type, record.class.name, id: nil %>
               <%= hidden_field_tag :record_id, record.id, id: nil %>
               <%= render "filter_fields" %>
-              <%# "None" clears the snapshot so the item just follows the profile —
-                  offered on anonymous items too, since that's how they're reconciled. %>
+              <%# "None" clears the snapshot so the item follows the profile. %>
               <%= select_tag "author_credit_preference",
                              options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
                              include_blank: "None (follow profile)",
@@ -60,7 +59,6 @@
     re-record what was consented to.
   </p>
 
-  <%# The action lands after the supportive data above: read the content, then apply. %>
   <div class="bg-gray-50 px-4 py-3 border-t border-gray-200">
     <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
                   class: "flex flex-wrap items-end gap-3" do %>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -58,7 +58,7 @@
       <%# Read-only current state on the left, so the row reads current → new. Only
           the fields to its right are applied. %>
       <div class="pb-2 whitespace-nowrap sm:min-w-[11rem]">
-        <span class="block text-xs font-medium text-gray-500">Currently credits as</span>
+        <span class="block text-xs font-medium text-gray-500">Current Display name preference</span>
         <span class="mt-1 block text-sm font-medium text-gray-800">
           <%= Person::DISPLAY_NAME_PREFERENCE_LABELS[person.display_name_preference.presence || "full_name"] %>
         </span>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -1,8 +1,11 @@
 <% person = group.person %>
-<div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border border-gray-200 bg-white shadow-sm scroll-mt-4">
+<% highlighted = params[:highlight].to_s == person.id.to_s %>
+<div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border shadow-sm scroll-mt-4 transition-colors duration-150 <%= highlighted ? "border-yellow-400 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200 bg-white" %>">
   <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
     <div>
-      <%= link_to person.full_name, person_path(person), class: "font-semibold text-gray-900 hover:underline" %>
+      <%= link_to person.full_name, person_path(person),
+                  target: "_blank", rel: "noopener", title: "Opens in a new tab",
+                  class: "font-semibold text-gray-900 hover:underline" %>
       <span class="text-sm text-gray-500">
         &mdash; profile currently credits as
         <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %></strong>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -1,0 +1,93 @@
+<% person = group.person %>
+<div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border border-gray-200 bg-white shadow-sm scroll-mt-4">
+  <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
+    <div>
+      <%= link_to person.full_name, person_path(person), class: "font-semibold text-gray-900 hover:underline" %>
+      <span class="text-sm text-gray-500">
+        &mdash; profile currently credits as
+        <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %></strong>
+      </span>
+    </div>
+    <% if person.author_credit_reconciled_at.present? %>
+      <%= render "shared/badge",
+            label: "Reconciled #{person.author_credit_reconciled_at.strftime('%b %-d, %Y')}",
+            classes: "bg-gray-50 text-gray-600 border-gray-200",
+            icon: "fa-solid fa-circle-info" %>
+    <% end %>
+  </div>
+
+  <table class="w-full text-sm">
+    <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
+      <tr>
+        <th class="px-4 py-2 font-medium">Content</th>
+        <th class="px-4 py-2 font-medium">Type</th>
+        <th class="px-4 py-2 font-medium">Renders as</th>
+        <th class="px-4 py-2 font-medium">Stored consent</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      <% group.records.each do |record| %>
+        <tr>
+          <td class="px-4 py-2"><%= divergence_record_link(record) %></td>
+          <td class="px-4 py-2 text-gray-600"><%= record.class.name.underscore.humanize %></td>
+          <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
+          <td class="px-4 py-2">
+            <%= form_with url: update_item_author_credit_divergences_path, method: :patch,
+                          data: { turbo_frame: "_top" },
+                          class: "flex items-center gap-2" do %>
+              <%= hidden_field_tag :record_type, record.class.name, id: nil %>
+              <%= hidden_field_tag :record_id, record.id, id: nil %>
+              <%= render "filter_fields" %>
+              <%= select_tag "author_credit_preference",
+                             options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
+                             id: nil,
+                             class: "rounded-md border-gray-300 text-sm" %>
+              <%= submit_tag "Save",
+                             class: "rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer" %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100">
+    Only <strong>Anonymous</strong> changes what renders &mdash; the other values just
+    re-record what was consented to.
+  </p>
+
+  <%# The action lands after the supportive data above: read the content, then apply. %>
+  <div class="bg-gray-50 px-4 py-3 border-t border-gray-200">
+    <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
+                  data: { turbo_frame: "_top" },
+                  class: "flex flex-wrap items-end gap-3" do %>
+      <%= hidden_field_tag :id, person.id, id: nil %>
+      <%= render "filter_fields" %>
+
+      <div>
+        <%= label_tag "person_display_name_preference_#{person.id}", "Set profile to",
+                      class: "block text-xs font-medium text-gray-700" %>
+        <%= select_tag "person[display_name_preference]",
+                       options_for_select(Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
+                                          suggested_display_name_preference(group)),
+                       id: "person_display_name_preference_#{person.id}",
+                       class: "mt-1 rounded-md border-gray-300 text-sm" %>
+      </div>
+
+      <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
+        <%= hidden_field_tag "person[contributions_anonymous]", "0", id: nil %>
+        <%= check_box_tag "person[contributions_anonymous]", "1",
+                          group.suggested_preference == AuthorCreditable::ANONYMOUS || person.contributions_anonymous?,
+                          id: "person_contributions_anonymous_#{person.id}",
+                          class: "rounded border-gray-300" %>
+        Contributions show as anonymous
+      </label>
+
+      <%= submit_tag "Apply to profile",
+                     class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
+      <span class="text-xs text-gray-500 pb-2">
+        Suggested: <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(group.suggested_preference) %></strong>
+        &mdash; the most restrictive consent across <%= person.full_name %>'s content.
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -18,7 +18,7 @@
       <tr>
         <th class="px-4 py-2 font-medium">Content</th>
         <th class="px-4 py-2 font-medium">Type</th>
-        <th class="px-4 py-2 font-medium">Renders as</th>
+        <th class="px-4 py-2 font-medium">Credit display</th>
         <th class="px-4 py-2 font-medium">Stored consent</th>
       </tr>
     </thead>
@@ -69,25 +69,24 @@
 
       <span class="pb-3 text-gray-400" aria-hidden="true">&rarr;</span>
 
-      <div>
+      <div class="pb-2">
         <%= label_tag "person_display_name_preference_#{person.id}", "Set profile to",
                       class: "block text-xs font-medium text-gray-700" %>
-        <%= select_tag "person[display_name_preference]",
-                       options_for_select(Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
-                                          suggested_display_name_preference(group)),
-                       id: "person_display_name_preference_#{person.id}",
-                       class: "mt-1 rounded-md border-gray-300 text-sm" %>
-      </div>
-
-      <div class="pb-2">
-        <label class="flex items-center gap-2 text-sm text-gray-700">
-          <%= hidden_field_tag "person[anonymous_contributions]", "0", id: nil %>
-          <%= check_box_tag "person[anonymous_contributions]", "1",
-                            group.suggested_preference == AuthorCreditable::ANONYMOUS || person.anonymous_contributions?,
-                            id: "person_anonymous_contributions_#{person.id}",
-                            class: "rounded border-gray-300" %>
-          Anonymous contributions
-        </label>
+        <div class="mt-1 flex flex-wrap items-center gap-4">
+          <%= select_tag "person[display_name_preference]",
+                         options_for_select(Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
+                                            suggested_display_name_preference(group)),
+                         id: "person_display_name_preference_#{person.id}",
+                         class: "rounded-md border-gray-300 text-sm" %>
+          <label class="flex items-center gap-2 text-sm text-gray-700">
+            <%= hidden_field_tag "person[anonymous_contributions]", "0", id: nil %>
+            <%= check_box_tag "person[anonymous_contributions]", "1",
+                              group.suggested_preference == AuthorCreditable::ANONYMOUS || person.anonymous_contributions?,
+                              id: "person_anonymous_contributions_#{person.id}",
+                              class: "rounded border-gray-300" %>
+            Anonymous contributions
+          </label>
+        </div>
         <p class="mt-0.5 text-xs text-gray-500">Hides your name on content, but not People/Profile</p>
       </div>
 

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -77,7 +77,6 @@
                                           suggested_display_name_preference(group)),
                        id: "person_display_name_preference_#{person.id}",
                        class: "mt-1 rounded-md border-gray-300 text-sm" %>
-        <p class="mt-0.5 text-xs text-gray-500">Suggested: <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(group.suggested_preference) %></strong></p>
       </div>
 
       <div class="pb-2">

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -76,14 +76,17 @@
                        class: "mt-1 rounded-md border-gray-300 text-sm" %>
       </div>
 
-      <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
-        <%= hidden_field_tag "person[anonymous_contributions]", "0", id: nil %>
-        <%= check_box_tag "person[anonymous_contributions]", "1",
-                          group.suggested_preference == AuthorCreditable::ANONYMOUS || person.anonymous_contributions?,
-                          id: "person_anonymous_contributions_#{person.id}",
-                          class: "rounded border-gray-300" %>
-        Anonymous contributions
-      </label>
+      <div class="pb-2">
+        <label class="flex items-center gap-2 text-sm text-gray-700">
+          <%= hidden_field_tag "person[anonymous_contributions]", "0", id: nil %>
+          <%= check_box_tag "person[anonymous_contributions]", "1",
+                            group.suggested_preference == AuthorCreditable::ANONYMOUS || person.anonymous_contributions?,
+                            id: "person_anonymous_contributions_#{person.id}",
+                            class: "rounded border-gray-300" %>
+          Anonymous contributions
+        </label>
+        <p class="mt-0.5 text-xs text-gray-500">Hides your name on content, but not People/Profile</p>
+      </div>
 
       <%= submit_tag "Apply to profile",
                      class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -78,10 +78,10 @@
       </div>
 
       <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
-        <%= hidden_field_tag "person[contributions_anonymous]", "0", id: nil %>
-        <%= check_box_tag "person[contributions_anonymous]", "1",
-                          group.suggested_preference == AuthorCreditable::ANONYMOUS || person.contributions_anonymous?,
-                          id: "person_contributions_anonymous_#{person.id}",
+        <%= hidden_field_tag "person[anonymous_contributions]", "0", id: nil %>
+        <%= check_box_tag "person[anonymous_contributions]", "1",
+                          group.suggested_preference == AuthorCreditable::ANONYMOUS || person.anonymous_contributions?,
+                          id: "person_anonymous_contributions_#{person.id}",
                           class: "rounded border-gray-300" %>
         Anonymous contributions
       </label>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -1,6 +1,6 @@
 <% person = group.person %>
 <% highlighted = params[:highlight].to_s == person.id.to_s %>
-<div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border shadow-sm scroll-mt-4 transition-colors duration-150 <%= highlighted ? "border-yellow-400 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200 bg-white" %>">
+<div id="<%= dom_id(person, :divergence) %>" class="overflow-hidden rounded-lg border shadow-sm scroll-mt-4 transition-colors duration-150 <%= highlighted ? "border-yellow-400 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200 bg-white" %>">
   <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person.full_name, person_path(person),
                 target: "_blank", rel: "noopener", title: "Opens in a new tab",
@@ -48,11 +48,6 @@
       <% end %>
     </tbody>
   </table>
-  <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100">
-    Only <strong>Anonymous</strong> changes what renders (to the generic
-    &ldquo;AWBW Facilitator&rdquo; credit) &mdash; the other values just re-record what was
-    consented to.
-  </p>
 
   <div class="bg-gray-50 px-4 py-3 border-t border-gray-200">
     <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
@@ -62,10 +57,13 @@
 
       <%# Read-only current state on the left, so the row reads current → new. Only
           the fields to its right are applied. %>
-      <div class="pb-2">
+      <div class="pb-2 whitespace-nowrap sm:min-w-[11rem]">
         <span class="block text-xs font-medium text-gray-500">Currently credits as</span>
         <span class="mt-1 block text-sm font-medium text-gray-800">
-          <%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %>
+          <%= Person::DISPLAY_NAME_PREFERENCE_LABELS[person.display_name_preference.presence || "full_name"] %>
+        </span>
+        <span class="mt-0.5 block text-xs text-gray-500">
+          Anonymous: <%= person.anonymous_contributions? ? "on" : "off" %>
         </span>
       </div>
 

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -40,12 +40,11 @@
               <%= hidden_field_tag :record_type, record.class.name, id: nil %>
               <%= hidden_field_tag :record_id, record.id, id: nil %>
               <%= render "filter_fields" %>
-              <%# "None" clears the snapshot so the item just follows the profile. Hidden
-                  for anonymous items — clearing that value would de-anonymize them. %>
-              <% allow_clear = record.author_credit_preference != AuthorCreditable::ANONYMOUS %>
+              <%# "None" clears the snapshot so the item just follows the profile —
+                  offered on anonymous items too, since that's how they're reconciled. %>
               <%= select_tag "author_credit_preference",
                              options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
-                             include_blank: (allow_clear ? "None (follow profile)" : false),
+                             include_blank: "None (follow profile)",
                              id: nil,
                              class: "rounded-md border-gray-300 text-sm" %>
               <%= submit_tag "Save",

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -41,8 +41,12 @@
               <%= hidden_field_tag :record_type, record.class.name, id: nil %>
               <%= hidden_field_tag :record_id, record.id, id: nil %>
               <%= render "filter_fields" %>
+              <%# "None" clears the snapshot so the item just follows the profile. Hidden
+                  for anonymous items — clearing that value would de-anonymize them. %>
+              <% allow_clear = record.author_credit_preference != AuthorCreditable::ANONYMOUS %>
               <%= select_tag "author_credit_preference",
                              options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
+                             include_blank: (allow_clear ? "None (follow profile)" : false),
                              id: nil,
                              class: "rounded-md border-gray-300 text-sm" %>
               <%= submit_tag "Save",
@@ -82,7 +86,7 @@
                           group.suggested_preference == AuthorCreditable::ANONYMOUS || person.contributions_anonymous?,
                           id: "person_contributions_anonymous_#{person.id}",
                           class: "rounded border-gray-300" %>
-        Contributions show as anonymous
+        Anonymous contributions
       </label>
 
       <%= submit_tag "Apply to profile",

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -55,8 +55,9 @@
     </tbody>
   </table>
   <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100">
-    Only <strong>Anonymous</strong> changes what renders &mdash; the other values just
-    re-record what was consented to.
+    Only <strong>Anonymous</strong> changes what renders (to the generic
+    &ldquo;AWBW Facilitator&rdquo; credit) &mdash; the other values just re-record what was
+    consented to.
   </p>
 
   <div class="bg-gray-50 px-4 py-3 border-t border-gray-200">

--- a/app/views/author_credit_divergences/_results_skeleton.html.erb
+++ b/app/views/author_credit_divergences/_results_skeleton.html.erb
@@ -1,0 +1,9 @@
+<div class="animate-pulse space-y-4">
+  <% 3.times do %>
+    <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <div class="h-5 w-48 bg-gray-200 rounded mb-3"></div>
+      <div class="h-4 w-full bg-gray-100 rounded mb-2"></div>
+      <div class="h-4 w-3/4 bg-gray-100 rounded"></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/author_credit_divergences/_section_clear.html.erb
+++ b/app/views/author_credit_divergences/_section_clear.html.erb
@@ -1,7 +1,5 @@
-<%# All-clear note for one section. Locals: message (required), cleanup (optional —
-    the code that can now be retired, which is the real payoff of clearing it).
-    Under a filter an empty section is the filter's doing, not a milestone, so both
-    the congratulations and the cleanup instruction are withheld. %>
+<%# Locals: message (required), cleanup (optional). Withheld under a filter, where
+    an empty section is the filter's doing rather than a milestone. %>
 <% if divergence_filters_applied? %>
   <div class="rounded-lg border border-gray-200 bg-gray-50 p-6">
     <p class="text-sm text-gray-600">

--- a/app/views/author_credit_divergences/_section_clear.html.erb
+++ b/app/views/author_credit_divergences/_section_clear.html.erb
@@ -1,0 +1,10 @@
+<%# All-clear note for one section. Locals: message (required), cleanup (optional —
+    the code that can now be retired, which is the real payoff of clearing it). %>
+<div class="rounded-lg border border-green-200 bg-green-50 p-6">
+  <p class="text-green-800 font-medium">
+    <i class="fa-solid fa-circle-check mr-1"></i><%= message %>
+  </p>
+  <% if local_assigns[:cleanup].present? %>
+    <p class="text-sm text-green-900 mt-2"><%= cleanup %></p>
+  <% end %>
+</div>

--- a/app/views/author_credit_divergences/_section_clear.html.erb
+++ b/app/views/author_credit_divergences/_section_clear.html.erb
@@ -1,10 +1,20 @@
 <%# All-clear note for one section. Locals: message (required), cleanup (optional —
-    the code that can now be retired, which is the real payoff of clearing it). %>
-<div class="rounded-lg border border-green-200 bg-green-50 p-6">
-  <p class="text-green-800 font-medium">
-    <i class="fa-solid fa-circle-check mr-1"></i><%= message %>
-  </p>
-  <% if local_assigns[:cleanup].present? %>
-    <p class="text-sm text-green-900 mt-2"><%= cleanup %></p>
-  <% end %>
-</div>
+    the code that can now be retired, which is the real payoff of clearing it).
+    Under a filter an empty section is the filter's doing, not a milestone, so both
+    the congratulations and the cleanup instruction are withheld. %>
+<% if divergence_filters_applied? %>
+  <div class="rounded-lg border border-gray-200 bg-gray-50 p-6">
+    <p class="text-sm text-gray-600">
+      <i class="fa-solid fa-filter mr-1"></i>Nothing in this section matches the current filters.
+    </p>
+  </div>
+<% else %>
+  <div class="rounded-lg border border-green-200 bg-green-50 p-6">
+    <p class="text-green-800 font-medium">
+      <i class="fa-solid fa-circle-check mr-1"></i><%= message %>
+    </p>
+    <% if local_assigns[:cleanup].present? %>
+      <p class="text-sm text-green-900 mt-2"><%= cleanup %></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/author_credit_divergences/_unlinked_table.html.erb
+++ b/app/views/author_credit_divergences/_unlinked_table.html.erb
@@ -1,0 +1,29 @@
+<%# Records with no author_id, each resolvable by crediting a person. Locals:
+    records (required), name_header (required), suggest_creator (required —
+    preselect the creating user's person in the picker). %>
+<div class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
+      <tr>
+        <th class="px-4 py-2 font-medium">Content</th>
+        <th class="px-4 py-2 font-medium">Type</th>
+        <th class="px-4 py-2 font-medium"><%= name_header %></th>
+        <th class="px-4 py-2 font-medium">Credit to</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      <% records.each do |record| %>
+        <tr>
+          <td class="px-4 py-2"><%= divergence_record_link(record) %></td>
+          <td class="px-4 py-2 text-gray-600"><%= record.class.name.underscore.humanize %></td>
+          <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
+          <td class="px-4 py-2">
+            <%= render "assign_author_form",
+                  record: record,
+                  suggested: (record.created_by&.person if suggest_creator) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/author_credit_divergences/_unlinked_table.html.erb
+++ b/app/views/author_credit_divergences/_unlinked_table.html.erb
@@ -1,6 +1,5 @@
-<%# Records with no author_id, each resolvable by crediting a person. Locals:
-    rows (required — objects responding to #record and #suggested_author),
-    name_header (required), suggestion_note (optional caption under the table). %>
+<%# Locals: rows (responding to #record and #suggested_author), name_header,
+    suggestion_note (optional). %>
 <div class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
   <table class="w-full text-sm">
     <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">

--- a/app/views/author_credit_divergences/_unlinked_table.html.erb
+++ b/app/views/author_credit_divergences/_unlinked_table.html.erb
@@ -1,6 +1,6 @@
 <%# Records with no author_id, each resolvable by crediting a person. Locals:
-    records (required), name_header (required), suggest_creator (required —
-    preselect the creating user's person in the picker). %>
+    rows (required — objects responding to #record and #suggested_author),
+    name_header (required), suggestion_note (optional caption under the table). %>
 <div class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
   <table class="w-full text-sm">
     <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
@@ -12,18 +12,19 @@
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-100">
-      <% records.each do |record| %>
+      <% rows.each do |row| %>
         <tr>
-          <td class="px-4 py-2"><%= divergence_record_link(record) %></td>
-          <td class="px-4 py-2 text-gray-600"><%= record.class.name.underscore.humanize %></td>
-          <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
+          <td class="px-4 py-2"><%= divergence_record_link(row.record) %></td>
+          <td class="px-4 py-2 text-gray-600"><%= row.record.class.name.underscore.humanize %></td>
+          <td class="px-4 py-2 text-gray-800"><%= row.record.author_credit %></td>
           <td class="px-4 py-2">
-            <%= render "assign_author_form",
-                  record: record,
-                  suggested: (record.created_by&.person if suggest_creator) %>
+            <%= render "assign_author_form", record: row.record, suggested: row.suggested_author %>
           </td>
         </tr>
       <% end %>
     </tbody>
   </table>
+  <% if local_assigns[:suggestion_note].present? %>
+    <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100"><%= suggestion_note %></p>
+  <% end %>
 </div>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -1,113 +1,138 @@
 <%= turbo_frame_tag :author_credit_divergences_results do %>
-  <% if @groups.empty? %>
+  <% if @result.empty? && divergence_filters_applied? %>
     <div class="rounded-lg border border-gray-200 bg-white p-8 text-center">
-      <i class="fa-solid fa-circle-check text-3xl text-green-600 mb-3"></i>
-      <p class="text-gray-700 font-medium">Nothing to reconcile.</p>
-      <p class="text-sm text-gray-500 mt-1">Every stored credit preference matches its author's profile.</p>
+      <i class="fa-solid fa-filter-circle-xmark text-3xl text-gray-400 mb-3"></i>
+      <p class="text-gray-700 font-medium">Nothing matches these filters.</p>
+      <p class="text-sm text-gray-500 mt-1">
+        Clear them to see whether anything is left to reconcile overall.
+      </p>
+    </div>
+  <% elsif @result.empty? %>
+    <div class="rounded-lg border border-green-200 bg-green-50 p-8 text-center">
+      <i class="fa-solid fa-trophy text-3xl text-green-600 mb-3"></i>
+      <p class="text-green-800 font-semibold text-lg">Every credit resolves through a profile.</p>
+      <p class="text-sm text-green-900 mt-2">
+        Nothing left to reconcile in any section. Ask your developers to remove any unused
+        author credit code &mdash; the stored <code>author_credit_preference</code> columns, the
+        legacy free-text name columns, and the creator and missing-author fallbacks in
+        <code>AuthorCreditable</code>.
+      </p>
     </div>
   <% else %>
-    <p class="text-sm text-gray-600 mb-4">
-      <%= pluralize(@groups.size, "person") %> with diverging content.
-    </p>
-
-    <div class="space-y-6">
-      <% @groups.each do |group| %>
-        <% person = group.person %>
-        <div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border border-gray-200 bg-white shadow-sm scroll-mt-4">
-          <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <%= link_to person.full_name, person_path(person), class: "font-semibold text-gray-900 hover:underline" %>
-              <span class="text-sm text-gray-500">
-                &mdash; profile currently credits as
-                <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %></strong>
-              </span>
-            </div>
-            <% if person.author_credit_reconciled_at.present? %>
-              <%= render "shared/badge",
-                    label: "Reconciled #{person.author_credit_reconciled_at.strftime('%b %-d, %Y')}",
-                    classes: "bg-gray-50 text-gray-600 border-gray-200",
-                    icon: "fa-solid fa-circle-info" %>
+    <%# Section counts up front so the admin can see the full scope and jump to any section. %>
+    <% overview = [
+         { anchor: "section-preference",   num: 1, label: "Preference drift", count: @result.preference.size,   unit: "person" },
+         { anchor: "section-legacy",       num: 2, label: "Legacy name",      count: @result.legacy.size,       unit: "record" },
+         { anchor: "section-creator",      num: 3, label: "Creator fallback", count: @result.creator.size,      unit: "person" },
+         { anchor: "section-unattributed", num: 4, label: "No author",        count: @result.unattributed.size, unit: "record" }
+       ] %>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+      <% overview.each do |section| %>
+        <% clear = section[:count].zero? %>
+        <%= link_to "##{section[:anchor]}",
+              class: "block rounded-lg border p-3 transition-colors #{clear ? "border-green-200 bg-green-50 hover:bg-green-100" : "border-gray-200 bg-white shadow-sm hover:bg-gray-50"}" do %>
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-xs font-medium uppercase tracking-wide text-gray-500"><%= section[:num] %>. <%= section[:label] %></span>
+            <% if clear %>
+              <i class="fa-solid fa-circle-check text-green-600" aria-hidden="true"></i>
             <% end %>
           </div>
-
-          <div class="bg-gray-50 px-4 py-3 border-b border-gray-200">
-            <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
-                          data: { turbo_frame: "_top" },
-                          class: "flex flex-wrap items-end gap-3" do |f| %>
-              <%= hidden_field_tag :id, person.id %>
-              <%= render "filter_fields" %>
-
-              <div>
-                <%= label_tag "person_display_name_preference_#{person.id}", "Set profile to",
-                              class: "block text-xs font-medium text-gray-700" %>
-                <%= select_tag "person[display_name_preference]",
-                               options_for_select(Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
-                                                  suggested_display_name_preference(group)),
-                               id: "person_display_name_preference_#{person.id}",
-                               class: "mt-1 rounded-md border-gray-300 text-sm" %>
-              </div>
-
-              <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
-                <%= hidden_field_tag "person[contributions_anonymous]", "0" %>
-                <%= check_box_tag "person[contributions_anonymous]", "1",
-                                  group.suggested_preference == AuthorCreditable::ANONYMOUS || person.contributions_anonymous?,
-                                  id: "person_contributions_anonymous_#{person.id}",
-                                  class: "rounded border-gray-300" %>
-                Contributions show as anonymous
-              </label>
-
-              <%= submit_tag "Apply to profile",
-                             class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
-              <span class="text-xs text-gray-500 pb-2">
-                Suggested: the most restrictive preference across their content.
-              </span>
-            <% end %>
-          </div>
-
-          <table class="w-full text-sm">
-            <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
-              <tr>
-                <th class="px-4 py-2 font-medium">Content</th>
-                <th class="px-4 py-2 font-medium">Type</th>
-                <th class="px-4 py-2 font-medium">Renders as</th>
-                <th class="px-4 py-2 font-medium">Stored consent</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100">
-              <% group.records.each do |record| %>
-                <tr>
-                  <td class="px-4 py-2">
-                    <%= link_to divergence_record_title(record), polymorphic_path(record),
-                                target: "_blank", rel: "noopener",
-                                title: "Opens in a new tab",
-                                class: "text-blue-700 hover:underline" %>
-                  </td>
-                  <td class="px-4 py-2 text-gray-600"><%= record.class.name.underscore.humanize %></td>
-                  <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
-                  <td class="px-4 py-2">
-                    <%= form_with url: update_item_author_credit_divergences_path, method: :patch,
-                                  data: { turbo_frame: "_top" },
-                                  class: "flex items-center gap-2" do %>
-                      <%= hidden_field_tag :record_type, record.class.name %>
-                      <%= hidden_field_tag :record_id, record.id %>
-                      <%= render "filter_fields" %>
-                      <%= select_tag "author_credit_preference",
-                                     options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
-                                     class: "rounded-md border-gray-300 text-sm" %>
-                      <%= submit_tag "Save",
-                                     class: "rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer" %>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-          <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100">
-            Only <strong>Anonymous</strong> changes what renders &mdash; the other values just
-            re-record what was consented to.
-          </p>
-        </div>
+          <div class="mt-1 text-2xl font-bold <%= clear ? "text-green-700" : "text-gray-900" %>"><%= section[:count] %></div>
+          <div class="text-xs text-gray-500"><%= clear ? "clear" : "#{section[:unit].pluralize(section[:count])} to review" %></div>
+        <% end %>
       <% end %>
     </div>
+
+    <p class="text-sm text-gray-600 mb-6">
+      Work these top to bottom. A record can appear in more than one section when it needs
+      more than one fix.
+    </p>
+
+    <%# ── 1. Stored consent snapshot drifted from the profile ───────────────── %>
+    <section id="section-preference" class="mb-10 scroll-mt-4">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">1. Preference no longer matches the profile</h2>
+      <p class="text-sm text-gray-600 mb-4">
+        These are credited correctly &mdash; the profile formats them &mdash; but the stored record of
+        what the submitter consented to has since drifted. Confirm which one is right.
+      </p>
+
+      <% if @result.preference.empty? %>
+        <%= render "section_clear",
+              message: "No preference divergences. Every stored consent snapshot matches its author's profile.",
+              cleanup: "Ask your developers to remove any unused author credit code." %>
+      <% else %>
+        <p class="text-sm text-gray-600 mb-3"><%= pluralize(@result.preference.size, "person") %> to review.</p>
+        <div class="space-y-6">
+          <%= render partial: "preference_group", collection: @result.preference, as: :group %>
+        </div>
+      <% end %>
+    </section>
+
+    <%# ── 2. Credited by a legacy free-text name ────────────────────────────── %>
+    <section id="section-legacy" class="mb-10 scroll-mt-4">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">2. Credited by a legacy name, not a person</h2>
+      <p class="text-sm text-gray-600 mb-4">
+        Pre-person records whose credit comes from a free-text column
+        (<code>workshops.full_name</code>, <code>resources.legacy_author_name</code>). The name shown
+        obeys nobody's profile and links nowhere. Crediting a real person replaces it.
+      </p>
+
+      <% if @result.legacy.empty? %>
+        <%= render "section_clear",
+              message: "No legacy author names left. Every record is credited to a real person.",
+              cleanup: "Ask your developers to remove any unused full_name code — the workshops.full_name and resources.legacy_author_name columns, their legacy_author_name_columns / legacy_author_name_text overrides, and the legacy branches in AuthorCreditable." %>
+      <% else %>
+        <%= render "unlinked_table", records: @result.legacy, name_header: "Legacy name", suggest_creator: false %>
+      <% end %>
+    </section>
+
+    <%# ── 3. author_id blank, credit falls back to the creator ──────────────── %>
+    <section id="section-creator" class="mb-10 scroll-mt-4">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">3. Credited to the creator, not an author</h2>
+      <p class="text-sm text-gray-600 mb-4">
+        These have no <code>author_id</code>, so the credit falls back to whoever created the record.
+        The name is right and follows that person's profile, but it never links to them and the record
+        doesn't appear on their profile. Confirm the creator is the author, or pick someone else.
+        Idea records are excluded &mdash; they have no <code>author_id</code>, so the creator is their
+        correct and only credit path.
+      </p>
+
+      <% if @result.creator.empty? %>
+        <%= render "section_clear",
+              message: "No creator fallbacks. Every record names its author explicitly.",
+              cleanup: "Ask your developers to remove the created_by fallback in AuthorCreditable#author_credit." %>
+      <% else %>
+        <p class="text-sm text-gray-600 mb-3"><%= pluralize(@result.creator.size, "person") %> to confirm.</p>
+        <div class="space-y-6">
+          <% @result.creator.each do |group| %>
+            <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+              <div class="border-b border-gray-200 px-4 py-3">
+                <%= link_to group.person.full_name, person_path(group.person),
+                            class: "font-semibold text-gray-900 hover:underline" %>
+                <span class="text-sm text-gray-500">&mdash; created <%= pluralize(group.records.size, "record") %> with no author set</span>
+              </div>
+              <%= render "unlinked_table", records: group.records, name_header: "Renders as", suggest_creator: true %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </section>
+
+    <%# ── 4. Nothing to credit at all ───────────────────────────────────────── %>
+    <section id="section-unattributed" class="scroll-mt-4">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">4. No author at all</h2>
+      <p class="text-sm text-gray-600 mb-4">
+        No author, no legacy name, and no person behind the creating account, so these fall back to a
+        generic label like &ldquo;AWBW Facilitator&rdquo;.
+      </p>
+
+      <% if @result.unattributed.empty? %>
+        <%= render "section_clear",
+              message: "Nothing unattributed. Every record has someone to credit.",
+              cleanup: "Ask your developers to remove the missing_author_label fallbacks." %>
+      <% else %>
+        <%= render "unlinked_table", records: @result.unattributed, name_header: "Renders as", suggest_creator: false %>
+      <% end %>
+    </section>
   <% end %>
 <% end %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -108,6 +108,7 @@
             <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
               <div class="border-b border-gray-200 px-4 py-3">
                 <%= link_to group.person.full_name, person_path(group.person),
+                            target: "_blank", rel: "noopener", title: "Opens in a new tab",
                             class: "font-semibold text-gray-900 hover:underline" %>
                 <span class="text-sm text-gray-500">&mdash; created <%= pluralize(group.records.size, "record") %> with no author set</span>
               </div>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -23,9 +23,10 @@
               </span>
             </div>
             <% if person.author_credit_reconciled_at.present? %>
-              <span class="text-xs text-gray-500">
-                <i class="fa-solid fa-circle-info mr-1"></i>Reconciled <%= person.author_credit_reconciled_at.strftime("%b %-d, %Y") %>
-              </span>
+              <%= render "shared/badge",
+                    label: "Reconciled #{person.author_credit_reconciled_at.strftime('%b %-d, %Y')}",
+                    classes: "bg-gray-50 text-gray-600 border-gray-200",
+                    icon: "fa-solid fa-circle-info" %>
             <% end %>
           </div>
 

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -126,8 +126,8 @@
     <section id="section-unattributed" class="scroll-mt-4">
       <h2 class="text-lg font-semibold text-gray-900 mb-1">4. No author at all</h2>
       <p class="text-sm text-gray-600 mb-4">
-        No author, no legacy name, and no person behind the creating account, so these fall back to a
-        generic placeholder like &ldquo;AWBW Facilitator&rdquo; or &ldquo;AWBW Staff&rdquo;.
+        No author, no legacy name, and no person behind the creating account, so these fall back to the
+        generic &ldquo;AWBW Facilitator&rdquo; credit.
       </p>
 
       <% if @result.unattributed.empty? %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -22,7 +22,7 @@
     <%# Section counts up front so the admin can see the full scope and jump to any section. %>
     <% overview = [
          { anchor: "section-preference",   num: 1, label: "Preference drift", count: @result.preference.size,   unit: "person" },
-         { anchor: "section-legacy",       num: 2, label: "Legacy name",      count: @result.legacy.size,       unit: "record" },
+         { anchor: "section-legacy",       num: 2, label: "Legacy name",      count: @result.legacy.sum { |g| g.entries.size },       unit: "record" },
          { anchor: "section-creator",      num: 3, label: "Creator fallback", count: @result.creator.size,      unit: "person" },
          { anchor: "section-unattributed", num: 4, label: "No author",        count: @result.unattributed.size, unit: "record" }
        ] %>
@@ -77,12 +77,12 @@
         obeys nobody's profile and links nowhere. Crediting a real person replaces it.
       </p>
 
-      <% if @result.legacy.empty? %>
+      <%= render partial: "legacy_group", collection: @result.legacy, as: :group %>
+
+      <% if @result.legacy_empty? %>
         <%= render "section_clear",
-              message: "No legacy author names left. Every record is credited to a real person.",
-              cleanup: "Ask your developers to remove any unused full_name code — the workshops.full_name and resources.legacy_author_name columns, their legacy_author_name_columns / legacy_author_name_text overrides, and the legacy branches in AuthorCreditable." %>
-      <% else %>
-        <%= render "unlinked_table", records: @result.legacy, name_header: "Legacy name", suggest_creator: false %>
+              message: "Every legacy name column is clear.",
+              cleanup: "Ask your developers to remove both unused fields and the legacy-name handling in AuthorCreditable that reads them." %>
       <% end %>
     </section>
 
@@ -112,7 +112,10 @@
                             class: "font-semibold text-gray-900 hover:underline" %>
                 <span class="text-sm text-gray-500">&mdash; created <%= pluralize(group.records.size, "record") %> with no author set</span>
               </div>
-              <%= render "unlinked_table", records: group.records, name_header: "Renders as", suggest_creator: true %>
+              <%= render "unlinked_table",
+                    rows: assignable_rows(group.records, suggested_author: group.person),
+                    name_header: "Renders as",
+                    suggestion_note: "Suggested: the person who created the record." %>
             </div>
           <% end %>
         </div>
@@ -124,15 +127,15 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-1">4. No author at all</h2>
       <p class="text-sm text-gray-600 mb-4">
         No author, no legacy name, and no person behind the creating account, so these fall back to a
-        generic label like &ldquo;AWBW Facilitator&rdquo;.
+        generic placeholder like &ldquo;AWBW Facilitator&rdquo; or &ldquo;AWBW Staff&rdquo;.
       </p>
 
       <% if @result.unattributed.empty? %>
         <%= render "section_clear",
               message: "Nothing unattributed. Every record has someone to credit.",
-              cleanup: "Ask your developers to remove the missing_author_label fallbacks." %>
+              cleanup: "Ask your developers to remove the generic placeholder names, since no record falls back to one any more." %>
       <% else %>
-        <%= render "unlinked_table", records: @result.unattributed, name_header: "Renders as", suggest_creator: false %>
+        <%= render "unlinked_table", rows: assignable_rows(@result.unattributed), name_header: "Renders as" %>
       <% end %>
     </section>
   <% end %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -88,13 +88,13 @@
 
     <%# ── 3. author_id blank, credit falls back to the creator ──────────────── %>
     <section id="section-creator" class="mb-10 scroll-mt-4">
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">3. Credited to the creator, not an author</h2>
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">3. No author named, but someone entered it</h2>
       <p class="text-sm text-gray-600 mb-4">
-        These have no <code>author_id</code>, so the credit falls back to whoever created the record.
-        The name is right and follows that person's profile, but it never links to them and the record
-        doesn't appear on their profile. Confirm the creator is the author, or pick someone else.
-        Idea records are excluded &mdash; they have no <code>author_id</code>, so the creator is their
-        correct and only credit path.
+        These have no <code>author_id</code>, so they credit the generic
+        &ldquo;AWBW Facilitator&rdquo; &mdash; entering a record isn't claiming it. The person who
+        created it is the most likely author, so they're grouped and suggested here, but confirm it
+        rather than assume it. Idea records are excluded &mdash; they have no <code>author_id</code>
+        at all, so the creator is their correct and only credit path.
       </p>
 
       <% if @result.creator.empty? %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -91,7 +91,7 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-1">3. No author named, but someone entered it</h2>
       <p class="text-sm text-gray-600 mb-4">
         These have no <code>author_id</code>, so they credit the generic
-        &ldquo;AWBW Facilitator&rdquo; &mdash; entering a record isn't claiming it. The person who
+        &ldquo;AWBW Staff&rdquo; &mdash; entering a record isn't claiming it. The person who
         created it is the most likely author, so they're grouped and suggested here, but confirm it
         rather than assume it. Idea records are excluded &mdash; they have no <code>author_id</code>
         at all, so they credit generically with no author to assign.
@@ -114,8 +114,7 @@
               </div>
               <%= render "unlinked_table",
                     rows: assignable_rows(group.records, suggested_author: group.person),
-                    name_header: "Renders as",
-                    suggestion_note: "Suggested: the person who created the record." %>
+                    name_header: "Renders as" %>
             </div>
           <% end %>
         </div>
@@ -127,7 +126,7 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-1">4. No author at all</h2>
       <p class="text-sm text-gray-600 mb-4">
         No author, no legacy name, and no person behind the creating account, so these fall back to the
-        generic &ldquo;AWBW Facilitator&rdquo; credit.
+        generic &ldquo;AWBW Staff&rdquo; credit.
       </p>
 
       <% if @result.unattributed.empty? %>
@@ -138,5 +137,26 @@
         <%= render "unlinked_table", rows: assignable_rows(@result.unattributed), name_header: "Renders as" %>
       <% end %>
     </section>
+  <% end %>
+
+  <%# Collapsed by default: everyone already reconciled, so they're off the worklist
+      above but still reviewable here. %>
+  <% if @reconciled_people.present? %>
+    <details class="mt-8 overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <summary class="cursor-pointer list-none px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50">
+        <i class="fa-solid fa-chevron-right mr-1 text-xs text-gray-400"></i>
+        Reconciled &mdash; <%= pluralize(@reconciled_people.size, "person") %>
+      </summary>
+      <ul class="divide-y divide-gray-100 border-t border-gray-200">
+        <% @reconciled_people.each do |person| %>
+          <li class="flex flex-wrap items-center justify-between gap-2 px-4 py-2 text-sm">
+            <%= link_to person.full_name,
+                  author_credit_divergences_path(person_id: person.id, include_reconciled: "1", highlight: person.id, anchor: dom_id(person, :divergence)),
+                  class: "text-blue-700 hover:underline" %>
+            <span class="text-xs text-gray-500">Reconciled <%= person.author_credit_reconciled_at.strftime("%b %-d, %Y") %></span>
+          </li>
+        <% end %>
+      </ul>
+    </details>
   <% end %>
 <% end %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -1,0 +1,112 @@
+<%= turbo_frame_tag :author_credit_divergences_results do %>
+  <% if @groups.empty? %>
+    <div class="rounded-lg border border-gray-200 bg-white p-8 text-center">
+      <i class="fa-solid fa-circle-check text-3xl text-green-600 mb-3"></i>
+      <p class="text-gray-700 font-medium">Nothing to reconcile.</p>
+      <p class="text-sm text-gray-500 mt-1">Every stored credit preference matches its author's profile.</p>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-600 mb-4">
+      <%= pluralize(@groups.size, "person") %> with diverging content.
+    </p>
+
+    <div class="space-y-6">
+      <% @groups.each do |group| %>
+        <% person = group.person %>
+        <div id="<%= dom_id(person, :divergence) %>" class="rounded-lg border border-gray-200 bg-white shadow-sm scroll-mt-4">
+          <div class="border-b border-gray-200 px-4 py-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <%= link_to person.full_name, person_path(person), class: "font-semibold text-gray-900 hover:underline" %>
+              <span class="text-sm text-gray-500">
+                &mdash; profile currently credits as
+                <strong><%= AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %></strong>
+              </span>
+            </div>
+            <% if person.author_credit_reconciled_at.present? %>
+              <span class="text-xs text-gray-500">
+                <i class="fa-solid fa-circle-info mr-1"></i>Reconciled <%= person.author_credit_reconciled_at.strftime("%b %-d, %Y") %>
+              </span>
+            <% end %>
+          </div>
+
+          <div class="bg-gray-50 px-4 py-3 border-b border-gray-200">
+            <%= form_with url: update_person_author_credit_divergences_path, method: :patch,
+                          data: { turbo_frame: "_top" },
+                          class: "flex flex-wrap items-end gap-3" do |f| %>
+              <%= hidden_field_tag :id, person.id %>
+              <%= render "filter_fields" %>
+
+              <div>
+                <%= label_tag "person_display_name_preference_#{person.id}", "Set profile to",
+                              class: "block text-xs font-medium text-gray-700" %>
+                <%= select_tag "person[display_name_preference]",
+                               options_for_select(Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
+                                                  suggested_display_name_preference(group)),
+                               id: "person_display_name_preference_#{person.id}",
+                               class: "mt-1 rounded-md border-gray-300 text-sm" %>
+              </div>
+
+              <label class="flex items-center gap-2 text-sm text-gray-700 pb-2">
+                <%= hidden_field_tag "person[contributions_anonymous]", "0" %>
+                <%= check_box_tag "person[contributions_anonymous]", "1",
+                                  group.suggested_preference == AuthorCreditable::ANONYMOUS || person.contributions_anonymous?,
+                                  id: "person_contributions_anonymous_#{person.id}",
+                                  class: "rounded border-gray-300" %>
+                Contributions show as anonymous
+              </label>
+
+              <%= submit_tag "Apply to profile",
+                             class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
+              <span class="text-xs text-gray-500 pb-2">
+                Suggested: the most restrictive preference across their content.
+              </span>
+            <% end %>
+          </div>
+
+          <table class="w-full text-sm">
+            <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
+              <tr>
+                <th class="px-4 py-2 font-medium">Content</th>
+                <th class="px-4 py-2 font-medium">Type</th>
+                <th class="px-4 py-2 font-medium">Renders as</th>
+                <th class="px-4 py-2 font-medium">Stored consent</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <% group.records.each do |record| %>
+                <tr>
+                  <td class="px-4 py-2">
+                    <%= link_to divergence_record_title(record), polymorphic_path(record),
+                                target: "_blank", rel: "noopener",
+                                title: "Opens in a new tab",
+                                class: "text-blue-700 hover:underline" %>
+                  </td>
+                  <td class="px-4 py-2 text-gray-600"><%= record.class.name.underscore.humanize %></td>
+                  <td class="px-4 py-2 text-gray-800"><%= record.author_credit %></td>
+                  <td class="px-4 py-2">
+                    <%= form_with url: update_item_author_credit_divergences_path, method: :patch,
+                                  data: { turbo_frame: "_top" },
+                                  class: "flex items-center gap-2" do %>
+                      <%= hidden_field_tag :record_type, record.class.name %>
+                      <%= hidden_field_tag :record_id, record.id %>
+                      <%= render "filter_fields" %>
+                      <%= select_tag "author_credit_preference",
+                                     options_for_select(AuthorCreditable::ADMIN_FORM_OPTIONS.to_a, record.author_credit_preference),
+                                     class: "rounded-md border-gray-300 text-sm" %>
+                      <%= submit_tag "Save",
+                                     class: "rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer" %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100">
+            Only <strong>Anonymous</strong> changes what renders &mdash; the other values just
+            re-record what was consented to.
+          </p>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -19,7 +19,6 @@
       </p>
     </div>
   <% else %>
-    <%# Section counts up front so the admin can see the full scope and jump to any section. %>
     <% overview = [
          { anchor: "section-preference",   num: 1, label: "Preference drift", count: @result.preference.size,   unit: "person" },
          { anchor: "section-legacy",       num: 2, label: "Legacy name",      count: @result.legacy.sum { |g| g.entries.size },       unit: "record" },

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -90,7 +90,7 @@
     <section id="section-creator" class="mb-10 scroll-mt-4">
       <h2 class="text-lg font-semibold text-gray-900 mb-1">3. No author named, but someone entered it</h2>
       <p class="text-sm text-gray-600 mb-4">
-        No <code>author_id</code>, so they credit the generic &ldquo;AWBW Staff&rdquo; &mdash; entering
+        No <code>author_id</code>, so they credit the generic &ldquo;<%= AuthorCreditable::MISSING_AUTHOR_LABEL %>&rdquo; &mdash; entering
         a record isn't claiming it. Grouped under whoever created them, the likeliest author to assign
         (but confirm it). Idea records are excluded: they never name an author.
       </p>
@@ -124,7 +124,7 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-1">4. No author at all</h2>
       <p class="text-sm text-gray-600 mb-4">
         No author, no legacy name, and no person behind the creating account, so these fall back to the
-        generic &ldquo;AWBW Staff&rdquo; credit.
+        generic &ldquo;<%= AuthorCreditable::MISSING_AUTHOR_LABEL %>&rdquo; credit.
       </p>
 
       <% if @result.unattributed.empty? %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -86,7 +86,7 @@
       <% end %>
     </section>
 
-    <%# ── 3. author_id blank, credit falls back to the creator ──────────────── %>
+    <%# ── 3. author_id blank, credited generically, creator suggested ──────────── %>
     <section id="section-creator" class="mb-10 scroll-mt-4">
       <h2 class="text-lg font-semibold text-gray-900 mb-1">3. No author named, but someone entered it</h2>
       <p class="text-sm text-gray-600 mb-4">
@@ -94,7 +94,7 @@
         &ldquo;AWBW Facilitator&rdquo; &mdash; entering a record isn't claiming it. The person who
         created it is the most likely author, so they're grouped and suggested here, but confirm it
         rather than assume it. Idea records are excluded &mdash; they have no <code>author_id</code>
-        at all, so the creator is their correct and only credit path.
+        at all, so they credit generically with no author to assign.
       </p>
 
       <% if @result.creator.empty? %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -28,7 +28,8 @@
        ] %>
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
       <% overview.each do |section| %>
-        <% clear = section[:count].zero? %>
+        <%# A zero under a filter is the filter's doing, so it isn't reported as clear. %>
+        <% clear = section[:count].zero? && !divergence_filters_applied? %>
         <%= link_to "##{section[:anchor]}",
               class: "block rounded-lg border p-3 transition-colors #{clear ? "border-green-200 bg-green-50 hover:bg-green-100" : "border-gray-200 bg-white shadow-sm hover:bg-gray-50"}" do %>
           <div class="flex items-baseline justify-between gap-2">

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -72,9 +72,9 @@
     <section id="section-legacy" class="mb-10 scroll-mt-4">
       <h2 class="text-lg font-semibold text-gray-900 mb-1">2. Credited by a legacy name, not a person</h2>
       <p class="text-sm text-gray-600 mb-4">
-        Pre-person records whose credit comes from a free-text column
-        (<code>workshops.full_name</code>, <code>resources.legacy_author_name</code>). The name shown
-        obeys nobody's profile and links nowhere. Crediting a real person replaces it.
+        Credited by a free-text name (<code>workshops.full_name</code>,
+        <code>resources.legacy_author_name</code>) that follows no profile and links nowhere.
+        Credit a real person to replace it.
       </p>
 
       <%= render partial: "legacy_group", collection: @result.legacy, as: :group %>
@@ -90,11 +90,9 @@
     <section id="section-creator" class="mb-10 scroll-mt-4">
       <h2 class="text-lg font-semibold text-gray-900 mb-1">3. No author named, but someone entered it</h2>
       <p class="text-sm text-gray-600 mb-4">
-        These have no <code>author_id</code>, so they credit the generic
-        &ldquo;AWBW Staff&rdquo; &mdash; entering a record isn't claiming it. The person who
-        created it is the most likely author, so they're grouped and suggested here, but confirm it
-        rather than assume it. Idea records are excluded &mdash; they have no <code>author_id</code>
-        at all, so they credit generically with no author to assign.
+        No <code>author_id</code>, so they credit the generic &ldquo;AWBW Staff&rdquo; &mdash; entering
+        a record isn't claiming it. Grouped under whoever created them, the likeliest author to assign
+        (but confirm it). Idea records are excluded: they never name an author.
       </p>
 
       <% if @result.creator.empty? %>
@@ -114,7 +112,7 @@
               </div>
               <%= render "unlinked_table",
                     rows: assignable_rows(group.records, suggested_author: group.person),
-                    name_header: "Renders as" %>
+                    name_header: "Credit display" %>
             </div>
           <% end %>
         </div>
@@ -134,7 +132,7 @@
               message: "Nothing unattributed. Every record has someone to credit.",
               cleanup: "Ask your developers to remove the generic placeholder names, since no record falls back to one any more." %>
       <% else %>
-        <%= render "unlinked_table", rows: assignable_rows(@result.unattributed), name_header: "Renders as" %>
+        <%= render "unlinked_table", rows: assignable_rows(@result.unattributed), name_header: "Credit display" %>
       <% end %>
     </section>
   <% end %>

--- a/app/views/author_credit_divergences/divergence_change.turbo_stream.erb
+++ b/app/views/author_credit_divergences/divergence_change.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%# Re-render the results frame and flash in place, so saving a divergence fix
+    doesn't reload the whole page. Shared by update_item and update_person. %>
+<%= turbo_stream.replace "author_credit_divergences_results" do %>
+  <%= render template: "author_credit_divergences/author_credit_divergences_results", formats: :html %>
+<% end %>
+
+<%= turbo_stream.replace "flash_now" do %>
+  <%= render "shared/flash_messages" %>
+<% end %>

--- a/app/views/author_credit_divergences/index.html.erb
+++ b/app/views/author_credit_divergences/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+  <section class="w-full">
+    <div class="flex flex-col items-start mb-4">
+      <h1 class="text-3xl font-bold text-gray-900 my-2">Author credit divergences</h1>
+      <p class="text-sm text-gray-600 max-w-3xl">
+        Content whose stored credit preference no longer matches the author's profile.
+        Credits render using the profile, so these are historical records that need a
+        decision &mdash; except <strong>anonymous</strong>, which always wins and keeps that
+        item uncredited no matter what the profile says.
+      </p>
+    </div>
+
+    <%= render "filters" %>
+
+    <% result_src = author_credit_divergences_path(request.query_parameters) %>
+
+    <%= turbo_frame_tag :author_credit_divergences_results, src: result_src, data: { turbo: "temporary" } do %>
+      <%= render "results_skeleton" %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/author_credit_divergences/index.html.erb
+++ b/app/views/author_credit_divergences/index.html.erb
@@ -4,10 +4,11 @@
     <div class="flex flex-col items-start mb-4">
       <h1 class="text-3xl font-bold text-gray-900 my-2">Author credit divergences</h1>
       <p class="text-sm text-gray-600 max-w-3xl">
-        Content whose stored credit preference no longer matches the author's profile.
-        Credits render using the profile, so these are historical records that need a
-        decision &mdash; except <strong>anonymous</strong>, which always wins and keeps that
-        item uncredited no matter what the profile says.
+        Content whose credit doesn't resolve cleanly through a person's profile &mdash; either the
+        stored preference drifted, or the credit isn't coming from an <code>author_id</code> at all.
+        An <code>author_id</code> is the only path that follows the person's profile, links to it,
+        and lists the record there. Note that <strong>anonymous</strong> always wins over the
+        profile and keeps that item uncredited.
       </p>
     </div>
 

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -61,13 +61,7 @@
                               data: { controller: "remote-select",
                                       remote_select_model_value: "person" } } %>
 
-    <%= f.input :author_credit_preference,
-                as: :select,
-                label: "Author credit preference",
-                hint: "Controls how the author's name is displayed",
-                collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
-                selected: f.object.author_credit_preference,
-                input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
+    <%= render "shared/author_credit_warning", record: f.object %>
   </div>
   <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
 

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -63,6 +63,7 @@
                                       remote_select_model_value: "person" } } %>
     <%= render "shared/author_credit_note", record: f.object %>
 
+    <%= render "shared/author_credit_field", f: f %>
     <%= render "shared/author_credit_warning", record: f.object %>
   </div>
   <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -51,7 +51,7 @@
                 input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
 
     <%# Optional on the model, so the form has to allow no author — the credit then
-        falls to the creator's person, or to "AWBW Facilitator" when there isn't one. %>
+        falls to "AWBW Staff" when there's no author. %>
     <%= f.input :author_id,
                 as: :select,
                 label: "Author",

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -50,14 +50,15 @@
                 selected: f.object.organization_id,
                 input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
 
+    <%# Optional on the model, so the form has to allow no author — the credit then
+        falls to the creator's person, or to "AWBW Staff" when there isn't one. %>
     <%= f.input :author_id,
                 as: :select,
                 label: "Author",
-                required: true,
                 collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
                 selected: author_picker_person(f.object)&.id,
-                input_html: { required: true,
-                              class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
+                include_blank: "Select an author",
+                input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
                               data: { controller: "remote-select",
                                       remote_select_model_value: "person" } } %>
     <%= render "shared/author_credit_note", record: f.object %>

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -51,7 +51,7 @@
                 input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
 
     <%# Optional on the model, so the form has to allow no author — the credit then
-        falls to the creator's person, or to "AWBW Staff" when there isn't one. %>
+        falls to the creator's person, or to "AWBW Facilitator" when there isn't one. %>
     <%= f.input :author_id,
                 as: :select,
                 label: "Author",

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -54,12 +54,13 @@
                 as: :select,
                 label: "Author",
                 required: true,
-                collection: f.object.author_person.present? ? [[ f.object.author_person.remote_search_label[:label], f.object.author_person.id ]] : [],
-                selected: f.object.author_id || current_user&.person_id,
+                collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
+                selected: author_picker_person(f.object)&.id,
                 input_html: { required: true,
                               class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
                               data: { controller: "remote-select",
                                       remote_select_model_value: "person" } } %>
+    <%= render "shared/author_credit_note", record: f.object %>
 
     <%= render "shared/author_credit_warning", record: f.object %>
   </div>

--- a/app/views/community_news/_form.html.erb
+++ b/app/views/community_news/_form.html.erb
@@ -51,7 +51,7 @@
                 input_html: { class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
 
     <%# Optional on the model, so the form has to allow no author — the credit then
-        falls to "AWBW Staff" when there's no author. %>
+        falls to `missing_author_label` when there's no author. %>
     <%= f.input :author_id,
                 as: :select,
                 label: "Author",

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -459,7 +459,7 @@
     </div>
   </div>
 
-  <div class="profile-preferences-section">
+  <div id="profile-preferences" class="profile-preferences-section scroll-mt-4">
     <div class="mb-2 block font-medium text-gray-700">
       Profile display preferences
     </div>
@@ -474,12 +474,8 @@
 
           <%= f.input :display_name_preference,
                     as: :select,
-                    collection: [
-                      ["First and Last Name", "full_name"],
-                      ["First Name and Last Initial", "first_name_last_initial"],
-                      ["First Name Only", "first_name_only"],
-                      ["Last Name Only", "last_name_only"]
-                    ],
+                    collection: Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
+                    hint: "Applies everywhere this person's name appears, including author credits",
                     selected: f.object.display_name_preference || "full_name" %>
 
           <%= f.input :anonymous_contributions,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -463,6 +463,9 @@
     <div class="mb-2 block font-medium text-gray-700">
       Profile display preferences
     </div>
+    <p class="mb-3 text-sm text-gray-500">
+      Updating these preferences applies to how you show up sitewide: stories, workshop variations, the people index, and more.
+    </p>
 
     <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
       <div class="px-3 pb-3">
@@ -475,12 +478,12 @@
           <%= f.input :display_name_preference,
                     as: :select,
                     collection: Person::DISPLAY_NAME_PREFERENCE_LABELS.invert.to_a,
-                    hint: "Applies everywhere this person's name appears, including author credits",
+                    hint: "Sitewide (People/Profile, Stories, Workshop Variations, etc)",
                     selected: f.object.display_name_preference || "full_name" %>
 
           <%= f.input :anonymous_contributions,
                     label: "Contribute anonymously",
-                    hint: "Hide your name on stories credited to you" %>
+                    hint: "Hides your name on content, but not People/Profile" %>
 
           <%= f.input :profile_show_credentials, label: "Show credentials" %>
 

--- a/app/views/people/_show_card.html.erb
+++ b/app/views/people/_show_card.html.erb
@@ -2,8 +2,9 @@
 <% record_title ||= record.title %>
 <% title_font_size ||= nil %>
 <% bookmarkable ||= record.object %>
+<% anonymous ||= false %>
 
-<div class="relative h-full">
+<div class="relative h-full <%= "opacity-70" if anonymous %>">
   <!-- BOOKMARK ICON -->
   <div class="absolute top-3 right-3 z-30">
     <%= render "bookmarks/editable_bookmark_icon", resource: bookmarkable %>
@@ -36,6 +37,15 @@
 
     <!-- RIGHT SIDE -->
     <div class="flex-1 min-w-0 pl-4 pr-10 py-1 flex flex-col justify-between">
+      <% if anonymous %>
+        <%# Admin/owner-only marker: this credit renders "Anonymous" publicly, so
+            the item is hidden from everyone else. %>
+        <span class="inline-flex items-center pl-2 pr-3 py-0.5 mt-2 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap"
+              title="Credited as Anonymous — hidden from public author credit">
+          <span class="inline-flex justify-center w-5"><i class="fa-solid fa-eye-slash"></i></span>
+          <span class="ml-1">Anonymous</span>
+        </span>
+      <% end %>
       <div class="my-2">
         <%= link_to record.link_target,
                     data: { turbo_frame: "_top"},

--- a/app/views/people/sections/_resources.html.erb
+++ b/app/views/people/sections/_resources.html.erb
@@ -2,7 +2,8 @@
   <% if resources.any? %>
     <div class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 gap-6 blur-on-submit">
       <% resources.each do |resource| %>
-        <%= render "show_card", record: resource.decorate, title_font_size: "text-sm" %>
+        <%= render "show_card", record: resource.decorate, title_font_size: "text-sm",
+                   anonymous: resource.credit_anonymous?(person) %>
       <% end %>
     </div>
     <div class="mt-6 flex justify-center">

--- a/app/views/people/sections/_stories.html.erb
+++ b/app/views/people/sections/_stories.html.erb
@@ -2,7 +2,10 @@
   <% if stories.any? %>
     <div class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 gap-6 blur-on-submit">
       <% stories.each do |story| %>
-        <%= render "show_card", record: story.decorate, title_font_size: "text-sm" %>
+        <%# Spotlight-only stories (person isn't the author) are never anonymized —
+            the anonymity flag governs authorship credit, not the spotlight. %>
+        <%= render "show_card", record: story.decorate, title_font_size: "text-sm",
+                   anonymous: story.author_id == person.id && story.credit_anonymous?(person) %>
       <% end %>
     </div>
     <div class="mt-6 flex justify-center">

--- a/app/views/people/sections/_workshop_variations.html.erb
+++ b/app/views/people/sections/_workshop_variations.html.erb
@@ -5,7 +5,8 @@
         <%= render "show_card",
                    record_title: "#{workshop_variation.name}<br>" +
                      "<span class='text-xs text-gray-500'>WORKSHOP: #{workshop_variation.workshop.name}<span>",
-                   record: workshop_variation.decorate, title_font_size: "text-sm" %>
+                   record: workshop_variation.decorate, title_font_size: "text-sm",
+                   anonymous: workshop_variation.credit_anonymous?(person) %>
       <% end %>
     </div>
     <div class="mt-6 flex justify-center">

--- a/app/views/people/sections/_workshops.html.erb
+++ b/app/views/people/sections/_workshops.html.erb
@@ -2,7 +2,8 @@
   <% if workshops.any? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
       <% workshops.each do |workshop| %>
-        <%= render "show_card", record: workshop.decorate, title_font_size: "text-sm" %>
+        <%= render "show_card", record: workshop.decorate, title_font_size: "text-sm",
+                   anonymous: workshop.credit_anonymous?(person) %>
       <% end %>
     </div>
     <div class="mt-6 flex justify-center">

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -28,7 +28,7 @@
           <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
         <% end %>
       <% end %>
-      <% unless @person.user %>
+      <% if @person.user.nil? && allowed_to?(:create?, User) %>
         <div class="admin-only bg-blue-100 p-2">
           No user!
           <%= link_to "Create user",
@@ -282,7 +282,7 @@
       <%= render "people/my_membership", membership: @membership, autopay: @membership_autopay %>
     <% end %>
     <!-- SUBMITTED SECTION -->
-    <% if allowed_to?(:show?, @person) %>
+    <% if allowed_to?(:own_record?, @person) %>
       <div class="user-only <%= DomainTheme.bg_class_for(:user_only) %>
             border <%= DomainTheme.border_class_for(:user_only) %> rounded-lg shadow-sm"
            data-controller="expandable-card"

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -77,6 +77,7 @@
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">
+      <%= render "shared/author_credit_field", f: f %>
       <%= render "shared/author_credit_warning", record: f.object %>
     </div>
   </div>

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -62,8 +62,8 @@
     <div class="flex-1 mb-4 md:mb-0">
       <%= f.input :author_id,
                   as: :select,
-                  collection: f.object.author_person.present? ? [[ f.object.author_person.remote_search_label[:label], f.object.author_person.id ]] : [],
-                  selected: f.object.author_person&.id || current_user.person_id,
+                  collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
+                  selected: author_picker_person(f.object)&.id,
                   include_blank: "Select an author",
                   label: (f.object.author ? (
                     link_to "Resource author",
@@ -73,9 +73,7 @@
                   input_html: { class: "w-full rounded border-gray-300",
                                 data: { controller: "remote-select",
                                         remote_select_model_value: "person" } } %>
-      <% if f.object.legacy_author_name.present? %>
-        <p class="mt-1 text-xs text-gray-500 italic">Legacy author credit: <%= f.object.legacy_author_name %></p>
-      <% end %>
+      <%= render "shared/author_credit_note", record: f.object %>
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">

--- a/app/views/resources/_form.html.erb
+++ b/app/views/resources/_form.html.erb
@@ -79,15 +79,7 @@
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">
-      <%= f.input :author_credit_preference,
-                  as: :select,
-                  collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
-                  include_blank: "Select a preference",
-                  selected: f.object.author_credit_preference || "full_name",
-                  label: "Author credit preference",
-                  hint: "Controls how the author’s name is displayed",
-                  label_html: { class: "block font-medium mb-1 text-gray-700" },
-                  input_html: { class: "w-full rounded border-gray-300" } %>
+      <%= render "shared/author_credit_warning", record: f.object %>
     </div>
   </div>
 

--- a/app/views/shared/_author_credit_field.html.erb
+++ b/app/views/shared/_author_credit_field.html.erb
@@ -1,0 +1,10 @@
+<%# Admin-facing credit preference. Interim, like the submitter forms: the value is
+    recorded but the credited person's profile decides what renders — so this sits
+    alongside the note and divergence warning, which link out to resolve it.
+    Locals: f. %>
+<%= f.input :author_credit_preference,
+            as: :select,
+            collection: AuthorCreditable::ADMIN_FORM_OPTIONS.to_a,
+            include_blank: "None (follow profile)",
+            label: "Credit preference",
+            hint: "Recorded on this item. The author's profile still decides what renders — resolve on the divergences page." %>

--- a/app/views/shared/_author_credit_note.html.erb
+++ b/app/views/shared/_author_credit_note.html.erb
@@ -7,7 +7,7 @@
     <i class="fa-solid fa-eye-slash mt-1"></i>
     <span>
       <%= person.full_name %>'s profile marks contributions anonymous, so this credit renders
-      &ldquo;Anonymous&rdquo; wherever it appears.
+      &ldquo;AWBW Facilitator&rdquo; wherever it appears.
       <%= link_to "Change it on their profile", edit_person_path(person, anchor: "profile-preferences"),
                   target: "_blank", rel: "noopener", title: "Opens in a new tab",
                   class: "underline hover:text-amber-900" %>

--- a/app/views/shared/_author_credit_note.html.erb
+++ b/app/views/shared/_author_credit_note.html.erb
@@ -2,7 +2,7 @@
     that isn't just the selected author: the person's profile suppresses credits, or
     no author is set and a legacy free-text name is standing in. Locals: record. %>
 <% person = author_picker_person(record) %>
-<% if person&.contributions_anonymous? %>
+<% if person&.anonymous_contributions? %>
   <p class="mt-1 flex items-start gap-2 text-sm text-amber-700">
     <i class="fa-solid fa-eye-slash mt-1"></i>
     <span>

--- a/app/views/shared/_author_credit_note.html.erb
+++ b/app/views/shared/_author_credit_note.html.erb
@@ -7,7 +7,7 @@
     <i class="fa-solid fa-eye-slash mt-1"></i>
     <span>
       <%= person.full_name %>'s profile marks contributions anonymous, so this credit renders
-      &ldquo;AWBW Facilitator&rdquo; wherever it appears.
+      &ldquo;<%= record.anonymous_author_label %>&rdquo; wherever it appears.
       <%= link_to "Change it on their profile", edit_person_path(person, anchor: "profile-preferences"),
                   target: "_blank", rel: "noopener", title: "Opens in a new tab",
                   class: "underline hover:text-amber-900" %>

--- a/app/views/shared/_author_credit_note.html.erb
+++ b/app/views/shared/_author_credit_note.html.erb
@@ -1,0 +1,25 @@
+<%# Sits under an author picker and says what the credit actually resolves to when
+    that isn't just the selected author: the person's profile suppresses credits, or
+    no author is set and a legacy free-text name is standing in. Locals: record. %>
+<% person = author_picker_person(record) %>
+<% if person&.contributions_anonymous? %>
+  <p class="mt-1 flex items-start gap-2 text-sm text-amber-700">
+    <i class="fa-solid fa-eye-slash mt-1"></i>
+    <span>
+      <%= person.full_name %>'s profile marks contributions anonymous, so this credit renders
+      &ldquo;Anonymous&rdquo; wherever it appears.
+      <%= link_to "Change it on their profile", edit_person_path(person, anchor: "profile-preferences"),
+                  target: "_blank", rel: "noopener", title: "Opens in a new tab",
+                  class: "underline hover:text-amber-900" %>
+    </span>
+  </p>
+<% elsif record.author.blank? && record.legacy_author_name_text.present? %>
+  <p class="mt-1 flex items-start gap-2 text-sm text-amber-700">
+    <i class="fa-solid fa-clock-rotate-left mt-1"></i>
+    <span>
+      No author is set, so this is credited to the legacy name
+      &ldquo;<%= record.legacy_author_name_text %>&rdquo;, which links nowhere and follows nobody's
+      profile. Pick a person to replace it.
+    </span>
+  </p>
+<% end %>

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -3,9 +3,9 @@
 <% person = current_user&.person %>
 <div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-700">
   <% if person %>
-    You'll be credited as <strong><%= person.anonymous_contributions? ? "AWBW Facilitator" : person.name %></strong>.
+    You'll be credited as <strong><%= person.anonymous_contributions? ? AuthorCreditable::ANONYMOUS_AUTHOR_LABEL : person.name %></strong>.
   <% else %>
-    You'll be credited as <strong>AWBW Staff</strong>.
+    You'll be credited as <strong><%= AuthorCreditable::MISSING_AUTHOR_LABEL %></strong>.
   <% end %>
   <p class="text-gray-500 mt-1">
     This comes from your profile and applies to everything you share.

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -5,7 +5,7 @@
   <% if person %>
     You'll be credited as <strong><%= person.anonymous_contributions? ? "AWBW Facilitator" : person.name %></strong>.
   <% else %>
-    You'll be credited as <strong>AWBW Facilitator</strong>.
+    You'll be credited as <strong>AWBW Staff</strong>.
   <% end %>
   <p class="text-gray-500 mt-1">
     This comes from your profile and applies to everything you share.

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -1,0 +1,14 @@
+<%# Submitter-facing. A new record has no stored snapshot to diverge from, so this is
+    unconditional — it's the only place a submitter learns how they'll be credited. %>
+<% person = current_user&.person %>
+<div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-700">
+  <% if person %>
+    You'll be credited as <strong><%= person.contributions_anonymous? ? "Anonymous" : person.name %></strong>.
+  <% else %>
+    You'll be credited as <strong>Anonymous</strong>.
+  <% end %>
+  <p class="text-gray-500 mt-1">
+    This comes from your profile and applies to everything you share.
+    <%= link_to "Contact us", contact_us_path, class: "underline hover:text-gray-700" %> to change it.
+  </p>
+</div>

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -3,9 +3,9 @@
 <% person = current_user&.person %>
 <div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-700">
   <% if person %>
-    You'll be credited as <strong><%= person.anonymous_contributions? ? "Anonymous" : person.name %></strong>.
+    You'll be credited as <strong><%= person.anonymous_contributions? ? "AWBW Facilitator" : person.name %></strong>.
   <% else %>
-    You'll be credited as <strong>Anonymous</strong>.
+    You'll be credited as <strong>AWBW Facilitator</strong>.
   <% end %>
   <p class="text-gray-500 mt-1">
     This comes from your profile and applies to everything you share.

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -1,14 +1,14 @@
-<%# Submitter-facing. A new record has no stored snapshot to diverge from, so this is
-    unconditional — it's the only place a submitter learns how they'll be credited. %>
+<%# What the credit renders as right now, which is the profile's answer — the field
+    above is a request, not a live switch. Interim until profiles are self-service. %>
 <% person = current_user&.person %>
-<div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-700">
+<p class="mt-1 text-sm text-gray-500">
   <% if person %>
-    You'll be credited as <strong><%= person.anonymous_contributions? ? AuthorCreditable::ANONYMOUS_AUTHOR_LABEL : person.name %></strong>.
+    Right now you're credited as
+    <strong><%= person.anonymous_contributions? ? AuthorCreditable::ANONYMOUS_AUTHOR_LABEL : person.name %></strong>,
+    from your profile. A different choice above reaches an admin, who applies it to your
+    profile so it covers everything you share.
   <% else %>
-    You'll be credited as <strong><%= AuthorCreditable::MISSING_AUTHOR_LABEL %></strong>.
+    You'll be credited as <strong><%= AuthorCreditable::MISSING_AUTHOR_LABEL %></strong> until
+    an admin links this account to a person.
   <% end %>
-  <p class="text-gray-500 mt-1">
-    This comes from your profile and applies to everything you share.
-    <%= link_to "Contact us", contact_us_path, class: "underline hover:text-gray-700" %> to change it.
-  </p>
-</div>
+</p>

--- a/app/views/shared/_author_credit_preview.html.erb
+++ b/app/views/shared/_author_credit_preview.html.erb
@@ -3,7 +3,7 @@
 <% person = current_user&.person %>
 <div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-700">
   <% if person %>
-    You'll be credited as <strong><%= person.contributions_anonymous? ? "Anonymous" : person.name %></strong>.
+    You'll be credited as <strong><%= person.anonymous_contributions? ? "Anonymous" : person.name %></strong>.
   <% else %>
     You'll be credited as <strong>Anonymous</strong>.
   <% end %>

--- a/app/views/shared/_author_credit_status.html.erb
+++ b/app/views/shared/_author_credit_status.html.erb
@@ -1,7 +1,15 @@
-<%# Idea forms are reached both by submitters (new) and admins (edit), so show the
-    submitter-facing preview on a new record and the divergence warning on a saved one. %>
-<% if record.new_record? %>
+<%# Interim: facilitators can't edit their own profile yet, so they record a credit
+    preference per submission here. The profile still decides what actually renders —
+    a choice that differs shows up on the author credit divergences page for an admin
+    to apply to the profile. Locals: f. %>
+<div class="mb-4">
+  <%= f.input :author_credit_preference,
+              as: :select,
+              collection: AuthorCreditable::SUBMITTER_FORM_OPTIONS.to_a,
+              include_blank: "Use my profile setting",
+              label: "How should we credit you?",
+              hint: "We'll apply this to your profile so it covers everything you share." %>
+
   <%= render "shared/author_credit_preview" %>
-<% else %>
-  <%= render "shared/author_credit_warning", record: record %>
-<% end %>
+  <%= render "shared/author_credit_warning", record: f.object unless f.object.new_record? %>
+</div>

--- a/app/views/shared/_author_credit_status.html.erb
+++ b/app/views/shared/_author_credit_status.html.erb
@@ -1,0 +1,7 @@
+<%# Idea forms are reached both by submitters (new) and admins (edit), so show the
+    submitter-facing preview on a new record and the divergence warning on a saved one. %>
+<% if record.new_record? %>
+  <%= render "shared/author_credit_preview" %>
+<% else %>
+  <%= render "shared/author_credit_warning", record: record %>
+<% end %>

--- a/app/views/shared/_author_credit_warning.html.erb
+++ b/app/views/shared/_author_credit_warning.html.erb
@@ -1,0 +1,23 @@
+<%# Renders only when the stored consent snapshot disagrees with the author's profile.
+    Credits render from the profile, so on most records this is silent. %>
+<% if record.persisted? && record.author_credit_diverged? %>
+  <% stored = AuthorCreditable::ADMIN_FORM_OPTIONS.key(record.author_credit_preference) %>
+  <% person = record.author_person %>
+  <% profile = AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %>
+
+  <% if record.author_credit_preference == AuthorCreditable::ANONYMOUS %>
+    <div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-500">
+      <i class="fa-solid fa-circle-info mr-1"></i>
+      Submitted anonymously. This item stays anonymous regardless of the profile setting.
+      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id),
+                  class: "underline hover:text-gray-700" %>
+    </div>
+  <% else %>
+    <div class="rounded-md bg-amber-50 border border-amber-200 p-3 mb-4 text-sm text-amber-700 font-medium">
+      &#9888; Submitted as "<%= stored %>", but this profile is now set to "<%= profile %>".
+      This item is credited using the profile setting.
+      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id),
+                  class: "underline hover:text-amber-900" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_author_credit_warning.html.erb
+++ b/app/views/shared/_author_credit_warning.html.erb
@@ -1,8 +1,9 @@
-<%# Renders only when the stored consent snapshot disagrees with the author's profile.
-    Credits render from the profile, so on most records this is silent. %>
-<% if record.persisted? && record.author_credit_diverged? %>
+<%# Renders when the record's stored preference disagrees with the author's current
+    profile — unless the person's already been reconciled, in which case the divergence
+    is deliberate. Per-item wins, so the item keeps rendering by its stored preference. %>
+<% person = record.credit_governing_person if record.persisted? %>
+<% if record.persisted? && record.author_credit_diverged? && person&.author_credit_reconciled_at.blank? %>
   <% stored = AuthorCreditable::ADMIN_FORM_OPTIONS.key(record.author_credit_preference) %>
-  <% person = record.credit_governing_person %>
   <% profile = AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %>
 
   <% if record.author_credit_preference == AuthorCreditable::ANONYMOUS %>
@@ -15,7 +16,7 @@
   <% else %>
     <div class="rounded-md bg-amber-50 border border-amber-200 p-3 mb-4 text-sm text-amber-700 font-medium">
       &#9888; Submitted as "<%= stored %>", but this profile is now set to "<%= profile %>".
-      This item is credited using the profile setting.
+      This item still renders as "<%= stored %>" until reconciled.
       <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id, highlight: person.id, anchor: dom_id(person, :divergence)),
                   class: "underline hover:text-amber-900" %>
     </div>

--- a/app/views/shared/_author_credit_warning.html.erb
+++ b/app/views/shared/_author_credit_warning.html.erb
@@ -2,7 +2,7 @@
     Credits render from the profile, so on most records this is silent. %>
 <% if record.persisted? && record.author_credit_diverged? %>
   <% stored = AuthorCreditable::ADMIN_FORM_OPTIONS.key(record.author_credit_preference) %>
-  <% person = record.author_person %>
+  <% person = record.credit_governing_person %>
   <% profile = AuthorCreditable::ADMIN_FORM_OPTIONS.key(person.effective_author_credit_preference) %>
 
   <% if record.author_credit_preference == AuthorCreditable::ANONYMOUS %>

--- a/app/views/shared/_author_credit_warning.html.erb
+++ b/app/views/shared/_author_credit_warning.html.erb
@@ -9,14 +9,14 @@
     <div class="rounded-md bg-gray-50 border border-gray-200 p-3 mb-4 text-sm text-gray-500">
       <i class="fa-solid fa-circle-info mr-1"></i>
       Submitted anonymously. This item stays anonymous regardless of the profile setting.
-      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id),
+      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id, highlight: person.id, anchor: dom_id(person, :divergence)),
                   class: "underline hover:text-gray-700" %>
     </div>
   <% else %>
     <div class="rounded-md bg-amber-50 border border-amber-200 p-3 mb-4 text-sm text-amber-700 font-medium">
       &#9888; Submitted as "<%= stored %>", but this profile is now set to "<%= profile %>".
       This item is credited using the profile setting.
-      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id),
+      <%= link_to "Reconcile", author_credit_divergences_path(person_id: person.id, highlight: person.id, anchor: dom_id(person, :divergence)),
                   class: "underline hover:text-amber-900" %>
     </div>
   <% end %>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -209,18 +209,7 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4 mt-4">
     <div class="flex-1 mb-4 md:mb-0">
-      <%= f.input :author_credit_preference,
-                  as: :select,
-                  collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
-                  prompt: "Select a preference",
-                  selected: f.object.author_credit_preference || story_idea&.author_credit_preference,
-                  label: "Author credit preference",
-                  hint: "Controls how the author's name is displayed",
-                  input_html: {
-                    class: select_caret_class(blank: f.object.author_credit_preference.blank?),
-                    style: custom_caret_style,
-                    onchange: select_caret_onchange
-                  } %>
+      <%= render "shared/author_credit_warning", record: f.object %>
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">
@@ -243,15 +232,8 @@
       <div class="flex-1 mb-4 md:mb-0">
         Story idea author credit:
         <br>
-        <% if story_idea.created_by.person %>
-          <%= person_profile_button(story_idea.created_by.person, display_name: story_idea.author_credit, subtitle: story_idea.created_by.person.full_name) %>
-        <% else %>
-          <%= story_idea.author_credit %>
-        <% end %>
-        <br>
-        Story idea "author credit preference":
-        <br>
-        <div class="italic"><%= link_to story_idea.author_credit_preference, edit_story_idea_path(story_idea, anchor: "publish-preferences"), class: "hover:underline hover:text-blue-600" %></div>
+        <%= credited_author_link(story_idea) %>
+        <%= render "shared/author_credit_warning", record: story_idea %>
       </div>
     </div>
   <% end %>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -240,12 +240,12 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4">
     <div class="flex-1 mb-4 md:mb-0">
-      <% story_author_id = f.object.author_person&.id || current_user.person_id %>
+      <% story_author = author_picker_person(f.object) %>
       <%= f.input :author_id,
-                  collection: f.object.author_person.present? ? [[ f.object.author_person.remote_search_label[:label], f.object.author_person.id ]] : [],
+                  collection: story_author.present? ? [[ story_author.remote_search_label[:label], story_author.id ]] : [],
                   prompt: "Select an author",
-                  selected: story_author_id,
-                  hint: "Defaults to the creator; change to credit someone else.",
+                  selected: story_author&.id,
+                  hint: "Defaults to the creator on a new story; change to credit someone else.",
                   label: (f.object.author ? (
                     link_to "Story author",
                             person_path(f.object.author),
@@ -255,6 +255,7 @@
                     data: { controller: "remote-select",
                             remote_select_model_value: "person" }
                   } %>
+      <%= render "shared/author_credit_note", record: f.object %>
     </div>
 
     <div class="flex-1 mb-4 md:mb-0">

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -209,6 +209,7 @@
 
   <div class="flex flex-col md:flex-row md:space-x-4 mt-4">
     <div class="flex-1 mb-4 md:mb-0">
+      <%= render "shared/author_credit_field", f: f %>
       <%= render "shared/author_credit_warning", record: f.object %>
     </div>
 

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -292,17 +292,7 @@
     </div>
 
     <div id="publish-preferences" class="flex pt-6 gap-4">
-      <%= f.input :author_credit_preference,
-                  as: :select,
-                  required: true,
-                  collection: AuthorCreditable::IDEA_FORM_OPTIONS,
-                  prompt: "Select a preference",
-                  selected: f.object.author_credit_preference,
-                  input_html: {
-                    class: select_caret_class(blank: f.object.author_credit_preference.blank?),
-                    style: custom_caret_style,
-                    onchange: select_caret_onchange
-                  } %>
+      <%= render "shared/author_credit_status", record: f.object %>
       <%= f.input :youtube_url,
                   as: :text,
                   label: "YouTube link <span class='text-normal text-sm text-gray-400'>(optional)</span>".html_safe,

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -292,7 +292,7 @@
     </div>
 
     <div id="publish-preferences" class="flex pt-6 gap-4">
-      <%= render "shared/author_credit_status", record: f.object %>
+      <%= render "shared/author_credit_status", f: f %>
       <%= f.input :youtube_url,
                   as: :text,
                   label: "YouTube link <span class='text-normal text-sm text-gray-400'>(optional)</span>".html_safe,

--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -42,10 +42,7 @@
         </div>
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= @story_idea.author_credit_preference&.humanize || "—" %>
-          <% if @story_idea.author_credit_preference.present? %>
-            <span class="text-gray-500">(<%= @story_idea.author_credit %>)</span>
-          <% end %>
+          <%= credited_author_link(@story_idea) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Permission given:</span>

--- a/app/views/workshop_ideas/_form.html.erb
+++ b/app/views/workshop_ideas/_form.html.erb
@@ -87,13 +87,7 @@
                                           focus:border-blue-500 sm:text-sm" } %>
             </div>
             <div>
-              <%= f.input :author_credit_preference,
-                          as: :select,
-                          collection: AuthorCreditable::IDEA_FORM_OPTIONS,
-                          include_blank: "Select a preference",
-                          selected: f.object.author_credit_preference,
-                          label: "Author credit preference",
-                          hint: "Controls how the author's name is displayed" %>
+              <%= render "shared/author_credit_status", record: f.object %>
             </div>
           </div>
         </div>

--- a/app/views/workshop_ideas/_form.html.erb
+++ b/app/views/workshop_ideas/_form.html.erb
@@ -93,7 +93,7 @@
 
     <%# Outside the admin block: this is how a submitter learns they'll be credited,
         so it can't be behind the manage check like the staff fields above. %>
-    <%= render "shared/author_credit_status", record: f.object %>
+    <%= render "shared/author_credit_status", f: f %>
 
     <%= render "shared/form_dropdown", field: :body, label: "Body", hidden: false,
                padding: "mb-4 border border-gray-300 rounded-md" do %>

--- a/app/views/workshop_ideas/_form.html.erb
+++ b/app/views/workshop_ideas/_form.html.erb
@@ -86,13 +86,14 @@
                                         class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500
                                           focus:border-blue-500 sm:text-sm" } %>
             </div>
-            <div>
-              <%= render "shared/author_credit_status", record: f.object %>
-            </div>
           </div>
         </div>
       </div>
     <% end %>
+
+    <%# Outside the admin block: this is how a submitter learns they'll be credited,
+        so it can't be behind the manage check like the staff fields above. %>
+    <%= render "shared/author_credit_status", record: f.object %>
 
     <%= render "shared/form_dropdown", field: :body, label: "Body", hidden: false,
                padding: "mb-4 border border-gray-300 rounded-md" do %>

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -31,10 +31,7 @@
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= @workshop_idea.author_credit_preference&.humanize || "—" %>
-          <% if @workshop_idea.author_credit_preference.present? %>
-            <span class="text-gray-500">(<%= @workshop_idea.author_credit %>)</span>
-          <% end %>
+          <%= credited_author_link(@workshop_idea) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Windows audience:</span>

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -43,12 +43,12 @@
         </div>
         <div>
           <span class="font-semibold text-gray-700">Created by:</span>
-          <%= @workshop_idea.created_by&.full_name %>
+          <%= @workshop_idea.created_by&.name %>
           <br><span class="text-gray-400"><%= @workshop_idea.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Updated by:</span>
-          <%= @workshop_idea.updated_by&.full_name %>
+          <%= @workshop_idea.updated_by&.name %>
           <br><span class="text-gray-400"><%= @workshop_idea.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
         </div>
       </div>

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -103,7 +103,7 @@
     <% end %>
 
     <div class="flex my-6 gap-4">
-      <%= render "shared/author_credit_status", record: f.object %>
+      <%= render "shared/author_credit_status", f: f %>
       <%= f.input :youtube_url,
                   as: :text,
                   label: "YouTube link <span class='text-normal text-sm text-gray-400'>(optional)</span>".html_safe,

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -103,13 +103,7 @@
     <% end %>
 
     <div class="flex my-6 gap-4">
-      <%= f.input :author_credit_preference,
-                  as: :select,
-                  required: true,
-                  collection: AuthorCreditable::IDEA_FORM_OPTIONS,
-                  include_blank: "Select a preference",
-                  selected: f.object.author_credit_preference,
-                  input_html: { class: "block w-full h-10 rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
+      <%= render "shared/author_credit_status", record: f.object %>
       <%= f.input :youtube_url,
                   as: :text,
                   label: "YouTube link <span class='text-normal text-sm text-gray-400'>(optional)</span>".html_safe,

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -67,14 +67,7 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-2 text-sm text-center">
-                  <% display_name = workshop_variation_idea.author_credit.presence || workshop_variation_idea.created_by&.name %>
-                  <% if workshop_variation_idea.created_by&.person %>
-                    <%= link_to display_name,
-                                person_path(workshop_variation_idea.created_by.person),
-                                class: "text-gray-500 hover:text-gray-700" %>
-                  <% elsif display_name %>
-                    <%= display_name %>
-                  <% end %>
+                  <%= credited_author_link(workshop_variation_idea, class: "text-gray-500 hover:text-gray-700") %>
                 </td>
                 <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
                   <% promoted_variation = workshop_variation_idea.workshop_variations.first %>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -62,10 +62,7 @@
         </div>
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= @workshop_variation_idea.author_credit_preference&.humanize || "—" %>
-          <% if @workshop_variation_idea.author_credit_preference.present? %>
-            <span class="text-gray-500">(<%= @workshop_variation_idea.author_credit %>)</span>
-          <% end %>
+          <%= credited_author_link(@workshop_variation_idea) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Permission given:</span>

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -90,6 +90,7 @@
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
+          <%= render "shared/author_credit_field", f: f %>
           <%= render "shared/author_credit_warning", record: f.object %>
 
           <% if allowed_to?(:manage?, WorkshopVariation) %>

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -103,8 +103,8 @@
                           link_to "Variation author",
                                   person_path(f.object.author),
                                   class: "hover:underline") : "Variation author").html_safe,
-                        collection: f.object.author_person.present? ? [[ f.object.author_person.remote_search_label[:label], f.object.author_person.id ]] : [],
-                        selected: f.object.author_person&.id || current_user.person_id,
+                        collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
+                        selected: author_picker_person(f.object)&.id,
                         include_blank: true,
                         input_html: {
                           data: {
@@ -112,6 +112,7 @@
                             remote_select_model_value: "person"
                           }
                         } %>
+              <%= render "shared/author_credit_note", record: f.object %>
             </div>
           <% end %>
         </div>

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -90,15 +90,7 @@
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
-          <%= f.input :author_credit_preference,
-                      as: :select,
-                      required: true,
-                      collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
-                      include_blank: "Select a preference",
-                      selected: f.object.author_credit_preference || "full_name",
-                      label: "Author credit preference",
-                      hint: "Controls how the author’s name is displayed",
-                      input_html: { class: "h-10 rounded-md" } %>
+          <%= render "shared/author_credit_warning", record: f.object %>
 
           <% if allowed_to?(:manage?, WorkshopVariation) %>
             <div class="admin-only bg-blue-100 p-4 rounded-lg mt-4">

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -62,14 +62,15 @@
                           link_to "Author",
                                   person_path(f.object.author),
                                   class: "hover:underline") : "Author").html_safe,
-                        collection: f.object.author_person.present? ? [[ f.object.author_person.remote_search_label[:label], f.object.author_person.id ]] : [],
-                        selected: (f.object.author_person&.id || current_user.person_id),
-                        hint: "Credited author — any person, not just active users. Defaults to the creator; change to credit someone else.",
+                        collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
+                        selected: author_picker_person(f.object)&.id,
+                        hint: "Credited author — any person, not just active users. Defaults to the creator on a new workshop; change to credit someone else.",
                         input_html: {
                           class: "block w-full rounded-md border-gray-300 shadow-sm
                           focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
                           data: { controller: "remote-select",
                                   remote_select_model_value: "person" } } %>
+            <%= render "shared/author_credit_note", record: f.object %>
           </div>
           <%= render "shared/author_credit_warning", record: f.object %>
         </div>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -71,13 +71,7 @@
                           data: { controller: "remote-select",
                                   remote_select_model_value: "person" } } %>
           </div>
-          <%= f.input :author_credit_preference,
-                      as: :select,
-                      collection: AuthorCreditable::ADMIN_FORM_OPTIONS,
-                      include_blank: "Select a preference",
-                      selected: f.object.author_credit_preference,
-                      label: "Author credit preference",
-                      hint: "Controls how the author's name is displayed" %>
+          <%= render "shared/author_credit_warning", record: f.object %>
         </div>
         <div class="admin-only bg-blue-100 p-3 space-y-4">
           <%= f.input :workshop_idea_id,

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -72,6 +72,7 @@
                                   remote_select_model_value: "person" } } %>
             <%= render "shared/author_credit_note", record: f.object %>
           </div>
+          <%= render "shared/author_credit_field", f: f %>
           <%= render "shared/author_credit_warning", record: f.object %>
         </div>
         <div class="admin-only bg-blue-100 p-3 space-y-4">

--- a/app/views/workshops/_show_associations.html.erb
+++ b/app/views/workshops/_show_associations.html.erb
@@ -86,7 +86,7 @@
                            link_to_object: true,
                            file: spotlight.decorate.display_image %>
                 <p class="text-sm text-gray-700 mt-1 leading-tight">
-                  <span class="block"><%= spotlight.author %></span>
+                  <span class="block"><%= spotlight.author_credit %></span>
                   <span class="block text-xs text-gray-500"><%= spotlight.title %></span>
                 </p>
               <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -80,6 +80,7 @@
   pro_tips:
     - "The suggested person on legacy rows is a name match — confirm it before saving, since two people can share a name."
     - "Clearing a single item's stored preference hands it back to the person's profile, which is the end state we want."
+
 - name: "Decline a scholarship award"
   area: scholarships
   display_status: public_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -33,25 +33,25 @@
   released_on: 2026-08-18
   pr_number: 2093
   summary: >-
-    Your profile now decides how your name appears on every story, workshop, variation
-    and resource credited to you — set it once instead of answering the question on each
+    Your profile decides how your name appears on every story, workshop, variation and
+    resource credited to you — one setting for all of them, instead of a question on each
     submission.
   description: >-
-    Your profile has two settings that control your name. The display preference picks
-    the format — full name, first name and last initial, first name only, or last name
-    only — and it applies everywhere at once: the people index, your profile header, and
-    every credit on content you've shared. Change it and all of them update together.
-    "Contribute anonymously" is separate. It hides your name from author credits only,
-    replacing it with "AWBW Facilitator", while you stay listed normally on the people
-    index. It's for people who want to share their work without their name attached to it.
-    Anything you submitted anonymously stays anonymous. Turning the setting off later
-    won't put your name back on it, and neither will an admin changing your display
-    preference — that choice is kept with the submission itself. Search follows the same
-    rules, so if your credit shows only your first name, searching your last name won't
-    surface your content, and anonymous work isn't findable by your name at all.
+    Your profile has two settings that control your name, and both apply to everything you
+    share. The display preference picks the format — full name, first name and last
+    initial, first name only, or last name only — and it applies everywhere at once: the
+    people index, your profile header, and every credit on your content. Change it and all
+    of them update together. "Contribute anonymously" is the second setting, and it's
+    all-or-nothing: either your contributions are credited to you, or they're all credited
+    to "AWBW Facilitator" instead. It hides your name from credits only — you stay listed
+    normally on the people index. It's for people who want to share their work without
+    their name attached to it. Search follows the same rules, so if your credit shows only
+    your first name, searching your last name won't surface your content, and anonymous
+    work isn't findable by your name at all.
   pro_tips:
     - "Ask an admin to change these for you — profile editing is admin-only for now."
     - "Anonymous content still appears on your own profile and to admins, so you can find it; it's hidden from everyone else."
+    - "Submissions made anonymously before this change stay that way until an admin reconciles them, even if you turn the setting off."
 
 - name: "Reconcile author credits"
   area: reporting
@@ -74,10 +74,13 @@
     fixed the same way — pick a real person — because naming an author is the only credit
     that follows their profile, links to it, and lists the content there. Filter by person,
     content type, stored preference, or whether they've already been reconciled. When a
-    section is clear it says which now-unused code the developers can retire.
+    section is clear it says which now-unused code the developers can retire. Where we're
+    headed: anonymity is a single profile setting covering all of someone's contributions.
+    Per-item anonymity is a legacy state this page exists to drain, not a choice
+    facilitators make.
   pro_tips:
     - "The suggested person on legacy rows is a name match — confirm it before saving, since two people can share a name."
-    - "Setting a single item to \"Anonymous\" hides that one credit without making the author anonymous everywhere."
+    - "Clearing a single item's stored preference hands it back to the person's profile, which is the end state we want."
 - name: "Decline a scholarship award"
   area: scholarships
   display_status: public_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -51,7 +51,6 @@
   pro_tips:
     - "Ask an admin to change these for you — profile editing is admin-only for now."
     - "Anonymous content still appears on your own profile and to admins, so you can find it; it's hidden from everyone else."
-    - "Submissions made anonymously before this change stay that way until an admin reconciles them, even if you turn the setting off."
 
 - name: "Reconcile author credits"
   area: reporting

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,57 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Choose how you're credited on what you share"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-18
+  pr_number: 2093
+  summary: >-
+    Your profile now decides how your name appears on every story, workshop, variation
+    and resource credited to you — set it once instead of answering the question on each
+    submission.
+  description: >-
+    Your profile has two settings that control your name. The display preference picks
+    the format — full name, first name and last initial, first name only, or last name
+    only — and it applies everywhere at once: the people index, your profile header, and
+    every credit on content you've shared. Change it and all of them update together.
+    "Contribute anonymously" is separate. It hides your name from author credits only,
+    replacing it with "AWBW Facilitator", while you stay listed normally on the people
+    index. It's for people who want to share their work without their name attached to it.
+    Anything you submitted anonymously stays anonymous. Turning the setting off later
+    won't put your name back on it, and neither will an admin changing your display
+    preference — that choice is kept with the submission itself. Search follows the same
+    rules, so if your credit shows only your first name, searching your last name won't
+    surface your content, and anonymous work isn't findable by your name at all.
+  pro_tips:
+    - "Ask an admin to change these for you — profile editing is admin-only for now."
+    - "Anonymous content still appears on your own profile and to admins, so you can find it; it's hidden from everyone else."
+
+- name: "Reconcile author credits"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-18
+  action_path: "/author_credit_divergences"
+  pr_number: 2093
+  summary: >-
+    An admin worklist of content whose credit doesn't resolve cleanly through someone's
+    profile, in four sections, each fixable in place.
+  description: >-
+    Credits come from the credited person's profile. This page lists everything that
+    doesn't, grouped so it can be worked top to bottom. Section one is content whose
+    stored record of what the submitter consented to has drifted from their profile —
+    apply one preference to the whole person, or correct a single item. Section two is
+    content credited by an old free-text name typed in before people had profiles, listed
+    per column so clearing one is a visible milestone. Section three is content with no
+    author named, credited generically, grouped under whoever entered it as the likeliest
+    author. Section four is content with nobody to credit at all. The last three are all
+    fixed the same way — pick a real person — because naming an author is the only credit
+    that follows their profile, links to it, and lists the content there. Filter by person,
+    content type, stored preference, or whether they've already been reconciled. When a
+    section is clear it says which now-unused code the developers can retire.
+  pro_tips:
+    - "The suggested person on legacy rows is a name match — confirm it before saving, since two people can share a name."
+    - "Setting a single item to \"Anonymous\" hides that one credit without making the author anonymous everywhere."
 - name: "Decline a scholarship award"
   area: scholarships
   display_status: public_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,6 +217,12 @@ Rails.application.routes.draw do
     resource :invoice, only: [ :show ], module: :events
     get "form_submissions/:person_id", to: "events/form_submissions#show", as: :registrant_submissions
   end
+  resources :author_credit_divergences, only: :index do
+    collection do
+      patch :update_person
+      patch :update_item
+    end
+  end
   resources :people do
     collection do
       get :check_duplicates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,6 +221,7 @@ Rails.application.routes.draw do
     collection do
       patch :update_person
       patch :update_item
+      patch :assign_author
     end
   end
   resources :people do

--- a/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
+++ b/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
@@ -1,7 +1,7 @@
 class AddAuthorCreditPreferencesToPeople < ActiveRecord::Migration[8.0]
   def up
-    unless column_exists?(:people, :contributions_anonymous)
-      add_column :people, :contributions_anonymous, :boolean, default: false, null: false
+    unless column_exists?(:people, :anonymous_contributions)
+      add_column :people, :anonymous_contributions, :boolean, default: false, null: false
     end
 
     # Stamped when an admin resolves this person on the author credit divergences
@@ -12,7 +12,7 @@ class AddAuthorCreditPreferencesToPeople < ActiveRecord::Migration[8.0]
   end
 
   def down
-    remove_column :people, :contributions_anonymous, if_exists: true
+    remove_column :people, :anonymous_contributions, if_exists: true
     remove_column :people, :author_credit_reconciled_at, if_exists: true
   end
 end

--- a/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
+++ b/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
@@ -1,18 +1,11 @@
 class AddAuthorCreditPreferencesToPeople < ActiveRecord::Migration[8.0]
   def up
-    unless column_exists?(:people, :anonymous_contributions)
-      add_column :people, :anonymous_contributions, :boolean, default: false, null: false
-    end
-
-    # Stamped when an admin resolves this person on the author credit divergences
-    # page, so a deliberate divergence stops reappearing on the worklist.
     unless column_exists?(:people, :author_credit_reconciled_at)
       add_column :people, :author_credit_reconciled_at, :datetime
     end
   end
 
   def down
-    remove_column :people, :anonymous_contributions, if_exists: true
     remove_column :people, :author_credit_reconciled_at, if_exists: true
   end
 end

--- a/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
+++ b/db/migrate/20260804140743_add_author_credit_preferences_to_people.rb
@@ -1,0 +1,18 @@
+class AddAuthorCreditPreferencesToPeople < ActiveRecord::Migration[8.0]
+  def up
+    unless column_exists?(:people, :contributions_anonymous)
+      add_column :people, :contributions_anonymous, :boolean, default: false, null: false
+    end
+
+    # Stamped when an admin resolves this person on the author credit divergences
+    # page, so a deliberate divergence stops reappearing on the worklist.
+    unless column_exists?(:people, :author_credit_reconciled_at)
+      add_column :people, :author_credit_reconciled_at, :datetime
+    end
+  end
+
+  def down
+    remove_column :people, :contributions_anonymous, if_exists: true
+    remove_column :people, :author_credit_reconciled_at, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1056,7 +1056,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_010750) do
     t.string "best_time_to_call"
     t.text "bio"
     t.boolean "blog_contributor", default: false, null: false
-    t.boolean "contributions_anonymous", default: false, null: false
     t.datetime "created_at", null: false
     t.integer "created_by_id"
     t.date "date_of_birth"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1052,9 +1052,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_010750) do
 
   create_table "people", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "anonymous_contributions", default: false, null: false
+    t.datetime "author_credit_reconciled_at"
     t.string "best_time_to_call"
     t.text "bio"
     t.boolean "blog_contributor", default: false, null: false
+    t.boolean "contributions_anonymous", default: false, null: false
     t.datetime "created_at", null: false
     t.integer "created_by_id"
     t.date "date_of_birth"

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -121,6 +121,10 @@ test_people.each do |data|
     email: data[:email],
     email_2: data[:email_2],
     profile_is_searchable: data[:searchable],
+    # Spread the credit preferences across seeded people so the author credit
+    # divergences page has something to triage in dev.
+    display_name_preference: Person::DISPLAY_NAME_PREFERENCES.sample,
+    contributions_anonymous: [ true, false, false, false ].sample,
     created_by: admin_user,
     updated_by: admin_user
   }

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -124,7 +124,7 @@ test_people.each do |data|
     # Spread the credit preferences across seeded people so the author credit
     # divergences page has something to triage in dev.
     display_name_preference: Person::DISPLAY_NAME_PREFERENCES.sample,
-    contributions_anonymous: [ true, false, false, false ].sample,
+    anonymous_contributions: [ true, false, false, false ].sample,
     created_by: admin_user,
     updated_by: admin_user
   }

--- a/db/seeds/dev/workshops.rb
+++ b/db/seeds/dev/workshops.rb
@@ -541,7 +541,7 @@ variations.each do |var_data|
     position: var_data[:position],
     published: [ true, true, false ].sample,
     windows_type_id: windows_type_id,
-    author_credit_preference: "anonymous"
+    author_credit_preference: "anonymous" # a real anonymity latch, kept per-item
   )
   variation.save!
 end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name.gsub("'", " ") }
 
     trait :anonymous_contributions do
-      contributions_anonymous { true }
+      anonymous_contributions { true }
     end
 
     trait :with_organization do

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     first_name { Faker::Name.first_name.gsub("'", " ") }
     last_name { Faker::Name.last_name.gsub("'", " ") }
 
+    trait :anonymous_contributions do
+      contributions_anonymous { true }
+    end
+
     trait :with_organization do
       after(:create) do |person|
         person.organizations << create(:organization)

--- a/spec/factories/story_ideas.rb
+++ b/spec/factories/story_ideas.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     title { "My Title" }
     rhino_body { "<p>My Body</p>" }
     permission_given { true }
-    author_credit_preference { "full_name" }
     association :created_by, factory: :user
     association :updated_by, factory: :user
 

--- a/spec/factories/workshop_ideas.rb
+++ b/spec/factories/workshop_ideas.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
     instructions { "MyText" }
     optional_materials { "MyText" }
     notes { "MyText" }
-    author_credit_preference { "full_name" }
 
     association :created_by, factory: :user
     association :updated_by, factory: :user

--- a/spec/factories/workshop_variation_ideas.rb
+++ b/spec/factories/workshop_variation_ideas.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     rhino_body { "<p>This is a variation idea description</p>" }
     youtube_url { "https://www.youtube.com/watch?v=example" }
     permission_given { true }
-    author_credit_preference { "full_name" }
     association :workshop
     association :organization
     association :windows_type

--- a/spec/factories/workshop_variations.rb
+++ b/spec/factories/workshop_variations.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     association :windows_type
     sequence(:name) { |n| "Variation #{n}" }
     rhino_body { "<p>Variation details using CKEditor</p>" }
-    author_credit_preference { "full_name" }
     sequence(:position) { |n| n }
     published { false }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.credited_author_link(workshop)).to eq("Ada Lovelace")
     end
 
-    it "never links an anonymous credit, even to a searchable person" do
+    it "never links a suppressed credit, even to a searchable person" do
       allow(person).to receive(:profile_is_searchable).and_return(true)
       workshop = create(:workshop, author_credit_preference: "anonymous")
       allow(workshop).to receive(:author).and_return(person)
 
-      expect(helper.credited_author_link(workshop)).to eq("Anonymous")
+      expect(helper.credited_author_link(workshop)).to eq("AWBW Facilitator")
     end
 
     it "renders a legacy free-text author as plain text with no link" do
@@ -38,7 +38,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.credited_author_link(workshop)).to eq("Jane Legacy")
     end
 
-    it "shows a creator-fallback credit as plain text, never linking the creator's profile" do
+    it "credits the org, not the creator, when no author is named" do
       creator_person = create(:person, first_name: "Cara", last_name: "Creator")
       allow(creator_person).to receive(:profile_is_searchable).and_return(true)
       creator = create(:user)
@@ -48,7 +48,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       allow(workshop).to receive(:created_by).and_return(creator)
 
       result = helper.credited_author_link(workshop)
-      expect(result).to eq("Cara Creator")
+      expect(result).to eq("AWBW Facilitator")
       expect(result).not_to include("<a")
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       allow(workshop).to receive(:created_by).and_return(creator)
 
       result = helper.credited_author_link(workshop)
-      expect(result).to eq("AWBW Facilitator")
+      expect(result).to eq("AWBW Staff")
       expect(result).not_to include("<a")
     end
   end

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe CommunityNews, type: :model do
       end
 
       it 'stops matching once the author marks contributions anonymous' do
-        person.update!(contributions_anonymous: true)
+        person.update!(anonymous_contributions: true)
         expect(CommunityNews.search_by_params(query: 'John')).to be_empty
       end
 

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -58,22 +58,13 @@ RSpec.describe CommunityNews, type: :model do
       end
     end
 
+    # Author names are no longer in the SearchCop index — see .search_by_params below,
+    # which ORs in `by_credited_person_name` so person search honors the credit
+    # preference. Indexing people.first_name/last_name here could not.
     context 'when searching by person name' do
-      it 'finds records by person first name' do
-        results = CommunityNews.search('John')
-        expect(results).to include(community_news_with_person)
-        expect(results).not_to include(community_news_without_person)
-      end
-
-      it 'finds records by person last name' do
-        results = CommunityNews.search('Doe')
-        expect(results).to include(community_news_with_person)
-        expect(results).not_to include(community_news_without_person)
-      end
-
-      it 'finds records by partial person name' do
-        results = CommunityNews.search('Joh')
-        expect(results).to include(community_news_with_person)
+      it 'does not match on the author name' do
+        expect(CommunityNews.search('John')).to be_empty
+        expect(CommunityNews.search('Doe')).to be_empty
       end
     end
 
@@ -97,15 +88,36 @@ RSpec.describe CommunityNews, type: :model do
     end
 
     context 'when searching with multiple terms' do
-      it 'finds records matching all terms across different fields' do
-        results = CommunityNews.search('John Breaking')
+      it 'finds records matching all terms across title and content' do
+        results = CommunityNews.search('Breaking technology')
         expect(results).to include(community_news_with_person)
         expect(results).not_to include(community_news_without_person)
       end
 
-      it 'finds records matching content and person name' do
-        results = CommunityNews.search('John technology')
+      # Deliberate tradeoff: an author name can no longer be one term of an AND
+      # query, because honoring the credit preference needs per-person branching
+      # that a flat SearchCop index can't express.
+      it 'does not combine an author name with a content term' do
+        expect(CommunityNews.search('John technology')).to be_empty
+      end
+    end
+
+    context 'via search_by_params (the user-facing path)' do
+      it 'finds records by the credited author name' do
+        results = CommunityNews.search_by_params(query: 'John')
         expect(results).to include(community_news_with_person)
+        expect(results).not_to include(community_news_without_person)
+      end
+
+      it 'stops matching once the author marks contributions anonymous' do
+        person.update!(contributions_anonymous: true)
+        expect(CommunityNews.search_by_params(query: 'John')).to be_empty
+      end
+
+      it 'stops matching the last name when only the first name is credited' do
+        person.update!(display_name_preference: 'first_name_only')
+        expect(CommunityNews.search_by_params(query: 'John')).to include(community_news_with_person)
+        expect(CommunityNews.search_by_params(query: 'Doe')).to be_empty
       end
     end
 
@@ -118,13 +130,13 @@ RSpec.describe CommunityNews, type: :model do
 
     context 'AND operator behavior for multiple search terms' do
       it 'requires all search terms to match across different fields' do
-        results = CommunityNews.search('John Breaking')
+        results = CommunityNews.search('Breaking important')
         expect(results).to include(community_news_with_person)
         expect(results).not_to include(community_news_without_person)
       end
 
       it 'finds no results when terms match different records' do
-        results = CommunityNews.search('John Report')
+        results = CommunityNews.search('technology Report')
         expect(results).to be_empty
       end
 

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe CommunityNews, type: :model do
   end
 
   describe "#missing_author_label" do
-    it "credits unattributed community news to AWBW Facilitator" do
+    it "credits unattributed community news to AWBW Staff" do
       news = create(:community_news, author: nil,
                                      created_by: create(:user, person: nil))
-      expect(news.missing_author_label).to eq("AWBW Facilitator")
-      expect(news.author_credit).to eq("AWBW Facilitator")
+      expect(news.missing_author_label).to eq("AWBW Staff")
+      expect(news.author_credit).to eq("AWBW Staff")
     end
   end
 

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe CommunityNews, type: :model do
       end
 
       it 'stops matching the last name when only the first name is credited' do
-        community_news_with_person.update!(author_credit_preference: 'first_name_only')
+        person.update!(display_name_preference: 'first_name_only')
         expect(CommunityNews.search_by_params(query: 'John')).to include(community_news_with_person)
         expect(CommunityNews.search_by_params(query: 'Doe')).to be_empty
       end

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe CommunityNews, type: :model do
   end
 
   describe "#missing_author_label" do
-    it "credits unattributed community news to AWBW Staff" do
+    it "credits unattributed community news to AWBW Facilitator" do
       news = create(:community_news, author: nil,
                                      created_by: create(:user, person: nil))
-      expect(news.missing_author_label).to eq("AWBW Staff")
-      expect(news.author_credit).to eq("AWBW Staff")
+      expect(news.missing_author_label).to eq("AWBW Facilitator")
+      expect(news.author_credit).to eq("AWBW Facilitator")
     end
   end
 

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe CommunityNews, type: :model do
       end
 
       it 'stops matching the last name when only the first name is credited' do
-        person.update!(display_name_preference: 'first_name_only')
+        community_news_with_person.update!(author_credit_preference: 'first_name_only')
         expect(CommunityNews.search_by_params(query: 'John')).to include(community_news_with_person)
         expect(CommunityNews.search_by_params(query: 'Doe')).to be_empty
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Person, type: :model do
     context "when display_name_preference is first_name_last_initial" do
       it "returns first name and last initial" do
         person.display_name_preference = "first_name_last_initial"
-        expect(person.name).to eq("Jane D")
+        expect(person.name).to eq("Jane D.")
       end
     end
 
@@ -255,6 +255,48 @@ RSpec.describe Person, type: :model do
         person.display_name_preference = nil
         expect(person.name).to eq("Jane Doe")
       end
+    end
+
+    it "is unaffected by contributions_anonymous" do
+      person.display_name_preference = "full_name"
+      person.contributions_anonymous = true
+      expect(person.name).to eq("Jane Doe")
+    end
+  end
+
+  describe "display_name_preference validation" do
+    it "accepts each allowed value" do
+      Person::DISPLAY_NAME_PREFERENCES.each do |value|
+        expect(build(:person, display_name_preference: value)).to be_valid
+      end
+    end
+
+    it "allows blank" do
+      expect(build(:person, display_name_preference: nil)).to be_valid
+    end
+
+    it "rejects anything else" do
+      person = build(:person, display_name_preference: "anonymous")
+      expect(person).not_to be_valid
+      expect(person.errors[:display_name_preference]).to be_present
+    end
+  end
+
+  describe "#effective_author_credit_preference" do
+    let(:person) { build(:person, display_name_preference: "first_name_only") }
+
+    it "is the display name preference by default" do
+      expect(person.effective_author_credit_preference).to eq("first_name_only")
+    end
+
+    it "falls back to full_name when unset" do
+      person.display_name_preference = nil
+      expect(person.effective_author_credit_preference).to eq("full_name")
+    end
+
+    it "is anonymous when contributions are anonymous, whatever the format" do
+      person.contributions_anonymous = true
+      expect(person.effective_author_credit_preference).to eq("anonymous")
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -257,9 +257,9 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    it "is unaffected by contributions_anonymous" do
+    it "is unaffected by anonymous_contributions" do
       person.display_name_preference = "full_name"
-      person.contributions_anonymous = true
+      person.anonymous_contributions = true
       expect(person.name).to eq("Jane Doe")
     end
   end
@@ -295,7 +295,7 @@ RSpec.describe Person, type: :model do
     end
 
     it "is anonymous when contributions are anonymous, whatever the format" do
-      person.contributions_anonymous = true
+      person.anonymous_contributions = true
       expect(person.effective_author_credit_preference).to eq("anonymous")
     end
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -75,6 +75,24 @@ RSpec.describe Resource do
       results = Resource.search(random_string)
       expect(results).to contain_exactly(resource1)
     end
+
+    describe "the legacy author name" do
+      let(:creator) { create(:user) }
+
+      it "still finds a resource credited by its legacy name" do
+        resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy")
+
+        expect(Resource.search_by_params(query: "Jane Legacy")).to include(resource)
+      end
+
+      it "does not find a resource whose legacy name is suppressed as anonymous" do
+        resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy",
+                                     author_credit_preference: "anonymous")
+
+        expect(resource.author_credit).to eq(AuthorCreditable::MISSING_AUTHOR_LABEL)
+        expect(Resource.search_by_params(query: "Jane Legacy")).not_to include(resource)
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe Resource do
     end
   end
 
+  describe "#author_credit with a legacy free-text name" do
+    let(:creator) { create(:user, :with_person) }
+
+    it "uses the legacy name when no author is credited" do
+      resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy")
+      expect(resource.author_credit).to eq("Jane Legacy")
+    end
+
+    it "stays anonymous rather than exposing the legacy name" do
+      resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy",
+                                   author_credit_preference: "anonymous")
+      expect(resource.author_credit).to eq("Anonymous")
+    end
+  end
+
   describe 'validations' do
     # Requires associations for create
     it { should validate_presence_of(:title) }

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Resource do
       expect(resource.author_credit).to eq("Jane Legacy")
     end
 
-    it "stays anonymous rather than exposing the legacy name" do
+    it "is suppressed rather than exposing the legacy name" do
       resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy",
                                    author_credit_preference: "anonymous")
-      expect(resource.author_credit).to eq("Anonymous")
+      expect(resource.author_credit).to eq("AWBW Facilitator")
     end
   end
 

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Resource do
     it "is suppressed rather than exposing the legacy name" do
       resource = create(:resource, created_by: creator, author: nil, legacy_author_name: "Jane Legacy",
                                    author_credit_preference: "anonymous")
-      expect(resource.author_credit).to eq("AWBW Facilitator")
+      expect(resource.author_credit).to eq("AWBW Staff")
     end
   end
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -171,10 +171,10 @@ RSpec.describe Story, type: :model do
         expect(results).not_to include(published_story)
       end
 
-      it "finds stories by the creating user's person name" do
+      it "does not find stories by the name of whoever entered them" do
         created_story = create(:story, :published, title: 'Creator Only', created_by: creator)
         results = Story.search_by_params(query: 'Zephyrina')
-        expect(results).to include(created_story)
+        expect(results).not_to include(created_story)
       end
     end
   end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -2,4 +2,15 @@ require 'rails_helper'
 
 RSpec.describe WorkshopIdea, type: :model do
   it_behaves_like "author_creditable", factory: :workshop_idea
+
+  # No author_id column, so the creator is the only credit an idea can carry.
+  describe "#author_credit" do
+    it "credits the creating user's person" do
+      creator = create(:user, :with_person)
+      idea = create(:workshop_idea, created_by: creator)
+
+      expect(idea.author_credit).to eq(creator.person.full_name)
+      expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to include(idea)
+    end
+  end
 end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 RSpec.describe WorkshopIdea, type: :model do
   it_behaves_like "author_creditable", factory: :workshop_idea
 
-  # No author_id column, so the creator is the only credit an idea can carry.
+  # No author_id column, and the creator never claims authorship, so an idea always
+  # falls to the generic label rather than crediting whoever entered it.
   describe "#author_credit" do
-    it "credits the creating user's person" do
+    it "credits the generic label, not the creating user's person" do
       creator = create(:user, :with_person)
       idea = create(:workshop_idea, created_by: creator)
 
-      expect(idea.author_credit).to eq(creator.person.full_name)
-      expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to include(idea)
+      expect(idea.author_credit).to eq("AWBW Facilitator")
+      expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to be_empty
     end
   end
 end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -14,4 +14,38 @@ RSpec.describe WorkshopIdea, type: :model do
       expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to be_empty
     end
   end
+
+  # Crediting nobody leaves `by_credited_person_name` empty for this model, so the
+  # admin filter has to reach the submitter directly or it matches nothing at all.
+  describe ".author_name" do
+    let(:creator) { create(:user, :with_person) }
+
+    before { creator.person.update!(first_name: "Marguerite", last_name: "Enterer") }
+
+    it "finds an idea by its submitter's first name" do
+      idea = create(:workshop_idea, created_by: creator)
+
+      expect(WorkshopIdea.author_name("Marguerite")).to include(idea)
+    end
+
+    it "finds an idea by its submitter's full name" do
+      idea = create(:workshop_idea, created_by: creator)
+
+      expect(WorkshopIdea.author_name("Marguerite Enterer")).to include(idea)
+    end
+
+    it "finds an idea by the submitter's account email" do
+      idea = create(:workshop_idea, created_by: creator)
+
+      expect(WorkshopIdea.author_name(creator.email)).to include(idea)
+    end
+
+    it "excludes ideas submitted by someone else" do
+      other = create(:user, :with_person)
+      other.person.update!(first_name: "Bartholomew", last_name: "Elsewhere")
+      create(:workshop_idea, created_by: other)
+
+      expect(WorkshopIdea.author_name("Marguerite")).to be_empty
+    end
+  end
 end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WorkshopIdea, type: :model do
       creator = create(:user, :with_person)
       idea = create(:workshop_idea, created_by: creator)
 
-      expect(idea.author_credit).to eq("AWBW Facilitator")
+      expect(idea.author_credit).to eq("AWBW Staff")
       expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to be_empty
     end
   end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe Workshop do
                                    author_credit_preference: "anonymous")
       expect(workshop.author_credit).to eq("Anonymous")
     end
+
+    it "has no governing person, so the creator's profile can't be said to have drifted" do
+      creator.person.update!(display_name_preference: "first_name_only")
+      workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy",
+                                   author_credit_preference: "full_name")
+
+      expect(workshop.credit_governing_person).to be_nil
+      expect(workshop.author_credit_diverged?).to be(false)
+    end
   end
 
   describe "#remote_search_label" do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe Workshop do
       expect(workshop.author_credit).to eq("Anonymous")
     end
 
+    it "takes no consent snapshot, since the creator's profile doesn't format it" do
+      creator.person.update!(display_name_preference: "first_name_only")
+      workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy")
+
+      expect(workshop.reload.author_credit_preference).to be_nil
+    end
+
+    it "is not findable by the creator's name, which the credit never shows" do
+      creator.person.update!(first_name: "Marguerite", last_name: "Enterer")
+      create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy")
+
+      expect(Workshop.by_credited_person_name("Marguerite")).to be_empty
+      expect(Workshop.by_credited_person_name("JaneLegacy")).not_to be_empty
+    end
+
     it "has no governing person, so the creator's profile can't be said to have drifted" do
       creator.person.update!(display_name_preference: "first_name_only")
       workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy",

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -111,6 +111,21 @@ RSpec.describe Workshop do
     end
   end
 
+  describe "#author_credit with a legacy free-text name" do
+    let(:creator) { create(:user, :with_person) }
+
+    it "uses the legacy name when no author is credited" do
+      workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy")
+      expect(workshop.author_credit).to eq("Jane Legacy")
+    end
+
+    it "stays anonymous rather than exposing the legacy name" do
+      workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy",
+                                   author_credit_preference: "anonymous")
+      expect(workshop.author_credit).to eq("Anonymous")
+    end
+  end
+
   describe "#remote_search_label" do
     it "returns title with windows type short_name" do
       record = create(:workshop, title: "Art Therapy", windows_type: create(:windows_type, :children))

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -173,6 +173,30 @@ RSpec.describe Workshop do
       expect(workshop.credit_governing_person).to be_nil
       expect(workshop.author_credit_diverged?).to be(false)
     end
+
+    # A person author outranks the legacy column for display, so the person's profile
+    # governs and the stale column must not be searchable behind an anonymous credit.
+    context "when a person author outranks it" do
+      let(:anonymous_author) do
+        create(:person, first_name: "Anon", last_name: "Person", anonymous_contributions: true)
+      end
+
+      it "is not findable by the legacy name when the snapshot is blank" do
+        workshop = create(:workshop, author: anonymous_author, full_name: "Jane Legacy")
+        workshop.update_column(:author_credit_preference, nil)
+
+        expect(workshop.reload.author_credit).to eq(AuthorCreditable::ANONYMOUS_AUTHOR_LABEL)
+        expect(Workshop.by_credited_person_name("JaneLegacy")).to be_empty
+      end
+
+      it "is not findable by the legacy name when the snapshot predates the profile going anonymous" do
+        workshop = create(:workshop, author: anonymous_author, full_name: "Jane Legacy")
+        workshop.update_column(:author_credit_preference, "full_name")
+
+        expect(workshop.reload.author_credit).to eq(AuthorCreditable::ANONYMOUS_AUTHOR_LABEL)
+        expect(Workshop.by_credited_person_name("JaneLegacy")).to be_empty
+      end
+    end
   end
 
   describe "#remote_search_label" do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -111,6 +111,31 @@ RSpec.describe Workshop do
     end
   end
 
+  describe "#author_credit with no author named" do
+    let(:creator) { create(:user, :with_person) }
+
+    it "credits the org rather than the person who entered it" do
+      workshop = create(:workshop, created_by: creator, author: nil)
+      expect(workshop.author_credit).to eq("AWBW Facilitator")
+    end
+
+    it "is not findable by the creator's name" do
+      creator.person.update!(first_name: "Marguerite", last_name: "Enterer")
+      create(:workshop, created_by: creator, author: nil)
+
+      expect(Workshop.by_credited_person_name("Marguerite")).to be_empty
+    end
+
+    it "is not findable by the creator when a different person is the author" do
+      creator.person.update!(first_name: "Marguerite", last_name: "Enterer")
+      author = create(:person, first_name: "Rosalind", last_name: "Franklin")
+      create(:workshop, created_by: creator, author: author)
+
+      expect(Workshop.by_credited_person_name("Marguerite")).to be_empty
+      expect(Workshop.by_credited_person_name("Rosalind")).not_to be_empty
+    end
+  end
+
   describe "#author_credit with a legacy free-text name" do
     let(:creator) { create(:user, :with_person) }
 
@@ -119,10 +144,10 @@ RSpec.describe Workshop do
       expect(workshop.author_credit).to eq("Jane Legacy")
     end
 
-    it "stays anonymous rather than exposing the legacy name" do
+    it "is suppressed rather than exposing the legacy name" do
       workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy",
                                    author_credit_preference: "anonymous")
-      expect(workshop.author_credit).to eq("Anonymous")
+      expect(workshop.author_credit).to eq("AWBW Facilitator")
     end
 
     it "takes no consent snapshot, since the creator's profile doesn't format it" do

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Workshop do
 
     it "credits the org rather than the person who entered it" do
       workshop = create(:workshop, created_by: creator, author: nil)
-      expect(workshop.author_credit).to eq("AWBW Facilitator")
+      expect(workshop.author_credit).to eq("AWBW Staff")
     end
 
     it "is not findable by the creator's name" do
@@ -147,7 +147,7 @@ RSpec.describe Workshop do
     it "is suppressed rather than exposing the legacy name" do
       workshop = create(:workshop, created_by: creator, author: nil, full_name: "Jane Legacy",
                                    author_credit_preference: "anonymous")
-      expect(workshop.author_credit).to eq("AWBW Facilitator")
+      expect(workshop.author_credit).to eq("AWBW Staff")
     end
 
     it "takes no consent snapshot, since the creator's profile doesn't format it" do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -95,6 +95,32 @@ RSpec.describe PersonPolicy, type: :policy do
     end
   end
 
+  describe "#own_record?" do
+    context "with admin user looking at someone else" do
+      subject { policy_for(record: non_searchable_person, user: admin_user) }
+
+      it { is_expected.to be_allowed_to(:own_record?) }
+    end
+
+    context "with owner" do
+      subject { policy_for(record: owned_person, user: owner_user) }
+
+      it { is_expected.to be_allowed_to(:own_record?) }
+    end
+
+    context "with a regular user who is not the owner (even a searchable person)" do
+      subject { policy_for(record: searchable_person, user: regular_user) }
+
+      it { is_expected.not_to be_allowed_to(:own_record?) }
+    end
+
+    context "with no user" do
+      subject { policy_for(record: searchable_person, user: nil) }
+
+      it { is_expected.not_to be_allowed_to(:own_record?) }
+    end
+  end
+
   describe "#workshop_logs?" do
     context "with admin user" do
       subject { policy_for(record: owned_person, user: admin_user) }

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -73,6 +73,60 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
     end
   end
 
+  describe "PATCH /author_credit_divergences/assign_author" do
+    before { sign_in admin }
+
+    let(:target) { create(:person, first_name: "Rosalind", last_name: "Franklin") }
+
+    it "credits a legacy free-text record to a real person" do
+      workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
+
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "Workshop", record_id: workshop.id, author_id: target.id }
+
+      expect(workshop.reload.author).to eq(target)
+      expect(workshop.author_credit).to eq("Rosalind Franklin")
+    end
+
+    it "credits a creator-fallback record so it links to the profile" do
+      story = create(:story, created_by: author_user, author: nil)
+      expect(story.author_credit_person).to be_nil
+
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_id: person.id }
+
+      expect(story.reload.author_credit_person).to eq(person)
+    end
+
+    it "requires a person" do
+      story = create(:story, created_by: author_user, author: nil)
+
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_id: "" }
+
+      expect(flash[:alert]).to eq("Choose a person to credit.")
+      expect(story.reload.author).to be_nil
+    end
+
+    it "refuses a type outside the allowlist" do
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "User", record_id: admin.id, author_id: target.id }
+
+      expect(flash[:alert]).to eq("Unknown record type.")
+    end
+
+    it "rejects a non-admin" do
+      sign_out admin
+      sign_in regular_user
+      story = create(:story, created_by: author_user, author: nil)
+
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_id: target.id }
+
+      expect(story.reload.author).to be_nil
+    end
+  end
+
   describe "PATCH /author_credit_divergences/update_item" do
     before { sign_in admin }
 

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
 
     it "updates the profile and stamps the person reconciled" do
       patch update_person_author_credit_divergences_path,
-            params: { id: person.id, person: { display_name_preference: "first_name_only", contributions_anonymous: "0" } }
+            params: { id: person.id, person: { display_name_preference: "first_name_only", anonymous_contributions: "0" } }
 
       expect(person.reload.display_name_preference).to eq("first_name_only")
       expect(person.author_credit_reconciled_at).to be_present
@@ -49,15 +49,15 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
 
     it "can mark contributions anonymous" do
       patch update_person_author_credit_divergences_path,
-            params: { id: person.id, person: { display_name_preference: "full_name", contributions_anonymous: "1" } }
+            params: { id: person.id, person: { display_name_preference: "full_name", anonymous_contributions: "1" } }
 
-      expect(person.reload.contributions_anonymous).to be(true)
+      expect(person.reload.anonymous_contributions).to be(true)
       expect(story.reload.author_credit).to eq("Anonymous")
     end
 
     it "updates the results in place with a Turbo Stream instead of a full-page redirect" do
       patch update_person_author_credit_divergences_path,
-            params: { id: person.id, person: { display_name_preference: "first_name_only", contributions_anonymous: "0" } },
+            params: { id: person.id, person: { display_name_preference: "first_name_only", anonymous_contributions: "0" } },
             as: :turbo_stream
 
       expect(response.media_type).to eq(Mime[:turbo_stream])
@@ -67,7 +67,7 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
     it "carries the active filters through the redirect" do
       patch update_person_author_credit_divergences_path,
             params: { id: person.id, type: "Story",
-                      person: { display_name_preference: "full_name", contributions_anonymous: "0" } }
+                      person: { display_name_preference: "full_name", anonymous_contributions: "0" } }
 
       expect(response).to redirect_to(author_credit_divergences_path(type: "Story"))
     end

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "AuthorCreditDivergences", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+  let(:author_user) { create(:user, :with_person) }
+  let(:person) { author_user.person }
+
+  let!(:story) do
+    person.update!(display_name_preference: "first_name_only")
+    record = create(:story, created_by: author_user, author: person, author_credit_preference: nil)
+    person.update!(display_name_preference: "full_name")
+    record
+  end
+
+  describe "GET /author_credit_divergences" do
+    it "requires an admin" do
+      sign_in regular_user
+      get author_credit_divergences_path
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "renders the page shell for an admin" do
+      sign_in admin
+      get author_credit_divergences_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Author credit divergences")
+    end
+
+    it "renders just the results inside the turbo frame" do
+      sign_in admin
+      get author_credit_divergences_path, headers: { "Turbo-Frame" => "author_credit_divergences_results" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(person.full_name)
+      expect(response.body).to include(story.title)
+    end
+  end
+
+  describe "PATCH /author_credit_divergences/update_person" do
+    before { sign_in admin }
+
+    it "updates the profile and stamps the person reconciled" do
+      patch update_person_author_credit_divergences_path,
+            params: { id: person.id, person: { display_name_preference: "first_name_only", contributions_anonymous: "0" } }
+
+      expect(person.reload.display_name_preference).to eq("first_name_only")
+      expect(person.author_credit_reconciled_at).to be_present
+    end
+
+    it "can mark contributions anonymous" do
+      patch update_person_author_credit_divergences_path,
+            params: { id: person.id, person: { display_name_preference: "full_name", contributions_anonymous: "1" } }
+
+      expect(person.reload.contributions_anonymous).to be(true)
+      expect(story.reload.author_credit).to eq("Anonymous")
+    end
+
+    it "carries the active filters through the redirect" do
+      patch update_person_author_credit_divergences_path,
+            params: { id: person.id, type: "Story",
+                      person: { display_name_preference: "full_name", contributions_anonymous: "0" } }
+
+      expect(response).to redirect_to(author_credit_divergences_path(type: "Story"))
+    end
+
+    it "rejects a non-admin" do
+      sign_out admin
+      sign_in regular_user
+      patch update_person_author_credit_divergences_path,
+            params: { id: person.id, person: { display_name_preference: "first_name_only" } }
+
+      expect(person.reload.display_name_preference).to eq("full_name")
+    end
+  end
+
+  describe "PATCH /author_credit_divergences/update_item" do
+    before { sign_in admin }
+
+    it "rewrites a single record's stored snapshot" do
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_credit_preference: "full_name" }
+
+      expect(story.reload.author_credit_preference).to eq("full_name")
+    end
+
+    it "makes one item anonymous without touching the person's others" do
+      other = create(:story, created_by: author_user, author: person)
+
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_credit_preference: "anonymous" }
+
+      expect(story.reload.author_credit).to eq("Anonymous")
+      expect(other.reload.author_credit).to eq(person.full_name)
+    end
+
+    it "refuses a type outside the allowlist instead of constantizing it" do
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "User", record_id: admin.id, author_credit_preference: "anonymous" }
+
+      expect(response).to redirect_to(author_credit_divergences_path)
+      expect(flash[:alert]).to eq("Unknown record type.")
+    end
+  end
+end

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -137,6 +137,25 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
       expect(story.reload.author_credit_preference).to eq("full_name")
     end
 
+    it "clears the stored snapshot when set to blank, so the item just follows the profile" do
+      story.update_column(:author_credit_preference, "last_name_only")
+
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_credit_preference: "" }
+
+      expect(story.reload.author_credit_preference).to be_nil
+    end
+
+    it "refuses to clear the snapshot of an item submitted anonymously" do
+      story.update_column(:author_credit_preference, "anonymous")
+
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_credit_preference: "" }
+
+      expect(story.reload.author_credit_preference).to eq("anonymous")
+      expect(flash[:alert]).to be_present
+    end
+
     it "makes one item anonymous without touching the person's others" do
       other = create(:story, created_by: author_user, author: person)
 

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
             params: { id: person.id, person: { display_name_preference: "full_name", anonymous_contributions: "1" } }
 
       expect(person.reload.anonymous_contributions).to be(true)
-      expect(story.reload.author_credit).to eq("Anonymous")
+      expect(story.reload.author_credit).to eq("AWBW Facilitator")
     end
 
     it "updates the results in place with a Turbo Stream instead of a full-page redirect" do
@@ -186,13 +186,13 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
       expect(story.author_credit).to eq(person.full_name)
     end
 
-    it "makes one item anonymous without touching the person's others" do
+    it "suppresses one item's credit without touching the person's others" do
       other = create(:story, created_by: author_user, author: person)
 
       patch update_item_author_credit_divergences_path,
             params: { record_type: "Story", record_id: story.id, author_credit_preference: "anonymous" }
 
-      expect(story.reload.author_credit).to eq("Anonymous")
+      expect(story.reload.author_credit).to eq("AWBW Facilitator")
       expect(other.reload.author_credit).to eq(person.full_name)
     end
 

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -176,14 +176,14 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
       expect(story.reload.author_credit_preference).to be_nil
     end
 
-    it "refuses to clear the snapshot of an item submitted anonymously" do
+    it "clears the snapshot of an item submitted anonymously, handing it to the profile" do
       story.update_column(:author_credit_preference, "anonymous")
 
       patch update_item_author_credit_divergences_path,
             params: { record_type: "Story", record_id: story.id, author_credit_preference: "" }
 
-      expect(story.reload.author_credit_preference).to eq("anonymous")
-      expect(flash[:alert]).to be_present
+      expect(story.reload.author_credit_preference).to be_nil
+      expect(story.author_credit).to eq(person.full_name)
     end
 
     it "makes one item anonymous without touching the person's others" do

--- a/spec/requests/author_credit_divergences_spec.rb
+++ b/spec/requests/author_credit_divergences_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
       expect(story.reload.author_credit).to eq("Anonymous")
     end
 
+    it "updates the results in place with a Turbo Stream instead of a full-page redirect" do
+      patch update_person_author_credit_divergences_path,
+            params: { id: person.id, person: { display_name_preference: "first_name_only", contributions_anonymous: "0" } },
+            as: :turbo_stream
+
+      expect(response.media_type).to eq(Mime[:turbo_stream])
+      expect(response.body).to include("author_credit_divergences_results")
+    end
+
     it "carries the active filters through the redirect" do
       patch update_person_author_credit_divergences_path,
             params: { id: person.id, type: "Story",
@@ -77,6 +86,17 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
     before { sign_in admin }
 
     let(:target) { create(:person, first_name: "Rosalind", last_name: "Franklin") }
+
+    it "updates the results in place with a Turbo Stream instead of a full-page redirect" do
+      workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
+
+      patch assign_author_author_credit_divergences_path,
+            params: { record_type: "Workshop", record_id: workshop.id, author_id: target.id },
+            as: :turbo_stream
+
+      expect(response.media_type).to eq(Mime[:turbo_stream])
+      expect(response.body).to include("author_credit_divergences_results")
+    end
 
     it "credits a legacy free-text record to a real person" do
       workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
@@ -135,6 +155,16 @@ RSpec.describe "AuthorCreditDivergences", type: :request do
             params: { record_type: "Story", record_id: story.id, author_credit_preference: "full_name" }
 
       expect(story.reload.author_credit_preference).to eq("full_name")
+    end
+
+    it "updates the results in place with a Turbo Stream instead of a full-page redirect" do
+      patch update_item_author_credit_divergences_path,
+            params: { record_type: "Story", record_id: story.id, author_credit_preference: "full_name" },
+            as: :turbo_stream
+
+      expect(response.media_type).to eq(Mime[:turbo_stream])
+      expect(response.body).to include("author_credit_divergences_results")
+      expect(response.body).to include("flash_now")
     end
 
     it "clears the stored snapshot when set to blank, so the item just follows the profile" do

--- a/spec/requests/community_news_spec.rb
+++ b/spec/requests/community_news_spec.rb
@@ -56,17 +56,19 @@ RSpec.describe "/community_news", type: :request do
       expect(response).to be_successful
     end
 
-    it "sorts by the credited person, falling back to the creator when no author" do
+    it "sorts by the credited author, not by whoever entered the record" do
       aaron = create(:person, first_name: "Aaron", last_name: "Adams")
-      late_creator = create(:user, :with_person)
-      late_creator.person.update!(first_name: "Zeke", last_name: "Zimmer")
+      zeke = create(:person, first_name: "Zeke", last_name: "Zimmer")
+      early_creator = create(:user, :with_person)
+      early_creator.person.update!(first_name: "Aaron", last_name: "Aardvark")
 
-      CommunityNews.create!(valid_attributes.merge(title: "Has Author", author: aaron))
-      CommunityNews.create!(valid_attributes.merge(title: "No Author", author: nil, created_by: late_creator))
+      CommunityNews.create!(valid_attributes.merge(title: "Adams Authored", author: aaron))
+      # Entered by an even earlier-sorting person, who must not influence the order.
+      CommunityNews.create!(valid_attributes.merge(title: "Zimmer Authored", author: zeke,
+                                                   created_by: early_creator))
 
       get community_news_index_url(sort: "author", direction: "asc"), headers: { "Turbo-Frame" => "community_news_results" }
-      # Aaron Adams (explicit author) sorts before Zeke Zimmer (creator fallback).
-      expect(response.body.index("Has Author")).to be < response.body.index("No Author")
+      expect(response.body.index("Adams Authored")).to be < response.body.index("Zimmer Authored")
     end
 
     it "filters by organization_id on lazy turbo-frame request" do

--- a/spec/requests/idea_form_author_credit_spec.rb
+++ b/spec/requests/idea_form_author_credit_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 # The idea forms are the only submission path a non-admin reaches, so they're the only
-# place a submitter learns how they'll be credited. They state the profile's current
-# answer rather than asking — the choice belongs on the profile, not per submission.
+# place a submitter learns how they'll be credited. Interim: profiles aren't self-service
+# yet, so the form both states the profile's current answer and collects a request an
+# admin applies on the divergences page. The request never changes what renders.
 RSpec.describe "Idea form author credit notice", type: :request do
   # WorkshopIdeaPolicy#new? is admin-only for now ("temp block until stakeholders are
   # ready"), so that form is driven by an admin until it opens up.
@@ -39,11 +40,11 @@ RSpec.describe "Idea form author credit notice", type: :request do
         expect(response.body).not_to include("credited as <strong>#{person.full_name}</strong>")
       end
 
-      it "points at contact us instead of asking the submitter to choose" do
+      it "collects a credit preference, defaulting to the profile" do
         get public_send(config[:path])
 
-        expect(response.body).to include(contact_us_path)
-        expect(response.body).not_to include("author_credit_preference")
+        expect(response.body).to include("author_credit_preference")
+        expect(response.body).to include("Use my profile setting")
       end
     end
   end

--- a/spec/requests/idea_form_author_credit_spec.rb
+++ b/spec/requests/idea_form_author_credit_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+# The idea forms are the only submission path a non-admin reaches, so they're the only
+# place a submitter learns how they'll be credited. They state the profile's current
+# answer rather than asking — the choice belongs on the profile, not per submission.
+RSpec.describe "Idea form author credit notice", type: :request do
+  # WorkshopIdeaPolicy#new? is admin-only for now ("temp block until stakeholders are
+  # ready"), so that form is driven by an admin until it opens up.
+  FORMS = {
+    "story idea" => { path: :new_story_idea_path, admin_only: false },
+    "workshop variation idea" => { path: :new_workshop_variation_idea_path, admin_only: false },
+    "workshop idea" => { path: :new_workshop_idea_path, admin_only: true }
+  }.freeze
+
+  FORMS.each do |label, config|
+    describe "the new #{label} form" do
+      let(:submitter) do
+        config[:admin_only] ? create(:user, :admin, :with_person) : create(:user, :with_person)
+      end
+      let(:person) { submitter.person }
+
+      before { sign_in submitter }
+
+      it "states how the submitter will be credited, formatted by their profile" do
+        person.update!(display_name_preference: "first_name_last_initial")
+
+        get public_send(config[:path])
+
+        expect(response.body).to include("credited as")
+        expect(response.body).to include("#{person.first_name} #{person.last_name.first}.")
+      end
+
+      it "names the generic credit when the profile suppresses credits" do
+        person.update!(anonymous_contributions: true)
+
+        get public_send(config[:path])
+
+        expect(response.body).to include("AWBW Facilitator")
+        expect(response.body).not_to include("credited as <strong>#{person.full_name}</strong>")
+      end
+
+      it "points at contact us instead of asking the submitter to choose" do
+        get public_send(config[:path])
+
+        expect(response.body).to include(contact_us_path)
+        expect(response.body).not_to include("author_credit_preference")
+      end
+    end
+  end
+end

--- a/spec/requests/people_private_sections_spec.rb
+++ b/spec/requests/people_private_sections_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Person profile private (submitted) sections", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+  let(:outsider) { create(:user) }
+
+  # The "Submitted content" sections load lazily via a Turbo Frame, so request
+  # story_ideas the way the frame does.
+  def get_story_ideas_section
+    get person_path(person, section: "story_ideas"),
+        headers: { "Turbo-Frame" => "person_story_ideas_section" }
+  end
+
+  before do
+    # The story-idea card titles by workshop_title, so put the marker there.
+    create(:story_idea, created_by: owner_user, updated_by: owner_user,
+                        external_workshop_title: "My Private Submission")
+  end
+
+  it "shows the submitted section to an admin" do
+    sign_in admin
+    get_story_ideas_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("My Private Submission")
+  end
+
+  it "shows the submitted section to the owner" do
+    sign_in owner_user
+    get_story_ideas_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("My Private Submission")
+  end
+
+  # own_record? stays narrow (admin || owner) even after show? is widened for
+  # public profile viewing, so a crafted ?section= request can't reach it.
+  it "denies the submitted section to a non-owner" do
+    sign_in outsider
+    get_story_ideas_section
+
+    expect(response).to redirect_to(root_path)
+    expect(response.body).not_to include("My Private Submission")
+  end
+end

--- a/spec/requests/people_stories_section_spec.rb
+++ b/spec/requests/people_stories_section_spec.rb
@@ -38,4 +38,24 @@ RSpec.describe "Person profile stories section", type: :request do
 
     expect(response.body).not_to include("Only Created Story")
   end
+
+  it "flags an anonymously-credited authored story" do
+    create(:story, :published, title: "Hush Story",
+                               author: person, author_credit_preference: "anonymous")
+
+    get_stories_section
+
+    expect(response.body).to include("Hush Story")
+    expect(response.body).to include("Credited as Anonymous")
+  end
+
+  it "never flags a spotlighted story, even when the person is anonymous" do
+    person.update!(contributions_anonymous: true)
+    create(:story, :published, title: "Spotlight Story", spotlighted_facilitator: person)
+
+    get_stories_section
+
+    expect(response.body).to include("Spotlight Story")
+    expect(response.body).not_to include("Credited as Anonymous")
+  end
 end

--- a/spec/requests/people_stories_section_spec.rb
+++ b/spec/requests/people_stories_section_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Person profile stories section", type: :request do
   end
 
   it "never flags a spotlighted story, even when the person is anonymous" do
-    person.update!(contributions_anonymous: true)
+    person.update!(anonymous_contributions: true)
     create(:story, :published, title: "Spotlight Story", spotlighted_facilitator: person)
 
     get_stories_section

--- a/spec/requests/people_workshops_section_spec.rb
+++ b/spec/requests/people_workshops_section_spec.rb
@@ -29,4 +29,35 @@ RSpec.describe "Person profile workshops section", type: :request do
 
     expect(response.body).not_to include("Only Created Workshop")
   end
+
+  it "flags an anonymously-credited authored workshop for an admin" do
+    create(:workshop, :published, title: "Hush Workshop",
+                                  author: person, author_credit_preference: "anonymous")
+
+    get_workshops_section
+
+    expect(response.body).to include("Hush Workshop")
+    expect(response.body).to include("Credited as Anonymous")
+  end
+
+  it "does not flag a normally-credited workshop" do
+    create(:workshop, :published, title: "Loud Workshop",
+                                  author: person, author_credit_preference: "full_name")
+
+    get_workshops_section
+
+    expect(response.body).to include("Loud Workshop")
+    expect(response.body).not_to include("Credited as Anonymous")
+  end
+
+  it "still shows the anonymous workshop, flagged, to the owner viewing their own profile" do
+    sign_in owner_user
+    create(:workshop, :published, title: "Hush Workshop",
+                                  author: person, author_credit_preference: "anonymous")
+
+    get_workshops_section
+
+    expect(response.body).to include("Hush Workshop")
+    expect(response.body).to include("Credited as Anonymous")
+  end
 end

--- a/spec/routing/author_credit_divergences_routing_spec.rb
+++ b/spec/routing/author_credit_divergences_routing_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe AuthorCreditDivergencesController, type: :routing do
         .to route_to("author_credit_divergences#update_person")
     end
 
+    it "routes to #assign_author" do
+      expect(patch: "/author_credit_divergences/assign_author")
+        .to route_to("author_credit_divergences#assign_author")
+    end
+
     it "routes to #update_item" do
       expect(patch: "/author_credit_divergences/update_item")
         .to route_to("author_credit_divergences#update_item")

--- a/spec/routing/author_credit_divergences_routing_spec.rb
+++ b/spec/routing/author_credit_divergences_routing_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe AuthorCreditDivergencesController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/author_credit_divergences").to route_to("author_credit_divergences#index")
+    end
+
+    it "routes to #update_person" do
+      expect(patch: "/author_credit_divergences/update_person")
+        .to route_to("author_credit_divergences#update_person")
+    end
+
+    it "routes to #update_item" do
+      expect(patch: "/author_credit_divergences/update_item")
+        .to route_to("author_credit_divergences#update_item")
+    end
+  end
+end

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe AuthorCreditDivergenceQuery do
+  let(:author_user) { create(:user, :with_person) }
+  let(:person) { author_user.person }
+
+  # Snapshot "first_name_only", then move the profile so the two disagree.
+  def diverged_story
+    person.update!(display_name_preference: "first_name_only")
+    story = create(:story, created_by: author_user, author: person, author_credit_preference: nil)
+    person.update!(display_name_preference: "full_name")
+    story
+  end
+
+  describe "#call" do
+    it "returns nothing when every snapshot matches its profile" do
+      person.update!(display_name_preference: "full_name")
+      create(:story, created_by: author_user, author: person, author_credit_preference: nil)
+
+      expect(described_class.new.call).to be_empty
+    end
+
+    it "groups diverging records under their credited person" do
+      story = diverged_story
+
+      groups = described_class.new.call
+
+      expect(groups.size).to eq(1)
+      expect(groups.first.person).to eq(person)
+      expect(groups.first.records).to include(story)
+    end
+
+    it "finds records credited through the creating user's person, not just author_id" do
+      person.update!(display_name_preference: "first_name_only")
+      idea = create(:story_idea, created_by: author_user, author_credit_preference: nil)
+      person.update!(display_name_preference: "full_name")
+
+      expect(described_class.new.call.first.records).to include(idea)
+    end
+
+    it "ignores records with no stored snapshot" do
+      create(:story, created_by: author_user, author: person, author_credit_preference: nil)
+      Story.update_all(author_credit_preference: nil)
+
+      expect(described_class.new.call).to be_empty
+    end
+
+    it "suggests the most restrictive preference across the person's records" do
+      diverged_story
+      create(:story, created_by: author_user, author: person, author_credit_preference: "anonymous")
+
+      expect(described_class.new.call.first.suggested_preference).to eq("anonymous")
+    end
+  end
+
+  describe "filters" do
+    before { diverged_story }
+
+    it "filters by person_id" do
+      expect(described_class.new(person_id: person.id).call.size).to eq(1)
+      expect(described_class.new(person_id: person.id + 9999).call).to be_empty
+    end
+
+    it "filters by type" do
+      expect(described_class.new(type: "Story").call.size).to eq(1)
+      expect(described_class.new(type: "Resource").call).to be_empty
+    end
+
+    it "filters by stored preference" do
+      expect(described_class.new(preference: "first_name_only").call.size).to eq(1)
+      expect(described_class.new(preference: "anonymous").call).to be_empty
+    end
+
+    it "hides reconciled people unless asked for" do
+      person.update!(author_credit_reconciled_at: Time.current)
+
+      expect(described_class.new.call).to be_empty
+      expect(described_class.new(include_reconciled: "1").call.size).to eq(1)
+    end
+  end
+
+  describe ".model_for" do
+    it "resolves an allowlisted name" do
+      expect(described_class.model_for("Story")).to eq(Story)
+    end
+
+    it "refuses anything else rather than constantizing it" do
+      expect(described_class.model_for("User")).to be_nil
+      expect(described_class.model_for("Kernel")).to be_nil
+      expect(described_class.model_for("NotAClass")).to be_nil
+    end
+  end
+end

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -30,12 +30,14 @@ RSpec.describe AuthorCreditDivergenceQuery do
       expect(groups.first.records).to include(story)
     end
 
-    it "finds records credited through the creating user's person, not just author_id" do
+    it "never puts an idea in the preference section — it credits generically, so nothing to reconcile" do
       person.update!(display_name_preference: "first_name_only")
       idea = create(:story_idea, created_by: author_user, author_credit_preference: nil)
       person.update!(display_name_preference: "full_name")
 
-      expect(described_class.new.call.preference.first.records).to include(idea)
+      records = described_class.new.call.preference.flat_map(&:records)
+      expect(records).not_to include(idea)
+      expect(described_class.new(type: "StoryIdea").call.preference).to be_empty
     end
 
     it "ignores records with no stored snapshot" do

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe AuthorCreditDivergenceQuery do
       person.update!(display_name_preference: "full_name")
       create(:story, created_by: author_user, author: person, author_credit_preference: nil)
 
-      expect(described_class.new.call).to be_empty
+      expect(described_class.new.call.preference).to be_empty
     end
 
     it "groups diverging records under their credited person" do
       story = diverged_story
 
-      groups = described_class.new.call
+      groups = described_class.new.call.preference
 
       expect(groups.size).to eq(1)
       expect(groups.first.person).to eq(person)
@@ -35,21 +35,35 @@ RSpec.describe AuthorCreditDivergenceQuery do
       idea = create(:story_idea, created_by: author_user, author_credit_preference: nil)
       person.update!(display_name_preference: "full_name")
 
-      expect(described_class.new.call.first.records).to include(idea)
+      expect(described_class.new.call.preference.first.records).to include(idea)
     end
 
     it "ignores records with no stored snapshot" do
       create(:story, created_by: author_user, author: person, author_credit_preference: nil)
       Story.update_all(author_credit_preference: nil)
 
-      expect(described_class.new.call).to be_empty
+      expect(described_class.new.call.preference).to be_empty
+    end
+
+    it "orders groups by first name then last name" do
+      person.update!(first_name: "Zoe", last_name: "Adams")
+      diverged_story
+      early_user = create(:user, :with_person)
+      early_user.person.update!(first_name: "Ada", last_name: "Zimmerman")
+      early_user.person.update!(display_name_preference: "first_name_only")
+      create(:story, created_by: early_user, author: early_user.person, author_credit_preference: nil)
+      early_user.person.update!(display_name_preference: "full_name")
+
+      names = described_class.new.call.preference.map { |group| group.person.first_name }
+
+      expect(names).to eq(%w[Ada Zoe])
     end
 
     it "suggests the most restrictive preference across the person's records" do
       diverged_story
       create(:story, created_by: author_user, author: person, author_credit_preference: "anonymous")
 
-      expect(described_class.new.call.first.suggested_preference).to eq("anonymous")
+      expect(described_class.new.call.preference.first.suggested_preference).to eq("anonymous")
     end
   end
 
@@ -57,25 +71,101 @@ RSpec.describe AuthorCreditDivergenceQuery do
     before { diverged_story }
 
     it "filters by person_id" do
-      expect(described_class.new(person_id: person.id).call.size).to eq(1)
-      expect(described_class.new(person_id: person.id + 9999).call).to be_empty
+      expect(described_class.new(person_id: person.id).call.preference.size).to eq(1)
+      expect(described_class.new(person_id: person.id + 9999).call.preference).to be_empty
     end
 
     it "filters by type" do
-      expect(described_class.new(type: "Story").call.size).to eq(1)
-      expect(described_class.new(type: "Resource").call).to be_empty
+      expect(described_class.new(type: "Story").call.preference.size).to eq(1)
+      expect(described_class.new(type: "Resource").call.preference).to be_empty
     end
 
     it "filters by stored preference" do
-      expect(described_class.new(preference: "first_name_only").call.size).to eq(1)
-      expect(described_class.new(preference: "anonymous").call).to be_empty
+      expect(described_class.new(preference: "first_name_only").call.preference.size).to eq(1)
+      expect(described_class.new(preference: "anonymous").call.preference).to be_empty
     end
 
     it "hides reconciled people unless asked for" do
       person.update!(author_credit_reconciled_at: Time.current)
 
+      expect(described_class.new.call.preference).to be_empty
+      expect(described_class.new(include_reconciled: "1").call.preference.size).to eq(1)
+    end
+  end
+
+  describe "the legacy section" do
+    it "lists records credited by a free-text name with no person" do
+      workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
+
+      legacy = described_class.new.call.legacy
+
+      expect(legacy).to include(workshop)
+      expect(workshop.author_credit).to eq("Marguerite Pre-Person")
+    end
+
+    it "drops a record once a real author is credited" do
+      workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
+      workshop.update!(author: person)
+
+      expect(described_class.new.call.legacy).not_to include(workshop)
+    end
+
+    it "excludes models that have no legacy column" do
+      create(:story, created_by: author_user, author: nil)
+      expect(described_class.new.call.legacy).to be_empty
+    end
+  end
+
+  describe "the creator section" do
+    it "groups records whose author_id is blank under the creating person" do
+      story = create(:story, created_by: author_user, author: nil)
+
+      groups = described_class.new.call.creator
+
+      expect(groups.map(&:person)).to include(person)
+      expect(groups.find { |g| g.person == person }.records).to include(story)
+    end
+
+    it "excludes records that already name an author" do
+      story = create(:story, created_by: author_user, author: person)
+      expect(described_class.new.call.creator.flat_map(&:records)).not_to include(story)
+    end
+
+    it "excludes idea models, whose only credit path is the creator" do
+      idea = create(:story_idea, created_by: author_user)
+      expect(described_class.new.call.creator.flat_map(&:records)).not_to include(idea)
+    end
+
+    it "excludes records covered by the legacy section instead" do
+      workshop = create(:workshop, created_by: author_user, author: nil, full_name: "Legacy Name")
+      expect(described_class.new.call.creator.flat_map(&:records)).not_to include(workshop)
+    end
+  end
+
+  describe "the unattributed section" do
+    let(:personless_user) { create(:user, person: nil) }
+
+    it "lists records with no author, no legacy name, and no creator person" do
+      story = create(:story, created_by: personless_user, author: nil)
+
+      expect(described_class.new.call.unattributed).to include(story)
+      expect(story.author_credit).to eq(story.missing_author_label)
+    end
+
+    it "drops a record once an author is credited" do
+      story = create(:story, created_by: personless_user, author: nil)
+      story.update!(author: person)
+
+      expect(described_class.new.call.unattributed).not_to include(story)
+    end
+  end
+
+  describe "#empty?" do
+    it "is true only when every section is clear" do
       expect(described_class.new.call).to be_empty
-      expect(described_class.new(include_reconciled: "1").call.size).to eq(1)
+
+      create(:story, created_by: create(:user, person: nil), author: nil)
+      expect(described_class.new.call).not_to be_empty
     end
   end
 

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -94,12 +94,15 @@ RSpec.describe AuthorCreditDivergenceQuery do
   end
 
   describe "the legacy section" do
+    def legacy_records_for(column)
+      group = described_class.new.call.legacy.find { |g| g.column == column }
+      group.entries.map(&:record)
+    end
+
     it "lists records credited by a free-text name with no person" do
       workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
 
-      legacy = described_class.new.call.legacy
-
-      expect(legacy).to include(workshop)
+      expect(legacy_records_for("workshops.full_name")).to include(workshop)
       expect(workshop.author_credit).to eq("Marguerite Pre-Person")
     end
 
@@ -107,12 +110,40 @@ RSpec.describe AuthorCreditDivergenceQuery do
       workshop = create(:workshop, author: nil, full_name: "Marguerite Pre-Person")
       workshop.update!(author: person)
 
-      expect(described_class.new.call.legacy).not_to include(workshop)
+      expect(legacy_records_for("workshops.full_name")).not_to include(workshop)
+    end
+
+    it "keeps a group per legacy column even when it is empty, so each can be retired" do
+      columns = described_class.new.call.legacy.map(&:column)
+
+      expect(columns).to contain_exactly("workshops.full_name", "resources.legacy_author_name")
+      expect(described_class.new.call).to be_legacy_empty
     end
 
     it "excludes models that have no legacy column" do
       create(:story, created_by: author_user, author: nil)
-      expect(described_class.new.call.legacy).to be_empty
+      expect(described_class.new.call.legacy.flat_map(&:entries)).to be_empty
+    end
+
+    it "suggests a person whose name matches the legacy text" do
+      match = create(:person, first_name: "Marguerite", last_name: "Duras")
+      workshop = create(:workshop, author: nil, full_name: "Marguerite Duras")
+
+      entry = described_class.new.call.legacy
+                             .find { |g| g.column == "workshops.full_name" }
+                             .entries.find { |e| e.record == workshop }
+
+      expect(entry.suggested_author).to eq(match)
+    end
+
+    it "suggests nothing when no person matches" do
+      workshop = create(:workshop, author: nil, full_name: "Nobody Byanyname")
+
+      entry = described_class.new.call.legacy
+                             .find { |g| g.column == "workshops.full_name" }
+                             .entries.find { |e| e.record == workshop }
+
+      expect(entry.suggested_author).to be_nil
     end
   end
 

--- a/spec/services/workshop_search_service_spec.rb
+++ b/spec/services/workshop_search_service_spec.rb
@@ -476,6 +476,30 @@ RSpec.describe WorkshopSearchService, type: :service do
           expect(service.workshops).not_to include(workshop_no_match)
         end
       end
+
+      # The free-text query has to honor the credit preference the same way the
+      # author_name filter does, or an anonymous credit is findable by real name.
+      context "through the free-text query" do
+        let!(:workshop_legacy) do
+          create(:workshop, :published, title: "Legacy Credit", full_name: "Bartholomew Snazzlepants")
+        end
+        let!(:workshop_legacy_anonymous) do
+          create(:workshop, :published, title: "Hidden Credit", full_name: "Bartholomew Snazzlepants",
+                                        author_credit_preference: "anonymous")
+        end
+
+        it "still finds a workshop credited by its legacy name" do
+          service = WorkshopSearchService.new({ query: "Bartholomew Snazzlepants" }, user: user).call
+          expect(service.workshops).to include(workshop_legacy)
+        end
+
+        it "does not find a workshop whose legacy name is suppressed as anonymous" do
+          expect(workshop_legacy_anonymous.author_credit).to eq(AuthorCreditable::MISSING_AUTHOR_LABEL)
+
+          service = WorkshopSearchService.new({ query: "Bartholomew Snazzlepants" }, user: user).call
+          expect(service.workshops).not_to include(workshop_legacy_anonymous)
+        end
+      end
     end
   end
 end

--- a/spec/services/workshop_search_service_spec.rb
+++ b/spec/services/workshop_search_service_spec.rb
@@ -421,8 +421,9 @@ RSpec.describe WorkshopSearchService, type: :service do
     context "filtering by author_name" do
       let!(:author_user) { create(:user, :with_person) }
       let!(:author_person) { author_user.person }
-      let!(:workshop_by_user) do
-        create(:workshop, :published, title: "User Workshop", created_by: author_user)
+      # Names its author explicitly — entering a record no longer credits the enterer.
+      let!(:workshop_by_person) do
+        create(:workshop, :published, title: "User Workshop", created_by: author_user, author: author_person)
       end
       let!(:workshop_with_full_name) do
         create(:workshop, :published, title: "Full Name Workshop", full_name: "#{author_person.first_name} #{author_person.last_name}")
@@ -433,13 +434,13 @@ RSpec.describe WorkshopSearchService, type: :service do
 
       it "finds workshops by person first_name" do
         service = WorkshopSearchService.new({ author_name: author_person.first_name }, user: user).call
-        expect(service.workshops).to include(workshop_by_user)
+        expect(service.workshops).to include(workshop_by_person)
         expect(service.workshops).not_to include(workshop_no_match)
       end
 
       it "finds workshops by person last_name" do
         service = WorkshopSearchService.new({ author_name: author_person.last_name }, user: user).call
-        expect(service.workshops).to include(workshop_by_user)
+        expect(service.workshops).to include(workshop_by_person)
         expect(service.workshops).not_to include(workshop_no_match)
       end
 
@@ -450,17 +451,17 @@ RSpec.describe WorkshopSearchService, type: :service do
 
       it "finds workshops by person name with reversed order" do
         service = WorkshopSearchService.new({ author_name: "#{author_person.last_name}#{author_person.first_name}" }, user: user).call
-        expect(service.workshops).to include(workshop_by_user)
+        expect(service.workshops).to include(workshop_by_person)
       end
 
       it "is case insensitive" do
         service = WorkshopSearchService.new({ author_name: "#{author_person.first_name} #{author_person.last_name}".downcase }, user: user).call
-        expect(service.workshops).to include(workshop_by_user)
+        expect(service.workshops).to include(workshop_by_person)
       end
 
       it "ignores blank author_name" do
         service = WorkshopSearchService.new({ author_name: "" }, user: user).call
-        expect(service.workshops).to include(workshop_by_user, workshop_no_match)
+        expect(service.workshops).to include(workshop_by_person, workshop_no_match)
       end
 
       context "with an explicit person author who is not the creator" do

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,83 +1,18 @@
 RSpec.shared_examples "author_creditable" do |factory:|
-  # A model with an author_id must name its author — the credit never falls back to
-  # whoever entered the record. The idea models have no author_id, so their creator
-  # is the only credit path they have.
-  def credits_creator?
-    !described_class.column_names.include?("author_id")
-  end
+  model = factory.to_s.camelize.constantize
+  names_author = model.column_names.include?("author_id")
 
-  def credited_record(factory, user, person, **attrs)
-    attrs[:author] = person unless credits_creator?
+  # Only a model with an author_id credits a person; the idea models (no author_id)
+  # never credit whoever entered them, so they always fall to the generic label.
+  def credited_record(factory, user, person, names_author, **attrs)
+    attrs[:author] = person if names_author
     create(factory, created_by: user, **attrs)
   end
 
   describe "#author_credit" do
     let(:author_user) { create(:user, :with_person) }
     let(:person) { author_user.person }
-    let(:record) { credited_record(factory, author_user, person) }
-
-    context "when the profile formats the name" do
-      it "returns the full name for full_name" do
-        person.update!(display_name_preference: "full_name")
-        expect(record.author_credit).to eq(person.full_name)
-      end
-
-      it "returns first name and last initial with period for first_name_last_initial" do
-        person.update!(display_name_preference: "first_name_last_initial")
-        expect(record.author_credit).to eq("#{person.first_name} #{person.last_name.first}.")
-      end
-
-      it "returns the first name for first_name_only" do
-        person.update!(display_name_preference: "first_name_only")
-        expect(record.author_credit).to eq(person.first_name)
-      end
-
-      it "returns the last name for last_name_only" do
-        person.update!(display_name_preference: "last_name_only")
-        expect(record.author_credit).to eq(person.last_name)
-      end
-
-      it "falls back to the full name when the profile has no preference" do
-        person.update!(display_name_preference: nil)
-        expect(record.author_credit).to eq(person.full_name)
-      end
-    end
-
-    context "when the profile marks contributions anonymous" do
-      before { person.update!(anonymous_contributions: true) }
-
-      # Behind a login, so a suppressed credit names the org rather than saying
-      # "Anonymous", which would read as being about the reader's access.
-      it "returns the generic label regardless of the name format" do
-        person.update!(display_name_preference: "full_name")
-        expect(record.author_credit).to eq("AWBW Facilitator")
-      end
-
-      it "does not link the credit to a profile" do
-        expect(record.author_credit_person).to be_nil
-      end
-    end
-
-    context "when the record itself was submitted anonymously" do
-      before { record.update!(author_credit_preference: "anonymous") }
-
-      it "stays suppressed even though the profile says otherwise" do
-        person.update!(display_name_preference: "full_name", anonymous_contributions: false)
-        expect(record.author_credit).to eq("AWBW Facilitator")
-      end
-
-      it "does not link the credit to a profile" do
-        expect(record.author_credit_person).to be_nil
-      end
-    end
-
-    context "when the stored preference is a name format" do
-      it "is ignored in favor of the profile" do
-        record.update!(author_credit_preference: "first_name_only")
-        person.update!(display_name_preference: "full_name")
-        expect(record.author_credit).to eq(person.full_name)
-      end
-    end
+    let(:record) { credited_record(factory, author_user, person, names_author) }
 
     context "when the preference is not one of the allowed values" do
       it "is invalid" do
@@ -87,60 +22,128 @@ RSpec.shared_examples "author_creditable" do |factory:|
       end
     end
 
-    context "when there is no credited person" do
-      # The portal is behind a login, so an unattributed credit names the org's
-      # facilitators rather than hiding behind "Anonymous".
-      it "falls back to AWBW Facilitator" do
-        record.update!(created_by: create(:user, person: nil))
-        record.update!(author: nil) unless credits_creator?
-        expect(record.missing_author_label).to eq("AWBW Facilitator")
-        expect(record.author_credit).to eq("AWBW Facilitator")
+    if names_author
+      context "with no stored preference, following the profile" do
+        before { record.update!(author_credit_preference: nil) }
+
+        it "returns the full name for full_name" do
+          person.update!(display_name_preference: "full_name")
+          expect(record.author_credit).to eq(person.full_name)
+        end
+
+        it "returns first name and last initial for first_name_last_initial" do
+          person.update!(display_name_preference: "first_name_last_initial")
+          expect(record.author_credit).to eq("#{person.first_name} #{person.last_name.first}.")
+        end
+
+        it "returns the first name for first_name_only" do
+          person.update!(display_name_preference: "first_name_only")
+          expect(record.author_credit).to eq(person.first_name)
+        end
+
+        it "returns the last name for last_name_only" do
+          person.update!(display_name_preference: "last_name_only")
+          expect(record.author_credit).to eq(person.last_name)
+        end
+      end
+
+      context "with its own stored preference, which wins over the profile" do
+        it "formats by the record's preference, not the profile's" do
+          person.update!(display_name_preference: "full_name")
+          record.update!(author_credit_preference: "first_name_only")
+          expect(record.author_credit).to eq(person.first_name)
+        end
+
+        it "keeps its preference after the profile changes, and reports the divergence" do
+          record.update!(author_credit_preference: "last_name_only")
+          person.update!(display_name_preference: "full_name")
+          expect(record.author_credit).to eq(person.last_name)
+          expect(record.author_credit_diverged?).to be(true)
+        end
+      end
+
+      context "when the profile marks contributions anonymous" do
+        before { person.update!(anonymous_contributions: true) }
+
+        # Behind a login, so a suppressed credit names the org rather than saying
+        # "Anonymous", which would read as being about the reader's access.
+        it "returns the generic label regardless of the name format" do
+          person.update!(display_name_preference: "full_name")
+          expect(record.author_credit).to eq("AWBW Facilitator")
+        end
+
+        it "does not link the credit to a profile" do
+          expect(record.author_credit_person).to be_nil
+        end
+      end
+
+      context "when the record itself was submitted anonymously" do
+        before { record.update!(author_credit_preference: "anonymous") }
+
+        it "stays suppressed even though the profile says otherwise" do
+          person.update!(display_name_preference: "full_name", anonymous_contributions: false)
+          expect(record.author_credit).to eq("AWBW Facilitator")
+        end
+
+        it "does not link the credit to a profile" do
+          expect(record.author_credit_person).to be_nil
+        end
+      end
+
+      context "when the author is removed" do
+        it "falls back to AWBW Facilitator rather than crediting the creator" do
+          record.update!(author: nil, author_credit_preference: nil)
+          expect(record.missing_author_label).to eq("AWBW Facilitator")
+          expect(record.author_credit).to eq("AWBW Facilitator")
+        end
+      end
+    else
+      context "on an idea record, which names no author" do
+        it "always credits the generic label, never the creator" do
+          person.update!(display_name_preference: "full_name")
+          expect(record.author_credit).to eq("AWBW Facilitator")
+        end
+
+        it "does not link the credit to a profile" do
+          expect(record.author_credit_person).to be_nil
+        end
       end
     end
   end
 
-  describe "the consent snapshot" do
-    let(:author_user) { create(:user, :with_person) }
-    let(:person) { author_user.person }
+  if names_author
+    describe "the consent snapshot" do
+      let(:author_user) { create(:user, :with_person) }
+      let(:person) { author_user.person }
 
-    it "records the profile's preference on create" do
-      person.update!(display_name_preference: "first_name_only")
-      record = credited_record(factory, author_user, person, author_credit_preference: nil)
-      expect(record.reload.author_credit_preference).to eq("first_name_only")
-    end
+      it "records the profile's preference on create" do
+        person.update!(display_name_preference: "first_name_only")
+        record = credited_record(factory, author_user, person, names_author, author_credit_preference: nil)
+        expect(record.reload.author_credit_preference).to eq("first_name_only")
+      end
 
-    it "records anonymous when the profile suppresses credits" do
-      person.update!(anonymous_contributions: true)
-      record = credited_record(factory, author_user, person, author_credit_preference: nil)
-      expect(record.reload.author_credit_preference).to eq("anonymous")
-    end
+      it "records anonymous when the profile suppresses credits" do
+        person.update!(anonymous_contributions: true)
+        record = credited_record(factory, author_user, person, names_author, author_credit_preference: nil)
+        expect(record.reload.author_credit_preference).to eq("anonymous")
+      end
 
-    it "does not overwrite a preference carried forward from an idea" do
-      record = credited_record(factory, author_user, person, author_credit_preference: "last_name_only")
-      expect(record.reload.author_credit_preference).to eq("last_name_only")
-    end
+      it "does not overwrite a preference carried forward from an idea" do
+        record = credited_record(factory, author_user, person, names_author, author_credit_preference: "last_name_only")
+        expect(record.reload.author_credit_preference).to eq("last_name_only")
+      end
 
-    it "normalizes a blank preference to nil so the record just follows the profile" do
-      record = credited_record(factory, author_user, person, author_credit_preference: "full_name")
-      record.update!(author_credit_preference: "")
-      expect(record.reload.author_credit_preference).to be_nil
-    end
+      it "normalizes a blank preference to nil so the record follows the profile" do
+        record = credited_record(factory, author_user, person, names_author, author_credit_preference: "full_name")
+        record.update!(author_credit_preference: "")
+        expect(record.reload.author_credit_preference).to be_nil
+      end
 
-    it "is left alone when the profile later changes, and reports the divergence" do
-      person.update!(display_name_preference: "first_name_only")
-      record = credited_record(factory, author_user, person, author_credit_preference: nil)
-
-      person.update!(display_name_preference: "full_name")
-
-      expect(record.reload.author_credit_preference).to eq("first_name_only")
-      expect(record.author_credit_diverged?).to be(true)
-      expect(record.author_credit).to eq(person.full_name)
-    end
-
-    it "reports no divergence when the snapshot matches the profile" do
-      person.update!(display_name_preference: "full_name")
-      record = credited_record(factory, author_user, person, author_credit_preference: nil)
-      expect(record.author_credit_diverged?).to be(false)
+      it "reports no divergence when the snapshot matches the profile" do
+        person.update!(display_name_preference: "full_name")
+        record = credited_record(factory, author_user, person, names_author, author_credit_preference: nil)
+        expect(record.author_credit_diverged?).to be(false)
+      end
     end
   end
 
@@ -148,75 +151,80 @@ RSpec.shared_examples "author_creditable" do |factory:|
     let(:author_user) { create(:user, :with_person) }
     let!(:record) { create(factory, created_by: author_user, author_credit_preference: "full_name") }
 
-    it "includes a record whose snapshot is a name format" do
-      expect(described_class.credited_openly).to include(record)
+    it "includes a record whose stored preference is a name format" do
+      expect(model.credited_openly).to include(record)
     end
 
     it "excludes a record submitted anonymously" do
       record.update!(author_credit_preference: "anonymous")
-      expect(described_class.credited_openly).not_to include(record)
+      expect(model.credited_openly).not_to include(record)
     end
 
-    it "includes a record with no snapshot, which just follows the profile" do
-      # The un-backfilled state of every pre-callback row, and what clearing the
-      # snapshot on the divergences page writes back.
-      described_class.where(id: record.id).update_all(author_credit_preference: nil)
-      expect(described_class.credited_openly).to include(record)
+    it "includes a record with no stored preference, which just follows the profile" do
+      model.where(id: record.id).update_all(author_credit_preference: nil)
+      expect(model.credited_openly).to include(record)
     end
   end
 
   describe ".by_credited_person_name" do
-    let(:author_user) { create(:user, :with_person) }
-    let(:person) { author_user.person }
-    let!(:record) { credited_record(factory, author_user, person) }
+    if names_author
+      let(:author_user) { create(:user, :with_person) }
+      let(:person) { author_user.person }
+      let!(:record) { credited_record(factory, author_user, person, names_author, author_credit_preference: nil) }
 
-    before { person.update!(first_name: "Zephyrine", last_name: "Quixotel") }
+      before { person.update!(first_name: "Zephyrine", last_name: "Quixotel") }
 
-    it "matches the credited person by name" do
-      expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
-      expect(described_class.by_credited_person_name("Quixotel")).to include(record)
-    end
+      it "matches the credited person by name" do
+        expect(model.by_credited_person_name("Zephyrine")).to include(record)
+        expect(model.by_credited_person_name("Quixotel")).to include(record)
+      end
 
-    it "does not match an unrelated name" do
-      expect(described_class.by_credited_person_name("Nonexistententry")).not_to include(record)
-    end
+      it "does not match an unrelated name" do
+        expect(model.by_credited_person_name("Nonexistententry")).not_to include(record)
+      end
 
-    it "matches nothing when the profile marks contributions anonymous" do
-      person.update!(anonymous_contributions: true)
-      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
-      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
-    end
+      it "matches nothing when the profile marks contributions anonymous" do
+        person.update!(anonymous_contributions: true)
+        expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
+        expect(model.by_credited_person_name("Quixotel")).not_to include(record)
+      end
 
-    it "matches nothing when the record was submitted anonymously" do
-      record.update!(author_credit_preference: "anonymous")
-      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
-    end
+      it "matches nothing when the record was submitted anonymously" do
+        record.update!(author_credit_preference: "anonymous")
+        expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
+      end
 
-    it "does not match on last name when only the first name is shown" do
-      person.update!(display_name_preference: "first_name_only")
-      expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
-      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
-    end
+      it "honors the record's own first_name_only preference over the profile" do
+        record.update!(author_credit_preference: "first_name_only")
+        expect(model.by_credited_person_name("Zephyrine")).to include(record)
+        expect(model.by_credited_person_name("Quixotel")).not_to include(record)
+      end
 
-    it "does not match on first name when only the last name is shown" do
-      person.update!(display_name_preference: "last_name_only")
-      expect(described_class.by_credited_person_name("Quixotel")).to include(record)
-      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
-    end
+      it "honors the record's own last_name_only preference over the profile" do
+        record.update!(author_credit_preference: "last_name_only")
+        expect(model.by_credited_person_name("Quixotel")).to include(record)
+        expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
+      end
 
-    it "matches only the initial when the last name is reduced to one" do
-      person.update!(display_name_preference: "first_name_last_initial")
-      expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
-      expect(described_class.by_credited_person_name("ZephyrineQ")).to include(record)
-      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
+      it "matches only the initial for first_name_last_initial" do
+        record.update!(author_credit_preference: "first_name_last_initial")
+        expect(model.by_credited_person_name("Zephyrine")).to include(record)
+        expect(model.by_credited_person_name("ZephyrineQ")).to include(record)
+        expect(model.by_credited_person_name("Quixotel")).not_to include(record)
+      end
+    else
+      it "matches nobody, since an idea names no author" do
+        create(factory)
+        expect(model.by_credited_person_name("anything")).to be_empty
+      end
     end
   end
 
   describe ".order_by_author" do
     it "runs without error in both directions" do
       create(factory)
-      expect { described_class.order_by_author("asc").to_a }.not_to raise_error
-      expect { described_class.order_by_author("desc").to_a }.not_to raise_error
+      expect { model.order_by_author("asc").to_a }.not_to raise_error
+      expect { model.order_by_author("desc").to_a }.not_to raise_error
     end
   end
 end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -104,6 +104,12 @@ RSpec.shared_examples "author_creditable" do |factory:|
       expect(record.reload.author_credit_preference).to eq("last_name_only")
     end
 
+    it "normalizes a blank preference to nil so the record just follows the profile" do
+      record = create(factory, created_by: author_user, author_credit_preference: "full_name")
+      record.update!(author_credit_preference: "")
+      expect(record.reload.author_credit_preference).to be_nil
+    end
+
     it "is left alone when the profile later changes, and reports the divergence" do
       person.update!(display_name_preference: "first_name_only")
       record = create(factory, created_by: author_user, author_credit_preference: nil)

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,8 +1,20 @@
 RSpec.shared_examples "author_creditable" do |factory:|
+  # A model with an author_id must name its author — the credit never falls back to
+  # whoever entered the record. The idea models have no author_id, so their creator
+  # is the only credit path they have.
+  def credits_creator?
+    !described_class.column_names.include?("author_id")
+  end
+
+  def credited_record(factory, user, person, **attrs)
+    attrs[:author] = person unless credits_creator?
+    create(factory, created_by: user, **attrs)
+  end
+
   describe "#author_credit" do
     let(:author_user) { create(:user, :with_person) }
     let(:person) { author_user.person }
-    let(:record) { create(factory, created_by: author_user) }
+    let(:record) { credited_record(factory, author_user, person) }
 
     context "when the profile formats the name" do
       it "returns the full name for full_name" do
@@ -34,9 +46,11 @@ RSpec.shared_examples "author_creditable" do |factory:|
     context "when the profile marks contributions anonymous" do
       before { person.update!(anonymous_contributions: true) }
 
-      it "returns Anonymous regardless of the name format" do
+      # Behind a login, so a suppressed credit names the org rather than saying
+      # "Anonymous", which would read as being about the reader's access.
+      it "returns the generic label regardless of the name format" do
         person.update!(display_name_preference: "full_name")
-        expect(record.author_credit).to eq("Anonymous")
+        expect(record.author_credit).to eq("AWBW Facilitator")
       end
 
       it "does not link the credit to a profile" do
@@ -47,9 +61,9 @@ RSpec.shared_examples "author_creditable" do |factory:|
     context "when the record itself was submitted anonymously" do
       before { record.update!(author_credit_preference: "anonymous") }
 
-      it "stays anonymous even though the profile says otherwise" do
+      it "stays suppressed even though the profile says otherwise" do
         person.update!(display_name_preference: "full_name", anonymous_contributions: false)
-        expect(record.author_credit).to eq("Anonymous")
+        expect(record.author_credit).to eq("AWBW Facilitator")
       end
 
       it "does not link the credit to a profile" do
@@ -77,8 +91,8 @@ RSpec.shared_examples "author_creditable" do |factory:|
       # The portal is behind a login, so an unattributed credit names the org's
       # facilitators rather than hiding behind "Anonymous".
       it "falls back to AWBW Facilitator" do
-        user_without_person = create(:user, person: nil)
-        record.update!(created_by: user_without_person)
+        record.update!(created_by: create(:user, person: nil))
+        record.update!(author: nil) unless credits_creator?
         expect(record.missing_author_label).to eq("AWBW Facilitator")
         expect(record.author_credit).to eq("AWBW Facilitator")
       end
@@ -91,30 +105,30 @@ RSpec.shared_examples "author_creditable" do |factory:|
 
     it "records the profile's preference on create" do
       person.update!(display_name_preference: "first_name_only")
-      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      record = credited_record(factory, author_user, person, author_credit_preference: nil)
       expect(record.reload.author_credit_preference).to eq("first_name_only")
     end
 
     it "records anonymous when the profile suppresses credits" do
       person.update!(anonymous_contributions: true)
-      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      record = credited_record(factory, author_user, person, author_credit_preference: nil)
       expect(record.reload.author_credit_preference).to eq("anonymous")
     end
 
     it "does not overwrite a preference carried forward from an idea" do
-      record = create(factory, created_by: author_user, author_credit_preference: "last_name_only")
+      record = credited_record(factory, author_user, person, author_credit_preference: "last_name_only")
       expect(record.reload.author_credit_preference).to eq("last_name_only")
     end
 
     it "normalizes a blank preference to nil so the record just follows the profile" do
-      record = create(factory, created_by: author_user, author_credit_preference: "full_name")
+      record = credited_record(factory, author_user, person, author_credit_preference: "full_name")
       record.update!(author_credit_preference: "")
       expect(record.reload.author_credit_preference).to be_nil
     end
 
     it "is left alone when the profile later changes, and reports the divergence" do
       person.update!(display_name_preference: "first_name_only")
-      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      record = credited_record(factory, author_user, person, author_credit_preference: nil)
 
       person.update!(display_name_preference: "full_name")
 
@@ -125,7 +139,7 @@ RSpec.shared_examples "author_creditable" do |factory:|
 
     it "reports no divergence when the snapshot matches the profile" do
       person.update!(display_name_preference: "full_name")
-      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      record = credited_record(factory, author_user, person, author_credit_preference: nil)
       expect(record.author_credit_diverged?).to be(false)
     end
   end
@@ -154,11 +168,11 @@ RSpec.shared_examples "author_creditable" do |factory:|
   describe ".by_credited_person_name" do
     let(:author_user) { create(:user, :with_person) }
     let(:person) { author_user.person }
-    let!(:record) { create(factory, created_by: author_user) }
+    let!(:record) { credited_record(factory, author_user, person) }
 
     before { person.update!(first_name: "Zephyrine", last_name: "Quixotel") }
 
-    it "matches the creating user's person by name" do
+    it "matches the credited person by name" do
       expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
       expect(described_class.by_credited_person_name("Quixotel")).to include(record)
     end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -91,17 +91,17 @@ RSpec.shared_examples "author_creditable" do |factory:|
       end
 
       context "when the author is removed" do
-        it "falls back to AWBW Facilitator rather than crediting the creator" do
+        it "falls back to AWBW Staff rather than crediting the creator" do
           record.update!(author: nil, author_credit_preference: nil)
-          expect(record.missing_author_label).to eq("AWBW Facilitator")
-          expect(record.author_credit).to eq("AWBW Facilitator")
+          expect(record.missing_author_label).to eq("AWBW Staff")
+          expect(record.author_credit).to eq("AWBW Staff")
         end
       end
     else
       context "on an idea record, which names no author" do
         it "always credits the generic label, never the creator" do
           person.update!(display_name_preference: "full_name")
-          expect(record.author_credit).to eq("AWBW Facilitator")
+          expect(record.author_credit).to eq("AWBW Staff")
         end
 
         it "does not link the credit to a profile" do

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -47,17 +47,19 @@ RSpec.shared_examples "author_creditable" do |factory:|
         end
       end
 
-      context "with its own stored preference, which wins over the profile" do
-        it "formats by the record's preference, not the profile's" do
+      context "with its own stored preference, which the profile still outranks" do
+        # The stored value is the submitter's request, recorded for an admin to apply
+        # to the profile — it doesn't change what renders on its own.
+        it "still formats by the profile" do
           person.update!(display_name_preference: "full_name")
           record.update!(author_credit_preference: "first_name_only")
-          expect(record.author_credit).to eq(person.first_name)
+          expect(record.author_credit).to eq(person.full_name)
         end
 
-        it "keeps its preference after the profile changes, and reports the divergence" do
+        it "reports the divergence so an admin can resolve it" do
           record.update!(author_credit_preference: "last_name_only")
           person.update!(display_name_preference: "full_name")
-          expect(record.author_credit).to eq(person.last_name)
+          expect(record.author_credit).to eq(person.full_name)
           expect(record.author_credit_diverged?).to be(true)
         end
       end
@@ -194,23 +196,29 @@ RSpec.shared_examples "author_creditable" do |factory:|
         expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
       end
 
-      it "honors the record's own first_name_only preference over the profile" do
-        record.update!(author_credit_preference: "first_name_only")
+      it "does not match the last name when the profile shows the first name only" do
+        person.update!(display_name_preference: "first_name_only")
         expect(model.by_credited_person_name("Zephyrine")).to include(record)
         expect(model.by_credited_person_name("Quixotel")).not_to include(record)
       end
 
-      it "honors the record's own last_name_only preference over the profile" do
-        record.update!(author_credit_preference: "last_name_only")
+      it "does not match the first name when the profile shows the last name only" do
+        person.update!(display_name_preference: "last_name_only")
         expect(model.by_credited_person_name("Quixotel")).to include(record)
         expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
       end
 
       it "matches only the initial for first_name_last_initial" do
-        record.update!(author_credit_preference: "first_name_last_initial")
+        person.update!(display_name_preference: "first_name_last_initial")
         expect(model.by_credited_person_name("Zephyrine")).to include(record)
         expect(model.by_credited_person_name("ZephyrineQ")).to include(record)
         expect(model.by_credited_person_name("Quixotel")).not_to include(record)
+      end
+
+      # The stored request doesn't gate search either — only the profile does.
+      it "still matches the full name when the record asked for first_name_only" do
+        record.update!(author_credit_preference: "first_name_only")
+        expect(model.by_credited_person_name("Quixotel")).to include(record)
       end
     else
       it "matches nobody, since an idea names no author" do

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -32,7 +32,7 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
 
     context "when the profile marks contributions anonymous" do
-      before { person.update!(contributions_anonymous: true) }
+      before { person.update!(anonymous_contributions: true) }
 
       it "returns Anonymous regardless of the name format" do
         person.update!(display_name_preference: "full_name")
@@ -48,7 +48,7 @@ RSpec.shared_examples "author_creditable" do |factory:|
       before { record.update!(author_credit_preference: "anonymous") }
 
       it "stays anonymous even though the profile says otherwise" do
-        person.update!(display_name_preference: "full_name", contributions_anonymous: false)
+        person.update!(display_name_preference: "full_name", anonymous_contributions: false)
         expect(record.author_credit).to eq("Anonymous")
       end
 
@@ -94,7 +94,7 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
 
     it "records anonymous when the profile suppresses credits" do
-      person.update!(contributions_anonymous: true)
+      person.update!(anonymous_contributions: true)
       record = create(factory, created_by: author_user, author_credit_preference: nil)
       expect(record.reload.author_credit_preference).to eq("anonymous")
     end
@@ -166,7 +166,7 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
 
     it "matches nothing when the profile marks contributions anonymous" do
-      person.update!(contributions_anonymous: true)
+      person.update!(anonymous_contributions: true)
       expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
       expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
     end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -74,11 +74,13 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
 
     context "when there is no credited person" do
-      it "falls back to the model's missing_author_label" do
+      # The portal is behind a login, so an unattributed credit names the org's
+      # facilitators rather than hiding behind "Anonymous".
+      it "falls back to AWBW Facilitator" do
         user_without_person = create(:user, person: nil)
         record.update!(created_by: user_without_person)
-        expect(record.author_credit).to eq(record.missing_author_label)
-        expect(record.missing_author_label).to be_present
+        expect(record.missing_author_label).to eq("AWBW Facilitator")
+        expect(record.author_credit).to eq("AWBW Facilitator")
       end
     end
   end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -4,68 +4,64 @@ RSpec.shared_examples "author_creditable" do |factory:|
     let(:person) { author_user.person }
     let(:record) { create(factory, created_by: author_user) }
 
-    context "when author_credit_preference is full_name" do
-      it "returns the person's full name" do
-        record.update!(author_credit_preference: "full_name")
+    context "when the profile formats the name" do
+      it "returns the full name for full_name" do
+        person.update!(display_name_preference: "full_name")
+        expect(record.author_credit).to eq(person.full_name)
+      end
+
+      it "returns first name and last initial with period for first_name_last_initial" do
+        person.update!(display_name_preference: "first_name_last_initial")
+        expect(record.author_credit).to eq("#{person.first_name} #{person.last_name.first}.")
+      end
+
+      it "returns the first name for first_name_only" do
+        person.update!(display_name_preference: "first_name_only")
+        expect(record.author_credit).to eq(person.first_name)
+      end
+
+      it "returns the last name for last_name_only" do
+        person.update!(display_name_preference: "last_name_only")
+        expect(record.author_credit).to eq(person.last_name)
+      end
+
+      it "falls back to the full name when the profile has no preference" do
+        person.update!(display_name_preference: nil)
         expect(record.author_credit).to eq(person.full_name)
       end
     end
 
-    context "when author_credit_preference is first_name_last_initial" do
-      it "returns first name and last initial with period" do
-        record.update!(author_credit_preference: "first_name_last_initial")
-        expect(record.author_credit).to eq("#{person.first_name} #{person.last_name.first}.")
-      end
-    end
+    context "when the profile marks contributions anonymous" do
+      before { person.update!(contributions_anonymous: true) }
 
-    context "when author_credit_preference is first_name_only" do
-      it "returns the person's first name" do
-        record.update!(author_credit_preference: "first_name_only")
-        expect(record.author_credit).to eq(person.first_name)
-      end
-    end
-
-    context "when author_credit_preference is last_name_only" do
-      it "returns the person's last name" do
-        record.update!(author_credit_preference: "last_name_only")
-        expect(record.author_credit).to eq(person.last_name)
-      end
-    end
-
-    context "when author_credit_preference is anonymous" do
-      it "returns Anonymous" do
-        record.update!(author_credit_preference: "anonymous")
+      it "returns Anonymous regardless of the name format" do
+        person.update!(display_name_preference: "full_name")
         expect(record.author_credit).to eq("Anonymous")
       end
+
+      it "does not link the credit to a profile" do
+        expect(record.author_credit_person).to be_nil
+      end
     end
 
-    if described_class.require_author_credit_preference?
-      context "when the preference is unset (required)" do
-        it "is invalid without a credit preference" do
-          record.author_credit_preference = nil
-          expect(record).not_to be_valid
-          expect(record.errors[:author_credit_preference]).to be_present
-        end
+    context "when the record itself was submitted anonymously" do
+      before { record.update!(author_credit_preference: "anonymous") }
 
-        it "does not default new records" do
-          expect(described_class.new.author_credit_preference).to be_blank
-        end
+      it "stays anonymous even though the profile says otherwise" do
+        person.update!(display_name_preference: "full_name", contributions_anonymous: false)
+        expect(record.author_credit).to eq("Anonymous")
       end
-    else
-      context "when the preference is unset (defaulted)" do
-        it "defaults new records to full_name" do
-          expect(described_class.new.author_credit_preference).to eq("full_name")
-        end
 
-        it "treats a blank preference as full_name at read time" do
-          record.author_credit_preference = nil
-          expect(record.author_credit).to eq(person.full_name)
-        end
+      it "does not link the credit to a profile" do
+        expect(record.author_credit_person).to be_nil
+      end
+    end
 
-        it "normalizes a blank preference to full_name on save (no backfill)" do
-          record.update!(author_credit_preference: nil)
-          expect(record.reload.author_credit_preference).to eq("full_name")
-        end
+    context "when the stored preference is a name format" do
+      it "is ignored in favor of the profile" do
+        record.update!(author_credit_preference: "first_name_only")
+        person.update!(display_name_preference: "full_name")
+        expect(record.author_credit).to eq(person.full_name)
       end
     end
 
@@ -87,19 +83,89 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
   end
 
+  describe "the consent snapshot" do
+    let(:author_user) { create(:user, :with_person) }
+    let(:person) { author_user.person }
+
+    it "records the profile's preference on create" do
+      person.update!(display_name_preference: "first_name_only")
+      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      expect(record.reload.author_credit_preference).to eq("first_name_only")
+    end
+
+    it "records anonymous when the profile suppresses credits" do
+      person.update!(contributions_anonymous: true)
+      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      expect(record.reload.author_credit_preference).to eq("anonymous")
+    end
+
+    it "does not overwrite a preference carried forward from an idea" do
+      record = create(factory, created_by: author_user, author_credit_preference: "last_name_only")
+      expect(record.reload.author_credit_preference).to eq("last_name_only")
+    end
+
+    it "is left alone when the profile later changes, and reports the divergence" do
+      person.update!(display_name_preference: "first_name_only")
+      record = create(factory, created_by: author_user, author_credit_preference: nil)
+
+      person.update!(display_name_preference: "full_name")
+
+      expect(record.reload.author_credit_preference).to eq("first_name_only")
+      expect(record.author_credit_diverged?).to be(true)
+      expect(record.author_credit).to eq(person.full_name)
+    end
+
+    it "reports no divergence when the snapshot matches the profile" do
+      person.update!(display_name_preference: "full_name")
+      record = create(factory, created_by: author_user, author_credit_preference: nil)
+      expect(record.author_credit_diverged?).to be(false)
+    end
+  end
+
   describe ".by_credited_person_name" do
     let(:author_user) { create(:user, :with_person) }
+    let(:person) { author_user.person }
     let!(:record) { create(factory, created_by: author_user) }
 
+    before { person.update!(first_name: "Zephyrine", last_name: "Quixotel") }
+
     it "matches the creating user's person by name" do
-      author_user.person.update!(first_name: "Zephyrine", last_name: "Quixotel")
       expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
       expect(described_class.by_credited_person_name("Quixotel")).to include(record)
     end
 
     it "does not match an unrelated name" do
-      author_user.person.update!(first_name: "Zephyrine", last_name: "Quixotel")
       expect(described_class.by_credited_person_name("Nonexistententry")).not_to include(record)
+    end
+
+    it "matches nothing when the profile marks contributions anonymous" do
+      person.update!(contributions_anonymous: true)
+      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
+      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
+    end
+
+    it "matches nothing when the record was submitted anonymously" do
+      record.update!(author_credit_preference: "anonymous")
+      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
+    end
+
+    it "does not match on last name when only the first name is shown" do
+      person.update!(display_name_preference: "first_name_only")
+      expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
+      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
+    end
+
+    it "does not match on first name when only the last name is shown" do
+      person.update!(display_name_preference: "last_name_only")
+      expect(described_class.by_credited_person_name("Quixotel")).to include(record)
+      expect(described_class.by_credited_person_name("Zephyrine")).not_to include(record)
+    end
+
+    it "matches only the initial when the last name is reduced to one" do
+      person.update!(display_name_preference: "first_name_last_initial")
+      expect(described_class.by_credited_person_name("Zephyrine")).to include(record)
+      expect(described_class.by_credited_person_name("ZephyrineQ")).to include(record)
+      expect(described_class.by_credited_person_name("Quixotel")).not_to include(record)
     end
   end
 

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -128,6 +128,27 @@ RSpec.shared_examples "author_creditable" do |factory:|
     end
   end
 
+  describe ".credited_openly" do
+    let(:author_user) { create(:user, :with_person) }
+    let!(:record) { create(factory, created_by: author_user, author_credit_preference: "full_name") }
+
+    it "includes a record whose snapshot is a name format" do
+      expect(described_class.credited_openly).to include(record)
+    end
+
+    it "excludes a record submitted anonymously" do
+      record.update!(author_credit_preference: "anonymous")
+      expect(described_class.credited_openly).not_to include(record)
+    end
+
+    it "includes a record with no snapshot, which just follows the profile" do
+      # The un-backfilled state of every pre-callback row, and what clearing the
+      # snapshot on the divergences page writes back.
+      described_class.where(id: record.id).update_all(author_credit_preference: nil)
+      expect(described_class.credited_openly).to include(record)
+    end
+  end
+
   describe ".by_credited_person_name" do
     let(:author_user) { create(:user, :with_person) }
     let(:person) { author_user.person }

--- a/spec/views/community_news/edit.html.erb_spec.rb
+++ b/spec/views/community_news/edit.html.erb_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe "community_news/edit", type: :view do
 
       assert_select "select[name=?]", "community_news[author_id]"
 
-      assert_select "select[name=?]", "community_news[author_credit_preference]"
 
       assert_select "textarea[name=?]", "community_news[reference_url]"
 

--- a/spec/views/community_news/new.html.erb_spec.rb
+++ b/spec/views/community_news/new.html.erb_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "community_news/new", type: :view do
 
       assert_select "select[name=?]", "community_news[author_id]"
 
-      assert_select "select[name=?]", "community_news[author_credit_preference]"
 
       assert_select "textarea[name=?]", "community_news[reference_url]"
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/event_registrations/index.html.erb"     => "admin-only bg-blue-100",
     "app/views/forms/index.html.erb"                   => "admin-only bg-blue-100",
     "app/views/forms/show.html.erb"                    => "admin-only bg-blue-100",
+    "app/views/author_credit_divergences/index.html.erb" => "admin-only bg-blue-100",
     "app/views/notifications/index.html.erb"           => "admin-only bg-white",
     "app/views/notifications/new.html.erb"             => "admin-only bg-blue-100",
     "app/views/organization_statuses/index.html.erb"   => "admin-only bg-blue-100",

--- a/spec/views/stories/edit.html.erb_spec.rb
+++ b/spec/views/stories/edit.html.erb_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "stories/edit", type: :view do
 
       assert_select "textarea[name=?]", "story[youtube_url]"
 
-      assert_select "select[name=?]", "story[author_credit_preference]"
 
       assert_select "select[name=?]", "story[author_id]"
     end

--- a/spec/views/stories/new.html.erb_spec.rb
+++ b/spec/views/stories/new.html.erb_spec.rb
@@ -128,10 +128,11 @@ RSpec.describe "stories/new", type: :view do
       expect(rendered).to include(story_idea.author_credit)
     end
 
-    it "does not offer a per-item credit preference select" do
+    it "offers a credit preference select that defaults to following the profile" do
       render
 
-      assert_select "select[name=?]", "story[author_credit_preference]", count: 0
+      assert_select "select[name=?]", "story[author_credit_preference]"
+      expect(rendered).to include("None (follow profile)")
     end
 
     context "with sectors and categories from story idea" do

--- a/spec/views/stories/new.html.erb_spec.rb
+++ b/spec/views/stories/new.html.erb_spec.rb
@@ -128,11 +128,10 @@ RSpec.describe "stories/new", type: :view do
       expect(rendered).to include(story_idea.author_credit)
     end
 
-    it "displays story idea author credit preference" do
+    it "does not offer a per-item credit preference select" do
       render
 
-      expect(rendered).to include("author credit preference")
-      expect(rendered).to include(story_idea.author_credit_preference)
+      assert_select "select[name=?]", "story[author_credit_preference]", count: 0
     end
 
     context "with sectors and categories from story idea" do

--- a/spec/views/story_ideas/edit.html.erb_spec.rb
+++ b/spec/views/story_ideas/edit.html.erb_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe "story_ideas/edit", type: :view do
         assert_select "select[name=?]", "story_idea[workshop_id]"
         assert_select "input[name=?][type=?]", "story_idea[rhino_body]", "hidden"
         assert_select "textarea[name=?]", "story_idea[youtube_url]"
-        assert_select "select[name=?]", "story_idea[author_credit_preference]"
       end
     end
 

--- a/spec/views/workshop_ideas/show.html.erb_spec.rb
+++ b/spec/views/workshop_ideas/show.html.erb_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe "workshop_ideas/show", type: :view do
     expect(rendered).to include(/MyTitle/)
     expect(rendered).to include(/MyDescription/)
   end
+
+  it "shows the created-by name through the person's display preference" do
+    author = create(:user, :with_person)
+    author.person.update!(first_name: "Rosalind", last_name: "Franklin",
+                          display_name_preference: "first_name_last_initial")
+    workshop_idea.update!(created_by: author, updated_by: author)
+    render
+
+    expect(rendered).to include("Rosalind F.")
+    expect(rendered).not_to include("Rosalind Franklin")
+  end
 end

--- a/spec/views/workshops/_show_associations.html.erb_spec.rb
+++ b/spec/views/workshops/_show_associations.html.erb_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "workshops/_show_associations", type: :view do
       allow(view).to receive(:allowed_to?).and_return(false)
     end
 
-    it "credits the spotlight through the author's profile, not the raw association" do
-      author.update!(display_name_preference: "first_name_last_initial")
+    it "credits the spotlight by its stored preference, formatted from the author" do
+      spotlight.update!(author_credit_preference: "first_name_last_initial")
       render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
 
       expect(rendered).to include("Rosalind F.")

--- a/spec/views/workshops/_show_associations.html.erb_spec.rb
+++ b/spec/views/workshops/_show_associations.html.erb_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe "workshops/_show_associations", type: :view do
       expect(rendered).not_to include("Rosalind Franklin")
     end
 
-    it "renders Anonymous when the author's profile suppresses credits" do
+    it "renders the generic credit when the author's profile suppresses credits" do
       author.update!(anonymous_contributions: true)
       render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
 
-      expect(rendered).to include("Anonymous")
+      expect(rendered).to include("AWBW Facilitator")
       expect(rendered).not_to include("Rosalind")
     end
   end

--- a/spec/views/workshops/_show_associations.html.erb_spec.rb
+++ b/spec/views/workshops/_show_associations.html.erb_spec.rb
@@ -13,6 +13,32 @@ RSpec.describe "workshops/_show_associations", type: :view do
     assign(:mentionees, {})
   end
 
+  describe "facilitator spotlights" do
+    let(:author) { create(:person, first_name: "Rosalind", last_name: "Franklin") }
+    let(:spotlight) { create(:resource, kind: "LeaderSpotlight", published: true, author: author) }
+
+    before do
+      assign(:leader_spotlights, [ spotlight ])
+      allow(view).to receive(:allowed_to?).and_return(false)
+    end
+
+    it "credits the spotlight through the author's profile, not the raw association" do
+      author.update!(display_name_preference: "first_name_last_initial")
+      render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
+
+      expect(rendered).to include("Rosalind F.")
+      expect(rendered).not_to include("Rosalind Franklin")
+    end
+
+    it "renders Anonymous when the author's profile suppresses credits" do
+      author.update!(anonymous_contributions: true)
+      render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
+
+      expect(rendered).to include("Anonymous")
+      expect(rendered).not_to include("Rosalind")
+    end
+  end
+
   context "when user can manage WorkshopVariation" do
     before do
       allow(view).to receive(:allowed_to?).and_return(false)

--- a/spec/views/workshops/_show_associations.html.erb_spec.rb
+++ b/spec/views/workshops/_show_associations.html.erb_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "workshops/_show_associations", type: :view do
       allow(view).to receive(:allowed_to?).and_return(false)
     end
 
-    it "credits the spotlight by its stored preference, formatted from the author" do
-      spotlight.update!(author_credit_preference: "first_name_last_initial")
+    it "credits the spotlight by the author's profile preference" do
+      author.update!(display_name_preference: "first_name_last_initial")
       render partial: "workshops/show_associations", locals: { workshop: workshop.decorate }
 
       expect(rendered).to include("Rosalind F.")


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 changes how every author credit renders app-wide, narrows search results, and adds an admin reconciliation page

Name display was asked in two unrelated places with two different value sets — `people.display_name_preference` (people index) and `<item>.author_credit_preference` (every credit, on 8 forms). `AuthorCreditable` deliberately called `person.full_name` rather than `person.name`, so the per-item answer won and the profile was ignored. One facilitator could render three different ways with no single place to fix it.

**Now:** the credited person's profile decides how every credit renders.

### Two axes on the profile
| | Column | Governs |
|---|---|---|
| Name format | `display_name_preference` (4 values) | `Person#name` **and** author credits |
| Anonymity | `anonymous_contributions` | Author credits only — the person stays listed and formatted normally on the people index |

`anonymous_contributions` already existed on main but was inert; nothing read it. This makes it govern credits, so `StoryImporter` flagging an anonymous import now genuinely suppresses that credit.

### Interim: forms still collect a per-item preference
Facilitators **cannot edit their own profile** (`PersonPolicy#edit?` is `admin?`), so all 8 forms still collect `author_credit_preference`. It records what the submitter wants — it does **not** drive display or search. A choice that differs from the profile surfaces on the divergences page, and an admin applies it to the profile. Admin forms show the field alongside the existing note and divergence warning, not instead of them.

Follow-up to hide the field from non-admins once profiles are self-service: **#2261**.

### The one asymmetry
Anonymity is a one-way latch — true if the profile says so *or* the item says so, and neither can strip it from the other. Anonymity is inherently per-item, admins need a per-item lever, and there is no backfill, so without it every item currently storing `anonymous` would start rendering its author's real name on deploy.

### Search follows the profile too
Anonymous matches nothing; `first_name_only` isn't findable by last name; `first_name_last_initial` matches the initial only. This meant dropping the `person_first`/`person_last` SearchCop attributes on `Story`/`CommunityNews`, which bypassed the gate. **Tradeoff:** an author name can no longer be one term of an AND full-text query — honoring the preference needs per-person branching a flat index can't express.

### How credit works now, per model

**Collection is unchanged across all 8.** Every form still submits `author_credit_preference`. If blank, `before_create` snapshots the credited person's profile value. The stored value is a consent record, not a formatter — only `anonymous` has live effect.

**Display is one method, `AuthorCreditable#author_credit`.** Precedence: person author → legacy free-text column → `"AWBW Staff"`. The person's `display_name_preference` decides the format; anonymity suppresses to `"AWBW Facilitator"`. No creator fallback — entering a record never credits the enterer.

| Model | Author source | Legacy column | Credit renders |
|---|---|---|---|
| Story | `author` | — | person → "AWBW Staff" |
| CommunityNews | `author` | — | person → "AWBW Staff" |
| WorkshopVariation | `author` | — | person → "AWBW Staff" |
| Workshop | `author` | `full_name` | person → legacy → "AWBW Staff" |
| Resource | `author` | `legacy_author_name` | person → legacy → "AWBW Staff" |
| StoryIdea | *none* | — | always "AWBW Staff" |
| WorkshopIdea | *none* | — | always "AWBW Staff" |
| WorkshopVariationIdea | *none* | — | always "AWBW Staff" |

The three idea models have no `author_id`. Their pages show the submitter via `created_by.name` — admin-facing attribution, not a credit.

**Keep in mind**
- The per-item field is interim — collected, not honored for display, until profiles are self-service (#2261).
- No backfill, so legacy rows carry a NULL preference. That shape is what the leaks below exploited.
- `Person#name` is format-only. Anonymity governs credits, never the people index or profile header.

### Legacy author names no longer escape the gate

`workshops.full_name` and `resources.legacy_author_name` were still full-text indexed, so a name the credit suppressed to a generic label was findable by typing it. Verified both, then fixed:

- Workshop needed more than dropping the SearchCop attribute — its free-text query **never used SearchCop at all**, building its own `LIKE` over a field list that included `full_name`.
- A legacy column is now only searchable when no person author outranks it for display. Otherwise a stale column leaks past an anonymous profile even when the record's own snapshot looks innocent.
- `WorkshopIdea.author_name` went through the credited-person path, which is empty for a model that credits nobody, so the admin filter silently matched nothing. It now matches the submitter the page shows.

### Reconciliation page (`/author_credit_divergences`, linked from admin home)
Four sections, in the order to work them, each naming the code it retires once cleared:

1. **Preference drift** — stored request no longer matches the profile, grouped by person
2. **Legacy name** — credited by a free-text column, reported per column so each field can be retired on its own, with a suggested person matched from the name
3. **Creator fallback** — no `author_id`, so the credit falls back to the creating user's person (idea models excluded — that's their only credit path)
4. **No author** — nothing to credit, renders a generic placeholder

Sections 2–4 all resolve by assigning an `author_id`, the only credit path that follows a profile, links to it, and lists the record there.

### Also swept
Four places where a real name escaped past an anonymized credit, two phantom strong params referencing columns that don't exist, and the fallback labels moved to constants so views stop hardcoding them.

### Verified
7403 examples, 0 failures. Rubocop clean on 1564 files, brakeman 0 warnings. Rebased onto main (conflict-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

