### PR TITLE
Add topic subscription list filter to bulk emails picker

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -353,7 +353,7 @@ class EventsController < ApplicationController
       .includes(
         :event, :organizations, :comments,
         { scholarships: { grant: :funder } },
-        registrant: [ :user, :contact_methods, :addresses ]
+        registrant: [ :user, :contact_methods, :addresses, :topic_subscriptions ]
       )
       .joins(:registrant)
       .select { |r| r.registrant.preferred_email.present? }
@@ -368,6 +368,7 @@ class EventsController < ApplicationController
     # filters reuse the registrants-roster scopes (via the event), so both pages
     # stay in sync; @dashboard supplies the state/county options.
     @dashboard = EventDashboard.new(@event)
+    @topic_subscription_types = TopicSubscriptionType.active.ordered
     recipient_filter = ReminderRecipientFilter.new(@event_registrations, params, event: @event)
     @matched_ids = recipient_filter.matched_ids
     @filtering = recipient_filter.filtering?

--- a/app/services/reminder_recipient_filter.rb
+++ b/app/services/reminder_recipient_filter.rb
@@ -18,7 +18,11 @@ class ReminderRecipientFilter
     attendance_status payment_status payment_method ce_status scholarship
     submission_status comment_status org_status account_status state county
   ].freeze
-  FILTER_KEYS = (TEXT_KEYS + DROPDOWN_KEYS).freeze
+  # Picker-only dropdowns that don't map to a shared roster scope. `topic_subscription`
+  # keeps registrants whose person holds an active subscription to the chosen topic
+  # subscription list; matched in memory against the registrant's topic_subscriptions.
+  PICKER_KEYS = %i[ topic_subscription ].freeze
+  FILTER_KEYS = (TEXT_KEYS + DROPDOWN_KEYS + PICKER_KEYS).freeze
   # Every key above that is also a registrants-roster param, so the roster's
   # "Send bulk emails" link can carry the active filters straight into the picker
   # (see EventHelper#reminder_recipient_filters). The remaining text keys (name,
@@ -33,7 +37,7 @@ class ReminderRecipientFilter
 
   def matched_ids
     text_matched = @event_registrations.select { |reg| matches_text?(reg) }.map(&:id).to_set
-    text_matched & dropdown_matched_ids
+    text_matched & dropdown_matched_ids & topic_matched_ids
   end
 
   # True when at least one filter is narrowing the list. The view uses this to
@@ -73,6 +77,20 @@ class ReminderRecipientFilter
     scope = scope.registrant_state(@params[:state]) if @params[:state].present?
     scope = scope.registrant_county(@params[:county]) if @params[:county].present?
     scope.pluck(:id).to_set
+  end
+
+  # Keeps registrants whose person holds an active subscription to the chosen topic
+  # subscription list. With no topic set this is every registration, so it passes
+  # the other matches through unchanged.
+  def topic_matched_ids
+    return @event_registrations.map(&:id).to_set if @params[:topic_subscription].blank?
+
+    type_id = @params[:topic_subscription].to_i
+    @event_registrations.select do |reg|
+      reg.registrant.topic_subscriptions.any? do |sub|
+        sub.active? && sub.topic_subscription_type_id == type_id
+      end
+    end.map(&:id).to_set
   end
 
   def matches_name?(reg)

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -23,7 +23,8 @@
 <% primary_text, more_text = Array(text_fields).partition { |f| f[:primary] } %>
 <%# Open the collapsed section on load when any control inside it already carries
     a value, so an active filter is never hidden behind the toggle. %>
-<% collapsed_keys = %i[submission_status payment_method org_status scholarship funder_name ce_status city state county account_status comment_status comment] %>
+<% topic_subscription_types = local_assigns.fetch(:topic_subscription_types, []) %>
+<% collapsed_keys = %i[submission_status payment_method org_status scholarship funder_name ce_status city state county account_status comment_status comment topic_subscription] %>
 <% more_active = more_text.any? { |f| params[f[:param]].present? } || collapsed_keys.any? { |k| params[k].present? } %>
 <%# The "More filters" drawer is a pure-CSS disclosure: a visually-hidden
     checkbox drives the drawer, chevron and label via :has() on this group
