### PR TITLE
Bump json to 2.21.2 (CVE-2026-71847)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -939,7 +939,7 @@ CHECKSUMS
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jquery-rails (4.6.1) sha256=619f3496cdcdeaae1fd6dafa52dbac3fc45b745d4e09712da4184a16b3a8d9c0
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 lockfile-only dependency bump, no app code touched

## Why
- `scan_ruby` (bundler-audit) fails on `json 2.21.1` — CVE-2026-71847 / GHSA-9hj4-r449-hfvc, a use-after-free in `JSON::ResumableParser#partial_value` on truncated duplicate-key streams. Solution is `>= 2.21.2`.
- Unrelated to any feature branch, so isolated into its own PR.

## What
- `bundle update json --conservative` → `2.21.2`. Lockfile-only; the existing `Gemfile` constraint (`>= 2.6, < 3`) already allowed it.

## Verification
- `bin/bundler-audit` → **No vulnerabilities found**
- `bin/brakeman --no-pager` → exits 0, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)