### PR TITLE
Jump-link icons on clickable stat boxes + make revenue KPIs drillable

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -120,6 +120,7 @@ class EventsController < ApplicationController
     scope = scope.keyword(params[:keyword]) if params[:keyword].present?
     scope = scope.payment_status(params[:payment_status]) if params[:payment_status].present?
     scope = scope.scholarship_status(params[:scholarship]) if params[:scholarship].present?
+    scope = scope.funder(params[:funder]) if params[:funder].present?
     scope = scope.ce_status(params[:ce_status]) if params[:ce_status].present?
     scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
     scope = scope.organization_status(params[:org_status], @event) if params[:org_status].present?

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -139,6 +139,39 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
+  scope :with_funded_scholarship, -> {
+    where(<<~SQL.squish)
+      EXISTS (
+        SELECT 1 FROM allocations
+        INNER JOIN scholarships ON scholarships.id = allocations.source_id
+        WHERE allocations.allocatable_type = 'EventRegistration'
+          AND allocations.allocatable_id = event_registrations.id
+          AND allocations.source_type = 'Scholarship'
+          AND scholarships.grant_id IS NOT NULL
+      )
+    SQL
+  }
+  scope :with_unfunded_scholarship, -> {
+    where(<<~SQL.squish)
+      EXISTS (
+        SELECT 1 FROM allocations
+        INNER JOIN scholarships ON scholarships.id = allocations.source_id
+        WHERE allocations.allocatable_type = 'EventRegistration'
+          AND allocations.allocatable_id = event_registrations.id
+          AND allocations.source_type = 'Scholarship'
+          AND scholarships.grant_id IS NULL
+      )
+    SQL
+  }
+  # Funder = the grant's donor. "awbw" = org-subsidized (a scholarship drawn from
+  # no grant); "donor" = grant-funded (drawn from an external donor's grant).
+  scope :funder, ->(value) {
+    case value
+    when "awbw" then with_unfunded_scholarship
+    when "donor" then with_funded_scholarship
+    else all
+    end
+  }
   scope :paid_in_full, -> {
     where(<<~SQL.squish)
       COALESCE((
@@ -296,6 +329,15 @@ class EventRegistration < ApplicationRecord
     end
     if params[:event_year].present?
       registrations = registrations.in_event_year(params[:event_year])
+    end
+    if params[:payment_status].present?
+      registrations = registrations.payment_status(params[:payment_status])
+    end
+    if params[:scholarship].present?
+      registrations = registrations.scholarship_status(params[:scholarship])
+    end
+    if params[:funder].present?
+      registrations = registrations.funder(params[:funder])
     end
     registrations
   end

--- a/app/views/admin/ahoy_activities/charts.html.erb
+++ b/app/views/admin/ahoy_activities/charts.html.erb
@@ -70,8 +70,9 @@
             <% end %>
           </h2>
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-            <%= link_to users_path, class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Total users</h3>
+            <%= link_to users_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Total users</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(@filtered_user_count) %></div>
                 <% if @audience_labels.include?("users") && @audience_labels.include?("staff") %>
@@ -87,8 +88,9 @@
               </div>
             <% end %>
 
-            <%= link_to users_path(invited: "true"), class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Invited users</h3>
+            <%= link_to users_path(invited: "true"), class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Invited users</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(@portal_access_users) %></div>
                 <div class="text-xs text-gray-400 mt-2">Sent the welcome instructions email</div>
@@ -100,8 +102,9 @@
               </div>
             <% end %>
 
-            <%= link_to users_path(authenticated: "true"), class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Authenticated users</h3>
+            <%= link_to users_path(authenticated: "true"), class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Authenticated users</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(@authenticated_users) %></div>
                 <div class="text-xs text-gray-400 mt-2">Logged in at least once</div>
@@ -131,8 +134,9 @@
         <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-4">Engagement patterns</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-            <%= link_to admin_activities_visits_path, class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Total visits</h3>
+            <%= link_to admin_activities_visits_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Total visits</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(scoped_visits.count) %></div>
                 <div class="text-xs text-gray-400 mt-2">Sessions in selected period</div>
@@ -142,8 +146,9 @@
               </div>
             <% end %>
 
-            <%= link_to admin_activities_events_path, class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Total activities</h3>
+            <%= link_to admin_activities_events_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Total activities</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(scoped_events.count) %></div>
                 <div class="text-xs text-gray-400 mt-2">Actions in selected period</div>
@@ -295,15 +300,17 @@
         <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-4">Tag analytics</h2>
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-            <%= link_to tags_path, class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Tags page views</h3>
+            <%= link_to tags_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Tags page views</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(@tags_page_views) %></div>
               </div>
             <% end %>
 
-            <%= link_to taggings_path, class: "group bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
-              <h3 class="text-sm font-semibold text-gray-700 mb-2">Taggings page views</h3>
+            <%= link_to taggings_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3.5 right-3.5 transition-colors"></i>
+              <h3 class="text-sm font-semibold text-gray-700 mb-2 pr-4">Taggings page views</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 group-hover:text-blue-600 tabular-nums transition-colors"><%= number_with_delimiter(@taggings_page_views) %></div>
               </div>

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -52,9 +52,10 @@
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
             <% @summary.each do |label, data| %>
               <%= link_to polymorphic_path(label.to_s.classify.constantize), class: "block group" do %>
-                <div class="<%= DomainTheme.bg_class_for(label) %> border border-gray-200 rounded-xl p-5
+                <div class="<%= DomainTheme.bg_class_for(label) %> relative border border-gray-200 rounded-xl p-5
                 shadow-sm hover:shadow-md transition min-h-[120px]">
-                  <div class="text-xs font-semibold tracking-wide uppercase text-gray-500">
+                  <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 group-hover:text-blue-600 absolute top-3 right-3 transition-colors"></i>
+                  <div class="text-xs font-semibold tracking-wide uppercase text-gray-500 pr-4">
                     <%= label.to_s.humanize %>
                   </div>
 

--- a/app/views/events/_participation_kpi.html.erb
+++ b/app/views/events/_participation_kpi.html.erb
@@ -3,8 +3,11 @@
 <% href = local_assigns[:href] %>
 <% tag = href ? :a : :div %>
 <%= content_tag tag, href: href,
-      class: class_names("block rounded-xl border p-4", card_class, "transition-shadow hover:shadow-md" => href.present?) do %>
-  <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= label %></div>
+      class: class_names("block rounded-xl border p-4", card_class, "relative transition-shadow hover:shadow-md" => href.present?) do %>
+  <% if href %>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 absolute top-2.5 right-2.5"></i>
+  <% end %>
+  <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 <%= class_names("pr-4" => href.present?) %>"><%= label %></div>
   <div class="mt-1 text-2xl font-bold tabular-nums <%= value_class %>"><%= number_with_delimiter(value) %></div>
   <% if note %>
     <div class="text-xs italic text-gray-400 whitespace-nowrap">(<%= note %>)</div>

--- a/app/views/events/_revenue_kpi.html.erb
+++ b/app/views/events/_revenue_kpi.html.erb
@@ -1,7 +1,13 @@
 <% note = local_assigns[:note] %>
 <% card_class = local_assigns.fetch(:card_class, "border-gray-200 bg-white") %>
-<div class="rounded-xl border <%= card_class %> p-4">
-  <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= label %></div>
+<% href = local_assigns[:href] %>
+<% tag = href ? :a : :div %>
+<%= content_tag tag, href: href,
+      class: class_names("block rounded-xl border p-4", card_class, "relative transition-shadow hover:shadow-md" => href.present?) do %>
+  <% if href %>
+    <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 absolute top-2.5 right-2.5"></i>
+  <% end %>
+  <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 <%= class_names("pr-4" => href.present?) %>"><%= label %></div>
   <div class="mt-1 text-2xl font-bold tabular-nums <%= value_class %>"><%= value %></div>
   <% if note %>
     <div class="text-xs italic text-gray-400 whitespace-nowrap">(<%= note %>)</div>
@@ -10,4 +16,4 @@
   <% if delta %>
     <div class="mt-1 flex items-center gap-1.5"><%= delta %><span class="text-xs text-gray-400">vs <%= prior_year %></span></div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/events/_stat_segment.html.erb
+++ b/app/views/events/_stat_segment.html.erb
@@ -2,7 +2,7 @@
     a label, linking to the matching filtered registrant list. Compact so several
     fit on one row. Locals: metric = { label:, value:, icon:, theme:, path:, sub? }. %>
 <%= link_to metric[:path],
-      class: "flex items-center gap-3 px-4 py-3 grow basis-40 hover:bg-gray-50 transition-colors" do %>
+      class: "group flex items-center gap-3 px-4 py-3 grow basis-40 hover:bg-gray-50 transition-colors" do %>
   <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(metric[:theme], intensity: 100) %> <%= DomainTheme.text_class_for(metric[:theme], intensity: 600) %>">
     <i class="fa-solid <%= metric[:icon] %>"></i>
   </span>
@@ -10,6 +10,7 @@
     <span class="block leading-tight">
       <span class="text-xl font-bold text-gray-900 tabular-nums"><%= metric[:value] %></span>
       <span class="text-xs text-gray-500"><%= metric[:label] %></span>
+      <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"></i>
     </span>
     <% if metric[:sub].present? %>
       <span class="block text-xs text-gray-400 mt-0.5 truncate"><%= metric[:sub] %></span>

--- a/app/views/events/background.html.erb
+++ b/app/views/events/background.html.erb
@@ -82,9 +82,10 @@
         <i class="fa-solid fa-users"></i>
       </span>
       <span class="min-w-0">
-        <%= link_to background_return_path(registrants_event_path(@event), "overview"), class: "block hover:underline leading-tight" do %>
+        <%= link_to background_return_path(registrants_event_path(@event), "overview"), class: "group/reg block hover:underline leading-tight" do %>
           <span class="text-xl font-bold text-gray-900 tabular-nums"><%= @dashboard.registrant_count %></span>
           <span class="text-xs text-gray-500">Registrants</span>
+          <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-gray-400 opacity-0 group-hover/reg:opacity-100 transition-opacity"></i>
         <% end %>
         <span class="block text-xs text-gray-400 mt-0.5">
           <%= link_to recipients_event_path(@event), class: "hover:underline whitespace-nowrap" do %><%= pluralize(@dashboard.scholarship_recipient_count, "scholarship") %><% end %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -44,16 +44,20 @@
         <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-[repeat(4,minmax(0,1fr))_minmax(0,1.5fr)_minmax(0,1.2fr)] gap-3">
           <%= render "revenue_kpi", label: "Fees collected", value: dollars_from_cents(featured.fees_cents),
                 value_class: "text-blue-700", card_class: "border-blue-300 bg-blue-100", note: "reg + CE paid", cents: featured.fees_cents,
-                prior_cents: prior&.fees_cents, prior_year: prior&.year %>
+                prior_cents: prior&.fees_cents, prior_year: prior&.year,
+                href: event_registrations_path(payment_status: "paid", event_year: featured.year, event_id: params[:event_id]) %>
           <%= render "revenue_kpi", label: "Scholarships", value: dollars_from_cents(featured.funded_scholarship_cents),
                 value_class: "text-fuchsia-700", card_class: "border-fuchsia-300 bg-fuchsia-50", note: "grant-funded only", cents: featured.funded_scholarship_cents,
-                prior_cents: prior&.funded_scholarship_cents, prior_year: prior&.year %>
+                prior_cents: prior&.funded_scholarship_cents, prior_year: prior&.year,
+                href: event_registrations_path(funder: "donor", event_year: featured.year, event_id: params[:event_id]) %>
           <%= render "revenue_kpi", label: "Org subsidy", value: dollars_from_cents(featured.org_subsidy_cents),
                 value_class: "text-red-600", card_class: "border-red-300 bg-red-50", note: "discounts + unfunded", cents: featured.org_subsidy_cents,
-                prior_cents: prior&.org_subsidy_cents, prior_year: prior&.year %>
+                prior_cents: prior&.org_subsidy_cents, prior_year: prior&.year,
+                href: event_registrations_path(funder: "awbw", event_year: featured.year, event_id: params[:event_id]) %>
           <%= render "revenue_kpi", label: "Outstanding", value: dollars_from_cents(featured.outstanding_cents),
                 value_class: "text-orange-600", card_class: "border-orange-300 bg-orange-50", note: "reg + CE owed", cents: featured.outstanding_cents,
-                prior_cents: prior&.outstanding_cents, prior_year: prior&.year %>
+                prior_cents: prior&.outstanding_cents, prior_year: prior&.year,
+                href: event_registrations_path(payment_status: "unpaid", event_year: featured.year, event_id: params[:event_id]) %>
           <%= render "revenue_kpi", label: "Net", value: signed_dollars_from_cents(featured.net_cents),
                 value_class: featured.net_cents.negative? ? "text-rose-700" : "text-gray-500", card_class: "border-gray-300 bg-gray-50",
                 note: "fees + scholarships − subsidies", cents: featured.net_cents, prior_cents: prior&.net_cents, prior_year: prior&.year %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -322,6 +322,31 @@ RSpec.describe EventRegistration, type: :model do
       end
     end
 
+    describe ".funder" do
+      let(:funded_reg) { create(:event_registration, event: event) }
+
+      before do
+        funded = create(:scholarship, recipient: funded_reg.registrant, grant: create(:grant), amount_cents: 1000)
+        create(:allocation, source: funded, allocatable: funded_reg, amount: 1000)
+      end
+
+      it "maps 'awbw' to recipients of grant-less (org-subsidized) scholarships" do
+        results = EventRegistration.funder("awbw")
+        expect(results).to include(scholarship_reg, incomplete_scholarship_reg)
+        expect(results).not_to include(funded_reg, paid_reg, unpaid_reg)
+      end
+
+      it "maps 'donor' to recipients of grant-funded scholarships" do
+        results = EventRegistration.funder("donor")
+        expect(results).to include(funded_reg)
+        expect(results).not_to include(scholarship_reg, incomplete_scholarship_reg, paid_reg, unpaid_reg)
+      end
+
+      it "returns an unfiltered relation for unknown values" do
+        expect(EventRegistration.funder("bogus")).to include(funded_reg, scholarship_reg, paid_reg, unpaid_reg)
+      end
+    end
+
     describe ".ce_status" do
       let(:ce_cost) { 15_000 }
       # Known license, fully paid (certificate not yet issued).

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -96,6 +96,36 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).not_to include(existing_registration.registrant.name)
       end
 
+      it "filters registrations by payment status" do
+        paid_event = create(:event, cost_cents: 1000)
+        paid = create(:event_registration, event: paid_event)
+        create(:allocation, source: create(:payment, amount_cents: 1000, amount_cents_remaining: 1000),
+                            allocatable: paid, amount: 1000)
+        unpaid = create(:event_registration, event: paid_event)
+
+        get event_registrations_path(payment_status: "paid")
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(paid.registrant.name)
+        expect(response.body).not_to include(unpaid.registrant.name)
+      end
+
+      it "filters registrations by funder (org-subsidized vs grant-funded)" do
+        org_subsidized = create(:event_registration)
+        unfunded = create(:scholarship, recipient: org_subsidized.registrant, amount_cents: 1000)
+        create(:allocation, source: unfunded, allocatable: org_subsidized, amount: 1000)
+        grant_funded = create(:event_registration)
+        funded = create(:scholarship, recipient: grant_funded.registrant, grant: create(:grant), amount_cents: 1000)
+        create(:allocation, source: funded, allocatable: grant_funded, amount: 1000)
+
+        get event_registrations_path(funder: "awbw")
+        expect(response.body).to include(org_subsidized.registrant.name)
+        expect(response.body).not_to include(grant_funded.registrant.name)
+
+        get event_registrations_path(funder: "donor")
+        expect(response.body).to include(grant_funded.registrant.name)
+        expect(response.body).not_to include(org_subsidized.registrant.name)
+      end
+
       it "exports CSV with headers and data only (no captions)" do
         get event_registrations_path, params: { format: :csv }
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -180,6 +180,15 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include('title="TAC 261"')
       end
 
+      it "links each drillable revenue KPI to its filtered registrant list" do
+        sign_in admin
+        get revenue_events_path
+        expect(response.body).to include("payment_status=paid")   # Fees collected
+        expect(response.body).to include("payment_status=unpaid") # Outstanding
+        expect(response.body).to include("funder=donor")          # Scholarships (grant-funded)
+        expect(response.body).to include("funder=awbw")           # Org subsidy
+      end
+
       # The Event dropdown lists every (paid) event, so the report rows are
       # identified by their per-event dashboard link rather than the title.
       it "narrows to facilitator trainings by event type" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -935,6 +935,28 @@ RSpec.describe "Events", type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it "does not crash on an invalid funder" do
+        get registrants_event_path(event, funder: "bogus")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "funder filter" do
+      it "narrows the roster to org-subsidized (unfunded) scholarship recipients" do
+        subsidized = create(:event_registration, event: event, registrant: create(:person, first_name: "Orgsubsidized", last_name: "Recipient"))
+        create(:allocation, source: create(:scholarship, recipient: subsidized.registrant, amount_cents: 1000),
+                            allocatable: subsidized, amount: 1000)
+        grant_funded = create(:event_registration, event: event, registrant: create(:person, first_name: "Grantfunded", last_name: "Recipient"))
+        create(:allocation, source: create(:scholarship, recipient: grant_funded.registrant, grant: create(:grant), amount_cents: 1000),
+                            allocatable: grant_funded, amount: 1000)
+
+        get registrants_event_path(event, funder: "awbw")
+
+        expect(response.body).to include("Orgsubsidized")
+        expect(response.body).not_to include("Grantfunded")
+      end
     end
 
     context "active/inactive filtering" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new registration query filters (payment/funder scopes) + revenue KPIs now link to filtered lists, across 5 stat-box surfaces

Makes clickable stat boxes signal that they navigate (jump-link icon), and makes the revenue report's KPI tiles drillable into a filtered registrant list.

**Why**
- Several stat boxes are fully clickable but nothing tells you so.
- Revenue KPIs looked identical to the (clickable) participation KPIs but went nowhere.

**Backend**
- `EventRegistration`: new `with_funded_scholarship` / `with_unfunded_scholarship` + a `funder` scope (`awbw` = org-subsidized, no grant; `donor` = grant-funded). Keyed on `scholarships.grant_id`.
- `search_by_params` (cross-event index) now honors `payment_status`, `scholarship`, `funder`; added `funder` to the per-event roster too (it already took the first two).

**Jump icons (all 5 clickable stat-box types)** — `fa-arrow-up-right-from-square`, top-right, matching the dashboard convention:
- Participation KPI tiles, revenue KPI tiles, admin analytics view-count cards, admin ahoy portal-usage cards → always-on.
- Event stat bar (Registrants / Organizations / Sectors segments) → hover-revealed (too crowded for always-on). Locations count stays unlinked (no single filter destination).

**Revenue KPIs now link** (year-level → cross-event index, carrying `event_id` when filtered to one event):
- Fees collected → `payment_status=paid` · Outstanding → `payment_status=unpaid` · Scholarships → `funder=donor` · Org subsidy → `funder=awbw`.
- Net / Total expected stay non-clickable (derived aggregates with no registrant list).

**Note:** a dollar figure vs. a registrant count isn't a 1:1 reconciliation (a partly-paid registrant adds to "Fees collected" but shows under `payment_status=unpaid`); the org-subsidy link lists only the unfunded-scholarship recipients, not the discount portion. Same approximation the participation KPIs already make.