### PR TITLE
Feature scholarship recipients for shout-outs from the recipients page

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -105,6 +105,7 @@ class EventRegistrationsController < ApplicationController
           when "preview_reminder" then redirect_to preview_reminder_event_path(@event_registration.event), notice: notice, status: :see_other
           when "onboarding" then redirect_to helpers.onboarding_event_row_path(@event_registration.event, @event_registration.id), notice: notice, status: :see_other
           when "training_attendees" then redirect_to training_attendees_events_path, notice: notice, status: :see_other
+          when "recipients" then redirect_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), notice: notice, status: :see_other
           else
             # No explicit origin: keep admins in the management context (the
             # roster) rather than dropping them on the public registration show.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   include AhoyTracking, TagAssignable
   skip_before_action :authenticate_user!, only: [ :index, :show, :staff ]
   skip_before_action :verify_authenticity_token, only: [ :preview ]
-  before_action :set_event, only: %i[ show edit update destroy preview dashboard sample_ticket background registrants onboarding staff edit_staff update_staff recipients preview_reminder confirm_reminder send_reminder copy_registration_form ]
+  before_action :set_event, only: %i[ show edit update destroy preview dashboard sample_ticket background registrants onboarding staff edit_staff update_staff recipients feature_recipient_shoutout preview_reminder confirm_reminder send_reminder copy_registration_form ]
   before_action :set_report_filters, only: %i[ revenue participation statistics scholarships ]
 
   def index
@@ -272,6 +272,27 @@ class EventsController < ApplicationController
     authorize! @event, to: :recipients?
     @event = @event.decorate
     @dashboard = EventDashboard.new(@event)
+  end
+
+  # From the recipients page "Add shoutout" control: flag the chosen registrant
+  # for the recipients-page shout-out, seed the shout-out text from their profile
+  # bio when it's blank, then send the admin to their registration edit form to
+  # review (the toggle and any seeded text are already saved on arrival).
+  def feature_recipient_shoutout
+    authorize! @event, to: :recipients?
+    registration = @event.event_registrations.active.find_by(id: params[:registration_id])
+    unless registration
+      redirect_to recipients_event_path(@event), alert: "Choose a recipient to feature." and return
+    end
+
+    authorize! registration, to: :update?
+    registrant = registration.registrant
+    registration.update!(shoutout: true)
+    if registrant.shoutout_text.blank? && (bio = shoutout_bio_from_profile(registrant))
+      registrant.update!(shoutout_text: bio)
+    end
+    redirect_to edit_event_registration_path(registration, return_to: "recipients", anchor: "shout-out"),
+                notice: "Featured on the recipients page — review their shout-out text below.", status: :see_other
   end
 
   def preview_reminder
@@ -894,6 +915,13 @@ class EventsController < ApplicationController
         .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
     @sectors = Sector.published.order(:name)
+  end
+
+  # The registrant's profile bio as plain text, usable to seed a shout-out — only
+  # when the bio is shown on their profile. Nil when hidden or blank.
+  def shoutout_bio_from_profile(person)
+    return unless person.profile_show_bio?
+    helpers.strip_tags(person.bio).to_s.strip.presence
   end
 
   def set_event

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -237,6 +237,13 @@ class EventDashboard
     @registration_slug_by_registrant ||= active_registrations.pluck(:registrant_id, :slug).to_h
   end
 
+  # Active registration id per registrant (Person id) — links a recipient's
+  # shout-out row on the recipients page to their registration edit form, where
+  # the shout-out flag and text are set. One active registration per event.
+  def registration_id_by_registrant
+    @registration_id_by_registrant ||= active_registrations.pluck(:registrant_id, :id).to_h
+  end
+
   # The [ event, participant slug ] a registrant's scholarship icon links to: this
   # event's recipients page, anchored to their entry. The shared roster partial
   # reads this so the same column works on the cross-event training-attendees

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -327,7 +327,7 @@
           shout-out block and edits the text shown there. The text lives on the
           registrant's profile (Person#shoutout_text); editing it here updates
           their profile via nested attributes. ---- %>
-      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <section id="shout-out" class="scroll-mt-24 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
           <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:scholarships, f.object.shoutout? || f.object.registrant.shoutout_text.present?) %>">
             <i class="fa-solid fa-bullhorn"></i>
@@ -335,8 +335,8 @@
           <h2 class="text-sm font-semibold text-gray-700">Shout out</h2>
         </div>
 
-        <div class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
-          <label class="flex shrink-0 items-center gap-2.5 cursor-pointer">
+        <div class="flex flex-col gap-3 p-4 sm:flex-row sm:items-start">
+          <label class="flex shrink-0 items-center gap-2.5 cursor-pointer sm:mt-6">
             <input type="hidden" name="event_registration[shoutout]" value="0" autocomplete="off">
             <input type="checkbox"
                    name="event_registration[shoutout]"
