### PR TITLE
Tidy the recipients roster layout and lighten primary chips

### DIFF
--- a/app/views/events/_registrant_roster.html.erb
+++ b/app/views/events/_registrant_roster.html.erb
@@ -49,7 +49,7 @@
       </thead>
       <tbody class="block sm:table-row-group divide-y divide-gray-100" data-table-sort-target="body">
         <% orgs_by_id = roster.organizations.index_by(&:id) %>
-        <% lime_chip_class = "inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-200 px-2 py-0.5 text-xs font-medium text-lime-800" %>
+        <% lime_chip_class = "inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-100 px-2 py-0.5 text-xs font-medium text-lime-800" %>
         <%# Per-cell label shown only in the stacked mobile card; the column
             header supplies it at sm+, so it's hidden there. %>
         <% mobile_label = ->(text) { tag.span(text, class: "sm:hidden shrink-0 w-24 pt-0.5 text-xs font-semibold uppercase tracking-wide text-gray-400") } %>

--- a/app/views/events/_staff_cards.html.erb
+++ b/app/views/events/_staff_cards.html.erb
@@ -98,7 +98,7 @@
                   <%= render "sectors/tagging_label", sector: lead_sector.sector, is_primary: lead_sector.is_primary? %>
                 <% end %>
                 <% if lead_age %>
-                  <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 <%= lead_age_primary ? "bg-lime-200 text-lime-800" : "bg-lime-50 text-gray-500" %> px-2 py-0.5 text-xs font-medium">
+                  <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 <%= lead_age_primary ? "bg-lime-100 text-lime-800" : "bg-lime-50 text-gray-500" %> px-2 py-0.5 text-xs font-medium">
                     <% if lead_age_primary %><i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><% end %><%= lead_age.name %>
                   </span>
                 <% end %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -50,32 +50,34 @@
   </div>
 
   <% if @dashboard.scholarship_applicants.any? %>
-    <h2 class="text-xl font-bold mb-4 flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
-      <i class="fa-solid fa-user-graduate"></i>
-      Recipients
-    </h2>
     <div data-controller="expandable-cards scholarship-status-toggle"
          data-scholarship-status-toggle-shown-value="true">
-      <%# Controls — show/hide scholarship status for all recipients, and expand/collapse all %>
-      <div class="flex flex-wrap items-center justify-end gap-4 mb-4 print:hidden">
-        <%# Show / hide each recipient's awarded amount + tasks-completed status %>
-        <button type="button" role="switch" aria-checked="true"
-                data-action="scholarship-status-toggle#toggle"
-                data-scholarship-status-toggle-target="switch"
-                class="group inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800">
-          <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-fuchsia-600 transition-colors"
-                data-scholarship-status-toggle-target="track">
-            <span class="inline-block h-4 w-4 translate-x-[1.125rem] transform rounded-full bg-white shadow transition-transform"
-                  data-scholarship-status-toggle-target="knob"></span>
-          </span>
-          <span>Show scholarship status</span>
-        </button>
-        <%# Expand / collapse all %>
-        <button type="button" data-action="expandable-cards#toggleAll"
-                class="inline-flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> hover:<%= DomainTheme.text_class_for(:scholarships) %>">
-          <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-cards-target="icon"></i>
-          <span data-expandable-cards-target="label">Collapse all</span>
-        </button>
+      <%# Title shares a row with the controls (show/hide scholarship status, expand/collapse all) %>
+      <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
+        <h2 class="text-xl font-bold flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+          <i class="fa-solid fa-user-graduate"></i>
+          Recipients
+        </h2>
+        <div class="flex flex-wrap items-center gap-4 print:hidden">
+          <%# Show / hide each recipient's awarded amount + tasks-completed status %>
+          <button type="button" role="switch" aria-checked="true"
+                  data-action="scholarship-status-toggle#toggle"
+                  data-scholarship-status-toggle-target="switch"
+                  class="group inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-800">
+            <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-fuchsia-600 transition-colors"
+                  data-scholarship-status-toggle-target="track">
+              <span class="inline-block h-4 w-4 translate-x-[1.125rem] transform rounded-full bg-white shadow transition-transform"
+                    data-scholarship-status-toggle-target="knob"></span>
+            </span>
+            <span>Show scholarship status</span>
+          </button>
+          <%# Expand / collapse all %>
+          <button type="button" data-action="expandable-cards#toggleAll"
+                  class="inline-flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> hover:<%= DomainTheme.text_class_for(:scholarships) %>">
+            <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-cards-target="icon"></i>
+            <span data-expandable-cards-target="label">Collapse all</span>
+          </button>
+        </div>
       </div>
 
       <div class="space-y-6">
@@ -130,10 +132,10 @@
               <% end %>
 
               <div class="min-w-0 flex-1 flex flex-wrap items-start gap-x-8 gap-y-3">
-                <%# Name with title / organization beneath. Fixed width on wider
-                    screens so the Serves / Ages strip starts at a consistent left
+                <%# Name with title / organization beneath. Fixed width on wide
+                    screens so the Serves / Ages columns start at a consistent left
                     edge across rows instead of a jagged one. %>
