### PR TITLE
Fix Report#image crash from Paperclip-style .file access

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -160,7 +160,7 @@ class Report < ApplicationRecord
   private
 
   def set_has_attachment
-    self.has_attachment = image&.file&.attached? || form_file&.attached? ||
+    self.has_attachment = image.attached? || form_file&.attached? ||
       media_files.any? { |media_file| media_file.file.attached? }
   end
 

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -110,10 +110,10 @@
               Choose File
             <% end %>
 
-          <% if @report.image %>
+          <% if @report.image.attached? %>
             <div class="row">
               <div class="col-xs-2">
-                <%= image_tag @report.image.file, class: "portrait-img" %>
+                <%= image_tag @report.image, class: "portrait-img" %>
                 </div>
              </div>
             <% end %>

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -27,4 +27,25 @@ RSpec.describe Report do
     it { should validate_content_type_of(:form_file).allowing(Report::FORM_FILE_CONTENT_TYPES) }
     it { should validate_content_type_of(:form_file).rejecting("text/plain", "text/xml") }
   end
+
+  describe "#set_has_attachment" do
+    let(:report) { create(:report) }
+
+    it "sets has_attachment when an image is attached" do
+      report.image.attach(
+        io: Rails.root.join("spec/fixtures/files/sample.png").open,
+        filename: "sample.png",
+        content_type: "image/png"
+      )
+      report.save!
+
+      expect(report.has_attachment).to be(true)
+    end
+
+    it "leaves has_attachment false with no attachments" do
+      report.save!
+
+      expect(report.has_attachment).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 same ActiveStorage fix as #2104, applied to Report#image in a save callback + edit view

### What is the goal of this PR and why is this important?
- Follow-up to the reset-password mailer fix (#2104): the same bug class exists for `Report#image`.
- `report.rb:16` declares `has_one_attached :image`, so `report.image` is an `ActiveStorage::Attached::One` with no `#file` method. Calling `.image.file` raises `undefined method 'file'`.
- Higher-severity than the mailer case because `set_has_attachment` is a `before_save` callback — any report save with an image attached hits it.

### How did you approach the change?
- `report.rb` — `image&.file&.attached?` → `image.attached?` in `set_has_attachment`.
- `reports/edit.html.erb` — `image_tag @report.image.file` → `image_tag @report.image`; also fixed the guard `if @report.image` (always truthy for an attachment object) → `if @report.image.attached?`.
- Added a model spec around `set_has_attachment` (reproduced the exact crash before the fix).