@@ -349,9 +349,9 @@
 
           <div class="flex-1">
             <%= f.simple_fields_for :registrant do |rf| %>
+              <%= rf.label :shoutout_text, "Shout-out text", class: "mb-1 block text-xs font-medium text-gray-700" %>
               <%= rf.input :shoutout_text,
-                    label: "Shout-out text",
-                    label_html: { class: "sr-only" },
+                    label: false,
                     as: :text,
                     placeholder: "Shown beneath their name on the recipients page",
                     wrapper_html: { class: "mb-0" },
@@ -427,12 +427,23 @@
         </span>
       <% end %>
 
-      <% cancel_path = case params[:return_to]
-                       when "registrants" then registrants_event_row_path(event_registration.event, event_registration.id)
-                       when "index" then event_registrations_path
-                       when "preview_reminder" then preview_reminder_event_path(event_registration.event)
-                       else allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path
-                       end %>
+      <%# Cancel returns where the eyebrow does — the event's registrants roster by
+          default, only the global index when the admin explicitly came from it. A
+          not-yet-saved registration has no event/roster to return to, so it falls
+          back to the index (or root for non-admins). %>
+      <% cancel_path = if event_registration.persisted? && event_registration.event
+        case params[:return_to]
+        when "index" then event_registrations_path
+        when "bulk_payments" then bulk_payments_return_path(event_registration.event)
+        when "preview_reminder" then preview_reminder_event_path(event_registration.event)
+        when "onboarding" then onboarding_event_row_path(event_registration.event, event_registration.id)
+        when "training_attendees" then training_attendees_events_path
+        when "recipients" then recipients_event_path(event_registration.event, anchor: "shout-outs")
+        else allowed_to?(:manage?, with: EventRegistrationPolicy) ? registrants_event_row_path(event_registration.event, event_registration.id) : registration_ticket_path(event_registration.slug)
+        end
+      else
+        allowed_to?(:index?, EventRegistration) ? event_registrations_path : root_path
+      end %>
 
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", cancel_path, class: "btn btn-secondary-outline" %>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -22,6 +22,14 @@
       <%= link_to training_attendees_events_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Training attendees
       <% end %>
+    <% elsif params[:return_to] == "recipients" %>
+      <%= link_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
+      <% end %>
+    <% elsif params[:return_to] == "index" %>
+      <%= link_to event_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
+      <% end %>
     <% else %>
       <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -260,15 +260,43 @@
 
   <%# ---- Shout outs: registrants who opted in, with their shout-out text ---- %>
   <% if @dashboard.shoutouts.any? %>
-    <div class="mt-10 break-inside-avoid">
-      <h2 class="text-xl font-bold mb-4 flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
-        <i class="fa-solid fa-bullhorn"></i>
-        Shout outs
-      </h2>
+    <div id="shout-outs" class="scroll-mt-24 mt-10 break-inside-avoid">
+      <% recipient_shoutout_options = @dashboard.scholarship_applicants.filter_map { |person|
+           reg_id = @dashboard.registration_id_by_registrant[person.id]
+           next unless reg_id
+           label = person.email.present? ? "#{person.name} (#{person.email})" : person.name
+           [ label, reg_id ]
+         } %>
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 class="text-xl font-bold flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+          <i class="fa-solid fa-bullhorn"></i>
+          Shout outs
+        </h2>
+        <%# Search a scholarship recipient and feature them: this flags their
+            registration for a shout-out, then lands on their registration edit
+            form to add the shout-out text (the toggle is already saved). %>
+        <% if recipient_shoutout_options.any? %>
+          <%= form_with url: feature_recipient_shoutout_event_path(@event), method: :post,
+                        data: { turbo: false }, class: "flex items-center gap-2 print:hidden" do %>
+            <div class="min-w-[220px]" data-controller="searchable-select" data-searchable-select-mode-value="person">
+              <%= select_tag :registration_id,
+                             options_for_select(recipient_shoutout_options),
+                             include_blank: true, prompt: "Search recipients…",
+                             aria: { label: "Search scholarship recipients to add a shout-out" },
+                             class: "ts-flat w-full bg-white border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-fuchsia-500 focus:border-fuchsia-500",
+                             data: { searchable_select_target: "select" } %>
+            </div>
+            <button type="submit" class="btn btn-utility-outline whitespace-nowrap">
+              <i class="fa-solid fa-plus"></i> Add shoutout
+            </button>
+          <% end %>
+        <% end %>
+      </div>
       <div class="bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm divide-y divide-gray-100">
         <% @dashboard.shoutouts.each do |shoutout| %>
           <% org_link_class = "text-sm font-semibold #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:#{DomainTheme.text_class_for(:scholarships)} hover:underline" %>
