### PR TITLE
Add "Someone else will pay" toggle to registration payments

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -351,6 +351,7 @@ class EventRegistrationsController < ApplicationController
       :scholarship_requested,
       :shoutout,
       :intends_to_pay,
+      :someone_else_will_pay,
       :expected_payment_method,
       :fee_note,
       *EventRegistration::DAY_FIELDS,

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -67,19 +67,37 @@
         <%# Intends to pay — grants ticket/material access while the balance above is
             still owed, for registrants who've committed to paying after the deadline.
             Does not change the amount due or mark the registration as paid. %>
-        <label class="flex items-start gap-2.5 cursor-pointer">
-          <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
-          <input type="checkbox"
-                 name="event_registration[intends_to_pay]"
-                 value="1"
-                 <%= "checked" if event_registration.intends_to_pay %>
-                 class="sr-only peer">
-          <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
-          <span>
-            <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
-            <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due. Doesn't mark the registration as paid.</span>
-          </span>
-        </label>
+        <div class="space-y-3">
+          <label class="flex items-start gap-2.5 cursor-pointer">
+            <input type="hidden" name="event_registration[intends_to_pay]" value="0" autocomplete="off">
+            <input type="checkbox"
+                   name="event_registration[intends_to_pay]"
+                   value="1"
+                   <%= "checked" if event_registration.intends_to_pay %>
+                   class="sr-only peer">
+            <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
+            <span>
+              <span class="block text-sm font-medium text-gray-700">Intends to pay</span>
+              <span class="block text-xs text-gray-400">Grant access to training materials and join links while the balance is still due.</span>
+            </span>
+          </label>
+
+          <%# Someone else will pay — buddy system: the registrant expects a
+              sponsor or partner to cover their cost, so they aren't the one paying. %>
+          <label class="flex items-start gap-2.5 cursor-pointer">
+            <input type="hidden" name="event_registration[someone_else_will_pay]" value="0" autocomplete="off">
+            <input type="checkbox"
+                   name="event_registration[someone_else_will_pay]"
+                   value="1"
+                   <%= "checked" if event_registration.someone_else_will_pay %>
+                   class="sr-only peer">
+            <span class="relative mt-0.5 h-6 w-11 shrink-0 rounded-full bg-gray-200 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:shadow after:transition-all after:content-[''] peer-checked:bg-teal-500 peer-checked:after:translate-x-5 peer-focus-visible:ring-2 peer-focus-visible:ring-teal-300"></span>
+            <span>
+              <span class="block text-sm font-medium text-gray-700">Someone else will pay</span>
+              <span class="block text-xs text-gray-400">Buddy system — the registrant expects a sponsor or partner to cover their cost.</span>
+            </span>
+          </label>
+        </div>
       </div>
     <% else %>
       <span class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-0.5 text-xs font-medium text-gray-500">

--- a/db/migrate/20260809210304_add_someone_else_will_pay_to_event_registrations.rb
+++ b/db/migrate/20260809210304_add_someone_else_will_pay_to_event_registrations.rb
@@ -1,0 +1,11 @@
+class AddSomeoneElseWillPayToEventRegistrations < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:event_registrations, :someone_else_will_pay)
+      add_column :event_registrations, :someone_else_will_pay, :boolean, default: false, null: false
+    end
+  end
+
+  def down
+    remove_column :event_registrations, :someone_else_will_pay, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_175302) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_210304) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -497,6 +497,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_175302) do
     t.boolean "scholarship_requested", default: false, null: false
     t.boolean "shoutout", default: false, null: false
     t.string "slug"
+    t.boolean "someone_else_will_pay", default: false, null: false
     t.string "status", default: "registered", null: false
     t.datetime "updated_at", null: false
     t.boolean "w9_requested", default: false, null: false

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -526,6 +526,13 @@ RSpec.describe "EventRegistrations", type: :request do
 
         expect(existing_registration.reload.expected_payment_method).to be_blank
       end
+
+      it "flags that someone else will pay when the toggle is on" do
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { someone_else_will_pay: "1" } }
+
+        expect(existing_registration.reload.someone_else_will_pay).to be(true)
+      end
     end
 
     describe "PATCH /event_registrations/:id scholarship handling" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small new boolean flag + toggle UI and copy tweak

### What is the goal of this PR and why is this important?
- Some registrants use a buddy system — they expect a sponsor or partner to cover their cost. Staff had no way to record that the registrant isn't the one paying.

### How did you approach the change?
- New `someone_else_will_pay` boolean on `event_registrations` (default false), permitted in the update params.
- Added a "Someone else will pay" toggle directly below "Intends to pay" on the registration payments card.
- Trimmed the redundant "Doesn't mark the registration as paid." sentence from the intends-to-pay hint.

### Anything else to add?
- Plain flag for now — not wired into filters, exports, or payment-access logic.