### PR TITLE
Unify grant-funder naming on "Funder" (drop Donor/Grantor)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ This codebase (Rails 8.1)
 | `Person` | Organization affiliates with contacts, addresses, sectors |
 | `OtherResponse` | A free-text "Other" typed on a form question, captured at submission time (registration, scholarship, bulk payment). Polymorphic `owner`: a **sector** "Other" is owned by the `Person` (promotable into a `Sector`, shown on their profile/edit chip); an **organization_type** "Other" is owned by the `Organization` (stored now, not promotable until `OrganizationType` is a model). `generic` questions aren't captured — that stays searchable in the form answers. `field_identifier` records the question; `kind` is derived. Curated at `/other_responses` (grouped by kind/question): `promote` (sectors only), `keep`, `dismiss`. `dismissed` hides the chip from the profile but stays in the review queue (still promotable later); only `promoted` leaves the queue. Admins deep-link there from a person's chip. |
 | `Organization` | Groups with affiliations, addresses, logos via ActiveStorage |
-| `Grant` | Donated funds (polymorphic `donor`: Organization or Person) with eligibility criteria, tasks, deadlines; parent of `Scholarship`. Scholarship totals cannot exceed the grant amount |
+| `Grant` | Funds (polymorphic `funder`: Organization or Person) with eligibility criteria, tasks, deadlines; parent of `Scholarship`. Scholarship totals cannot exceed the grant amount |
 | `Scholarship` | Award to a `Person`; optionally drawn from a `Grant`, syncs to event registration `Allocation` |
 | `ProfessionalLicense` | A license a `Person` holds (`number`, `kind`, `issuing_state`, `expires_on`); a null `number` is a placeholder. `find_or_create_for` keeps one license per (person, number) |
 | `ContinuingEducationRegistration` | A registrant's CE for one event against one `ProfessionalLicense`; billable `allocatable` (`Registerable`) with stored `hours` + `cost_cents` (default from the event). Payment is computed (no stored status); the certificate is delivered via `certificate_sent_at` and gated by its own `certificate_available?` |
@@ -121,7 +121,7 @@ This codebase (Rails 8.1)
 ### Polymorphic Associations
 
 - **Bookmarks** (`bookmarkable`): Workshop, Event, Resource, etc.
-- **Grant donor** (`donor`): Organization, Person
+- **Grant funder** (`funder`): Organization, Person
 - **Assets** (`owner`): Workshop, Story, Resource, Report, etc.
 - **Comments** (`commentable`): Person, User, EventRegistration, Scholarship, ContinuingEducationRegistration, TopicSubscription, Organization, Workshop
 - **Categorizable/Sectorable** items: Workshop, Story, Resource, etc.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -313,7 +313,7 @@ class EventsController < ApplicationController
     @event_registrations = @event.event_registrations
       .includes(
         :event, :organizations, :comments,
-        { scholarships: { grant: :donor } },
+        { scholarships: { grant: :funder } },
         registrant: [ :user, :contact_methods ]
       )
       .joins(:registrant)

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -5,20 +5,20 @@ class GrantsController < ApplicationController
   def index
     authorize!
 
-    # Scoped to a single donor when linked from a person/org edit page. Resolve
-    # the donor from a matching grant (avoids reflection on the type param) so the
-    # header banner can name it; filter_grants scopes the rows to the same donor.
-    if params[:donor_id].present? && Grant::DONOR_TYPES.include?(params[:donor_type])
-      @donor = authorized_scope(Grant.all)
-                 .where(donor_id: params[:donor_id], donor_type: params[:donor_type])
-                 .first&.donor
+    # Scoped to a single funder when linked from a person/org edit page. Resolve
+    # the funder from a matching grant (avoids reflection on the type param) so the
+    # header banner can name it; filter_grants scopes the rows to the same funder.
+    if params[:funder_id].present? && Grant::FUNDER_TYPES.include?(params[:funder_type])
+      @funder = authorized_scope(Grant.all)
+                 .where(funder_id: params[:funder_id], funder_type: params[:funder_type])
+                 .first&.funder
     end
 
     # The full page renders only the header, filters, and an empty results frame;
     # the frame's src request (turbo_frame_request?) loads the filtered rows.
     if turbo_frame_request?
       @grants = filter_grants(authorized_scope(Grant.all))
-                  .includes(:donor, scholarships: { allocation: :allocatable })
+                  .includes(:funder, scholarships: { allocation: :allocatable })
                   .by_deadline
                   .page(params[:page])
       track_index_intent(Grant, @grants, params)
@@ -85,7 +85,7 @@ class GrantsController < ApplicationController
   # its param is blank or unrecognized, so combinations stack cleanly.
   def filter_grants(scope)
     scope = scope.where("grants.name LIKE ?", "%#{Grant.sanitize_sql_like(params[:name])}%") if params[:name].present?
-    scope = filter_by_donor_name(scope, params[:donor_name]) if params[:donor_name].present?
+    scope = filter_by_funder_name(scope, params[:funder_name]) if params[:funder_name].present?
 
     scope = case params[:funds]
     when "available" then scope.with_funds_remaining
@@ -93,8 +93,8 @@ class GrantsController < ApplicationController
     else scope
     end
 
-    scope = scope.where(donor_type: params[:donor_type]) if Grant::DONOR_TYPES.include?(params[:donor_type])
-    scope = scope.where(donor_id: params[:donor_id]) if params[:donor_id].present?
+    scope = scope.where(funder_type: params[:funder_type]) if Grant::FUNDER_TYPES.include?(params[:funder_type])
+    scope = scope.where(funder_id: params[:funder_id]) if params[:funder_id].present?
 
     case params[:tasks]
     when "completed" then scope.all_tasks_completed
@@ -103,15 +103,15 @@ class GrantsController < ApplicationController
     end
   end
 
-  # Match grants whose polymorphic donor (Organization or Person) name contains
-  # the query. Resolve matching donor ids per type, then OR the two sides so the
+  # Match grants whose polymorphic funder (Organization or Person) name contains
+  # the query. Resolve matching funder ids per type, then OR the two sides so the
   # other active filters on `scope` apply to both.
-  def filter_by_donor_name(scope, query)
+  def filter_by_funder_name(scope, query)
     like = "%#{Grant.sanitize_sql_like(query)}%"
     org_ids = Organization.where("name LIKE ?", like).pluck(:id)
     person_ids = Person.where("first_name LIKE :q OR last_name LIKE :q OR CONCAT(first_name, ' ', last_name) LIKE :q", q: like).pluck(:id)
-    scope.where(donor_type: "Organization", donor_id: org_ids)
-         .or(scope.where(donor_type: "Person", donor_id: person_ids))
+    scope.where(funder_type: "Organization", funder_id: org_ids)
+         .or(scope.where(funder_type: "Person", funder_id: person_ids))
   end
 
   def set_grant
@@ -127,7 +127,7 @@ class GrantsController < ApplicationController
 
   def grant_params
     params.require(:grant).permit(
-      :name, :description, :amount_dollars, :amount_cents, :donor_sgid,
+      :name, :description, :amount_dollars, :amount_cents, :funder_sgid,
       :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks
     )
   end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -134,7 +134,7 @@ class ScholarshipsController < ApplicationController
     # Eager-load everything the grid derives so each row's funder, program,
     # location, training, and status cells add no per-row queries.
     scope = authorized_scope(Scholarship.all).includes(
-      { grant: :donor },
+      { grant: :funder },
       { recipient: [ { affiliations: { organization: :addresses } }, { event_registrations: :event } ] }
     )
     if params[:recipient_id].present?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ class SearchController < ApplicationController
   skip_before_action :preload_current_user_associations, raise: false
 
   # Virtual "model" that searches people and organizations together for the
-  # compound payer / donor pickers, listing organizations first.
+  # compound payer / funder pickers, listing organizations first.
   COMPOUND_MODEL = "person_or_organization".freeze
 
   def index
@@ -40,7 +40,7 @@ class SearchController < ApplicationController
   private
 
   # Search people and organizations, listing organizations first (the more
-  # common donor/payer).
+  # common funder/payer).
   def compound_results
     authorize! Organization, to: :search?
     authorize! Person, to: :search?

