### PR TITLE
Add per-registrant drilldowns to the events revenue report

### DIFF
--- a/app/services/event_revenue_figures.rb
+++ b/app/services/event_revenue_figures.rb
@@ -33,12 +33,45 @@ class EventRevenueFigures
     ce_outstanding_cents: 0
   ).freeze
 
+  # One person's share of a component, for the report's per-figure drilldowns.
+  Contributor = Struct.new(:person, :cents, keyword_init: true)
+
+  # The people behind each component figure, mirroring Figures — each list sums
+  # to the matching cents total, so an expanded row reconciles with its subtotal.
+  Breakdown = Struct.new(
+    :registration_payments,
+    :registration_outstanding,
+    :funded_scholarships,
+    :unfunded_scholarships,
+    :discounts,
+    :ce_paid,
+    :ce_outstanding,
+    keyword_init: true
+  )
+
+  EMPTY_BREAKDOWN = Breakdown.new(
+    registration_payments: [],
+    registration_outstanding: [],
+    funded_scholarships: [],
+    unfunded_scholarships: [],
+    discounts: [],
+    ce_paid: [],
+    ce_outstanding: []
+  ).freeze
+
   def initialize(events)
     @events = events.to_a
   end
 
   def for(event)
     figures_by_event_id.fetch(event.id, EMPTY)
+  end
+
+  # Per-person contributors behind each component figure for the event's
+  # drilldowns. Loaded lazily (one extra Person query) so the plain totals stay
+  # at their fixed query count when the breakdowns aren't needed.
+  def breakdown_for(event)
+    breakdowns_by_event_id.fetch(event.id, EMPTY_BREAKDOWN)
   end
 
   private
@@ -55,6 +88,82 @@ class EventRevenueFigures
 
   def figures_by_event_id
     @figures_by_event_id ||= @events.to_h { |event| [ event.id, build(event) ] }
+  end
+
+  def breakdowns_by_event_id
+    @breakdowns_by_event_id ||= @events.to_h { |event| [ event.id, build_breakdown(event) ] }
+  end
+
+  # Roll every component up per person from the same bulk-loaded rows as #build,
+  # so a drilldown list and its subtotal are computed the same way. Registration
+  # payments, outstanding, and both discount kinds key by the registration's
+  # registrant; scholarships key by their recipient.
+  def build_breakdown(event)
+    registration_ids = registration_ids_by_event.fetch(event.id, [])
+    cost_cents = event.cost_cents.to_i
+
+    registration_payments = Hash.new(0)
+    registration_outstanding = Hash.new(0)
+    discounts = Hash.new(0)
+    funded_scholarships = Hash.new(0)
+    unfunded_scholarships = Hash.new(0)
+    ce_paid = Hash.new(0)
+    ce_outstanding = Hash.new(0)
+
+    registration_ids.each do |id|
+      registrant_id = registrant_id_by_registration[id]
+      next unless registrant_id
+
+      registration_payments[registrant_id] += registration_allocations[[ id, "Payment" ]].to_i
+      registration_outstanding[registrant_id] += [ cost_cents - registration_allocated_total[id], 0 ].max
+      discounts[registrant_id] += registration_allocations[[ id, "Discount" ]].to_i
+
+      scholarship_rows_by_registration.fetch(id, []).each do |grant_id, amount_cents, recipient_id|
+        recipient_id ||= registrant_id
+        bucket = external_grant?(grant_id) ? funded_scholarships : unfunded_scholarships
+        bucket[recipient_id] += amount_cents
+      end
+
+      ce_rows_by_registration.fetch(id, []).each do |ce_id, cost|
+        ce_paid[registrant_id] += ce_allocations[[ ce_id, "Payment" ]].to_i
+        ce_outstanding[registrant_id] += [ cost.to_i - ce_allocated_total[ce_id], 0 ].max
+        discounts[registrant_id] += ce_allocations[[ ce_id, "Discount" ]].to_i
+      end
+    end
+
+    Breakdown.new(
+      registration_payments: contributors_from(registration_payments),
+      registration_outstanding: contributors_from(registration_outstanding),
+      funded_scholarships: contributors_from(funded_scholarships),
+      unfunded_scholarships: contributors_from(unfunded_scholarships),
+      discounts: contributors_from(discounts),
+      ce_paid: contributors_from(ce_paid),
+      ce_outstanding: contributors_from(ce_outstanding)
+    )
+  end
+
+  # Turn a { person_id => cents } map into name-sorted Contributors, dropping
+  # zero (and negative) shares so only people who actually moved the total show.
+  def contributors_from(cents_by_person_id)
+    cents_by_person_id
+      .filter_map do |person_id, cents|
+        next unless cents.positive?
+        person = people_by_id[person_id]
+        next unless person
+        Contributor.new(person: person, cents: cents)
+      end
+      .sort_by { |contributor| contributor.person.name.downcase }
+  end
+
+  # Every registrant and scholarship recipient across the report, loaded once for
+  # the drilldown lists' names and links.
+  def people_by_id
+    @people_by_id ||= Person.where(id: breakdown_person_ids).index_by(&:id)
+  end
+
+  def breakdown_person_ids
+    recipient_ids = scholarship_rows_by_registration.values.flatten(1).map { |row| row[2] }
+    (registrant_id_by_registration.values + recipient_ids).compact.uniq
   end
 
   def build(event)
