### PR TITLE
Add a file-upload answer type to the form engine

### DIFF
--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -11,7 +11,20 @@ class FormAnswer < ApplicationRecord
   belongs_to :form_field, optional: true
   belongs_to :form_submission
 
+  # A file-upload answer stores its file on a polymorphic Asset (the same
+  # attachment/validation/display machinery story ideas use). Text answers leave
+  # this nil; submitted_answer still holds the filename so every text-only
+  # display and export shows something readable.
+  has_one :asset, as: :owner, dependent: :destroy
+
   def name
     "#{question_name_when_answered.presence || form_field&.name}: #{submitted_answer}"
+  end
+
+  # The attached upload, when this answer is a file-upload answer with a file on
+  # file. nil for text answers or an unanswered file question.
+  def uploaded_file
+    file = asset&.file
+    file if file&.attached?
   end
 end

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -118,7 +118,8 @@ class FormField < ApplicationRecord
     :no_user_input,
     :multi_select_checkbox,
     :group_header,
-    :single_select_dropdown
+    :single_select_dropdown,
+    :file_upload
   ]
 
   enum :input_type, [
@@ -148,6 +149,7 @@ class FormField < ApplicationRecord
     "single_select_radio" => "Single select radio",
     "single_select_dropdown" => "Single select dropdown",
     "multi_select_checkbox" => "Multiple select checkbox",
+    "file_upload" => "File upload",
     "no_user_input" => "Informational-only"
   }.freeze
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -511,15 +511,40 @@ module EventRegistrationServices
         next unless field
         next if field.group_header? || field.field_identifier == "confirm_email"
 
-        text = if raw_value.is_a?(Array)
-          raw_value.reject(&:blank?).join(", ")
-        else
-          raw_value.to_s
-        end
-
-        record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+        persist_answer(submission, field, raw_value)
       end
+    end
+
+    # Save one field's answer. File-upload fields attach their blob to the
+    # answer's Asset; everything else stores the (comma-joined) text.
+    def persist_answer(submission, field, raw_value)
+      record = submission.form_answers.find_or_initialize_by(form_field: field)
+      record.question_name_when_answered = field.name
+
+      if field.file_upload?
+        attach_uploaded_file(record, raw_value)
+      else
+        record.update!(submitted_answer: answer_text(raw_value))
+      end
+    end
+
+    def answer_text(raw_value)
+      raw_value.is_a?(Array) ? raw_value.reject(&:blank?).join(", ") : raw_value.to_s
+    end
+
+    # Attach the uploaded blob (a direct-upload signed id, or an uploaded file)
+    # to the answer's Asset. The answer row is saved first so the polymorphic
+    # owner id resolves; submitted_answer keeps the filename so text-only views,
+    # exports, and notifications still read. Asset enforces the content type on
+    # save, rolling back the whole submission on an unaccepted file.
+    def attach_uploaded_file(record, raw_value)
+      record.update!(submitted_answer: "")
+      return if raw_value.blank?
+
+      asset = record.asset || record.build_asset
+      asset.file.attach(raw_value)
+      asset.save!
+      record.update!(submitted_answer: asset.file.filename.to_s)
     end
 
     # Persist the answers to the separate scholarship form (when one is asked and a
@@ -539,14 +564,7 @@ module EventRegistrationServices
         next unless field
         next if field.group_header?
 
-        text = if raw_value.is_a?(Array)
-          raw_value.reject(&:blank?).join(", ")
-        else
-          raw_value.to_s
-        end
-
-        record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+        persist_answer(submission, field, raw_value)
       end
 
       OtherResponses::CaptureFromSubmission.call(submission)
@@ -566,14 +584,7 @@ module EventRegistrationServices
         next unless field
         next if field.group_header?
 
-        text = if raw_value.is_a?(Array)
-          raw_value.reject(&:blank?).join(", ")
-        else
-          raw_value.to_s
-        end
-
-        record = submission.form_answers.find_or_initialize_by(form_field: field)
-        record.update!(submitted_answer: text, question_name_when_answered: field.name)
+        persist_answer(submission, field, raw_value)
       end
     end
 

--- a/app/services/form_answer_validator.rb
+++ b/app/services/form_answer_validator.rb
@@ -36,6 +36,11 @@ class FormAnswerValidator
     return "can't be blank" if field.required && blank_answer?(value)
     return if value.blank?
 
+    # A file upload arrives as a signed blob id (or an uploaded file), not text —
+    # the word/character/format/inclusion checks below don't apply. Its content
+    # type is enforced by Asset when the file is attached during submission.
+    return if field.file_upload?
+
     if field.number_integer? && value.to_s !~ WHOLE_NUMBER_FORMAT
       "must be a whole number"
     elsif field.email_field? && value.to_s !~ EMAIL_FORMAT

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -45,7 +45,7 @@
           <% section[:fields].each do |field, response| %>
             <div class="flex gap-4 py-1.5">
               <div class="w-1/3 shrink-0 text-xs text-gray-500"><%= display_question_label(field, response) %></div>
