### PR TITLE
Remove avatar section from reset_password_fyi mailer

### DIFF
--- a/app/views/notification_mailer/reset_password_fyi.html.erb
+++ b/app/views/notification_mailer/reset_password_fyi.html.erb
@@ -24,19 +24,6 @@
     (<%= mail_to @user.email %>)
     requested a password reset.
   </p>
-
-  <% if @person&.avatar&.attached? %>
-    <h2 style="margin-bottom: 8px; text-align: left;">
-      Avatar
-    </h2>
-
-    <p style="margin: 0;">
-      <%= image_tag @person.avatar,
-                    width: 96,
-                    height: 96,
-                    style: "border-radius: 50%; display: block;" %>
-    </p>
-  <% end %>
 </div>
 
 <hr style="margin: 24px 0;">

--- a/app/views/notification_mailer/reset_password_fyi.html.erb
+++ b/app/views/notification_mailer/reset_password_fyi.html.erb
@@ -25,13 +25,13 @@
     requested a password reset.
   </p>
 
-  <% if @person&.avatar&.file&.attached? %>
+  <% if @person&.avatar&.attached? %>
     <h2 style="margin-bottom: 8px; text-align: left;">
       Avatar
     </h2>
 
     <p style="margin: 0;">
-      <%= image_tag @person.avatar.file,
+      <%= image_tag @person.avatar,
                     width: 96,
                     height: 96,
                     style: "border-radius: 50%; display: block;" %>

--- a/app/views/notification_mailer/reset_password_fyi.text.erb
+++ b/app/views/notification_mailer/reset_password_fyi.text.erb
@@ -19,10 +19,10 @@ requested a password reset.
 Profile:
 <%= profile_url %>
 
-<% if @person&.avatar&.file&.attached? %>
+<% if @person&.avatar&.attached? %>
 
   Avatar available:
-  <%= url_for(@person.avatar.file) %>
+  <%= url_for(@person.avatar) %>
 
 <% end %>
 

--- a/app/views/notification_mailer/reset_password_fyi.text.erb
+++ b/app/views/notification_mailer/reset_password_fyi.text.erb
@@ -19,13 +19,6 @@ requested a password reset.
 Profile:
 <%= profile_url %>
 
-<% if @person&.avatar&.attached? %>
-
-  Avatar available:
-  <%= url_for(@person.avatar) %>
-
-<% end %>
-
 ------------------------------------------------------------
 
 View notifications:

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -318,9 +318,9 @@ RSpec.describe NotificationMailer, type: :mailer do
         )
       end
 
-      it "renders the avatar section" do
+      it "renders without touching the avatar" do
         expect(mail.body.encoded).to match("requested a password reset")
-        expect(mail.body.encoded).to include("Avatar")
+        expect(mail.body.encoded).not_to include("Avatar")
       end
     end
   end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -306,5 +306,22 @@ RSpec.describe NotificationMailer, type: :mailer do
         mail.deliver_now
       }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    context "when the user's person has an avatar attached" do
+      let(:user) { create(:user, :with_person, email: "user@example.com") }
+
+      before do
+        user.person.avatar.attach(
+          io: Rails.root.join("spec/fixtures/files/sample.png").open,
+          filename: "sample.png",
+          content_type: "image/png"
+        )
+      end
+
+      it "renders the avatar section" do
+        expect(mail.body.encoded).to match("requested a password reset")
+        expect(mail.body.encoded).to include("Avatar")
+      end
+    end
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 removes one section from a mailer's two templates + a spec

### What is the goal of this PR and why is this important?
- Honeybadger: `reset_password_fyi` raised `undefined method 'file' for an instance of ActiveStorage::Attached::One` whenever a person with an attached avatar triggered a password-reset FYI email.
- The avatar was incidental to a password-reset FYI notification and was the sole source of the crash, so it's removed from the mailer rather than gated/fixed.

### How did you approach the change?
- Dropped the avatar block from both the HTML and text templates.
- Updated the spec to attach an avatar and assert the mail still renders without an avatar section (the old code crashed here).