-                <div class="min-w-0 lg:w-72 lg:shrink-0">
+                <div class="min-w-0 xl:w-72 xl:shrink-0">
                   <%= link_to person.name, person_path(person), data: { turbo_frame: "_top" },
                               class: "text-lg font-bold text-gray-900 hover:underline" %>
                   <% recipient_affiliations.each do |affiliation| %>
@@ -153,32 +155,28 @@
                   <% end %>
                 </div>
 
-                <%# Serves / Ages — parallel with the name %>
-                <% if has_sectors || sector_text.present? || has_age_groups || age_group_text.present? %>
-                  <div class="flex flex-wrap items-center gap-x-8 gap-y-2 lg:flex-1 lg:min-w-0">
+                <%# Serves / Ages — two fixed-width columns so each label starts at
+                    a consistent x across rows and its chips wrap within its own
+                    column instead of pushing the next column out of alignment. %>
+                <% if has_sectors || sector_text.present? %>
+                  <div class="flex flex-wrap items-center gap-2 xl:w-96 xl:shrink-0">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
                     <% if has_sectors %>
-                      <div class="flex flex-wrap items-center gap-2">
-                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
-                        <% sectorable_items.each do |si| %>
-                          <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
-                        <% end %>
-                      </div>
-                    <% elsif sector_text.present? %>
-                      <div class="text-sm text-gray-600">
-                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
-                        <%= sector_text %>
-                      </div>
+                      <% sectorable_items.each do |si| %>
+                        <%= render "sectors/tagging_label", sector: si.sector, is_primary: si.is_primary? %>
+                      <% end %>
+                    <% else %>
+                      <span class="text-sm text-gray-600"><%= sector_text %></span>
                     <% end %>
+                  </div>
+                <% end %>
+                <% if has_age_groups || age_group_text.present? %>
+                  <div class="flex flex-wrap items-center gap-2 xl:w-80 xl:shrink-0">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
                     <% if has_age_groups %>
-                      <div class="flex flex-wrap items-center gap-2">
-                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
-                        <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
-                      </div>
-                    <% elsif age_group_text.present? %>
-                      <div class="flex items-center gap-2">
-                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
-                        <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-600"><%= age_group_text %></span>
-                      </div>
+                      <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
+                    <% else %>
+                      <span class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-600"><%= age_group_text %></span>
                     <% end %>
                   </div>
                 <% end %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -171,7 +171,7 @@
                   </div>
                 <% end %>
                 <% if has_age_groups || age_group_text.present? %>
-                  <div class="flex flex-wrap items-center gap-2 xl:w-80 xl:shrink-0">
+                  <div class="flex flex-wrap items-center gap-2 xl:w-[28rem] xl:shrink-0">
                     <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
                     <% if has_age_groups %>
                       <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -159,7 +159,7 @@
                     a consistent x across rows and its chips wrap within its own
                     column instead of pushing the next column out of alignment. %>
                 <% if has_sectors || sector_text.present? %>
-                  <div class="flex flex-wrap items-center gap-2 xl:w-96 xl:shrink-0">
+                  <div class="flex flex-wrap items-center gap-2 xl:w-[28rem] xl:shrink-0">
                     <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>
                     <% if has_sectors %>
                       <% sectorable_items.each do |si| %>
@@ -171,7 +171,7 @@
                   </div>
                 <% end %>
                 <% if has_age_groups || age_group_text.present? %>
-                  <div class="flex flex-wrap items-center gap-2 xl:w-[28rem] xl:shrink-0">
+                  <div class="flex flex-wrap items-center gap-2 xl:w-[27rem] xl:shrink-0">
                     <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Ages</span>
                     <% if has_age_groups %>
                       <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -155,7 +155,7 @@
 
                 <%# Serves / Ages — parallel with the name %>
                 <% if has_sectors || sector_text.present? || has_age_groups || age_group_text.present? %>
-                  <div class="flex flex-wrap items-center gap-x-8 gap-y-2">
+                  <div class="flex flex-wrap items-center gap-x-8 gap-y-2 lg:flex-1 lg:min-w-0">
                     <% if has_sectors %>
                       <div class="flex flex-wrap items-center gap-2">
                         <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Serves</span>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -129,9 +129,11 @@
                 <span class="w-10 h-10 rounded-full flex items-center justify-center bg-gray-100 text-gray-500 font-bold border border-gray-200 shrink-0"><%= person.name.to_s.first&.upcase %></span>
               <% end %>
 
-              <div class="min-w-0 flex-1 flex flex-wrap items-start justify-between gap-x-8 gap-y-3">
-                <%# Name with title / organization beneath %>
-                <div class="min-w-0">
+              <div class="min-w-0 flex-1 flex flex-wrap items-start gap-x-8 gap-y-3">
+                <%# Name with title / organization beneath. Fixed width on wider
+                    screens so the Serves / Ages strip starts at a consistent left
+                    edge across rows instead of a jagged one. %>
+                <div class="min-w-0 lg:w-72 lg:shrink-0">
                   <%= link_to person.name, person_path(person), data: { turbo_frame: "_top" },
                               class: "text-lg font-bold text-gray-900 hover:underline" %>
                   <% recipient_affiliations.each do |affiliation| %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -57,7 +57,7 @@
     <div data-controller="expandable-cards scholarship-status-toggle"
          data-scholarship-status-toggle-shown-value="true">
       <%# Controls — show/hide scholarship status for all recipients, and expand/collapse all %>