-              <div class="text-sm text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></div>
+              <div class="text-sm text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></div>
             </div>
           <% end %>
         </div>

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -174,6 +174,28 @@
       <% end %>
     <% end %>
 
+  <% when "file_upload" %>
+    <%# Direct upload: the file streams to storage via JS and the input's value
+        becomes a signed blob id, submitted as a normal param — so the form needs
+        no multipart encoding and the persistence service attaches the blob.
+        Reuses the file_preview controller (image thumbnail / file-type icon). %>
+    <div data-controller="file-preview">
+      <input type="file"
+             name="<%= field_name %>"
+             id="<%= field_id %>"
+             accept="<%= Asset.accept_attribute %>"
+             data-direct-upload-url="<%= rails_direct_uploads_path %>"
+             data-file-preview-target="input"
+             data-action="change->file-preview#update"
+             class="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 rounded-lg border <%= error_border %> bg-white px-2 py-2"
+             <%= "required" if field.required %>>
+      <p data-file-preview-target="filename" class="mt-1.5 text-xs font-medium text-gray-600"></p>
+      <p class="mt-1 text-xs text-gray-400">Accepted: <%= Asset.accepted_types_label %></p>
+      <img data-file-preview-target="preview"
+           class="hidden mt-3 max-h-48 w-auto rounded-lg border border-gray-200 shadow-sm"
+           alt="Selected file preview">
+    </div>
+
   <% end %>
 
   <% if field.hint_text.present? %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -69,7 +69,7 @@
             <% response = @responses[field.id] %>
             <div class="<%= field.grid_span_class %> pb-8">
               <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
-              <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
+              <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></dd>
             </div>
           <% end %>
         <% end %>
@@ -118,7 +118,7 @@
               <% response = @scholarship_responses[field.id] %>
               <div class="<%= field.grid_span_class %> pb-8">
                 <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
-                <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
+                <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></dd>
               </div>
             <% end %>
           <% end %>
@@ -169,7 +169,7 @@
               <% response = @continuing_education_responses[field.id] %>
               <div class="<%= field.grid_span_class %> pb-8">
                 <dt class="rich-label text-xs font-medium text-gray-500 uppercase tracking-wide"><%= form_label_html(display_question_label(field, response)) %></dt>
-                <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
+                <dd class="mt-0.5 text-base font-semibold text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></dd>
               </div>
             <% end %>
           <% end %>

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -22,8 +22,8 @@
         <dd class="mt-1 text-sm text-gray-900">
           <%# Resolves the sector / age-group ids stored behind the professional
               fields to their names; free-text ("Other: …") and plain answers pass
-              through unchanged. %>
-          <%= display_response_text(field, response) %>
+              through unchanged. File-upload answers render a preview + link. %>
+          <%= render "shared/form_answer_value", field: field, response: response %>
         </dd>
       </div>
     <% end %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -67,7 +67,7 @@
       <div class="flex flex-wrap items-center gap-2">
         <%= f.text_area :name, required: true, rows: 1, class: "min-w-0 flex-[3_1_10rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
         <%
-          type_order = %w[free_form_input_one_line free_form_input_paragraph single_select_radio single_select_dropdown multi_select_checkbox no_user_input group_header]
+          type_order = %w[free_form_input_one_line free_form_input_paragraph single_select_radio single_select_dropdown multi_select_checkbox file_upload no_user_input group_header]
           type_options = type_order.map { |t| [ FormField::ANSWER_TYPE_LABELS[t] || t.titleize, t ] }
         %>
         <%= f.select :answer_type, type_options,

--- a/app/views/scholarships/_form_submission.html.erb
+++ b/app/views/scholarships/_form_submission.html.erb
@@ -25,7 +25,7 @@
         <% @scholarship_answers.each do |field, response| %>
           <div>
             <dt class="text-xs font-medium uppercase tracking-wide text-gray-400"><%= display_question_label(field, response) %></dt>
-            <dd class="mt-0.5 text-sm text-gray-900 whitespace-pre-line"><%= display_response_text(field, response) %></dd>
+            <dd class="mt-0.5 text-sm text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></dd>
           </div>
         <% end %>
       </dl>