@@ -75,13 +184,26 @@ class EventRevenueFigures
     )
   end
 
-  # { event_id => [ registration_id, ... ] } across every event in the report.
-  def registration_ids_by_event
-    @registration_ids_by_event ||= EventRegistration
+  # [ event_id, registration_id, registrant_id ] for every active registration in
+  # the report — the basis for both the per-event grouping and the drilldowns'
+  # registrant lookup, loaded in one query.
+  def registration_rows
+    @registration_rows ||= EventRegistration
       .active
       .where(event_id: @events.map(&:id))
-      .pluck(:event_id, :id)
-      .each_with_object({}) { |(event_id, id), map| (map[event_id] ||= []) << id }
+      .pluck(:event_id, :id, :registrant_id)
+  end
+
+  # { event_id => [ registration_id, ... ] } across every event in the report.
+  def registration_ids_by_event
+    @registration_ids_by_event ||= registration_rows
+      .each_with_object({}) { |(event_id, id, _registrant_id), map| (map[event_id] ||= []) << id }
+  end
+
+  # { registration_id => registrant_id (Person id) } for the drilldowns.
+  def registrant_id_by_registration
+    @registrant_id_by_registration ||= registration_rows
+      .each_with_object({}) { |(_event_id, id, registrant_id), map| map[id] = registrant_id }
   end
 
   def registration_ids
@@ -96,13 +218,14 @@ class EventRevenueFigures
       .each_with_object({}) { |(registration_id, id, cost), map| (map[registration_id] ||= []) << [ id, cost ] }
   end
 
-  # { registration_id => [ [ grant_id, amount_cents ], ... ] }.
+  # { registration_id => [ [ grant_id, amount_cents, recipient_id ], ... ] }. The
+  # recipient id feeds the scholarship drilldowns; #build reads only the first two.
   def scholarship_rows_by_registration
     @scholarship_rows_by_registration ||= Scholarship
       .joins(:allocation)
       .where(allocations: { allocatable_type: "EventRegistration", allocatable_id: registration_ids })
-      .pluck(Arel.sql("allocations.allocatable_id"), :grant_id, :amount_cents)
-      .each_with_object({}) { |(registration_id, grant_id, amount), map| (map[registration_id] ||= []) << [ grant_id, amount ] }
+      .pluck(Arel.sql("allocations.allocatable_id"), :grant_id, :amount_cents, :recipient_id)
+      .each_with_object({}) { |(registration_id, grant_id, amount, recipient_id), map| (map[registration_id] ||= []) << [ grant_id, amount, recipient_id ] }
   end
 
   # { [ allocatable_id, source_type ] => cents } for each allocatable kind, plus

