### PR TITLE
Move story share admin URLs under /story_share/admin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,11 +278,11 @@ Rails.application.routes.draw do
   get "search/:model", to: "search#index"
   resources :story_ideas
   resources :stories
+  get "story_share/admin", to: "story_share_admin#show", as: :story_share_admin
+  match "story_share/admin/reorder", to: "story_share_admin#reorder", via: [ :put, :patch ], as: :story_share_admin_reorder
+  post "story_share/admin/add", to: "story_share_admin#add", as: :story_share_admin_add
+  delete "story_share/admin/remove", to: "story_share_admin#remove", as: :story_share_admin_remove
   resources :story_shares, path: "story_share", only: [ :index, :show, :new ]
-  get "story_share_admin", to: "story_share_admin#show"
-  match "story_share_admin/reorder", to: "story_share_admin#reorder", via: [ :put, :patch ], as: :story_share_admin_reorder
-  post "story_share_admin/add", to: "story_share_admin#add", as: :story_share_admin_add
-  delete "story_share_admin/remove", to: "story_share_admin#remove", as: :story_share_admin_remove
   resources :video_recordings
   resources :user_forms
   resources :windows_types

--- a/spec/requests/story_share_admin_spec.rb
+++ b/spec/requests/story_share_admin_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "StoryShareAdmin", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:regular_user) { create(:user) }
 
-  describe "GET /story_share_admin" do
+  describe "GET /story_share/admin" do
     it "renders for admins" do
       sign_in admin
       get story_share_admin_path
@@ -23,7 +23,7 @@ RSpec.describe "StoryShareAdmin", type: :request do
     end
   end
 
-  describe "POST /story_share_admin/add" do
+  describe "POST /story_share/admin/add" do
     before { sign_in admin }
 
     it "sets story_share_position on a sector and redirects" do
@@ -47,7 +47,7 @@ RSpec.describe "StoryShareAdmin", type: :request do
     end
   end
 
-  describe "PUT /story_share_admin/reorder" do
+  describe "PUT /story_share/admin/reorder" do
     before { sign_in admin }
 
     it "renumbers story_share_position to place the moved item at the new position" do
@@ -63,7 +63,7 @@ RSpec.describe "StoryShareAdmin", type: :request do
     end
   end
 
-  describe "DELETE /story_share_admin/remove" do
+  describe "DELETE /story_share/admin/remove" do
     before { sign_in admin }
 
     it "clears story_share_position and renumbers the rest" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 route-only change; ordering matters so /story_share/admin isn't caught by the show matcher

### What is the goal of this PR and why is this important?
- Rename the admin portal URLs from `/story_share_admin…` to `/story_share/admin…`, nesting admin under the public portal path.

### How did you approach the change?
- Rewrote the four `story_share_admin` routes to the new paths and moved them **above** `resources :story_shares` so `/story_share/admin` isn't swallowed by the resource's `show` (`/story_share/:id`) route.
- Route helper names are unchanged, so no view/controller call sites needed edits.
- Updated the request spec's `describe` URL strings for accuracy.

### Anything else to add?
- Verified via the admin, portal, and routing specs (36 examples) that `/story_share/admin` and `/story_share/:id` both resolve correctly with no id collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)