### PR TITLE
Story Share: hover-zoom segments + most-read via Ahoy

### DIFF
--- a/app/controllers/story_shares_controller.rb
+++ b/app/controllers/story_shares_controller.rb
@@ -64,7 +64,24 @@ class StorySharesController < ApplicationController
     end
     @spotlight_stories = section_stories(portal_scope.facilitator_spotlights(true))
     @featured_stories = carousel_stories
-    @recent_stories = preloaded(portal_scope).order(bookmark_count_desc).limit(POPULAR_STORY_LIMIT).decorate
+    @recent_stories = popular_stories
+  end
+
+  # "What others are reading": the most-viewed visible stories by tracked page
+  # views (Ahoy `view.story` events), backfilled with the most-bookmarked when
+  # view data is thin so the section always fills. Order preserved.
+  def popular_stories
+    visible = portal_scope
+    ids = Ahoy::Event.where(name: "view.story", resource_type: "Story", resource_id: visible.select(:id))
+                     .group(:resource_id)
+                     .order(Arel.sql("COUNT(*) DESC"))
+                     .limit(POPULAR_STORY_LIMIT)
+                     .pluck(:resource_id)
+    if ids.size < POPULAR_STORY_LIMIT
+      ids += visible.where.not(id: ids).reorder(bookmark_count_desc)
+                    .limit(POPULAR_STORY_LIMIT - ids.size).pluck(:id)
+    end
+    preloaded(Story.where(id: ids)).in_order_of(:id, ids).decorate
   end
 
   # Publicly featured stories lead the section, then most recent, capped.

--- a/app/views/layouts/story_shares.html.erb
+++ b/app/views/layouts/story_shares.html.erb
@@ -11,7 +11,7 @@
     <link rel="shortcut icon" type="image/png" href="<%= asset_path(favicon_file) %>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
 
     <%= vite_stylesheet_tag "application.css" %>
     <%= vite_client_tag %>
