### PR TITLE
Fix charge.succeeded webhook crash on removed Charge#subscription

### DIFF
--- a/app/webhooks/stripe_charge_succeeded_processor.rb
+++ b/app/webhooks/stripe_charge_succeeded_processor.rb
@@ -2,7 +2,10 @@ class StripeChargeSucceededProcessor
   def call(event)
     stripe_charge = event.data.object
     return unless stripe_charge.paid
-    return if stripe_charge.subscription.present?
+    # Subscription (membership) charges carry an invoice and are recorded via the
+    # membership/invoice flow — skip them here. Newer Stripe API versions dropped
+    # Charge#subscription, so detect them by the presence of an invoice.
+    return if stripe_charge.invoice.present?
 
     return if Payment.exists?(stripe_charge_id: stripe_charge.id)
 

--- a/spec/webhooks/stripe_charge_succeeded_processor_spec.rb
+++ b/spec/webhooks/stripe_charge_succeeded_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StripeChargeSucceededProcessor do
       billing_details: nil,
       receipt_email: nil,
       customer: nil,
-      subscription: nil,
+      invoice: nil,
       to_hash: { "id" => stripe_charge_id, "amount" => 30_00 }
     )
   end
@@ -47,8 +47,8 @@ RSpec.describe StripeChargeSucceededProcessor do
       expect { processor.call(event) }.not_to change(ExternalProcessorPayment, :count)
     end
 
-    it "does nothing when the charge belongs to a subscription" do
-      allow(stripe_charge).to receive(:subscription).and_return("sub_membership")
+    it "does nothing when the charge belongs to a subscription (has an invoice)" do
+      allow(stripe_charge).to receive(:invoice).and_return("in_membership")
 
       expect { processor.call(event) }.not_to change(ExternalProcessorPayment, :count)
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line webhook guard swap + spec update, contained

### What is the goal of this PR and why is this important?
- Production `charge.succeeded` webhooks were crashing with `NoMethodError: undefined method 'subscription' for #<Stripe::Charge>` (Honeybadger), so no `ExternalProcessorPayment` records were being created.
- Cause: `stripe` gem 19.x pins an API version that dropped `Charge#subscription`.

### How did you approach the change?
- Subscription (membership) charges carry an `invoice` and are recorded via the membership/invoice flow, so skip them by `invoice.present?` instead of the removed `subscription`.
- Updated the spec double to match a real `Stripe::Charge` (no `subscription` method), which reproduced the crash before the fix.

### Anything else to add?
- `invoice.present?` skips any invoice-backed charge; for this app that's the intended set (membership dues are the only Stripe-invoice flow).