-          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 px-5 py-4 break-inside-avoid">
+          <div class="flex items-start gap-3 px-5 py-4 break-inside-avoid">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 flex-1 min-w-0">
             <%# Organization on the left, linked to its website when it has one,
                 otherwise to its profile page. %>
             <div class="sm:col-span-1">
@@ -290,6 +318,16 @@
               <% if meta.any? %><span class="text-gray-500">(<%= meta.join(", ") %>)</span><% end %>
               — <%= shoutout.text %>
             </div>
+            </div>
+            <%# Jump to this recipient's registration edit form, anchored to the
+                shout-out section, to change the flag or text. %>
+            <% reg_id = @dashboard.registration_id_by_registrant[shoutout.recipient.id] %>
+            <% if reg_id %>
+              <%= link_to edit_event_registration_path(reg_id, return_to: "recipients", anchor: "shout-out"),
+                          class: "shrink-0 inline-flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline print:hidden" do %>
+                <i class="fa-solid fa-pen"></i> Edit
+              <% end %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -344,35 +344,17 @@
     </div>
 
     <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-      <%# Bio and Shout-out share one row, each half width. %>
-      <div class="flex flex-col sm:flex-row gap-6 items-start">
-        <div class="w-full sm:w-1/2 space-y-4">
-          <%= f.input :bio,
-                      wrapper_html: { class: "w-full" },
-                      as: :text,
-                      input_html: {
-                        rows: 2,
-                        maxlength: 1650,
-                        class: "w-full rounded-md border-gray-300 shadow-sm
-                            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                      },
-                      hint: "Maximum 250 characters" %>
-        </div>
-
-        <div class="w-full sm:w-1/2 space-y-4">
-          <%= f.input :shoutout_text,
-                      label: "Shout-out",
-                      wrapper_html: { class: "w-full" },
-                      as: :text,
-                      input_html: {
-                        rows: 2,
-                        maxlength: 1650,
-                        class: "w-full rounded-md border-gray-300 shadow-sm
-                            focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                      },
-                      hint: "Shown on an event's scholarship recipients page if designated for a shout-out" %>
-        </div>
-      </div>
+      <%# Shout-out text is edited on the registration's "Shout out" section, not here. %>
+      <%= f.input :bio,
+                  wrapper_html: { class: "w-full" },
+                  as: :text,
+                  input_html: {
+                    rows: 2,
+                    maxlength: 1650,
+                    class: "w-full rounded-md border-gray-300 shadow-sm
+                        focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                  },
+                  hint: "Maximum 250 characters" %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
       get "staff/edit", action: :edit_staff, as: :edit_staff
       patch "staff", action: :update_staff
       get :recipients
+      post :feature_recipient_shoutout
       get :bulk_payments, to: "events/bulk_payments#index"
       get :preview_reminder
       patch :preview

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -438,6 +438,21 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).not_to include("reverted payments still count")
       end
 
+      it "points Cancel at the event's registrants roster by default" do
+        get edit_event_registration_path(existing_registration)
+
+        cancel_href = Capybara.string(response.body).find_link("Cancel")[:href]
+        expect(cancel_href).to start_with(registrants_event_path(existing_registration.event))
+      end
+
+      it "points Cancel at the registrations index only when the admin came from it" do
+        get edit_event_registration_path(existing_registration, return_to: "index")
+
+        cancel_href = Capybara.string(response.body).find_link("Cancel")[:href]
+        expect(cancel_href).to eq(event_registrations_path)
+      end
+
+
       it "shows the scholarship agreement status on the scholarship card" do
         scholarship = Scholarship.new(recipient: existing_registration.registrant, amount_cents: 1_000)
         scholarship.build_allocation(allocatable: existing_registration, amount: 1_000)
@@ -487,6 +502,13 @@ RSpec.describe "EventRegistrations", type: :request do
 
         expect(existing_registration.reload.shoutout).to be(true)
         expect(existing_registration.registrant.reload.shoutout_text).to eq("Grateful to bring art to survivors.")
+      end
+
+      it "returns to the recipients page shout-outs section when return_to is recipients" do
+        patch event_registration_path(existing_registration),
+              params: { return_to: "recipients", event_registration: { shoutout: "1" } }
+
+        expect(response).to redirect_to(recipients_event_path(existing_registration.event, anchor: "shout-outs"))
       end
 
       it "records an admin-set expected payment method even when the form was never filled out" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -2731,6 +2731,75 @@ RSpec.describe "Events", type: :request do
 
         expect(response.body).not_to include("Shout outs")
       end
