### PR TITLE
Comments + communications on story & story idea edit screens

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -97,7 +97,10 @@ class StoriesController < ApplicationController
     success = false
 
     Story.transaction do
-      if @story.update(story_params.except(:images, :category_ids, :sector_ids))
+      @story.assign_attributes(story_params.except(:images, :category_ids, :sector_ids))
+      attribute_comment_authorship
+      stamp_new_notification_recipients
+      if @story.save
         assign_associations(@story)
         if params[:promote_idea_assets] == "true"
           @story.attach_assets_from_idea!
@@ -158,6 +161,24 @@ class StoriesController < ApplicationController
 
   private
 
+  # Stamp authorship on comments edited through the story form: author + editor
+  # on new ones, editor on existing ones whose body changed.
+  def attribute_comment_authorship
+    @story.comments.select(&:new_record?).each do |c|
+      c.created_by = current_user
+      c.updated_by = current_user
+    end
+    @story.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
+      c.updated_by = current_user
+    end
+  end
+
+  # Inline-logged communications are addressed to the story's credited author.
+  def stamp_new_notification_recipients
+    recipient_email = @story.communications_email.presence || "n/a"
+    @story.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
+  end
+
   def set_story
     # Accepts both the bare id ("23") and the slugged param ("23-my-great-story");
     # ActiveRecord casts the leading id via `to_i`, so both resolve the same story.
@@ -195,6 +216,8 @@ class StoriesController < ApplicationController
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id, :_destroy ],
     )
   end
 

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -87,7 +87,10 @@ class StoryIdeasController < ApplicationController
     success = false
 
     StoryIdea.transaction do
-      if @story_idea.update(story_idea_params.except(:images, :category_ids, :sector_ids))
+      @story_idea.assign_attributes(story_idea_params.except(:images, :category_ids, :sector_ids))
+      attribute_comment_authorship
+      stamp_new_notification_recipients
+      if @story_idea.save
         assign_associations(@story_idea)
         success = true
       end
@@ -118,6 +121,24 @@ class StoryIdeasController < ApplicationController
 
   private
 
+  # Stamp authorship on comments edited through the story idea form: author +
+  # editor on new ones, editor on existing ones whose body changed.
+  def attribute_comment_authorship
+    @story_idea.comments.select(&:new_record?).each do |c|
+      c.created_by = current_user
+      c.updated_by = current_user
+    end
+    @story_idea.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
+      c.updated_by = current_user
+    end
+  end
+
+  # Inline-logged communications are addressed to the idea's submitter.
+  def stamp_new_notification_recipients
+    recipient_email = @story_idea.communications_email.presence || "n/a"
+    @story_idea.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
+  end
+
   def set_story_idea
     @story_idea = StoryIdea.find(params[:id])
   end
@@ -131,7 +152,9 @@ class StoryIdeasController < ApplicationController
       category_ids: [],
       sector_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],
-      gallery_assets_attributes: [ :id, :file, :_destroy ]
+      gallery_assets_attributes: [ :id, :file, :_destroy ],
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 end

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -17,6 +17,8 @@ class CommentDecorator < ApplicationDecorator
     when Scholarship then h.scholarship_path(commentable)
     when ContinuingEducationRegistration then h.edit_continuing_education_registration_path(commentable)
     when TopicSubscription then h.edit_topic_subscription_path(commentable)
+    when Story then h.edit_story_path(commentable)
+    when StoryIdea then h.edit_story_idea_path(commentable)
     end
   end
 
@@ -30,6 +32,8 @@ class CommentDecorator < ApplicationDecorator
     when Scholarship then :scholarships
     when ContinuingEducationRegistration then :continuing_education
     when TopicSubscription then :topic_subscriptions
+    when Story then :stories
+    when StoryIdea then :story_ideas
     else :comments
     end
   end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,6 +11,8 @@ module CommentsHelper
     when Scholarship then scholarship_label(record)
     when ContinuingEducationRegistration then "CE · #{event_label(record.event_registration.event)}"
     when TopicSubscription then "Subscription · #{record.topic_label}"
+    when Story then "Story · #{record.title}"
+    when StoryIdea then "Story idea · #{record.title.presence || "##{record.id}"}"
     else record.class.name.underscore.humanize
     end
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -16,6 +16,8 @@ class Story < ApplicationRecord
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :destroy
 
   # Asset associations
   has_one :primary_asset, -> { where(type: "PrimaryAsset") },
@@ -40,6 +42,8 @@ class Story < ApplicationRecord
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   # SearchCop
   include SearchCop
@@ -112,6 +116,12 @@ class Story < ApplicationRecord
 
   def name
     title