--- a/app/helpers/grant_helper.rb
+++ b/app/helpers/grant_helper.rb
@@ -1,11 +1,11 @@
 module GrantHelper
-  # Renders a grant's funder (donor) as an icon + name: a person icon tinted
+  # Renders a grant's funder (funder) as an icon + name: a person icon tinted
   # in the people theme color, or a building icon tinted in the organizations
   # theme color.
-  def grant_donor_badge(grant)
-    return "" unless grant&.donor
+  def grant_funder_badge(grant)
+    return "" unless grant&.funder
 
-    person = grant.donor.is_a?(Person)
+    person = grant.funder.is_a?(Person)
     icon_name = person ? "fa-user" : "fa-building"
     color_key = person ? :people : :organizations
 

--- a/app/helpers/scholarship_helper.rb
+++ b/app/helpers/scholarship_helper.rb
@@ -1,12 +1,12 @@
 module ScholarshipHelper
-  # Funder label for a funder group on the scholarship index: the donor's name
-  # with a person/organization icon, mirroring grant_donor_badge. Grant-free
-  # ("Unfunded") groups have no donor, so they render the plain label.
+  # Funder label for a funder group on the scholarship index: the funder's name
+  # with a person/organization icon, mirroring grant_funder_badge. Grant-free
+  # ("Unfunded") groups have no funder, so they render the plain label.
   def funder_badge(funder_group)
-    donor = funder_group.donor
-    return tag.span(funder_group.name) unless donor
+    funder = funder_group.funder
+    return tag.span(funder_group.name) unless funder
 
-    person = donor.is_a?(Person)
+    person = funder.is_a?(Person)
     icon_name = person ? "fa-user" : "fa-building"
     color_key = person ? :people : :organizations
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -169,12 +169,13 @@ class EventRegistration < ApplicationRecord
       )
     SQL
   }
-  # Funder = the grant's donor. "awbw" = org-subsidized (a scholarship drawn from
-  # no grant); "donor" = grant-funded (drawn from an external donor's grant).
+  # Funding source of a registrant's scholarship. "awbw" = org-subsidized (a
+  # scholarship drawn from no grant); "external" = grant-funded (drawn from an
+  # external funder's grant).
   scope :funder, ->(value) {
     case value
     when "awbw" then with_unfunded_scholarship
-    when "donor" then with_funded_scholarship
+    when "external" then with_funded_scholarship
     else all
     end
   }

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,15 +1,15 @@
 class Grant < ApplicationRecord
-  belongs_to :donor, polymorphic: true
+  belongs_to :funder, polymorphic: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
 
   has_many :scholarships, dependent: :restrict_with_error
 
-  DONOR_TYPES = %w[Organization Person].freeze
+  FUNDER_TYPES = %w[Organization Person].freeze
 
   validates :name, presence: true
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
-  validates :donor_type, inclusion: { in: DONOR_TYPES }
+  validates :funder_type, inclusion: { in: FUNDER_TYPES }
   validate :amount_covers_scholarships_already_issued
 
   scope :by_deadline, -> { order(Arel.sql("funds_allocation_deadline IS NULL, funds_allocation_deadline ASC")) }
@@ -46,9 +46,9 @@ class Grant < ApplicationRecord
   # stays selectable even when fully allocated, since this scholarship is what
   # exhausted it and deselecting it should remain possible.
   def self.selectable_for(scholarship)
-    # Eager-load the polymorphic donor: the picker renders name_with_funder (→
-    # funder_name → donor) for every grant, which is an N+1 without this.
-    grants = with_funds_remaining.includes(:donor).by_deadline.to_a
+    # Eager-load the polymorphic funder: the picker renders name_with_funder (→
+    # funder_name → funder) for every grant, which is an N+1 without this.
+    grants = with_funds_remaining.includes(:funder).by_deadline.to_a
     connected = scholarship&.grant
     grants << connected if connected && grants.exclude?(connected)
     grants
@@ -63,19 +63,19 @@ class Grant < ApplicationRecord
     self.amount_cents = (value.to_d * 100).to_i if value.present?
   end
 
-  # Resolve the polymorphic donor from a signed global id, mirroring the
+  # Resolve the polymorphic funder from a signed global id, mirroring the
   # GlobalID pattern used for scholarship allocatables.
-  def donor_sgid
-    donor&.to_signed_global_id&.to_s
+  def funder_sgid
+    funder&.to_signed_global_id&.to_s
   end
 
-  def donor_sgid=(sgid)
-    self.donor = GlobalID::Locator.locate_signed(sgid) if sgid.present?
+  def funder_sgid=(sgid)
+    self.funder = GlobalID::Locator.locate_signed(sgid) if sgid.present?
   end
 
-  # The donor is the funder of any scholarships drawn from the grant.
+  # Human-readable name of the grant's funder (an Organization or Person).
   def funder_name
-    donor&.try(:full_name) || donor&.try(:name) || donor&.to_s
+    funder&.try(:full_name) || funder&.try(:name) || funder&.to_s
   end
 
   # Display label for dropdowns: the grant name with its funder in parens

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -15,7 +15,7 @@ class Organization < ApplicationRecord
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :reports
   has_many :workshop_logs
-  has_many :grants, as: :donor, dependent: :destroy
+  has_many :grants, as: :funder, dependent: :destroy
 
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, as: :sectorable, dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,7 +40,7 @@ class Person < ApplicationRecord
   has_many :topic_subscriptions, dependent: :destroy
   has_many :event_staffs, dependent: :destroy
   has_many :scholarships, foreign_key: :recipient_id, dependent: :destroy
-  has_many :grants, as: :donor, dependent: :destroy
+  has_many :grants, as: :funder, dependent: :destroy
   has_many :events, through: :event_registrations
   has_many :staffed_events, through: :event_staffs, source: :event
   has_many :categories, through: :categorizable_items

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -19,9 +19,9 @@ class Scholarship < ApplicationRecord
   scope :completed, -> { where(tasks_completed: true) }
   scope :agreement_signed, -> { where.not(agreement_signed_at: nil) }
 
-  # Scholarships from grants a given donor (Person/Organization) gave — the
-  # "funder" filter. A blank donor matches nothing.
-  scope :from_funder, ->(donor) { where(grant_id: Grant.where(donor: donor).select(:id)) }
+  # Scholarships from grants a given funder (Person/Organization) gave — the
+  # "funder" filter. A blank funder matches nothing.
+  scope :from_funder, ->(funder) { where(grant_id: Grant.where(funder: funder).select(:id)) }
 
   # Scholarships awarded at the given events, via the allocation → event
   # registration chain (a scholarship's allocation is on an EventRegistration).

--- a/app/presenters/scholarships_grouping.rb
+++ b/app/presenters/scholarships_grouping.rb
@@ -1,6 +1,6 @@
 # Groups a set of scholarships for the index into the two-level hierarchy the
-# page renders: funder (the grant's donor) → grant → recipient rows. A funder
-# can hold several grants (e.g. a donor who funds a new grant each year), so
+# page renders: funder (the grant's funder) → grant → recipient rows. A funder
+# can hold several grants (e.g. a funder who funds a new grant each year), so
 # grants are nested under their shared funder rather than flattened.
 #
 # Scholarships drawn from no grant have no funder; they collect under a single
@@ -13,7 +13,7 @@ class ScholarshipsGrouping
     def count = scholarships.size
   end
 
-  FunderGroup = Struct.new(:name, :donor, :grant_groups, keyword_init: true) do
+  FunderGroup = Struct.new(:name, :funder, :grant_groups, keyword_init: true) do
     def total_cents = grant_groups.sum(&:total_cents)
     def count = grant_groups.sum(&:count)
   end
@@ -35,7 +35,7 @@ class ScholarshipsGrouping
     sample_grant = scholarships.filter_map(&:grant).first
     FunderGroup.new(
       name: sample_grant&.funder_name.presence || UNFUNDED_LABEL,
-      donor: sample_grant&.donor,
+      funder: sample_grant&.funder,
       grant_groups: grant_groups_for(scholarships)
     )
   end
@@ -51,13 +51,13 @@ class ScholarshipsGrouping
     scholarships.sort_by { |s| s.recipient&.full_name.to_s.downcase }
   end
 
