### PR TITLE
Retire pre-launch undelivered communications from the pending treatment

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -104,6 +104,12 @@ class Notification < ApplicationRecord
   scope :delivered, -> { where.not(delivered_at: nil) }
   scope :undelivered, -> { where(delivered_at: nil) }
 
+  # The portal launched on this date. Any undelivered email created before it is
+  # pre-launch data (imported/legacy) whose delivery job is long gone — it will
+  # never send, so we retire it from the "pending" treatment (see #archived?)
+  # rather than flagging tens of thousands of old rows as stuck.
+  LAUNCHED_ON = Date.new(2026, 1, 1)
+
   validates :kind, presence: true, inclusion: { in: KINDS }
   validates :recipient_role, presence: true, inclusion: { in: RECIPIENT_ROLES }
   validates :recipient_email, presence: true
@@ -183,14 +189,24 @@ class Notification < ApplicationRecord
     error_at.present? && !delivered?
   end
 
+  # A pre-launch undelivered email — legacy data that never sent. Shown as
+  # "Archived" (neutral) instead of "Pending" so the old backlog doesn't read
+  # as a live problem. Delivered/failed rows keep their own status.
+  def archived?
+    return false if delivered? || failed?
+
+    created_at.present? && created_at.to_date < LAUNCHED_ON
+  end
+
   # An autoemail normally delivers within seconds of enqueue, so one still
   # undelivered past this window is stuck (its job never completed). Fresh
   # pending emails inside the window aren't flagged, so a normal in-flight send
-  # doesn't briefly read as a problem.
+  # doesn't briefly read as a problem; archived ones are intentionally retired,
+  # so they aren't flagged either.
   DELIVERY_GRACE_PERIOD = 1.hour
 
   def stuck_pending?
-    return false if delivered? || failed?
+    return false if delivered? || failed? || archived?
 
     created_at.present? && created_at < DELIVERY_GRACE_PERIOD.ago
   end

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -20,6 +20,8 @@
           <%= time_ago_in_words(notification.delivered_at.in_time_zone("Pacific Time (US & Canada)")) %> ago
         <% elsif notification.failed? %>
           <span class="text-red-600 font-medium" title="<%= notification.error_class %>: <%= notification.error_message %>">Failed</span>
+        <% elsif notification.archived? %>
+          <span class="text-gray-400 font-medium" title="Retired — old undelivered email, no longer tracked as pending">Archived</span>
         <% else %>
           <span class="text-yellow-600 font-medium">Pending</span>
         <% end %>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -31,6 +31,12 @@
           <i class="fas fa-exclamation-circle"></i>
           Failed
         </span>
+      <% elsif @notification.archived? %>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-gray-100 text-gray-600"
+              title="Retired — old undelivered email, no longer tracked as pending">
+          <i class="fas fa-box-archive"></i>
+          Archived
+        </span>
       <% else %>
         <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-yellow-100 text-yellow-700">
           <i class="fas fa-clock"></i>

--- a/db/seeds/dev/notifications.rb
+++ b/db/seeds/dev/notifications.rb
@@ -139,21 +139,25 @@ end
   notification.update!(email_body_html: body_html, email_body_text: body_text) if notification.email_body_html.blank?
 end
 
-# A few emails that never went out, so the warning styling is visible: the index
-# tints the whole row (and the detail card) amber for a stuck-pending email and
-# red for a failed one. Created a few hours ago so they sort to the top (index is
-# created_at desc) and are past the 1-hour delivery grace period, so the pending
-# ones read as stuck rather than fresh. Left undelivered with no subject/body —
-# exactly the state a real stuck or failed send leaves behind.
+# A few emails that never went out, so each status is visible in the index: a
+# stuck-pending one (amber row + card), a failed one (red), and an archived one
+# (neutral — a stale row an admin retired so it stops reading as pending).
+# Created a few hours ago so they sort to the top (index is created_at desc) and
+# are past the 1-hour delivery grace period. Left undelivered with no
+# subject/body — exactly the state a real stuck, failed, or retired send leaves.
 delivery_problem_samples = [
   { kind: "idea_submitted_fyi", hours_ago: 2, state: :failed },
   { kind: "workshop_log_submitted_fyi", hours_ago: 3, state: :pending },
-  { kind: "event_registration_confirmation_fyi", hours_ago: 4, state: :pending }
+  { kind: "event_registration_confirmation_fyi", hours_ago: 4, state: :pending },
+  { kind: "report_submitted_fyi", hours_ago: 5, state: :archived }
 ]
 
 delivery_problem_samples.each do |sample|
