### PR TITLE
Fix pagination reading as grayed-out/disabled

### DIFF
--- a/app/renderers/tailwind_pagination_renderer.rb
+++ b/app/renderers/tailwind_pagination_renderer.rb
@@ -82,20 +82,20 @@ class TailwindPaginationRenderer < WillPaginate::ActionView::LinkRenderer
   private
 
   def arrow_classes
-    "arrow-classes px-3 py-1 border border-gray-200 rounded-md
-     bg-white text-gray-300 hover:bg-gray-100 hover:text-gray-200"
+    "arrow-classes px-3 py-1 border border-gray-300 rounded-md
+     bg-white text-gray-700 hover:bg-gray-100 hover:text-gray-900"
   end
 
   def active_page_classes
-    "active-classes px-3 py-1 rounded-md bg-transparent text-gray-700"
+    "active-classes px-3 py-1 rounded-md bg-primary text-white font-semibold"
   end
 
   def page_link_classes
-    "page-link-classes px-3 py-1 border border-gray-200 rounded-md
-     bg-white text-gray-300 hover:bg-gray-100 hover:text-gray-200"
+    "page-link-classes px-3 py-1 border border-gray-300 rounded-md
+     bg-white text-gray-700 hover:bg-gray-100 hover:text-gray-900"
   end
 
   def gap_classes
-    "gap-classes px-3 py-1 text-gray-300"
+    "gap-classes px-3 py-1 text-gray-400"
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only styling change to the shared pagination renderer

Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- Feedback: page numbers at the bottom looked grayed out, as if they couldn't be clicked.

### How did you approach the change?
- In `TailwindPaginationRenderer`, clickable page links/arrows went from pale `text-gray-300` (which hovered *lighter*) to readable `text-gray-700` with a `hover:text-gray-900` darken, and the current page became a filled banner-blue (`bg-primary`) chip so the affordance and "you are here" state read correctly.

### UI Testing Checklist
- [ ] Visit any paginated index (grants, payments, workshops, organizations, comments, etc.) and confirm inactive numbers look clickable and the current page is the blue chip.

### Anything else to add?
- Affects every `tailwind_paginate` page since it's the shared renderer.