### PR TITLE
Rename event Manage→Registrations; one shared filter bar across roster, picker & attendees

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -817,7 +817,16 @@ class EventsController < ApplicationController
     # organization linking and readiness are event/form-specific, so they stay on the
     # single-event roster/picker only.)
     ATTENDEE_REGISTRATION_FILTERS.each do |param, scope_name|
-      scope = scope.where(id: registration_scope_person_ids(scope_name, params[param])) if params[param].present?
+      next if params[param].blank?
+      # "No comments" is the one negative among them: matched on any single
+      # registration it lets through anyone who commented on a different one, so ask
+      # the positive scope and exclude — the same shape as "No scholarship" above.
+      # (Scoped to one event the two agree, so this needs no @filter_event branch.)
+      scope = if param == :comment_status && params[param] == NO_COMMENTS
+        scope.where.not(id: registration_scope_person_ids(scope_name, "present"))
+      else
+        scope.where(id: registration_scope_person_ids(scope_name, params[param]))
+      end
     end
 
     scope
@@ -837,6 +846,9 @@ class EventsController < ApplicationController
     comment: :comment_text,
     topic_subscription: :registrant_topic_subscription
   }.freeze
+  # The comment_status value meaning "commented on nothing" — a person-level
+  # question cross-event, unlike every other value in the table above.
+  NO_COMMENTS = "none".freeze
 
   # People behind the attended registrations that match a registration-level scope.
   def registration_scope_person_ids(scope_name, value)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -786,14 +786,24 @@ class EventsController < ApplicationController
     scope = scope.where(id: person_linked_organization_ids(params[:organization_id])) if params[:organization_id].present?
     scope = scope.where(id: person_linked_org_city_ids(params[:org_city])) if params[:org_city].present?
     if params[:scholarship].present?
-      ids = scholarship_recipient_person_ids
-      scope = params[:scholarship] == "no" ? scope.where.not(id: ids) : scope.where(id: ids)
+      # Scoped to one event, every status (including "no") is unambiguous at the
+      # registration level, so reuse the shared scope. Cross-event, "No scholarship"
+      # instead means "never a recipient in any attended registration" — a person-
+      # level question the registration scope can't express — so answer it person-side.
+      scope = if params[:scholarship] == "no" && @filter_event.nil?
+        scope.where.not(id: scholarship_recipient_person_ids)
+      else
+        scope.where(id: scholarship_status_person_ids(params[:scholarship]))
+      end
     end
     if params[:ce].present?
       ids = ce_person_ids
       scope = params[:ce] == "no" ? scope.where.not(id: ids) : scope.where(id: ids)
     end
+    # Address filters read the person's own address data directly (no registration
+    # required) — city is a free-text match, state/county exact.
     scope = scope.where(id: person_address_ids(state: params[:state])) if params[:state].present?
+    scope = scope.where(id: person_address_ids(city: params[:city])) if params[:city].present?
     if params[:county].present?
       # County options carry their state ("STATE::County") so same-named counties
       # across states don't collide.
@@ -801,9 +811,39 @@ class EventsController < ApplicationController
       scope = scope.where(id: person_address_ids(state: county_state, county: county_name))
     end
 
+    # Shared registration-level filters, applied cross-event with "any registration
+    # matches" semantics: reuse each EventRegistration scope against the attended
+    # registrations and keep the people behind the matches. (Submission status,
+    # organization linking and readiness are event/form-specific, so they stay on the
+    # single-event roster/picker only.)
+    ATTENDEE_REGISTRATION_FILTERS.each do |param, scope_name|
+      scope = scope.where(id: registration_scope_person_ids(scope_name, params[param])) if params[param].present?
+    end
+
     scope
       .includes(:affiliations, { sectorable_items: :sector }, { age_range_categorizable_items: { category: :category_type } })
       .order(:first_name, :last_name)
+  end
+
+  # param => EventRegistration scope for the registration-level filters the
+  # cross-event attendees index shares with the registrants roster. (payment_status
+  # and funder are already applied to attendee_registrations, so they're not here.)
+  ATTENDEE_REGISTRATION_FILTERS = {
+    payment_method: :payment_method,
+    ce_status: :ce_status,
+    funder_name: :funder_name,
+    account_status: :account_status,
+    comment_status: :comment_status,
+    comment: :comment_text,
+    topic_subscription: :registrant_topic_subscription
+  }.freeze
+
+  # People behind the attended registrations that match a registration-level scope.
+  def registration_scope_person_ids(scope_name, value)
+    EventRegistration
+      .where(id: attendee_registrations.select(:id))
+      .public_send(scope_name, value)
+      .select(:registrant_id)
   end
 
   def person_sector_ids(sector_id)
@@ -873,6 +913,15 @@ class EventsController < ApplicationController
       .select(:registrant_id)
   end
 
+  # People behind the attended registrations whose scholarship matches a recipient
+  # sub-status (yes/agreed/complete/incomplete), via the shared scope.
+  def scholarship_status_person_ids(value)
+    EventRegistration
+      .where(id: attendee_registrations.select(:id))
+      .scholarship_status(value)
+      .select(:registrant_id)
+  end
+
   def ce_person_ids
     EventRegistration
       .where(id: ContinuingEducationRegistration.where(event_registration_id: attendee_registrations.select(:id)).select(:event_registration_id))
@@ -885,10 +934,18 @@ class EventsController < ApplicationController
     Affiliation.with_status(status).select(:person_id)
   end
 
-  def person_address_ids(state: nil, county: nil)
+  # Person ids behind active person addresses, narrowed by any of state, county or
+  # city. City is a free-text LIKE (matching the roster's registrant_city filter),
+  # state/county are exact. Street isn't a filter anywhere yet, but the column
+  # exists — add a `street:` clause here the same way if one is ever needed.
+  def person_address_ids(state: nil, county: nil, city: nil)
     scope = Address.active.where(addressable_type: "Person")
     scope = scope.where(state: state) if state.present?
     scope = scope.where(county: county) if county.present?
+    if city.present?
+      like = "%#{Address.sanitize_sql_like(city.downcase.strip)}%"
+      scope = scope.where("LOWER(addresses.city) LIKE ?", like)
+    end
     scope.select(:addressable_id)
   end
 
@@ -903,6 +960,7 @@ class EventsController < ApplicationController
     addresses = Address.active.where(addressable_type: "Person", addressable_id: person_ids)
     @attendee_states = addresses.where.not(state: [ nil, "" ]).distinct.pluck(:state).sort
     @attendee_counties = addresses.where.not(county: [ nil, "" ]).where.not(state: [ nil, "" ]).distinct.pluck(:state, :county).sort
+    @attendee_topic_types = TopicSubscriptionType.active.ordered
   end
 
   def invite_mode?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -797,9 +797,13 @@ class EventsController < ApplicationController
       end
     end
     # Address filters read the person's own address data directly (no registration
-    # required) — city is a free-text match, state/county exact.
-    scope = scope.where(id: person_address_ids(state: params[:state])) if params[:state].present?
-    scope = scope.where(id: person_address_ids(city: params[:city])) if params[:city].present?
+    # required) — city is a free-text match, state/county exact. City and state ask
+    # one subquery so they describe the same address, matching the roster's shared
+    # join; two subqueries would let someone with homes in two states through on a
+    # city from one and a state from the other.
+    if params[:state].present? || params[:city].present?
+      scope = scope.where(id: person_address_ids(state: params[:state], city: params[:city]))
+    end
     if params[:county].present?
       # County options carry their state ("STATE::County") so same-named counties
       # across states don't collide.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -796,10 +796,6 @@ class EventsController < ApplicationController
         scope.where(id: scholarship_status_person_ids(params[:scholarship]))
       end
     end
-    if params[:ce].present?
-      ids = ce_person_ids
-      scope = params[:ce] == "no" ? scope.where.not(id: ids) : scope.where(id: ids)
-    end
     # Address filters read the person's own address data directly (no registration
     # required) — city is a free-text match, state/county exact.
     scope = scope.where(id: person_address_ids(state: params[:state])) if params[:state].present?
@@ -817,15 +813,18 @@ class EventsController < ApplicationController
     # organization linking and readiness are event/form-specific, so they stay on the
     # single-event roster/picker only.)
     ATTENDEE_REGISTRATION_FILTERS.each do |param, scope_name|
-      next if params[param].blank?
-      # "No comments" is the one negative among them: matched on any single
-      # registration it lets through anyone who commented on a different one, so ask
-      # the positive scope and exclude — the same shape as "No scholarship" above.
-      # (Scoped to one event the two agree, so this needs no @filter_event branch.)
-      scope = if param == :comment_status && params[param] == NO_COMMENTS
-        scope.where.not(id: registration_scope_person_ids(scope_name, "present"))
+      value = params[param].presence
+      next if value.nil?
+      # A value asking for an absence ("No comments", "No CE") can't be matched one
+      # registration at a time: that lets through anyone who commented — or took CE —
+      # on a different one. Ask the positive scope and exclude instead, the same shape
+      # as "No scholarship" above. (Scoped to one event the two readings agree, so
+      # this needs no @filter_event branch.)
+      positive = ATTENDEE_NEGATIVE_FILTER_VALUES[[ param, value ]]
+      scope = if positive
+        scope.where.not(id: registration_scope_person_ids(scope_name, positive))
       else
-        scope.where(id: registration_scope_person_ids(scope_name, params[param]))
+        scope.where(id: registration_scope_person_ids(scope_name, value))
       end
     end
 
@@ -846,9 +845,13 @@ class EventsController < ApplicationController
     comment: :comment_text,
     topic_subscription: :registrant_topic_subscription
   }.freeze
-  # The comment_status value meaning "commented on nothing" — a person-level
-  # question cross-event, unlike every other value in the table above.
-  NO_COMMENTS = "none".freeze
+  # [ param, value ] => the positive value to ask for and exclude. These are the
+  # values that assert an absence about the person, which cross-event can only be
+  # answered by inverting the positive set — see the loop above.
+  ATTENDEE_NEGATIVE_FILTER_VALUES = {
+    [ :comment_status, "none" ] => "present",
+    [ :ce_status, EventRegistration::NO_CE ] => "registered"
+  }.freeze
 
   # People behind the attended registrations that match a registration-level scope.
   def registration_scope_person_ids(scope_name, value)
@@ -931,12 +934,6 @@ class EventsController < ApplicationController
     EventRegistration
       .where(id: attendee_registrations.select(:id))
       .scholarship_status(value)
-      .select(:registrant_id)
-  end
-
-  def ce_person_ids
-    EventRegistration
-      .where(id: ContinuingEducationRegistration.where(event_registration_id: attendee_registrations.select(:id)).select(:event_registration_id))
       .select(:registrant_id)
   end
 

--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -65,8 +65,12 @@ export default class extends Controller {
   clearAndSubmit(event) {
     event.preventDefault();
 
+    // Clear to empty rather than calling form.reset(): a page reached with its
+    // filters already in the URL renders them as value/selected attributes, which
+    // are exactly what reset() restores — so resetting puts back the filters we
+    // just cleared and "Clear filters" re-submits them.
     this.element
-      .querySelectorAll('input[type="text"], input[type="search"]')
+      .querySelectorAll('input[type="text"], input[type="search"], input[type="date"]')
       .forEach((input) => {
         input.value = "";
       });
@@ -81,11 +85,10 @@ export default class extends Controller {
         }
         input.checked = false;
       });
-    this.element.reset();
 
-    // TomSelect (remote-select) renders its own UI and ignores selectedIndex and
-    // form.reset(), so clear each enhanced control explicitly. Silent clear avoids
-    // a redundant submit before the one below.
+    // TomSelect (remote-select) renders its own UI and ignores selectedIndex, so
+    // clear each enhanced control explicitly. Silent clear avoids a redundant
+    // submit before the one below.
     this.element.querySelectorAll("select").forEach((select) => {
       if (select.tomselect) select.tomselect.clear(true);
     });

--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -74,8 +74,16 @@ export default class extends Controller {
       .forEach((input) => {
         input.value = "";
       });
+    // Index 0 is the neutral state only for a select with a placeholder first
+    // option. One rendered pre-selected (no include_blank) leads with a real value,
+    // so it says what it clears to via data-clear-to.
     this.element.querySelectorAll("select").forEach((select) => {
-      select.selectedIndex = 0;
+      const { clearTo } = select.dataset;
+      if (clearTo === undefined) {
+        select.selectedIndex = 0;
+      } else {
+        select.value = clearTo;
+      }
     });
     this.element
       .querySelectorAll('input[type="checkbox"], input[type="radio"]')

--- a/app/frontend/javascript/controllers/reveal_section_controller.js
+++ b/app/frontend/javascript/controllers/reveal_section_controller.js
@@ -24,5 +24,11 @@ export default class extends Controller {
       this.toggleTarget.click()
     }
     this.element.scrollIntoView({ behavior: "smooth", block: "start" })
+    // Drop the hash once it has been honoured. A section inside a lazily-loaded
+    // frame reconnects on every frame render (each filter change), and a Turbo
+    // frame submit never touches the address bar — so the hash would still match
+    // and pull the page back here for the rest of the visit.
+    const { pathname, search } = window.location
+    history.replaceState(history.state, "", pathname + search)
   }
 }

--- a/app/frontend/javascript/controllers/reveal_section_controller.js
+++ b/app/frontend/javascript/controllers/reveal_section_controller.js
@@ -11,6 +11,9 @@ import { Controller } from "@hotwired/stimulus"
 //
 // The toggle target is clicked (reusing the dropdown controller) only when the
 // content is currently hidden, keeping the dropdown's open/closed state honest.
+// Both targets are optional: with neither, this is a scroll-to-my-anchor on
+// connect, which is what a section arriving inside a lazily-loaded Turbo frame
+// needs (the browser resolved the hash long before the frame's content existed).
 export default class extends Controller {
   static targets = ["toggle", "content"]
   static values = { anchor: String }

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -178,6 +178,18 @@ module EventsHelper
     }.compact
   end
 
