### PR TITLE
Bump brakeman 8.0.5 → 8.0.6 so pre-push --ensure-latest passes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       safely_block (>= 1)
     bootsnap (1.22.0)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bullet (8.1.0)
@@ -873,7 +873,7 @@ CHECKSUMS
   binding_of_caller (1.0.1)
   blazer (3.5.0) sha256=734b883b843fbd6d5c9db7a09ec267a068f504908f2d01b94fce151bd00ad4e2
   bootsnap (1.22.0) sha256=5820c9d42c2efef095bee6565484bdc511f1223bf950140449c9385ae775793e
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.1.0) sha256=604b7e2636ec2137dcab3ba61a56248c39a0004a0c9405d58bad0686d23b98ff
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 dependency lockfile bump only, no app code

### What is the goal of this PR and why is this important?
- `bin/brakeman` prepends `--ensure-latest`, so the pre-push hook fails whenever a newer Brakeman is released before the lockfile is bumped — this was blocking pushes even though the scan itself is clean.

### How did you approach the change?
- `bundle update brakeman` to move `Gemfile.lock` from 8.0.5 → 8.0.6 (the `~> 8.0.1` constraint already allowed it). Verified `bin/brakeman --no-pager -q` exits 0 with 0 security warnings.

### Anything else to add?
- Lockfile-only change; unblocks the pre-push hook repo-wide so nobody needs `--no-verify` for the version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)