### PR TITLE
Scope scholarship allocation validation to new allocations; fix over-funded spec

### DIFF
--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -56,13 +56,16 @@ class Scholarship < ApplicationRecord
     end
   end
 
-  # A built allocation is only persisted by has_one autosave *after* the parent
-  # saves, and Rails silently drops it (returning true from save) if it's invalid.
-  # That left orphaned scholarships with no allocation — awarded per the success
-  # flash, but invisible on the registration, which finds them through allocations.
-  # Validate it up front so an over-owed amount fails the save with a clear message.
+  # A newly built allocation is only persisted by has_one autosave *after* the
+  # parent saves, and Rails silently drops it (returning true from save) if it's
+  # invalid. That left orphaned scholarships with no allocation — awarded per the
+  # success flash, but invisible on the registration, which finds them through
+  # allocations. Validate it up front so an over-owed amount fails the save with a
+  # clear message. Scoped to a new allocation so unrelated re-saves of an existing
+  # scholarship aren't blocked by an already-persisted (possibly legacy) allocation.
   def allocation_must_be_valid
-    return if allocation.nil? || allocation.valid?
+    return unless allocation&.new_record?
+    return if allocation.valid?
 
     allocation.errors.full_messages.each { |message| errors.add(:base, message) }
   end

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -30,6 +30,31 @@ RSpec.describe Scholarship, type: :model do
       end
     end
 
+    describe "allocation_must_be_valid" do
+      let(:event) { create(:event, cost_cents: 10_000) }
+      let(:person) { create(:person) }
+      let(:registration) { create(:event_registration, event:, registrant: person) }
+
+      it "is invalid when a newly built allocation overshoots the remaining owed" do
+        scholarship = build(:scholarship, recipient: person, amount_cents: 15_000)
+        scholarship.build_allocation(allocatable: registration, amount: 15_000)
+
+        expect(scholarship).not_to be_valid
+        expect(scholarship.errors[:base]).to include(a_string_matching(/Cannot allocate more than remaining event cost/))
+      end
+
+      it "does not re-validate an already-persisted allocation on an unrelated re-save" do
+        scholarship = create(:scholarship, recipient: person, amount_cents: 10_000)
+        create(:allocation, source: scholarship, allocatable: registration, amount: 10_000)
+        # Shrinking the event below the funded amount would fail the allocation's own
+        # cost check — but a persisted allocation is out of scope, so saving an
+        # unrelated attribute must still succeed.
+        event.update!(cost_cents: 5_000)
+
+        expect { scholarship.update!(agreement_signed: true) }.not_to raise_error
+      end
+    end
+
     describe "within_grant_budget" do
       let(:grant) { create(:grant, amount_cents: 100_000) }
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe "EventRegistrations", type: :request do
 
       it "keeps a funded scholarship when unrequested" do
         existing_registration.update!(scholarship_requested: true)
-        link_scholarship(existing_registration, amount_cents: 5000)
+        link_scholarship(existing_registration, amount_cents: 1000)
 
         expect { unrequest(existing_registration) }
           .not_to change { existing_registration.scholarships.count }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 narrows one validation + repairs a latent broken test; follow-up to #2096

Follow-up to #2096, which merged but turned `main` red.

### What is the goal of this PR and why is this important?
- #2096's `Scholarship#allocation_must_be_valid` ran on **every** save, so an unrelated re-save of an existing scholarship (e.g. toggling `agreement_signed`) could be blocked by an **already-persisted** allocation whose amount no longer fits the event cost (legacy data). Scope it to `new_record?` so it targets only the create-orphan case it was written for.
- It also exposed a latent broken test — `event_registrations_spec` "keeps a funded scholarship when unrequested" funded **\$50 on a \$10.99 event**. That only ever passed because the invalid allocation was silently dropped — the exact orphan bug #2096 fixed. Now it funds within the event cost so the scholarship is actually linked.

### How did you approach the change?
- `allocation_must_be_valid` now returns early unless the allocation is a new record.
- Added two model specs: over-funded new allocation is rejected; an unrelated re-save of an existing scholarship with a now-over-cost persisted allocation still succeeds.
- Fixed the over-funded amount in the registrations spec.

### Anything else to add?
- Green locally: `event_registrations_spec`, `scholarships_spec`, `scholarship_spec` (171 examples, 0 failures).