### PR TITLE
Add Event staff section to the edit event form, gated on staff

### DIFF
--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -147,6 +147,12 @@ class RegistrationTicketCallout < ApplicationRecord
     builtin_key == "payment"
   end
 
+  # The built-in whose page lists the event's staff roster, pulled from the
+  # Event staff section — editing this row only owns the title/subtitle/intro copy.
+  def staff?
+    builtin_key == "staff"
+  end
+
   # Whether the callout's page content is drip-scheduled to reveal only from a
   # future date. The card still shows on the ticket; the page withholds its
   # content until then (see the callout show page).

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -186,7 +186,8 @@ class EventPolicy < ApplicationPolicy
                   primary_asset_attributes: [ :id, :file, :_destroy ],
                   gallery_assets_attributes: [ :id, :file, :_destroy ],
                   registration_ticket_callouts_attributes: [ :id, :builtin_key, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :display_from, :payment_access_gated, :published, :reset_to_default, :_destroy,
-                    { registration_ticket_callout_resources_attributes: [ :id, :resource_id, :subtitle, :page_content, :_destroy ] } ]
+                    { registration_ticket_callout_resources_attributes: [ :id, :resource_id, :subtitle, :page_content, :_destroy ] } ],
+                  event_staffs_attributes: [ :id, :person_id, :title, :expected_to_attend, :bio, :_destroy ]
         ]
 
     permitted.prepend(:ga4_snippet, :gtm_head_snippet, :gtm_body_snippet) if admin?

--- a/app/services/builtin_callout_cards.rb
+++ b/app/services/builtin_callout_cards.rb
@@ -54,7 +54,7 @@ class BuiltinCalloutCards
       EditorCard.new("payment", "fa-solid fa-credit-card", "orange", "Payment", "Your balance and payment history", "When the event has a cost", nil),
       EditorCard.new("scholarship", "fa-solid fa-award", "fuchsia", "Scholarship", "Your scholarship request and award", "When the registrant requested a scholarship", nil),
       EditorCard.new("videoconference", "fa-solid fa-video", "blue", "Videoconference", "Join details and add to calendar links", "When the event has a videoconference link", "Details come from this event's videoconference settings."),
-      EditorCard.new("staff", "fa-solid fa-people-group", "blue", "Meet the staff", "The team for this event", "Always shown when published", "The roster comes from this event's staff."),
+      EditorCard.new("staff", "fa-solid fa-people-group", "blue", "Meet the staff", "The team for this event", "When the event has staff", "The roster comes from this event's staff."),
       EditorCard.new("handouts", "fa-solid fa-folder-open", "blue", "Handouts", "Worksheets and resources for the event", "On facilitator trainings", "Items link to their relevant resources."),
       EditorCard.new("certificate", "fa-solid fa-certificate", "green", "Certificate of completion", "View and download your certificate", "Once the certificate is unlocked", nil),
       EditorCard.new("faq", "fa-solid fa-circle-question", "blue", "Frequently asked questions", "Common questions about the 2-day training", "On facilitator trainings", nil)
@@ -90,6 +90,8 @@ class BuiltinCalloutCards
       "this event offers no CE hours" unless event.ce_eligible?
     when "videoconference"
       "this event has no videoconference link" if event.videoconference_url.blank?
+    when "staff"
+      "this event has no staff" unless event.event_staffs.exists?
     end
   end
 
@@ -103,7 +105,8 @@ class BuiltinCalloutCards
       "payment" => "set an event cost above $0",
       "scholarship" => "add a scholarship form under form settings",
       "ce_hours" => "set CE hours above 0 under form settings",
-      "videoconference" => "add a videoconference link"
+      "videoconference" => "add a videoconference link",
+      "staff" => "connect some staff"
     }[builtin_key]
   end
 
@@ -351,9 +354,10 @@ class BuiltinCalloutCards
     deadline.in_time_zone(Time.zone).strftime("%b %-d")
   end
 
-  # Always shown once published — the roster page (which shares its card grid
-  # with the admin staff page) handles the empty case, so there's no config gap.
+  # Hidden until the event has staff — an empty roster page is nothing to link to,
+  # so the card only appears once someone's been connected in the Event staff section.
   def staff_card
