### PR TITLE
Carry the "expects to pay for yourself?" answer onto the registration

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -37,11 +37,12 @@ module EventRegistrationServices
     ORGANIZATION_NAME_IDENTIFIER = "agency_name".freeze
     ORGANIZATION_POSITION_IDENTIFIER = "agency_position".freeze
 
-    # Well-known field_identifier of the "Do you expect to pay for yourself?"
-    # question seeded after the payment method. Answering it "No" sets the
-    # registration's someone_else_will_pay flag (a sponsor or partner covers the
-    # cost). Kept here so the seed, service, and specs agree.
-    PAYS_FOR_SELF_IDENTIFIER = "pays_for_self".freeze
+    # Well-known field_identifier of the "Will someone else be paying?" question
+    # seeded after the payment method. Answering it "Yes" sets the registration's
+    # someone_else_will_pay flag (a sponsor or partner covers the cost). Named to
+    # match the column so the mapping is direct. Kept here so the seed, service,
+    # and specs agree.
+    SOMEONE_ELSE_WILL_PAY_IDENTIFIER = "someone_else_will_pay".freeze
 
     def self.call(event:, registration_form:, form_params:, scholarship_requested: false, person: nil,
                   scholarship_form: nil, scholarship_params: {},
@@ -423,13 +424,13 @@ module EventRegistrationServices
       )
     end
 
-    # Inverse of the "Do you expect to pay for yourself?" answer: "No" means a
-    # sponsor or partner covers the cost. Returns nil when unanswered so we never
-    # clobber an existing flag with a blank.
+    # "Will someone else be paying?" — "Yes" means a sponsor or partner covers the
+    # cost. Returns nil when unanswered so we never clobber an existing flag with a
+    # blank.
     def someone_else_will_pay_answer
-      answer = field_value(PAYS_FOR_SELF_IDENTIFIER)&.strip
+      answer = field_value(SOMEONE_ELSE_WILL_PAY_IDENTIFIER)&.strip
       return nil if answer.blank?
-      !answer.casecmp?("yes")
+      answer.casecmp?("yes")
     end
 
     # Create the registrant's CE registration when they opt in, against a license

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -37,6 +37,12 @@ module EventRegistrationServices
     ORGANIZATION_NAME_IDENTIFIER = "agency_name".freeze
     ORGANIZATION_POSITION_IDENTIFIER = "agency_position".freeze
 
+    # Well-known field_identifier of the "Do you expect to pay for yourself?"
+    # question seeded after the payment method. Answering it "No" sets the
+    # registration's someone_else_will_pay flag (a sponsor or partner covers the
+    # cost). Kept here so the seed, service, and specs agree.
+    PAYS_FOR_SELF_IDENTIFIER = "pays_for_self".freeze
+
     def self.call(event:, registration_form:, form_params:, scholarship_requested: false, person: nil,
                   scholarship_form: nil, scholarship_params: {},
                   continuing_education_form: nil, continuing_education_params: {})
@@ -86,6 +92,8 @@ module EventRegistrationServices
           existing.update!(invoice_requested: true) if invoice_requested?
           payment_method = field_value("payment_method")&.strip
           existing.update!(expected_payment_method: payment_method) if payment_method.present?
+          someone_else = someone_else_will_pay_answer
+          existing.update!(someone_else_will_pay: someone_else) unless someone_else.nil?
           if existing.status == "cancelled"
             existing.update!(status: "registered")
             send_notifications(existing)
@@ -410,8 +418,18 @@ module EventRegistrationServices
         scholarship_requested: @scholarship_requested,
         w9_requested: w9_requested?,
         invoice_requested: invoice_requested?,
-        expected_payment_method: field_value("payment_method")&.strip.presence
+        expected_payment_method: field_value("payment_method")&.strip.presence,
+        someone_else_will_pay: someone_else_will_pay_answer || false
       )
+    end
+
+    # Inverse of the "Do you expect to pay for yourself?" answer: "No" means a
+    # sponsor or partner covers the cost. Returns nil when unanswered so we never
+    # clobber an existing flag with a blank.
+    def someone_else_will_pay_answer
+      answer = field_value(PAYS_FOR_SELF_IDENTIFIER)&.strip
+      return nil if answer.blank?
+      !answer.casecmp?("yes")
     end
 
     # Create the registrant's CE registration when they opt in, against a license

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -54,7 +54,7 @@ class FormBuilderService
     marketing: %w[referral_source training_motivation interested_in_more],
     continuing_education: %w[ce_credit_interest ce_license_number],
     scholarship: %w[scholarship_eligibility scholarship_contribution impact_description implementation_plan additional_comments],
