### PR TITLE
Collapse unpublished and long-past events into an index archive list for admins

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,17 @@ class EventsController < ApplicationController
   def index
     authorize!
     base_scope = authorized_scope(Event.all)
-    @events  = base_scope.search_by_params(params).order(start_date: :desc)
+    events = base_scope.search_by_params(params).order(start_date: :desc)
+    # Admins see every event, including unpublished drafts and long-past ones;
+    # collapse those into a compact archive list so the cards grid stays focused
+    # on current events. Non-admins never receive those events, so they keep
+    # every card.
+    if allowed_to?(:new?, Event)
+      @events, @archived_events = events.partition(&:shown_as_card?)
+    else
+      @events = events
+      @archived_events = []
+    end
   end
 
   def show

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -84,6 +84,12 @@ class EventDecorator < ApplicationDecorator
     length ? description&.truncate(length) : description
   end
 
+  # Short reason an event sits in the index archive list rather than the cards
+  # grid: unpublished drafts read as "Draft", everything else there has ended.
+  def archive_status_label
+    published? ? "Ended" : "Draft"
+  end
+
   # Compact event label for tight/tabular or multi-event contexts: the admin-set
   # abbreviation (e.g. "TOS205") when present, otherwise the full title. Pair it
   # with the full title as a tooltip so the abbreviation is never ambiguous.

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,11 @@ class Event < ApplicationRecord
   # link is available to paid registrants.
   VIDEOCONFERENCE_JOIN_BUFFER = 30.minutes
 
+  # How long a finished event keeps a full card on the events index before it
+  # collapses into the compact archive list (admins only — they're the only ones
+  # who see past and unpublished events there).
+  CARD_ARCHIVE_AGE = 1.month
+
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
@@ -148,6 +153,13 @@ class Event < ApplicationRecord
 
   def ended?
     end_date < Time.current
+  end
+
+  # Whether the event shows as a full card on the events index. Unpublished
+  # events and events that ended more than a month ago collapse into the compact
+  # archive list instead of taking up a card.
+  def shown_as_card?
+    published? && end_date >= CARD_ARCHIVE_AGE.ago
   end
 
   def videoconference_window_open?

--- a/app/views/events/_archived_events.html.erb
+++ b/app/views/events/_archived_events.html.erb
@@ -1,0 +1,23 @@
+<%# Compact linked list of admin-only events kept off the cards grid: unpublished
+    drafts and events that ended more than a month ago. %>
+<div class="admin-only bg-blue-100 mt-10 rounded-lg p-4">
+  <h2 class="text-lg font-semibold text-gray-700 mb-3">Drafts and past events</h2>
+  <ul class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white">
+    <% events.each do |event| %>
+      <% event = event.decorate %>
+      <li class="flex items-center justify-between gap-4 px-4 py-2.5">
+        <%= link_to event_path(event),
+                    class: "min-w-0 text-sm font-medium text-gray-800 hover:underline truncate",
+                    data: { turbo_prefetch: false, turbo: false } do %>
+          <%= event.title %>
+        <% end %>
+        <div class="shrink-0 flex items-center gap-3 text-xs text-gray-500">
+          <span><%= event.short_date_range %></span>
+          <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600">
+            <%= event.archive_status_label %>
+          </span>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -40,6 +40,7 @@
       </div>
     <% end %>
 
+    <% archived_events = @archived_events.to_a %>
     <% if @events.any? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <% @events.each do |event| %>
@@ -47,15 +48,15 @@
         <% end %>
       </div>
 
-    <% elsif @archived_events.none? %>
+    <% elsif archived_events.none? %>
       <!-- Empty State -->
       <div class="text-center py-12 text-gray-500">
         No events available.
       </div>
     <% end %>
 
-    <% if @archived_events.any? %>
-      <%= render "archived_events", events: @archived_events %>
+    <% if archived_events.any? %>
+      <%= render "archived_events", events: archived_events %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -47,11 +47,15 @@
         <% end %>
       </div>
 
-    <% else %>
+    <% elsif @archived_events.none? %>
       <!-- Empty State -->
       <div class="text-center py-12 text-gray-500">
         No events available.
       </div>
