### PR TITLE
Story Share footer: match awbw.org styling (Contact button + Candid seal)

### DIFF
--- a/app/views/story_shares/_portal_footer.html.erb
+++ b/app/views/story_shares/_portal_footer.html.erb
@@ -2,20 +2,26 @@
   <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 md:grid-cols-3 gap-8 items-center">
     <div class="flex justify-center md:justify-start">
       <%= awbw_menu_link "Contact us", "/about-us/contact-us/",
-                         html_class: "inline-block border border-white/70 px-6 py-2 text-sm font-medium tracking-wide hover:bg-white hover:text-black transition-colors" %>
+                         html_class: "inline-block rounded border border-white px-6 py-2 text-sm font-bold uppercase tracking-wide hover:bg-white hover:text-black transition-colors" %>
     </div>
 
-    <div class="text-center text-sm space-y-1">
+    <div class="text-center text-sm space-y-3">
       <p>Registered 501(c)(3). EIN: 95-448606</p>
       <p>© 2021–<%= Date.current.year %> A Window Between Worlds</p>
     </div>
 
     <div class="flex justify-center md:justify-end">
-      <div class="bg-white text-black text-center text-xs px-5 py-3 rounded">
-        <p class="tracking-wide">Platinum Transparency</p>
-        <p class="font-semibold"><%= Date.current.year %></p>
-        <p class="font-bold mt-1">Candid.</p>
-      </div>
+      <a href="https://www.guidestar.org/profile/95-4448606"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="bg-white p-1 rounded-sm border border-[#a9c5dd]">
+        <span class="block border-2 border-[#a9c5dd] px-5 py-4 text-black text-sm leading-tight">
+          <span class="block">Platinum</span>
+          <span class="block">Transparency</span>
+          <span class="block"><%= Date.current.year %></span>
+          <span class="block font-bold mt-3">Candid.</span>
+        </span>
+      </a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only footer markup/styling changes, no logic

Restyle the Story Share portal footer to match awbw.org:

- **Contact us** button → rounded, bold, uppercase to match the site
- Wider spacing between the two copyright lines
- **Candid** badge → official-style double-framed Platinum Transparency seal, now linking to the org's [GuideStar profile](https://www.guidestar.org/profile/95-4448606)

⚠️ The displayed EIN (`95-448606`, 8 digits) looks like it's missing a digit — GuideStar lists `95-4448606`. Left as-is to match the current site; flagging for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)