### PR TITLE
Add a certificate slider to the registrants roster, synced to certificate_sent_at

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -2,7 +2,7 @@ class EventRegistrationsController < ApplicationController
   require "csv"
 
   # show redirects to slug URL; kept for backwards compatibility
-  before_action :set_event_registration, only: [ :show, :edit, :update, :destroy, :update_onboarding ]
+  before_action :set_event_registration, only: [ :show, :edit, :update, :destroy, :update_onboarding, :toggle_certificate_issued ]
 
   def index
     authorize!
@@ -153,6 +153,17 @@ class EventRegistrationsController < ApplicationController
     respond_to do |format|
       format.turbo_stream
       format.html { redirect_to helpers.onboarding_event_row_path(@event_registration.event, @event_registration.id) }
+    end
+  end
+
+  # Inline toggle of the "certificate issued" flag from the registrants roster.
+  # Replaces just the cell so the whole roster doesn't re-render on every toggle.
+  def toggle_certificate_issued
+    authorize! @event_registration, to: :toggle_certificate_issued?
+    @event_registration.mark_certificate_issued!(ActiveModel::Type::Boolean.new.cast(params[:value]))
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to helpers.registrants_event_row_path(@event_registration.event, @event_registration.id) }
     end
   end
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -551,6 +551,23 @@ class EventRegistration < ApplicationRecord
     continuing_education_registrations.all? { |c| c.certificate_sent_at.present? }
   end
 
+  # The registration's completion certificate, as shown by the registrants-roster
+  # toggle. For a CE-eligible registration that's the CE certificate
+  # (certificate_sent_at on its CE registrations, so it stays in sync with the CE
+  # edit page); otherwise the registration's own certificate_sent_at (Certifiable).
+  def certificate_issued?
+    ce_registered? ? ce_certificate_issued? : certificate_sent?
+  end
+
+  def mark_certificate_issued!(issued)
+    at = issued ? Time.current : nil
+    if ce_registered?
+      continuing_education_registrations.each { |c| c.update!(certificate_sent_at: at) }
+    else
+      update!(certificate_sent_at: at)
+    end
+  end
+
   # True when a CE registration exists and every one is fully paid.
   def ce_paid_in_full?
     return false unless ce_registered?

--- a/app/policies/event_registration_policy.rb
+++ b/app/policies/event_registration_policy.rb
@@ -18,6 +18,9 @@ class EventRegistrationPolicy < ApplicationPolicy
   # Editing the onboarding matrix is an admin management action; event owners
   # (the event's creator) manage their own events' onboarding too.
   def update_onboarding? = admin? || event_owner?
+  # Marking a certificate issued from the registrants roster is an event-management
+  # action, so mirror the roster's audience (admins and the event's owner).
+  def toggle_certificate_issued? = admin? || event_owner?
 
 
   relation_scope do |relation|

--- a/app/views/event_registrations/_certificate_issued_toggle.html.erb
+++ b/app/views/event_registrations/_certificate_issued_toggle.html.erb
@@ -1,0 +1,15 @@
+<%# Inline "certificate issued" slider toggle, targeted by id for turbo replacement.
+    The track is a direct sibling of the checkbox so peer-checked applies (it only
+    reaches later siblings, not their descendants); the knob is the track's ::after. %>
+<span id="<%= dom_id(registration, :certificate_issued) %>" class="inline-block">
+  <%= form_with url: toggle_certificate_issued_event_registration_path(registration), method: :patch, class: "inline" do %>
+    <%= hidden_field_tag :value, "0" %>
+    <label class="relative inline-flex items-center cursor-pointer select-none">
+      <%= check_box_tag :value, "1", registration.certificate_issued?,
+            onchange: "this.form.requestSubmit()",
+            "aria-label": "Certificate issued",
+            class: "peer sr-only" %>
+      <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-teal-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
+    </label>
+  <% end %>
+</span>

--- a/app/views/event_registrations/toggle_certificate_issued.turbo_stream.erb
+++ b/app/views/event_registrations/toggle_certificate_issued.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%# Replace just the toggled cell — avoids re-rendering the whole roster. %>
+<%= turbo_stream.replace dom_id(@event_registration, :certificate_issued) do %>
+  <%= render "event_registrations/certificate_issued_toggle", registration: @event_registration %>
+<% end %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -130,6 +130,24 @@
             <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
           </span>
         </label>