-  # Scholarships from grants by the same donor share a funder; grant-free ones
+  # Scholarships from grants by the same funder share a funder; grant-free ones
   # fall into the single unfunded bucket.
   def funder_key(scholarship)
     grant = scholarship.grant
     return :unfunded unless grant
 
-    [ grant.donor_type, grant.donor_id ]
+    [ grant.funder_type, grant.funder_id ]
   end
 
   # Alphabetical by funder, with the unfunded group pinned last.

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -1,11 +1,11 @@
 class EventDashboard
-  # scholarship_donor: when set, every scholarship figure (funded/unfunded cents
-  # and counts, totals, recipients) is scoped to grants that donor gave — for the
+  # scholarship_funder: when set, every scholarship figure (funded/unfunded cents
+  # and counts, totals, recipients) is scoped to grants that funder gave — for the
   # funder-filtered scholarship report. Attendance/registration figures are
   # unaffected. Default nil = every scholarship, as before.
-  def initialize(event, scholarship_donor: nil)
+  def initialize(event, scholarship_funder: nil)
     @event = event
-    @scholarship_donor = scholarship_donor
+    @scholarship_funder = scholarship_funder
   end
 
   attr_reader :event
@@ -227,7 +227,7 @@ class EventDashboard
   # decide whether to flag a registrant as a scholarship recipient. First
   # scholarship wins if a person has several.
   def scholarship_by_recipient
-    @scholarship_by_recipient ||= scholarships.includes(grant: :donor).group_by(&:recipient_id).transform_values(&:first)
+    @scholarship_by_recipient ||= scholarships.includes(grant: :funder).group_by(&:recipient_id).transform_values(&:first)
   end
 
   # Active registration slug per registrant (Person id) — a stable, non-db
@@ -1166,18 +1166,18 @@ class EventDashboard
       scope = Scholarship
         .joins(:allocation)
         .where(allocations: { allocatable_type: "EventRegistration", allocatable_id: active_registration_ids })
-      scope = scope.where(grant_id: donor_grant_ids) if @scholarship_donor
+      scope = scope.where(grant_id: funder_grant_ids) if @scholarship_funder
       scope
     end
   end
 
-  # Ids of grants the scoped donor gave — used to narrow scholarships to one
-  # funder. Empty (so no scholarships match) when the donor gave none.
-  def donor_grant_ids
-    @donor_grant_ids ||= Grant.where(donor: @scholarship_donor).ids
+  # Ids of grants the scoped funder gave — used to narrow scholarships to one
+  # funder. Empty (so no scholarships match) when the funder gave none.
+  def funder_grant_ids
+    @funder_grant_ids ||= Grant.where(funder: @scholarship_funder).ids
   end
 
-  # Externally funded = backed by a grant whose donor isn't the org itself.
+  # Externally funded = backed by a grant whose funder isn't the org itself.
   def funded_scholarships
     scholarships.where.not(grant_id: [ nil, *awbw_grant_ids ])
   end
@@ -1190,7 +1190,7 @@ class EventDashboard
   # Ids of grants the org donated to itself; empty when the AWBW org isn't on
   # file, collapsing the split back to grant-present vs grant-absent.
   def awbw_grant_ids
-    @awbw_grant_ids ||= Grant.where(donor: Organization.awbw).ids
+    @awbw_grant_ids ||= Grant.where(funder: Organization.awbw).ids
   end
 
   # [ [ organization_id, registrant_id ], ... ] from the organizations linked on

--- a/app/services/event_revenue_figures.rb
+++ b/app/services/event_revenue_figures.rb
@@ -83,7 +83,7 @@ class EventRevenueFigures
   end
 
   def awbw_grant_ids
-    @awbw_grant_ids ||= Grant.where(donor: Organization.awbw).ids.to_set
+    @awbw_grant_ids ||= Grant.where(funder: Organization.awbw).ids.to_set
   end
 
   def figures_by_event_id

--- a/app/services/event_scholarship_report.rb
+++ b/app/services/event_scholarship_report.rb
@@ -89,7 +89,7 @@ class EventScholarshipReport
   end
 
   def columns
-    @columns ||= @events.map { |event| Column.new(event: event, dashboard: EventDashboard.new(event, scholarship_donor: @funder)) }
+    @columns ||= @events.map { |event| Column.new(event: event, dashboard: EventDashboard.new(event, scholarship_funder: @funder)) }
   end
 
   def any?

--- a/app/services/reminder_recipient_filter.rb
+++ b/app/services/reminder_recipient_filter.rb
@@ -7,7 +7,7 @@
 # account without extra per-filter SQL.
 class ReminderRecipientFilter
   # Free-text inputs matched in memory against the loaded registrations.
-  TEXT_KEYS = %i[ name reg_org grantor comment email ].freeze
+  TEXT_KEYS = %i[ name reg_org funder comment email ].freeze
   # Dropdown filters shared with the registrants roster. They reuse the
   # EventRegistration scopes (run once as a query) so both pages stay in sync —
   # same param names, options, and semantics.
@@ -40,7 +40,7 @@ class ReminderRecipientFilter
   def matches_text?(reg)
     matches_name?(reg) &&
       matches_reg_org?(reg) &&
-      matches_grantor?(reg) &&
+      matches_funder?(reg) &&
       matches_comment?(reg) &&
       matches_email?(reg)
   end
@@ -75,10 +75,10 @@ class ReminderRecipientFilter
     end
   end
 
-  # Grantor = the funder behind a scholarship's grant. Only registrants who hold a
+  # The funder behind a scholarship's grant. Only registrants who hold a
   # scholarship drawn from a grant can match, per the filter label.
-  def matches_grantor?(reg)
-    any_term?(:grantor) do |term|
+  def matches_funder?(reg)
+    any_term?(:funder) do |term|
       reg.scholarships.any? do |scholarship|
         grant = scholarship.grant
         grant.present? && grant.funder_name.to_s.downcase.include?(term)

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -37,9 +37,9 @@
 
         <% if scholarship.grant&.funder_name.present? %>
           <p class="text-xs text-gray-500">
-            Grantor:
-            <% if scholarship.grant.donor %>
-              <%= link_to scholarship.grant.funder_name, polymorphic_path(scholarship.grant.donor),
+            Funder:
+            <% if scholarship.grant.funder %>
+              <%= link_to scholarship.grant.funder_name, polymorphic_path(scholarship.grant.funder),
                           class: "font-medium text-gray-700 hover:underline" %>
             <% else %>
               <span class="font-medium text-gray-700"><%= scholarship.grant.funder_name %></span>

--- a/app/views/events/_funder_filter.html.erb
+++ b/app/views/events/_funder_filter.html.erb
@@ -1,5 +1,5 @@
 <%# Funder filter shared by the scholarship report forms: a remote-select over
-    people and organizations (grant donors), bound to the signed global id in
+    people and organizations (grant funders), bound to the signed global id in
     `funder_sgid`. Seeded with just the current funder's option so the value
     shows without preloading everyone; the rest arrive via the remote search.
     Submits the form on change, matching the sibling selects. %>

--- a/app/views/events/_reminder_recipient_filters.html.erb
+++ b/app/views/events/_reminder_recipient_filters.html.erb
@@ -19,8 +19,8 @@
       <%= text_field_tag :reg_org, params[:reg_org], class: field_class, placeholder: "Organization name" %>
     </div>
     <div class="w-full md:w-48">
-      <%= label_tag :grantor, "Grantor", class: label_class %>
-      <%= text_field_tag :grantor, params[:grantor], class: field_class, placeholder: "Grantor name" %>
+      <%= label_tag :funder, "Funder", class: label_class %>
+      <%= text_field_tag :funder, params[:funder], class: field_class, placeholder: "Funder name" %>
     </div>
     <div class="w-full md:w-48">
       <%= label_tag :comment, "Comment", class: label_class %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -52,7 +52,7 @@
           <%= render "revenue_kpi", label: "Scholarships", value: dollars_from_cents(featured.funded_scholarship_cents),
                 value_class: "text-fuchsia-700", card_class: "border-fuchsia-300 bg-fuchsia-50", note: "grant-funded only", cents: featured.funded_scholarship_cents,
                 prior_cents: prior&.funded_scholarship_cents, prior_year: prior&.year,