-    payment: %w[payment_method pays_for_self],
+    payment: %w[payment_method someone_else_will_pay],
     consent: %w[communication_consent],
     post_event_feedback: %w[event_rating most_valuable improvement_suggestions],
     bulk_payment: %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees payment_method bulk_payment_attendees]
@@ -109,7 +109,7 @@ class FormBuilderService
       "Please describe one way in which you plan to use art workshops and how you envision it will help.",
       "Anything else you'd like to share with us?"
     ],
-    payment: [ "Payment method", "Do you expect to pay for this registration yourself?" ],
+    payment: [ "Payment method", "Will someone else be paying for your registration?" ],
     consent: [ "I agree to receive email communications from A Window Between Worlds." ],
     post_event_feedback: [ "How would you rate this event?", "What did you find most valuable?", "Any suggestions for improvement?" ],
     bulk_payment: [
@@ -580,9 +580,9 @@ class FormBuilderService
     position = add_field(form, position, "Payment method", :single_select_radio,
                          key: "payment_method", group: "payment", required: true,
                          options: PAYMENT_METHOD_OPTIONS)
-    position = add_field(form, position, "Do you expect to pay for this registration yourself?", :single_select_radio,
-                         key: "pays_for_self", group: "payment", required: true,
-                         subtitle: "Choose \"No\" if a sponsor, partner, or organization will be covering your cost.",
+    position = add_field(form, position, "Will someone else be paying for your registration?", :single_select_radio,
+                         key: "someone_else_will_pay", group: "payment", required: true,
+                         subtitle: "Choose \"Yes\" if a sponsor, partner, or organization will be covering your cost.",
                          options: %w[Yes No])
     position
   end

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -54,7 +54,7 @@ class FormBuilderService
     marketing: %w[referral_source training_motivation interested_in_more],
     continuing_education: %w[ce_credit_interest ce_license_number],
     scholarship: %w[scholarship_eligibility scholarship_contribution impact_description implementation_plan additional_comments],
-    payment: %w[payment_method],
+    payment: %w[payment_method pays_for_self],
     consent: %w[communication_consent],
     post_event_feedback: %w[event_rating most_valuable improvement_suggestions],
     bulk_payment: %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees payment_method bulk_payment_attendees]
@@ -109,7 +109,7 @@ class FormBuilderService
       "Please describe one way in which you plan to use art workshops and how you envision it will help.",
       "Anything else you'd like to share with us?"
     ],
-    payment: [ "Payment method" ],
+    payment: [ "Payment method", "Do you expect to pay for this registration yourself?" ],
     consent: [ "I agree to receive email communications from A Window Between Worlds." ],
     post_event_feedback: [ "How would you rate this event?", "What did you find most valuable?", "Any suggestions for improvement?" ],
     bulk_payment: [
@@ -580,6 +580,10 @@ class FormBuilderService
     position = add_field(form, position, "Payment method", :single_select_radio,
                          key: "payment_method", group: "payment", required: true,
                          options: PAYMENT_METHOD_OPTIONS)
+    position = add_field(form, position, "Do you expect to pay for this registration yourself?", :single_select_radio,
+                         key: "pays_for_self", group: "payment", required: true,
+                         subtitle: "Choose \"No\" if a sponsor, partner, or organization will be covering your cost.",
+                         options: %w[Yes No])
     position
   end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -184,9 +184,9 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
   end
 
   describe "someone else will pay" do
-    it "flags the registration when the registrant answers they won't pay for themselves" do
+    it "flags the registration when the registrant answers someone else will pay" do
       params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
-        field_id("pays_for_self") => "No"
+        field_id("someone_else_will_pay") => "Yes"
       )
 
       described_class.call(event: event, registration_form: form, form_params: params)
@@ -194,9 +194,9 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(EventRegistration.last.someone_else_will_pay).to be(true)
     end
 
-    it "leaves the flag off when the registrant answers they will pay for themselves" do
+    it "leaves the flag off when the registrant answers they will pay themselves" do
       params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
-        field_id("pays_for_self") => "Yes"
+        field_id("someone_else_will_pay") => "No"
       )
 
       described_class.call(event: event, registration_form: form, form_params: params)
