### PR TITLE
HOLD UNTIL FEES LAUNCH: Update facilitator-fees FAQ default for per-person membership (#2095)

### DIFF
--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -49,9 +49,11 @@ class BuiltinCallouts
     { q: "Can multiple staff members from one organization participate?",
       a: [ "Yes. Multiple staff members from the same organization are welcome and encouraged to participate in the training.",
            "Many organizations choose to train teams of staff members in order to integrate trauma-informed healing arts practices more broadly across their programs, services, and communities." ] },
+    # Amount is sourced from Membership::ANNUAL_COST_CENTS so this default copy
+    # tracks the real per-person figure instead of drifting from a hard-coded number.
     { q: "Are there any fees, other than the training fee, associated with becoming a facilitator?",
-      a: [ "AWBW facilitators pay annual dues of $25 to support the sustainability of the organization and continued facilitator resources and support.",
-           "Dues are billed per facilitator and renew automatically each year. You can manage or cancel your subscription at any time." ] }
+      a: [ "AWBW facilitators pay an annual membership fee of #{MoneyFormatter.dollars_from_cents(::Membership::ANNUAL_COST_CENTS)} to support the sustainability of the organization and continued facilitator resources and support.",
+           "The membership fee is billed per facilitator and renews automatically each year. You can manage or cancel your membership at any time." ] }
   ].freeze
 
   # Hidden Resource (by title) backing the handout links, in display order.

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -50,7 +50,7 @@ class BuiltinCallouts
       a: [ "Yes. Multiple staff members from the same organization are welcome and encouraged to participate in the training.",
            "Many organizations choose to train teams of staff members in order to integrate trauma-informed healing arts practices more broadly across their programs, services, and communities." ] },
     { q: "Are there any fees, other than the training fee, associated with becoming a facilitator?",
-      a: [ "AWBW facilitators pay annual dues to support the sustainability of the organization and continued facilitator resources and support.",
+      a: [ "AWBW facilitators pay annual dues of $25 to support the sustainability of the organization and continued facilitator resources and support.",
            "Dues are billed per facilitator and renew automatically each year. You can manage or cancel your subscription at any time." ] }
   ].freeze
 

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -50,8 +50,8 @@ class BuiltinCallouts
       a: [ "Yes. Multiple staff members from the same organization are welcome and encouraged to participate in the training.",
            "Many organizations choose to train teams of staff members in order to integrate trauma-informed healing arts practices more broadly across their programs, services, and communities." ] },
     { q: "Are there any fees, other than the training fee, associated with becoming a facilitator?",
-      a: [ "AWBW has an annual membership fee of $100 per program to support the sustainability of the organization and continued facilitator resources and support.",
-           "The membership fee covers all facilitators connected to the same program or organization for the calendar year, regardless of the number of facilitators participating. Only one membership fee payment is required per program annually." ] }
+      a: [ "AWBW facilitators pay annual dues to support the sustainability of the organization and continued facilitator resources and support.",
+           "Dues are billed per facilitator and renew automatically each year. You can manage or cancel your subscription at any time." ] }
   ].freeze
 
   # Hidden Resource (by title) backing the handout links, in display order.


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 FAQ default-copy change now interpolates a live constant

**⚠️ DO NOT MERGE** — should land only when the per-person membership feature launches.

Closes #2095

### Why
- The `"Are there any fees…"` FAQ default described the **old model**: $100 **per program**, one payment covering all facilitators in a program.
- The new membership feature (#2094, renamed to "membership" in #2106) is a **per-person, auto-renewing annual membership**, making the old copy inaccurate.

### What
- Reworked the answer in `BuiltinCallouts::FAQS` to describe a **per-facilitator annual membership fee** that renews automatically, using membership terminology to match the post-#2106 rename.
- **Amount is interpolated from `Membership::ANNUAL_COST_CENTS`** (currently \$25) rather than hard-coded, so the copy can't silently drift from the real figure years from now.
- This is the default seeded onto new FAQ callout cards (admin-editable per event) and the FAQ page fallback — forward-looking only, no backfill of existing/edited cards.

### Note
- The value is captured at class-load time, so a change to `ANNUAL_MEMBERSHIP_CENTS` takes effect on the next deploy (not live per-request) — fine for static default copy.

### Outstanding (why DNM)
- Merge to coincide with the membership launch so the FAQ doesn't advertise a model that isn't live (still gated behind `Membership.enabled?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)