-                href: event_registrations_path(funder: "donor", event_year: featured.year, event_id: params[:event_id]) %>
+                href: event_registrations_path(funder: "external", event_year: featured.year, event_id: params[:event_id]) %>
           <%= render "revenue_kpi", label: "Org subsidy", value: dollars_from_cents(featured.org_subsidy_cents),
                 value_class: "text-red-600", card_class: "border-red-300 bg-red-50", note: "discounts + unfunded", cents: featured.org_subsidy_cents,
                 prior_cents: prior&.org_subsidy_cents, prior_year: prior&.year,

--- a/app/views/grants/_filters.html.erb
+++ b/app/views/grants/_filters.html.erb
@@ -1,6 +1,6 @@
 <%# Index filters, mirroring the registrants search: a GET form driven by the
     collection controller. Selects submit on change and the text boxes (grant/
-    donor name) debounce-submit as you type, all into the grants_results frame —
+    funder name) debounce-submit as you type, all into the grants_results frame —
     so the old rows blur (blur-on-submit) while the next page loads. %>
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
                   focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
@@ -15,8 +15,8 @@
       <%= text_field_tag :name, params[:name], class: field_class, placeholder: "Grant name" %>
     </div>
     <div class="w-full md:flex-1">
-      <%= label_tag :donor_name, "Donor name", class: label_class %>
-      <%= text_field_tag :donor_name, params[:donor_name], class: field_class, placeholder: "Organization or person" %>
+      <%= label_tag :funder_name, "Funder name", class: label_class %>
+      <%= text_field_tag :funder_name, params[:funder_name], class: field_class, placeholder: "Organization or person" %>
     </div>
     <div class="w-full md:w-32">
       <%= label_tag :funds, "Funds remaining", class: label_class %>
@@ -26,9 +26,9 @@
                      class: field_class %>
     </div>
     <div class="w-full md:w-32">
-      <%= label_tag :donor_type, "Donor type", class: label_class %>
-      <%= select_tag :donor_type,
-                     options_for_select([ [ "Organization", "Organization" ], [ "Individual", "Person" ] ], params[:donor_type]),
+      <%= label_tag :funder_type, "Funder type", class: label_class %>
+      <%= select_tag :funder_type,
+                     options_for_select([ [ "Organization", "Organization" ], [ "Individual", "Person" ] ], params[:funder_type]),
                      include_blank: "All",
                      class: field_class %>
     </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -10,10 +10,10 @@
     </div>
 
     <div>
-      <% donor_label_data = @grant.donor&.compound_search_label %>
-      <%= f.input :donor_sgid,
-                  collection: donor_label_data ? [ [ donor_label_data[:label], donor_label_data[:id] ] ] : [],
-                  selected: donor_label_data&.dig(:id),
+      <% funder_label_data = @grant.funder&.compound_search_label %>
+      <%= f.input :funder_sgid,
+                  collection: funder_label_data ? [ [ funder_label_data[:label], funder_label_data[:id] ] ] : [],
+                  selected: funder_label_data&.dig(:id),
                   required: true,
                   input_html: {
                     class: "bg-white",
@@ -23,7 +23,7 @@
                     }
                   },
                   prompt: "Search organizations and people",
-                  label: "Donor",
+                  label: "Funder",
                   hint: "The organization or person donating the funds." %>
     </div>
 

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -6,7 +6,7 @@
   <td class="px-4 py-3.5 align-middle" data-sort-value="<%= grant.object.name.to_s.downcase %>">
     <%= link_to grant.name, grant_path(grant), class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } %>
   </td>
-  <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.funder_name.to_s.downcase %>"><%= grant_donor_badge(grant) %></td>
+  <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.funder_name.to_s.downcase %>"><%= grant_funder_badge(grant) %></td>
   <td class="px-4 py-3.5 align-middle text-sm font-medium text-gray-900 text-right tabular-nums" data-sort-value="<%= grant.object.amount_cents.to_i %>"><%= grant.amount %></td>
   <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.remaining_cents.to_i %>">
     <%# Bar tracks funds left: green shrinks as the grant is awarded, fully grey

--- a/app/views/grants/_results.html.erb
+++ b/app/views/grants/_results.html.erb
@@ -11,7 +11,7 @@
               cells carry a numeric/ISO data-sort-value so they sort correctly. %>
           <% columns = [
                { label: "Name", index: 0, align: "text-left" },
-               { label: "Donor", index: 1, align: "text-left" },
+               { label: "Funder", index: 1, align: "text-left" },
                { label: "Amount", index: 2, align: "text-right" },
                { label: "Remaining", index: 3, align: "text-left" },
                { label: "Allocated", index: 4, align: "text-right" },

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -40,7 +40,7 @@
 
     <%= render "filters" %>
 
-    <%= render "shared/filtered_to", record: @donor, clear_path: grants_path %>
+    <%= render "shared/filtered_to", record: @funder, clear_path: grants_path %>
 
     <%# Results load in a turbo frame so the filter form (outside the frame) can
         swap just the table — blurring the old rows while the next page loads and

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -17,7 +17,7 @@
     <div class="flex items-start justify-between">
       <div>
         <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
-        <p class="text-gray-600 mt-1"><%= grant_donor_badge(grant) %></p>
+        <p class="text-gray-600 mt-1"><%= grant_funder_badge(grant) %></p>
       </div>
       <% if allowed_to?(:edit?, @grant) %>
         <%= link_to "Edit", edit_grant_path(@grant), class: "btn btn-primary-outline" %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -10,7 +10,7 @@
     <li class="break-inside-avoid mb-2"><%= index_button notifications, params: { email: email }, label: "#{t("communications.title")} (universal)" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { donor_id: person.id, donor_type: "Person" }, label: "Grants (as donor)" %></li>
+    <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button Payment.where(person_id: person.id), params: { person_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Subscriptions" %></li>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -132,11 +132,11 @@
 
   <div class="space-y-6 p-4">
     <% if grant_funded %>
-      <% donor_icon = grant.donor.is_a?(Person) ? "fa-user #{DomainTheme.text_class_for(:people)}" : "fa-building #{DomainTheme.text_class_for(:organizations)}" %>
+      <% funder_icon = grant.funder.is_a?(Person) ? "fa-user #{DomainTheme.text_class_for(:people)}" : "fa-building #{DomainTheme.text_class_for(:organizations)}" %>
       <div>
         <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Funder</dt>
         <dd class="mt-1 text-sm text-gray-900 flex items-center gap-2">
-          <i class="fa-solid <%= donor_icon %>" aria-hidden="true"></i>
+          <i class="fa-solid <%= funder_icon %>" aria-hidden="true"></i>
           <%= link_to grant.funder_name, grant_path(grant), class: "text-blue-700 hover:underline" %>
         </dd>
       </div>

--- a/db/migrate/20260809224320_rename_grants_donor_to_funder.rb
+++ b/db/migrate/20260809224320_rename_grants_donor_to_funder.rb
@@ -1,0 +1,17 @@
+class RenameGrantsDonorToFunder < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :grants, :donor_id, :funder_id if column_exists?(:grants, :donor_id)
+    rename_column :grants, :donor_type, :funder_type if column_exists?(:grants, :donor_type)
+    if index_exists?(:grants, [ :funder_type, :funder_id ], name: "index_grants_on_donor")
+      rename_index :grants, "index_grants_on_donor", "index_grants_on_funder"
+    end
+  end
+
+  def down
+    rename_column :grants, :funder_id, :donor_id if column_exists?(:grants, :funder_id)
+    rename_column :grants, :funder_type, :donor_type if column_exists?(:grants, :funder_type)
+    if index_exists?(:grants, [ :donor_type, :donor_id ], name: "index_grants_on_funder")
+      rename_index :grants, "index_grants_on_funder", "index_grants_on_donor"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_210304) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_224320) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -687,9 +687,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_210304) do
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.text "description"
-    t.bigint "donor_id", null: false
-    t.string "donor_type", null: false
     t.text "eligibility_criteria"