-  created_at = sample[:hours_ago].hours.ago
   failed = sample[:state] == :failed
+  archived = sample[:state] == :archived
+  # Archived reads off the pre-launch date, so date it before the portal launched;
+  # the rest sit a few hours back so they sort to the top of the list.
+  created_at = archived ? (Notification::LAUNCHED_ON - 2.weeks).to_time : sample[:hours_ago].hours.ago
 
   notification = Notification.find_or_create_by!(
     recipient_email: reply_to_email,
@@ -168,11 +172,10 @@ delivery_problem_samples.each do |sample|
     n.error_class = failed ? "Net::SMTPServerBusy" : nil
     n.error_message = failed ? "451 Temporary server error. Please try again later." : nil
   end
-  # Re-anchor to a fresh few-hours-ago each seed run so they stay at the top.
   notification.update_columns(created_at: created_at)
 end
 
-puts "  Created #{delivery_problem_samples.size} undelivered notifications (pending → warning, failed → error styling)"
+puts "  Created #{delivery_problem_samples.size} undelivered notifications (pending → warning, failed → error, archived → neutral)"
 
 puts "  Created #{Notification.where(kind: %w[contact_us contact_us_fyi]).count} contact_us notifications"
 

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe NotificationDecorator, type: :decorator do
 
       expect(notification.decorate.row_class).to eq("hover:bg-gray-50")
     end
+
+    it "uses the default hover treatment for an archived (pre-launch) email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: Date.new(2025, 12, 1))
+
+      expect(notification.decorate.row_class).to eq("hover:bg-gray-50")
+    end
   end
 
   describe "#card_bg_class" do
@@ -60,6 +66,12 @@ RSpec.describe NotificationDecorator, type: :decorator do
 
     it "uses the notifications domain colour once delivered" do
       notification = build_stubbed(:notification, delivered_at: Time.current)
+
+      expect(notification.decorate.card_bg_class).to eq("#{DomainTheme.bg_class_for(:notifications)} border-gray-200")
+    end
+
+    it "uses the notifications domain colour for an archived (pre-launch) email" do
+      notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: Date.new(2025, 12, 1))
 
       expect(notification.decorate.card_bg_class).to eq("#{DomainTheme.bg_class_for(:notifications)} border-gray-200")
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -256,6 +256,30 @@ RSpec.describe Notification do
 
       expect(notification.stuck_pending?).to be false
     end
+
+    it "is false once archived (pre-launch), even past the grace period" do
+      notification = create(:notification, delivered_at: nil, error_at: nil, created_at: Date.new(2025, 12, 1))
+
+      expect(notification.stuck_pending?).to be false
+    end
+  end
+
+  describe "#archived?" do
+    it "is true for an undelivered email created before launch" do
+      expect(build(:notification, delivered_at: nil, error_at: nil, created_at: Date.new(2025, 12, 1)).archived?).to be true
+    end
+
+    it "is false for an undelivered email created on/after launch" do
+      expect(build(:notification, delivered_at: nil, error_at: nil, created_at: Notification::LAUNCHED_ON).archived?).to be false
+    end
+
+    it "is false when delivered, even if created before launch" do
+      expect(build(:notification, delivered_at: Time.current, created_at: Date.new(2025, 12, 1)).archived?).to be false
+    end
+
+    it "is false when failed, even if created before launch" do
+      expect(build(:notification, delivered_at: nil, error_at: Time.current, created_at: Date.new(2025, 12, 1)).archived?).to be false
+    end
   end
 
   describe "#record_error!" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small date-based classification + view labels on the notifications model/views

### What is the goal of this PR and why is this important?
- The portal launched Jan 1 2026, so the ~63k undelivered notifications created before then are legacy/imported data that will never send — but they render as "Pending" (and would all flag amber under the new warning styling).

### How did you approach the change?
- Added `Notification::LAUNCHED_ON` (Jan 1 2026); `#archived?` classifies an undelivered, non-failed row created before it as **Archived** (neutral) instead of Pending, and `stuck_pending?` excludes it so it never warns.
- Index + detail now show an "Archived" status for those rows; post-launch stuck sends still surface as real problems.
- No column, backfill, or migration — it's date-derived, so it applies on deploy. Dev seed gains one archived sample.

### UI Testing Checklist
- [ ] Communications index: a pre-launch undelivered row shows "Archived" (neutral), not "Pending"/amber.
- [ ] A post-launch stuck-pending row still shows amber; failed still red.

### Anything else to add?
- Cutoff is a single constant if the launch date ever needs adjusting. Depends on the warning styling merged in #2184.
