### PR TITLE
Fix scholarships silently orphaned when the award exceeds remaining owed

### DIFF
--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -10,6 +10,7 @@ class Scholarship < ApplicationRecord
 
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
   validate :recipient_must_match_allocation_registrant
+  validate :allocation_must_be_valid
   validate :within_grant_budget, if: :grant
 
   after_update :sync_allocation_amount, if: -> { saved_change_to_amount_cents? }
@@ -53,6 +54,17 @@ class Scholarship < ApplicationRecord
     if others_total + amount_cents > grant.amount_cents
       errors.add(:amount_cents, "would exceed the grant's available funds")
     end
+  end
+
+  # A built allocation is only persisted by has_one autosave *after* the parent
+  # saves, and Rails silently drops it (returning true from save) if it's invalid.
+  # That left orphaned scholarships with no allocation — awarded per the success
+  # flash, but invisible on the registration, which finds them through allocations.
+  # Validate it up front so an over-owed amount fails the save with a clear message.
+  def allocation_must_be_valid
+    return if allocation.nil? || allocation.valid?
+
+    allocation.errors.full_messages.each { |message| errors.add(:base, message) }
   end
 
   def recipient_must_match_allocation_registrant

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -1,7 +1,6 @@
 <%# ---- Scholarship — "Requested" is a plain flag saved with the form; it does
-    not create or destroy an award on its own. Awarding is a deliberate action
-    via "Add scholarship". On save, the controller cleans up an unrequested
-    scholarship only when it is an empty stub (no amount, tasks incomplete). ---- %>
+    not create or destroy an award. Awarding is a deliberate action via
+    "Add scholarship". ---- %>
 <section class="flex min-h-[12rem] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
   <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
     <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:scholarships, scholarship.present? || event_registration.scholarship_requested) %>">

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -191,6 +191,17 @@ RSpec.describe "Scholarships", type: :request do
 
       expect(response).to redirect_to(edit_event_registration_path(registration))
     end
+
+    it "does not create the scholarship and re-renders with a warning when the amount exceeds the remaining owed" do
+      # Event costs $100 with $50 already allocated; a $60 award overshoots the $50 remaining.
+      expect {
+        post scholarships_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registration"),
+             params: { scholarship: { amount_dollars: "60" } }
+      }.not_to change(Scholarship, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Cannot allocate more than remaining event cost")
+    end
   end
 
   describe "back link follows the page the user came from" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one model validation + a stale-comment cleanup, backed by a failing-first spec

### What is the goal of this PR and why is this important?
- Adding a scholarship whose amount exceeds the registration's remaining owed produced a "Scholarship created" flash and redirect, but **no scholarship showed on the registration**.
- Root cause: a scholarship links to a registration only through its `Allocation` (built in-memory in `create` and left to `has_one` autosave). When the amount overshoots remaining owed the allocation is invalid, but autosave **silently drops it and still returns true** — leaving an orphaned scholarship the registration can't find.

### How did you approach the change?
- `Scholarship#allocation_must_be_valid` validates the built allocation up front and surfaces its message, so an over-owed amount fails the whole save and re-renders the form with the real warning (e.g. *"Cannot allocate more than remaining event cost. Remaining: \$50"*). Grant-funded scholarships (no allocation) are unaffected.
- Removed a stale comment in `_scholarship.html.erb` referencing `cleanup_unrequested_scholarship`, deleted back in #1674.

### Anything else to add?
- Failing-first request spec covers the over-amount case (no scholarship created, `422`, warning shown). Scholarship request specs (48) and Scholarship/Allocation/EventRegistration model specs (172) pass.