+    t.bigint "funder_id", null: false
+    t.string "funder_type", null: false
     t.date "funds_allocation_deadline"
     t.date "funds_received_on"
     t.string "name", null: false
@@ -697,7 +697,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_210304) do
     t.datetime "updated_at", null: false
     t.bigint "updated_by_id"
     t.index ["created_by_id"], name: "index_grants_on_created_by_id"
-    t.index ["donor_type", "donor_id"], name: "index_grants_on_donor"
+    t.index ["funder_type", "funder_id"], name: "index_grants_on_funder"
     t.index ["updated_by_id"], name: "index_grants_on_updated_by_id"
   end
 

--- a/db/seeds/dev/scholarships.rb
+++ b/db/seeds/dev/scholarships.rb
@@ -11,9 +11,9 @@
 #     visible as "potentially awarded" but the registrant still owes the cost.
 #
 # Most of these event-allocated scholarships are drawn from a parent grant, so the
-# recipients page (events/recipients) shows the funding donor's name — a mix of
-# organization and individual (Person) funders, since a grant's donor is
-# polymorphic. A few are left grant-free so the no-donor case is covered too.
+# recipients page (events/recipients) shows the funding funder's name — a mix of
+# organization and individual (Person) funders, since a grant's funder is
+# polymorphic. A few are left grant-free so the no-funder case is covered too.
 #
 # A couple of scholarship + payment combos are seeded alongside the payments in
 # db/seeds/dev/payments.rb (Amy, Jessica); this file fills out the flagship
@@ -37,27 +37,27 @@ end
 
 # --- Grants (funding sources) ----------------------------------------------
 # Create the grants up front so the event-allocated scholarships below can be
-# drawn from them (recipients page → donor name). Grants cap the total
+# drawn from them (recipients page → funder name). Grants cap the total
 # scholarship dollars from a single source, so amounts are sized to comfortably
 # cover both the event-allocated draws here and the standalone grant awards
 # further down.
-#   * a mix of donor types — three organization funders and two individual
-#     (Person) funders, since donor is polymorphic;
+#   * a mix of funder types — three organization funders and two individual
+#     (Person) funders, since funder is polymorphic;
 #   * distinct donation totals, eligibility criteria, and tasks per grant.
 puts "Creating Grants…"
 
-# Resolve a grant's donor by type: organizations by name, individuals by their
-# first/last name (so a Person can fund a grant, mirroring the polymorphic donor).
-resolve_donor = ->(donor_type, donor_name) do
-  if donor_type == "Person"
-    first, last = donor_name.split(" ", 2)
+# Resolve a grant's funder by type: organizations by name, individuals by their
+# first/last name (so a Person can fund a grant, mirroring the polymorphic funder).
+resolve_funder = ->(funder_type, funder_name) do
+  if funder_type == "Person"
+    first, last = funder_name.split(" ", 2)
     Person.find_by(first_name: first, last_name: last)
   else
-    Organization.find_by(name: donor_name)
+    Organization.find_by(name: funder_name)
   end
 end
 
