### PR TITLE
Add bulk "Send login invites" mode to the reminders flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page
 - `BulkInviteService` — Bulk send welcome instructions and reset created_at for users
-- `PersonInviter` — Invites a single person to the portal: creates a user account if they have none, then sends the welcome/invite email attributed to the sender. Backs the bulk "Send portal invite (confirmation) emails" flow on the reminders page (`?mode=invite`)
+- `PersonInviter` — Invites a single person to the portal: creates a user account if they have none, then sends the welcome/invite email attributed to the sender. Backs the bulk "Send Portal invite emails" flow on the reminders page (`?mode=invite`)
 - `FormBuilderService` — Builds configurable forms from composable sections with per-field visibility
 - `ModelDeduper` — Deduplication logic
 - `RichTextMigrator` — Rich text migration utility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page
 - `BulkInviteService` — Bulk send welcome instructions and reset created_at for users
-- `PersonInviter` — Invites a single person to the portal: creates a user account if they have none, then sends the welcome/invite email attributed to the sender. Backs the bulk "Send login invites" flow on the reminders page (`?mode=invite`)
+- `PersonInviter` — Invites a single person to the portal: creates a user account if they have none, then sends the welcome/invite email attributed to the sender. Backs the bulk "Send portal invite (confirmation) emails" flow on the reminders page (`?mode=invite`)
 - `FormBuilderService` — Builds configurable forms from composable sections with per-field visibility
 - `ModelDeduper` — Deduplication logic
 - `RichTextMigrator` — Rich text migration utility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ This codebase (Rails 8.1)
 | Directory | Purpose | Count |
 |---|---|---|
 | `app/models/` | ActiveRecord models | ~80 files |
-| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display, `StoryImporter` for WordPress CSV import) | ~56 files |
+| `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display, `StoryImporter` for WordPress CSV import) | ~57 files |
 | `app/jobs/` | SolidQueue background jobs | 5 files |
 | `app/models/concerns/` | Shared model modules | 16 concerns |
 
@@ -212,6 +212,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `PersonFromUserService` — Create Person from User account
 - `PersonCommentAggregator` — Unifies every comment connected to a person (their profile, event registrations, scholarships, CE registrations, topic subscriptions, and user account) into one newest-first `Comment` relation for the aggregated `/people/:id/all_comments` page
 - `BulkInviteService` — Bulk send welcome instructions and reset created_at for users
+- `PersonInviter` — Invites a single person to the portal: creates a user account if they have none, then sends the welcome/invite email attributed to the sender. Backs the bulk "Send login invites" flow on the reminders page (`?mode=invite`)
 - `FormBuilderService` — Builds configurable forms from composable sections with per-field visibility
 - `ModelDeduper` — Deduplication logic
 - `RichTextMigrator` — Rich text migration utility

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1061,7 +1061,7 @@ class EventsController < ApplicationController
       row << (registration.checklist_step_completed?(step) ? "Yes" : "No")
     end
     account_status = registration.account_status
-    row << { "none" => "No account", "has_access" => "Has access", "invited" => "Already invited", "no_access" => "Not invited yet" }.fetch(account_status, account_status.to_s.humanize)
+    row << { "none" => "No account", "has_access" => "Has access", "invited" => "Invited", "no_access" => "No access" }.fetch(account_status, account_status.to_s.humanize)
     row << (account_status == "has_access" ? "Yes" : "No")
     (1..day_count).each do |day|
       row << (registration.public_send("completed_day_#{day}") ? "Yes" : "No")

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -347,6 +347,7 @@ class EventsController < ApplicationController
   def preview_reminder
     authorize! @event
     @event = @event.decorate
+    @invite_mode = invite_mode?
     @ce_eligible = @event.ce_eligible?
     @event_registrations = @event.event_registrations
       .includes(
@@ -356,6 +357,10 @@ class EventsController < ApplicationController
       )
       .joins(:registrant)
       .select { |r| r.registrant.preferred_email.present? }
+
+    # Invite mode targets only registrants with no portal account yet — those are
+    # the people a login invite is for.
+    @event_registrations = @event_registrations.select { |r| r.registrant.user.nil? } if @invite_mode
 
     # Filters keep every registrant in the list and only flag who still matches,
     # so the recipient checkboxes pre-check the matched set rather than removing
@@ -370,6 +375,11 @@ class EventsController < ApplicationController
     return render partial: "events/reminder_recipients" if turbo_frame_request?
 
     @sample_registration = @event_registrations.first
+
+    # Invite mode sends the fixed portal welcome email — no editable subject/message,
+    # just a read-only preview built from a sample recipient.
+    return build_invite_preview(@sample_registration) if @invite_mode
+
     days_until_event = @event.start_date.present? ? (@event.start_date.to_date - Date.current).to_i : nil
     # Pre-fill the editable message with the standard reminder sentence (days
     # resolved now). Absent param = first load → default; a present-but-blank
@@ -394,12 +404,19 @@ class EventsController < ApplicationController
   def confirm_reminder
     authorize! @event, to: :send_reminder?
     @event = @event.decorate
+    @invite_mode = invite_mode?
     @event_registrations = selected_reminder_registrations
     @custom_message = params[:custom_message].to_s
     @custom_subject = params[:custom_subject].to_s
 
     if @event_registrations.empty?
-      redirect_to preview_reminder_event_path(@event, custom_message: @custom_message, custom_subject: @custom_subject), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject), alert: "Please select at least one recipient."
+      return
+    end
+
+    if @invite_mode
+      build_invite_preview(@event_registrations.first)
+      @reminder_subject = @invite_subject
       return
     end
 
@@ -410,14 +427,17 @@ class EventsController < ApplicationController
 
   def send_reminder
     authorize! @event, to: :send_reminder?
-    custom_message = params[:custom_message].to_s
-    custom_subject = params[:custom_subject].to_s
     registrations = selected_reminder_registrations
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event, custom_message: custom_message, custom_subject: custom_subject), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s), alert: "Please select at least one recipient."
       return
     end
+
+    return send_bulk_invites(registrations) if invite_mode?
+
+    custom_message = params[:custom_message].to_s
+    custom_subject = params[:custom_subject].to_s
 
     # Record an individual notification per recipient (delivered + persisted via
     # NotificationMailerJob), so each reminder shows up in that person's
@@ -881,6 +901,35 @@ class EventsController < ApplicationController
     addresses = Address.active.where(addressable_type: "Person", addressable_id: person_ids)
     @attendee_states = addresses.where.not(state: [ nil, "" ]).distinct.pluck(:state).sort
     @attendee_counties = addresses.where.not(county: [ nil, "" ]).where.not(state: [ nil, "" ]).distinct.pluck(:state, :county).sort
+  end
+
+  def invite_mode?
+    params[:mode] == "invite"
+  end
+
+  # Sends the portal welcome/invite email to each selected registrant, creating a
+  # user account for anyone who doesn't have one yet (PersonInviter skips people
+  # who already have a confirmed account). Each invite is delivered async and logs
+  # its own communication record, so there's no separate per-recipient notification
+  # or admin FYI here.
+  def send_bulk_invites(registrations)
+    invited = registrations.count { |reg| PersonInviter.call(person: reg.registrant, sender: current_user).invited }
+
+    track_view("events.send_invites", { event_id: @event.id, recipient_count: invited })
+    redirect_to registrants_event_path(@event), notice: "Login invites are being sent to #{invited} #{'person'.pluralize(invited)}."
+  end
+
+  # Builds the read-only invite-email preview shown in invite mode. For a registrant
+  # with no account, a throwaway in-memory user carries the name into the template;
+  # the preview flag keeps rendering side-effect-free (no notification logged).
+  def build_invite_preview(sample_registration)
+    return unless sample_registration
+
+    person = sample_registration.registrant
+    sample_user = person.user || User.new(person: person, email: person.preferred_email)
+    mail = DeviseMailer.confirmation_instructions(sample_user, "preview-token", preview: true)
+    @invite_subject = mail.subject
+    @reminder_preview_html = mail.html_part&.body&.decoded
   end
 
   # The registrations the admin checked on the recipient picker, narrowed to those

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -916,7 +916,7 @@ class EventsController < ApplicationController
     invited = registrations.count { |reg| PersonInviter.call(person: reg.registrant, sender: current_user).invited }
 
     track_view("events.send_invites", { event_id: @event.id, recipient_count: invited })
-    redirect_to registrants_event_path(@event), notice: "Login invites are being sent to #{invited} #{'person'.pluralize(invited)}."
+    redirect_to registrants_event_path(@event), notice: "Portal invite (confirmation) emails are being sent to #{invited} #{'person'.pluralize(invited)}."
   end
 
   # Builds the read-only invite-email preview shown in invite mode. For a registrant

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1061,7 +1061,7 @@ class EventsController < ApplicationController
       row << (registration.checklist_step_completed?(step) ? "Yes" : "No")
     end
     account_status = registration.account_status
-    row << { "none" => "No account", "has_access" => "Has access", "invited" => "Invited", "no_access" => "No access" }.fetch(account_status, account_status.to_s.humanize)
+    row << { "none" => "Not invited yet", "has_access" => "Has access", "invited" => "Already invited", "no_access" => "No access" }.fetch(account_status, account_status.to_s.humanize)
     row << (account_status == "has_access" ? "Yes" : "No")
     (1..day_count).each do |day|
       row << (registration.public_send("completed_day_#{day}") ? "Yes" : "No")

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1061,7 +1061,7 @@ class EventsController < ApplicationController
       row << (registration.checklist_step_completed?(step) ? "Yes" : "No")
     end
     account_status = registration.account_status
-    row << { "none" => "Not invited yet", "has_access" => "Has access", "invited" => "Already invited", "no_access" => "No access" }.fetch(account_status, account_status.to_s.humanize)
+    row << { "none" => "No account", "has_access" => "Has access", "invited" => "Already invited", "no_access" => "Not invited yet" }.fetch(account_status, account_status.to_s.humanize)
     row << (account_status == "has_access" ? "Yes" : "No")
     (1..day_count).each do |day|
       row << (registration.public_send("completed_day_#{day}") ? "Yes" : "No")

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -5,8 +5,10 @@ class DeviseMailer < Devise::Mailer
   include Rails.application.routes.url_helpers
 
   before_action :set_branding
-  after_action :create_notification_record
-  after_action :track_devise_email_event
+  # Skipped when rendering an on-page preview (e.g. the bulk invite picker), so
+  # previewing the email doesn't log a notification or emit an auth event.
+  after_action :create_notification_record, unless: :preview?
+  after_action :track_devise_email_event, unless: :preview?
 
   default from: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
   default reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
@@ -19,6 +21,8 @@ class DeviseMailer < Devise::Mailer
   end
 
   def confirmation_instructions(record, token, opts = {})
+    # Preview requests render the body only; the after_actions above are skipped.
+    @preview = opts.delete(:preview) { false }
     # The invite sender arrives as a plain id in opts (GlobalID-safe for async
     # delivery); pull it out before super so Devise doesn't fold it into the headers.
     @confirmation_sender_id = opts.delete(:sender_id)
@@ -53,6 +57,10 @@ class DeviseMailer < Devise::Mailer
   end
 
   private
+
+  def preview?
+    @preview == true
+  end
 
   def notification_kind_for_devise_action
     {

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -339,7 +339,10 @@ class EventRegistration < ApplicationRecord
     where(id: Comment.where(commentable_type: "EventRegistration").matching(term).select(:commentable_id))
   }
   # Mirrors EventRegistration#account_status (none / has_access / invited /
-  # no_access) as a DB filter, joining the registrant's login account.
+  # no_access) as a DB filter, joining the registrant's login account. Also
+  # supports "not_invited" — an umbrella for everyone who still needs an invite
+  # (no account at all, or an account that was never sent a welcome invite),
+  # i.e. none ∪ no_access.
   scope :account_status, ->(value) {
     # Guard every subquery against NULL person_id (system/audit users) — a NULL in
     # a NOT IN list makes the whole comparison return no rows.
@@ -351,6 +354,7 @@ class EventRegistration < ApplicationRecord
     when "has_access" then where(registrant_id: has_access)
     when "invited" then where(registrant_id: invited).where.not(registrant_id: has_access)
     when "no_access" then where(registrant_id: with_user).where.not(registrant_id: has_access).where.not(registrant_id: invited)
+    when "not_invited" then where.not(registrant_id: invited).where.not(registrant_id: has_access)
     else all
     end
   }

--- a/app/services/person_inviter.rb
+++ b/app/services/person_inviter.rb
@@ -1,7 +1,7 @@
 # Invites a single person to the portal: creates a portal user for them when they
 # don't have one yet, then sends the welcome/invite email (Devise confirmation
 # instructions), attributing it to the staff member who triggered it. Drives the
-# bulk "send portal invite (confirmation) emails" flow on the reminders page, and mirrors the create-user
+# bulk "Send Portal invite emails" flow on the reminders page, and mirrors the create-user
 # + send-invite steps in EventRegistrationServices::ProcessConfirmation.
 class PersonInviter
   Result = Struct.new(:invited, :reason, keyword_init: true)

--- a/app/services/person_inviter.rb
+++ b/app/services/person_inviter.rb
@@ -1,7 +1,7 @@
 # Invites a single person to the portal: creates a portal user for them when they
 # don't have one yet, then sends the welcome/invite email (Devise confirmation
 # instructions), attributing it to the staff member who triggered it. Drives the
-# bulk "send login invites" flow on the reminders page, and mirrors the create-user
+# bulk "send portal invite (confirmation) emails" flow on the reminders page, and mirrors the create-user
 # + send-invite steps in EventRegistrationServices::ProcessConfirmation.
 class PersonInviter
   Result = Struct.new(:invited, :reason, keyword_init: true)

--- a/app/services/person_inviter.rb
+++ b/app/services/person_inviter.rb
@@ -1,0 +1,55 @@
+# Invites a single person to the portal: creates a portal user for them when they
+# don't have one yet, then sends the welcome/invite email (Devise confirmation
+# instructions), attributing it to the staff member who triggered it. Drives the
+# bulk "send login invites" flow on the reminders page, and mirrors the create-user
+# + send-invite steps in EventRegistrationServices::ProcessConfirmation.
+class PersonInviter
+  Result = Struct.new(:invited, :reason, keyword_init: true)
+
+  def self.call(person:, sender: nil)
+    new(person: person, sender: sender).call
+  end
+
+  def initialize(person:, sender: nil)
+    @person = person
+    @sender = sender
+  end
+
+  def call
+    email = @person.preferred_email
+    return Result.new(invited: false, reason: :no_email) if email.blank?
+
+    user = @person.user || create_user(email)
+    return Result.new(invited: false, reason: :no_user) unless user
+    return Result.new(invited: false, reason: :already_confirmed) if user.confirmed_at.present?
+
+    send_invite(user)
+    Result.new(invited: true, reason: nil)
+  end
+
+  private
+
+  def create_user(email)
+    password = SecureRandom.hex(8)
+    user = User.new(
+      email: email,
+      password: password,
+      password_confirmation: password,
+      person: @person,
+      created_by: @sender,
+      updated_by: @sender
+    )
+    user.skip_confirmation_notification!
+    return unless user.save
+
+    @person.reload
+    @person.user
+  end
+
+  def send_invite(user)
+    user.updated_by = @sender
+    user.set_welcome_instructions_token!
+    user.update!(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: @sender)
+    user.send_confirmation_instructions(sender: @sender)
+  end
+end

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -16,7 +16,7 @@
     <% reminder_filters = reminder_recipient_filters %>
     <%= link_to reminder_filters.any? ? "Send bulk emails (filtered)" : "Send bulk emails",
         preview_reminder_event_path(@event, reminder_filters), class: item_class %>
-    <%= link_to "Send Portal invite emails", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
+    <%= link_to "Send invite emails", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
     <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: item_class %>
     <%= link_to registrants_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
       Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -16,7 +16,7 @@
     <% reminder_filters = reminder_recipient_filters %>
     <%= link_to reminder_filters.any? ? "Send bulk emails (filtered)" : "Send bulk emails",
         preview_reminder_event_path(@event, reminder_filters), class: item_class %>
-    <%= link_to "Send login invites", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
+    <%= link_to "Send portal invite (confirmation) emails", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
     <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: item_class %>
     <%= link_to registrants_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
       Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -16,7 +16,7 @@
     <% reminder_filters = reminder_recipient_filters %>
     <%= link_to reminder_filters.any? ? "Send bulk emails (filtered)" : "Send bulk emails",
         preview_reminder_event_path(@event, reminder_filters), class: item_class %>
-    <%= link_to "Send portal invite (confirmation) emails", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
+    <%= link_to "Send Portal invite emails", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
     <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: item_class %>
     <%= link_to registrants_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
       Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>

--- a/app/views/events/_bulk_actions_menu.html.erb
+++ b/app/views/events/_bulk_actions_menu.html.erb
@@ -16,6 +16,7 @@
     <% reminder_filters = reminder_recipient_filters %>
     <%= link_to reminder_filters.any? ? "Send bulk emails (filtered)" : "Send bulk emails",
         preview_reminder_event_path(@event, reminder_filters), class: item_class %>
+    <%= link_to "Send login invites", preview_reminder_event_path(@event, mode: "invite"), class: item_class %>
     <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: item_class %>
     <%= link_to registrants_event_path(@event, format: :csv), class: item_class, data: { turbo_frame: "_top" } do %>
       Download CSV <i class="fa-solid fa-download text-gray-400 ml-1"></i>

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -145,7 +145,7 @@
       <% end %>
 
       <%= render "events/filter_select", param: :account_status, label: "User account",
-            options: [ [ "No account", "none" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+            options: [ [ "Not invited yet", "none" ], [ "Already invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
             selected: params[:account_status], blank: "Any account status", field_class: field_class %>
 
       <%= render "events/filter_text", param: :city, label: "City",

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -12,7 +12,9 @@
                              primary fields sit in the first row (search adds a
                              magnifier + flex width); the rest collapse
       include_readiness    – show the readiness "Status" select (roster only)
-      status_filter_hidden – carry the active/inactive hidden field (roster only) %>
+      status_filter_hidden – carry the active/inactive hidden field (roster only)
+      hidden_params        – { name => value } carried as hidden fields so they
+                             survive the GET filter submit (e.g. mode: "invite") %>
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 <% include_readiness = local_assigns.fetch(:include_readiness, false) %>
@@ -36,6 +38,9 @@
         class: "bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
     <% if status_filter_hidden %>
       <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
+    <% end %>
+    <% local_assigns.fetch(:hidden_params, {}).each do |name, value| %>
+      <%= hidden_field_tag name, value %>
     <% end %>
 
   <div class="flex items-center gap-2 text-gray-600 mb-3">

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -145,7 +145,7 @@
       <% end %>
 
       <%= render "events/filter_select", param: :account_status, label: "User account",
-            options: [ [ "No account", "none" ], [ "Not invited yet", "no_access" ], [ "Already invited", "invited" ], [ "Has access", "has_access" ] ],
+            options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
             selected: params[:account_status], blank: "Any account status", field_class: field_class %>
 
       <%= render "events/filter_text", param: :city, label: "City",

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -145,7 +145,7 @@
       <% end %>
 
       <%= render "events/filter_select", param: :account_status, label: "User account",
-            options: [ [ "Not invited yet", "none" ], [ "Already invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+            options: [ [ "No account", "none" ], [ "Not invited yet", "no_access" ], [ "Already invited", "invited" ], [ "Has access", "has_access" ] ],
             selected: params[:account_status], blank: "Any account status", field_class: field_class %>
 
       <%= render "events/filter_text", param: :city, label: "City",

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send login invites" : "Send bulk emails" %></h1>
+    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send portal invite (confirmation) emails" : "Send bulk emails" %></h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send portal invite (confirmation) emails" : "Send bulk emails" %></h1>
+    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send Portal invite emails" : "Send bulk emails" %></h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
@@ -21,7 +21,7 @@
       <div class="text-sm text-blue-800">
         <% if @invite_mode %>
           <p class="font-medium">You're about to invite <%= count %> <%= "person".pluralize(count) %>.</p>
-          <p class="mt-1">Review the recipients and the invite email below, then send. Anyone without a portal account gets one created, and each person receives a personalized link to set their password.</p>
+          <p class="mt-1">Review the recipients and the invite email below, then send. Anyone without a Portal account gets one created, and each person receives a personalized link to set their password.</p>
         <% else %>
           <p class="font-medium">You're about to email <%= count %> registrant<%= "s" if count != 1 %>.</p>
           <p class="mt-1">Review the recipients and the message below, then send. Each person receives their own copy, and one FYI email will be sent to the admin.</p>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,12 +3,12 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, custom_subject: @custom_subject, custom_message: @custom_message), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900">Send bulk emails</h1>
+    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send login invites" : "Send bulk emails" %></h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
@@ -19,8 +19,13 @@
     <div class="flex items-start gap-2">
       <i class="fa-solid fa-circle-info text-blue-500 mt-0.5"></i>
       <div class="text-sm text-blue-800">
-        <p class="font-medium">You're about to email <%= count %> registrant<%= "s" if count != 1 %>.</p>
-        <p class="mt-1">Review the recipients and the message below, then send. Each person receives their own copy, and one FYI email will be sent to the admin.</p>
+        <% if @invite_mode %>
+          <p class="font-medium">You're about to invite <%= count %> <%= "person".pluralize(count) %>.</p>
+          <p class="mt-1">Review the recipients and the invite email below, then send. Anyone without a portal account gets one created, and each person receives a personalized link to set their password.</p>
+        <% else %>
+          <p class="font-medium">You're about to email <%= count %> registrant<%= "s" if count != 1 %>.</p>
+          <p class="mt-1">Review the recipients and the message below, then send. Each person receives their own copy, and one FYI email will be sent to the admin.</p>
+        <% end %>
       </div>
     </div>
   </div>
@@ -63,12 +68,16 @@
     <% @event_registrations.each do |reg| %>
       <%= hidden_field_tag "registration_ids[]", reg.id %>
     <% end %>
-    <%# Carry the composed subject/message through to the send untouched. %>
-    <%= hidden_field_tag :custom_subject, @custom_subject %>
-    <%= hidden_field_tag :custom_message, @custom_message %>
+    <% if @invite_mode %>
+      <%= hidden_field_tag :mode, "invite" %>
+    <% else %>
+      <%# Carry the composed subject/message through to the send untouched. %>
+      <%= hidden_field_tag :custom_subject, @custom_subject %>
+      <%= hidden_field_tag :custom_message, @custom_message %>
+    <% end %>
     <div class="flex justify-center gap-3">
-      <%= link_to "Cancel", preview_reminder_event_path(@event, custom_subject: @custom_subject, custom_message: @custom_message), class: "btn btn-secondary-outline" %>
-      <%= f.submit "Send reminder", class: "btn btn-primary" %>
+      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message), class: "btn btn-secondary-outline" %>
+      <%= f.submit(@invite_mode ? "Send invites" : "Send reminder", class: "btn btn-primary") %>
     </div>
   <% end %>
 </div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -13,6 +13,15 @@
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
+    <% if @invite_mode %>
+      <%= link_to preview_reminder_event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 mt-2" do %>
+        <i class="fa-solid fa-envelope text-xs"></i> Send a bulk email instead
+      <% end %>
+    <% else %>
+      <%= link_to preview_reminder_event_path(@event, mode: "invite"), class: "inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 mt-2" do %>
+        <i class="fa-solid fa-user-plus text-xs"></i> Send login invites to people with no account instead
+      <% end %>
+    <% end %>
   </div>
   <% if @event_registrations.empty? %>
     <% if @invite_mode %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -6,22 +6,28 @@
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
-  <div class="mb-6">
+  <div class="mb-4">
     <h1 class="text-2xl font-semibold text-gray-900">
-      <%= @invite_mode ? "Send login invites" : "Send bulk emails" %>
+      <%= @invite_mode ? "Send portal invite (confirmation) emails" : "Send bulk emails" %>
     </h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
-    <% if @invite_mode %>
-      <%= link_to preview_reminder_event_path(@event), class: "btn btn-secondary-outline inline-flex items-center gap-1.5 mt-3" do %>
-        Send a bulk email instead <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
+  </div>
+
+  <%# Banner: what this page does, plus a plain link to the other mode. %>
+  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-start gap-2 text-sm text-gray-600">
+    <i class="fa-solid fa-circle-info text-gray-400 mt-0.5 shrink-0"></i>
+    <p>
+      <% if @invite_mode %>
+        You're sending the standard portal invite (confirmation) email to registrants
+        who don't have an account yet. Want to email everyone instead?
+        <%= link_to "Send a bulk email", preview_reminder_event_path(@event), class: "text-blue-600 hover:text-blue-800 font-medium whitespace-nowrap" %>.
+      <% else %>
+        You're composing a bulk email to registrants. To invite people who can't sign
+        in yet, <%= link_to "send portal invite (confirmation) emails", preview_reminder_event_path(@event, mode: "invite"), class: "text-blue-600 hover:text-blue-800 font-medium" %> instead.
       <% end %>
-    <% else %>
-      <%= link_to preview_reminder_event_path(@event, mode: "invite"), class: "btn btn-secondary-outline inline-flex items-center gap-1.5 mt-3" do %>
-        Send login invites to people with no account instead <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
-      <% end %>
-    <% end %>
+    </p>
   </div>
   <% if @event_registrations.empty? %>
     <% if @invite_mode %>
@@ -34,8 +40,9 @@
     <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
     <% if @invite_mode %>
       <p class="text-gray-600 mb-3">
-        Only registrants with no portal account yet are listed — a login invite is
-        for people who can't sign in. Filters keep everyone in the list and check
+        Only registrants with no portal account yet are listed — a portal invite
+        (confirmation) email is for people who can't sign in. Filters keep everyone
+        in the list and check
         the matches. Separate multiple values with
         <code class="font-mono">'--'</code> to match multiple values (e.g.
         <code class="font-mono">amy--aisha</code>).

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <%# Banner: what this page does, plus a plain link to the other mode. %>
-  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-center gap-2.5 text-sm text-gray-600">
+  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-baseline gap-2.5 text-sm text-gray-600">
     <i class="fa-solid fa-circle-info text-gray-400 shrink-0"></i>
     <p>
       <% if @invite_mode %>
@@ -77,8 +77,8 @@
       <% if @invite_mode %>
         <div class="my-14">
           <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email</h2>
-          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start gap-2 text-sm text-blue-800">
-            <i class="fa-solid fa-lock mt-0.5 shrink-0"></i>
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-baseline gap-2 text-sm text-blue-800">
+            <i class="fa-solid fa-lock shrink-0"></i>
             <p>
               This is the standard Portal invite email. It can't be edited — each
               recipient gets a personalized link to set their password. Preview it below.

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -14,12 +14,12 @@
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
     <% if @invite_mode %>
-      <%= link_to preview_reminder_event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 mt-2" do %>
-        <i class="fa-solid fa-envelope text-xs"></i> Send a bulk email instead
+      <%= link_to preview_reminder_event_path(@event), class: "btn btn-secondary-outline inline-flex items-center gap-1.5 mt-3" do %>
+        Send a bulk email instead <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
       <% end %>
     <% else %>
-      <%= link_to preview_reminder_event_path(@event, mode: "invite"), class: "inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 mt-2" do %>
-        <i class="fa-solid fa-user-plus text-xs"></i> Send login invites to people with no account instead
+      <%= link_to preview_reminder_event_path(@event, mode: "invite"), class: "btn btn-secondary-outline inline-flex items-center gap-1.5 mt-3" do %>
+        Send login invites to people with no account instead <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
       <% end %>
     <% end %>
   </div>
@@ -70,9 +70,9 @@
       <% if @invite_mode %>
         <div class="my-14">
           <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email</h2>
-          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start gap-2">
-            <i class="fa-solid fa-lock text-blue-500 mt-0.5"></i>
-            <p class="text-sm text-blue-800">
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start gap-2 text-sm text-blue-800">
+            <i class="fa-solid fa-lock mt-0.5 shrink-0"></i>
+            <p>
               This is the standard portal invite email. It can't be edited — each
               recipient gets a personalized link to set their password. Preview it below.
             </p>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -8,7 +8,7 @@
 
   <div class="mb-4">
     <h1 class="text-2xl font-semibold text-gray-900">
-      <%= @invite_mode ? "Send portal invite (confirmation) emails" : "Send bulk emails" %>
+      <%= @invite_mode ? "Send Portal invite emails" : "Send bulk emails" %>
     </h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
@@ -16,16 +16,16 @@
   </div>
 
   <%# Banner: what this page does, plus a plain link to the other mode. %>
-  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-start gap-2 text-sm text-gray-600">
-    <i class="fa-solid fa-circle-info text-gray-400 mt-0.5 shrink-0"></i>
+  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-center gap-2.5 text-sm text-gray-600">
+    <i class="fa-solid fa-circle-info text-gray-400 shrink-0"></i>
     <p>
       <% if @invite_mode %>
-        You're sending the standard portal invite (confirmation) email to registrants
+        You're sending the standard Portal invite (confirmation) email to registrants
         who don't have an account yet. Want to email everyone instead?
         <%= link_to "Send a bulk email", preview_reminder_event_path(@event), class: "text-blue-600 hover:text-blue-800 font-medium whitespace-nowrap" %>.
       <% else %>
         You're composing a bulk email to registrants. To invite people who can't sign
-        in yet, <%= link_to "send portal invite (confirmation) emails", preview_reminder_event_path(@event, mode: "invite"), class: "text-blue-600 hover:text-blue-800 font-medium" %> instead.
+        in yet, <%= link_to "send Portal invite (confirmation) emails", preview_reminder_event_path(@event, mode: "invite"), class: "text-blue-600 hover:text-blue-800 font-medium" %> instead.
       <% end %>
     </p>
   </div>
@@ -40,7 +40,7 @@
     <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
     <% if @invite_mode %>
       <p class="text-gray-600 mb-3">
-        Only registrants with no portal account yet are listed — a portal invite
+        Only registrants with no Portal account yet are listed — a Portal invite
         (confirmation) email is for people who can't sign in. Filters keep everyone
         in the list and check
         the matches. Separate multiple values with
@@ -80,7 +80,7 @@
           <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start gap-2 text-sm text-blue-800">
             <i class="fa-solid fa-lock mt-0.5 shrink-0"></i>
             <p>
-              This is the standard portal invite email. It can't be edited — each
+              This is the standard Portal invite email. It can't be edited — each
               recipient gets a personalized link to set their password. Preview it below.
             </p>
           </div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -8,27 +8,42 @@
 
   <div class="mb-6">
     <h1 class="text-2xl font-semibold text-gray-900">
-      Send bulk emails
+      <%= @invite_mode ? "Send login invites" : "Send bulk emails" %>
     </h1>
     <p class="text-gray-600 mt-1">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
   </div>
   <% if @event_registrations.empty? %>
-    <p class="text-gray-600 mb-4">There are no registrants with an email address to send a reminder to.</p>
+    <% if @invite_mode %>
+      <p class="text-gray-600 mb-4">Every registrant with an email already has a portal account — there's no one to invite.</p>
+    <% else %>
+      <p class="text-gray-600 mb-4">There are no registrants with an email address to send a reminder to.</p>
+    <% end %>
     <%= link_to "Back to registrants", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
   <% else %>
     <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
-    <p class="text-gray-600 mb-3">
-      Choose who will receive this reminder. Filters keep everyone in the list and
-      check the matches. Separate multiple values with
-      <code class="font-mono">'--'</code> to match multiple values (e.g.
-      <code class="font-mono">amy--aisha</code>).
-    </p>
+    <% if @invite_mode %>
+      <p class="text-gray-600 mb-3">
+        Only registrants with no portal account yet are listed — a login invite is
+        for people who can't sign in. Filters keep everyone in the list and check
+        the matches. Separate multiple values with
+        <code class="font-mono">'--'</code> to match multiple values (e.g.
+        <code class="font-mono">amy--aisha</code>).
+      </p>
+    <% else %>
+      <p class="text-gray-600 mb-3">
+        Choose who will receive this reminder. Filters keep everyone in the list and
+        check the matches. Separate multiple values with
+        <code class="font-mono">'--'</code> to match multiple values (e.g.
+        <code class="font-mono">amy--aisha</code>).
+      </p>
+    <% end %>
     <%= render "events/registrant_filters",
-          url: preview_reminder_event_path(@event),
+          url: preview_reminder_event_path(@event, mode: ("invite" if @invite_mode)),
           frame: "reminder_recipients",
-          clear_url: preview_reminder_event_path(@event),
+          clear_url: preview_reminder_event_path(@event, mode: ("invite" if @invite_mode)),
+          hidden_params: (@invite_mode ? { mode: "invite" } : {}),
           text_fields: [
             { param: :name, label: "Name", placeholder: "Registrant name", primary: true },
             { param: :email, label: "Email", placeholder: "Email address", primary: true },
@@ -36,43 +51,64 @@
           ] %>
     <%# Turbo disabled: this POST renders the confirmation interstitial (a full
         page), not a redirect, so a normal browser navigation is what we want.
-        reminder-preview drives the live message/subject preview as the admin types. %>
-    <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: "reminder-preview", turbo: false } do |f| %>
+        reminder-preview drives the live message/subject preview as the admin types
+        (reminder mode only — the invite email is fixed and can't be edited). %>
+    <%= form_with url: confirm_reminder_event_path(@event), method: :post, data: { controller: ("reminder-preview" unless @invite_mode), turbo: false } do |f| %>
+      <% if @invite_mode %>
+        <%= hidden_field_tag :mode, "invite" %>
+      <% end %>
       <%= render "events/reminder_recipients" %>
-      <div class="my-14">
-        <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email draft</h2>
-        <div class="bg-white border border-gray-200 rounded-lg p-6 pb-8 space-y-6">
-          <div>
-            <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
-            <p class="text-gray-600 mb-2">
-              The subject line recipients will see. Edit it as you like — leave it as is to use the default.
-            </p>
-            <%= text_field_tag :custom_subject, @custom_subject,
-                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm bg-white",
-                  data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
-          </div>
-          <div>
-            <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
-            <p class="text-gray-600 mb-2">
-              The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
-            </p>
-            <%= text_area_tag :custom_message, @custom_message,
-                  rows: 4,
-                  class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
-                  data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
-            <p class="text-xs text-gray-400 mt-1.5">
-              Accepts basic HTML — bold, italics, links, lists, and line breaks.
+      <% if @invite_mode %>
+        <div class="my-14">
+          <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email</h2>
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start gap-2">
+            <i class="fa-solid fa-lock text-blue-500 mt-0.5"></i>
+            <p class="text-sm text-blue-800">
+              This is the standard portal invite email. It can't be edited — each
+              recipient gets a personalized link to set their password. Preview it below.
             </p>
           </div>
         </div>
-      </div>
+      <% else %>
+        <div class="my-14">
+          <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email draft</h2>
+          <div class="bg-white border border-gray-200 rounded-lg p-6 pb-8 space-y-6">
+            <div>
+              <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
+              <p class="text-gray-600 mb-2">
+                The subject line recipients will see. Edit it as you like — leave it as is to use the default.
+              </p>
+              <%= text_field_tag :custom_subject, @custom_subject,
+                    class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm bg-white",
+                    data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
+            </div>
+            <div>
+              <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
+              <p class="text-gray-600 mb-2">
+                The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
+              </p>
+              <%= text_area_tag :custom_message, @custom_message,
+                    rows: 4,
+                    class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
+                    data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
+              <p class="text-xs text-gray-400 mt-1.5">
+                Accepts basic HTML — bold, italics, links, lists, and line breaks.
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
       <% if @reminder_preview_html.present? %>
         <div class="mb-6">
           <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">Preview (sample registrant)</h2>
           <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
             <div class="border-b border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700">
               <span class="font-semibold text-gray-500">Subject:</span>
-              <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
+              <% if @invite_mode %>
+                <span><%= @invite_subject %></span>
+              <% else %>
+                <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
+              <% end %>
             </div>
             <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif; zoom: 0.6;">
               <%= raw @reminder_preview_html %>
@@ -82,7 +118,7 @@
       <% end %>
       <div class="mt-8 flex justify-center gap-3">
         <%= link_to "Cancel", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
-        <%= f.submit "Review & send", class: "btn btn-primary" %>
+        <%= f.submit(@invite_mode ? "Review & send invites" : "Review & send", class: "btn btn-primary") %>
       </div>
     <% end %>
   <% end %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -643,6 +643,12 @@ RSpec.describe EventRegistration, type: :model do
         expect(results).not_to include(none_reg, access_reg, invited_reg)
       end
 
+      it "maps 'not_invited' to everyone who still needs an invite (no account or never invited)" do
+        results = EventRegistration.account_status("not_invited")
+        expect(results).to include(none_reg, no_access_reg)
+        expect(results).not_to include(access_reg, invited_reg)
+      end
+
       it "returns an unfiltered relation for unknown values" do
         expect(EventRegistration.account_status("bogus")).to include(none_reg, access_reg, invited_reg, no_access_reg)
       end

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+# The bulk reminder page gains an invite mode (?mode=invite) that sends the portal
+# welcome email to registrants with no account yet. The email is fixed — the admin
+# can only preview it, not edit a subject/message.
+RSpec.describe "Events::BulkInvites", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event) }
+  let!(:no_account) do
+    create(:event_registration, event: event,
+      registrant: create(:person, user: nil, email: "newbie@example.com", first_name: "Newbie", last_name: "One"))
+  end
+  let!(:has_account) do
+    create(:event_registration, event: event,
+      registrant: create(:person, first_name: "Existing", last_name: "Two"))
+  end
+
+  before { sign_in admin }
+
+  def checked?(body, registration)
+    node = Nokogiri::HTML(body).at_css("#registration_ids_#{registration.id}")
+    node.present? && node["checked"].present?
+  end
+
+  describe "the invite picker" do
+    it "lists only registrants with no portal account, pre-checked" do
+      get preview_reminder_event_path(event, mode: "invite")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Send login invites")
+      expect(response.body).to include("Newbie One")
+      expect(response.body).not_to include("Existing Two")
+      expect(checked?(response.body, no_account)).to be(true)
+    end
+
+    it "previews the fixed invite email and hides the editable subject/message" do
+      get preview_reminder_event_path(event, mode: "invite")
+
+      expect(response.body).to include("Welcome to the AWBW Portal!")
+      expect(response.body).to include("can't be edited")
+      # No editable draft fields in invite mode.
+      expect(response.body).not_to include('name="custom_message"')
+      expect(response.body).not_to include('name="custom_subject"')
+    end
+  end
+
+  describe "confirm interstitial" do
+    it "shows the invite email without sending" do
+      expect {
+        post confirm_reminder_event_path(event), params: { mode: "invite", registration_ids: [ no_account.id ] }
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Send login invites")
+      expect(response.body).to include("Welcome instructions for Newbie One")
+    end
+  end
+
+  describe "sending invites" do
+    it "creates an account for each recipient and sends the invite email" do
+      expect {
+        post send_reminder_event_path(event), params: { mode: "invite", registration_ids: [ no_account.id ] }
+      }.to change { no_account.registrant.reload.user }.from(nil)
+        .and change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(response).to redirect_to(registrants_event_path(event))
+      expect(flash[:notice]).to include("Login invites")
+    end
+
+    it "attributes the invite to the admin who sent it" do
+      post send_reminder_event_path(event), params: { mode: "invite", registration_ids: [ no_account.id ] }
+
+      user = no_account.registrant.reload.user
+      expect(user.welcome_instructions_sent_by).to eq(admin)
+    end
+
+    it "redirects back to the picker when nothing is selected" do
+      post send_reminder_event_path(event), params: { mode: "invite", registration_ids: [] }
+
+      expect(response).to redirect_to(preview_reminder_event_path(event, mode: "invite", custom_message: "", custom_subject: ""))
+      expect(flash[:alert]).to be_present
+    end
+  end
+end

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
       get preview_reminder_event_path(event, mode: "invite")
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Send login invites")
+      expect(response.body).to include("Send portal invite (confirmation) emails")
       expect(response.body).to include("Newbie One")
       expect(response.body).not_to include("Existing Two")
       expect(checked?(response.body, no_account)).to be(true)
@@ -38,7 +38,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
       expect(response.body).to include(preview_reminder_event_path(event, mode: "invite"))
 
       get preview_reminder_event_path(event, mode: "invite")
-      expect(response.body).to include("Send a bulk email instead")
+      expect(response.body).to include("Send a bulk email")
     end
 
     it "previews the fixed invite email and hides the editable subject/message" do
@@ -59,7 +59,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
       }.not_to change(User, :count)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Send login invites")
+      expect(response.body).to include("Send portal invite (confirmation) emails")
       expect(response.body).to include("Welcome instructions for Newbie One")
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
         .and change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(response).to redirect_to(registrants_event_path(event))
-      expect(flash[:notice]).to include("Login invites")
+      expect(flash[:notice]).to include("Portal invite (confirmation) emails")
     end
 
     it "attributes the invite to the admin who sent it" do

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
       get preview_reminder_event_path(event, mode: "invite")
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Send portal invite (confirmation) emails")
+      expect(response.body).to include("Send Portal invite emails")
       expect(response.body).to include("Newbie One")
       expect(response.body).not_to include("Existing Two")
       expect(checked?(response.body, no_account)).to be(true)
@@ -59,7 +59,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
       }.not_to change(User, :count)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Send portal invite (confirmation) emails")
+      expect(response.body).to include("Send Portal invite emails")
       expect(response.body).to include("Welcome instructions for Newbie One")
     end
   end

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe "Events::BulkInvites", type: :request do
       expect(checked?(response.body, no_account)).to be(true)
     end
 
+    it "links between bulk email and invite mode in both directions" do
+      get preview_reminder_event_path(event)
+      expect(response.body).to include(preview_reminder_event_path(event, mode: "invite"))
+
+      get preview_reminder_event_path(event, mode: "invite")
+      expect(response.body).to include("Send a bulk email instead")
+    end
+
     it "previews the fixed invite email and hides the editable subject/message" do
       get preview_reminder_event_path(event, mode: "invite")
 

--- a/spec/services/person_inviter_spec.rb
+++ b/spec/services/person_inviter_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe PersonInviter do
+  # Referenced up front so lazily creating the admin doesn't skew User.count
+  # assertions inside the expectation blocks below.
+  let!(:sender) { create(:user, :admin) }
+
+  describe ".call" do
+    it "creates a portal account for a person who has none and sends the invite" do
+      person = create(:person, user: nil, email: "newbie@example.com")
+
+      result = nil
+      expect {
+        result = described_class.call(person: person, sender: sender)
+      }.to change { person.reload.user }.from(nil)
+        .and change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(result.invited).to be(true)
+      user = person.reload.user
+      expect(user.email).to eq("newbie@example.com")
+      expect(user.welcome_instructions_sent_at).to be_present
+      expect(user.welcome_instructions_sent_by).to eq(sender)
+    end
+
+    it "invites an existing unconfirmed user without creating a second account" do
+      person = create(:person, user: create(:user, :unconfirmed, email: "pending@example.com"))
+
+      expect {
+        result = described_class.call(person: person, sender: sender)
+        expect(result.invited).to be(true)
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        .and change(User, :count).by(0)
+    end
+
+    it "skips a person who already has a confirmed account" do
+      person = create(:person) # factory associates a confirmed user
+
+      expect {
+        result = described_class.call(person: person, sender: sender)
+        expect(result.invited).to be(false)
+        expect(result.reason).to eq(:already_confirmed)
+      }.not_to change { ActionMailer::Base.deliveries.count }
+    end
+
+    it "skips a person with no email address" do
+      person = create(:person, user: nil, email: nil, email_2: nil)
+
+      expect {
+        result = described_class.call(person: person, sender: sender)
+        expect(result.invited).to be(false)
+        expect(result.reason).to eq(:no_email)
+      }.not_to change(User, :count)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic reusing the reminders flow via a mode branch; new one-person invite service

### What is the goal of this PR and why is this important?
- Staff had no bulk way to invite registrants who have **no portal account** yet — only a per-user "send welcome instructions" action and a console-only `BulkInviteService`.
- This adds a **"Send login invites"** entry to the event Bulk actions menu that reuses the existing bulk-reminders recipient picker.

### How did you approach the change?
- Threaded a `mode=invite` param through `preview_reminder` → `confirm_reminder` → `send_reminder` rather than building a parallel page, so recipient filtering, the checkbox picker, and the confirm interstitial are all reused.
- In invite mode:
  - The recipient list is restricted to registrants whose person has **no user**.
  - The email is the **fixed** portal welcome/confirmation email — the subject/message editors are hidden and the admin only gets a read-only preview.
  - Sending creates an account for anyone without one, then delivers the invite, attributed to the admin.
- New `PersonInviter` service encapsulates "create a user if needed + send the welcome email" (mirrors the steps in `ProcessConfirmation`); skips people who already have a confirmed account.
- `DeviseMailer#confirmation_instructions` gained a `preview:` flag so rendering the on-page preview doesn't log a notification or emit an auth event.

### Anything else to add?
- No new routes or page views — reuses the reminder actions/views, so `page_bg_class` mappings are unchanged.
- Invite mode intentionally sends **no admin FYI** (the reminder path does); each welcome email already logs its own communication record.
- Specs: `spec/services/person_inviter_spec.rb`, `spec/requests/events/bulk_invites_spec.rb`.