### PR TITLE
Add ticket payment due date to events

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -48,6 +48,14 @@ class EventDecorator < ApplicationDecorator
     ce_payment_due_deadline.in_time_zone(Time.zone).strftime("%-l:%M %p %Z on %B %-d, %Y")
   end
 
+  # The ticket payment deadline in the viewer's TZ (e.g. "5:00 PM UTC on April 9,
+  # 2026"). Nil when unset. Distinct from ce_payment_due_deadline, which is the
+  # continuing-education payment deadline.
+  def payment_due_deadline_display
+    return if payment_due_deadline.blank?
+    payment_due_deadline.in_time_zone(Time.zone).strftime("%-l:%M %p %Z on %B %-d, %Y")
+  end
+
   # Weekday-prefixed date range (e.g. "Thu-Fri, Jan 1-2, 2026") that collapses the
   # year — and the month/weekday where possible — so nothing repeats unnecessarily.
   def date_range

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -234,7 +234,8 @@ class Event < ApplicationRecord
   attr_writer :start_date_date, :start_date_time,
               :end_date_date, :end_date_time,
               :registration_close_date_date, :registration_close_date_time,
-              :ce_payment_due_deadline_date, :ce_payment_due_deadline_time
+              :ce_payment_due_deadline_date, :ce_payment_due_deadline_time,
+              :payment_due_deadline_date, :payment_due_deadline_time
 
   def start_date_date
     @start_date_date || start_date&.strftime("%Y-%m-%d")
@@ -266,6 +267,14 @@ class Event < ApplicationRecord
 
   def ce_payment_due_deadline_time
     @ce_payment_due_deadline_time || ce_payment_due_deadline&.strftime("%H:%M")
+  end
+
+  def payment_due_deadline_date
+    @payment_due_deadline_date || payment_due_deadline&.strftime("%Y-%m-%d")
+  end
+
+  def payment_due_deadline_time
+    @payment_due_deadline_time || payment_due_deadline&.strftime("%H:%M")
   end
 
   # Virtual attribute for cost in dollars (converts to/from cost_cents)
@@ -333,6 +342,7 @@ class Event < ApplicationRecord
     merge_date_time(:end_date)
     merge_date_time(:registration_close_date)
     merge_date_time(:ce_payment_due_deadline)
+    merge_date_time(:payment_due_deadline)
   end
 
   def merge_date_time(field)

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -153,6 +153,8 @@ class EventPolicy < ApplicationPolicy
                   :ce_hours_request_deadline,
                   :ce_payment_due_deadline_date,
                   :ce_payment_due_deadline_time,
+                  :payment_due_deadline_date,
+                  :payment_due_deadline_time,
                   :autoshow_cost,
                   :autoshow_date,
                   :autoshow_location,

--- a/app/services/builtin_callout_cards.rb
+++ b/app/services/builtin_callout_cards.rb
@@ -183,10 +183,19 @@ class BuiltinCalloutCards
     Card.new(icon_class: "fa-solid fa-credit-card", color: due ? "orange" : "blue",
              title: due ? "Make your payment" : "Payment",
              subtitle: due ? "view your balance" : "view your payment history",
-             badge: due ? "#{MoneyFormatter.dollars_from_cents(registration.remaining_cost)} due" : "Paid",
+             badge: due ? payment_due_badge : "Paid",
              badge_classes: due ? nil : "bg-blue-100 text-blue-800 border border-blue-300",
              href: registration_payment_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right")
+  end
+
+  # The amount-owed chip while a balance is due, with the event's ticket payment
+  # deadline appended when set (e.g. "$1,350 due by Apr 9"). Mirrors the CE card's
+  # amount-due chip.
+  def payment_due_badge
+    amount = MoneyFormatter.dollars_from_cents(registration.remaining_cost)
+    return "#{amount} due" if event.payment_due_deadline.blank?
+    "#{amount} due by #{ce_deadline_text(event.payment_due_deadline)}"
   end
 
   # Shown only once the certificate of completion is unlocked (training over,

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -80,7 +80,7 @@
         <div class="md:col-span-2 space-y-6">
           <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13rem),1fr))] gap-3">
             <div class="bg-white border border-gray-200 rounded-lg p-3">
-              <h3 class="font-medium mb-2">Start</h3>
+              <h3 class="font-medium mb-2">Start <abbr title="required">*</abbr></h3>
 
               <div class="mb-2"><label class="block text-xs text-gray-600 mb-0.5">Date</label><%= f.text_field :start_date_date,
                          type: "date",
@@ -97,7 +97,7 @@
             </div>
 
             <div class="bg-white border border-gray-200 rounded-lg p-3">
-              <h3 class="font-medium mb-2">End</h3>
+              <h3 class="font-medium mb-2">End <abbr title="required">*</abbr></h3>
 
               <div class="mb-2"><label class="block text-xs text-gray-600 mb-0.5">Date</label><%= f.text_field :end_date_date,
                          type: "date",
@@ -160,6 +160,18 @@
               <% end %>
             </div>
 