+
+      it "offers a recipient search that posts to feature a chosen recipient" do
+        applicant.update!(shoutout_text: "Grateful to serve.")
+        registration = event.event_registrations.find_by(registrant: applicant)
+        registration.update!(shoutout: true)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include("Add shoutout")
+        expect(response.body).to include(feature_recipient_shoutout_event_path(event))
+        # The recipient is an option, valued by their registration id.
+        expect(response.body).to include("value=\"#{registration.id}\"")
+      end
+
+      it "links each shout-out row to that registrant's registration edit form" do
+        applicant.update!(shoutout_text: "Grateful to serve.")
+        registration = event.event_registrations.find_by(registrant: applicant)
+        registration.update!(shoutout: true)
+
+        get recipients_event_path(event)
+
+        expect(response.body).to include(edit_event_registration_path(registration.id, return_to: "recipients", anchor: "shout-out"))
+      end
+
+      describe "POST /events/:id/feature_recipient_shoutout" do
+        it "flags the registration and sends the admin to its edit form" do
+          registration = event.event_registrations.find_by(registrant: applicant)
+
+          post feature_recipient_shoutout_event_path(event), params: { registration_id: registration.id }
+
+          expect(registration.reload.shoutout).to be(true)
+          expect(response).to redirect_to(
+            edit_event_registration_path(registration, return_to: "recipients", anchor: "shout-out")
+          )
+        end
+
+        it "seeds the shout-out text from the profile bio when it is blank" do
+          applicant.update!(bio: "Two decades bringing art to survivors.", profile_show_bio: true, shoutout_text: nil)
+          registration = event.event_registrations.find_by(registrant: applicant)
+
+          post feature_recipient_shoutout_event_path(event), params: { registration_id: registration.id }
+
+          expect(applicant.reload.shoutout_text).to eq("Two decades bringing art to survivors.")
+        end
+
+        it "does not overwrite existing shout-out text with the bio" do
+          applicant.update!(bio: "Bio text.", shoutout_text: "Custom shout-out.")
+          registration = event.event_registrations.find_by(registrant: applicant)
+
+          post feature_recipient_shoutout_event_path(event), params: { registration_id: registration.id }
+
+          expect(applicant.reload.shoutout_text).to eq("Custom shout-out.")
+        end
+
+        it "leaves the shout-out text blank when the profile bio is hidden" do
+          applicant.update!(bio: "Hidden bio.", profile_show_bio: false, shoutout_text: nil)
+          registration = event.event_registrations.find_by(registrant: applicant)
+
+          post feature_recipient_shoutout_event_path(event), params: { registration_id: registration.id }
+
+          expect(applicant.reload.shoutout_text).to be_blank
+        end
+
+        it "returns to the recipients page with an alert when no recipient is chosen" do
+          post feature_recipient_shoutout_event_path(event), params: { registration_id: "" }
+
+          expect(response).to redirect_to(recipients_event_path(event))
+        end
+      end
     end
 
     context "as non-admin non-owner" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -503,6 +503,13 @@ RSpec.describe EventDashboard do
       expect(dashboard.scholarship_applicants).to eq([ separate_applicant, embedded_applicant ])
     end
 
+    it "maps each active registrant to their registration id" do
+      map = dashboard.registration_id_by_registrant
+
+      expect(map[embedded_applicant.id]).to eq(EventRegistration.find_by(event: event, registrant: embedded_applicant).id)
+      expect(map[separate_applicant.id]).to eq(EventRegistration.find_by(event: event, registrant: separate_applicant).id)
+    end
+
     it "gathers scholarship answers wherever they were captured, keyed by applicant" do
       answers = dashboard.scholarship_answers_by_applicant
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained flow + navigation changes across the recipients/registration-edit views with request-spec coverage

### What is the goal of this PR and why is this important?
Let admins feature a scholarship recipient for the recipients-page shout-out without hand-editing profiles, and fix where the registration edit form returns on cancel/back.

### How did you approach the change?
- **Recipients page:** a recipient-scoped search + **Add shoutout** button. It flags the registration (`shoutout: true`), seeds the shout-out text from the registrant's *visible* profile bio when blank (never overwrites existing text), then lands on the registration edit form anchored to the Shout out section. Search box uses the existing `ts-flat` pattern (single outline).
- **Each shout-out row** gets an **Edit** link to that same edit form.
- **Shout-out text is now managed only on the registration** — removed the field from the profile edit form.
- **Registration edit navigation:** new `recipients` return target (eyebrow + save redirect land on the shout-outs anchor). **Cancel and the back eyebrow now default to the event's registrants roster** — only the global index when the admin explicitly came from it — keeping both return affordances in sync.

### Anything else to add?
- Branch is currently 2 commits behind `main`, with overlap in `events_controller.rb` and `events_spec.rb` (the merged staff/archive PRs). Happy to rebase.
- Considered a silent "show bio when text is empty" fallback and a client-side Fill button; dropped both in favor of the explicit server-side seed (no new JS).