### PR TITLE
Flag registrations with no linked organization on the dashboard

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -262,14 +262,16 @@ class EventRegistration < ApplicationRecord
     else all
     end
   }
-  # "linked" = at least one organization linked; "pending" = the registrant
-  # submitted an agency name on the event's registration form but nothing is
-  # linked yet (mirrors the Pending chip on the roster). Needs the event to
-  # resolve its registration form's agency_name field.
+  # "linked" = at least one organization linked; "unlinked" = no organization
+  # linked (whether or not an agency name was submitted); "pending" = the
+  # registrant submitted an agency name on the event's registration form but
+  # nothing is linked yet (mirrors the Pending chip on the roster). Needs the
+  # event to resolve its registration form's agency_name field.
   scope :organization_status, ->(value, event) {
     linked = EventRegistrationOrganization.select(:event_registration_id)
     case value
     when "linked" then where(id: linked)
+    when "unlinked" then where.not(id: linked)
     when "pending"
       field = event.registration_form&.form_fields&.find_by(field_identifier: "agency_name")
       next none unless field

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -19,6 +19,13 @@ class EventDashboard
     event.event_registrations.where(status: EventRegistration::INACTIVE_STATUSES).count
   end
 
+  # Active registrations with no organization linked (via
+  # EventRegistrationOrganization) — flags registrants still needing an agency
+  # linked, mirroring the "Unlinked" registrants filter.
+  def unlinked_registration_count
+    @unlinked_registration_count ||= active_registrations.where.not(id: linked_registration_ids).count
+  end
+
   # Registrant (Person) ids behind the inactive (cancelled / no-show)
   # registrations — for drilling into the matching manage list.
   def inactive_registrant_ids
@@ -916,6 +923,14 @@ class EventDashboard
 
   def active_registration_ids
     @active_registration_ids ||= active_registrations.pluck(:id)
+  end
+
+  # Ids of active registrations that have at least one organization linked.
+  def linked_registration_ids
+    @linked_registration_ids ||= EventRegistrationOrganization
+      .where(event_registration_id: active_registration_ids)
+      .distinct
+      .pluck(:event_registration_id)
   end
 
   def registrant_ids

--- a/app/views/events/_registrants_search.html.erb
+++ b/app/views/events/_registrants_search.html.erb
@@ -55,7 +55,7 @@
           selected: params[:readiness], blank: "All statuses", field_class: field_class %>
 
     <%= render "events/filter_select", param: :org_status, label: "Organization linking",
-          options: [ [ "Pending", "pending" ], [ "Linked", "linked" ] ],
+          options: [ [ "Pending", "pending" ], [ "Linked", "linked" ], [ "Unlinked", "unlinked" ] ],
           selected: params[:org_status], blank: "Any linking", field_class: field_class %>
 
     <%= render "events/filter_select", param: :comment_status, label: "Comments",

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -278,14 +278,16 @@
         </div>
         <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{@dashboard.registrant_count} active", path: registrants_event_path(@event, status_filter: "active") %><% if @dashboard.inactive_registration_count.positive? %> · <%= render "stat_link", label: "#{@dashboard.inactive_registration_count} inactive", path: registrants_event_path(@event, status_filter: "inactive") %><% end %></p>
         <% if @dashboard.unlinked_registration_count.positive? %>
+          <%# Rectangular amber callout matching the "Unallocated bulk payments"
+              card in the grand-total equation: same rounded-lg border, amber-50
+              fill, and darker amber-700 circle-exclamation. %>
           <div class="mt-1.5">
-            <%= render "shared/badge",
-                  href: registrants_event_path(@event, org_status: "unlinked"),
-                  label: "#{@dashboard.unlinked_registration_count} unlinked",
-                  classes: "bg-amber-50 text-amber-700 border-amber-300",
-                  icon: "fa-solid fa-circle-exclamation text-amber-500",
-                  title: "Registrants with no organization linked",
-                  extra: "shrink-0" %>
+            <%= link_to registrants_event_path(@event, org_status: "unlinked"),
+                  class: "inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-700 hover:bg-amber-100 transition-colors",
+                  title: "Registrants with no organization linked" do %>
+              <i class="fa-solid fa-circle-exclamation"></i>
+              <%= @dashboard.unlinked_registration_count %> unlinked
+            <% end %>
           </div>
         <% end %>
       </summary>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -277,6 +277,17 @@
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{@dashboard.registrant_count} active", path: registrants_event_path(@event, status_filter: "active") %><% if @dashboard.inactive_registration_count.positive? %> · <%= render "stat_link", label: "#{@dashboard.inactive_registration_count} inactive", path: registrants_event_path(@event, status_filter: "inactive") %><% end %></p>
+        <% if @dashboard.unlinked_registration_count.positive? %>
+          <div class="mt-1.5">
+            <%= render "shared/badge",
+                  href: registrants_event_path(@event, org_status: "unlinked"),
+                  label: "#{@dashboard.unlinked_registration_count} unlinked",
+                  classes: "bg-amber-50 text-amber-700 border-amber-300",
+                  icon: "fa-solid fa-circle-exclamation text-amber-500",
+                  title: "Registrants with no organization linked",
+                  extra: "shrink-0" %>
+          </div>
+        <% end %>
       </summary>
       <div class="mt-3 pt-3 border-t border-gray-100">
         <% if @dashboard.registrants.any? %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -714,6 +714,19 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe ".organization_status scope" do
+    let(:event) { create(:event) }
+
+    it "filters linked / unlinked by organization link presence" do
+      linked = create(:event_registration, event: event)
+      create(:event_registration_organization, event_registration: linked)
+      unlinked = create(:event_registration, event: event)
+
+      expect(EventRegistration.organization_status("linked", event)).to contain_exactly(linked)
+      expect(EventRegistration.organization_status("unlinked", event)).to contain_exactly(unlinked)
+    end
+  end
+
   describe "#paid_in_full?" do
     let(:event) { create(:event, cost_cents: 1000) }
     let(:user) { create(:user, :with_person) }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1929,6 +1929,21 @@ RSpec.describe "Events", type: :request do
         expect(page).to have_link(href: registrants_event_path(event, status_filter: "inactive"), visible: :all)
       end
 
+      it "flags registrations with no organization linked via an unlinked badge" do
+        get dashboard_event_path(event)
+
+        page = Capybara.string(response.body)
+        expect(page).to have_link("1 unlinked", href: registrants_event_path(event, org_status: "unlinked"), visible: :all)
+      end
+
+      it "omits the unlinked badge when every registration has an organization linked" do
+        create(:event_registration_organization, event_registration: registration)
+
+        get dashboard_event_path(event)
+
+        expect(response.body).not_to include("unlinked")
+      end
+
       it "drills the CE card into the registrants filtered to continuing education" do
         create(:continuing_education_registration, event_registration: registration, cost_cents: 6_000)
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -996,6 +996,25 @@ RSpec.describe EventDashboard do
     end
   end
 
+  describe "unlinked registrations" do
+    let(:event) { create(:event) }
+
+    it "counts active registrations with no organization linked" do
+      linked = create(:event_registration, event: event, status: "registered")
+      create(:event_registration_organization, event_registration: linked)
+      create(:event_registration, event: event, status: "registered")
+      create(:event_registration, event: event, status: "attended")
+
+      expect(dashboard.unlinked_registration_count).to eq(2)
+    end
+
+    it "ignores inactive registrations" do
+      create(:event_registration, event: event, status: "cancelled")
+
+      expect(dashboard.unlinked_registration_count).to eq(0)
+    end
+  end
+
   describe "attendance stats" do
     let(:event) { create(:event) }
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small scope: one new dashboard badge + a filter branch, with model/service/request tests

### What & why
- The Registrants headcount card on the event dashboard now shows an amber **"N unlinked"** badge counting active registrations with no organization linked, so staff can spot and fix them.
- Badge links into the registrants list via a new **"Unlinked"** option on the "Organization linking" filter (`org_status=unlinked` → active regs with no `EventRegistrationOrganization`).

### Notes for reviewer
- "Unlinked" = no `EventRegistrationOrganization` row (mirrors the existing "linked"/"pending" filter semantics); badge count and filter cover the same set.