### PR TITLE
Correct icon() helper docs to reflect actual behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -232,7 +232,7 @@ this). Match the existing pattern:
 - **Strongly prefer Stimulus** for JavaScript behavior — do not write raw/inline JS or jQuery
 - **Always use Tailwind CSS** utility classes for styling — do not write custom CSS unless absolutely necessary
 - **Prefer static Tailwind classes over dynamically-constructed ones.** Tailwind's JIT scanner only generates classes it finds as complete literal strings in the source — a class built by interpolation (e.g. `bg-#{color}-500`, `text-${size}`, `class="w-#{n}"`) won't be generated and silently renders unstyled. Write the full class names out, and select between complete literals (e.g. a lookup hash mapping a value to a whole class string, or a ternary picking between two literal classes) rather than splicing fragments. Only build a class dynamically when the set of values is open-ended and can't be enumerated; in that case add the candidates to the Tailwind safelist.
-- **Prefer Font Awesome (free)** icons over inline SVGs — use `icon("fa-solid fa-foo")` helper. Inline SVGs are acceptable when a specific icon design is preferred.
+- **Prefer Font Awesome (free)** icons over inline SVGs — render them as markup: `<i class="fa-solid fa-foo"></i>`. Inline SVGs are acceptable when a specific icon design is preferred; the `icon("name")` helper (`app/helpers/icon_helper.rb`) inlines a local SVG from `app/frontend/icons/` by filename — it is not a Font Awesome helper.
 - Prefer Turbo for navigation and form submissions before reaching for Stimulus
 - Controller naming: `[name]_controller.js`
 - Keep controllers focused and small

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ this). Match the existing pattern:
 - **Strongly prefer Stimulus** for JavaScript behavior — do not write raw/inline JS or jQuery
 - **Always use Tailwind CSS** utility classes for styling — do not write custom CSS unless absolutely necessary
 - **Prefer static Tailwind classes over dynamically-constructed ones.** Tailwind's JIT scanner only generates classes it finds as complete literal strings in the source — a class built by interpolation (e.g. `bg-#{color}-500`, `text-${size}`, `class="w-#{n}"`) won't be generated and silently renders unstyled. Write the full class names out, and select between complete literals (e.g. a lookup hash mapping a value to a whole class string, or a ternary picking between two literal classes) rather than splicing fragments. Only build a class dynamically when the set of values is open-ended and can't be enumerated; in that case add the candidates to the Tailwind safelist.
-- **Prefer Font Awesome (free)** icons over inline SVGs — use `icon("fa-solid fa-foo")` helper. Inline SVGs are acceptable when a specific icon design is preferred.
+- **Prefer Font Awesome (free)** icons over inline SVGs — render them as markup: `<i class="fa-solid fa-foo"></i>`. Inline SVGs are acceptable when a specific icon design is preferred; the `icon("name")` helper (`app/helpers/icon_helper.rb`) inlines a local SVG from `app/frontend/icons/` by filename — it is not a Font Awesome helper.
 - Prefer Turbo for navigation and form submissions before reaching for Stimulus
 - Controller naming: `[name]_controller.js`
 - Keep controllers focused and small


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 docs-only fix to two AI instruction files, no code changes

### What is the goal of this PR and why is this important?
- The AI files (`CLAUDE.md` + `.github/copilot-instructions.md`) told contributors to render Font Awesome icons with `icon("fa-solid fa-foo")`, but that helper doesn't do that — it inlines a local SVG by filename (`app/frontend/icons/*.svg`) and silently returns `""` when the file is missing. Following the doc would render nothing.

### How did you approach the change?
- Corrected both files to document the two mechanisms accurately: Font Awesome icons render as `<i class="fa-solid fa-foo"></i>` markup, while the `icon("name")` helper inlines a local SVG by filename and is not a Font Awesome helper.

### Anything else to add?
- Docs-only; both AI files kept in sync per the "keep in sync" rule.