-      <div class="flex flex-wrap items-center justify-between gap-3 mb-4 print:hidden">
+      <div class="flex flex-wrap items-center justify-end gap-4 mb-4 print:hidden">
         <%# Show / hide each recipient's awarded amount + tasks-completed status %>
         <button type="button" role="switch" aria-checked="true"
                 data-action="scholarship-status-toggle#toggle"

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -147,7 +147,7 @@
       <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> p-4 shadow-sm
                   flex flex-wrap items-center content-start gap-2 flex-1"
            data-controller="primary-tag"
-           data-primary-tag-primary-class="border-lime-500 bg-lime-200"
+           data-primary-tag-primary-class="border-lime-500 bg-lime-100"
            data-primary-tag-default-class="border-gray-300 bg-white">
         <% sectors_owner = f.object.respond_to?(:object) ? f.object.object : f.object %>
         <%# "Other" is never a real sector tag (it's captured as an OtherResponse),

--- a/app/views/sectors/_tagging_label.html.erb
+++ b/app/views/sectors/_tagging_label.html.erb
@@ -23,7 +23,7 @@
 <%# Primary sectors read as a darker-green chip with a star so they stand
     out from the additional sectors, matching the star used in the chip editor;
     everyone else keeps the light-lime default. %>
-<% bg_color ||= is_primary ? "bg-lime-200" : DomainTheme.bg_class_for(:sectors) %>
+<% bg_color ||= is_primary ? "bg-lime-100" : DomainTheme.bg_class_for(:sectors) %>
 
 <%# bg_hover_color ||= DomainTheme.bg_class_for(:sectors, hover: true) %>
 

--- a/app/views/shared/_age_group_tags.html.erb
+++ b/app/views/shared/_age_group_tags.html.erb
@@ -8,7 +8,7 @@
 <% padding = compact ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm" %>
 <div class="flex flex-wrap gap-1.5">
   <% primary.each do |category| %>
-    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-200 <%= padding %> font-medium text-lime-800">
+    <span class="inline-flex items-center whitespace-nowrap rounded-md border border-lime-300 bg-lime-100 <%= padding %> font-medium text-lime-800">
       <i class="fa-solid fa-star mr-1 text-xs text-amber-400" aria-hidden="true" title="Primary age group"></i><%= category.name %>
     </span>
   <% end %>

--- a/app/views/shared/_age_range_item_fields.html.erb
+++ b/app/views/shared/_age_range_item_fields.html.erb
@@ -6,7 +6,7 @@
 <% collection ||= @age_ranges_collection || Category.age_ranges.published.order(:position, :name).pluck(:name, :id) %>
 <% is_primary = f.object&.is_primary? %>
 <div class="nested-fields inline-flex items-center gap-2
-            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-200" : "bg-lime-50" %>
+            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
             text-gray-700 px-3 py-1 text-sm font-medium transition"
      data-primary-tag-target="chip">
   <% if f.object&.category_id.present? %>

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -3,7 +3,7 @@
 <% is_primary = f.object&.is_primary? %>
 
 <div class="nested-fields inline-flex items-center gap-2
-            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-200" : "bg-lime-50" %>
+            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
             text-gray-700 px-3 py-1 text-sm font-medium transition"
      data-primary-tag-target="chip">
   <% if f.object&.sector_id.present? %>

--- a/spec/views/sectors/_tagging_label.html.erb_spec.rb
+++ b/spec/views/sectors/_tagging_label.html.erb_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe "sectors/_tagging_label", type: :view do
     expect(rendered).to include(DomainTheme.bg_class_for(:sectors))
   end
 
-  it "marks a primary sector with a darker-green chip and a star" do
+  it "marks a primary sector with a light-green chip and a star" do
     render partial: "sectors/tagging_label", locals: { sector: sector, is_primary: true }
 
     expect(rendered).to include("fa-star")
-    expect(rendered).to include("bg-lime-200")
+    expect(rendered).to include("bg-lime-100")
   end
 
   context "when the sector is hidden from the public (unpublished)" do


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only styling across the recipients roster plus a lime-200→lime-100 swap on primary chips app-wide

### What is the goal of this PR and why is this important?
- Clean up the scholarship recipients roster layout and make the primary chips a touch lighter.

### How did you approach the change?
- **Serves / Ages columns:** split into two fixed-width columns (`xl:`) so each label starts at a consistent x across rows and its chips wrap within its own column, instead of one wrapping strip that knocked the next label out of alignment.
- **Header row:** moved the "Recipients" title onto the same row as the show-status toggle and Expand/collapse all control.
- **Primary chips:** lightened the background from `bg-lime-200` to `bg-lime-100` everywhere a primary sector/age chip renders (recipients roster, registrant roster, staff cards, tagging labels, person form).