### PR TITLE
Make single-day event spec date relative so it stops going stale

### DIFF
--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -315,9 +315,10 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     it "uses singular date and time labels for a single-day event" do
       pacific = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
+      day = 2.weeks.from_now.in_time_zone(pacific)
       event.update!(autoshow_registration_details: true,
-                    start_date: pacific.local(2026, 8, 12, 9),
-                    end_date: pacific.local(2026, 8, 12, 12))
+                    start_date: day.change(hour: 9),
+                    end_date: day.change(hour: 12))
 
       get new_event_public_registration_path(event)
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 one-line test-only date fix, no app logic

### What is the goal of this PR and why is this important?
- The single-day event spec in `public_registrations_spec.rb` hardcoded `2026-08-12`, which has since fallen into the past and made the spec fail on `main` independent of any code change.

### How did you approach the change?
- Replaced the fixed date with `2.weeks.from_now`, matching the sibling multi-day spec so the event stays a valid future single-day event over time.

### UI Testing Checklist
- [ ] N/A — test-only change

### Anything else to add?
- No app code touched; `public_registrations_spec.rb` passes in full (49 examples, 0 failures).