+    <% end %>
+
+    <% if @archived_events.any? %>
+      <%= render "archived_events", events: @archived_events %>
     <% end %>
   </div>
 </div>

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#archive_status_label" do
+    it "reads as Draft for an unpublished event" do
+      event = build(:event, :unpublished).decorate
+      expect(event.archive_status_label).to eq("Draft")
+    end
+
+    it "reads as Ended for a published event" do
+      event = build(:event, :published).decorate
+      expect(event.archive_status_label).to eq("Ended")
+    end
+  end
+
   describe "#videoconference_room" do
     it "pulls the Zoom meeting ID from the join URL and groups the digits" do
       event = build(:event, videoconference_url: "https://awbw-org.zoom.us/j/88285411273").decorate

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -96,6 +96,28 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "#shown_as_card?" do
+    it "is true for a published event that has not ended" do
+      event = build(:event, :published, end_date: 1.day.from_now)
+      expect(event.shown_as_card?).to be true
+    end
+
+    it "is true for a published event that ended within the last month" do
+      event = build(:event, :published, end_date: 1.week.ago)
+      expect(event.shown_as_card?).to be true
+    end
+
+    it "is false for an unpublished event" do
+      event = build(:event, :unpublished, end_date: 1.day.from_now)
+      expect(event.shown_as_card?).to be false
+    end
+
+    it "is false for a published event that ended more than a month ago" do
+      event = build(:event, :published, end_date: (1.month + 1.day).ago)
+      expect(event.shown_as_card?).to be false
+    end
+  end
+
   describe "#videoconference_window_open?" do
     it "returns false more than 30 minutes before the start" do
       event = build(:event, start_date: 31.minutes.from_now, end_date: 2.hours.from_now)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -54,6 +54,48 @@ RSpec.describe "Events", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    context "as an admin with unpublished and long-past events" do
+      let!(:current_event) do
+        create(:event, :published, title: "Current workshop",
+          start_date: 5.days.from_now, end_date: 6.days.from_now)
+      end
+      let!(:draft_event) { create(:event, :unpublished, title: "Draft workshop") }
+      let!(:old_event) do
+        create(:event, :published, title: "Old workshop",
+          start_date: 3.months.ago, end_date: 3.months.ago + 1.day)
+      end
+
+      before do
+        sign_in admin
+        get events_path
+      end
+
+      it "shows current published events as cards" do
+        expect(response.body).to include(ActionView::RecordIdentifier.dom_id(current_event, :card))
+      end
+
+      it "lists unpublished and long-ended events instead of carding them" do
+        expect(response.body).to include("Drafts and past events")
+        expect(response.body).not_to include(ActionView::RecordIdentifier.dom_id(draft_event, :card))
+        expect(response.body).not_to include(ActionView::RecordIdentifier.dom_id(old_event, :card))
+        expect(response.body).to include("Draft workshop")
+        expect(response.body).to include("Old workshop")
+      end
+    end
+
+    context "as a non-admin" do
+      let!(:current_event) do
+        create(:event, :published, :publicly_visible, title: "Public workshop",
+          start_date: 5.days.from_now, end_date: 6.days.from_now)
+      end
+
+      it "never shows the drafts and past events list" do
+        sign_in user
+        get events_path
+        expect(response.body).not_to include("Drafts and past events")
+      end
+    end
+
     context "when user time_zone is set" do
       # 19:00 UTC = 12:00 noon PT = 15:00 (3 pm) ET (June 15, 2031 with DST)
       let(:utc_start) { Time.utc(2031, 6, 15, 19, 0, 0) }

--- a/spec/views/events/index.html.erb_spec.rb
+++ b/spec/views/events/index.html.erb_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe "events/index", type: :view do
     end
   end
 
+  describe "with archived events" do
+    let(:draft) { create(:event, :unpublished, title: "Draft Event") }
+
+    before do
+      assign(:events, [])
+      assign(:archived_events, [ draft ])
+      render
+    end
+
+    it "lists archived events instead of the empty message" do
+      expect(rendered).to include("Drafts and past events")
+      expect(rendered).to include("Draft Event")
+      expect(rendered).not_to include("No events available")
+    end
+  end
+
   describe "when not allowed" do
     before do
       allow(view).to receive(:allowed_to?).and_return(false)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained index-partition change with admin-only blast radius

### What is the goal of this PR and why is this important?
- Admins are the only ones who see draft and long-ended events on the events index, and they crowd out the current-events grid.
- Unpublished events and events that ended more than a month ago now drop out of the cards grid into a compact linked list ("Drafts and past events") below it.

### How did you approach the change?
- `Event#shown_as_card?` (published and not ended > `CARD_ARCHIVE_AGE` = 1 month ago) decides card vs. list.
- `EventsController#index` partitions into `@events` / `@archived_events`, but only for admins — non-admins never receive those events, so they keep every card.
- New `events/_archived_events` partial renders the linked list; `EventDecorator#archive_status_label` labels each row Draft/Ended.

### Anything else to add?
- Non-admins are unaffected: the archive list is admin-only and their scope already excludes these events.