### PR TITLE
Flag undelivered communications with warning/error styling

### DIFF
--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -25,19 +25,23 @@ class NotificationDecorator < ApplicationDecorator
   end
 
   # Whole-row tint on the communications index: red error for a failed send,
-  # amber warning for one still pending, default hover once delivered.
+  # amber warning for one stuck pending past the grace period, default hover
+  # otherwise (delivered, or still within the fresh-send window).
   def row_class
-    return "hover:bg-gray-50" if delivered?
+    return "bg-red-50 hover:bg-red-100" if failed?
+    return "bg-amber-50 hover:bg-amber-100" if stuck_pending?
 
-    failed? ? "bg-red-50 hover:bg-red-100" : "bg-amber-50 hover:bg-amber-100"
+    "hover:bg-gray-50"
   end
 
   # Detail-page card background: red error for a failed send, amber warning for
-  # one still pending, the notifications domain colour once delivered.
+  # one stuck pending past the grace period, the notifications domain colour
+  # otherwise (delivered, or still within the fresh-send window).
   def card_bg_class
-    return "#{DomainTheme.bg_class_for(:notifications)} border-gray-200" if delivered?
+    return "bg-red-50 border-red-300" if failed?
+    return "bg-amber-50 border-amber-300" if stuck_pending?
 
-    failed? ? "bg-red-50 border-red-300" : "bg-amber-50 border-amber-300"
+    "#{DomainTheme.bg_class_for(:notifications)} border-gray-200"
   end
 
   def channel_icon(**options)

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -24,6 +24,22 @@ class NotificationDecorator < ApplicationDecorator
   def detail(length: nil)
   end
 
+  # Whole-row tint on the communications index: red error for a failed send,
+  # amber warning for one still pending, default hover once delivered.
+  def row_class
+    return "hover:bg-gray-50" if delivered?
+
+    failed? ? "bg-red-50 hover:bg-red-100" : "bg-amber-50 hover:bg-amber-100"
+  end
+
+  # Detail-page card background: red error for a failed send, amber warning for
+  # one still pending, the notifications domain colour once delivered.
+  def card_bg_class
+    return "#{DomainTheme.bg_class_for(:notifications)} border-gray-200" if delivered?
+
+    failed? ? "bg-red-50 border-red-300" : "bg-amber-50 border-amber-300"
+  end
+
   def channel_icon(**options)
     icon_class = CHANNEL_ICONS[channel]
     return "" if icon_class.blank?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -183,6 +183,18 @@ class Notification < ApplicationRecord
     error_at.present? && !delivered?
   end
 