--- a/app/services/event_revenue_report.rb
+++ b/app/services/event_revenue_report.rb
@@ -91,14 +91,18 @@ class EventRevenueReport
   end
 
   def rows
-    @rows ||= begin
-      figures = EventRevenueFigures.new(@events)
-      @events.map { |event| build_row(event, figures.for(event)) }
-    end
+    @rows ||= @events.map { |event| build_row(event, figures_loader.for(event)) }
   end
 
   def any?
     rows.any?
+  end
+
+  # The people (and their individual amounts) behind an event row's component
+  # figures, for the report's per-figure drilldowns. Computed lazily off the same
+  # loader, so pages that only read the totals never pay for it.
+  def breakdown_for(event)
+    figures_loader.breakdown_for(event)
   end
 
   # Calendar-year groups, newest first, each with a subtotal. Events without a
@@ -148,6 +152,10 @@ class EventRevenueReport
   end
 
   private
+
+  def figures_loader
+    @figures_loader ||= EventRevenueFigures.new(@events)
+  end
 
   # A zeroed year group for a period with no events, so the summary card renders
   # $0 rather than blank.

--- a/app/views/events/_revenue_breakdown_row.html.erb
+++ b/app/views/events/_revenue_breakdown_row.html.erb
@@ -1,0 +1,44 @@
+<%#
+  One component figure in an event's revenue card, expandable to the people
+  behind it and each person's share. Reads as "[label] … [amount]"; the summary
+  toggles the contributor list, each row linking to that registrant in the manage
+  list. A zero row (no contributors) renders as a plain, non-expandable line.
+
+  Locals:
+    event:        the Event the figure belongs to (for the drill-in links)
+    label:        row label (e.g. "Registration payments")
+    cents:        the component subtotal, in integer cents
+    contributors: EventRevenueFigures::Contributor records behind the subtotal
+    value_class:  optional amount color class (defaults to neutral gray)
+%>
+<%
+  value_class = local_assigns.fetch(:value_class, "text-gray-800")
+%>
+<% if contributors.blank? %>
+  <div class="flex items-baseline justify-between gap-3">
+    <span class="text-gray-500"><%= label %></span>
+    <span class="tabular-nums <%= value_class %>"><%= dollars_from_cents(cents) %></span>
+  </div>
+<% else %>
+  <details class="group/rev">
+    <summary class="flex items-baseline justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden rounded px-1 -mx-1 py-0.5 hover:bg-gray-100">
+      <span class="flex items-center gap-1.5 min-w-0 text-gray-500">
+        <i class="fa-solid fa-chevron-down text-[10px] text-gray-300 shrink-0 transition-transform group-open/rev:rotate-180"></i>
+        <span class="truncate min-w-0" title="<%= label %>"><%= label %></span>
+      </span>
+      <span class="tabular-nums <%= value_class %> shrink-0"><%= dollars_from_cents(cents) %></span>
+    </summary>
+    <ul class="mt-1 mb-1 ml-5 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
+      <% contributors.each do |contributor| %>
+        <li>
+          <%= link_to registrants_event_path(event, registrant_ids: contributor.person.id),
+                title: contributor.person.name,
+                class: "group/revlink flex items-baseline justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-100" do %>
+            <span class="truncate min-w-0 group-hover/revlink:underline"><%= contributor.person.name %></span>
+            <span class="tabular-nums text-gray-600 shrink-0"><%= dollars_from_cents(contributor.cents) %></span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </details>
+<% end %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -139,27 +139,28 @@
                   </summary>
                   <div class="px-3 pb-3 pl-8 bg-gray-50">
                     <% ce_class = DomainTheme.text_class_for(:continuing_education, intensity: 600) %>