-# [ name, donor_type, donor name, amount_cents, [ standalone award amounts… ], eligibility, tasks ]
+# [ name, funder_type, funder name, amount_cents, [ standalone award amounts… ], eligibility, tasks ]
 grant_plans = [
   [ "Healing Arts Scholarship Fund", "Organization", "Joyful Heart Foundation", 2_000_000, [ 250_000, 150_000, 100_000 ],
     "Lead expressive-arts groups for trauma survivors\nServe a community-based partner organization",
@@ -79,12 +79,12 @@ grant_plans = [
 # Build the grants, re-syncing funder + descriptive fields for grants left over
 # from an earlier run. Indexed by plan so the standalone-award amounts stay paired
 # with their grant.
-grants = grant_plans.filter_map do |(name, donor_type, donor_name, amount_cents, _awards, eligibility, tasks)|
-  donor = resolve_donor.(donor_type, donor_name)
-  next unless donor
+grants = grant_plans.filter_map do |(name, funder_type, funder_name, amount_cents, _awards, eligibility, tasks)|
+  funder = resolve_funder.(funder_type, funder_name)
+  next unless funder
 
   grant = Grant.find_or_create_by!(name: name) do |g|
-    g.donor = donor
+    g.funder = funder
     g.amount_cents = amount_cents
     g.funds_allocation_deadline = Date.current + 30
     g.funds_received_on = Date.current - 30
@@ -92,15 +92,15 @@ grants = grant_plans.filter_map do |(name, donor_type, donor_name, amount_cents,
     g.tasks = tasks
   end
 
-  if grant.donor != donor || grant.amount_cents != amount_cents ||
+  if grant.funder != funder || grant.amount_cents != amount_cents ||
      grant.eligibility_criteria != eligibility || grant.tasks != tasks
-    grant.update!(donor: donor, amount_cents: amount_cents, eligibility_criteria: eligibility, tasks: tasks)
+    grant.update!(funder: funder, amount_cents: amount_cents, eligibility_criteria: eligibility, tasks: tasks)
   end
 
   grant
 end
 
-# Round-robin across grants for donor variety, but only hand back one that can
+# Round-robin across grants for funder variety, but only hand back one that can
 # still absorb this award within its donation cap; returns nil when none has room
 # (the scholarship is then created grant-free).
 grant_cursor = 0
@@ -120,7 +120,7 @@ end
 # set amount + tasks_completed so sync_allocation_amount funds the allocation only
 # when the recipient's tasks are complete (completed → allocated; pending → $0).
 # When grant_funded, draws the award from a parent grant so the recipients page
-# can name the funding donor.
+# can name the funding funder.
 award_scholarship = ->(registration, amount_cents:, tasks_completed:, grant_funded: false) do
   return unless registration
   return if registration.scholarships.exists?
@@ -392,8 +392,8 @@ if facilitator_training
 
   # Fund the newly chosen recipients (Amy already has hers from payments); varied
   # shares and completion states give the dashboard both allocated and pending awards.
-  # Most draw from a parent grant so the recipients page shows the funding donor;
-  # one is left grant-free to cover the no-donor case.
+  # Most draw from a parent grant so the recipients page shows the funding funder;
+  # one is left grant-free to cover the no-funder case.
   # [ share of the registration fee, tasks_completed, grant_funded ]
   award_plan = [ [ 1.0, true, true ], [ 0.5, true, true ], [ 0.75, false, true ], [ 0.5, true, true ], [ 0.25, false, false ] ]
   plan_index = 0
@@ -507,7 +507,7 @@ grant_has_standalone = ->(grant) do
   Scholarship.where(grant: grant).left_outer_joins(:allocation).where(allocations: { id: nil }).exists?
 end
 
-grant_plans.each do |(name, _donor_type, _donor_name, _amount_cents, awards, _eligibility, _tasks)|
+grant_plans.each do |(name, _funder_type, _funder_name, _amount_cents, awards, _eligibility, _tasks)|
   grant = grants.find { |g| g.name == name }
   next unless grant && grant_recipient_pool.any?
   next if grant_has_standalone.(grant)
@@ -533,7 +533,7 @@ puts "Creating scholarship index demo states (multi-grant funder, Reinstate)…"
 anchor_grant = grants.first
 if anchor_grant && recipient_orgs.any?
   sibling = Grant.find_or_create_by!(name: "#{anchor_grant.name} (2026)") do |g|
-    g.donor = anchor_grant.donor
+    g.funder = anchor_grant.funder
     g.amount_cents = 600_000
     g.funds_allocation_deadline = Date.current + 60
     g.funds_received_on = Date.current - 10

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :grant do
     name { "Healing Arts Scholarship Fund" }
     amount_cents { 500_000 }
-    association :donor, factory: :organization
+    association :funder, factory: :organization
     funds_allocation_deadline { Date.current + 30 }
     funds_received_on { Date.current - 7 }
     eligibility_criteria { "Must be a current facilitator\nMust serve a partner organization" }
     tasks { "Submit application form\nComplete intake interview" }
 
     trait :donated_by_person do
-      association :donor, factory: :person
+      association :funder, factory: :person
     end
   end
 end

--- a/spec/helpers/grant_helper_spec.rb
+++ b/spec/helpers/grant_helper_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe GrantHelper, type: :helper do
-  describe "#grant_donor_badge" do
-    it "renders a person donor with the people-colored person icon and name" do
+  describe "#grant_funder_badge" do
+    it "renders a person funder with the people-colored person icon and name" do
       person = create(:person, first_name: "Bob", last_name: "Barker")
-      grant = create(:grant, donor: person)
+      grant = create(:grant, funder: person)
 
-      badge = helper.grant_donor_badge(grant)
+      badge = helper.grant_funder_badge(grant)
 
       expect(badge).to include("fa-user")
       expect(badge).to include(DomainTheme.text_class_for(:people))
@@ -14,11 +14,11 @@ RSpec.describe GrantHelper, type: :helper do
       expect(badge).not_to include("Person:")
     end
 
-    it "renders an organization donor with the organizations-colored building icon and name" do
+    it "renders an organization funder with the organizations-colored building icon and name" do
       organization = create(:organization, name: "Helping Hands")
-      grant = create(:grant, donor: organization)
+      grant = create(:grant, funder: organization)
 
-      badge = helper.grant_donor_badge(grant)
+      badge = helper.grant_funder_badge(grant)
 
       expect(badge).to include("fa-building")
       expect(badge).to include(DomainTheme.text_class_for(:organizations))

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -336,8 +336,8 @@ RSpec.describe EventRegistration, type: :model do
         expect(results).not_to include(funded_reg, paid_reg, unpaid_reg)
       end
 
-      it "maps 'donor' to recipients of grant-funded scholarships" do
-        results = EventRegistration.funder("donor")
+      it "maps 'external' to recipients of grant-funded scholarships" do
+        results = EventRegistration.funder("external")
         expect(results).to include(funded_reg)
         expect(results).not_to include(scholarship_reg, incomplete_scholarship_reg, paid_reg, unpaid_reg)
       end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Grant, type: :model do
   describe "associations" do
-    it { is_expected.to belong_to(:donor) }
+    it { is_expected.to belong_to(:funder) }
     it { is_expected.to belong_to(:created_by).class_name("User").optional }
     it { is_expected.to belong_to(:updated_by).class_name("User").optional }
     it { is_expected.to have_many(:scholarships).dependent(:restrict_with_error) }
@@ -12,11 +12,11 @@ RSpec.describe Grant, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
 
-    it "is valid with an organization donor" do
+    it "is valid with an organization funder" do
       expect(build(:grant)).to be_valid
     end
 
-    it "is valid with a person donor" do
+    it "is valid with a person funder" do
       expect(build(:grant, :donated_by_person)).to be_valid
     end
 
@@ -64,13 +64,13 @@ RSpec.describe Grant, type: :model do
     end
   end
 
-  describe "#donor_sgid" do
-    it "round-trips a donor through a signed global id" do
+  describe "#funder_sgid" do
+    it "round-trips a funder through a signed global id" do
       organization = create(:organization)
       grant = build(:grant)
-      grant.donor_sgid = organization.to_signed_global_id.to_s
-      expect(grant.donor).to eq(organization)
-      expect(GlobalID::Locator.locate_signed(grant.donor_sgid)).to eq(organization)
+      grant.funder_sgid = organization.to_signed_global_id.to_s
+      expect(grant.funder).to eq(organization)
+      expect(GlobalID::Locator.locate_signed(grant.funder_sgid)).to eq(organization)
     end
   end
 
@@ -89,7 +89,7 @@ RSpec.describe Grant, type: :model do
   describe "#name_with_funder" do
     it "appends the funder name in parens" do
       organization = build(:organization, name: "Acme Foundation")
-      grant = build(:grant, name: "Spring Fund", donor: organization)
+      grant = build(:grant, name: "Spring Fund", funder: organization)
       expect(grant.name_with_funder).to eq("Spring Fund (Acme Foundation)")
     end
 

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Scholarship, type: :model do
 
     let!(:from_funder) do
       reg = create(:event_registration, event: event, registrant: person1, status: "attended")
-      scholarship = create(:scholarship, recipient: person1, amount_cents: 4_000, grant: create(:grant, donor: funder))
+      scholarship = create(:scholarship, recipient: person1, amount_cents: 4_000, grant: create(:grant, funder: funder))
       create(:allocation, source: scholarship, allocatable: reg, amount: 4_000)
       scholarship
     end
@@ -162,7 +162,7 @@ RSpec.describe Scholarship, type: :model do
       scholarship
     end
 
-    it ".from_funder returns only scholarships whose grant that donor gave" do
+    it ".from_funder returns only scholarships whose grant that funder gave" do
       expect(Scholarship.from_funder(funder)).to contain_exactly(from_funder)
     end
 

--- a/spec/presenters/scholarships_grouping_spec.rb
+++ b/spec/presenters/scholarships_grouping_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe ScholarshipsGrouping do
   describe "#funder_groups" do
     it "nests grants under their shared funder and sums each level" do
-      donor = create(:person, first_name: "Elisa", last_name: "Perlman")
-      grant_2025 = create(:grant, name: "Elisa 2025", donor: donor, amount_cents: 1_000_000)
-      grant_2026 = create(:grant, name: "Elisa 2026", donor: donor, amount_cents: 1_000_000)
+      funder = create(:person, first_name: "Elisa", last_name: "Perlman")
+      grant_2025 = create(:grant, name: "Elisa 2025", funder: funder, amount_cents: 1_000_000)
+      grant_2026 = create(:grant, name: "Elisa 2026", funder: funder, amount_cents: 1_000_000)
       create(:scholarship, grant: grant_2025, amount_cents: 100_000)
       create(:scholarship, grant: grant_2026, amount_cents: 50_000)
 
@@ -19,7 +19,7 @@ RSpec.describe ScholarshipsGrouping do
     end
 
     it "puts grant-free scholarships in an Unfunded group sorted last" do
-      create(:scholarship, grant: create(:grant, name: "Aardvark Fund", donor: create(:organization, name: "Aardvark")))
+      create(:scholarship, grant: create(:grant, name: "Aardvark Fund", funder: create(:organization, name: "Aardvark")))
       create(:scholarship, grant: nil)
 
       names = described_class.new(Scholarship.all).funder_groups.map(&:name)

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include(org_subsidized.registrant.name)
         expect(response.body).not_to include(grant_funded.registrant.name)
 
-        get event_registrations_path(funder: "donor")
+        get event_registrations_path(funder: "external")
         expect(response.body).to include(grant_funded.registrant.name)
         expect(response.body).not_to include(org_subsidized.registrant.name)
       end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe "Events", type: :request do
         get revenue_events_path
         expect(response.body).to include("payment_status=paid")   # Fees collected
         expect(response.body).to include("payment_status=unpaid") # Outstanding
-        expect(response.body).to include("funder=donor")          # Scholarships (grant-funded)
+        expect(response.body).to include("funder=external")       # Scholarships (grant-funded)
         expect(response.body).to include("funder=awbw")           # Org subsidy
       end
 
@@ -492,7 +492,7 @@ RSpec.describe "Events", type: :request do
         unfunded_person = create(:person, first_name: "Uma", last_name: "Unfunded")
         funded_reg = create(:event_registration, event: training, registrant: funded_person, status: "attended")
         unfunded_reg = create(:event_registration, event: training, registrant: unfunded_person, status: "attended")
-        funded_award = create(:scholarship, recipient: funded_person, amount_cents: 4_000, grant: create(:grant, donor: funder))
+        funded_award = create(:scholarship, recipient: funded_person, amount_cents: 4_000, grant: create(:grant, funder: funder))
         create(:allocation, source: funded_award, allocatable: funded_reg, amount: 4_000)
         unfunded_award = create(:scholarship, recipient: unfunded_person, amount_cents: 2_500, grant: nil)
         create(:allocation, source: unfunded_award, allocatable: unfunded_reg, amount: 2_500)
@@ -510,7 +510,7 @@ RSpec.describe "Events", type: :request do
         funder = create(:organization, name: "Community Trust")
         person = create(:person)
         reg = create(:event_registration, event: training, registrant: person, status: "attended")
-        award = create(:scholarship, recipient: person, amount_cents: 4_000, grant: create(:grant, donor: funder))
+        award = create(:scholarship, recipient: person, amount_cents: 4_000, grant: create(:grant, funder: funder))
         create(:allocation, source: award, allocatable: reg, amount: 4_000)
 
         sign_in admin
@@ -2715,10 +2715,10 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include(CGI.escapeHTML(edit_scholarship_path(scholarship, return_to: "recipients", participant: registration.slug)))
       end
 
-      it "names the funding donor when the scholarship is drawn from a grant" do
+      it "names the funder when the scholarship is drawn from a grant" do
         registration = event.event_registrations.find_by(registrant: applicant)
         org = create(:organization, name: "Joyful Heart Foundation")
-        grant = create(:grant, name: "Healing Arts Fund", donor: org, amount_cents: 100_000)
+        grant = create(:grant, name: "Healing Arts Fund", funder: org, amount_cents: 100_000)
         scholarship = create(:scholarship, recipient: applicant, grant: grant, amount_cents: 1_000, tasks_completed: true)
         create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
 
@@ -2728,7 +2728,7 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include("Joyful Heart Foundation")
       end
 
-      it "omits the donor line for a scholarship with no parent grant" do
+      it "omits the funder line for a scholarship with no parent grant" do
         registration = event.event_registrations.find_by(registrant: applicant)
         scholarship = create(:scholarship, recipient: applicant, amount_cents: 1_000, tasks_completed: true)
         create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "/grants", type: :request do
     {
       name: "Healing Arts Grant",
       amount_dollars: "5000",
-      donor_sgid: organization.to_signed_global_id.to_s,
+      funder_sgid: organization.to_signed_global_id.to_s,
       funds_allocation_deadline: "2026-12-31",
       eligibility_criteria: "Must be a facilitator",
       tasks: "Submit application"
@@ -16,7 +16,7 @@ RSpec.describe "/grants", type: :request do
   end
 
   let(:invalid_attributes) do
-    { name: "", amount_dollars: "1000", donor_sgid: "" }
+    { name: "", amount_dollars: "1000", funder_sgid: "" }
   end
 
   describe "authorization" do
@@ -68,15 +68,15 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("Has funds")
       end
 
-      it "filters by donor type" do
-        org_grant = create(:grant, name: "Org grant", donor: create(:organization))
-        person_grant = create(:grant, name: "Person grant", donor: create(:person))
+      it "filters by funder type" do
+        org_grant = create(:grant, name: "Org grant", funder: create(:organization))
+        person_grant = create(:grant, name: "Person grant", funder: create(:person))
 
-        get grants_url(donor_type: "Organization"), headers: frame_headers
+        get grants_url(funder_type: "Organization"), headers: frame_headers
         expect(response.body).to include("Org grant")
         expect(response.body).not_to include("Person grant")
 
-        get grants_url(donor_type: "Person"), headers: frame_headers
+        get grants_url(funder_type: "Person"), headers: frame_headers
         expect(response.body).to include("Person grant")
         expect(response.body).not_to include("Org grant")
       end
@@ -90,16 +90,16 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("Music Therapy Grant")
       end
 
-      it "filters by donor name across organizations and people" do
-        org_grant = create(:grant, name: "Org-funded", donor: create(:organization, name: "Acme Foundation"))
-        person_grant = create(:grant, name: "Person-funded", donor: create(:person, first_name: "Jane", last_name: "Donor"))
-        create(:grant, name: "Other grant", donor: create(:organization, name: "Unrelated Inc"))
+      it "filters by funder name across organizations and people" do
+        org_grant = create(:grant, name: "Org-funded", funder: create(:organization, name: "Acme Foundation"))
+        person_grant = create(:grant, name: "Person-funded", funder: create(:person, first_name: "Jane", last_name: "Funder"))
+        create(:grant, name: "Other grant", funder: create(:organization, name: "Unrelated Inc"))
 
-        get grants_url(donor_name: "acme"), headers: frame_headers
+        get grants_url(funder_name: "acme"), headers: frame_headers
         expect(response.body).to include("Org-funded")
         expect(response.body).not_to include("Other grant")
 
-        get grants_url(donor_name: "jane donor"), headers: frame_headers
+        get grants_url(funder_name: "jane funder"), headers: frame_headers
         expect(response.body).to include("Person-funded")
         expect(response.body).not_to include("Other grant")
       end
@@ -119,18 +119,18 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("All done")
       end
 
-      it "scopes to a single donor via donor_id and names it in the banner" do
-        donor = create(:person, first_name: "Dana", last_name: "Donor")
-        create(:grant, name: "Dana Fund", donor: donor)
-        create(:grant, name: "Other Fund", donor: create(:organization, name: "Big Org"))
+      it "scopes to a single funder via funder_id and names it in the banner" do
+        funder = create(:person, first_name: "Dana", last_name: "Funder")
+        create(:grant, name: "Dana Fund", funder: funder)
+        create(:grant, name: "Other Fund", funder: create(:organization, name: "Big Org"))
 
-        # Banner renders on the full page (donor resolved in the non-frame branch).
-        get grants_url(donor_id: donor.id, donor_type: "Person")
+        # Banner renders on the full page (funder resolved in the non-frame branch).
+        get grants_url(funder_id: funder.id, funder_type: "Person")
         expect(response.body).to include("Filtered to")
-        expect(response.body).to include("Dana Donor")
+        expect(response.body).to include("Dana Funder")
 
-        # Rows are scoped to that donor inside the results frame.
-        get grants_url(donor_id: donor.id, donor_type: "Person"), headers: frame_headers
+        # Rows are scoped to that funder inside the results frame.
+        get grants_url(funder_id: funder.id, funder_type: "Person"), headers: frame_headers
         expect(response.body).to include("Dana Fund")
         expect(response.body).not_to include("Other Fund")
       end
@@ -165,7 +165,7 @@ RSpec.describe "/grants", type: :request do
           }.to change(Grant, :count).by(1)
 
           grant = Grant.last
-          expect(grant.donor).to eq(organization)
+          expect(grant.funder).to eq(organization)
           expect(grant.amount_cents).to eq(500_000)
           expect(grant.created_by).to eq(admin)
         end

--- a/spec/requests/people_associated_records_spec.rb
+++ b/spec/requests/people_associated_records_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Person edit associated records", type: :request do
       create(:event_registration, registrant: person)
       create(:workshop_log, created_by: person.user)
       create(:scholarship, recipient: person)
-      create(:grant, donor: person)
+      create(:grant, funder: person)
       create(:form_submission, person: person)
       create(:payment, person: person)
       create(:notification, recipient_email: person.preferred_email)
@@ -35,13 +35,13 @@ RSpec.describe "Person edit associated records", type: :request do
       expect(response.body).to include(community_news_index_path(author_id: person.id))
       expect(response.body).to include(resources_path(author_id: person.id))
       expect(response.body).to include(scholarships_path(recipient_id: person.id))
-      expect(response.body).to include(CGI.escapeHTML(grants_path(donor_id: person.id, donor_type: "Person")))
+      expect(response.body).to include(CGI.escapeHTML(grants_path(funder_id: person.id, funder_type: "Person")))
       expect(response.body).to include(form_submissions_path(person_id: person.id))
       expect(response.body).to include(payments_path(person_id: person.id))
       expect(response.body).to include(notifications_path(email: person.preferred_email))
 
       # Custom card labels
-      expect(response.body).to include("Grants (as donor)")
+      expect(response.body).to include("Grants (as funder)")
       expect(response.body).to include("Communications (universal)")
     end
 

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -369,8 +369,8 @@ RSpec.describe "GET /scholarships (index)", type: :request do
       training = create(:event, title: "TAC251", facilitator_training: true)
       create(:event_registration, registrant: recipient, event: training, status: "attended")
 
-      donor = create(:organization, name: "JDI Foundation")
-      grant = create(:grant, name: "JDI", donor: donor, amount_cents: 1_000_000)
+      funder = create(:organization, name: "JDI Foundation")
+      grant = create(:grant, name: "JDI", funder: funder, amount_cents: 1_000_000)
       create(:scholarship, grant: grant, recipient: recipient, amount_cents: 150_000)
 
       get scholarships_path
@@ -409,8 +409,8 @@ RSpec.describe "GET /scholarships (index)", type: :request do
     it "narrows the list to a selected funder" do
       keep = create(:organization, name: "Keep Foundation")
       drop = create(:organization, name: "Drop Foundation")
-      create(:scholarship, grant: create(:grant, donor: keep), recipient: create(:person, first_name: "Kept", last_name: "One"))
-      create(:scholarship, grant: create(:grant, donor: drop), recipient: create(:person, first_name: "Dropped", last_name: "Two"))
+      create(:scholarship, grant: create(:grant, funder: keep), recipient: create(:person, first_name: "Kept", last_name: "One"))
+      create(:scholarship, grant: create(:grant, funder: drop), recipient: create(:person, first_name: "Dropped", last_name: "Two"))
 
       get scholarships_path(funder_sgid: keep.to_signed_global_id.to_s)
 
@@ -444,8 +444,8 @@ end
 
 RSpec.describe "/scholarships (grant-funded flow)", type: :request do
   let(:admin) { create(:user, :admin) }
-  let(:donor) { create(:organization, name: "Helping Hands") }
-  let(:grant) { create(:grant, donor:, amount_cents: 100_000) }
+  let(:funder) { create(:organization, name: "Helping Hands") }
+  let(:grant) { create(:grant, funder:, amount_cents: 100_000) }
   let(:recipient) { create(:person, first_name: "Bob", last_name: "Barker") }
 
   before { sign_in admin }

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -1097,7 +1097,7 @@ RSpec.describe EventDashboard do
 
       # A grant the org donated to itself is subsidy, so it counts as UNFUNDED.
       awbw = create(:organization, name: "A Window Between Worlds")
-      awbw_award = create(:scholarship, recipient: person4, amount_cents: 1_000, grant: create(:grant, donor: awbw))
+      awbw_award = create(:scholarship, recipient: person4, amount_cents: 1_000, grant: create(:grant, funder: awbw))
       create(:allocation, source: awbw_award, allocatable: reg4, amount: 1_000)
 
       # A scholarship on a cancelled registration must be ignored everywhere.

--- a/spec/services/event_scholarship_report_spec.rb
+++ b/spec/services/event_scholarship_report_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe EventScholarshipReport do
 
     before do
       awbw = create(:organization, name: "A Window Between Worlds")
-      awbw_grant = create(:grant, donor: awbw)
+      awbw_grant = create(:grant, funder: awbw)
       award = create(:scholarship, recipient: person, amount_cents: 3_000, grant: awbw_grant)
       create(:allocation, source: award, allocatable: reg, amount: 3_000)
     end
@@ -84,7 +84,7 @@ RSpec.describe EventScholarshipReport do
       reg1 = create(:event_registration, event: event, registrant: person1, status: "attended")
       reg2 = create(:event_registration, event: event, registrant: person2, status: "attended")
 
-      from_funder = create(:scholarship, recipient: person1, amount_cents: 4_000, grant: create(:grant, donor: funder))
+      from_funder = create(:scholarship, recipient: person1, amount_cents: 4_000, grant: create(:grant, funder: funder))
       create(:allocation, source: from_funder, allocatable: reg1, amount: 4_000)
 
       other = create(:scholarship, recipient: person2, amount_cents: 2_000, grant: create(:grant))

--- a/spec/services/reminder_recipient_filter_spec.rb
+++ b/spec/services/reminder_recipient_filter_spec.rb
@@ -64,14 +64,14 @@ RSpec.describe ReminderRecipientFilter do
       expect(matched({ reg_org: "hope" }, [ reg, other ])).to eq([ reg.id ].to_set)
     end
 
-    it "filters by grantor name of an associated grant" do
-      donor = create(:organization, name: "Acme Foundation")
-      grant = create(:grant, donor: donor)
+    it "filters by funder name of an associated grant" do
+      funder = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, funder: funder)
       reg = registration
       award_scholarship(reg, grant: grant)
       ungranted = registration(first_name: "Sam")
       award_scholarship(ungranted) # scholarship with no grant
-      expect(matched({ grantor: "acme" }, [ reg, ungranted ])).to eq([ reg.id ].to_set)
+      expect(matched({ funder: "acme" }, [ reg, ungranted ])).to eq([ reg.id ].to_set)
     end
 
     it "filters by email address" do
@@ -222,12 +222,12 @@ RSpec.describe ReminderRecipientFilter do
     end
 
     it "combines filters with AND" do
-      donor = create(:organization, name: "Acme Foundation")
-      grant = create(:grant, donor: donor)
+      funder = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, funder: funder)
       match = registration(first_name: "Jane", last_name: "Adams").tap { |r| award_scholarship(r, grant: grant) }
       name_only = registration(first_name: "Jane", last_name: "Brooks")
-      grantor_only = registration(first_name: "Sam", last_name: "Cole").tap { |r| award_scholarship(r, grant: grant) }
-      expect(matched({ name: "jane", grantor: "acme" }, [ match, name_only, grantor_only ]))
+      funder_only = registration(first_name: "Sam", last_name: "Cole").tap { |r| award_scholarship(r, grant: grant) }
+      expect(matched({ name: "jane", funder: "acme" }, [ match, name_only, funder_only ]))
         .to eq([ match.id ].to_set)
     end
   end

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Event registration edit page", type: :system do
 
     it "links the grant's organization funder to its profile" do
       organization = create(:organization, name: "Acme Foundation")
-      grant = create(:grant, donor: organization)
+      grant = create(:grant, funder: organization)
       scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, grant: grant)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
 
@@ -136,14 +136,14 @@ RSpec.describe "Event registration edit page", type: :system do
       visit edit_event_registration_path(registration)
 
       within("section", text: "Scholarship") do
-        expect(page).to have_text("Grantor:")
+        expect(page).to have_text("Funder:")
         expect(page).to have_link("Acme Foundation", href: organization_path(organization))
       end
     end
 
     it "links the grant's person funder to its profile" do
-      funder = create(:person, first_name: "Dana", last_name: "Donor")
-      grant = create(:grant, :donated_by_person, donor: funder)
+      funder = create(:person, first_name: "Dana", last_name: "Funder")
+      grant = create(:grant, :donated_by_person, funder: funder)
       scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000, grant: grant)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
 
