### PR TITLE
Make dev seed re-runnable: clear demo registrants' payments before destroy

### DIFF
--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1492,7 +1492,13 @@ if facilitator_training && registration_form
   demo_people = Person.where("email LIKE ? OR email LIKE ?",
     "orgchip.demo.%@seed.example.com", "affdemo.%@seed.example.com")
   Resource.where(author_id: demo_people).update_all(author_id: nil)
-  demo_people.find_each(&:destroy)
+  # Drop payments first: payments.rb (which runs later) records payments against
+  # some of these registrants, and payments reference the person without a destroy
+  # cascade, so on a re-seed the person destroy would hit that foreign key.
+  demo_people.find_each do |person|
+    Payment.where(person: person).destroy_all
+    person.destroy
+  end
 
   # Each scenario => one registrant. :orgs link real orgs (→ chip shows links);
   # :agency stores a submitted name. A typed name matching an existing org is linked


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line idempotency fix in a dev-only seed

### What is the goal of this PR and why is this important?
- Re-running `bin/rails db:seed:dev` on an existing DB crashed with `ActiveRecord::InvalidForeignKey` on `payments.person_id`.
- `events_management.rb` recreates its `orgchip.demo.*` / `affdemo.*` registrants from scratch each run, but `payments.rb` (runs later) records payments against some of them. Payments reference the person with no destroy cascade, so the second run's person `destroy` hit that FK.

### How did you approach the change?
- Drop each demo person's payments before destroying the person, mirroring the cleanup `payments.rb` already does for its own demo registrants.
- Verified: two consecutive `db:seed:dev` runs on a seeded DB now both exit 0.

### Anything else to add?
- The original report also mentioned `NameError: uninitialized constant Story` during seeding. That was **not reproducible** on a clean DB on either branch — a full clean `db:seed:dev` runs green. It looks like a one-off Zeitwerk autoload hiccup during that setup run (the polymorphic `belongs_to :categorizable` presence check constantizes `"Story"`); re-running `bin/setup`, which drops/recreates the DB, clears it. No code change was warranted there.