### PR TITLE
Remove "My events" nav shortcut and staffed_by_me filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,7 +74,6 @@ class ApplicationController < ActionController::Base
                                                   .active
                                                   .includes(:organization)
                                                   .load
-    @current_user_staffs_events = current_user.person.event_staffs.exists?
   end
 
   def set_current_user

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,6 @@ class EventsController < ApplicationController
   def index
     authorize!
     base_scope = authorized_scope(Event.all)
-    base_scope = base_scope.staffed_by(current_user.person) if params[:staffed_by_me].present? && current_user&.person
     @events  = base_scope.search_by_params(params).order(start_date: :desc)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -86,7 +86,6 @@ class Event < ApplicationRecord
   scope :publicly_featured, -> { where(published: true, publicly_visible: true, publicly_featured: true) } # overrides Featureable
   scope :registerable, -> { where("registration_close_date IS NULL OR registration_close_date >= ?", Time.current) }
   scope :using_form, ->(form_id) { joins(:event_forms).where(event_forms: { form_id: form_id }).distinct }
-  scope :staffed_by, ->(person) { joins(:event_staffs).where(event_staffs: { person_id: person }).distinct }
   # Events flagged as facilitator trainings (the "TAC" a scholarship recipient
   # attends). Drives the scholarship index's training column.
   scope :facilitator_trainings, -> { where(facilitator_training: true) }

--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -65,17 +65,9 @@
       <% end %>
     <% end %>
 
-    <% if @current_user_staffs_events %>
-      <%= link_to events_path(staffed_by_me: true),
-                  class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>
-        <i class="fas fa-calendar-check"></i>
-        <span>My events</span>
-      <% end %>
-    <% end %>
-
     <% if user&.favorite_event && allowed_to?(:dashboard?, user.favorite_event) %>
       <%= link_to dashboard_event_path(user.favorite_event),
-                  class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>
+                  class: "admin-only bg-blue-100 flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 space-x-2" do %>
         <i class="fas fa-calendar-day"></i>
         <span>My favorite event</span>
       <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2870,20 +2870,6 @@ RSpec.describe "Events", type: :request do
         expect(response).to redirect_to(root_path)
       end
     end
-
-    describe "GET /index?staffed_by_me" do
-      it "returns only events the current user's person staffs" do
-        admin_with_person = create(:user, :admin, :with_person)
-        staffed = create(:event, :published, title: "Staffed event")
-        create(:event, :published, title: "Other event")
-        create(:event_staff, event: staffed, person: admin_with_person.person)
-
-        sign_in admin_with_person
-        get events_path(staffed_by_me: true)
-        expect(response.body).to include("Staffed event")
-        expect(response.body).not_to include("Other event")
-      end
-    end
   end
 
   describe "GET /show register button for signed-in users" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained removal + one nav styling change, low blast radius

### What is the goal of this PR and why is this important?
- Removes the redundant "My events" shortcut from the user nav dropdown — admins already reach the events index directly, and "My favorite event" is the intended single-event entry point.
- Removes the `staffed_by_me` feature entirely rather than leaving a dead URL filter behind.

### How did you approach the change?
- Dropped the "My events" nav link and its `@current_user_staffs_events` preload flag.
- Removed the `staffed_by_me` controller filter, the `Event.staffed_by` scope, and the request spec that covered them.
- Gave "My favorite event" the `admin-only bg-blue-100` styling matching sibling admin items (it is admin-gated via `dashboard?`).

### Anything else to add?
- `EventStaff` and its associations stay — they still power the event staffing management UI.
- events request spec + event model spec pass (346 examples, 0 failures).