### PR TITLE
Add scholarship recipient drilldowns to the events scholarships report

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -49,6 +49,19 @@ module EventsHelper
       report_filters: params.permit(*REPORT_FILTER_KEYS).to_h.compact_blank)
   end
 
+  # Forward: from a scholarships report row's expanded recipient list into that
+  # recipient's registration for the training, stamped like #attended_registrants_path
+  # so the roster's eyebrow returns to the exact row (highlight + anchor) with the
+  # report's filters/toggle restored.
+  def scholarship_recipient_registrants_path(event, recipient)
+    registrants_event_path(event,
+      registrant_ids: recipient.id,
+      return_to: "scholarships",
+      return_highlight: event.id,
+      return_anchor: training_report_row_id(event),
+      report_filters: params.permit(*REPORT_FILTER_KEYS).to_h.compact_blank)
+  end
+
   # Back: the registrants eyebrow's path to the scholarships report, restoring the
   # carried filters/toggle and highlighting the row the user drilled in from.
   def scholarships_report_return_path

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -253,6 +253,30 @@ class EventDashboard
     @scholarship_amounts_by_recipient ||= scholarships.group(:recipient_id).sum(:amount_cents)
   end
 
+  # Funded / unfunded scholarship dollars per recipient (Person id => cents) — the
+  # per-person split behind funded_scholarship_cents / unfunded_scholarship_cents.
+  # Recipients with no award in that split are absent, so a recipient can appear in
+  # one map, both, or neither.
+  def funded_scholarship_cents_by_recipient
+    @funded_scholarship_cents_by_recipient ||= funded_scholarships.group(:recipient_id).sum(:amount_cents)
+  end
+
+  def unfunded_scholarship_cents_by_recipient
+    @unfunded_scholarship_cents_by_recipient ||= unfunded_scholarships.group(:recipient_id).sum(:amount_cents)
+  end
+
+  # Scholarship recipients (Person records, name-sorted) with a funded / unfunded
+  # award — the people behind each split, for the scholarship report row's expander.
+  # Both reuse the recipients already loaded by #scholarship_registrants, so the
+  # split adds no extra Person query.
+  def funded_scholarship_recipients
+    @funded_scholarship_recipients ||= recipients_for(funded_scholarship_cents_by_recipient.keys)
+  end
+
+  def unfunded_scholarship_recipients
+    @unfunded_scholarship_recipients ||= recipients_for(unfunded_scholarship_cents_by_recipient.keys)
+  end
+
   # Per-registrant payment-sourced cents received, keyed by Person id. Aggregates
   # across a person's registrations; sums to received_cents.
   def registration_paid_by_registrant
@@ -1204,6 +1228,16 @@ class EventDashboard
 
   def people_sorted(person_ids)
     Person.where(id: person_ids).sort_by(&:name)
+  end
+
+  # Recipient Person records for the given ids, name-sorted, drawn from the
+  # already-loaded scholarship_registrants so a funded/unfunded split reuses one query.
+  def recipients_for(recipient_ids)
+    recipient_ids.filter_map { |id| scholarship_recipients_by_id[id] }.sort_by(&:name)
+  end
+
+  def scholarship_recipients_by_id
+    @scholarship_recipients_by_id ||= scholarship_registrants.index_by(&:id)
   end
 
   def organization_ids

--- a/app/services/event_scholarship_report.rb
+++ b/app/services/event_scholarship_report.rb
@@ -25,6 +25,14 @@ class EventScholarshipReport
     # Trainees who fully attended (registration status "attended").
     def attended_count = dashboard.attendance_count_for("attended")
 
+    # Per-recipient scholarship breakdown for the row's expander: the funded /
+    # unfunded recipients (name-sorted Person records) and their dollars keyed by
+    # Person id. A recipient can appear in one split, both, or neither.
+    def funded_recipients = dashboard.funded_scholarship_recipients
+    def unfunded_recipients = dashboard.unfunded_scholarship_recipients
+    def funded_cents_by_recipient = dashboard.funded_scholarship_cents_by_recipient
+    def unfunded_cents_by_recipient = dashboard.unfunded_scholarship_cents_by_recipient
+
     def on_demand? = event.on_demand?
     def label = event.compact_label
     def date_label = event.start_date? ? event.short_date_range : nil

