### PR TITLE
Match Get involved footer buttons to website styling

### DIFF
--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -8,7 +8,7 @@
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
                          html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-gray-100 hover:text-gray-900 transition-colors" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-50 transition-colors" %>
+                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 transition-colors" %>
     </div>
   </div>
 </section>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -4,9 +4,9 @@
 
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <%= awbw_menu_link "Attend our training", "/programs/facilitator-trainings/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-gray-100 hover:text-gray-900 transition-colors" %>
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-gray-100 hover:text-gray-900 transition-colors" %>
       <%= link_to "Share your story", new_story_share_path,
                   class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-50 transition-colors" %>
     </div>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -4,11 +4,11 @@
 
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <%= awbw_menu_link "Attend our training", "/programs/facilitator-trainings/",
-                         html_class: "inline-flex items-center justify-center px-8 py-3 text-base font-medium text-white bg-purple-700 hover:bg-purple-800 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
-                         html_class: "inline-flex items-center justify-center px-8 py-3 text-base font-medium text-white bg-purple-700 hover:bg-purple-800 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-3 text-base font-medium text-purple-700 border border-purple-700 hover:bg-purple-50 transition-colors" %>
+                  class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-50 transition-colors" %>
     </div>
   </div>
 </section>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -4,11 +4,11 @@
 
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <%= awbw_menu_link "Attend our training", "/programs/facilitator-trainings/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-gray-100 hover:text-gray-900 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-100 hover:text-purple-900 transition-colors duration-500" %>
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-gray-100 hover:text-gray-900 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-100 hover:text-purple-900 transition-colors duration-500" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 transition-colors" %>
+                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 transition-colors duration-500" %>
     </div>
   </div>
 </section>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -8,7 +8,7 @@
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
                          html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-100 hover:text-purple-900 transition-colors duration-500" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 transition-colors duration-500" %>
+                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 hover:border-purple-100 transition-colors duration-500" %>
     </div>
   </div>
 </section>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -4,11 +4,11 @@
 
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
       <%= awbw_menu_link "Attend our training", "/programs/facilitator-trainings/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
+                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-950 transition-colors" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-4 rounded-xl font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-50 transition-colors" %>
+                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-50 transition-colors" %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only styling change to three footer buttons

### What is the goal of this PR and why is this important?
- Make the Story Share "Get involved!" footer CTAs match awbw.org so the portal feels on-brand.

### How did you approach the change?
- Applied the Telefon Bold brand font, larger `text-xl`, `rounded-xl` corners, and the site's deeper `purple-900` to the two filled buttons.
- Kept "Share your story" inverse (outlined), now sharing the same font, size, rounding, and purple.