### PR TITLE
Keep scholarship status toggle label fixed and default it on

### DIFF
--- a/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_status_toggle_controller.js
@@ -3,10 +3,10 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="scholarship-status-toggle"
 // Shows or hides every recipient's scholarship status (awarded amount + whether
 // the tasks are completed) across all recipient cards at once, keeping the
-// switch's label, track, knob, and aria-checked state in sync.
+// switch's track, knob, and aria-checked state in sync. The label stays fixed.
 export default class extends Controller {
-  static targets = ["status", "label", "switch", "track", "knob"]
-  static values = { shown: { type: Boolean, default: false } }
+  static targets = ["status", "switch", "track", "knob"]
+  static values = { shown: { type: Boolean, default: true } }
 
   toggle() {
     this.shownValue = !this.shownValue
@@ -14,9 +14,6 @@ export default class extends Controller {
 
   shownValueChanged() {
     this.statusTargets.forEach((el) => el.classList.toggle("hidden", !this.shownValue))
-    if (this.hasLabelTarget) {
-      this.labelTarget.textContent = this.shownValue ? "Hide scholarship status" : "Show scholarship status"
-    }
     if (this.hasSwitchTarget) {
       this.switchTarget.setAttribute("aria-checked", this.shownValue)
     }

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -62,7 +62,7 @@
             <span class="inline-block h-4 w-4 translate-x-[1.125rem] transform rounded-full bg-white shadow transition-transform"
                   data-scholarship-status-toggle-target="knob"></span>
           </span>
-          <span data-scholarship-status-toggle-target="label">Hide scholarship status</span>
+          <span>Show scholarship status</span>
         </button>
         <%# Expand / collapse all %>
         <button type="button" data-action="expandable-cards#toggleAll"

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2390,7 +2390,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include('data-controller="expandable-cards scholarship-status-toggle"')
         expect(response.body).to include('data-action="scholarship-status-toggle#toggle"')
         expect(response.body).to include('data-scholarship-status-toggle-shown-value="true"')
-        expect(response.body).to include("Hide scholarship status")
+        expect(response.body).to include("Show scholarship status")
       end
 
       it "renders the Recipients and Statistics section headers with placeholder breakdowns" do


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 tiny toggle label/default change, no logic

### What is the goal of this PR and why is this important?
- The scholarship status switch on the event recipients page flipped its label between "Show"/"Hide", reading as the action rather than the state.

### How did you approach the change?
- Fixed the label to "Show scholarship status" (describes the feature), dropped the unused `label` target.
- Aligned the Stimulus `shown` default (`true`) with the view so it's on by default even without the explicit attribute. Fuchsia on-state unchanged.