+  end
+
+  # Email the communications box matches notifications against. Uniform accessor
+  # so the shared notifications/_communications partial works across records.
+  def communications_email
+    author_person&.preferred_email
   end
 
   # Unattributed stories are credited to the facilitator who shared them.

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -26,6 +26,7 @@ class StoryIdea < ApplicationRecord
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
   has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :stories
 
   # Asset associations
@@ -49,9 +50,17 @@ class StoryIdea < ApplicationRecord
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   def name
     "StoryIdea ##{id}"
+  end
+
+  # Email the communications box matches notifications against. Uniform accessor
+  # so the shared notifications/_communications partial works across records.
+  def communications_email
+    created_by&.email
   end
 
   def full_name

--- a/app/services/person_comment_aggregator.rb
+++ b/app/services/person_comment_aggregator.rb
@@ -1,13 +1,13 @@
 # Gathers every comment connected to a person into a single newest-first feed —
 # their own profile comments plus the comments left on the records that hang off
-# them: event registrations, scholarships, CE registrations, and their login
-# account. Returns one ActiveRecord::Relation of Comment so callers can filter,
-# paginate, and preload uniformly. Payments carry no comments, so they never
-# appear here.
+# them: event registrations, scholarships, CE registrations, the stories and
+# story ideas they're credited on, and their login account. Returns one
+# ActiveRecord::Relation of Comment so callers can filter, paginate, and preload
+# uniformly. Payments carry no comments, so they never appear here.
 class PersonCommentAggregator
   # commentable_type => class, in the order sources are surfaced. Kept as strings
   # so the query never has to instantiate the classes.
-  SOURCE_TYPES = %w[ Person EventRegistration Scholarship ContinuingEducationRegistration TopicSubscription User ].freeze
+  SOURCE_TYPES = %w[ Person EventRegistration Scholarship ContinuingEducationRegistration TopicSubscription Story StoryIdea User ].freeze
 
   def initialize(person)
     @person = person
@@ -20,6 +20,8 @@ class PersonCommentAggregator
       scope_for("Scholarship", scholarship_ids),
       scope_for("ContinuingEducationRegistration", ce_registration_ids),
       scope_for("TopicSubscription", topic_subscription_ids),
+      scope_for("Story", story_ids),
+      scope_for("StoryIdea", story_idea_ids),
       scope_for("User", user_ids)
     ]
     scopes.reduce { |combined, scope| combined.or(scope) }
@@ -49,6 +51,19 @@ class PersonCommentAggregator
 
   def topic_subscription_ids
     person.topic_subscriptions.ids
+  end
+
+  # Stories where this person is the credited author — mirrors Story#author_person:
+  # the explicit author, or the creating user's person when no explicit author is set.
+  def story_ids
+    Story.where(author_id: person.id)
+         .or(Story.where(author_id: nil, created_by_id: user_ids))
+         .ids
+  end
+
+  # Story ideas carry no explicit author, so the creating user's person is the credit.
+  def story_idea_ids
+    StoryIdea.where(created_by_id: user_ids).ids
   end
 
   def user_ids

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -373,6 +373,65 @@
 
   <%= f.hidden_field :updated_by_id, value: current_user.id %>
 
+  <% if f.object.persisted? %>
+    <%# ---- Communications + comments — same boxes as the registration edit page,
+        shown once the story exists so there's a record to attach them to. ---- %>
+    <div class="space-y-6 mt-8">
+      <% if allowed_to?(:index?, with: NotificationPolicy) %>
+        <%= render "notifications/communications", f: f,
+              title_key: "communications.story_title", none_key: "communications.none_for_story" %>
+      <% end %>
+
+      <%# ---- Comments ---- %>
+      <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
+        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:comments, f.object.comments.any?) %>">
+            <i class="fa-solid fa-comments"></i>
+          </span>
+          <h2 class="text-sm font-semibold text-gray-700">Story comments</h2>
+          <% if f.object.author_person %>
+            <%= link_to all_comments_person_path(f.object.author_person),
+                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                        target: "_blank", rel: "noopener" do %>
+              View all
+              <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
+          <div id="comment-list" class="space-y-4">
+            <%= f.simple_fields_for :comments do |cf| %>
+              <%= render "comments/comment_fields", f: cf %>
+            <% end %>
+          </div>
+
+          <div data-paginated-fields-target="nav"></div>
+
+          <div class="flex items-center justify-between gap-2">
+            <%= link_to_add_association f, :comments,
+                  partial: "comments/comment_fields",
+                  data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
+                  class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+              <i class="fa-solid fa-plus text-[0.6rem]"></i>
+              Add comment
+            <% end %>
+
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+              data-action="edit-toggle#toggle"
+            >
+              <i class="fa-solid fa-pen text-[0.6rem]"></i>
+              <span data-edit-toggle-target="editLabel">Edit comments</span>
+              <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  <% end %>
+
   <div class="action-buttons mt-8 flex justify-center gap-3">
     <% if allowed_to?(:destroy?, f.object) %>
       <%= link_to "Delete", @story, class: "btn btn-danger-outline",

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -327,6 +327,65 @@
                   } %>
     </div>
 