+            <div>
+              <%= f.label :payment_due_deadline_date, "Payment due by", class: "block font-medium mb-1" %>
+              <div class="flex gap-2">
+                <%= f.text_field :payment_due_deadline_date, type: "date",
+                      class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+                <%= f.text_field :payment_due_deadline_time, type: "time",
+                      class: "w-28 shrink-0 rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div><%= f.input :pre_date_text,
                   label: "Pre-date text",
                   input_html: {

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -24,6 +24,9 @@
       <p class="mt-1">
         <span class="inline-flex items-center rounded-full px-3 py-1 text-2xl font-semibold tabular-nums <%= @event_registration.remaining_cost.positive? ? "bg-amber-200 text-amber-900" : "bg-blue-100 text-blue-800" %>"><%= dollars_from_cents(@event_registration.remaining_cost) %></span>
       </p>
+      <% if @event_registration.remaining_cost.positive? && (due_display = @event.decorate.payment_due_deadline_display) %>
+        <p class="mt-2 text-sm font-medium text-amber-800">Due by <%= due_display %></p>
+      <% end %>
     </div>
   </div>
 
@@ -48,7 +51,11 @@
         <p class="font-medium text-gray-900">1210 Fernside Dr.<br>La Cañada, CA 91011</p>
         <p>Please send us an email letting us know the date the check will be mailed. If that date changes, please let us know.</p>
         <p><strong>Note:</strong> AWBW had an address change in recent years. Please be sure your accounting department has this current address — mail sent to the old address will not be received.</p>
-        <p>Payment is due no later than 5:00 PM PT on April 9th. We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
+        <% if (due_display = @event.decorate.payment_due_deadline_display) %>
+          <p>Payment is due no later than <%= due_display %>. We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
+        <% else %>
+          <p>We'll send more information after your payment is received, so we encourage you to submit it as soon as possible.</p>
+        <% end %>
       </div>
     </details>
   <% end %>

--- a/db/migrate/20260812015152_add_payment_due_deadline_to_events.rb
+++ b/db/migrate/20260812015152_add_payment_due_deadline_to_events.rb
@@ -1,0 +1,9 @@
+class AddPaymentDueDeadlineToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :payment_due_deadline, :datetime
+  end
+
+  def down
+    remove_column :events, :payment_due_deadline, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_225127) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_015152) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -560,6 +560,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_225127) do
     t.boolean "inactive", default: true, null: false
     t.integer "location_id"
     t.boolean "on_demand", default: false, null: false
+    t.datetime "payment_due_deadline"
     t.string "pre_date_text"
     t.string "pre_title"
     t.boolean "public_registration_enabled", default: false, null: false

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -471,6 +471,20 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#payment_due_deadline_display" do
+    it "renders the deadline with the time and zone, e.g. '5:00 PM PDT on April 9, 2026'" do
+      deadline = Time.zone.local(2026, 4, 9, 17, 0)
+      event = build(:event, payment_due_deadline: deadline).decorate
+      tz = deadline.strftime("%Z")
+      expect(event.payment_due_deadline_display).to eq("5:00 PM #{tz} on April 9, 2026")
+    end
+
+    it "is nil when no deadline is set" do
+      event = build(:event, payment_due_deadline: nil).decorate
+      expect(event.payment_due_deadline_display).to be_nil
+    end
+  end
+
   describe "#times" do
     it "shows a multi-day event as a date range with a single daily time range" do
       event = build(:event, start_date: Time.zone.local(2026, 4, 21, 9), end_date: Time.zone.local(2026, 4, 23, 16, 30)).decorate

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -213,6 +213,25 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).to include("Custom W-9 line")
       expect(response.body).not_to include("AWBW's W-9 tax form for your records")
     end
+
+    it "shows the ticket payment deadline while a balance is due" do
+      event.update!(payment_due_deadline: Time.zone.local(2026, 4, 9, 17, 0))
+
+      get registration_payment_path(registration.slug)
+
+      expect(response.body).to include("Due by")
+      expect(response.body).to include("April 9, 2026")
+    end
+
+    it "omits the deadline once the balance is paid in full" do
+      event.update!(payment_due_deadline: Time.zone.local(2026, 4, 9, 17, 0))
+      payment = create(:payment, type: "CashPayment", amount_cents: event.cost_cents, amount_cents_remaining: nil)
+      create(:allocation, source: payment, allocatable: registration, amount: event.cost_cents)
+
+      get registration_payment_path(registration.slug)
+
+      expect(response.body).not_to include("April 9, 2026")
+    end
   end
 
   describe "GET /registration/:slug/videoconference" do

--- a/spec/services/builtin_callout_cards_spec.rb
+++ b/spec/services/builtin_callout_cards_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe BuiltinCalloutCards do
       expect(paid.trailing_icon).to eq("fa-solid fa-arrow-right")
     end
 
+    it "appends the ticket payment deadline to the due badge when the event sets one" do
+      event.update!(payment_due_deadline: Time.zone.local(2026, 4, 9, 17, 0))
+      due = card(registration, "Make your payment")
+      expect(due.badge).to eq("$10.99 due by Apr 9")
+    end
+
+    it "shows a plain due badge when the event sets no payment deadline" do
+      event.update!(payment_due_deadline: nil)
+      due = card(registration, "Make your payment")
+      expect(due.badge).to eq("$10.99 due")
+    end
+
     it "uses the arrow trailing icon for every card" do
       event.update!(videoconference_url: "https://example.zoom.us/j/1")
       trailing = described_class.new(registration).cards.map(&:trailing_icon).uniq


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new event column surfaced on the payment callout; contained logic, no scheduled sends

### What is the goal of this PR and why is this important?
- Adds a **ticket payment due date** to events, distinct from the existing CE payment deadline (the only payment deadline we had — the ticket one was hardcoded copy on the payment page).
- Surfaces it on the ticket **payment callout card** ("$X due by Apr 9") and the **payment callout page**.

### How did you approach the change?
- New `events.payment_due_deadline` datetime, mirroring the CE deadline pattern: virtual date/time accessors, decorator display, permitted params, and an admin form field next to cost.
- Marks the required start/end date inputs with SimpleForm's required marker (matching the admin-form convention).
- `BuiltinCalloutCards#payment_card` appends the deadline to the "due" badge; `payment.html.erb` renders the real deadline instead of the hardcoded "April 9th".

### Anything else to add?
- The **automated payment reminder emails** built on this column are split into a follow-up PR stacked on this one.
