### PR TITLE
Add comments to topic subscriptions

### DIFF
--- a/app/controllers/topic_subscriptions_controller.rb
+++ b/app/controllers/topic_subscriptions_controller.rb
@@ -121,7 +121,8 @@ class TopicSubscriptionsController < ApplicationController
   end
 
   def topic_subscription_params
-    params.require(:topic_subscription).permit(:person_id, :topic_subscription_type_id, :interested_event_id, :source, :note)
+    params.require(:topic_subscription).permit(:person_id, :topic_subscription_type_id, :interested_event_id, :source,
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ])
   end
 
   # Prefill the topic when opened from an event's Forms menu: an explicit type id

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -6,6 +6,9 @@ class TopicSubscription < ApplicationRecord
   belongs_to :interested_event, class_name: "Event", optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
 
   before_validation :set_subscribed_at, on: :create
   before_validation :clear_event_for_non_event_topic
@@ -17,6 +20,15 @@ class TopicSubscription < ApplicationRecord
   scope :unsubscribed, -> { where.not(unsubscribed_at: nil) }
   scope :for_topic_type, ->(type) { where(topic_subscription_type: type) }
   scope :newest_first, -> { order(subscribed_at: :desc) }
+  scope :comment_status, ->(value) {
+    commented = Comment.where(commentable_type: "TopicSubscription").select(:commentable_id)
+    case value
+    when "none" then where.not(id: commented)
+    when "present" then where(id: commented)
+    when "flagged" then where(id: Comment.where(commentable_type: "TopicSubscription", flagged: true).select(:commentable_id))
+    else all
+    end
+  }
 
   # Drives the subscriptions index filters: person, topic type, and status
   # ("active"/"unsubscribed" — the two the segmented toggle emits). The person
@@ -26,6 +38,7 @@ class TopicSubscription < ApplicationRecord
     scope = all
     scope = scope.where(person_id: params[:person_id]) if params[:person_id].present?
     scope = scope.for_topic_type(params[:topic_subscription_type_id]) if params[:topic_subscription_type_id].present?
+    scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
 
     case params[:status]
     when "active" then scope = scope.active

--- a/app/views/topic_subscriptions/_form.html.erb
+++ b/app/views/topic_subscriptions/_form.html.erb
@@ -16,7 +16,7 @@
 
 <% cancel_path = topic_subscription_return_path %>
 
-<%= form_with model: @topic_subscription, class: "space-y-5", data: { controller: "dirty-form conditional-fields" } do |f| %>
+<%= simple_form_for @topic_subscription, html: { class: "space-y-5", data: { controller: "dirty-form conditional-fields" } } do |f| %>
   <%# Where this form was opened from, so the redirect after save matches the eyebrow. %>
   <% topic_subscription_return_params.each do |key, value| %>
     <%= hidden_field_tag key, value, id: nil %>
@@ -87,10 +87,44 @@
     <%= f.text_field :source, class: field_class, placeholder: "e.g. Facilitator Training registration, admin" %>
   </div>
 
-  <div>
-    <%= f.label :note, "Note (optional)", class: label_class %>
-    <%= f.text_area :note, rows: 3, class: field_class %>
-  </div>
+  <%# ---- Comments (saved with the subscription; shown on the person's aggregated
+      comments page). Replaces the old free-text note field. ---- %>
+  <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
+    <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+      <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:topic_subscriptions, intensity: 100) %> <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>">
+        <i class="fa-solid fa-comments"></i>
+      </span>
+      <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
+    </div>
+
+    <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
+      <div id="comment-list" class="space-y-4">
+        <%= f.simple_fields_for :comments do |cf| %>
+          <%= render "comments/comment_fields", f: cf %>
+        <% end %>
+      </div>
+
+      <div data-paginated-fields-target="nav"></div>
+
+      <div class="flex items-center justify-between gap-2">
+        <%= link_to_add_association f, :comments,
+              partial: "comments/comment_fields",
+              data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
+              class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+          <i class="fa-solid fa-plus text-[0.6rem]"></i>
+          Add comment
+        <% end %>
+
+        <button type="button"
+                class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                data-action="edit-toggle#toggle">
+          <i class="fa-solid fa-pen text-[0.6rem]"></i>
+          <span data-edit-toggle-target="editLabel">Edit comments</span>
+          <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
+        </button>
+      </div>
+    </div>
+  </section>
 
   <div class="flex gap-2 justify-end">
     <%= link_to "Cancel", cancel_path, class: "btn btn-utility-outline", data: { action: "dirty-form#confirmCancel" } %>

--- a/app/views/topic_subscriptions/_search_boxes.html.erb
+++ b/app/views/topic_subscriptions/_search_boxes.html.erb
@@ -26,6 +26,12 @@
               { include_blank: "All topics" },
               class: field_class, onchange: "this.form.requestSubmit()" %>
       </div>
+      <div class="min-w-[150px]">
+        <%= f.label :comment_status, "Comments", class: label_class %>
+        <%= f.select :comment_status,
+              options_for_select([ [ "All", "" ], [ "Has comments", "present" ], [ "Flagged", "flagged" ], [ "None", "none" ] ], params[:comment_status]),
+              {}, class: field_class, onchange: "this.form.requestSubmit()" %>
+      </div>
       <%# Active/unsubscribed lives in the segmented toggle above the results;
           carry the current selection so filtering here doesn't reset it. %>
       <%= hidden_field_tag :status, params[:status], id: nil if params[:status].present? %>

