### PR TITLE
Link registrants CE column to the CE registration

### DIFF
--- a/app/controllers/continuing_education_registrations_controller.rb
+++ b/app/controllers/continuing_education_registrations_controller.rb
@@ -21,7 +21,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
       apply_ce_params(@ce_registration)
       @ce_registration.save!
     end
-    redirect_to edit_event_registration_path(@ce_registration.event_registration), notice: "CE registration created.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(@ce_registration.event_registration), notice: "CE registration created.", status: :see_other
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = @ce_registration.errors.full_messages.to_sentence
     render :new, status: :unprocessable_content
@@ -38,7 +38,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
       apply_ce_params(@ce_registration)
       @ce_registration.save!
     end
-    redirect_to edit_event_registration_path(@ce_registration.event_registration), notice: "CE registration updated.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(@ce_registration.event_registration), notice: "CE registration updated.", status: :see_other
   rescue ActiveRecord::RecordInvalid
     flash.now[:alert] = @ce_registration.errors.full_messages.to_sentence
     render :edit, status: :unprocessable_content
@@ -54,7 +54,7 @@ class ContinuingEducationRegistrationsController < ApplicationController
 
     registration = @ce_registration.event_registration
     @ce_registration.destroy!
-    redirect_to edit_event_registration_path(registration), notice: "CE registration removed.", status: :see_other
+    redirect_to helpers.ce_registration_return_path(registration), notice: "CE registration removed.", status: :see_other
   end
 
   def toggle_certificate

--- a/app/helpers/continuing_education_registrations_helper.rb
+++ b/app/helpers/continuing_education_registrations_helper.rb
@@ -1,0 +1,11 @@
+module ContinuingEducationRegistrationsHelper
+  # One source of truth for where a CE registration form (new or edit) returns to —
+  # the eyebrow, Cancel, and the controller's post-save/create/destroy redirects all
+  # agree. Reached from the registrants roster (return_to=registrants) it lands back
+  # on that registrant's row (scroll + highlight); any other origin falls back to the
+  # registration's own edit page.
+  def ce_registration_return_path(registration)
+    return registrants_event_row_path(registration.event, registration.id) if params[:return_to] == "registrants"
+    edit_event_registration_path(registration)
+  end
+end

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -5,8 +5,8 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + secondary links, matching the scholarship edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to edit_event_registration_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+    <%= link_to ce_registration_return_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= params[:return_to] == "registrants" ? "Registrants" : "Registration" %>
     <% end %>
     <div class="flex items-center gap-3">
       <%# Admin jump to the registrant-facing CE callout (what the registrant sees /
@@ -115,7 +115,7 @@
       <% end %>
 
       <div class="ml-auto flex items-center gap-3">
-        <%= link_to "Cancel", edit_event_registration_path(registration), class: "btn btn-secondary-outline" %>
+        <%= link_to "Cancel", ce_registration_return_path(registration), class: "btn btn-secondary-outline" %>
         <%# Submits the CE details form above (which the certificate section sits outside of). %>
         <button type="submit" form="ce_registration_form" class="btn btn-primary">Save changes</button>
       </div>

--- a/app/views/continuing_education_registrations/new.html.erb
+++ b/app/views/continuing_education_registrations/new.html.erb
@@ -5,8 +5,8 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + Home, matching the CE edit page. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to edit_event_registration_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Registration
+    <%= link_to ce_registration_return_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= params[:return_to] == "registrants" ? "Registrants" : "Registration" %>
     <% end %>
     <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>
@@ -22,13 +22,14 @@
     <%= form_with model: @ce_registration, url: continuing_education_registrations_path,
           method: :post, id: "ce_registration_form", data: { turbo: false } do |f| %>
       <%= hidden_field_tag :allocatable_sgid, registration.to_sgid.to_s %>
+      <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
       <%= render "details_section", f: f, license: @ce_registration.professional_license, ce_registration: @ce_registration, event: event %>
     <% end %>
 
     <%# ---- Footer actions ---- %>
     <div class="flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
-        <%= link_to "Cancel", edit_event_registration_path(registration), class: "btn btn-secondary-outline" %>
+        <%= link_to "Cancel", ce_registration_return_path(registration), class: "btn btn-secondary-outline" %>
         <button type="submit" form="ce_registration_form" class="btn btn-primary">Create CE registration</button>
       </div>
     </div>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -332,16 +332,18 @@
                 <% if ce_col %>
                   <td class="px-4 py-2 text-sm text-center" data-column-toggle-col="ce" data-sort-value="<%= registration.decorate.ce_status_sort_key %>">
                     <%# Canonical CE badge (Requested → License # needed → $X due →