+
+        <%# Off by default — Certificate issued is hidden until the admin reveals it. %>
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+               data-controller="column-toggle" data-column-toggle-group-value="certificate">
+          <span class="text-sm text-gray-500">Certificate</span>
+
+          <input
+            type="checkbox"
+            data-column-toggle-target="toggle"
+            data-action="column-toggle#toggle"
+            class="sr-only"
+          >
+
+          <span class="relative inline-block w-9 h-5">
+            <span data-column-toggle-target="track" class="absolute inset-0 rounded-full bg-gray-300 transition-colors"></span>
+            <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform"></span>
+          </span>
+        </label>
       </div>
     </div>
 
@@ -193,6 +211,8 @@
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700" aria-sort="none">
                 <%= render "shared/sortable_header", label: "Status", index: status_index %>
               </th>
+              <%# Off by default; kept out of the sortable index range (last data column). %>
+              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 hidden" data-column-toggle-col="certificate">Certificate</th>
               <th class="px-4 py-2"></th>
             </tr>
           </thead>
@@ -448,6 +468,9 @@
                         label: readiness.status_label,
                         issues: readiness.status_issues,
                         subtext: readiness.status_reason %>
+                </td>
+                <td class="px-4 py-2 text-sm text-center hidden" data-column-toggle-col="certificate">
+                  <%= render "event_registrations/certificate_issued_toggle", registration: registration %>
                 </td>
                 <td class="px-4 py-2 text-right text-sm"><%= link_to "Edit", edit_event_registration_path(registration, return_to: "registrants"), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
               </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
       post :create_organization
       delete :unlink_organization
       patch :update_onboarding
+      patch :toggle_certificate_issued
     end
     resources :comments, only: [ :index, :create, :update ]
   end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -268,6 +268,42 @@ RSpec.describe "EventRegistrations", type: :request do
       end
     end
 
+    describe "PATCH /event_registrations/:id/toggle_certificate_issued" do
+      let(:registration) { create(:event_registration, event: event) }
+
+      def toggle_certificate(value)
+        patch toggle_certificate_issued_event_registration_path(registration),
+              params: { value: value },
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+
+      it "marks the registration's certificate issued" do
+        toggle_certificate("1")
+        expect(registration.reload.certificate_issued?).to be(true)
+      end
+
+      it "clears the certificate when unchecked" do
+        registration.mark_certificate_sent!
+        toggle_certificate("0")
+        expect(registration.reload.certificate_issued?).to be(false)
+      end
+
+      it "drives the CE certificate for a CE registration, so it stays in sync with the CE edit page" do
+        ce = create(:continuing_education_registration, event_registration: registration)
+
+        toggle_certificate("1")
+        expect(ce.reload.certificate_sent_at).to be_present
+
+        toggle_certificate("0")
+        expect(ce.reload.certificate_sent_at).to be_nil
+      end
+
+      it "replaces just the toggled cell in the turbo stream" do
+        toggle_certificate("1")
+        expect(response.body).to include("certificate_issued_event_registration_#{registration.id}")
+      end
+    end
+
     describe "POST /event_registrations" do
       it "creates registration and redirects admin to confirm page" do
         expect {
@@ -1090,6 +1126,14 @@ RSpec.describe "EventRegistrations", type: :request do
       it "redirects to root (unauthorized)" do
         get event_registration_path(existing_registration)
         expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "PATCH /event_registrations/:id/toggle_certificate_issued" do
+      it "is forbidden for the registrant themselves" do
+        patch toggle_certificate_issued_event_registration_path(existing_registration), params: { value: "1" }
+        expect(response).to redirect_to(root_path)
+        expect(existing_registration.reload.certificate_issued?).to be(false)
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 removes a column and adds model/controller logic that writes CE certificate_sent_at

### What is the goal of this PR and why is this important?
- Admins can mark a completion certificate issued from the registrants roster, and it stays in sync with the CE registration edit page.

### How did you approach the change?
- **Certificate** column-toggle switch on the roster header (off by default) reveals a per-row **slider**. Toggling it writes `certificate_sent_at` — the CE registrations’ timestamp when CE-eligible (so it mirrors the CE edit page), otherwise the registration’s own. No new column: the earlier `certificate_issued` boolean is dropped.
- Slider is teal (the CE domain color). Fixed its knob, which never moved because `peer-checked:` was on descendant spans instead of a sibling — the click submitted fine but the control looked frozen.

### Anything else to add?
- Certificate state is intentionally *one* concept now (`certificate_sent_at`), not a separate boolean.
- The CE-column link rework that was originally bundled here is now split out into #2127.