-                    <dl class="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm py-2">
-                      <% columns = [
-                           [ [ "Registration payments", row.registration_payments_cents, "text-gray-800" ],
-                             [ "CE paid", row.ce_paid_cents, ce_class ] ],
-                           [ [ "Funded scholarships", row.funded_scholarship_cents, "text-gray-800" ],
-                             [ "Unfunded scholarships", row.unfunded_scholarship_cents, "text-gray-800" ],
-                             [ "Discounts", row.discount_cents, "text-gray-800" ] ],
-                           [ [ "Registration owed", row.registration_outstanding_cents, "text-orange-600" ],
-                             [ "CE owed", row.ce_outstanding_cents, "text-orange-600" ] ]
-                         ] %>
+                    <% breakdown = @report.breakdown_for(row.event) %>
+                    <%# Each figure expands to the registrants (or recipients) behind it,
+                        with their individual amounts — the per-figure drilldown. %>
+                    <% columns = [
+                         [ [ "Registration payments", row.registration_payments_cents, "text-gray-800", breakdown.registration_payments ],
+                           [ "CE paid", row.ce_paid_cents, ce_class, breakdown.ce_paid ] ],
+                         [ [ "Funded scholarships", row.funded_scholarship_cents, "text-gray-800", breakdown.funded_scholarships ],
+                           [ "Unfunded scholarships", row.unfunded_scholarship_cents, "text-gray-800", breakdown.unfunded_scholarships ],
+                           [ "Discounts", row.discount_cents, "text-gray-800", breakdown.discounts ] ],
+                         [ [ "Registration owed", row.registration_outstanding_cents, "text-orange-600", breakdown.registration_outstanding ],
+                           [ "CE owed", row.ce_outstanding_cents, "text-orange-600", breakdown.ce_outstanding ] ]
+                       ] %>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm py-2">
                       <% columns.each do |pair| %>
                         <div class="space-y-1.5">
-                          <% pair.each do |label, cents, value_class| %>
-                            <div class="flex items-baseline justify-between gap-3">
-                              <dt class="text-gray-500"><%= label %></dt>
-                              <dd class="tabular-nums <%= value_class %>"><%= dollars_from_cents(cents) %></dd>
-                            </div>
+                          <% pair.each do |label, cents, value_class, contributors| %>
+                            <%= render "revenue_breakdown_row", event: row.event, label: label,
+                                  cents: cents, value_class: value_class, contributors: contributors %>
                           <% end %>
                         </div>
                       <% end %>
-                    </dl>
+                    </div>
                     <%= link_to "Open event dashboard →", dashboard_event_path(row.event),
                           class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
                   </div>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -189,6 +189,20 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("funder=awbw")           # Org subsidy
       end
 
+      it "expands a subtotal to the registrants behind it with their amounts" do
+        registrant = create(:person, first_name: "Dana", last_name: "Rivers")
+        registration = create(:event_registration, event: paid_training, registrant: registrant, status: "registered")
+        create(:allocation, source: create(:payment, amount_cents: 4_000, amount_cents_remaining: 4_000),
+                            allocatable: registration, amount: 4_000)
+
+        sign_in admin
+        get revenue_events_path
+
+        expect(response.body).to include("Registration payments")
+        expect(response.body).to include("Dana Rivers")
+        expect(response.body).to include(CGI.escapeHTML(registrants_event_path(paid_training, registrant_ids: registrant.id)))
+      end
+
       # The Event dropdown lists every (paid) event, so the report rows are
       # identified by their per-event dashboard link rather than the title.
       it "narrows to facilitator trainings by event type" do

--- a/spec/services/event_revenue_figures_spec.rb
+++ b/spec/services/event_revenue_figures_spec.rb
@@ -75,6 +75,52 @@ RSpec.describe EventRevenueFigures do
     expect(described_class.new([ event, other ]).for(other)).to eq(described_class::EMPTY)
   end
 