--- a/app/views/topic_subscriptions/email_addresses.html.erb
+++ b/app/views/topic_subscriptions/email_addresses.html.erb
@@ -12,8 +12,6 @@
     </h1>
     <p class="text-gray-600 mt-1">
       <%= pluralize(@email_addresses.size, "unique email address") %> from the current subscriptions filter.
-      This list is narrower than the index: people who unsubscribed are left out, as are people already
-      registered for the event their subscription names. Switch either back on below.
     </p>
 
     <%# The index filters carried through, so it's clear which subscribers this list covers. %>

--- a/db/migrate/20260805023506_remove_note_from_topic_subscriptions.rb
+++ b/db/migrate/20260805023506_remove_note_from_topic_subscriptions.rb
@@ -1,0 +1,11 @@
+class RemoveNoteFromTopicSubscriptions < ActiveRecord::Migration[8.1]
+  # The free-text note field is replaced by polymorphic comments, which surface
+  # on the person's aggregated comments page.
+  def up
+    remove_column :topic_subscriptions, :note, if_exists: true
+  end
+
+  def down
+    add_column :topic_subscriptions, :note, :text unless column_exists?(:topic_subscriptions, :note)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_021441) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_023506) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1318,7 +1318,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_021441) do
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.bigint "interested_event_id"
-    t.text "note"
     t.bigint "person_id", null: false
     t.string "source"
     t.datetime "subscribed_at", null: false

--- a/spec/models/topic_subscription_spec.rb
+++ b/spec/models/topic_subscription_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe TopicSubscription, type: :model do
 
     it "still allows saving an unrelated edit to an active subscription" do
       subscription = create(:topic_subscription)
-      expect(subscription.update(note: "Called in")).to be(true)
+      expect(subscription.update(source: "Called in")).to be(true)
     end
   end
 

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -379,6 +379,35 @@ RSpec.describe "TopicSubscriptions", type: :request do
   # Leaving the index for a row's edit page and coming back must land on the same
   # filtered list, not the bare index — the filters ride along on the link, the
   # form's hidden fields, and the edit page's action buttons.
+  describe "comments on a subscription" do
+    let(:subscription) { create(:topic_subscription) }
+
+    it "renders a comments box on the edit page" do
+      get edit_topic_subscription_path(subscription)
+      expect(response.body).to include("comment-list")
+    end
+
+    it "saves a comment added on the subscription form" do
+      expect {
+        patch topic_subscription_path(subscription),
+              params: { topic_subscription: { comments_attributes: { "0" => { body: "Reached out via email" } } } }
+      }.to change(subscription.comments, :count).by(1)
+
+      expect(subscription.comments.last.body).to eq("Reached out via email")
+    end
+
+    it "filters the index to subscriptions that have comments" do
+      commented = create(:topic_subscription, topic_subscription_type: trainings, person: create(:person, first_name: "Comm", last_name: "Ented"))
+      create(:comment, commentable: commented)
+      create(:topic_subscription, topic_subscription_type: trainings, person: create(:person, first_name: "No", last_name: "Comments"))
+
+      get topic_subscriptions_path(comment_status: "present"), headers: { "Turbo-Frame" => "topic_subscriptions_results" }
+
+      expect(response.body).to include("Comm Ented")
+      expect(response.body).not_to include("No Comments")
+    end
+  end
+
   describe "returning to the filtered index" do
     let(:person) { create(:person, first_name: "Dana", last_name: "Rivers") }
     let!(:subscription) { create(:topic_subscription, person: person, topic_subscription_type: trainings) }
@@ -419,7 +448,7 @@ RSpec.describe "TopicSubscriptions", type: :request do
     it "redirects back to the filtered index after saving" do
       patch topic_subscription_path(subscription), params: filters.merge(
         return_to: "index",
-        topic_subscription: { person_id: person.id, topic_subscription_type_id: trainings.id, note: "Called in" }
+        topic_subscription: { person_id: person.id, topic_subscription_type_id: trainings.id }
       )
 
       expect(response).to redirect_to(topic_subscriptions_path(filters))


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained: one model made commentable, a form field swap, a filter, and a column-drop migration

### What is the goal of this PR and why is this important?
- Topic subscriptions had a single free-text **Note** field. This replaces it with the app's polymorphic **comments** so subscription notes are structured, attributed, and (in the follow-up PR) roll up onto the person's aggregated comments page.

### How did you approach the change?
- Make `TopicSubscription` commentable (nested attrs).
- Swap the form's Note textarea for a **save-with-record comments box** (form converted to `simple_form_for` + cocoon nested fields).
- Add a **Comments filter** (has comments / flagged / none) to the subscriptions index.
- Drop the now-unused `note` column (reversible migration).
- Trim a redundant explanatory blurb on the email-addresses page.

### Anything else to add?
- Split out of #2059 to merge first. The follow-up (#2059) wires these subscription comments into the aggregated per-person comments report + global comments index.
- No data migration for existing `note` values (feature is new; column had little/no data).