### PR TITLE
Link registrants CE column to the CE registration

### DIFF
--- a/app/controllers/continuing_education_registrations_controller.rb
+++ b/app/controllers/continuing_education_registrations_controller.rb
@@ -21,7 +21,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
       apply_ce_params(@ce_registration)
       @ce_registration.save!
     end
-    redirect_to edit_event_registration_path(@ce_registration.event_registration), notice: "CE registration created.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(@ce_registration.event_registration, params[:return_to]), notice: "CE registration created.", status: :see_other
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = @ce_registration.errors.full_messages.to_sentence
     render :new, status: :unprocessable_content
@@ -38,7 +38,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
       apply_ce_params(@ce_registration)
       @ce_registration.save!
     end
-    redirect_to edit_event_registration_path(@ce_registration.event_registration), notice: "CE registration updated.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(@ce_registration.event_registration, params[:return_to]), notice: "CE registration updated.", status: :see_other
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = @ce_registration.errors.full_messages.to_sentence
     render :edit, status: :unprocessable_content
@@ -54,7 +54,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
 
     registration = @ce_registration.event_registration
     @ce_registration.destroy!
-    redirect_to edit_event_registration_path(registration), notice: "CE registration removed.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(registration, params[:return_to]), notice: "CE registration removed.", status: :see_other
   end
 
   def toggle_certificate

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -25,6 +25,22 @@ module EventsHelper
     registrants_event_path(event_or_id, anchor: registrant_row_id(registration_id), highlight: registration_id)
   end
 
+  # Where the CE registration new/edit pages return to, based on the origin. From
+  # the registrants roster, back to that registrant's row; otherwise the
+  # registration edit page (the default origin).
+  def ce_registration_return_path(event_registration, return_to)
+    if return_to == "registrants"
+      registrants_event_row_path(event_registration.event, event_registration.id)
+    else
+      edit_event_registration_path(event_registration)
+    end
+  end
+
+  # Eyebrow label matching ce_registration_return_path.
+  def ce_registration_return_label(return_to)
+    return_to == "registrants" ? "Registrants" : "Registration"
+  end
+
   # The scholarships report's filter/toggle state, carried through a drill-in so
   # its eyebrow can rebuild the exact view (period, event type/id, search, funder,
   # split/combined layout, and the report's own origin) the user came from.

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -5,8 +5,8 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + secondary links, matching the scholarship edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to edit_event_registration_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+    <%= link_to ce_registration_return_path(registration, params[:return_to]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label(params[:return_to]) %>
     <% end %>
     <div class="flex items-center gap-3">
       <%# Admin jump to the registrant-facing CE callout (what the registrant sees /
@@ -115,7 +115,7 @@
       <% end %>
 
       <div class="ml-auto flex items-center gap-3">
-        <%= link_to "Cancel", edit_event_registration_path(registration), class: "btn btn-secondary-outline" %>
+        <%= link_to "Cancel", ce_registration_return_path(registration, params[:return_to]), class: "btn btn-secondary-outline" %>
         <%# Submits the CE details form above (which the certificate section sits outside of). %>
         <button type="submit" form="ce_registration_form" class="btn btn-primary">Save changes</button>
       </div>

--- a/app/views/continuing_education_registrations/new.html.erb
+++ b/app/views/continuing_education_registrations/new.html.erb
@@ -5,8 +5,8 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + Home, matching the CE edit page. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to edit_event_registration_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+    <%= link_to ce_registration_return_path(registration, params[:return_to]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label(params[:return_to]) %>
     <% end %>
     <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>
@@ -22,13 +22,14 @@
     <%= form_with model: @ce_registration, url: continuing_education_registrations_path,
           method: :post, id: "ce_registration_form", data: { turbo: false } do |f| %>
       <%= hidden_field_tag :allocatable_sgid, registration.to_sgid.to_s %>
+      <%= hidden_field_tag :return_to, params[:return_to] %>
       <%= render "details_section", f: f, license: @ce_registration.professional_license, ce_registration: @ce_registration, event: event %>
     <% end %>
 
     <%# ---- Footer actions ---- %>
     <div class="flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
-        <%= link_to "Cancel", edit_event_registration_path(registration), class: "btn btn-secondary-outline" %>
+        <%= link_to "Cancel", ce_registration_return_path(registration, params[:return_to]), class: "btn btn-secondary-outline" %>
         <button type="submit" form="ce_registration_form" class="btn btn-primary">Create CE registration</button>
       </div>
     </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -334,14 +334,16 @@
                     <%# Canonical CE badge (Requested → License # needed → $X due →
                         Pending → Issued). "Create" when CE isn't in play yet. %>
                     <% if registration.decorate.ce_status_badge.nil? %>
+                      <%# No CE yet — open the new CE registration form. %>
                       <%= render "shared/badge",
                             label: "Create",
                             classes: "bg-gray-50 text-gray-400 border-gray-200",
-                            href: edit_event_registration_path(registration, return_to: "registrants"),
+                            href: new_continuing_education_registration_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
                             title: "No CE credit requested" %>
                     <% else %>
+                      <%# Issued/due/etc. — jump straight to the connected CE registration. %>
                       <%= render "event_registrations/ce_status_badge", registration: registration,
-                            href: edit_event_registration_path(registration, return_to: "registrants") %>
+                            href: edit_continuing_education_registration_path(registration.continuing_education_registrations.first, return_to: "registrants") %>
                     <% end %>
                   </td>
                 <% end %>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small link-target + navigation change across the CE column and CE new/edit pages

### What is the goal of this PR and why is this important?
- From the registrants roster, the CE column should take admins straight to the relevant CE screen instead of the general registration edit page.

### How did you approach the change?
- **Issued/due** (and other CE states) link to the **connected CE registration**’s edit page; **Create** opens the **new CE registration form**.
- CE new/edit pages return to the roster row when reached from it — eyebrow, Cancel, and post-save/create/destroy redirects — via a shared `ce_registration_return_path` helper (falls back to the registration edit page for other origins).

### Anything else to add?
- Split out of #2107 (certificate toggle); no overlap beyond the one CE-column hunk.