@@ -208,7 +208,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       person = create(:person, first_name: "Pat", last_name: "Doe", email: "pat@example.com")
       create(:event_registration, event: event, registrant: person, someone_else_will_pay: false)
       params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
-        field_id("pays_for_self") => "No"
+        field_id("someone_else_will_pay") => "Yes"
       )
 
       described_class.call(event: event, registration_form: form, form_params: params)
@@ -220,7 +220,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       person = create(:person, first_name: "Pat", last_name: "Doe", email: "pat@example.com")
       create(:event_registration, event: event, registrant: person, someone_else_will_pay: true)
       params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
-        field_id("pays_for_self") => ""
+        field_id("someone_else_will_pay") => ""
       )
 
       described_class.call(event: event, registration_form: form, form_params: params)

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -183,6 +183,52 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "someone else will pay" do
+    it "flags the registration when the registrant answers they won't pay for themselves" do
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("pays_for_self") => "No"
+      )
+
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(EventRegistration.last.someone_else_will_pay).to be(true)
+    end
+
+    it "leaves the flag off when the registrant answers they will pay for themselves" do
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("pays_for_self") => "Yes"
+      )
+
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(EventRegistration.last.someone_else_will_pay).to be(false)
+    end
+
+    it "updates the flag when an existing registrant re-registers" do
+      person = create(:person, first_name: "Pat", last_name: "Doe", email: "pat@example.com")
+      create(:event_registration, event: event, registrant: person, someone_else_will_pay: false)
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("pays_for_self") => "No"
+      )
+
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(event.event_registrations.find_by(registrant: person).someone_else_will_pay).to be(true)
+    end
+
+    it "does not clobber an existing flag when the answer is blank" do
+      person = create(:person, first_name: "Pat", last_name: "Doe", email: "pat@example.com")
+      create(:event_registration, event: event, registrant: person, someone_else_will_pay: true)
+      params = base_form_params(first_name: "Pat", last_name: "Doe", email: "pat@example.com").merge(
+        field_id("pays_for_self") => ""
+      )
+
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(event.event_registrations.find_by(registrant: person).someone_else_will_pay).to be(true)
+    end
+  end
+
   describe "mailing list consent" do
     it "stamps the consent time and source when the registrant opts in" do
       params = base_form_params(first_name: "Coco", last_name: "Lee", email: "coco@example.com").merge(

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -115,12 +115,12 @@ RSpec.describe FormBuilderService do
 
       it "creates payment fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
-        expect(keys).to include("payment_method", "pays_for_self")
+        expect(keys).to include("payment_method", "someone_else_will_pay")
       end
 
-      it "seeds the pays-for-self question after the payment method" do
+      it "seeds the someone-else-will-pay question after the payment method" do
         keys = form.form_fields.reorder(:position).pluck(:field_identifier).compact
-        expect(keys.index("pays_for_self")).to eq(keys.index("payment_method") + 1)
+        expect(keys.index("someone_else_will_pay")).to eq(keys.index("payment_method") + 1)
       end
     end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -115,7 +115,12 @@ RSpec.describe FormBuilderService do
 
       it "creates payment fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
-        expect(keys).to include("payment_method")
+        expect(keys).to include("payment_method", "pays_for_self")
+      end
+
+      it "seeds the pays-for-self question after the payment method" do
+        keys = form.form_fields.reorder(:position).pluck(:field_identifier).compact
+        expect(keys.index("pays_for_self")).to eq(keys.index("payment_method") + 1)
       end
     end
 

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       choose_pr_radio ce_field("ce_credit_interest"), "Yes"
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio reg_field("pays_for_self"), "No"
       check_pr_box reg_field("additional_forms"), "W-9"
 
       click_button "Register"
@@ -76,7 +77,8 @@ RSpec.describe "Public form submissions", type: :system do
 
       registration = event.event_registrations.find_by!(registrant: person)
       expect(registration).to have_attributes(scholarship_requested: false,
-                                              w9_requested: true, invoice_requested: false)
+                                              w9_requested: true, invoice_requested: false,
+                                              someone_else_will_pay: true)
       expect(registration.continuing_education_registrations.count).to eq(1)
 
       answers = answers_by_identifier(registration_form.form_submissions.find_by!(person: person))
@@ -109,6 +111,7 @@ RSpec.describe "Public form submissions", type: :system do
         "referral_source" => "Online Search",
         "training_motivation" => "Address staff burnout through art",
         "payment_method" => "Check",