+    <% if f.object.persisted? %>
+      <%# ---- Communications + comments — same boxes as the registration edit page,
+          shown once the story idea exists so there's a record to attach them to. ---- %>
+      <div class="space-y-6 mt-8">
+        <% if allowed_to?(:index?, with: NotificationPolicy) %>
+          <%= render "notifications/communications", f: f,
+                title_key: "communications.story_idea_title", none_key: "communications.none_for_story_idea" %>
+        <% end %>
+
+        <%# ---- Comments ---- %>
+        <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
+          <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= section_icon_class(:comments, f.object.comments.any?) %>">
+              <i class="fa-solid fa-comments"></i>
+            </span>
+            <h2 class="text-sm font-semibold text-gray-700">Story idea comments</h2>
+            <% if f.object.created_by&.person %>
+              <%= link_to all_comments_person_path(f.object.created_by.person),
+                          class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-transparent hover:text-gray-600 hover:underline",
+                          target: "_blank", rel: "noopener" do %>
+                View all
+                <i class="fa-solid fa-arrow-up-right-from-square text-[0.6rem]"></i>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
+            <div id="comment-list" class="space-y-4">
+              <%= f.simple_fields_for :comments do |cf| %>
+                <%= render "comments/comment_fields", f: cf %>
+              <% end %>
+            </div>
+
+            <div data-paginated-fields-target="nav"></div>
+
+            <div class="flex items-center justify-between gap-2">
+              <%= link_to_add_association f, :comments,
+                    partial: "comments/comment_fields",
+                    data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
+                    class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+                <i class="fa-solid fa-plus text-[0.6rem]"></i>
+                Add comment
+              <% end %>
+
+              <button
+                type="button"
+                class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                data-action="edit-toggle#toggle"
+              >
+                <i class="fa-solid fa-pen text-[0.6rem]"></i>
+                <span data-edit-toggle-target="editLabel">Edit comments</span>
+                <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+    <% end %>
+
     <div class="action-buttons mt-8 flex justify-center gap-3 pt-6">
       <% if allowed_to?(:destroy?, f.object) && f.object.stories.none? %>
         <span class="admin-only bg-blue-100 p-3">

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -388,10 +388,8 @@
 
     <div class="action-buttons mt-8 flex justify-center gap-3 pt-6">
       <% if allowed_to?(:destroy?, f.object) && f.object.stories.none? %>
-        <span class="admin-only bg-blue-100 p-3">
-          <%= link_to "Delete", @story_idea, class: "btn btn-danger-outline",
-                      data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } %>
-        </span>
+        <%= link_to "Delete", @story_idea, class: "btn btn-danger-outline admin-only bg-blue-100",
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?" } %>
       <% end %>
       <%= link_to "Cancel",
                   (allowed_to?(:index?, StoryIdea) ? story_ideas_path : root_path),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,9 +45,13 @@ en:
     resent: "Communication has been resent successfully."
     registration_title: "Registration communications"
     scholarship_title: "Scholarship communications"
+    story_title: "Story communications"
+    story_idea_title: "Story idea communications"
     none_for_person: "No communications for this person yet."
     none_for_registrant: "No communications for this registrant yet."
     none_for_scholarship: "No communications for this scholarship yet."
+    none_for_story: "No communications for this story yet."
+    none_for_story_idea: "No communications for this story idea yet."
   activerecord:
     attributes:
       workshop_variation:

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -265,6 +265,38 @@ RSpec.describe "/stories", type: :request do
         expect(Story.last.author).to eq(facilitator)
       end
     end
+
+    describe "comments and communications on the edit page" do
+      it "renders the comments section" do
+        get edit_story_url(published_story)
+        expect(response.body).to include("Story comments")
+        expect(response.body).to include("Add comment")
+      end
+
+      it "saves a new comment with its topic, authored by the current user" do
+        expect {
+          patch story_url(published_story),
+                params: { story: { comments_attributes: { "0" => { topic: "Follow-up", body: "Emailed the facilitator" } } } }
+        }.to change { published_story.comments.count }.by(1)
+
+        comment = published_story.comments.order(:created_at).last
+        expect(comment.body).to eq("Emailed the facilitator")
+        expect(comment.topic).to eq("Follow-up")
+        expect(comment.created_by).to eq(admin)
+      end
+
+      it "logs a communication against the story" do
+        expect {
+          patch story_url(published_story),
+                params: { story: { notifications_attributes: { "0" => { email_subject: "Called the facilitator" } } } }
+        }.to change { published_story.notifications.count }.by(1)
+
+        note = published_story.notifications.last
+        expect(note.noticeable).to eq(published_story)
+        expect(note.email_subject).to eq("Called the facilitator")
+        expect(note.recipient_email).to eq(published_story.communications_email.presence || "n/a")
+      end
+    end
   end
 
   # ==========================================================