-                        Pending → Issued). "Create" when CE isn't in play yet. %>
-                    <% if registration.decorate.ce_status_badge.nil? %>
+                        Pending → Issued). Each state links to the connected CE
+                        registration's edit page; "Create" opens the new CE form. %>
+                    <% ce_registration = registration.continuing_education_registrations.first %>
+                    <% if ce_registration.nil? %>
                       <%= render "shared/badge",
                             label: "Create",
                             classes: "bg-gray-50 text-gray-400 border-gray-200",
-                            href: edit_event_registration_path(registration, return_to: "registrants"),
-                            title: "No CE credit requested" %>
+                            href: new_continuing_education_registration_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants"),
+                            title: "Add CE registration" %>
                     <% else %>
                       <%= render "event_registrations/ce_status_badge", registration: registration,
-                            href: edit_event_registration_path(registration, return_to: "registrants") %>
+                            href: edit_continuing_education_registration_path(ce_registration, return_to: "registrants") %>
                     <% end %>
                   </td>
                 <% end %>

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -192,6 +192,41 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
       expect(ContinuingEducationRegistration.exists?(ce_registration.id)).to be(true)
       expect(flash[:alert]).to match(/has payments/)
     end
+
+    context "reached from the registrants roster (return_to=registrants)" do
+      let(:row_path) do
+        registrants_event_path(event, anchor: "registrant-row-#{registration.id}", highlight: registration.id)
+      end
+
+      it "shows the Registrants eyebrow and carries return_to through the new form" do
+        get new_continuing_education_registration_path(allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants")
+
+        expect(response.body).to include("Registrants")
+        expect(response.body).to match(/name="return_to"[^>]*value="registrants"/)
+      end
+
+      it "sends the create redirect back to the registrant's row" do
+        post continuing_education_registrations_path,
+             params: { allocatable_sgid: registration.to_sgid.to_s, return_to: "registrants",
+               continuing_education_registration: { hours: "6", cost_dollars: "120", license_kind: "LMFT", license_number: "555" } }
+
+        expect(response).to redirect_to(row_path)
+      end
+
+      it "sends the update redirect back to the registrant's row" do
+        patch continuing_education_registration_path(ce_registration, return_to: "registrants"),
+              params: { continuing_education_registration: { hours: "6", cost_dollars: "120", license_kind: "LMFT", license_number: "555" } }
+
+        expect(response).to redirect_to(row_path)
+      end
+
+      it "sends the destroy redirect back to the registrant's row" do
+        ce_registration
+        delete continuing_education_registration_path(ce_registration, return_to: "registrants")
+
+        expect(response).to redirect_to(row_path)
+      end
+    end
   end
 
   it "forbids non-admins" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1034,6 +1034,25 @@ RSpec.describe "Events", type: :request do
       end
     end
 
+    context "CE column links" do
+      before { offer_ce!(event) }
+
+      it "links a registrant without a CE registration to the new CE form" do
+        get registrants_event_path(event)
+
+        expect(response.body).to match(%r{/continuing_education_registrations/new\?[^"]*return_to=registrants})
+      end
+
+      it "links a registrant with a CE registration to its edit page" do
+        ce = create(:continuing_education_registration, event_registration: registration,
+          professional_license: create(:professional_license, :placeholder, person: person))
+
+        get registrants_event_path(event)
+
+        expect(response.body).to include(edit_continuing_education_registration_path(ce, return_to: "registrants"))
+      end
+    end
+
     context "with unknown filter params" do
       it "does not crash on an invalid payment_status" do
         get registrants_event_path(event, payment_status: "bogus")


### PR DESCRIPTION
Closes #2127

🤖 suggested review level: 3 Read 📖 small link-target + navigation change across the CE column and CE new/edit pages

### What is the goal of this PR and why is this important?
- From the registrants roster, the CE column should take admins straight to the relevant CE screen instead of the general registration edit page.

### How did you approach the change?
- CE states link to the **connected CE registration**'s edit page; **Create** opens the **new CE registration form**.
- CE new/edit pages return to the roster row when reached from it — eyebrow, Cancel, and post-save/create/destroy redirects — via a shared `ce_registration_return_path` helper (falls back to the registration edit page for other origins).

### Anything else to add?
- Split out of #2107 (certificate toggle); no overlap beyond the one CE-column hunk.
