### PR TITLE
Don't 500 the homepage when a DB blip breaks the banner query

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -436,6 +436,9 @@ module ApplicationHelper
     content_tag(:div, id: "banner-news", class: "bg-yellow-200 text-black text-center px-4 py-2") do
       content_tag(:div, safe_content.html_safe, class: "font-medium")
     end
+  rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed
+    # A transient DB connection drop shouldn't 500 the whole page over a decorative banner
+    nil
   end
 
   def sortable_field_display_name(name)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -588,11 +588,13 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.display_banner).to include("Hello world")
     end
 
-    it "returns nil without raising when the database connection drops" do
-      allow(Banner).to receive(:published).and_raise(ActiveRecord::ConnectionFailed)
+    [ ActiveRecord::ConnectionFailed, ActiveRecord::ConnectionNotEstablished ].each do |error|
+      it "returns nil without raising on a transient #{error}" do
+        allow(Banner).to receive(:published).and_raise(error)
 
-      expect { helper.display_banner }.not_to raise_error
-      expect(helper.display_banner).to be_nil
+        expect { helper.display_banner }.not_to raise_error
+        expect(helper.display_banner).to be_nil
+      end
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -580,4 +580,19 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.badge_classes("bg-blue-50", padding: "px-5 py-0.5")).to include("px-5 py-0.5")
     end
   end
+
+  describe "#display_banner" do
+    it "renders published banner content" do
+      create(:banner, content: "Hello world", published: true)
+
+      expect(helper.display_banner).to include("Hello world")
+    end
+
+    it "returns nil without raising when the database connection drops" do
+      allow(Banner).to receive(:published).and_raise(ActiveRecord::ConnectionFailed)
+
+      expect { helper.display_banner }.not_to raise_error
+      expect(helper.display_banner).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained rescue on a decorative helper, one new spec

### What is the goal of this PR and why is this important?
- A dropped DB connection (`Trilogy::EOFError: TRILOGY_CLOSED_CONNECTION`, wrapped as `ActiveRecord::ConnectionFailed`) during the banner query 500'd the entire page — including the public homepage that uptime probes hit. Honeybadger flagged it on `home#index`.
- The banner is purely decorative; a transient connection blip shouldn't take down the page.

### How did you approach the change?
- `ApplicationHelper#display_banner` now rescues `ActiveRecord::ConnectionNotEstablished`/`ConnectionFailed` and returns `nil` (renders nothing) instead of raising.
- Scoped to those two transient connection errors so real query bugs still surface.
- Added `#display_banner` specs (red→green): renders published content, and returns `nil` without raising on a connection drop.

### Anything else to add?
- This only stops the banner from crashing the page. The one-off `TRILOGY_CLOSED_CONNECTION` itself (1 occurrence) points at DB pool connection reaping/keepalive — out of scope here; worth watching if it recurs.
