### PR TITLE
Bootstrap mise in conductor-setup so a fresh machine can set up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ Either option below will get you a working development environment. Pick whichev
    - Verify that mise is working by running `mise --version`
 2. Install MySQL
    - **macOS**: [Use Homebrew](https://formulae.brew.sh/formula/mysql@8.0)
+     ```
+     brew install mysql@8.0
+     brew services start mysql@8.0
+     ```
+     `mysql@8.0` is keg-only, so add its `bin` to your PATH (or `brew link mysql@8.0`) — otherwise `bin/setup` can't find the `mysql` client:
+     ```
+     echo 'export PATH="$(brew --prefix)/opt/mysql@8.0/bin:$PATH"' >> ~/.zshrc
+     ```
    - **Windows**: Use WSL2 with Ubuntu - follow [the MariaDB install guide from digital ocean](https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-on-ubuntu-20-04#step-1-installing-mariadb)
    - **Linux/Ubuntu**: Follow [the MariaDB install guide from digital ocean](https://www.digitalocean.com/community/tutorials/how-to-install-mariadb-on-ubuntu-20-04#step-1-installing-mariadb)
    - Alternative (Docker): with docker installed run `mise docker-db` to start the DB only (after cloning the repo)

--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -7,19 +7,49 @@
 set -e
 cd $(dirname "$0")/..
 
-# Activate mise so the project's Ruby/Node are on PATH. This script runs
-# under /bin/sh, which does not source ~/.zshenv, so the shims-in-zshenv
-# install documented in CONTRIBUTING.md does not apply here.
+# Resolve mise so the project's Ruby/Node are on PATH. This script runs under
+# /bin/sh, which does not source ~/.zshenv, so the shims-in-zshenv install
+# documented in CONTRIBUTING.md does not apply here — and a fresh machine may
+# have no mise at all, only the system Ruby (2.6), which can't satisfy the
+# Gemfile and yields a cryptic "Could not find 'bundler'" error. Check the
+# common install locations (the official installer lands mise in ~/.local/bin,
+# Homebrew in /opt/homebrew/bin) and bootstrap it if it's missing, so setup is
+# self-contained and doesn't depend on the developer's shell being configured.
+MISE=""
+if command -v mise > /dev/null 2>&1; then
+  MISE="mise"
+else
+  for candidate in /opt/homebrew/bin/mise /usr/local/bin/mise "$HOME/.local/bin/mise"; do
+    if [ -x "$candidate" ]; then
+      MISE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$MISE" ]; then
+  echo "mise not found — installing it (needed for the project's Ruby/Node)..."
+  curl -fsSL https://mise.run | sh
+  MISE="$HOME/.local/bin/mise"
+fi
+
+if [ ! -x "$MISE" ] && ! command -v "$MISE" > /dev/null 2>&1; then
+  echo "Error: mise is required but could not be installed."
+  echo "Install it manually, then re-run: https://mise.jdx.dev/getting-started.html"
+  exit 1
+fi
+
+# Trust mise.toml (avoids a per-workspace prompt) and install the pinned
+# toolchain (.ruby-version + node) before activating — a fresh machine won't
+# have Ruby 4.0.1 yet, so the shims would otherwise resolve to nothing.
 # Use shims (not the activate hook): the shims output is a single POSIX
 # `export PATH=...` line, so it runs under any /bin/sh — including dash on
 # Linux — whereas `mise activate <shell>` emits shell-specific code that only
 # works in that exact shell. The script's interpreter, not the developer's
 # login shell, is what matters here.
-if command -v mise > /dev/null 2>&1; then
-  eval "$(mise activate bash --shims)"
-elif [ -x /opt/homebrew/bin/mise ]; then
-  eval "$(/opt/homebrew/bin/mise activate bash --shims)"
-fi
+"$MISE" trust > /dev/null 2>&1 || true
+"$MISE" install
+eval "$("$MISE" activate bash --shims)"
 
 # CONDUCTOR_PORT is Conductor-specific. Expose it under the generic
 # WORKSPACE_PORT name so the rest of the app (database.yml, initializers,
@@ -42,12 +72,6 @@ if [ -z "$CONDUCTOR_ROOT_PATH" ]; then
 fi
 
 echo "Setting up Conductor workspace..."
-
-# Trust mise.toml so we don't get prompted every workspace
-if command -v mise > /dev/null 2>&1; then
-  echo "Trusting mise.toml..."
-  mise trust
-fi
 
 # Symlink .env from the root repo so all workspaces share the same config.
 if [ -f "$CONDUCTOR_ROOT_PATH/.env" ]; then


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained change to one setup script; verify the mise-resolution/bootstrap branch order

### What is the goal of this PR and why is this important?
- Setting up a **brand-new machine** failed at dependency install with a cryptic `Could not find 'bundler' (4.0.3)`.
- Root cause: the machine had no mise (and no Homebrew), so the old activation block **silently fell through to system Ruby 2.6**, which can't satisfy the Gemfile. It also never ran `mise install`, so the pinned Ruby (`.ruby-version` = 4.0.1) / Node were never installed.
- Fix lives in the repo, not the machine — a fresh checkout now provisions its own toolchain.

### How did you approach the change?
- Resolve mise across the common install locations (adds `/usr/local/bin` and `~/.local/bin`, where the official installer lands).
- **Bootstrap mise** via the official installer when it's absent; fail loudly with instructions if that can't work.
- `mise trust` + `mise install` the pinned toolchain **before** activating, so shims resolve to a real Ruby.
- Removed the now-redundant later `mise trust` block (it used bare `mise`, not on PATH after a `~/.local/bin` bootstrap).
- **CONTRIBUTING.md**: replaced the bare Homebrew-formula link with concrete `brew install mysql@8.0` + `brew services start` commands and the keg-only PATH note, so contributors don't hit `bin/setup`'s opaque "no mysql client on PATH" error.

### Anything else to add?
- **Follow-up still open — the database.** On a truly bare machine there's also no MySQL/MariaDB/Docker, so `bin/setup` next fails at `db:drop` with `Connection refused … localhost:3306`. The CONTRIBUTING docs now cover the macOS documented-prerequisite path; automating provisioning (mise vs. Docker) remains a separate, everyone-affecting decision **not** in this PR.