@@ -147,6 +148,14 @@
       <%= render "events/filter_select", param: :account_status, label: "User account",
             options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
             selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+
+      <%# Picker-only: registrants with an active subscription to a topic subscription
+          list. Only rendered when the caller supplies the topic types. %>
+      <% if topic_subscription_types.any? %>
+        <%= render "events/filter_select", param: :topic_subscription, label: "Topic subscription list",
+              options: topic_subscription_types.map { |t| [ t.name, t.id ] },
+              selected: params[:topic_subscription], blank: "Any topic", field_class: field_class %>
+      <% end %>
 
       <%= render "events/filter_text", param: :city, label: "City",
             placeholder: "City name", field_class: field_class %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -60,6 +60,7 @@
           frame: "reminder_recipients",
           clear_url: preview_reminder_event_path(@event, mode: ("invite" if @invite_mode)),
           hidden_params: (@invite_mode ? { mode: "invite" } : {}),
+          topic_subscription_types: @topic_subscription_types,
           text_fields: [
             { param: :name, label: "Name", placeholder: "Registrant name", primary: true },
             { param: :email, label: "Email", placeholder: "Email address", primary: true },

--- a/spec/services/reminder_recipient_filter_spec.rb
+++ b/spec/services/reminder_recipient_filter_spec.rb
@@ -230,6 +230,27 @@ RSpec.describe ReminderRecipientFilter do
       end
     end
 
+    context "topic subscription" do
+      let(:topic) { create(:topic_subscription_type) }
+      let(:other_topic) { create(:topic_subscription_type) }
+      let!(:subscribed) do
+        registration(first_name: "Sub").tap { |r| create(:topic_subscription, person: r.registrant, topic_subscription_type: topic) }
+      end
+      let!(:other) do
+        registration(first_name: "Other").tap { |r| create(:topic_subscription, person: r.registrant, topic_subscription_type: other_topic) }
+      end
+      let!(:none) { registration(first_name: "None") }
+
+      it "filters registrants with an active subscription to the chosen topic" do
+        expect(matched({ topic_subscription: topic.id }, [ subscribed, other, none ])).to eq([ subscribed.id ].to_set)
+      end
+
+      it "ignores unsubscribed subscriptions" do
+        create(:topic_subscription, :unsubscribed, person: none.registrant, topic_subscription_type: topic)
+        expect(matched({ topic_subscription: topic.id }, [ subscribed, other, none ])).to eq([ subscribed.id ].to_set)
+      end
+    end
+
     it "combines filters with AND" do
       funder = create(:organization, name: "Acme Foundation")
       grant = create(:grant, funder: funder)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small in-memory predicate on the picker filter + one shared-partial select

### What is the goal of this PR and why is this important?
- Adds a "Topic subscription list" filter to the extra (More filters) section of the "Send bulk emails" recipient picker.
- Lets an admin target a reminder to registrants whose person holds an **active** subscription to a chosen topic subscription list.

### How did you approach the change?
- `ReminderRecipientFilter`: new picker-only `topic_subscription` key, matched in memory against each registrant's `topic_subscriptions` (active only), intersected with the existing text/dropdown matches.
- Eager-load `registrant: :topic_subscriptions` in `EventsController#preview_reminder` to avoid an N+1; expose `TopicSubscriptionType.active.ordered`.
- Shared `_registrant_filters` partial renders the new select **only when the caller passes topic types** (picker passes them, roster does not), and opens the drawer when the filter is active.
- Specs cover matching an active subscription and ignoring unsubscribed ones.

### Anything else to add?
- Picker-only; not added to the shared roster scopes, so it doesn't affect the registrants roster.