+  describe "#breakdown_for" do
+    subject(:breakdown) { described_class.new([ event ]).breakdown_for(event) }
+
+    def amounts(contributors)
+      contributors.to_h { |contributor| [ contributor.person, contributor.cents ] }
+    end
+
+    it "names the registrants (and recipients) behind each component with their amounts" do
+      expect(amounts(breakdown.registration_payments)).to eq(person1 => 6_000, person2 => 3_000)
+      expect(amounts(breakdown.registration_outstanding)).to eq(person2 => 4_000)
+      expect(amounts(breakdown.funded_scholarships)).to eq(person1 => 4_000)
+      expect(amounts(breakdown.unfunded_scholarships)).to eq(person2 => 2_000)
+      expect(amounts(breakdown.discounts)).to eq(person2 => 1_000)
+      expect(amounts(breakdown.ce_paid)).to eq(person1 => 7_500, person2 => 2_000)
+      expect(amounts(breakdown.ce_outstanding)).to eq(person2 => 4_000)
+    end
+
+    it "reconciles each drilldown list with its subtotal" do
+      totals = described_class.new([ event ]).for(event)
+
+      expect(breakdown.registration_payments.sum(&:cents)).to eq(totals.registration_payments_cents)
+      expect(breakdown.registration_outstanding.sum(&:cents)).to eq(totals.registration_outstanding_cents)
+      expect(breakdown.funded_scholarships.sum(&:cents)).to eq(totals.funded_scholarship_cents)
+      expect(breakdown.unfunded_scholarships.sum(&:cents)).to eq(totals.unfunded_scholarship_cents)
+      expect(breakdown.discounts.sum(&:cents)).to eq(totals.discount_cents)
+      expect(breakdown.ce_paid.sum(&:cents)).to eq(totals.ce_paid_cents)
+      expect(breakdown.ce_outstanding.sum(&:cents)).to eq(totals.ce_outstanding_cents)
+    end
+
+    it "omits people with a zero share and excludes cancelled registrants" do
+      cancelled_person = EventRegistration.find_by(status: "cancelled")&.registrant
+      expect(breakdown.registration_payments.map(&:person)).not_to include(cancelled_person)
+      expect(breakdown.registration_outstanding.map(&:person)).not_to include(person1)
+    end
+
+    it "sorts contributors by name" do
+      names = breakdown.registration_payments.map { |contributor| contributor.person.name }
+      expect(names).to eq(names.sort_by(&:downcase))
+    end
+
+    it "returns an empty breakdown for an event with no registrations" do
+      other = create(:event, cost_cents: 10_000)
+      expect(described_class.new([ event, other ]).breakdown_for(other)).to eq(described_class::EMPTY_BREAKDOWN)
+    end
+  end
+
   it "loads every event in a fixed number of queries" do
     events = [ event ] + Array.new(3) do
       other = create(:event, cost_cents: 5_000)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained per-person breakdown added to the existing bulk figures loader, plus a view/partial change on one report page

### What is the goal of this PR and why is this important?
- On the **Events revenue report**, each event card's seven money subtotals (Registration payments, CE paid, Funded / Unfunded scholarships, Discounts, Registration owed, CE owed) is now an expandable `<details>` revealing **who** is behind the total and **each person's amount**.
- Part of moving drilldowns off the event dashboard onto the report pages.

### How did you approach the change?
- Extended `EventRevenueFigures` (the report's existing fixed-query bulk loader) with a `breakdown_for(event)` returning per-person `Contributor` lists for each component — computed from the **same bulk-loaded rows** as the totals, so a drilldown reconciles with its subtotal. Chose this over building an `EventDashboard` per event, which would reintroduce the N+1 the report was deliberately built to avoid (a query-count test guards the constant query count; breakdowns add exactly one lazy `Person` query only when a report page reads them).
- `EventRevenueReport#breakdown_for` delegates to a single memoized loader; the statistics summary page never triggers it.
- New partial `app/views/events/_revenue_breakdown_row.html.erb` renders each figure as a native `<details>` matching the dashboard's attendance-row idiom (chevron + label + amount, expanding to a name list). Zero rows render as a plain, non-expandable line. Each person row links to that registrant in the manage list.

### Anything else to add?
- **Discounts breakdown**: keyed by the registration's registrant (covers both registration and CE discounts, mirroring the totals). Scholarships key by recipient.
- No `page_bg_class` change (existing page).