+  # Reports hub filters → attendees index query params, plus the reports origin so
+  # the index's eyebrow comes back here. The index defaults its event-type filter
+  # to facilitator trainings, so a hub scoped to an event of any other type would
+  # drill in to an empty list — when one event is the scope it already answers the
+  # question the event-type filter asks, so pin that filter open.
+  def hub_to_attendees_params(extra = {})
+    attendees_params = hub_to_report_params.merge(return_to: "reports")
+    attendees_params[:event_type] ||= EventRegistration::FILTER_ALL if attendees_params[:event_id].present?
+    attendees_params[:event_year] = time_period_to_event_year(attendees_params.delete(:time_period))
+    attendees_params.compact.merge(extra)
+  end
+
   # Full report filters → reports hub query params.
   def report_to_hub_params
     {
@@ -186,6 +198,16 @@ module EventsHelper
       event_id: params[:event_id].presence,
       period: time_period_to_hub_period(@time_period)
     }.compact
+  end
+
+  # Report time_period → the attendees index's `event_year` filter. The index has
+  # no time_period vocabulary of its own — it narrows by the event's calendar year
+  # (the same translation the participation card's figure links already do) — so
+  # passing time_period through would silently drop the period. "all_time" is nil,
+  # which leaves the year filter open.
+  def time_period_to_event_year(time_period)
+    return Date.current.year.to_s if time_period == "this_year"
+    time_period if Integer(time_period, exception: false)
   end
 
   # "last_year" becomes the prior calendar year (reports name specific years

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -158,6 +158,10 @@ class EventRegistration < ApplicationRecord
       .where(sectorable_items: { sector_id: sector_id })
       .distinct
   }
+  # Registrant holds an active subscription to the given topic subscription list.
+  scope :registrant_topic_subscription, ->(type_id) {
+    where(registrant_id: TopicSubscription.active.where(topic_subscription_type_id: type_id).select(:person_id)).distinct
+  }
   scope :with_scholarship, -> {
     where(<<~SQL.squish)
       EXISTS (
@@ -194,9 +198,20 @@ class EventRegistration < ApplicationRecord
       )
     SQL
   }
+  scope :without_scholarship, -> {
+    where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1 FROM allocations
+        WHERE allocations.allocatable_type = 'EventRegistration'
+          AND allocations.allocatable_id = event_registrations.id
+          AND allocations.source_type = 'Scholarship'
+      )
+    SQL
+  }
   scope :scholarship_status, ->(value) {
     case value
     when "yes" then with_scholarship
+    when "no" then without_scholarship
     when "agreed" then with_agreed_scholarship
     when "complete" then scholarship_tasks_completed
     when "incomplete" then scholarship_tasks_incomplete

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -70,6 +70,43 @@ class EventRegistration < ApplicationRecord
     [ "Grant-funded", "external" ],
     [ "Org-subsidized", "awbw" ]
   ].freeze
+  # Scholarship-status filter options (the .scholarship_status scope's vocabulary).
+  SCHOLARSHIP_STATUS_FILTER_OPTIONS = [
+    [ "All recipients", "yes" ],
+    [ "Agreed", "agreed" ],
+    [ "Tasks complete", "complete" ],
+    [ "Tasks not complete", "incomplete" ],
+    [ "No scholarship", "no" ]
+  ].freeze
+  # The ce_status value meaning "never signed up for CE" — the only one that asks
+  # about the absence of a CE registration rather than its stage.
+  NO_CE = "none".freeze
+  # CE-status filter options (the .ce_status scope's vocabulary). Issued/not issued
+  # are worded as the certificate's state because they read as overlapping
+  # otherwise — one person can match both across two registrations.
+  CE_STATUS_FILTER_OPTIONS = [
+    [ "Registered for CE", "registered" ],
+    [ "Requested", "requested" ],
+    [ "Needs license", "needs_license" ],
+    [ "Paid", "paid" ],
+    [ "Certificate issued", "issued" ],
+    [ "Certificate outstanding", "not_issued" ],
+    [ "No CE", NO_CE ]
+  ].freeze
+  # Login-account filter options (the .account_status scope's vocabulary).
+  ACCOUNT_STATUS_FILTER_OPTIONS = [
+    [ "No account", "none" ],
+    [ "Not invited yet", "not_invited" ],
+    [ "Invited", "invited" ],
+    [ "Has access", "has_access" ],
+    [ "No access", "no_access" ]
+  ].freeze
+  # Comment filter options (the .comment_status scope's vocabulary).
+  COMMENT_STATUS_FILTER_OPTIONS = [
+    [ "None", "none" ],
+    [ "Present", "present" ],
+    [ "Flagged", "flagged" ]
+  ].freeze
 
   # Human labels for each attendance status — the single source of truth for
   # status display (badges, filters, the dashboard breakdown).
@@ -313,9 +350,7 @@ class EventRegistration < ApplicationRecord
   # issued/not_issued read the certificate delivery; needs_license is a CE
   # registration sitting on a placeholder license. "registered" adds no condition
   # of its own — the EXISTS alone means "signed up for CE, whatever its state".
