### PR TITLE
Register Conductor run script via .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,12 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "bin/conductor-setup"
+archive = "bin/conductor-archive"
+run_mode = "concurrent"
+
+[scripts.run.server]
+command = "bin/conductor-server"
+default = true
+available_in = [ "local" ]
+icon = "play"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-  "scripts": {
-    "setup": "bin/conductor-setup",
-    "server": "bin/conductor-server",
-    "archive": "bin/conductor-archive"
-  }
-}


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 config-only migration, no app code

### What is the goal of this PR and why is this important?
- The workspace run script never launched on workspace creation. The command lived under a legacy `server` key in `conductor.json`, which the legacy format doesn't recognize as a run script — so nothing was registered for `auto_run_after_setup` to start.

### How did you approach the change?
- Migrated to `.conductor/settings.toml`, declaring the run command as `[scripts.run.server]` with `default = true` (so it auto-runs), `available_in = ["local"]` (needs `CONDUCTOR_PORT`), and `run_mode = "concurrent"` (per-workspace ports).
- Removed the migrated `conductor.json`.

### Anything else to add?
- Takes effect once merged to `main`: the Mac app reads shared `.conductor/settings.toml` from the default branch.