--- a/app/views/events/_scholarship_recipient_group.html.erb
+++ b/app/views/events/_scholarship_recipient_group.html.erb
@@ -1,0 +1,26 @@
+<%# One funded/unfunded group inside a training row's recipient expander: a labeled
+    list of recipients, each linking into their filtered registrant view with their
+    scholarship dollars. Renders nothing when the group has no recipients. Pass
+    `event`, `title`, `dot_color`, `recipients`, `amounts_by_recipient_id`. %>
+<% if recipients.any? %>
+  <div>
+    <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+      <i class="fa-solid fa-circle <%= dot_color %> text-[7px] mr-1 align-middle"></i><%= title %>
+    </p>
+    <ul class="mt-0.5 ml-3 space-y-0.5 text-xs text-gray-700 max-h-40 overflow-y-auto">
+      <% recipients.each do |recipient| %>
+        <li>
+          <%= link_to scholarship_recipient_registrants_path(event, recipient),
+                title: recipient.name,
+                class: "group/reciplink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
+            <span class="truncate min-w-0 group-hover/reciplink:underline"><%= recipient.name %></span>
+            <span class="flex items-center gap-2 shrink-0">
+              <span class="tabular-nums text-gray-500"><%= dollars_from_cents(amounts_by_recipient_id[recipient.id]) %></span>
+              <i class="fa-solid fa-arrow-up-right-from-square text-[10px] text-transparent group-hover/reciplink:text-gray-500"></i>
+            </span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/events/_scholarship_recipients_cell.html.erb
+++ b/app/views/events/_scholarship_recipients_cell.html.erb
@@ -1,0 +1,29 @@
+<%# The Training cell for a scholarship report row. When the training awarded any
+    scholarships the training name becomes a <details> disclosure that expands to
+    list recipients (name + scholarship $) split funded vs unfunded; otherwise it
+    renders a plain, non-expandable label. Pass `column` (an
+    EventScholarshipReport::Column). %>
+<td class="px-3 py-2 border border-gray-200 align-top" title="<%= column.event.title %>">
+  <% if column.scholarship_count.positive? %>
+    <details class="group/recipients">
+      <summary class="flex items-start justify-between gap-2 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden -mx-1 px-1 py-0.5 rounded hover:bg-fuchsia-50">
+        <span class="min-w-0">
+          <%= render "scholarship_report_training_label", column: column %>
+        </span>
+        <i class="fa-solid fa-chevron-down text-[10px] text-fuchsia-300 shrink-0 mt-1 transition-transform group-open/recipients:rotate-180"></i>
+      </summary>
+      <div class="mt-2 space-y-2">
+        <%= render "scholarship_recipient_group",
+              event: column.event, title: "Funded", dot_color: "text-emerald-500",
+              recipients: column.funded_recipients,
+              amounts_by_recipient_id: column.funded_cents_by_recipient %>
+        <%= render "scholarship_recipient_group",
+              event: column.event, title: "Unfunded", dot_color: "text-amber-500",
+              recipients: column.unfunded_recipients,
+              amounts_by_recipient_id: column.unfunded_cents_by_recipient %>
+      </div>
+    </details>
+  <% else %>
+    <%= render "scholarship_report_training_label", column: column %>
+  <% end %>
+</td>

--- a/app/views/events/_scholarship_report_training_label.html.erb
+++ b/app/views/events/_scholarship_report_training_label.html.erb
@@ -1,0 +1,10 @@
+<%# A training's name, date range, and on-demand note for a scholarship report
+    row's Training cell — shared by the plain cell and the recipient-expander
+    summary. Pass `column` (an EventScholarshipReport::Column). %>
+<span class="font-medium text-gray-900"><%= column.label %></span>
+<% if column.date_label %>
+  <span class="block text-xs text-gray-500"><%= column.date_label %></span>
+<% end %>
+<% if column.on_demand? %>
+  <span class="block text-xs text-gray-500">On-demand</span>
+<% end %>

--- a/app/views/events/_scholarships_report_table.html.erb
+++ b/app/views/events/_scholarships_report_table.html.erb
@@ -65,15 +65,7 @@
           <% group.columns.each do |column| %>
             <% highlighted = params[:highlight].to_s == column.event.id.to_s %>
             <tr id="<%= training_report_row_id(column.event) %>" class="scroll-mt-24 transition-colors duration-150 <%= "bg-yellow-50 ring-2 ring-inset ring-yellow-500" if highlighted %>">
-              <td class="px-3 py-2 border border-gray-200" title="<%= column.event.title %>">
-                <span class="font-medium text-gray-900"><%= column.label %></span>
-                <% if column.date_label %>
-                  <span class="block text-xs text-gray-500"><%= column.date_label %></span>
-                <% end %>
-                <% if column.on_demand? %>
-                  <span class="block text-xs text-gray-500">On-demand</span>
-                <% end %>
-              </td>
+              <%= render "scholarship_recipients_cell", column: column %>
               <%= render "scholarships_report_figures", source: column, combined: combined, event: column.event %>
             </tr>
           <% end %>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -430,6 +430,26 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("TAC261")
       end
 