-  # The ce_status value meaning "never signed up for CE" — the only one that asks
-  # about the absence of a CE registration rather than its stage.
-  NO_CE = "none".freeze
+  # NO_CE is the one value asking about the absence of a CE registration.
   scope :ce_status, ->(value) {
     paid_sql = <<~SQL.squish
       COALESCE((SELECT SUM(a.amount) FROM allocations a

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -313,6 +313,9 @@ class EventRegistration < ApplicationRecord
   # issued/not_issued read the certificate delivery; needs_license is a CE
   # registration sitting on a placeholder license. "registered" adds no condition
   # of its own — the EXISTS alone means "signed up for CE, whatever its state".
+  # The ce_status value meaning "never signed up for CE" — the only one that asks
+  # about the absence of a CE registration rather than its stage.
+  NO_CE = "none".freeze
   scope :ce_status, ->(value) {
     paid_sql = <<~SQL.squish
       COALESCE((SELECT SUM(a.amount) FROM allocations a
@@ -327,11 +330,17 @@ class EventRegistration < ApplicationRecord
       when "requested" then "NOT (#{paid_sql})"
       when "issued" then "cer.certificate_sent_at IS NOT NULL"
       when "not_issued" then "cer.certificate_sent_at IS NULL"
+      when NO_CE then "TRUE"
       end
     next all if condition.blank?
 
+    # "No CE" is the one value that asks for the absence of a CE registration, so it
+    # negates the same EXISTS the others qualify. The license join never drops a row
+    # (professional_license_id is NOT NULL), so "registered" and NO_CE are exact
+    # complements.
+    existence = value == NO_CE ? "NOT EXISTS" : "EXISTS"
     where(<<~SQL.squish)
-      EXISTS (
+      #{existence} (
         SELECT 1 FROM continuing_education_registrations cer
         JOIN professional_licenses pl ON pl.id = cer.professional_license_id
         WHERE cer.event_registration_id = event_registrations.id

--- a/app/services/attendees_active_filters.rb
+++ b/app/services/attendees_active_filters.rb
@@ -7,7 +7,8 @@
 # event, year, sector, program status, affiliation status, and the registration-level
 # filters shared with the roster — payment method, scholarship, funder name, CE
 # status, user account, topic subscription, city, state, county, comment status and
-# text) are intentionally omitted — the control itself already shows them.
+# text) are intentionally omitted — the control itself already shows them. That's why
+# the CE pie's drill-ins use ce_status rather than a chip-only param.
 class AttendeesActiveFilters
   # Drill-in params in chip display order. Each renders via #label_for. Keep this
   # in step with every param the attendees index narrows on: a param the index
@@ -15,7 +16,7 @@ class AttendeesActiveFilters
   # filter form's hidden fields on the next change, since both read this list.
   CHIP_PARAMS = %w[
     registrant_ids organization_id org_city age_group life_experience setting
-    country school_district ce payment_status funder
+    country school_district payment_status funder
   ].freeze
   # The roster has no filter form at all, so every drill-in it accepts needs a
   # chip — including the two the index leaves out because it has controls for them.
@@ -52,7 +53,6 @@ class AttendeesActiveFilters
     when "setting" then record_label("Setting", Category, value)
     when "country" then "Country: #{value}"
     when "school_district" then "School district: #{value}"
-    when "ce" then value == "no" ? "No continuing education" : "Continuing education"
     when "payment_status" then option_label("Payment", EventRegistration::PAYMENT_STATUS_FILTER_OPTIONS, value)
     when "funder" then option_label("Funding", EventRegistration::FUNDER_FILTER_OPTIONS, value)
     end

--- a/app/services/attendees_active_filters.rb
+++ b/app/services/attendees_active_filters.rb
@@ -3,9 +3,11 @@
 # (they arrive from a chart-row click, the participation summary, or a shared
 # link). The index surfaces each as a removable chip so an admin can see and
 # clear a filter that would otherwise silently shrink the list. Params that
-# already have their own visible control (contact_info, event, sector, program
-# status, affiliation status, state, county) are intentionally omitted — the
-# control itself already shows them.
+# already have their own visible control in events/_attendees_search (contact_info,
+# event, year, sector, program status, affiliation status, and the registration-level
+# filters shared with the roster — payment method, scholarship, funder name, CE
+# status, user account, topic subscription, city, state, county, comment status and
+# text) are intentionally omitted — the control itself already shows them.
 class AttendeesActiveFilters
   # Drill-in params in chip display order. Each renders via #label_for. Keep this
   # in step with every param the attendees index narrows on: a param the index
@@ -13,7 +15,7 @@ class AttendeesActiveFilters
   # filter form's hidden fields on the next change, since both read this list.
   CHIP_PARAMS = %w[
     registrant_ids organization_id org_city age_group life_experience setting
-    country school_district scholarship ce payment_status funder
+    country school_district ce payment_status funder
   ].freeze
   # The roster has no filter form at all, so every drill-in it accepts needs a
   # chip — including the two the index leaves out because it has controls for them.
@@ -50,7 +52,6 @@ class AttendeesActiveFilters
     when "setting" then record_label("Setting", Category, value)
     when "country" then "Country: #{value}"
     when "school_district" then "School district: #{value}"
-    when "scholarship" then value == "no" ? "No scholarship" : "Scholarship recipients"
     when "ce" then value == "no" ? "No continuing education" : "Continuing education"
     when "payment_status" then option_label("Payment", EventRegistration::PAYMENT_STATUS_FILTER_OPTIONS, value)
     when "funder" then option_label("Funding", EventRegistration::FUNDER_FILTER_OPTIONS, value)

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     <% elsif params[:return_to] == "roster" %>
       <%= link_to roster_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
-        <i class="fa-solid fa-arrow-left text-xs"></i> Registrant roster
+        <i class="fa-solid fa-arrow-left text-xs"></i> Roster
       <% end %>
     <%# Two ways in from the recipients page: a recipient's name (back to their own
         card) and the feature-a-shout-out flow (back to the shout-outs section). %>

--- a/app/views/events/_attendees_chips.html.erb
+++ b/app/views/events/_attendees_chips.html.erb
@@ -1,0 +1,21 @@
+<%# The attendees index's applied drill-in filters, as removable chips. Rendered
+    into the filter bar on the shell and replaced out-of-band by the results frame
+    on every filter change: the bar sits outside that frame, so the remove links
+    would otherwise keep pointing at the params the page loaded with and drop
+    whatever the admin has filtered on since. The wrapper renders even with no
+    chips so the frame always has something to replace. %>
+<div id="attendees_chips" class="ml-auto flex flex-wrap items-center justify-end gap-2">
+  <% active_filters = AttendeesActiveFilters.new(params).chips %>
+  <% if active_filters.any? %>
+    <span class="text-xs font-semibold uppercase text-gray-500 tracking-wide">Applied</span>
+    <% active_filters.each do |filter| %>
+      <span class="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+        <%= filter[:label] %>
+        <%= link_to attendees_events_path(request.query_parameters.except("page", filter[:param])),
+              class: "text-blue-400 hover:text-blue-700", aria: { label: "Remove #{filter[:label]} filter" } do %>
+          <i class="fa-solid fa-xmark"></i>
+        <% end %>
+      </span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/events/_attendees_search.html.erb
+++ b/app/views/events/_attendees_search.html.erb
@@ -108,7 +108,7 @@
         placeholder: "Funder name", field_class: field_class %>
 
   <%= render "events/filter_select", param: :ce_status, label: "CE status",
-        options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
+        options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Certificate issued", "issued" ], [ "Certificate outstanding", "not_issued" ], [ "No CE", "none" ] ],
         selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
 
   <%= render "events/filter_select", param: :account_status, label: "User account",

--- a/app/views/events/_attendees_search.html.erb
+++ b/app/views/events/_attendees_search.html.erb
@@ -40,14 +40,18 @@
   <%# Attendance and event type default to "attended" / "trainings" — the population
       this page has always shown — so the neutral "All …" is the first option rather
       than a blank placeholder. These two plus the search make up the primary row,
-      mirroring the registrants bar's search + attendance + payment status. %>
+      mirroring the registrants bar's search + attendance + payment status. They
+      clear back to that default population rather than to the "All …" they lead
+      with, since the default is what this page means by unfiltered. %>
   <%= render "events/filter_select", param: :attendance_status, label: "Attendance",
         options: [ [ "All outcomes", EventRegistration::FILTER_ALL ] ] + EventRegistration::ATTENDANCE_FILTER_OPTIONS,
-        selected: @attendance_status, blank: nil, field_class: field_class, wrapper_class: "w-full md:w-40" %>
+        selected: @attendance_status, blank: nil, clear_to: EventsController::DEFAULT_ATTENDANCE_STATUS,
+        field_class: field_class, wrapper_class: "w-full md:w-40" %>
 
   <%= render "events/filter_select", param: :event_type, label: "Event type",
         options: [ [ "All events", EventRegistration::FILTER_ALL ] ] + EventRegistration::EVENT_TYPE_FILTER_OPTIONS,
-        selected: @attendee_event_type, blank: nil, field_class: field_class, wrapper_class: "w-full md:w-52" %>
+        selected: @attendee_event_type, blank: nil, clear_to: EventsController::DEFAULT_ATTENDEE_EVENT_TYPE,
+        field_class: field_class, wrapper_class: "w-full md:w-52" %>
 <% end %>
 
 <% more = capture do %>

--- a/app/views/events/_attendees_search.html.erb
+++ b/app/views/events/_attendees_search.html.erb
@@ -87,7 +87,7 @@
         selected: params[:payment_method], blank: "Any payment method", field_class: field_class %>
 
   <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
-        options: [ [ "All recipients", "yes" ], [ "Agreed", "agreed" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ], [ "No scholarship", "no" ] ],
+        options: EventRegistration::SCHOLARSHIP_STATUS_FILTER_OPTIONS,
         selected: params[:scholarship], blank: "Any status", field_class: field_class %>
 
   <%# Free-text on the funder behind a scholarship. Param :funder_name stays clear
@@ -96,11 +96,11 @@
         placeholder: "Funder name", field_class: field_class %>
 
   <%= render "events/filter_select", param: :ce_status, label: "CE status",
-        options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Certificate issued", "issued" ], [ "Certificate outstanding", "not_issued" ], [ "No CE", "none" ] ],
+        options: EventRegistration::CE_STATUS_FILTER_OPTIONS,
         selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
 
   <%= render "events/filter_select", param: :account_status, label: "User account",
-        options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+        options: EventRegistration::ACCOUNT_STATUS_FILTER_OPTIONS,
         selected: params[:account_status], blank: "Any account status", field_class: field_class %>
 
   <% if @attendee_topic_types.any? %>
@@ -121,7 +121,7 @@
         selected: params[:county], blank: "All counties", field_class: field_class, wrapper_class: "w-full md:w-52" %>
 
   <%= render "events/filter_select", param: :comment_status, label: "Comment status",
-        options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+        options: EventRegistration::COMMENT_STATUS_FILTER_OPTIONS,
         selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
 
   <%= render "events/filter_text", param: :comment, label: "Comment text",

--- a/app/views/events/_attendees_search.html.erb
+++ b/app/views/events/_attendees_search.html.erb
@@ -24,23 +24,7 @@
   <% end %>
 <% end %>
 
-<% chips = capture do %>
-  <% active_filters = AttendeesActiveFilters.new(params).chips %>
-  <% if active_filters.any? %>
-    <div class="flex flex-wrap items-center justify-end gap-2">
-      <span class="text-xs font-semibold uppercase text-gray-500 tracking-wide">Applied</span>
-      <% active_filters.each do |filter| %>
-        <span class="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
-          <%= filter[:label] %>
-          <%= link_to attendees_events_path(request.query_parameters.except("page", filter[:param])),
-                class: "text-blue-400 hover:text-blue-700", aria: { label: "Remove #{filter[:label]} filter" } do %>
-            <i class="fa-solid fa-xmark"></i>
-          <% end %>
-        </span>
-      <% end %>
-    </div>
-  <% end %>
-<% end %>
+<% chips = render "events/attendees_chips" %>
 
 <% primary = capture do %>
   <div class="w-full md:flex-1 md:min-w-[14rem]">

--- a/app/views/events/_attendees_search.html.erb
+++ b/app/views/events/_attendees_search.html.erb
@@ -1,23 +1,33 @@
-<%# Filters for the attendees index. Submits into the results frame; the
-    selects auto-submit on change and the text search on enter/click. `return_to`
-    rides along so the eyebrow keeps pointing back to wherever the admin arrived
-    from. %>
-<% select_class = "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500 has-[option:first-child:checked]:text-gray-400" %>
-<%= form_tag(attendees_events_path, method: :get,
-      data: { controller: "collection", turbo_frame: "attendees_results" },
-      autocomplete: "off",
-      class: "rounded-xl border border-gray-200 bg-white p-4 shadow-sm mb-6") do %>
+<%# Filters for the cross-event attendees index, rendered through the shared
+    events/_filter_bar shell so it reads consistently with the registrants roster:
+    a minimal primary row (search + attendance outcome) with the rest collapsed in
+    the "More filters" drawer. Selects auto-submit into the results frame via the
+    collection controller; the drill-in params (chips) ride as hidden fields and are
+    surfaced/cleared by the chip row. Reads the @attendee_* ivars set by
+    EventsController#attendees. %>
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<%# Open the drawer on load when any collapsed filter already carries a value, so an
+    active filter is never hidden behind the toggle. %>
+<% collapsed_keys = %i[event_id event_year sector program_status affiliation_status payment_method scholarship funder_name ce_status account_status topic_subscription city state county comment_status comment] %>
+<% more_active = collapsed_keys.any? { |k| params[k].present? } %>
+
+<%# Keep drill-in filters applied while the admin tweaks a visible select — the
+    auto-submit only sends this form's fields, so the drill-ins ride as hidden
+    inputs and are surfaced (and cleared) via the chip row below. `return_to` rides
+    along too: the results frame's own links (the charts frame and its breakdown
+    drill-ins) are built from the frame request's params, so dropping it here would
+    lose the origin the eyebrow points back to. %>
+<% hidden = capture do %>
   <%= hidden_field_tag :return_to, params[:return_to] %>
-  <%# Keep drill-in filters applied while the admin tweaks a visible select — the
-      auto-submit only sends this form's fields, so the drill-ins ride as hidden
-      inputs and are surfaced (and cleared) via the chip row below. %>
   <% AttendeesActiveFilters::CHIP_PARAMS.each do |param| %>
     <%= hidden_field_tag param, params[param] if params[param].present? %>
   <% end %>
+<% end %>
 
+<% chips = capture do %>
   <% active_filters = AttendeesActiveFilters.new(params).chips %>
   <% if active_filters.any? %>
-    <div class="flex flex-wrap items-center gap-2 mb-4">
+    <div class="flex flex-wrap items-center justify-end gap-2">
       <span class="text-xs font-semibold uppercase text-gray-500 tracking-wide">Applied</span>
       <% active_filters.each do |filter| %>
         <span class="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
@@ -30,96 +40,106 @@
       <% end %>
     </div>
   <% end %>
+<% end %>
 
-  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
-    <div class="w-full md:flex-1 md:min-w-[14rem]">
-      <%= label_tag :contact_info, "Name, email, or phone", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <div class="relative">
-        <%= text_field_tag :contact_info, params[:contact_info],
-              class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 pr-10 focus:ring-blue-500 focus:border-blue-500" %>
-        <button type="submit" class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
-          <i class="fa fa-search"></i>
-        </button>
-      </div>
-    </div>
-
-    <%# Attendance outcome and event type default to "attended" / "trainings" — the
-        population this page has always shown. Rendered pre-selected rather than as a
-        blank "All" so the default filter is visible instead of hidden. %>
-    <div class="w-full md:w-40">
-      <%= label_tag :attendance_status, "Attendance", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :attendance_status,
-            options_for_select([ [ "All outcomes", EventRegistration::FILTER_ALL ] ] + EventRegistration::ATTENDANCE_FILTER_OPTIONS, @attendance_status),
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-52">
-      <%= label_tag :event_type, "Event type", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :event_type,
-            options_for_select([ [ "All events", EventRegistration::FILTER_ALL ] ] + EventRegistration::EVENT_TYPE_FILTER_OPTIONS, @attendee_event_type),
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-52">
-      <%= label_tag :event_id, "Event", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :event_id,
-            options_from_collection_for_select(@attendee_event_options, :id, :time_title, params[:event_id].to_i),
-            include_blank: "All events",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-32">
-      <%= label_tag :event_year, "Year", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :event_year,
-            options_for_select(@attendee_years.map { |year| [ year.to_s, year ] }, params[:event_year].presence&.to_i),
-            include_blank: "All years",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-44">
-      <%= label_tag :sector, "Sector", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :sector,
-            options_from_collection_for_select(@attendee_sectors, :id, :name, params[:sector].to_i),
-            include_blank: "All sectors",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-44">
-      <%= label_tag :program_status, "Program status", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :program_status,
-            options_for_select(Organization::FACILITATOR_PROGRAM_STATUSES.map { |status| [ status.to_s.titleize, status.to_s ] }, params[:program_status]),
-            include_blank: "All program statuses",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-40">
-      <%= label_tag :affiliation_status, "Affiliation status", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :affiliation_status,
-            options_for_select(Affiliation::FILTER_STATUSES, params[:affiliation_status]),
-            include_blank: "All statuses",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-32">
-      <%= label_tag :state, "State", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :state,
-            options_for_select(@attendee_states, params[:state]),
-            include_blank: "All states",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-52">
-      <%= label_tag :county, "County", class: "block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" %>
-      <%= select_tag :county,
-            options_for_select(@attendee_counties.map { |state, county| [ "#{county} (#{state})", "#{state}::#{county}" ] }, params[:county]),
-            include_blank: "All counties",
-            class: select_class, onchange: "this.form.submit();" %>
-    </div>
-
-    <div class="w-full md:w-auto flex justify-end">
-      <%= link_to "Clear filters", attendees_events_path,
-            class: "btn btn-utility-outline",
-            data: { action: "collection#clearAndSubmit" } %>
+<% primary = capture do %>
+  <div class="w-full md:flex-1 md:min-w-[14rem]">
+    <%= label_tag :contact_info, "Name, email, or phone", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <div class="relative">
+      <%= text_field_tag :contact_info, params[:contact_info], class: "#{field_class} pr-10" %>
+      <button type="submit" class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
+        <i class="fa fa-search"></i>
+      </button>
     </div>
   </div>
+
+  <%# Attendance and event type default to "attended" / "trainings" — the population
+      this page has always shown — so the neutral "All …" is the first option rather
+      than a blank placeholder. These two plus the search make up the primary row,
+      mirroring the registrants bar's search + attendance + payment status. %>
+  <%= render "events/filter_select", param: :attendance_status, label: "Attendance",
+        options: [ [ "All outcomes", EventRegistration::FILTER_ALL ] ] + EventRegistration::ATTENDANCE_FILTER_OPTIONS,
+        selected: @attendance_status, blank: nil, field_class: field_class, wrapper_class: "w-full md:w-40" %>
+
+  <%= render "events/filter_select", param: :event_type, label: "Event type",
+        options: [ [ "All events", EventRegistration::FILTER_ALL ] ] + EventRegistration::EVENT_TYPE_FILTER_OPTIONS,
+        selected: @attendee_event_type, blank: nil, field_class: field_class, wrapper_class: "w-full md:w-52" %>
 <% end %>
+
+<% more = capture do %>
+  <%= render "events/filter_select", param: :event_id, label: "Event",
+        options: @attendee_event_options.map { |event| [ event.time_title, event.id ] },
+        selected: params[:event_id].to_i, blank: "All events", field_class: field_class, wrapper_class: "w-full md:w-52" %>
+
+  <%= render "events/filter_select", param: :event_year, label: "Year",
+        options: @attendee_years.map { |year| [ year.to_s, year ] },
+        selected: params[:event_year].presence&.to_i, blank: "All years", field_class: field_class, wrapper_class: "w-full md:w-32" %>
+
+  <%= render "events/filter_select", param: :sector, label: "Sector",
+        options: @attendee_sectors.map { |sector| [ sector.name, sector.id ] },
+        selected: params[:sector].to_i, blank: "All sectors", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :program_status, label: "Program status",
+        options: Organization::FACILITATOR_PROGRAM_STATUSES.map { |status| [ status.to_s.titleize, status.to_s ] },
+        selected: params[:program_status], blank: "All program statuses", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :affiliation_status, label: "Affiliation status",
+        options: Affiliation::FILTER_STATUSES,
+        selected: params[:affiliation_status], blank: "All statuses", field_class: field_class, wrapper_class: "w-full md:w-40" %>
+
+  <%# The registration-level filters shared with the registrants roster (see
+      EventsController::ATTENDEE_REGISTRATION_FILTERS), in the roster's own order so
+      the two bars read the same. Cross-event they match on any attended
+      registration, and none of them is gated on the event's cost or CE eligibility
+      the way the single-event roster gates them. Every param the index narrows on
+      needs a control here or a chip in AttendeesActiveFilters::CHIP_PARAMS —
+      otherwise it shrinks the list silently and is dropped on the next change. %>
+  <%= render "events/filter_select", param: :payment_method, label: "Payment method",
+        options: EventRegistrationDecorator.payment_method_filter_choices,
+        selected: params[:payment_method], blank: "Any payment method", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
+        options: [ [ "All recipients", "yes" ], [ "Agreed", "agreed" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ], [ "No scholarship", "no" ] ],
+        selected: params[:scholarship], blank: "Any status", field_class: field_class %>
+
+  <%# Free-text on the funder behind a scholarship. Param :funder_name stays clear
+      of the awbw/external :funder funding-source drill-in. %>
+  <%= render "events/filter_text", param: :funder_name, label: "Funder",
+        placeholder: "Funder name", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :ce_status, label: "CE status",
+        options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
+        selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :account_status, label: "User account",
+        options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+        selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+
+  <% if @attendee_topic_types.any? %>
+    <%= render "events/filter_select", param: :topic_subscription, label: "Topic subscription list",
+          options: @attendee_topic_types.map { |type| [ type.name, type.id ] },
+          selected: params[:topic_subscription], blank: "Any topic", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_text", param: :city, label: "City",
+        placeholder: "City name", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :state, label: "State",
+        options: @attendee_states,
+        selected: params[:state], blank: "All states", field_class: field_class, wrapper_class: "w-full md:w-32" %>
+
+  <%= render "events/filter_select", param: :county, label: "County",
+        options: @attendee_counties.map { |state, county| [ "#{county} (#{state})", "#{state}::#{county}" ] },
+        selected: params[:county], blank: "All counties", field_class: field_class, wrapper_class: "w-full md:w-52" %>
+
+  <%= render "events/filter_select", param: :comment_status, label: "Comment status",
+        options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+        selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
+
+  <%= render "events/filter_text", param: :comment, label: "Comment text",
+        placeholder: "Topic or content", field_class: field_class %>
+<% end %>
+
+<%= render "events/filter_bar", url: attendees_events_path, frame: "attendees_results",
+      clear_url: attendees_events_path, more_active: more_active,
+      hidden: hidden, applied: chips, primary: primary, more: more %>

--- a/app/views/events/_charts_toggle_bar.html.erb
+++ b/app/views/events/_charts_toggle_bar.html.erb
@@ -10,6 +10,9 @@
                which already spaces itself. %>
 <div class="flex flex-wrap items-center justify-end gap-2 <%= local_assigns.fetch(:margin, "mb-3") %> print:hidden">
   <% buttons.each do |button| %>
+    <%# Styled as a text toggle (not a pill button), matching the "More filters"
+        control: a chevron rotates up when its panel is open (driven by the
+        aria-expanded panel-toggle keeps in sync). %>
     <button type="button"
             data-panel-toggle-target="button"
             data-panel-toggle-name="<%= button[:name] %>"
@@ -17,9 +20,10 @@
             data-panel-toggle-hidden-label="<%= button[:hidden_label] %>"
             data-action="panel-toggle#toggle"
             aria-expanded="<%= button[:expanded] %>"
-            class="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-800">
+            class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700">
       <i class="fa-solid <%= button[:icon] %>"></i>
       <span data-panel-toggle-target="label"><%= button[:expanded] ? button[:shown_label] : button[:hidden_label] %></span>
+      <i class="fa-solid fa-chevron-down text-xs transition-transform in-aria-expanded:rotate-180"></i>
     </button>
   <% end %>
 </div>

--- a/app/views/events/_filter_bar.html.erb
+++ b/app/views/events/_filter_bar.html.erb
@@ -1,0 +1,81 @@
+<%# Shared filter-bar shell for the event registrant/attendee filter forms. A
+    primary row of the most meaningful controls sits beside a "More filters"
+    chevron and "Clear filters"; the rest collapse into a drawer until expanded.
+    Each caller supplies its own fields as captured markup (via events/filter_select
+    and events/filter_text), so the registrants roster, the bulk-reminder picker and
+    the attendees index all read identically while filtering different populations.
+    Locals:
+      url         – form action path
+      frame       – turbo frame id the form submits into
+      clear_url   – "Clear filters" href
+      more_active – start the drawer open (an already-active collapsed filter)
+      primary     – captured markup for the primary row's fields
+      more        – captured markup for the drawer's fields (optional; when blank
+                    the drawer, its toggle and checkbox are omitted entirely)
+      hidden      – captured hidden inputs carried through the GET submit (optional)
+      applied     – captured markup pinned to the right of the "Filters" heading
+                    row, e.g. the applied-filter chip row (optional) %>
+<% hidden = local_assigns.fetch(:hidden, "") %>
+<% applied = local_assigns.fetch(:applied, "") %>
+<% more = local_assigns.fetch(:more, "") %>
+<%# A page with no collapsed fields (e.g. the attendees index shows every filter)
+    skips the drawer, toggle and its checkbox entirely. %>
+<% has_more = more.present? %>
+<%# The "More filters" drawer is a pure-CSS disclosure: a visually-hidden checkbox
+    drives the drawer, chevron and label via :has() on this group wrapper. It's
+    rendered outside the form so the collection controller's change-submit doesn't
+    fire when toggling, and starts checked when a collapsed filter is already active
+    so an active filter is never hidden behind the toggle. %>
+<div class="group mb-6">
+  <% if has_more %>
+    <input type="checkbox" id="more-filters-toggle" class="sr-only"<%= " checked" if more_active %>>
+  <% end %>
+  <%= form_with url: url, method: :get,
+        data: { controller: "collection", turbo_frame: frame },
+        autocomplete: "off",
+        class: "bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
+    <%= hidden %>
+
+    <%# The applied-filter chips share the heading's row, pushed to the far right —
+        they read as a summary of the bar rather than a band above it. They wrap to
+        their own line when the chips outgrow the row. %>
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2 mb-3">
+      <div class="flex items-center gap-2 text-gray-600">
+        <i class="fa-solid fa-filter text-xs"></i>
+        <span class="text-xs font-semibold uppercase tracking-wide">Filters</span>
+      </div>
+      <% if applied.present? %>
+        <div class="ml-auto"><%= applied %></div>
+      <% end %>
+    </div>
+
+    <%# Row 1: the most meaningful filters + More filters toggle + Clear. %>
+    <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
+      <%= primary %>
+
+      <div class="w-full md:w-auto md:ml-auto flex items-end gap-4">
+        <% if has_more %>
+          <label for="more-filters-toggle"
+                 class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition">
+            <span class="group-has-[#more-filters-toggle:checked]:hidden">More filters</span>
+            <span class="hidden group-has-[#more-filters-toggle:checked]:inline">Fewer filters</span>
+            <i class="fa-solid fa-chevron-down text-xs transition-transform group-has-[#more-filters-toggle:checked]:rotate-180"></i>
+          </label>
+        <% end %>
+        <%= link_to "Clear filters", clear_url, class: "btn btn-utility",
+              data: { action: "collection#clearAndSubmit" } %>
+      </div>
+    </div>
+
+    <%# Collapsible: the remaining filters. Shown when the toggle checkbox is
+        checked (via :has() on the group wrapper), which starts checked when a
+        collapsed filter is already active. %>
+    <% if has_more %>
+      <div class="hidden group-has-[#more-filters-toggle:checked]:block">
+        <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
+          <%= more %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/events/_filter_bar.html.erb
+++ b/app/views/events/_filter_bar.html.erb
@@ -18,8 +18,8 @@
 <% hidden = local_assigns.fetch(:hidden, "") %>
 <% applied = local_assigns.fetch(:applied, "") %>
 <% more = local_assigns.fetch(:more, "") %>
-<%# A page with no collapsed fields (e.g. the attendees index shows every filter)
-    skips the drawer, toggle and its checkbox entirely. %>
+<%# Both current callers fill the drawer; a page that passes no collapsed fields
+    skips the drawer, its toggle and the checkbox entirely. %>
 <% has_more = more.present? %>
 <%# The "More filters" drawer is a pure-CSS disclosure: a visually-hidden checkbox
     drives the drawer, chevron and label via :has() on this group wrapper. It's

--- a/app/views/events/_filter_bar.html.erb
+++ b/app/views/events/_filter_bar.html.erb
@@ -13,8 +13,10 @@
       more        – captured markup for the drawer's fields (optional; when blank
                     the drawer, its toggle and checkbox are omitted entirely)
       hidden      – captured hidden inputs carried through the GET submit (optional)
-      applied     – captured markup pinned to the right of the "Filters" heading
-                    row, e.g. the applied-filter chip row (optional) %>
+      applied     – captured markup sharing the "Filters" heading row, e.g. the
+                    applied-filter chip row (optional). It owns its own placement
+                    (ml-auto) so it can be a stable element the results frame
+                    replaces out-of-band. %>
 <% hidden = local_assigns.fetch(:hidden, "") %>
 <% applied = local_assigns.fetch(:applied, "") %>
 <% more = local_assigns.fetch(:more, "") %>
@@ -44,9 +46,7 @@
         <i class="fa-solid fa-filter text-xs"></i>
         <span class="text-xs font-semibold uppercase tracking-wide">Filters</span>
       </div>
-      <% if applied.present? %>
-        <div class="ml-auto"><%= applied %></div>
-      <% end %>
+      <%= applied %>
     </div>
 
     <%# Row 1: the most meaningful filters + More filters toggle + Clear. %>

--- a/app/views/events/_filter_select.html.erb
+++ b/app/views/events/_filter_select.html.erb
@@ -8,7 +8,11 @@
       selected     – currently selected value
       blank        – include_blank placeholder label
       field_class  – Tailwind classes for the <select>
-      wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
+      wrapper_class – optional wrapper width (defaults to the roster's w-48)
+      clear_to     – optional value "Clear filters" resets this select to. Only
+                     needed when the select renders pre-selected (blank: nil), so
+                     its first option is a real value rather than a neutral
+                     placeholder — see collection#clearAndSubmit. %>
 <div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-44") %>">
   <%= label_tag param, label, class: "block text-sm font-medium text-gray-700 mb-1" %>
   <%# Grey the text only while the include_blank placeholder (the first option) is
@@ -16,5 +20,6 @@
   <%= select_tag param,
                  options_for_select(options, selected),
                  include_blank: blank,
+                 data: { clear_to: local_assigns[:clear_to] },
                  class: "#{field_class} has-[option:first-child:checked]:text-gray-400" %>
 </div>

--- a/app/views/events/_panel_cta.html.erb
+++ b/app/views/events/_panel_cta.html.erb
@@ -12,6 +12,8 @@
       section: the section's name, for the accessible label ("Toggle breakdowns")
       open:    whether the panel is open on this render. Default false. %>
 <% open = local_assigns.fetch(:open, false) %>
+<%# Text toggle (not a pill button), matching the "More filters" control: the
+    chevron rotates up when the panel is open, driven by aria-expanded. %>
 <button type="button"
         data-panel-toggle-target="button"
         data-panel-toggle-name="<%= name %>"
@@ -20,6 +22,7 @@
         data-action="panel-toggle#toggle"
         aria-expanded="<%= open %>"
         aria-label="Toggle <%= section %>"
-        class="shrink-0 rounded-md border border-gray-300 bg-white px-2 py-0.5 text-xs font-medium text-gray-600 hover:bg-gray-50 hover:text-gray-800 print:hidden">
+        class="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 print:hidden">
   <span data-panel-toggle-target="label"><%= open ? "Hide" : "Show" %></span>
+  <i class="fa-solid fa-chevron-down text-xs transition-transform in-aria-expanded:rotate-180"></i>
 </button>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -7,15 +7,16 @@
     <div class="flex flex-col items-end gap-1">
       <%= link_to "Details →", participation_events_path(hub_to_report_params),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
-      <%= link_to "Attendees →", attendees_events_path(hub_to_report_params.merge(return_to: "reports")),
+      <%= link_to "Attendees →", attendees_events_path(hub_to_attendees_params),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
       <%# Demographics live next to the people they describe, so this points at the
           attendees index's breakdowns rather than duplicating them here — scoped to
-          the one event when the hub is, cross-event otherwise (hub_to_report_params
-          carries event_id either way). ?charts=1 opens the panel on arrival and the
-          #breakdowns anchor scrolls to it, so the link doesn't land on a collapsed
-          section. return_to keeps the eyebrow pointing back to the reports hub. %>
-      <%= link_to "Breakdowns →", attendees_events_path(hub_to_report_params.merge(charts: 1, anchor: "breakdowns", return_to: "reports")),
+          the one event when the hub is, cross-event otherwise (hub_to_attendees_params
+          carries event_id either way, and opens the index's event-type filter so a
+          non-training event isn't filtered out). ?charts=1 opens the panel on arrival
+          and the #breakdowns anchor scrolls to it, so the link doesn't land on a
+          collapsed section. return_to keeps the eyebrow pointing back to the hub. %>
+      <%= link_to "Breakdowns →", attendees_events_path(hub_to_attendees_params(charts: 1, anchor: "breakdowns")),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
     </div>
   </div>

--- a/app/views/events/_participation_summary.html.erb
+++ b/app/views/events/_participation_summary.html.erb
@@ -5,17 +5,17 @@
   <div class="flex items-start justify-between mb-4">
     <h3 class="text-base font-semibold text-gray-900">Participation</h3>
     <div class="flex flex-col items-end gap-1">
-      <%= link_to "Full report →", participation_events_path(hub_to_report_params),
+      <%= link_to "Details →", participation_events_path(hub_to_report_params),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
-      <%= link_to "Attendees →", attendees_events_path(hub_to_report_params),
+      <%= link_to "Attendees →", attendees_events_path(hub_to_report_params.merge(return_to: "reports")),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
       <%# Demographics live next to the people they describe, so this points at the
-          breakdowns rather than duplicating them here: one event's roster when the
-          hub is scoped, the cross-event attendees index otherwise. ?charts=1 opens
-          the panel on arrival so the link doesn't land on a collapsed section. %>
-      <% breakdowns_path = @filter_event ? roster_event_path(@filter_event, charts: 1) :
-           attendees_events_path(hub_to_report_params.merge(charts: 1)) %>
-      <%= link_to "Breakdowns →", breakdowns_path,
+          attendees index's breakdowns rather than duplicating them here — scoped to
+          the one event when the hub is, cross-event otherwise (hub_to_report_params
+          carries event_id either way). ?charts=1 opens the panel on arrival and the
+          #breakdowns anchor scrolls to it, so the link doesn't land on a collapsed
+          section. return_to keeps the eyebrow pointing back to the reports hub. %>
+      <%= link_to "Breakdowns →", attendees_events_path(hub_to_report_params.merge(charts: 1, anchor: "breakdowns", return_to: "reports")),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
     </div>
   </div>

--- a/app/views/events/_registrant_breakdowns.html.erb
+++ b/app/views/events/_registrant_breakdowns.html.erb
@@ -66,7 +66,9 @@
   <% program_status_paths = program_status_data.to_h { |label, _| [ label, index_path.(program_status: label.downcase) ] } %>
   <% other_response_paths = {} %>
   <% scholarship_pie_paths = { "Scholarship" => index_path.(scholarship: "yes"), "No scholarship" => index_path.(scholarship: "no") } %>
-  <% ce_pie_paths = { "CE" => index_path.(ce: "yes"), "No CE" => index_path.(ce: "no") } %>
+  <%# Both slices drill into the CE status dropdown rather than a chip-only param, so
+      the arrival shows which filter is applied in the control itself. %>
+  <% ce_pie_paths = { "CE" => index_path.(ce_status: "registered"), "No CE" => index_path.(ce_status: EventRegistration::NO_CE) } %>
 <% elsif event_context %>
   <% primary_sector_paths = data.primary_sectors.to_h { |s| [ s.name, by_ids.(data.primary_sector_registrant_ids_by_sector.fetch(s.id, [])) ] } %>
   <% sector_paths = data.sectors.to_h { |s| [ s.name, roster_event_path(event, sector: s.id, charts: 1) ] } %>

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -102,7 +102,7 @@
 
   <% if has_cost %>
     <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
-          options: [ [ "All recipients", "yes" ], [ "Agreed", "agreed" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ], [ "No scholarship", "no" ] ],
+          options: EventRegistration::SCHOLARSHIP_STATUS_FILTER_OPTIONS,
           selected: params[:scholarship], blank: "Any status", field_class: field_class %>
 
     <%# Free-text on the funder behind a scholarship. Param :funder_name stays
@@ -113,12 +113,12 @@
 
   <% if @ce_eligible %>
     <%= render "events/filter_select", param: :ce_status, label: "CE status",
-          options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Certificate issued", "issued" ], [ "Certificate outstanding", "not_issued" ], [ "No CE", "none" ] ],
+          options: EventRegistration::CE_STATUS_FILTER_OPTIONS,
           selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
   <% end %>
 
   <%= render "events/filter_select", param: :account_status, label: "User account",
-        options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+        options: EventRegistration::ACCOUNT_STATUS_FILTER_OPTIONS,
         selected: params[:account_status], blank: "Any account status", field_class: field_class %>
 
   <%# Picker-only: registrants with an active subscription to a topic subscription
@@ -144,7 +144,7 @@
   <% end %>
 
   <%= render "events/filter_select", param: :comment_status, label: "Comment status",
-        options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+        options: EventRegistration::COMMENT_STATUS_FILTER_OPTIONS,
         selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
 
   <%= render "events/filter_text", param: :comment, label: "Comment text",

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -113,7 +113,7 @@
 
   <% if @ce_eligible %>
     <%= render "events/filter_select", param: :ce_status, label: "CE status",
-          options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
+          options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Certificate issued", "issued" ], [ "Certificate outstanding", "not_issued" ], [ "No CE", "none" ] ],
           selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
   <% end %>
 

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -1,183 +1,155 @@
-<%# Shared registrant filter bar for the registrants roster and the bulk reminder
-    recipient picker. One visible row holds a "Filters" heading, the most meaningful
-    filters, a "More filters" chevron toggle and "Clear filters"; the rest of the
-    dropdowns collapse until expanded. The dropdowns reuse events/filter_select
-    with the same param names and options on both pages, so filters carry between
-    them (see ReminderRecipientFilter / EventsController#registrants).
+<%# Registrant filter bar for the registrants roster and the bulk reminder
+    recipient picker, rendered through the shared events/_filter_bar shell so it
+    matches the attendees index. The dropdowns reuse events/filter_select with the
+    same param names and options across pages, so filters carry between them (see
+    ReminderRecipientFilter / EventsController#registrants).
     Locals:
-      url                  – form action path
-      frame                – turbo frame id the form submits into
-      clear_url            – "Clear filters" href
-      text_fields          – [{ param:, label:, placeholder:, primary:, search: }]
-                             primary fields sit in the first row (search adds a
-                             magnifier + flex width); the rest collapse
-      include_readiness    – show the readiness "Status" select (roster only)
-      status_filter_hidden – carry the active/inactive hidden field (roster only)
-      hidden_params        – { name => value } carried as hidden fields so they
-                             survive the GET filter submit (e.g. mode: "invite") %>
+      url                     – form action path
+      frame                   – turbo frame id the form submits into
+      clear_url               – "Clear filters" href
+      text_fields             – [{ param:, label:, placeholder:, primary:, search: }]
+                                primary fields sit in the first row (search adds a
+                                magnifier + flex width); the rest collapse
+      include_readiness       – show the readiness "Progress" select (roster only)
+      status_filter_hidden    – carry the active/inactive hidden field (roster only)
+      hidden_params           – { name => value } carried as hidden fields so they
+                                survive the GET filter submit (e.g. mode: "invite")
+      topic_subscription_types – topic subscription lists to offer as a filter
+                                (picker only; omitted elsewhere) %>
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 <% include_readiness = local_assigns.fetch(:include_readiness, false) %>
 <% status_filter_hidden = local_assigns.fetch(:status_filter_hidden, false) %>
 <% has_cost = @event.cost_cents.to_i > 0 %>
+<% topic_subscription_types = local_assigns.fetch(:topic_subscription_types, []) %>
 <% primary_text, more_text = Array(text_fields).partition { |f| f[:primary] } %>
 <%# Open the collapsed section on load when any control inside it already carries
     a value, so an active filter is never hidden behind the toggle. %>
-<% topic_subscription_types = local_assigns.fetch(:topic_subscription_types, []) %>
 <% collapsed_keys = %i[submission_status payment_method org_status scholarship funder_name ce_status city state county account_status comment_status comment topic_subscription] %>
 <% more_active = more_text.any? { |f| params[f[:param]].present? } || collapsed_keys.any? { |k| params[k].present? } %>
-<%# The "More filters" drawer is a pure-CSS disclosure: a visually-hidden
-    checkbox drives the drawer, chevron and label via :has() on this group
-    wrapper. It's rendered outside the form so the collection controller's
-    change-submit doesn't fire when toggling, and starts checked when a collapsed
-    filter is already active so an active filter is never hidden. %>
-<div class="group mb-6">
-  <input type="checkbox" id="more-filters-toggle" class="sr-only"<%= " checked" if more_active %>>
-  <%= form_with url: url, method: :get,
-        data: { controller: "collection", turbo_frame: frame },
-        autocomplete: "off",
-        class: "bg-white border border-gray-200 rounded-xl shadow-sm p-4" do %>
-    <% if status_filter_hidden %>
-      <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
-    <% end %>
-    <% local_assigns.fetch(:hidden_params, {}).each do |name, value| %>
-      <%= hidden_field_tag name, value %>
-    <% end %>
 
-  <div class="flex items-center gap-2 text-gray-600 mb-3">
-    <i class="fa-solid fa-filter text-xs"></i>
-    <span class="text-xs font-semibold uppercase tracking-wide">Filters</span>
-  </div>
-
-  <%# Row 1: the most meaningful filters + More filters toggle + Clear. %>
-  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
-    <% primary_text.each do |f| %>
-      <div class="<%= f[:search] ? "w-full md:flex-1 md:min-w-0" : "w-full md:w-48" %>">
-        <%= label_tag f[:param], f[:label], class: label_class %>
-        <div class="relative">
-          <%= text_field_tag f[:param], params[f[:param]], class: field_class, placeholder: f[:placeholder] %>
-          <% if f[:search] %>
-            <button type="submit"
-                    class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
-              <i class="fa fa-search"></i>
-            </button>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-
-    <%# Top three, in the order an admin works a registration: overall progress,
-        are they coming, did they pay. %>
-    <% if include_readiness %>
-      <%# Mirrors the far-right Progress column: Not ready → Ready → Certificate
-          pending → Completed. Param stays :readiness (backed by
-          EventRegistrationReadiness); the user-facing label reads "Progress". %>
-      <%= render "events/filter_select", param: :readiness, label: "Progress",
-            options: [ [ "Not ready", "not_ready" ], [ "Ready", "ready" ], [ "Certificate pending", "certificate_due" ], [ "Completed", "completed" ] ],
-            selected: params[:readiness], blank: "Any stage", field_class: field_class %>
-    <% end %>
-
-    <%= render "events/filter_select", param: :attendance_status, label: "Attendance",
-          options: EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
-          selected: params[:attendance_status], blank: "All statuses", field_class: field_class %>
-
-    <% if has_cost %>
-      <%= render "events/filter_select", param: :payment_status, label: "Payment status",
-            options: EventRegistration::PAYMENT_STATUS_FILTER_OPTIONS,
-            selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
-    <% end %>
-
-    <div class="w-full md:w-auto md:ml-auto flex items-end gap-4">
-      <label for="more-filters-toggle"
-             class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition">
-        <span class="group-has-[#more-filters-toggle:checked]:hidden">More filters</span>
-        <span class="hidden group-has-[#more-filters-toggle:checked]:inline">Fewer filters</span>
-        <i class="fa-solid fa-chevron-down text-xs transition-transform group-has-[#more-filters-toggle:checked]:rotate-180"></i>
-      </label>
-      <%= link_to "Clear filters", clear_url, class: "btn btn-utility",
-            data: { action: "collection#clearAndSubmit" } %>
-    </div>
-  </div>
-
-  <%# Collapsible: the remaining filters. Shown when the toggle checkbox is
-      checked (via :has() on the group wrapper), which starts checked when a
-      collapsed filter is already active. %>
-  <div class="hidden group-has-[#more-filters-toggle:checked]:block">
-    <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
-      <%# Page-specific collapsed text fields (e.g. the picker's Organization/Name
-          boxes). Funder/City/Comment text below are shared across both pages. %>
-      <% more_text.each do |f| %>
-        <%= render "events/filter_text", param: f[:param], label: f[:label],
-              placeholder: f[:placeholder], field_class: field_class %>
-      <% end %>
-
-      <%# Ordered by how a registration is worked after the top three: how they
-          pay, whether they submitted, their org, scholarship and funder, CE,
-          then portal access and location — with comments handled last. %>
-      <% if has_cost %>
-        <%= render "events/filter_select", param: :payment_method, label: "Payment method",
-              options: EventRegistrationDecorator.payment_method_filter_choices,
-              selected: params[:payment_method], blank: "Any payment method", field_class: field_class %>
-      <% end %>
-
-      <%= render "events/filter_select", param: :submission_status, label: "Submission status",
-            options: [ [ "No submission", "none" ], [ "Has form submission", "has" ], [ "Multiple form submissions", "multiple" ] ],
-            selected: params[:submission_status], blank: "All statuses", field_class: field_class %>
-
-      <%= render "events/filter_select", param: :org_status, label: "Organization linking",
-            options: [ [ "Pending", "pending" ], [ "Linked", "linked" ], [ "Unlinked", "unlinked" ] ],
-            selected: params[:org_status], blank: "Any linking", field_class: field_class %>
-
-      <% if has_cost %>
-        <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
-              options: [ [ "All recipients", "yes" ], [ "Agreed", "agreed" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ] ],
-              selected: params[:scholarship], blank: "Any status", field_class: field_class %>
-
-        <%# Free-text on the funder behind a scholarship. Param :funder_name stays
-            clear of the awbw/external :funder funding-source scope. %>
-        <%= render "events/filter_text", param: :funder_name, label: "Funder",
-              placeholder: "Funder name", field_class: field_class %>
-      <% end %>
-
-      <% if @ce_eligible %>
-        <%= render "events/filter_select", param: :ce_status, label: "CE status",
-              options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
-              selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
-      <% end %>
-
-      <%= render "events/filter_select", param: :account_status, label: "User account",
-            options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
-            selected: params[:account_status], blank: "Any account status", field_class: field_class %>
-
-      <%# Picker-only: registrants with an active subscription to a topic subscription
-          list. Only rendered when the caller supplies the topic types. %>
-      <% if topic_subscription_types.any? %>
-        <%= render "events/filter_select", param: :topic_subscription, label: "Topic subscription list",
-              options: topic_subscription_types.map { |t| [ t.name, t.id ] },
-              selected: params[:topic_subscription], blank: "Any topic", field_class: field_class %>
-      <% end %>
-
-      <%= render "events/filter_text", param: :city, label: "City",
-            placeholder: "City name", field_class: field_class %>
-
-      <% if @dashboard&.states&.any? %>
-        <%= render "events/filter_select", param: :state, label: "State",
-              options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class, wrapper_class: "w-full md:w-32" %>
-      <% end %>
-
-      <% if @dashboard&.counties&.any? %>
-        <%= render "events/filter_select", param: :county, label: "County",
-              options: @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
-              selected: params[:county], blank: "All counties", field_class: field_class %>
-      <% end %>
-
-      <%= render "events/filter_select", param: :comment_status, label: "Comment status",
-            options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
-            selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
-
-      <%= render "events/filter_text", param: :comment, label: "Comment text",
-            placeholder: "Topic or content", field_class: field_class %>
-    </div>
-  </div>
+<% hidden = capture do %>
+  <% if status_filter_hidden %>
+    <%= hidden_field_tag :status_filter, params[:status_filter].presence || "active" %>
   <% end %>
-</div>
+  <% local_assigns.fetch(:hidden_params, {}).each do |name, value| %>
+    <%= hidden_field_tag name, value %>
+  <% end %>
+<% end %>
+
+<% primary = capture do %>
+  <% primary_text.each do |f| %>
+    <div class="<%= f[:search] ? "w-full md:flex-1 md:min-w-0" : "w-full md:w-48" %>">
+      <%= label_tag f[:param], f[:label], class: label_class %>
+      <div class="relative">
+        <%= text_field_tag f[:param], params[f[:param]], class: field_class, placeholder: f[:placeholder] %>
+        <% if f[:search] %>
+          <button type="submit"
+                  class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-blue-600">
+            <i class="fa fa-search"></i>
+          </button>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%# Top three, in the order an admin works a registration: overall progress,
+      are they coming, did they pay. %>
+  <% if include_readiness %>
+    <%# Mirrors the far-right Progress column: Not ready → Ready → Certificate
+        pending → Completed. Param stays :readiness (backed by
+        EventRegistrationReadiness); the user-facing label reads "Progress". %>
+    <%= render "events/filter_select", param: :readiness, label: "Progress",
+          options: [ [ "Not ready", "not_ready" ], [ "Ready", "ready" ], [ "Certificate pending", "certificate_due" ], [ "Completed", "completed" ] ],
+          selected: params[:readiness], blank: "Any stage", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_select", param: :attendance_status, label: "Attendance",
+        options: EventRegistration::ATTENDANCE_STATUSES.map { |s| [ EventRegistration.new(status: s).attendance_status_label, s ] },
+        selected: params[:attendance_status], blank: "All statuses", field_class: field_class %>
+
+  <% if has_cost %>
+    <%= render "events/filter_select", param: :payment_status, label: "Payment status",
+          options: EventRegistration::PAYMENT_STATUS_FILTER_OPTIONS,
+          selected: params[:payment_status], blank: "Any payment status", field_class: field_class %>
+  <% end %>
+<% end %>
+
+<% more = capture do %>
+  <%# Page-specific collapsed text fields (e.g. the picker's Organization/Name
+      boxes). Funder/City/Comment text below are shared across both pages. %>
+  <% more_text.each do |f| %>
+    <%= render "events/filter_text", param: f[:param], label: f[:label],
+          placeholder: f[:placeholder], field_class: field_class %>
+  <% end %>
+
+  <%# Ordered by how a registration is worked after the top three: how they pay,
+      whether they submitted, their org, scholarship and funder, CE, then portal
+      access and location — with comments handled last. %>
+  <% if has_cost %>
+    <%= render "events/filter_select", param: :payment_method, label: "Payment method",
+          options: EventRegistrationDecorator.payment_method_filter_choices,
+          selected: params[:payment_method], blank: "Any payment method", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_select", param: :submission_status, label: "Submission status",
+        options: [ [ "No submission", "none" ], [ "Has form submission", "has" ], [ "Multiple form submissions", "multiple" ] ],
+        selected: params[:submission_status], blank: "All statuses", field_class: field_class %>
+
+  <%= render "events/filter_select", param: :org_status, label: "Organization linking",
+        options: [ [ "Pending", "pending" ], [ "Linked", "linked" ], [ "Unlinked", "unlinked" ] ],
+        selected: params[:org_status], blank: "Any linking", field_class: field_class %>
+
+  <% if has_cost %>
+    <%= render "events/filter_select", param: :scholarship, label: "Scholarship",
+          options: [ [ "All recipients", "yes" ], [ "Agreed", "agreed" ], [ "Tasks complete", "complete" ], [ "Tasks not complete", "incomplete" ], [ "No scholarship", "no" ] ],
+          selected: params[:scholarship], blank: "Any status", field_class: field_class %>
+
+    <%# Free-text on the funder behind a scholarship. Param :funder_name stays
+        clear of the awbw/external :funder funding-source scope. %>
+    <%= render "events/filter_text", param: :funder_name, label: "Funder",
+          placeholder: "Funder name", field_class: field_class %>
+  <% end %>
+
+  <% if @ce_eligible %>
+    <%= render "events/filter_select", param: :ce_status, label: "CE status",
+          options: [ [ "Registered for CE", "registered" ], [ "Requested", "requested" ], [ "Needs license", "needs_license" ], [ "Paid", "paid" ], [ "Issued", "issued" ], [ "Not issued", "not_issued" ] ],
+          selected: params[:ce_status], blank: "Any CE status", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_select", param: :account_status, label: "User account",
+        options: [ [ "No account", "none" ], [ "Not invited yet", "not_invited" ], [ "Invited", "invited" ], [ "Has access", "has_access" ], [ "No access", "no_access" ] ],
+        selected: params[:account_status], blank: "Any account status", field_class: field_class %>
+
+  <%# Picker-only: registrants with an active subscription to a topic subscription
+      list. Only rendered when the caller supplies the topic types. %>
+  <% if topic_subscription_types.any? %>
+    <%= render "events/filter_select", param: :topic_subscription, label: "Topic subscription list",
+          options: topic_subscription_types.map { |t| [ t.name, t.id ] },
+          selected: params[:topic_subscription], blank: "Any topic", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_text", param: :city, label: "City",
+        placeholder: "City name", field_class: field_class %>
+
+  <% if @dashboard&.states&.any? %>
+    <%= render "events/filter_select", param: :state, label: "State",
+          options: @dashboard.states, selected: params[:state], blank: "All states", field_class: field_class, wrapper_class: "w-full md:w-32" %>
+  <% end %>
+
+  <% if @dashboard&.counties&.any? %>
+    <%= render "events/filter_select", param: :county, label: "County",
+          options: @dashboard.counties.map { |state, county| [ "#{state} - #{county}", "#{state}|#{county}" ] },
+          selected: params[:county], blank: "All counties", field_class: field_class %>
+  <% end %>
+
+  <%= render "events/filter_select", param: :comment_status, label: "Comment status",
+        options: [ [ "None", "none" ], [ "Present", "present" ], [ "Flagged", "flagged" ] ],
+        selected: params[:comment_status], blank: "Any comments", field_class: field_class %>
+
+  <%= render "events/filter_text", param: :comment, label: "Comment text",
+        placeholder: "Topic or content", field_class: field_class %>
+<% end %>
+
+<%= render "events/filter_bar", url: url, frame: frame, clear_url: clear_url,
+      more_active: more_active, hidden: hidden, primary: primary, more: more %>

--- a/app/views/events/_revenue_summary.html.erb
+++ b/app/views/events/_revenue_summary.html.erb
@@ -2,9 +2,12 @@
     Expects `report` (an EventRevenueReport) and `period` (its resolved
     PeriodScope: #label, #year and #metrics). %>
 <div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-  <div class="flex items-center justify-between mb-4">
+  <%# min-h reserves the height the participation/scholarship cards get from their
+      stacked Attendees/Breakdowns links, so this card's period label and stat
+      boxes line up with theirs even though it has only the one link. %>
+  <div class="flex items-start justify-between mb-4 min-h-[3.5rem]">
     <h3 class="text-base font-semibold text-gray-900">Revenue</h3>
-    <%= link_to "Full report →", revenue_events_path(hub_to_report_params),
+    <%= link_to "Details →", revenue_events_path(hub_to_report_params),
           class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
   </div>
 

--- a/app/views/events/_scholarship_summary.html.erb
+++ b/app/views/events/_scholarship_summary.html.erb
@@ -11,7 +11,7 @@
       <%# Attendees and breakdowns for the scholarship population — the attendees
           index pre-filtered to scholarship recipients. ?charts=1 + #breakdowns opens
           and scrolls to the panel; return_to keeps the eyebrow on the reports hub. %>
-      <% scholarship_attendee_params = hub_to_report_params.merge(scholarship: "yes", return_to: "reports") %>
+      <% scholarship_attendee_params = hub_to_attendees_params(scholarship: "yes") %>
       <%= link_to "Attendees →", attendees_events_path(scholarship_attendee_params),
             class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
       <%= link_to "Breakdowns →", attendees_events_path(scholarship_attendee_params.merge(charts: 1, anchor: "breakdowns")),

--- a/app/views/events/_scholarship_summary.html.erb
+++ b/app/views/events/_scholarship_summary.html.erb
@@ -1,11 +1,22 @@
-<%# Compact scholarship headline for the reports hub, linking to the full
-    report. Expects `report` (an EventScholarshipReport) and `period` (its
-    resolved PeriodScope: #label, #year and #metrics). %>
+<%# Compact scholarship headline for the reports hub, linking to the full report
+    (Details) plus the recipient attendees/breakdowns. Expects `report` (an
+    EventScholarshipReport) and `period` (its resolved PeriodScope: #label, #year
+    and #metrics). %>
 <div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-  <div class="flex items-center justify-between mb-4">
+  <div class="flex items-start justify-between mb-4">
     <h3 class="text-base font-semibold text-gray-900">Scholarships</h3>
-    <%= link_to "Full report →", scholarships_events_path(hub_to_report_params),
-          class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+    <div class="flex flex-col items-end gap-1">
+      <%= link_to "Details →", scholarships_events_path(hub_to_report_params),
+            class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <%# Attendees and breakdowns for the scholarship population — the attendees
+          index pre-filtered to scholarship recipients. ?charts=1 + #breakdowns opens
+          and scrolls to the panel; return_to keeps the eyebrow on the reports hub. %>
+      <% scholarship_attendee_params = hub_to_report_params.merge(scholarship: "yes", return_to: "reports") %>
+      <%= link_to "Attendees →", attendees_events_path(scholarship_attendee_params),
+            class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+      <%= link_to "Breakdowns →", attendees_events_path(scholarship_attendee_params.merge(charts: 1, anchor: "breakdowns")),
+            class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
+    </div>
   </div>
 
   <% if report.any? %>

--- a/app/views/events/_section_heading.html.erb
+++ b/app/views/events/_section_heading.html.erb
@@ -18,11 +18,17 @@
                  (e.g. the page's panel toggle bar).
       spacing:   extra wrapper classes (e.g. "mt-10").
       margin:    bottom margin, "mb-4" by default; pass "" when the caller already
-                 spaces the row (e.g. a heading sharing a row with an action). %>
+                 spaces the row (e.g. a heading sharing a row with an action).
+      id:        optional anchor id; adds scroll-mt so a #fragment link isn't
+                 hidden under the sticky header, plus reveal-section so the scroll
+                 still happens when the heading arrives inside a lazily-loaded
+                 Turbo frame (the browser has given up on the hash by then). %>
 <% intensity = local_assigns[:intensity] %>
 <% actions = local_assigns[:actions] %>
+<% anchor_id = local_assigns[:id] %>
+<% anchor_attrs = tag.attributes(id: anchor_id, data: { controller: "reveal-section", reveal_section_anchor_value: anchor_id }) if anchor_id %>
 <% text_class = intensity ? DomainTheme.text_class_for(theme, intensity: intensity) : DomainTheme.text_class_for(theme) %>
-<div class="flex flex-wrap items-center gap-3 <%= local_assigns.fetch(:margin, "mb-4") %> <%= local_assigns[:spacing] %>">
+<div <%= anchor_attrs %> class="flex flex-wrap items-center gap-3 <%= "scroll-mt-24" if anchor_id %> <%= local_assigns.fetch(:margin, "mb-4") %> <%= local_assigns[:spacing] %>">
   <h2 class="text-xl font-bold flex items-center gap-2 <%= text_class %>">
     <i class="fa-solid <%= icon %>"></i>
     <%= title %>

--- a/app/views/events/_subnav.html.erb
+++ b/app/views/events/_subnav.html.erb
@@ -8,7 +8,7 @@
 <nav class="flex flex-wrap items-center gap-1" aria-label="Event views">
   <% tabs = [
        { key: :dashboard, label: "Dashboard", path: dashboard_event_path(event), visible: allowed_to?(:dashboard?, event) },
-       { key: :registrants, label: "Manage", path: registrants_event_path(event), visible: allowed_to?(:registrants?, event) },
+       { key: :registrants, label: "Registrations", path: registrants_event_path(event), visible: allowed_to?(:registrants?, event) },
        { key: :roster, label: "Roster", path: roster_event_path(event), visible: allowed_to?(:roster?, event) },
        { key: :reports, label: "Reports", path: reports_events_path(event_id: event.id), visible: allowed_to?(:event_reports?, event) },
        { key: :scholarships, label: "Scholarships", path: recipients_event_path(event), visible: allowed_to?(:recipients?, event) },
@@ -16,8 +16,6 @@
      ] %>
   <% tabs.each do |tab| %>
     <% next unless tab[:visible] %>
-    <%# The dashboard is the event's home; don't echo a Dashboard tab back on it. %>
-    <% next if tab[:key] == :dashboard && current == :dashboard %>
     <% if tab[:key] == current %>
       <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
     <% else %>

--- a/app/views/events/attendees_results.html.erb
+++ b/app/views/events/attendees_results.html.erb
@@ -5,6 +5,10 @@
     data-attributes drive every toggle after that. %>
 <% charts_open = params[:charts].present? %>
   <%= turbo_stream.replace("attendees_count", partial: "attendees_count") %>
+  <%# The filter bar sits outside this frame, so its chips are refreshed from here:
+      their remove links are built from the request's params and would otherwise
+      still describe the page's original URL, dropping every filter set since. %>
+  <%= turbo_stream.replace("attendees_chips", partial: "events/attendees_chips") %>
 
   <% if @people.any? %>
     <% charts_src = attendees_events_path(request.query_parameters) %>

--- a/app/views/events/attendees_results.html.erb
+++ b/app/views/events/attendees_results.html.erb
@@ -50,7 +50,7 @@
 
       <%# Charts panel — hidden by default; the lazy frame loads on first reveal. %>
       <%= render "events/section_heading", title: "Breakdowns", icon: "fa-chart-pie",
-            theme: :event_registrations, intensity: 700, panel: "charts", open: charts_open, spacing: "mt-10" %>
+            theme: :event_registrations, intensity: 700, panel: "charts", open: charts_open, spacing: "mt-10", id: "breakdowns" %>
       <div data-panel-toggle-target="panel" data-panel-toggle-name="charts" class="<%= "hidden" unless charts_open %>">
         <%= turbo_frame_tag :attendees_charts, src: charts_src, loading: :lazy do %>
           <%= render "events/charts_loading" %>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -81,7 +81,7 @@
                     class: "text-3xl sm:text-4xl font-bold #{DomainTheme.text_class_for(:event_dashboard, intensity: 700)} tabular-nums #{addend_class.call(:event_dashboard)}",
                     title: "View the event revenue report" %>
               <span class="text-2xl font-light text-gray-300 select-none">=</span>
-              <%= link_to registrants_event_path(@event), class: addend_class.call(:payments), title: "Manage registrants" do %>
+              <%= link_to registrants_event_path(@event), class: addend_class.call(:payments), title: "Manage registrations" do %>
                 <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></p>
                 <p class="hidden lg:block text-xs text-gray-500">Registration fees</p>
               <% end %>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -37,7 +37,7 @@
       <% end %>
       <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
         <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:event_registrations, intensity: 800) %>"></i>
-        Manage registrants
+        Manage registrations
       </h1>
       <p class="text-gray-500 mt-2"><%= pluralize(@active_count, "person") %></p>
     </div>

--- a/app/views/events/roster.html.erb
+++ b/app/views/events/roster.html.erb
@@ -28,7 +28,7 @@
       own attendance pill. %>
   <% partial_count = @dashboard.attendance_count_for("incomplete_attendance") %>
   <%= render "events/report_header",
-        title: "Registrant roster",
+        title: "Roster",
         icon: "fa-solid fa-users-viewfinder",
         theme: :people,
         event: @event,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -27,7 +27,7 @@
     <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <% if allowed_to?(:manage?, @event) %>
-    <%= link_to "Manage", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    <%= link_to "Registrations", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
   </div>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -422,6 +422,14 @@ RSpec.describe EventRegistration, type: :model do
       end
     end
 
+    describe ".without_scholarship" do
+      it "returns only registrations with no scholarship" do
+        results = EventRegistration.without_scholarship
+        expect(results).to include(paid_reg, unpaid_reg)
+        expect(results).not_to include(scholarship_reg, incomplete_scholarship_reg)
+      end
+    end
+
     describe ".scholarship_tasks_completed" do
       it "returns recipients whose scholarship tasks are complete" do
         results = EventRegistration.scholarship_tasks_completed
@@ -442,6 +450,11 @@ RSpec.describe EventRegistration, type: :model do
       it "maps 'yes' to all recipients" do
         expect(EventRegistration.scholarship_status("yes")).to include(scholarship_reg, incomplete_scholarship_reg)
         expect(EventRegistration.scholarship_status("yes")).not_to include(paid_reg, unpaid_reg)
+      end
+
+      it "maps 'no' to registrations without a scholarship" do
+        expect(EventRegistration.scholarship_status("no")).to include(paid_reg, unpaid_reg)
+        expect(EventRegistration.scholarship_status("no")).not_to include(scholarship_reg, incomplete_scholarship_reg)
       end
 
       it "maps 'complete' to completed-task recipients" do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -591,6 +591,23 @@ RSpec.describe EventRegistration, type: :model do
         expect(results).not_to include(issued_ce, no_ce)
       end
 
+      it "maps 'none' to registrations that never signed up for CE" do
+        results = EventRegistration.ce_status(EventRegistration::NO_CE)
+        expect(results).to include(no_ce)
+        expect(results).not_to include(paid_ce, requested_ce, needs_license_ce, issued_ce)
+      end
+
+      # The license join is an inner join, so this only holds because
+      # professional_license_id is NOT NULL — every CE row has one.
+      it "makes 'none' the exact complement of 'registered'" do
+        all_ids = EventRegistration.where(event: event).ids
+        registered = EventRegistration.where(event: event).ce_status("registered").ids
+        none = EventRegistration.where(event: event).ce_status(EventRegistration::NO_CE).ids
+
+        expect(registered & none).to be_empty
+        expect((registered + none).sort).to eq(all_ids.sort)
+      end
+
       it "returns an unfiltered relation for unknown values" do
         expect(EventRegistration.ce_status("bogus")).to include(paid_ce, requested_ce, no_ce)
       end

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -507,6 +507,20 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).not_to include("Cara Coast")
         end
 
+        # City and state have to describe one address, the way the roster's shared
+        # join does — otherwise someone with homes in two states matches a city from
+        # one and a state from the other.
+        it "matches city and state against the same address" do
+          create(:address, addressable: attendee, city: "Portland", state: "OR", inactive: false)
+          create(:address, addressable: attendee, city: "Seattle", state: "WA", inactive: false)
+
+          get attendees_events_url(city: "Seattle", state: "WA"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+
+          get attendees_events_url(city: "Seattle", state: "OR"), headers: frame_headers
+          expect(response.body).not_to include("Ada Lovelace")
+        end
+
         it "filters by an active topic subscription, matching any of the person's registrations" do
           type = create(:topic_subscription_type)
           create(:topic_subscription, person: attendee, topic_subscription_type: type)

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -476,6 +476,26 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).to include("Ada Lovelace")
         end
 
+        it "answers 'No CE' person-wide cross-event, per event when scoped" do
+          # Ada took CE at the recent training but not at the older one she also
+          # attended.
+          create(:continuing_education_registration, event_registration: attendee_registration)
+          older_reg = create(:event_registration, event: older_training, registrant: attendee, status: "attended")
+
+          never = create(:person, first_name: "Nan", last_name: "Nocredit")
+          create(:event_registration, event: recent_training, registrant: never, status: "attended")
+
+          # Cross-event: "No CE" means never signed up — excludes Ada, whose
+          # older-training registration carries no CE.
+          get attendees_events_url(ce_status: "none"), headers: frame_headers
+          expect(response.body).to include("Nan Nocredit")
+          expect(response.body).not_to include("Ada Lovelace")
+
+          # Scoped to the older training, where Ada took no CE — includes her.
+          get attendees_events_url(ce_status: "none", event_id: older_reg.event_id), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+        end
+
         it "filters by address data (city) without requiring a registration to carry it" do
           create(:address, addressable: attendee, city: "Portland", state: "OR", inactive: false)
           other = create(:person, first_name: "Cara", last_name: "Coast")
@@ -538,7 +558,7 @@ RSpec.describe "Events attendees", type: :request do
           get attendees_events_url(ce_status: "issued", city: "Portland", comment: "late")
 
           page = Capybara.string(response.body)
-          expect(page).to have_selector("select#ce_status option[selected][value='issued']", text: "Issued")
+          expect(page).to have_selector("select#ce_status option[selected][value='issued']", text: "Certificate issued")
           expect(page).to have_selector("input#city[value='Portland']", visible: :all)
           expect(page).to have_selector("input#comment[value='late']", visible: :all)
         end

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -573,6 +573,24 @@ RSpec.describe "Events attendees", type: :request do
             .to have_selector("input[type=hidden][name=return_to][value=participation]", visible: :all)
         end
 
+        # The chip row lives outside the results frame, so its remove links would
+        # otherwise keep pointing at the params the page loaded with — dropping every
+        # filter the admin set through the frame since.
+        it "refreshes the applied-filter chips from the results frame" do
+          get attendees_events_url(country: "Canada", ce_status: "issued"), headers: frame_headers
+
+          # Turbo stream payloads sit inside a <template>, which selectors don't
+          # descend into — read the replacement's markup out first.
+          template = Nokogiri::HTML5(response.body)
+            .at_css("turbo-stream[action='replace'][target='attendees_chips'] template")
+          expect(template).to be_present
+
+          remove_link = "a[aria-label='Remove Country: Canada filter']"
+          expect(Capybara.string(template.inner_html)).to have_selector(
+            "#{remove_link}[href='#{attendees_events_path(ce_status: "issued")}']", visible: :all
+          )
+        end
+
         it "filters by the org's facilitator program status" do
           # Ada's org is new (no earlier facilitator affiliation); Zed's org is
           # ongoing (a facilitator affiliation predates and still overlaps today).

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -455,6 +455,27 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).to include("Ada Lovelace")
         end
 
+        it "answers 'No comments' person-wide cross-event, per event when scoped" do
+          # Ada commented on her recent-training registration but not on the older
+          # training she also attended.
+          create(:comment, commentable: attendee_registration)
+          older_reg = create(:event_registration, event: older_training, registrant: attendee, status: "attended")
+
+          quiet = create(:person, first_name: "Quinn", last_name: "Quiet")
+          create(:event_registration, event: recent_training, registrant: quiet, status: "attended")
+
+          # Cross-event: "None" means commented on nothing — excludes Ada, whose
+          # older-training registration is uncommented.
+          get attendees_events_url(comment_status: "none"), headers: frame_headers
+          expect(response.body).to include("Quinn Quiet")
+          expect(response.body).not_to include("Ada Lovelace")
+
+          # Scoped to the older training, where Ada's registration carries no
+          # comment — includes her.
+          get attendees_events_url(comment_status: "none", event_id: older_reg.event_id), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+        end
+
         it "filters by address data (city) without requiring a registration to carry it" do
           create(:address, addressable: attendee, city: "Portland", state: "OR", inactive: false)
           other = create(:person, first_name: "Cara", last_name: "Coast")

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -299,6 +299,16 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).not_to include("All sectors")
         end
 
+        # The heading lands in the DOM only once the results frame resolves, long
+        # after the browser gave up on the #breakdowns fragment — so it has to scroll
+        # itself into view on connect rather than rely on the hash.
+        it "anchors the breakdowns heading so a #breakdowns link still scrolls to it" do
+          get attendees_events_url, headers: frame_headers
+
+          expect(Capybara.string(response.body))
+            .to have_selector("#breakdowns[data-controller='reveal-section'][data-reveal-section-anchor-value='breakdowns']", visible: :all)
+        end
+
         it "renders the breakdown charts in the lazy charts frame" do
           create(:sectorable_item, sectorable: attendee, sector: create(:sector, name: "Healthcare"), is_primary: true)
           get attendees_events_url, headers: charts_frame_headers
@@ -398,6 +408,128 @@ RSpec.describe "Events attendees", type: :request do
 
           expect(Capybara.string(response.body))
             .to have_selector("select#affiliation_status option[selected]", text: "Active & Upcoming")
+        end
+
+        it "filters by scholarship status, including the recipient sub-statuses" do
+          complete = create(:scholarship, recipient: attendee, amount_cents: 1_000, grant: create(:grant), tasks_completed: true)
+          create(:allocation, source: complete, allocatable: attendee_registration, amount: 1_000)
+
+          incomplete_person = create(:person, first_name: "Ivy", last_name: "Incomplete")
+          incomplete_reg = create(:event_registration, event: recent_training, registrant: incomplete_person, status: "attended")
+          incomplete = create(:scholarship, recipient: incomplete_person, amount_cents: 1_000, grant: create(:grant), tasks_completed: false)
+          create(:allocation, source: incomplete, allocatable: incomplete_reg, amount: 1_000)
+
+          no_award = create(:person, first_name: "Nell", last_name: "Nograant")
+          create(:event_registration, event: recent_training, registrant: no_award, status: "attended")
+
+          get attendees_events_url(scholarship: "yes"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace", "Ivy Incomplete")
+          expect(response.body).not_to include("Nell Nograant")
+
+          get attendees_events_url(scholarship: "complete"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+          expect(response.body).not_to include("Ivy Incomplete", "Nell Nograant")
+
+          get attendees_events_url(scholarship: "no"), headers: frame_headers
+          expect(response.body).to include("Nell Nograant")
+          expect(response.body).not_to include("Ada Lovelace", "Ivy Incomplete")
+        end
+
+        it "answers 'No scholarship' per event when scoped, but person-wide cross-event" do
+          # Ada is a recipient at the recent training but holds no scholarship at the
+          # older one she also attended.
+          award = create(:scholarship, recipient: attendee, amount_cents: 1_000, grant: create(:grant))
+          create(:allocation, source: award, allocatable: attendee_registration, amount: 1_000)
+          create(:event_registration, event: older_training, registrant: attendee, status: "attended")
+
+          never = create(:person, first_name: "Nora", last_name: "Never")
+          create(:event_registration, event: recent_training, registrant: never, status: "attended")
+
+          # Cross-event: "No scholarship" means never a recipient — excludes Ada.
+          get attendees_events_url(scholarship: "no"), headers: frame_headers
+          expect(response.body).to include("Nora Never")
+          expect(response.body).not_to include("Ada Lovelace")
+
+          # Scoped to the older training, where Ada holds no scholarship — includes her.
+          get attendees_events_url(scholarship: "no", event_id: older_training.id), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+        end
+
+        it "filters by address data (city) without requiring a registration to carry it" do
+          create(:address, addressable: attendee, city: "Portland", state: "OR", inactive: false)
+          other = create(:person, first_name: "Cara", last_name: "Coast")
+          create(:event_registration, event: recent_training, registrant: other, status: "attended")
+          create(:address, addressable: other, city: "Seattle", state: "WA", inactive: false)
+
+          get attendees_events_url(city: "portland"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+          expect(response.body).not_to include("Cara Coast")
+        end
+
+        it "filters by an active topic subscription, matching any of the person's registrations" do
+          type = create(:topic_subscription_type)
+          create(:topic_subscription, person: attendee, topic_subscription_type: type)
+          unsubbed = create(:person, first_name: "Uma", last_name: "Unsub")
+          create(:event_registration, event: recent_training, registrant: unsubbed, status: "attended")
+          create(:topic_subscription, :unsubscribed, person: unsubbed, topic_subscription_type: type)
+
+          get attendees_events_url(topic_subscription: type.id), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+          expect(response.body).not_to include("Uma Unsub")
+        end
+
+        it "filters by a registration-level attribute (CE status) across events" do
+          # Ada has a CE registration at the older training; the filter should surface
+          # her on the cross-event index even though her recent-training reg has none.
+          older_reg = create(:event_registration, event: older_training, registrant: attendee, status: "attended")
+          create(:continuing_education_registration, event_registration: older_reg)
+          plain = create(:person, first_name: "Cy", last_name: "Noce")
+          create(:event_registration, event: recent_training, registrant: plain, status: "attended")
+
+          get attendees_events_url(ce_status: "registered"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+          expect(response.body).not_to include("Cy Noce")
+        end
+
+        it "always offers the scholarship filter and keeps its selection" do
+          get attendees_events_url(scholarship: "complete")
+          expect(response.body).to include("Scholarship")
+          expect(Capybara.string(response.body))
+            .to have_selector("select#scholarship option[selected][value='complete']", text: "Tasks complete")
+        end
+
+        # A param the index narrows on but the form doesn't render would shrink the
+        # list silently and then be dropped by the form's next auto-submit, since
+        # only rendered fields and the CHIP_PARAMS hidden inputs are sent.
+        it "renders a control for every registration-level filter it honours" do
+          topic = create(:topic_subscription_type)
+          get attendees_events_url
+
+          page = Capybara.string(response.body)
+          EventsController::ATTENDEE_REGISTRATION_FILTERS.each_key do |param|
+            expect(page).to have_selector("##{param}", visible: :all), "no control for #{param}"
+          end
+          expect(page).to have_selector("#city", visible: :all)
+          expect(page).to have_selector("#topic_subscription option[value='#{topic.id}']", visible: :all)
+        end
+
+        it "keeps the registration-level filter selections" do
+          get attendees_events_url(ce_status: "issued", city: "Portland", comment: "late")
+
+          page = Capybara.string(response.body)
+          expect(page).to have_selector("select#ce_status option[selected][value='issued']", text: "Issued")
+          expect(page).to have_selector("input#city[value='Portland']", visible: :all)
+          expect(page).to have_selector("input#comment[value='late']", visible: :all)
+        end
+
+        # The form posts into the results frame, and the frame's own links (the
+        # charts frame, its drill-ins) are built from that request's params — so
+        # return_to has to survive a filter change or the eyebrow loses its origin.
+        it "carries return_to through the filter form" do
+          get attendees_events_url(return_to: "participation")
+
+          expect(Capybara.string(response.body))
+            .to have_selector("input[type=hidden][name=return_to][value=participation]", visible: :all)
         end
 
         it "filters by the org's facilitator program status" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -470,18 +470,27 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include(CGI.escapeHTML(attendees_events_path(charts: 1)))
       end
 
-      it "links to that event's own breakdowns when scoped to one event" do
+      it "links to that event's own breakdowns on the attendees index when scoped to one event" do
         sign_in admin
         get reports_events_path(event_id: training.id)
 
-        expect(response.body).to include(CGI.escapeHTML(roster_event_path(training, charts: 1)))
+        # The scoped breakdowns link now lands on the attendees index (not the
+        # roster), pre-filtered to the event with its charts panel open.
+        expect(response.body).to include(attendees_events_path)
+        expect(response.body).to include("event_id=#{training.id}", "charts=1")
+        expect(response.body).not_to include(CGI.escapeHTML(roster_event_path(training, charts: 1)))
       end
 
-      it "shows the scholarship summary card linking to its full report" do
+      it "shows the scholarship summary card linking to its details and to the recipient attendees/breakdowns" do
         sign_in admin
         get reports_events_path
         expect(response.body).to include("Scholarships")
         expect(response.body).to include(scholarships_events_path)
+        # Attendees and Breakdowns eyebrows land on the attendees index pre-filtered
+        # to scholarship recipients, returning to the reports hub. (Rails serializes
+        # query params alphabetically, so return_to precedes scholarship.)
+        expect(response.body).to match(%r{/events/attendees\?[^"']*scholarship=yes})
+        expect(response.body).to match(%r{/events/attendees\?[^"']*return_to=reports[^"']*scholarship=yes})
       end
 
       it "carries the active filters into the full report links" do
@@ -2545,7 +2554,7 @@ RSpec.describe "Events", type: :request do
           get roster_event_path(owned_event)
 
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include("Registrant roster")
+          expect(response.body).to include("Roster")
           expect(response.body).to include("Ada")
           expect(response.body).to include("Lovelace")
           expect(response.body).to include("Roster Org")
@@ -2728,7 +2737,7 @@ RSpec.describe "Events", type: :request do
         it "returns to the roster from the registration it opened" do
           get edit_event_registration_path(registration, return_to: "roster")
 
-          expect(response.body).to include("Registrant roster")
+          expect(response.body).to include("Roster")
           expect(response.body).to include(roster_event_path(owned_event))
         end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -481,6 +481,47 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include(CGI.escapeHTML(roster_event_path(training, charts: 1)))
       end
 
+      # The attendees index defaults its event-type filter to facilitator trainings,
+      # so a hub scoped to an event of any other type has to pin that filter open —
+      # otherwise the event is filtered out and the drill-in lands on an empty list.
+      it "opens the attendees event-type filter when scoped to a non-training event" do
+        webinar = create(:event, facilitator_training: false, start_date: Date.current)
+        create(:event_registration, event: webinar, status: "attended")
+        sign_in admin
+        get reports_events_path(event_id: webinar.id)
+
+        expect(response.body).to match(%r{/events/attendees\?[^"']*event_id=#{webinar.id}[^"']*event_type=all})
+      end
+
+      # Unscoped, the index's own "trainings" default is the population the hub
+      # counted, so the link leaves the filter alone.
+      it "leaves the attendees event-type filter alone when the hub is unscoped" do
+        sign_in admin
+        get reports_events_path
+
+        expect(response.body).to include(
+          CGI.escapeHTML(attendees_events_path(charts: 1, event_year: Date.current.year.to_s, return_to: "reports", anchor: "breakdowns"))
+        )
+      end
+
+      # The index has no time_period vocabulary — it narrows by the event's calendar
+      # year, the same translation the card's own figure links already do — so the
+      # hub's period is converted rather than passed along to be silently dropped.
+      it "translates the hub period into the attendees year filter" do
+        sign_in admin
+        get reports_events_path(period: "last_year")
+
+        expect(response.body).to match(%r{/events/attendees\?charts=1[^"']*event_year=#{Date.current.year - 1}})
+        expect(response.body).not_to match(%r{/events/attendees\?[^"']*time_period=})
+      end
+
+      it "leaves the attendees year filter open for an all-time hub" do
+        sign_in admin
+        get reports_events_path(period: "all_time")
+
+        expect(response.body).to include(CGI.escapeHTML(attendees_events_path(charts: 1, return_to: "reports", anchor: "breakdowns")))
+      end
+
       it "shows the scholarship summary card linking to its details and to the recipient attendees/breakdowns" do
         sign_in admin
         get reports_events_path

--- a/spec/services/attendees_active_filters_spec.rb
+++ b/spec/services/attendees_active_filters_spec.rb
@@ -36,15 +36,13 @@ RSpec.describe AttendeesActiveFilters do
     expect(chips_for(org_city: "Austin, TX").first[:label]).to eq("Org city: Austin, TX")
   end
 
-  it "labels the yes/no CE drill-in" do
-    expect(chips_for(ce: "yes").first[:label]).to eq("Continuing education")
-    expect(chips_for(ce: "no").first[:label]).to eq("No continuing education")
-  end
-
-  # Scholarship status has its own visible select on the index, so it's not a chip.
-  it "does not chip scholarship status" do
+  # Scholarship and CE status each have their own visible select on the index, so
+  # neither is a chip — the CE pie's drill-ins target ce_status for that reason.
+  it "does not chip scholarship or CE status" do
     expect(chips_for(scholarship: "yes")).to eq([])
     expect(chips_for(scholarship: "no")).to eq([])
+    expect(chips_for(ce_status: "registered")).to eq([])
+    expect(chips_for(ce_status: "none")).to eq([])
   end
 
   # These two have no select on the index — they arrive from the revenue report —
@@ -65,7 +63,7 @@ RSpec.describe AttendeesActiveFilters do
   end
 
   it "emits chips in CHIP_PARAMS order regardless of param order" do
-    params = chips_for(ce: "yes", country: "Canada", registrant_ids: "1-2")
-    expect(params.map { |c| c[:param] }).to eq(%w[ registrant_ids country ce ])
+    params = chips_for(payment_status: "unpaid", country: "Canada", registrant_ids: "1-2")
+    expect(params.map { |c| c[:param] }).to eq(%w[ registrant_ids country payment_status ])
   end
 end

--- a/spec/services/attendees_active_filters_spec.rb
+++ b/spec/services/attendees_active_filters_spec.rb
@@ -36,11 +36,15 @@ RSpec.describe AttendeesActiveFilters do
     expect(chips_for(org_city: "Austin, TX").first[:label]).to eq("Org city: Austin, TX")
   end
 
-  it "labels the yes/no scholarship and CE drill-ins" do
-    expect(chips_for(scholarship: "yes").first[:label]).to eq("Scholarship recipients")
-    expect(chips_for(scholarship: "no").first[:label]).to eq("No scholarship")
+  it "labels the yes/no CE drill-in" do
     expect(chips_for(ce: "yes").first[:label]).to eq("Continuing education")
     expect(chips_for(ce: "no").first[:label]).to eq("No continuing education")
+  end
+
+  # Scholarship status has its own visible select on the index, so it's not a chip.
+  it "does not chip scholarship status" do
+    expect(chips_for(scholarship: "yes")).to eq([])
+    expect(chips_for(scholarship: "no")).to eq([])
   end
 
   # These two have no select on the index — they arrive from the revenue report —
@@ -61,7 +65,7 @@ RSpec.describe AttendeesActiveFilters do
   end
 
   it "emits chips in CHIP_PARAMS order regardless of param order" do
-    params = chips_for(scholarship: "yes", country: "Canada", registrant_ids: "1-2")
-    expect(params.map { |c| c[:param] }).to eq(%w[ registrant_ids country scholarship ])
+    params = chips_for(ce: "yes", country: "Canada", registrant_ids: "1-2")
+    expect(params.map { |c| c[:param] }).to eq(%w[ registrant_ids country ce ])
   end
 end

--- a/spec/system/community_news_index_spec.rb
+++ b/spec/system/community_news_index_spec.rb
@@ -144,6 +144,29 @@ RSpec.describe "Community News Index", type: :system do
     expect(find_field("query").value).to eq("")
   end
 
+  # Arriving with the filters already in the URL (a shared link, a drill-in) is the
+  # case where the server renders them as value/selected attributes — so clearing
+  # has to beat the browser's notion of the form's defaults, not just the fields'
+  # current state.
+  scenario "Admin clears filters that arrived in the URL" do
+    org = create(:organization, name: "Banana Org")
+    create(:community_news, :published, title: "Banana News", rhino_body: "content", organization: org)
+    create(:community_news, :published, title: "Apple News", rhino_body: "content")
+
+    sign_in admin
+    visit community_news_index_path(title: "Banana", organization_id: org.id)
+
+    expect(page).to have_content("Banana News")
+    expect(page).not_to have_content("Apple News")
+
+    click_link "Clear filters"
+
+    expect(page).to have_content("Banana News")
+    expect(page).to have_content("Apple News")
+    expect(find_field("title").value).to eq("")
+    expect(find_field("organization_id").value).to eq("")
+  end
+
   scenario "Admin sees message when no community news exist" do
     sign_in admin
 

--- a/spec/system/events_attendees_spec.rb
+++ b/spec/system/events_attendees_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Event attendees index", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:training) { create(:event, title: "TAC 261", facilitator_training: true, start_date: 1.month.ago) }
+  let!(:attendee) { create(:person, first_name: "Ada", last_name: "Lovelace") }
+  let!(:registration) { create(:event_registration, event: training, registrant: attendee, status: "attended") }
+
+  before { sign_in admin }
+
+  # The Breakdowns heading arrives inside the lazily-loaded results frame, long
+  # after the browser gave up on the hash, so it scrolls itself into view on
+  # connect. Turbo frame submits never touch the address bar, so the hash has to be
+  # dropped once it's been honoured — otherwise every later filter change would
+  # re-render the heading and yank the page back to it.
+  scenario "Admin lands on the breakdowns section and the hash stops pulling them back" do
+    visit attendees_events_path(charts: 1, anchor: "breakdowns")
+
+    expect(page).to have_css("#breakdowns")
+    expect(page).to have_current_path(%r{/events/attendees\?charts=1\z}, url: true)
+  end
+end

--- a/spec/system/events_attendees_spec.rb
+++ b/spec/system/events_attendees_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe "Event attendees index", type: :system do
     expect(page).to have_css("#breakdowns")
     expect(page).to have_current_path(%r{/events/attendees\?charts=1\z}, url: true)
   end
+
+  # Attendance and Event type render pre-selected rather than blank, so their first
+  # option is the widest one rather than a neutral placeholder. Clearing has to land
+  # on the page's default population — the controller's "unfiltered" — instead of
+  # quietly widening the report to no-shows and non-trainings.
+  scenario "Admin clears filters back to the page's default population" do
+    visit attendees_events_path(attendance_status: "no_show", contact_info: "Ada")
+
+    expect(page).to have_field("attendance_status", with: "no_show")
+
+    click_link "Clear filters"
+
+    expect(page).to have_field("attendance_status", with: EventsController::DEFAULT_ATTENDANCE_STATUS)
+    expect(page).to have_field("event_type", with: EventsController::DEFAULT_ATTENDEE_EVENT_TYPE)
+    expect(page).to have_field("contact_info", with: "")
+  end
 end

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Event show page", type: :system do
       visit event_path(event)
 
       expect(page).to have_link("Dashboard", href: dashboard_event_path(event))
-      expect(page).to have_link("Manage", href: registrants_event_path(event))
+      expect(page).to have_link("Registrations", href: registrants_event_path(event))
     end
 
     it "hides admin controls for regular users" do
@@ -120,7 +120,7 @@ RSpec.describe "Event show page", type: :system do
       visit event_path(event)
 
       expect(page).not_to have_link("Dashboard")
-      expect(page).not_to have_link("Manage")
+      expect(page).not_to have_link("Registrations")
     end
   end
 

--- a/spec/views/events/edit.html.erb_spec.rb
+++ b/spec/views/events/edit.html.erb_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "events/edit", type: :view do
     render
 
     expect(rendered).to have_link("Dashboard", href: dashboard_event_path(event))
-    expect(rendered).to have_link("Manage", href: registrants_event_path(event))
+    expect(rendered).to have_link("Registrations", href: registrants_event_path(event))
   end
 
   it "renders submit button" do

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "events/show", type: :view do
     render
 
     expect(rendered).to have_link("Dashboard", href: dashboard_event_path(event))
-    expect(rendered).to have_link("Manage", href: registrants_event_path(event))
+    expect(rendered).to have_link("Registrations", href: registrants_event_path(event))
     expect(rendered).to have_link("Events", href: events_path)
   end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 one shared filter bar across roster / bulk-reminder picker / cross-event attendees, plus new EventRegistration scopes and cross-event "any registration" filtering

### What is the goal of this PR and why is this important?
- "Registrations" reads clearer than "Manage" across the event subnav/links; the dashboard tab shows on the dashboard page.
- Reports **Breakdowns** links drill into the attendees index (charts open, scrolled to `#breakdowns`) instead of the roster; reports→attendees eyebrows return to the reports hub. "Full report" → "Details" on all three cards.
- **One shared filter bar** across the registrants roster, the bulk-reminder picker, and the cross-event attendees index.

### How did you approach the change?
- Extracted `events/_filter_bar` (Filters heading with the applied-chip row pinned right + primary row + optional More-filters drawer). All three pages render one shared field list, gated by visibility:
  - **Everywhere:** search, Attendance, Payment status/method, Scholarship, Funder, CE status, User account, Comment status/text, City, State, County, Sector, Program status, Affiliation status, Topic subscription.
  - **Cross-event only:** Event type, Event, Year.
  - **Single-event only:** Submission status, Organization linking, Progress (all event/form- or in-memory-computed).
- **Cross-event matching:** a registration-level filter matches a person if **any** of their attended registrations qualifies — reusing the `EventRegistration` scopes against `attendee_registrations`. New scopes: `registrant_topic_subscription`; `person_address_ids` gains `city`.
- **Negative values invert instead**, since "any registration matches" would let them through on a technicality: **No scholarship** and **No comments** ask the positive scope and exclude, so someone who was funded (or commented) on a *different* attended registration isn't counted. Scoped to one event both readings agree.
- **Address filters** (city/state/county) read the person's own address data directly, no registration required.
- Scholarship is one dropdown everywhere (recipient sub-statuses + new **No scholarship**, backed by `without_scholarship`).
- **CE status reads as certificate state:** Issued/Not issued → **Certificate issued** / **Certificate outstanding** (they overlapped — one person could match both), plus a new **No CE**. That absence case was previously the chip-only `ce` param, so the CE pie now drills into the dropdown and `ce` is retired; `registered` and `none` are exact complements because the license join is on a NOT NULL column.
- Every param the attendees index narrows on now has a visible control or an `AttendeesActiveFilters` chip — otherwise it shrinks the list silently and is dropped by the form's next auto-submit. A spec asserts a control exists for each `ATTENDEE_REGISTRATION_FILTERS` key. `return_to` rides the form so the results frame's own links keep the eyebrow's origin.
- Panel Show/Hide controls became text toggles with a rotating chevron; the section-heading anchor uses `reveal-section` so `#breakdowns` scrolls even inside a lazy Turbo frame.

### Anything else to add?
- Full suite green (6405 examples, 0 failures, 17 pending). Rebased on main (folds in #2179's topic-subscription filter).


- **Clear filters** resets Attendance and Event type to the page's default population, not to the widest option they lead with — they render pre-selected, so index 0 isn't neutral for them (`clear_to:` on `events/_filter_select`).
- City and state ask **one** address subquery, so they describe the same address the way the roster's shared join does.
- The four option lists both bars render (scholarship, CE, account, comment status) are now `EventRegistration::*_FILTER_OPTIONS` constants alongside the four that already existed, so the two bars can't drift.
- **The filter bar sits outside the results frame**, so two things it renders had to be kept honest across frame-only submits:
  - The applied-chip row is replaced out-of-band from the results frame (alongside the count) — its remove links are built from the request's params and otherwise still described the URL the page loaded with, dropping every filter set since.
  - `reveal-section` drops the `#breakdowns` hash once it has scrolled there; a frame submit never touches the address bar, so the hash kept matching and pulled the page back on every filter change.