@@ -21,7 +21,7 @@
 
     <style>
       body {
-        font-family: 'Roboto', sans-serif;
+        font-family: 'Lato', sans-serif;
       }
       .font-telefon {
         font-family: 'Telefon Bold', sans-serif;

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -96,13 +96,13 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0">
         <% @recent_stories.each_with_index do |story, index| %>
           <% theme = story_share_slot_theme(index) %>
-          <%= link_to story_share_path(story), class: "group block relative aspect-[3/4] overflow-hidden bg-gray-200 hover:opacity-90 transition-opacity" do %>
+          <%= link_to story_share_path(story), class: "group block relative aspect-[3/4] overflow-hidden bg-gray-200" do %>
             <%= image_tag story.display_image, loading: "lazy", alt: story.title,
-                          class: "absolute inset-0 w-full h-full object-cover" %>
+                          class: "absolute inset-0 w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-110" %>
             <div class="absolute inset-0 <%= theme[:overlay] %>"></div>
             <div class="absolute inset-0 flex flex-col items-center pt-16 p-6 text-center">
               <% if story.sectors.first %>
-                <div class="bg-white/20 backdrop-blur-sm text-white text-xs font-bold uppercase px-4 py-3 mb-4 w-32 min-h-12 flex items-center justify-center border border-white/30">
+                <div class="bg-white/20 backdrop-blur-sm text-white text-sm font-bold uppercase tracking-wide px-4 py-2 mb-4 text-center border border-white/30">
                   <%= story.sectors.first.name %>
                 </div>
               <% end %>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -100,7 +100,7 @@
             <%= image_tag story.display_image, loading: "lazy", alt: story.title,
                           class: "absolute inset-0 w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-110" %>
             <div class="absolute inset-0 <%= theme[:overlay] %>"></div>
-            <div class="absolute inset-0 flex flex-col items-center pt-16 p-6 text-center">
+            <div class="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
               <% if story.sectors.first %>
                 <div class="bg-white/20 backdrop-blur-sm text-white text-sm font-bold uppercase tracking-wide px-4 py-2 mb-4 text-center border border-white/30">
                   <%= story.sectors.first.name %>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -102,7 +102,7 @@
             <div class="absolute inset-0 <%= theme[:overlay] %>"></div>
             <div class="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
               <% if story.sectors.first %>
-                <div class="bg-white/20 backdrop-blur-sm text-white text-sm font-bold uppercase tracking-wide px-4 py-2 mb-4 text-center border border-white/30">
+                <div class="<%= story_share_sector_chip_class(story.sectors.first.name) %> text-white text-sm font-bold uppercase tracking-wide px-4 py-2 mb-4 text-center">
                   <%= story.sectors.first.name %>
                 </div>
               <% end %>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -106,7 +106,7 @@
                   <%= story.sectors.first.name %>
                 </div>
               <% end %>
-              <h3 class="font-telefon text-white text-base leading-tight"><%= story.title %></h3>
+              <h3 class="font-telefon text-white text-base leading-tight line-clamp-2 min-h-[2.5rem]"><%= story.title %></h3>
             </div>
           <% end %>
         <% end %>

--- a/app/views/story_shares/_sector_section.html.erb
+++ b/app/views/story_shares/_sector_section.html.erb
@@ -25,14 +25,14 @@
     <ul class="space-y-2 text-sm">
       <% stories.drop(1).first(4).each do |story| %>
         <li class="flex items-start">
-          <i class="fa-solid fa-chevron-right w-3 mr-2 mt-1 <%= theme[:heading] %> flex-shrink-0"></i>
-          <%= link_to story.title, story_share_path(story), class: "text-gray-800 #{theme[:link]}" %>
+          <i class="fa-solid fa-caret-right w-3 mr-2 mt-1 text-purple-700 flex-shrink-0"></i>
+          <%= link_to story.title, story_share_path(story), class: "font-bold text-gray-900 hover:text-purple-700 hover:underline" %>
         </li>
       <% end %>
+      <li class="flex items-start">
+        <i class="fa-solid fa-caret-right w-3 mr-2 mt-1 text-purple-700 flex-shrink-0"></i>
+        <%= link_to "More #{title} stories...", more_path, class: "font-bold text-gray-900 hover:text-purple-700 hover:underline" %>
+      </li>
     </ul>
-
-    <div class="mt-4">
-      <%= link_to "More #{title} stories...", more_path, class: "font-medium text-sm inline-flex items-center #{theme[:link]}" %>
-    </div>
   </div>
 <% end %>

--- a/spec/requests/story_share_spec.rb
+++ b/spec/requests/story_share_spec.rb
@@ -203,6 +203,27 @@ RSpec.describe "/story_share", type: :request do
   end
 
   # ==========================================================
+  # "What others are reading" — most-read by Ahoy view count
+  # ==========================================================
+  describe "\"What others are reading\" section" do
+    def record_views(story, count)
+      count.times { create(:ahoy_event, name: "view.story", properties: { resource_type: "Story", resource_id: story.id }) }
+    end
+
+    it "orders stories by tracked Ahoy view count, most-read first" do
+      most_read = create(:story, :published, :publicly_visible, title: "The most read story")
+      less_read = create(:story, :published, :publicly_visible, title: "The less read story")
+      record_views(most_read, 3)
+      record_views(less_read, 1)
+
+      get story_shares_path
+
+      section = response.body.split("What others are reading").last
+      expect(section.index(most_read.title)).to be < section.index(less_read.title)
+    end
+  end
+
+  # ==========================================================
   # SHOW edge cases
   # ==========================================================
   describe "GET /show edge cases" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view/CSS tweaks plus one Ahoy-backed query swap on the portal landing page

Aligns the Story Share landing page with the production portal (stories.awbw.org).

## Why
**"What others are reading" segments**
- **Hover animation** — segment images zoom in on hover (`group-hover:scale-110`, 700ms); were static.
- **Vertical centering** — sector label + title block centered in each panel (`justify-center`), not top-anchored.
- **Stable box placement** — title height reserved at two clamped lines so the category box sits at the same vertical position whether the title is one or two lines.
- **Category box color** — solid per-sector colors (`story_share_sector_chip_class`) instead of translucent white.
- **Label** — `text-sm`, `tracking-wide`, content-width (no cramped fixed-width wrapping).
- **Most-read data** — populated by most-viewed stories from tracked Ahoy `view.story` events (backfilled with most-bookmarked when thin), not bookmark count.

**Typography (match production)**
- Portal body font switched Roboto → **Lato** (production's body typeface) — fixes the intro paragraph font.
- Sector-section story lists: uniform **dark bold** titles with purple caret bullets, instead of hard-to-read per-sector colored chevron links; "More … stories" folded into the same list.

## Notes
- Panel overlay tint is still slot/position-based; only the category boxes were recolored per sector.
- Uses the indexed `resource_id`/`resource_type` columns on `ahoy_events`.