@@ -155,7 +155,7 @@ RSpec.describe "Event registration edit page", type: :system do
       end
     end
 
-    it "shows no grantor text (just a spacer) when the scholarship has no grant" do
+    it "shows no funder text (just a spacer) when the scholarship has no grant" do
       scholarship = create(:scholarship, recipient: registration.registrant, amount_cents: 1_000)
       create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)
 
@@ -163,7 +163,7 @@ RSpec.describe "Event registration edit page", type: :system do
       visit edit_event_registration_path(registration)
 
       within("section", text: "Scholarship") do
-        expect(page).to have_no_text("Grantor:")
+        expect(page).to have_no_text("Funder:")
       end
     end
   end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 schema rename (donor→funder columns) plus a wide identifier/label sweep across models, views, services, and specs

The grant-funding entity was named three ways: `donor` (DB + models), "Funder" (most UI), and "Grantor" (two spots). This unifies everything on **Funder**.

## What changed
- **DB**: `grants.donor_id/donor_type` → `funder_id/funder_type` (+ index), via a reversible rename migration. The historical create migration is left intact.
- **Code**: polymorphic `belongs_to :funder`, `FUNDER_TYPES`, `funder_sgid`, `grant_funder_badge`, `FunderGroup#funder`, all `params`, factories, seeds, and specs.
- **UI labels**: the remaining "Donor" labels (grants form/filters/results) and both "Grantor" labels (reminder-recipient filter, event-registration scholarship card) now read "Funder".
- **Revenue category value**: the event-revenue drill-down value `funder: "donor"` → `funder: "external"` so no stray "donor" remains in the funding domain (scope stays `funder`: `"awbw"` = org subsidy, `"external"` = outside funder).

## Left intentionally unchanged (different meanings)
- `"Fundraising/Donor Engagement"` sector — a nonprofit job function, not a grant's funder.
- `"Foundation/Funder"` referral-source option — how someone heard about AWBW.

## Tests
Affected model/service/presenter/request/system specs pass; migration verified reversible & idempotent.