+    return if config_gap?("staff")
     Card.new(icon_class: "fa-solid fa-people-group", color: "blue",
              title: "Meet the staff",
              subtitle: "The team for this event",

--- a/app/views/events/_event_staff_fields.html.erb
+++ b/app/views/events/_event_staff_fields.html.erb
@@ -1,8 +1,19 @@
-<div class="nested-fields rounded-lg border border-gray-200 bg-white p-3 mb-3"
-     data-controller="event-staff-bio"
+<div class="nested-fields rounded-lg border border-gray-300 bg-white p-4 mb-4 shadow-sm relative"
+     data-controller="event-staff-bio expandable-card"
+     data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse"
      data-event-staff-bio-url-template-value="<%= bio_person_path("__ID__") %>"
+     data-expandable-card-expanded-value="<%= !f.object.persisted? %>"
      <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>>
-  <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
+  <%# Saved staff collapse to the summary row (person, title, attendance); the
+      chevron expands to reveal the bio editor. New rows start expanded. %>
+  <button type="button"
+          class="absolute top-3 right-3 leading-none text-gray-400 hover:text-gray-600"
+          data-action="expandable-card#toggle"
+          aria-label="Collapse or expand staff details">
+    <i class="fa-solid fa-chevron-down text-xs transition-transform <%= "rotate-180" unless f.object.persisted? %>" data-expandable-card-target="icon"></i>
+  </button>
+
+  <div class="flex flex-wrap items-end gap-x-4 gap-y-2 pr-8">
     <div style="width: 320px; min-width: 320px; flex-shrink: 0;">
       <% if f.object.persisted? && f.object.person.present? %>
         <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
@@ -40,11 +51,12 @@
     </div>
   </div>
 
-  <%# Event bio (left) overrides the person's profile bio (right) on the public
-      staff page; blank falls back to the profile bio — see EventStaff#public_bio. %>
+  <%# Bio editor — collapsed by default on saved rows (see the card root). Event
+      bio (left) overrides the person's profile bio (right) on the public staff
+      page; blank falls back to the profile bio — see EventStaff#public_bio. %>
   <% staff_person = f.object.person %>
   <% profile_bio = staff_person.bio if staff_person&.profile_show_bio? %>
-  <div class="w-full border-t border-gray-100 pt-3 mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <div class="<%= "hidden" if f.object.persisted? %> border-t border-gray-100 pt-3 mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4" data-expandable-card-target="body">
     <div>
       <label class="block text-sm font-medium text-gray-700 mb-1" for="<%= f.field_id(:bio) %>">
         Bio <span class="font-normal text-gray-400">(optional)</span>

--- a/app/views/events/_event_staff_fields.html.erb
+++ b/app/views/events/_event_staff_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields rounded-lg border border-gray-300 bg-white p-4 mb-4 shadow-sm relative"
+<div class="nested-fields rounded-lg border border-gray-300 bg-white p-4 shadow-sm relative"
      data-controller="event-staff-bio expandable-card"
      data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse"
      data-event-staff-bio-url-template-value="<%= bio_person_path("__ID__") %>"

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -541,6 +541,48 @@
       </div>
     </div>
 
+    <div class="staff-section" data-controller="dropdown">
+      <button
+        type="button"
+        id="staff_button"
+        class="
+          flex items-center justify-between cursor-pointer w-full
+          bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md
+        "
+        data-action="dropdown#toggle"
+        data-dropdown-payload-param='[{"staff":"hidden"}, {"staff_arrow":"rotate-180"}, {"staff_button":"rounded-md rounded-t-md"}]'
+      >
+        Event staff
+        <i id="staff_arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
+      </button>
+
+      <div id="staff" class="hidden border border-gray-300 bg-gray-50 p-4 rounded-b-md" data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
+        <div class="flex items-center justify-between mb-3">
+          <button type="button" data-action="expandable-cards#toggleAll"
+                  class="inline-flex items-center gap-2 text-sm font-medium text-blue-700 hover:text-blue-900">
+            <i class="fa-solid fa-chevron-down transition-transform" data-expandable-cards-target="icon"></i>
+            <span data-expandable-cards-target="label">Expand all</span>
+          </button>
+
+          <% if @event.persisted? %>
+            <%= link_to "View staff page", staff_event_path(@event), class: "btn btn-secondary-outline" %>
+          <% end %>
+        </div>
+
+        <div id="event-staffs">
+          <%= f.fields_for :event_staffs do |staff_form| %>
+            <%= render "event_staff_fields", f: staff_form %>
+          <% end %>
+        </div>
+
+        <div class="mt-2">
+          <%= link_to_add_association "➕ Add staff", f, :event_staffs,
+                data: { association_insertion_node: "#event-staffs", association_insertion_method: "append" },
+                class: "btn btn-secondary-outline" %>
+        </div>
+      </div>
+    </div>
+
     <%# ---- REGISTRATION TICKET CALLOUTS (built-in + custom ticket call-outs) ---- %>
     <%#
       ?expand=callouts (from the ticket's "Edit event" link) auto-opens this

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -566,17 +566,17 @@
               they reflect saved staff, not unsaved edits in this form. %>
           <div class="mb-4">
             <div class="flex flex-wrap items-center gap-2">
-              <%= link_to staff_event_path(@event), target: "_blank", rel: "noopener",
-                    class: "inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
-                <i class="fa-solid fa-users" aria-hidden="true"></i>
-                View staff page
-                <i class="fa-solid fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
-              <% end %>
-
               <%= link_to sample_staff_event_path(@event), target: "_blank", rel: "noopener",
                     class: "inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
                 <i class="fa-solid fa-eye" aria-hidden="true"></i>
                 Preview sample staff callout
+                <i class="fa-solid fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+              <% end %>
+
+              <%= link_to staff_event_path(@event), target: "_blank", rel: "noopener",
+                    class: "inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
+                <i class="fa-solid fa-users" aria-hidden="true"></i>
+                View staff page
                 <i class="fa-solid fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
               <% end %>
             </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -557,11 +557,34 @@
       </button>
 
       <div id="staff" class="hidden border border-gray-300 bg-gray-50 p-4 rounded-b-md" data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
-        <div class="flex flex-col items-end gap-1 mb-2">
-          <% if @event.persisted? %>
-            <%= link_to "View staff page", staff_event_path(@event), class: "btn btn-secondary-outline" %>
-          <% end %>
+        <p class="text-sm text-gray-500 mb-4">
+          The people shown on this event's public staff page and on the ticket's “Meet the staff” callout. Add each person, set their role, and toggle who's expected to attend. A person's bio falls back to their profile bio when left blank.
+        </p>
 
+        <% if @event.persisted? %>
+          <%# Both open in a new tab so the admin keeps their place in the editor;
+              they reflect saved staff, not unsaved edits in this form. %>
+          <div class="mb-4">
+            <div class="flex flex-wrap items-center gap-2">
+              <%= link_to staff_event_path(@event), target: "_blank", rel: "noopener",
+                    class: "inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
+                <i class="fa-solid fa-users" aria-hidden="true"></i>
+                View staff page
+                <i class="fa-solid fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+              <% end %>
+
+              <%= link_to sample_staff_event_path(@event), target: "_blank", rel: "noopener",
+                    class: "inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100" do %>
+                <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                Preview sample staff callout
+                <i class="fa-solid fa-arrow-up-right-from-square text-xs" aria-hidden="true"></i>
+              <% end %>
+            </div>
+            <p class="mt-1 text-xs text-gray-400">Both open in a new tab and reflect saved staff — save your edits first. Edit the callout page's title and intro copy on the “Meet the staff” built-in in the Registration ticket callouts section below.</p>
+          </div>
+        <% end %>
+
+        <div class="flex justify-end mb-3">
           <button type="button" data-action="expandable-cards#toggleAll"
                   class="inline-flex items-center gap-2 text-sm font-medium text-blue-700 hover:text-blue-900">
             <i class="fa-solid fa-chevron-down transition-transform" data-expandable-cards-target="icon"></i>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -557,7 +557,7 @@
       </button>
 
       <div id="staff" class="hidden border border-gray-300 bg-gray-50 p-4 rounded-b-md" data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
-        <div class="flex flex-col items-end gap-2 mb-3">
+        <div class="flex flex-col items-end gap-1 mb-2">
           <% if @event.persisted? %>
             <%= link_to "View staff page", staff_event_path(@event), class: "btn btn-secondary-outline" %>
           <% end %>
@@ -569,7 +569,7 @@
           </button>
         </div>
 
-        <div id="event-staffs">
+        <div id="event-staffs" class="space-y-3">
           <%= f.fields_for :event_staffs do |staff_form| %>
             <%= render "event_staff_fields", f: staff_form %>
           <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -557,16 +557,16 @@
       </button>
 
       <div id="staff" class="hidden border border-gray-300 bg-gray-50 p-4 rounded-b-md" data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
-        <div class="flex items-center justify-between mb-3">
+        <div class="flex flex-col items-end gap-2 mb-3">
+          <% if @event.persisted? %>
+            <%= link_to "View staff page", staff_event_path(@event), class: "btn btn-secondary-outline" %>
+          <% end %>
+
           <button type="button" data-action="expandable-cards#toggleAll"
                   class="inline-flex items-center gap-2 text-sm font-medium text-blue-700 hover:text-blue-900">
             <i class="fa-solid fa-chevron-down transition-transform" data-expandable-cards-target="icon"></i>
             <span data-expandable-cards-target="label">Expand all</span>
           </button>
-
-          <% if @event.persisted? %>
-            <%= link_to "View staff page", staff_event_path(@event), class: "btn btn-secondary-outline" %>
-          <% end %>
         </div>
 
         <div id="event-staffs">

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -90,6 +90,13 @@
         the matching initial state to avoid a flash before the controller connects.
         `mt-5` keeps the preview card clear of the controls above it. %>
     <div class="<%= "hidden" unless f.object.published? %> space-y-3 mt-5 cursor-auto select-auto" data-expandable-card-target="body">
+      <% if f.object.staff? %>
+        <div class="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
+          <i class="fa-solid fa-circle-info mt-0.5 shrink-0" aria-hidden="true"></i>
+          <span>This callout's page automatically lists the roster from the event's staff section — you don't need to add anyone here. The title, subtitle, and any page text you enter appear above that list.</span>
+        </div>
+      <% end %>
+
       <%#
         Live preview of how this callout appears on the ticket — the same card
         registrants see (icon, title, subtitle, themed color). Seeded from the

--- a/app/views/events/edit_staff.html.erb
+++ b/app/views/events/edit_staff.html.erb
@@ -24,8 +24,16 @@
       <%= render "shared/errors", resource: @event %>
     <% end %>
 
-    <div class="bg-gray-50 border border-gray-200 rounded-md p-4 sm:p-6 mb-6">
-      <div id="event-staffs">
+    <div class="bg-gray-50 border border-gray-200 rounded-md p-4 sm:p-6 mb-6" data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
+      <div class="flex justify-end mb-3">
+        <button type="button" data-action="expandable-cards#toggleAll"
+                class="inline-flex items-center gap-2 text-sm font-medium text-blue-700 hover:text-blue-900">
+          <i class="fa-solid fa-chevron-down transition-transform" data-expandable-cards-target="icon"></i>
+          <span data-expandable-cards-target="label">Expand all</span>
+        </button>
+      </div>
+
+      <div id="event-staffs" class="space-y-3">
         <%= f.fields_for :event_staffs do |staff_form| %>
           <%= render "event_staff_fields", f: staff_form %>
         <% end %>

--- a/spec/decorators/registration_ticket_callout_decorator_spec.rb
+++ b/spec/decorators/registration_ticket_callout_decorator_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe RegistrationTicketCalloutDecorator, type: :decorator do
       expect(callout.decorate.config_suppression_hint).to eq("set CE hours above 0 under form settings")
     end
 
+    it "names connecting staff for a staff callout on an event with none" do
+      callout = builtin_callout("staff", event: create(:event))
+      expect(callout.decorate.config_suppression_hint).to eq("connect some staff")
+    end
+
+    it "is nil for a staff callout once the event has staff" do
+      event = create(:event)
+      create(:event_staff, event:)
+      callout = builtin_callout("staff", event:)
+      expect(callout.decorate.config_suppression_hint).to be_nil
+    end
+
     it "is nil once the event is configured for the callout" do
       callout = builtin_callout("payment", event: create(:event, cost_cents: 5_000))
       expect(callout.decorate.config_suppression_hint).to be_nil

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -912,6 +912,17 @@ RSpec.describe "Events", type: :request do
         pacific = event.ce_payment_due_deadline.in_time_zone("Pacific Time (US & Canada)")
         expect(pacific.strftime("%Y-%m-%d %H:%M")).to eq("2026-08-15 09:00")
       end
+
+      it "adds event staff via nested attributes" do
+        person = create(:person)
+        patch event_path(event), params: { event: {
+          event_staffs_attributes: { "0" => { person_id: person.id, title: "Lead facilitator", expected_to_attend: "1" } }
+        } }
+        staff = event.reload.event_staffs.first
+        expect(staff.person).to eq(person)
+        expect(staff.title).to eq("Lead facilitator")
+        expect(staff.expected_to_attend).to be(true)
+      end
     end
 
     context "as non-admin" do

--- a/spec/services/builtin_callout_cards_spec.rb
+++ b/spec/services/builtin_callout_cards_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe BuiltinCalloutCards do
   end
 
   describe "#cards" do
-    it "shows the payment and staff cards for a bare paid, non-training registration" do
-      # Staff has no config gate, so it always shows in the code fallback (for
-      # events not yet materialized); every other card here gates on config. On a
-      # legacy event with no staff row the card just links back to the ticket.
+    it "shows the staff card only once the event has connected staff" do
+      # An empty roster is nothing to link to, so the staff card gates on the event
+      # having staff — like every other fallback card gates on its own config.
+      expect(card_titles(registration)).to eq([ "Make your payment" ])
+
+      create(:event_staff, event:)
       expect(card_titles(registration)).to eq([ "Make your payment", "Meet the staff" ])
     end
 
@@ -227,6 +229,7 @@ RSpec.describe BuiltinCalloutCards do
                     videoconference_url: "https://example.zoom.us/j/123",
                     start_date: 3.days.ago, end_date: 2.days.ago)
       add_scholarship_form(event)
+      create(:event_staff, event:)
       registration.update!(status: "attended", scholarship_requested: true)
       license = create(:professional_license, :placeholder, person: registration.registrant)
       create(:continuing_education_registration, event_registration: registration, professional_license: license)
@@ -284,12 +287,20 @@ RSpec.describe BuiltinCalloutCards do
     end
 
     it "links the staff card to the registrant's roster page, keeping the row's text" do
+      create(:event_staff, event:)
       callout = create(:registration_ticket_callout, event:, builtin_key: "staff",
         title: "Meet our team", subtitle: "Who you'll learn from")
 
       card = described_class.new(registration).card_for(callout)
       expect(card.title).to eq("Meet our team")            # row owns the text
       expect(card.href).to eq("/registration/#{registration.slug}/staff")
+    end
+
+    it "returns nil for a materialized staff row when the event has no staff" do
+      callout = create(:registration_ticket_callout, event:, builtin_key: "staff",
+        title: "Meet the staff")
+
+      expect(described_class.new(registration).card_for(callout)).to be_nil
     end
 
     it "keeps the live CE deadline badge on a materialized CE row" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained UI plus a small policy param, a model predicate, and one built-in visibility gate; reuses existing staff nested-attrs and expandable-card plumbing

## What
- Add an **Event staff** section to the main edit-event form (below *Event show page*) — manages `event_staffs` via nested attributes, reusing the model plumbing and `_event_staff_fields` partial from the dedicated staff editor.
- Permit `event_staffs_attributes` in `EventPolicy#params_filter` (the main form's params come from the policy, not a controller permit list).
- Intro copy + two new-tab preview links (**Preview sample staff callout** → `sample_staff_event_path`, then **View staff page**), positioned like the callouts section's sample-ticket button.
- Cards are `expandable-card`s: saved rows collapse to a summary (person / title / attendance) and expand for the bio editor; new rows start expanded. Section-level **Expand all / Collapse all** control on both the edit form and the standalone staff editor.
- New `RegistrationTicketCallout#staff?` predicate drives a note on the *Meet the staff* built-in callout explaining its page auto-lists the roster from the Event staff section.
- **Gate the *Meet the staff* built-in on the event having staff** — the card was the only built-in with no config gate; now it hides until staff are connected and shows the shared "Won't show unless you connect some staff" editor warning, via the existing `config_gap` mechanism.
- Card styling (gray backdrop, firmer borders, shadow, `space-y-3`) so cards read as distinct.

## Why
- Editing staff previously required a separate page; inline editing keeps it with the rest of the event config, and collapsing saved rows keeps a long roster scannable.
- A published *Meet the staff* card that links to an empty roster is a dead end — gating it (like Payment/Scholarship/CE/Videoconference) keeps the ticket honest.

## Test
- Request spec: staff created via nested attributes on `PATCH /update`.
- Service spec: staff card gated on staff presence; `card_for` returns nil for a staff row with no staff.
- Decorator spec: "connect some staff" hint appears with no staff, clears once staff exist.
- Existing edit / staff-edit render specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