+  # An autoemail normally delivers within seconds of enqueue, so one still
+  # undelivered past this window is stuck (its job never completed). Fresh
+  # pending emails inside the window aren't flagged, so a normal in-flight send
+  # doesn't briefly read as a problem.
+  DELIVERY_GRACE_PERIOD = 1.hour
+
+  def stuck_pending?
+    return false if delivered? || failed?
+
+    created_at.present? && created_at < DELIVERY_GRACE_PERIOD.ago
+  end
+
   def record_error!(exception)
     update!(
       error_message: exception.message.truncate(500),

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -13,7 +13,7 @@
 
   <tbody class="divide-y divide-gray-100">
   <% @notifications.each do |notification| %>
-    <tr class="hover:bg-gray-50">
+    <tr class="<%= notification.decorate.row_class %>">
       <!-- Sent -->
       <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
         <% if notification.delivered_at.present? %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -4,7 +4,7 @@
    Safe email preview + metadata
    ========================================= %>
 
-<div class="<%= DomainTheme.bg_class_for(:notifications) %> border border-gray-200 rounded-xl shadow p-6" data-turbo="false">
+<div class="<%= @notification.decorate.card_bg_class %> border rounded-xl shadow p-6" data-turbo="false">
   <div class="space-y-6">
 
   <!-- Header -->

--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -139,6 +139,40 @@ end
   notification.update!(email_body_html: body_html, email_body_text: body_text) if notification.email_body_html.blank?
 end
 
+# A few emails that never went out, so the warning styling is visible: the index
+# tints the whole row amber and the detail card takes the warning background for
+# any undelivered email (pending or failed). Created a few hours ago so they sort
+# to the top (index is created_at desc). Left undelivered with no subject/body —
+# exactly the state a real stuck or failed send leaves behind.
+delivery_problem_samples = [
+  { kind: "idea_submitted_fyi", hours_ago: 2, state: :failed },
+  { kind: "workshop_log_submitted_fyi", hours_ago: 3, state: :pending },
+  { kind: "event_registration_confirmation_fyi", hours_ago: 4, state: :pending }
+]
+
+delivery_problem_samples.each do |sample|
+  created_at = sample[:hours_ago].hours.ago
+  failed = sample[:state] == :failed
+
+  notification = Notification.find_or_create_by!(
+    recipient_email: reply_to_email,
+    kind: sample[:kind],
+    email_subject: nil
+  ) do |n|
+    n.noticeable = sample_user&.person
+    n.recipient_role = "admin"
+    n.notification_type = 0
+    n.delivered_at = nil
+    n.error_at = failed ? created_at : nil
+    n.error_class = failed ? "Net::SMTPServerBusy" : nil
+    n.error_message = failed ? "451 Temporary server error. Please try again later." : nil
+  end
+  # Re-anchor to a fresh few-hours-ago each seed run so they stay at the top.
+  notification.update_columns(created_at: created_at)
+end
+
+puts "  Created #{delivery_problem_samples.size} undelivered notifications (pending → warning, failed → error styling)"
+
 puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications"
 
 # Custom event reminders Amy received. These demonstrate the editable subject and

--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -140,9 +140,10 @@ end
 end
 
 # A few emails that never went out, so the warning styling is visible: the index
-# tints the whole row amber and the detail card takes the warning background for
-# any undelivered email (pending or failed). Created a few hours ago so they sort
-# to the top (index is created_at desc). Left undelivered with no subject/body —
+# tints the whole row (and the detail card) amber for a stuck-pending email and
+# red for a failed one. Created a few hours ago so they sort to the top (index is
+# created_at desc) and are past the 1-hour delivery grace period, so the pending
+# ones read as stuck rather than fresh. Left undelivered with no subject/body —
 # exactly the state a real stuck or failed send leaves behind.
 delivery_problem_samples = [
   { kind: "idea_submitted_fyi", hours_ago: 2, state: :failed },

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -13,6 +13,46 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
   end
 
+  describe "#row_class" do
+    it "tints the row amber for a pending (not-yet-delivered) email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil)
+
+      expect(notification.decorate.row_class).to eq("bg-amber-50 hover:bg-amber-100")
+    end
+
+    it "tints the row red for a failed email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: Time.current)
+
+      expect(notification.decorate.row_class).to eq("bg-red-50 hover:bg-red-100")
+    end
+
+    it "uses the default hover treatment once delivered" do
+      notification = build_stubbed(:notification, delivered_at: Time.current)
+
+      expect(notification.decorate.row_class).to eq("hover:bg-gray-50")
+    end
+  end
+
+  describe "#card_bg_class" do
+    it "uses the amber warning background for a pending email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil)
+
+      expect(notification.decorate.card_bg_class).to eq("bg-amber-50 border-amber-300")
+    end
+
+    it "uses the red error background for a failed email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: Time.current)
+
+      expect(notification.decorate.card_bg_class).to eq("bg-red-50 border-red-300")
+    end
+
+    it "uses the notifications domain colour once delivered" do
+      notification = build_stubbed(:notification, delivered_at: Time.current)
+
+      expect(notification.decorate.card_bg_class).to eq("#{DomainTheme.bg_class_for(:notifications)} border-gray-200")
+    end
+  end
+
   describe "#channel_icon" do
     {
       "email" => "fa-envelope",

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe NotificationDecorator, type: :decorator do
   end
 
   describe "#row_class" do
-    it "tints the row amber for a pending (not-yet-delivered) email" do
-      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil)
+    it "tints the row amber for an email stuck pending past the grace period" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: 2.hours.ago)
 
       expect(notification.decorate.row_class).to eq("bg-amber-50 hover:bg-amber-100")
     end
@@ -26,6 +26,12 @@ RSpec.describe NotificationDecorator, type: :decorator do
       expect(notification.decorate.row_class).to eq("bg-red-50 hover:bg-red-100")
     end
 
+    it "uses the default hover treatment for a fresh in-flight send" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: 5.minutes.ago)
+
+      expect(notification.decorate.row_class).to eq("hover:bg-gray-50")
+    end
+
     it "uses the default hover treatment once delivered" do
       notification = build_stubbed(:notification, delivered_at: Time.current)
 