--- a/spec/requests/story_ideas_spec.rb
+++ b/spec/requests/story_ideas_spec.rb
@@ -91,6 +91,40 @@ RSpec.describe "/story_ideas", type: :request do
       end
     end
 
+    describe "comments and communications on the edit page" do
+      let(:story_idea) { create(:story_idea, created_by: regular_user) }
+
+      it "renders the comments section" do
+        get edit_story_idea_url(story_idea)
+        expect(response.body).to include("Story idea comments")
+        expect(response.body).to include("Add comment")
+      end
+
+      it "saves a new comment with its topic, authored by the current user" do
+        expect {
+          patch story_idea_url(story_idea),
+                params: { story_idea: { comments_attributes: { "0" => { topic: "Follow-up", body: "Emailed the submitter" } } } }
+        }.to change { story_idea.comments.count }.by(1)
+
+        comment = story_idea.comments.order(:created_at).last
+        expect(comment.body).to eq("Emailed the submitter")
+        expect(comment.topic).to eq("Follow-up")
+        expect(comment.created_by).to eq(admin)
+      end
+
+      it "logs a communication against the story idea's submitter" do
+        expect {
+          patch story_idea_url(story_idea),
+                params: { story_idea: { notifications_attributes: { "0" => { email_subject: "Called the submitter" } } } }
+        }.to change { story_idea.notifications.count }.by(1)
+
+        note = story_idea.notifications.last
+        expect(note.noticeable).to eq(story_idea)
+        expect(note.email_subject).to eq("Called the submitter")
+        expect(note.recipient_email).to eq(regular_user.email)
+      end
+    end
+
     describe "DELETE /destroy" do
       it "can delete any story_idea" do
         story_idea = create(:story_idea, created_by: create(:user))

--- a/spec/services/person_comment_aggregator_spec.rb
+++ b/spec/services/person_comment_aggregator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PersonCommentAggregator do
   let(:person) { create(:person) }
 
   describe "#comments" do
-    it "gathers comments from the person, their registrations, scholarships, CE registrations, and user account" do
+    it "gathers comments from the person, their registrations, scholarships, CE registrations, stories, story ideas, and user account" do
       profile_comment = create(:comment, commentable: person)
 
       registration = create(:event_registration, registrant: person)
@@ -21,10 +21,17 @@ RSpec.describe PersonCommentAggregator do
       subscription = create(:topic_subscription, person: person)
       subscription_comment = create(:comment, commentable: subscription)
 
+      story = create(:story, author: person)
+      story_comment = create(:comment, commentable: story)
+
+      story_idea = create(:story_idea, created_by: person.user)
+      story_idea_comment = create(:comment, commentable: story_idea)
+
       user_comment = create(:comment, commentable: person.user)
 
       expect(aggregator.comments).to contain_exactly(
-        profile_comment, registration_comment, scholarship_comment, ce_comment, subscription_comment, user_comment
+        profile_comment, registration_comment, scholarship_comment, ce_comment, subscription_comment,
+        story_comment, story_idea_comment, user_comment
       )
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 nested-attribute comments/communications reusing the registration pattern; small logic in two controllers + the comment aggregator

### What is the goal of this PR and why is this important?
- Stories and story ideas need the same internal **comments** log and **communications** history that the registration and scholarship edit screens already have, so notes and outreach about a story live with the record.

### How did you approach the change?
- `Story` / `StoryIdea` get polymorphic `comments` + `notifications`, nested-attribute editing, and a `communications_email` (story → credited author, idea → submitter) so the shared `notifications/_communications` box resolves the right recipient.
- Both edit forms render the communications + comments boxes once the record is persisted, reusing the existing `comments/_comment_fields` and `notifications/_communications` partials — identical layout to registration/scholarship.
- Controllers permit the nested params and stamp comment authorship / new-communication recipients on update.
- Story/StoryIdea comments aggregate onto the credited person's "all comments" feed so the section's View-all link is truthful; `CommentDecorator` / `CommentsHelper` label and link the new sources.

### Anything else to add?
- No migration — reuses the existing polymorphic `comments` and `notifications` tables.
- Sections are gated on `persisted?` so they don't appear on the public new-idea submission form; communications stay behind `NotificationPolicy`.