### PR TITLE
Sort registrants scholarship & CE columns by lifecycle

### DIFF
--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -23,6 +23,16 @@ class EventRegistrationDecorator < ApplicationDecorator
     ce_badge("#{h.dollars_from_cents(ce_amount_due_cents)} due", "fa-solid fa-dollar-sign", :amber)
   end
 
+  # Priority for sorting the CE column: most-complete first, "Create" (no CE) last.
+  # Mirrors the ce_status_badge guard order so the two never drift.
+  def ce_status_sort_key
+    return 4 unless ce_registered?
+    return 0 if ce_certificate_issued?
+    return 3 unless ce_license_provided?
+    return 1 if ce_paid_in_full?
+    2
+  end
+
   def title
     name
   end

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -330,7 +330,7 @@
                 </td>
 
                 <% if ce_col %>
-                  <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce">
+                  <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce" data-sort-value="<%= registration.decorate.ce_status_sort_key %>">
                     <%# Canonical CE badge (Requested → License # needed → $X due →
                         Pending → Issued). "Create" when CE isn't in play yet. %>
                     <% if registration.decorate.ce_status_badge.nil? %>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -346,8 +346,18 @@
                   </td>
                 <% end %>
 
-                <td class="px-4 py-2 text-sm text-center <%= "hidden" unless scholarship_on %>" data-column-toggle-col="scholarship">
-                  <% if (s = registration.scholarships.first) %>
+                <% scholarship = registration.scholarships.first %>
+                <% scholarship_sort = if scholarship&.tasks_completed?
+                     0
+                   elsif scholarship
+                     1
+                   elsif registration.scholarship_requested?
+                     2
+                   else
+                     3
+                   end %>
+                <td class="px-4 py-2 text-sm text-center <%= "hidden" unless scholarship_on %>" data-column-toggle-col="scholarship" data-sort-value="<%= scholarship_sort %>">
+                  <% if (s = scholarship) %>
                     <% if s.tasks_completed? %>
                       <%= render "shared/badge",
                             label: "Completed",

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -148,4 +148,55 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
       end
     end
   end
+
+  describe "#ce_status_sort_key" do
+    subject(:sort_key) { registration.decorate.ce_status_sort_key }
+
+    let(:registration) { create(:event_registration) }
+
+    def add_ce(placeholder: false, cost_cents: 15_000)
+      license = placeholder ?
+        create(:professional_license, :placeholder, person: registration.registrant) :
+        create(:professional_license, person: registration.registrant)
+      create(:continuing_education_registration, event_registration: registration,
+        professional_license: license, cost_cents: cost_cents)
+    end
+
+    def pay(cer, amount)
+      payment = create(:payment, person: registration.registrant, amount_cents: amount, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: cer, amount: amount)
+    end
+
+    context "when the certificate has been issued" do
+      before do
+        cer = add_ce
+        pay(cer, 15_000)
+        cer.mark_certificate_sent!
+      end
+
+      it { is_expected.to eq(0) }
+    end
+
+    context "when paid in full but not issued" do
+      before { pay(add_ce, 15_000) }
+
+      it { is_expected.to eq(1) }
+    end
+
+    context "when the license is on file but unpaid" do
+      before { add_ce }
+
+      it { is_expected.to eq(2) }
+    end
+
+    context "when the CE registration sits on a placeholder license" do
+      before { add_ce(placeholder: true) }
+
+      it { is_expected.to eq(3) }
+    end
+
+    context "when CE isn't in play" do
+      it { is_expected.to eq(4) }
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 adds two numeric sort keys for the registrants Scholarship + CE columns; new decorator method w/ specs, no data changes

## Why
The registrants **Scholarship** and **CE** column headers were clickable, but their cells had no `data-sort-value`, so the shared table-sort controller fell back to the badge text and ordered them alphabetically — meaningless. CE was worse: its `$X due` state embeds a dollar amount, so `$120 due` sorted before `$5 due`.

## What
- **Scholarship:** add a numeric `data-sort-value` so it sorts by lifecycle — **Completed → Recipient → Requested → Create(none)**, clean mirror on reverse.
- **CE:** add `EventRegistrationDecorator#ce_status_sort_key` (mirrors the `ce_status_badge` guard order so the two can't drift) and expose it on the cell — sorts **Issued → Pending → $X due → License # needed → Create**.
- No shared-controller change; reuses already-eager-loaded associations (no new queries).

## Tests
- `spec/decorators/event_registration_decorator_spec.rb` — 5 new `#ce_status_sort_key` cases covering every CE state.