+      it "expands a training row to list its scholarship recipients and amounts, split funded vs unfunded" do
+        funder = create(:organization, name: "Community Trust")
+        funded_person = create(:person, first_name: "Fern", last_name: "Funded")
+        unfunded_person = create(:person, first_name: "Uma", last_name: "Unfunded")
+        funded_reg = create(:event_registration, event: training, registrant: funded_person, status: "attended")
+        unfunded_reg = create(:event_registration, event: training, registrant: unfunded_person, status: "attended")
+        funded_award = create(:scholarship, recipient: funded_person, amount_cents: 4_000, grant: create(:grant, donor: funder))
+        create(:allocation, source: funded_award, allocatable: funded_reg, amount: 4_000)
+        unfunded_award = create(:scholarship, recipient: unfunded_person, amount_cents: 2_500, grant: nil)
+        create(:allocation, source: unfunded_award, allocatable: unfunded_reg, amount: 2_500)
+
+        sign_in admin
+        get scholarships_events_path
+        expect(response.body).to include("Fern Funded", "Uma Unfunded")
+        expect(response.body).to include("$40", "$25")
+        # Each recipient links into that training's registrants, filtered to them,
+        # stamped so the eyebrow returns to the report.
+        expect(response.body).to include("registrant_ids=#{funded_person.id}", "return_to=scholarships")
+      end
+
       it "narrows to trainings a selected funder scholarshipped" do
         funder = create(:organization, name: "Community Trust")
         person = create(:person)

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -1108,5 +1108,22 @@ RSpec.describe EventDashboard do
       expect(dashboard.unfunded_scholarship_count).to eq(2)
       expect(dashboard.unfunded_scholarship_cents).to eq(3_000)
     end
+
+    it "maps funded dollars per recipient, reconciling with the funded total" do
+      amounts = dashboard.funded_scholarship_cents_by_recipient
+      expect(amounts).to eq(person1.id => 4_000)
+      expect(amounts.values.sum).to eq(dashboard.funded_scholarship_cents)
+    end
+
+    it "maps unfunded dollars per recipient, reconciling with the unfunded total" do
+      amounts = dashboard.unfunded_scholarship_cents_by_recipient
+      expect(amounts).to eq(person2.id => 2_000, person4.id => 1_000)
+      expect(amounts.values.sum).to eq(dashboard.unfunded_scholarship_cents)
+    end
+
+    it "lists funded and unfunded recipients as name-sorted Person records" do
+      expect(dashboard.funded_scholarship_recipients).to eq([ person1 ])
+      expect(dashboard.unfunded_scholarship_recipients).to match_array([ person2, person4 ])
+    end
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic: 4 new memoized EventDashboard methods + a native <details> expander partial, covered by request/service specs

### What is the goal of this PR and why is this important?
- Part of moving drilldowns off the event dashboard onto the report pages.
- On the events scholarships report, each training row's name is now a native `<details>` disclosure that expands to show that training's scholarship recipients — name + scholarship $ — split funded vs unfunded, so admins can see who a row's totals are made of without leaving the report.

### How did you approach the change?
- Added memoized per-recipient split methods to `EventDashboard` (`funded_scholarship_cents_by_recipient`, `unfunded_scholarship_cents_by_recipient`, `funded_scholarship_recipients`, `unfunded_scholarship_recipients`). The recipient lists reuse the people already loaded by `scholarship_registrants`, so the split adds no extra Person query.
- Exposed them on `EventScholarshipReport::Column` and rendered them in a new Training-cell partial that only expands when the training has scholarships (zero-scholarship rows stay plain labels).
- Reused the dashboard's `<details>`/summary + name-list idiom (no new Stimulus). Each recipient links into that training's registrants filtered to them, stamped with `return_to`/highlight/anchor so the roster eyebrow returns to the exact report row (via a new `scholarship_recipient_registrants_path` helper mirroring `attended_registrants_path`).

### Anything else to add?
- Performance: the expander's per-recipient `group.sum` runs per training row with scholarships (~2 extra grouped queries each); acceptable for this admin-only report and consistent with the row's existing funded/unfunded queries.
- Specs: extended `spec/services/event_dashboard_spec.rb` (per-recipient split) and `spec/requests/events_spec.rb` (row expands with recipient names/amounts + drill-in link).
