### PR TITLE
Keep roster column toggles selected across search filters

### DIFF
--- a/app/frontend/javascript/controllers/column_toggle_controller.js
+++ b/app/frontend/javascript/controllers/column_toggle_controller.js
@@ -6,13 +6,28 @@ import { Controller } from "@hotwired/stimulus"
 // table can host several independent column toggles (e.g. "User confirmation",
 // "CE status"). Columns live outside the switch's element, under a shared
 // [data-column-toggle-root] ancestor.
+//
+// The chosen state is remembered per group in sessionStorage and reapplied on
+// connect, so it survives Turbo frame re-renders (e.g. applying a search
+// filter) instead of snapping back to the server-rendered defaults.
 
 export default class extends Controller {
   static targets = ["toggle", "track", "knob"]
   static values = { group: String }
 
+  connect() {
+    const stored = this.storedState()
+    if (stored !== null) this.apply(stored)
+  }
+
   toggle() {
     const checked = this.toggleTarget.checked
+    this.store(checked)
+    this.apply(checked)
+  }
+
+  apply(checked) {
+    this.toggleTarget.checked = checked
     const root = this.element.closest("[data-column-toggle-root]") || document
 
     root.querySelectorAll(`[data-column-toggle-col="${this.groupValue}"]`).forEach((el) => {
@@ -22,5 +37,26 @@ export default class extends Controller {
     this.trackTarget.classList.toggle("bg-gray-300", !checked)
     this.trackTarget.classList.toggle("bg-blue-600", checked)
     this.knobTarget.style.transform = checked ? "translateX(16px)" : ""
+  }
+
+  storageKey() {
+    return `column-toggle:${this.groupValue}`
+  }
+
+  storedState() {
+    try {
+      const value = sessionStorage.getItem(this.storageKey())
+      return value === null ? null : value === "1"
+    } catch {
+      return null
+    }
+  }
+
+  store(checked) {
+    try {
+      sessionStorage.setItem(this.storageKey(), checked ? "1" : "0")
+    } catch {
+      // sessionStorage can be unavailable (private mode); toggling still works in-page.
+    }
   }
 }

--- a/app/frontend/javascript/controllers/column_toggle_controller.js
+++ b/app/frontend/javascript/controllers/column_toggle_controller.js
@@ -9,7 +9,9 @@ import { Controller } from "@hotwired/stimulus"
 //
 // The chosen state is remembered per group in sessionStorage and reapplied on
 // connect, so it survives Turbo frame re-renders (e.g. applying a search
-// filter) instead of snapping back to the server-rendered defaults.
+// filter) instead of snapping back to the server-rendered defaults. State is
+// namespaced by the scope declared on the [data-column-toggle-root] ancestor
+// (e.g. the event id) so different tables/records keep independent toggles.
 
 export default class extends Controller {
   static targets = ["toggle", "track", "knob"]
@@ -28,7 +30,7 @@ export default class extends Controller {
 
   apply(checked) {
     this.toggleTarget.checked = checked
-    const root = this.element.closest("[data-column-toggle-root]") || document
+    const root = this.rootElement || document
 
     root.querySelectorAll(`[data-column-toggle-col="${this.groupValue}"]`).forEach((el) => {
       el.classList.toggle("hidden", !checked)
@@ -39,8 +41,13 @@ export default class extends Controller {
     this.knobTarget.style.transform = checked ? "translateX(16px)" : ""
   }
 
+  get rootElement() {
+    return this.element.closest("[data-column-toggle-root]")
+  }
+
   storageKey() {
-    return `column-toggle:${this.groupValue}`
+    const scope = this.rootElement?.dataset.columnToggleScope || "default"
+    return `column-toggle:${scope}:${this.groupValue}`
   }
 
   storedState() {

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :registrants_results do %>
   <%# Scholarship column shows by default only when the event charges a fee. %>
   <% scholarship_on = @event.cost_cents.to_i > 0 %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-column-toggle-root>
+  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit" data-column-toggle-root data-column-toggle-scope="event-<%= @event.id %>">
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <% current_filter = params[:attendance_status].present? ? nil : (params[:status_filter].presence || "active") %>
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Attendance filter">


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small client-side Stimulus change to persist toggle state

## What
The registrants roster column toggles (Linked org, CE, Scholarship, Payment method, Date registered, Attendance, User account, Certificate) reset to their server defaults whenever a search filter is applied.

## Why
The toggles and the table share one Turbo frame (`registrants_results`). Applying a filter re-renders that frame, and `column_toggle_controller` kept no persisted state — the freshly-connected switches came back at their hard-coded ERB defaults, wiping the admin's choices.

## Fix
- Persist each toggle's on/off state in `sessionStorage` and reapply it in `connect()`, so selections survive the frame re-render (and other Turbo visits within the tab session). Falls back gracefully when storage is unavailable.
- Namespace the stored state per event via `data-column-toggle-scope` on the toggle root, so each event's roster keeps its own selections and generic group names can't collide if the controller is reused elsewhere.

## Notes
- State lives in browser `sessionStorage` (per-tab, client-side — not the Rails session). It survives in-tab navigation/reload and resets when the tab is closed.