--- a/app/views/shared/_form_answer_value.html.erb
+++ b/app/views/shared/_form_answer_value.html.erb
@@ -1,0 +1,22 @@
+<%# Renders one form answer's value: a file-upload answer shows an inline image
+    preview (or a file link for non-images) plus a download link; every other
+    answer type shows its resolved text. Locals: field, response. %>
+<% if field.file_upload? && (uploaded = response&.uploaded_file) %>
+  <div class="mt-1 flex flex-col items-start gap-2">
+    <% if uploaded.content_type.to_s.start_with?("image/") %>
+      <%= link_to url_for(uploaded), target: "_blank", rel: "noopener" do %>
+        <%= image_tag(uploaded.variable? ? uploaded.variant(:thumbnail) : uploaded,
+              class: "max-h-48 w-auto rounded-lg border border-gray-200 shadow-sm",
+              alt: uploaded.filename.to_s) %>
+      <% end %>
+    <% end %>
+    <%= link_to url_for(uploaded), target: "_blank", rel: "noopener",
+          class: "inline-flex items-center gap-1.5 text-sm text-blue-700 hover:text-blue-900 underline" do %>
+      <i class="fa-solid fa-paperclip text-xs"></i><%= uploaded.filename %>
+    <% end %>
+  </div>
+<% elsif field.file_upload? %>
+  <span class="text-gray-400">—</span>
+<% else %>
+  <%= display_response_text(field, response) %>
+<% end %>

--- a/spec/factories/form_fields.rb
+++ b/spec/factories/form_fields.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     required { FormField::NON_INPUT_ANSWER_TYPES.exclude?(answer_type.to_s) }
 
     # Add other attributes based on schema if needed
+
+    trait :file_upload do
+      answer_type { :file_upload }
+    end
   end
 end

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -4,6 +4,27 @@ RSpec.describe FormAnswer do
   describe "associations" do
     it { should belong_to(:form_field).optional }
     it { should belong_to(:form_submission) }
+    it { should have_one(:asset).dependent(:destroy) }
+  end
+
+  describe "#uploaded_file" do
+    let(:form) { create(:form) }
+    let(:submission) { create(:form_submission, form: form) }
+    let(:answer) { create(:form_answer, form_submission: submission, submitted_answer: "sample.png") }
+
+    it "returns nil when no asset is attached" do
+      expect(answer.uploaded_file).to be_nil
+    end
+
+    it "returns the attachment when a file is on file" do
+      asset = answer.build_asset
+      asset.file.attach(io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+                        filename: "sample.png", content_type: "image/png")
+      asset.save!
+
+      expect(answer.reload.uploaded_file).to be_attached
+      expect(answer.uploaded_file.filename.to_s).to eq("sample.png")
+    end
   end
 
   describe "#name" do

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -48,6 +48,31 @@ RSpec.describe FormField do
         field = build(:form_field, form: form, answer_type: :free_form_input_one_line, required: true)
         expect(field).to be_valid
       end
+
+      it "allows a required file-upload field" do
+        field = build(:form_field, form: form, answer_type: :file_upload, required: true)
+        expect(field).to be_valid
+      end
+    end
+
+    describe "file-upload answer type" do
+      let(:form) { create(:form) }
+      let(:field) { build(:form_field, :file_upload, form: form) }
+
+      it "is a valid answer type" do
+        expect(field).to be_valid
+        expect(field.answer_type).to eq("file_upload")
+      end
+
+      it "collects input but is neither selectable nor free-form text" do
+        expect(field.collects_input?).to be(true)
+        expect(field.selectable?).to be(false)
+        expect(field.free_form_text?).to be(false)
+      end
+
+      it "labels the type in sentence case" do
+        expect(field.answer_type_label).to eq("File upload")
+      end
     end
 
     describe "field_identifier uniqueness" do
@@ -94,7 +119,7 @@ RSpec.describe FormField do
     it { should define_enum_for(:status).with_values([ :inactive, :active ]) }
     it { should define_enum_for(:answer_type).with_values([ :free_form_input_one_line, :free_form_input_paragraph,
                                                            :single_select_radio, :no_user_input, :multi_select_checkbox,
-                                                           :group_header, :single_select_dropdown ]) }
+                                                           :group_header, :single_select_dropdown, :file_upload ]) }
     it { should define_enum_for(:input_type).with_values([ :text_alphanumeric, :number_integer, :number_decimal, :date ]) }
   end
 

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -630,6 +630,24 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).not_to include("Reworded after submission")
     end
 
+    it "renders an uploaded file answer as an image preview and download link" do
+      upload_field = create(:form_field, :file_upload, form: form, name: "Photo of your creation")
+      submission = FormSubmission.find_by(person: person, form: form)
+      answer = submission.form_answers.create!(form_field: upload_field, submitted_answer: "sample.png")
+      answer.build_asset.tap do |asset|
+        asset.file.attach(io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+                          filename: "sample.png", content_type: "image/png")
+        asset.save!
+      end
+
+      get event_public_registration_path(event, person_id: person.id)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Photo of your creation")
+      expect(response.body).to include("sample.png")
+      expect(response.body).to include(rails_blob_path(answer.uploaded_file, only_path: true))
+    end
+
     context "when the registrant filled out a separate scholarship form" do
       let(:scholarship_form) { create(:form, role: "scholarship") }
       let!(:scholarship_field) do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -955,4 +955,57 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(FormSubmission.where(person: person, role: "scholarship")).to be_empty
     end
   end