+        "pays_for_self" => "No",
         "additional_forms" => "W-9",
         "communication_consent" => "Yes"
       )
@@ -144,6 +147,7 @@ RSpec.describe "Public form submissions", type: :system do
       choose_pr_radio reg_field("racial_ethnic_identity"), "Asian"
       choose_pr_radio reg_field("referral_source"), "Social Media"
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio reg_field("pays_for_self"), "Yes"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 
@@ -161,6 +165,7 @@ RSpec.describe "Public form submissions", type: :system do
         "racial_ethnic_identity" => "Asian",
         "referral_source" => "Social Media",
         "payment_method" => "Check",
+        "pays_for_self" => "Yes",
         "communication_consent" => "Yes"
       )
       logged_in_person.reload
@@ -175,6 +180,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       fill_full_registration
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio reg_field("pays_for_self"), "No"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
 
       choose_pr_radio schol_field("scholarship_eligibility"), "Yes"
@@ -207,6 +213,7 @@ RSpec.describe "Public form submissions", type: :system do
       visit new_event_public_registration_path(event, scholarship_requested: true)
 
       choose_pr_radio reg_field("payment_method"), "Check"
+      choose_pr_radio reg_field("pays_for_self"), "No"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       choose_pr_radio ce_field("ce_credit_interest"), "Yes"
       choose_pr_radio reg_field("payment_method"), "Check"
-      choose_pr_radio reg_field("pays_for_self"), "No"
+      choose_pr_radio reg_field("someone_else_will_pay"), "Yes"
       check_pr_box reg_field("additional_forms"), "W-9"
 
       click_button "Register"
@@ -111,7 +111,7 @@ RSpec.describe "Public form submissions", type: :system do
         "referral_source" => "Online Search",
         "training_motivation" => "Address staff burnout through art",
         "payment_method" => "Check",
-        "pays_for_self" => "No",
+        "someone_else_will_pay" => "Yes",
         "additional_forms" => "W-9",
         "communication_consent" => "Yes"
       )
@@ -147,7 +147,7 @@ RSpec.describe "Public form submissions", type: :system do
       choose_pr_radio reg_field("racial_ethnic_identity"), "Asian"
       choose_pr_radio reg_field("referral_source"), "Social Media"
       choose_pr_radio reg_field("payment_method"), "Check"
-      choose_pr_radio reg_field("pays_for_self"), "Yes"
+      choose_pr_radio reg_field("someone_else_will_pay"), "No"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 
@@ -165,7 +165,7 @@ RSpec.describe "Public form submissions", type: :system do
         "racial_ethnic_identity" => "Asian",
         "referral_source" => "Social Media",
         "payment_method" => "Check",
-        "pays_for_self" => "Yes",
+        "someone_else_will_pay" => "No",
         "communication_consent" => "Yes"
       )
       logged_in_person.reload
@@ -180,7 +180,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       fill_full_registration
       choose_pr_radio reg_field("payment_method"), "Check"
-      choose_pr_radio reg_field("pays_for_self"), "No"
+      choose_pr_radio reg_field("someone_else_will_pay"), "No"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
 
       choose_pr_radio schol_field("scholarship_eligibility"), "Yes"
@@ -213,7 +213,7 @@ RSpec.describe "Public form submissions", type: :system do
       visit new_event_public_registration_path(event, scholarship_requested: true)
 
       choose_pr_radio reg_field("payment_method"), "Check"
-      choose_pr_radio reg_field("pays_for_self"), "No"
+      choose_pr_radio reg_field("someone_else_will_pay"), "No"
       choose_pr_radio ce_field("ce_credit_interest"), "No"
       check_pr_box reg_field("communication_consent"), "Yes"
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small mapping + one seeded form question

### What is the goal of this PR and why is this important?
- Registrants can self-report on the form whether someone else will cover their cost, instead of relying on staff to toggle it after the fact.

### How did you approach the change?
- Seed a "Will someone else be paying for your registration?" radio (`someone_else_will_pay`) right after the payment method on every new form (`FormBuilderService`).
- On registration completion, `PublicRegistration` maps the answer onto the existing `someone_else_will_pay` column (answering "Yes" ⇒ true). Set on both new and re-registration paths; a blank answer never clobbers an existing flag.

### Anything else to add?
- Reuses the existing `someone_else_will_pay` column + admin toggle — no migration.
- Identifier, question wording, options, and column share one polarity, so the mapping is direct (no inversion) and raw `FormAnswer`s read the same way the flag does.