@@ -34,8 +40,8 @@ RSpec.describe NotificationDecorator, type: :decorator do
   end
 
   describe "#card_bg_class" do
-    it "uses the amber warning background for a pending email" do
-      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil)
+    it "uses the amber warning background for an email stuck pending past the grace period" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: 2.hours.ago)
 
       expect(notification.decorate.card_bg_class).to eq("bg-amber-50 border-amber-300")
     end
@@ -44,6 +50,12 @@ RSpec.describe NotificationDecorator, type: :decorator do
       notification = build_stubbed(:notification, delivered_at: nil, error_at: Time.current)
 
       expect(notification.decorate.card_bg_class).to eq("bg-red-50 border-red-300")
+    end
+
+    it "uses the notifications domain colour for a fresh in-flight send" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: 5.minutes.ago)
+
+      expect(notification.decorate.card_bg_class).to eq("#{DomainTheme.bg_class_for(:notifications)} border-gray-200")
     end
 
     it "uses the notifications domain colour once delivered" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -232,6 +232,32 @@ RSpec.describe Notification do
     end
   end
 
+  describe "#stuck_pending?" do
+    it "is true when undelivered past the grace period" do
+      notification = create(:notification, delivered_at: nil, error_at: nil, created_at: 2.hours.ago)
+
+      expect(notification.stuck_pending?).to be true
+    end
+
+    it "is false while still within the grace period (a normal in-flight send)" do
+      notification = create(:notification, delivered_at: nil, error_at: nil, created_at: 5.minutes.ago)
+
+      expect(notification.stuck_pending?).to be false
+    end
+
+    it "is false once delivered" do
+      notification = create(:notification, delivered_at: Time.current, created_at: 2.hours.ago)
+
+      expect(notification.stuck_pending?).to be false
+    end
+
+    it "is false when failed (that is an error, not a stuck-pending state)" do
+      notification = create(:notification, error_at: Time.current, delivered_at: nil, created_at: 2.hours.ago)
+
+      expect(notification.stuck_pending?).to be false
+    end
+  end
+
   describe "#record_error!" do
     it "stores exception details on the notification" do
       notification = create(:notification)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small presentation-only logic on the notifications decorator + two views

### What is the goal of this PR and why is this important?
- A communication's subject is only persisted when its email is delivered, so undelivered (pending or failed) emails show a blank subject with no visual signal that something is wrong.

### How did you approach the change?
- Added `NotificationDecorator#row_class` / `#card_bg_class` and wired them into the communications index rows and the detail card: **failed → red error**, **stuck pending → amber warning**, **delivered / fresh in-flight → neutral**.
- "Stuck pending" is gated behind `Notification#stuck_pending?` (a 1-hour delivery grace period) so a normal in-flight send doesn't briefly read as a problem.
- Seeded a failed + two stuck-pending samples at the top of the dev communications list so all three states are visible without waiting on a real stuck send.

### UI Testing Checklist
- [ ] Communications index: failed rows tint red, stuck-pending rows tint amber, delivered/fresh rows unchanged.
- [ ] Communication detail card: red when failed, amber when stuck pending, default otherwise.

### Anything else to add?
- Grace period is `Notification::DELIVERY_GRACE_PERIOD` (1 hour) — easy to tune.