+
+  describe "file-upload answers" do
+    let!(:upload_field) do
+      form.form_fields.create!(name: "Photo of your creation", answer_type: :file_upload,
+                               status: :active, position: 999)
+    end
+
+    def signed_id_for(fixture, content_type)
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: File.open(Rails.root.join("spec/fixtures/files", fixture)),
+        filename: fixture, content_type: content_type
+      )
+      blob.signed_id
+    end
+
+    it "attaches the uploaded blob to the answer and stores its filename" do
+      params = base_form_params(first_name: "Pat", last_name: "Art", email: "pat@example.com").merge(
+        upload_field.id.to_s => signed_id_for("sample.png", "image/png")
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.success?).to be true
+      answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(answer.uploaded_file).to be_attached
+      expect(answer.uploaded_file.filename.to_s).to eq("sample.png")
+      expect(answer.submitted_answer).to eq("sample.png")
+    end
+
+    it "leaves the answer fileless when nothing was uploaded" do
+      params = base_form_params(first_name: "No", last_name: "File", email: "nofile@example.com").merge(
+        upload_field.id.to_s => ""
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.success?).to be true
+      answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(answer.uploaded_file).to be_nil
+      expect(answer.submitted_answer).to eq("")
+    end
+
+    it "rejects a file whose content type Asset does not accept" do
+      params = base_form_params(first_name: "Bad", last_name: "Type", email: "bad@example.com").merge(
+        upload_field.id.to_s => signed_id_for("sample.txt", "text/plain")
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.success?).to be false
+      expect(Person.find_by(email: "bad@example.com")).to be_nil
+    end
+  end
 end

--- a/spec/services/form_answer_validator_spec.rb
+++ b/spec/services/form_answer_validator_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe FormAnswerValidator do
     end
   end
 
+  describe "file upload" do
+    it "flags a required file question with no upload" do
+      field = create(:form_field, :file_upload, form: form, required: true)
+
+      expect(validate(field, "")).to eq(field.id => "can't be blank")
+    end
+
+    it "accepts a signed blob id and skips the text-shaped checks" do
+      field = create(:form_field, :file_upload, form: form, required: true)
+
+      # A long signed id would trip a character cap, but file uploads have none.
+      expect(validate(field, "a" * 5_000)).to eq({})
+    end
+  end
+
   describe "min words / max characters" do
     it "surfaces the min-words error" do
       field = create(:form_field, form: form, answer_type: :free_form_input_paragraph, min_words: 3)


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new answer type wired through the model enum, submission service, validator, and 6 answer-display sites

Closes #2109

### What is the goal of this PR and why is this important?
- The form engine had no way to represent a file upload, so the post-event survey's "upload a photo of one of your creations" question had to be dropped.
- Adds a `file_upload` `answer_type` so form authors can ask for a file (photo, PDF, doc).

### How did you approach the change?
- **Reuse, no migration.** A file-upload answer stores its blob on the existing polymorphic `Asset` (`FormAnswer has_one :asset, as: :owner`) — the same attachment, content-type validation (`Asset::ACCEPTED_CONTENT_TYPES`), and image/PDF display machinery story ideas use. No schema change.
- **Direct upload.** The public form renders a `file` input wired to the existing `file_preview` Stimulus controller; JS streams the file to storage and submits a signed blob id as a normal param — so the form stays non-multipart and the existing params/validator flow is unchanged.
- **Persistence.** The three near-identical answer-save loops in `PublicRegistration` were folded into one `persist_answer`, which attaches the blob for file fields and stores the filename in `submitted_answer` (so text-only views/exports still read).
- **Display.** All six answer-display sites now go through one `shared/_form_answer_value` partial: file answers show an inline image thumbnail (or a link for non-images) plus a download link; everything else is unchanged.
- **Validation.** `FormAnswerValidator` treats a required file question as present/blank; `Asset` enforces the content type on attach.

### Anything else to add?
- **Consent pairing deferred** — the source survey pairs the photo with a "how may we share this" consent; that's a normal select question an author can add alongside, tracked separately.
- **No-JS fallback:** without JS the file isn't uploaded (the form is non-multipart by design); the whole form is Turbo/Stimulus-driven already.
- On a validation error elsewhere, the file input clears (browsers never re-populate file inputs) and must be reselected.