### PR TITLE
Unify story sharing footer via shared organization_footer partial

### DIFF
--- a/app/views/story_shares/show.html.erb
+++ b/app/views/story_shares/show.html.erb
@@ -78,10 +78,7 @@
 
       <!-- Boilerplate footer -->
       <p class="text-xs text-gray-400 leading-relaxed border-t border-gray-200 pt-6">
-        A Window Between Worlds (AWBW) supports hundreds of art workshop facilitators across the
-        country to incorporate creative expression into their work with trauma survivors. These
-        Windows Facilitators serve over 140,000 adults, teens, and children each year. Through
-        these stories, we invite you to explore and share their journeys toward transformation and healing.
+        <%= render "shared/organization_footer" %>
       </p>
     </div>
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 copy/markup only — swaps inline text for an existing shared partial

Closes #2152

## Why
The public Story Share portal (`story_shares/show`) rendered its own hardcoded "140,000 facilitators" footer, while the internal story page (`stories/show`) already rendered `shared/_organization_footer`. Two copies drift.

## What
- Point the portal footer at `shared/_organization_footer` ("leader in creativity..." text), so both story pages use one shared partial and future edits update both.
- Per @maebeale, going with the "leader in creativity" wording for both.