### PR TITLE
Harden spec suite against test-order pollution (Faker reseed + Current reset + Faker-order address flake)

### DIFF
--- a/spec/current_attributes_reset_spec.rb
+++ b/spec/current_attributes_reset_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+# Regression guard for test-order pollution via ActiveSupport::CurrentAttributes.
+# The executor only auto-resets Current around real requests/jobs; a spec that
+# sets Current in the test thread (controller/view/service specs) has nothing to
+# clear it, so a stale value leaks into later examples and silently changes
+# model behavior that branches on Current (Organization affiliation-lock
+# validation, AhoyTrackable lifecycle tracking). rails_helper resets Current
+# after every example — this proves it. order: :defined pins the two examples so
+# the second reliably follows the first regardless of the suite seed.
+RSpec.describe "Current attributes reset between examples", order: :defined do
+  it "leaves Current set within an example" do
+    Current.user = User.new
+    Current.source = "leak_probe"
+
+    expect(Current.source).to eq "leak_probe"
+  end
+
+  it "starts the next example with a clean Current" do
+    expect(Current.user).to be_nil
+    expect(Current.source).to be_nil
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,14 @@ RSpec.configure do |config|
   # each example (no-op when time wasn't traveled).
   config.after { travel_back }
 
+  # ActiveSupport::CurrentAttributes (Current.user/source) is only auto-reset by
+  # the executor around real requests/jobs. Controller/view/service specs set it
+  # in the test thread with no executor to clear it, so a stale Current leaks
+  # into later examples and silently changes model behavior that branches on it
+  # (Organization affiliation-lock validation, AhoyTrackable lifecycle tracking).
+  # Reset after every example, like travel_back above (no-op when nothing set it).
+  config.after { Current.reset }
+
   # Include pagination helper globally
   config.include PaginationHelpers
 

--- a/spec/services/organization_services/upsert_address_spec.rb
+++ b/spec/services/organization_services/upsert_address_spec.rb
@@ -87,7 +87,12 @@ RSpec.describe OrganizationServices::UpsertAddress do
   end
 
   it "updates the matching city/state address in place instead of duplicating" do
-    existing = create(:address, addressable: organization, city: "Austin", state: "TX", primary: true)
+    # Pin the fields this example expects to change to values distinct from the
+    # upsert below. The factory otherwise fills them from Faker's shared,
+    # order-dependent stream, which can coincidentally match a new value (e.g.
+    # country "Canada") and drop it from the reported changes under some seeds.
+    existing = create(:address, addressable: organization, city: "Austin", state: "TX", primary: true,
+                      street_address: "1 Old St", zip_code: "10001", country: "United States")
 
     result = described_class.call(
       organization: organization,

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,5 +1,16 @@
-# give it a specific seed to ensure the same data is generated. This combined
-# with running rspec with a specific seed value will ensure that specs are run
-# in the same order and the same "faked" data is generated each time: giving
-# us deterministic results.
+# Reseed Faker's RNG before every example so each example draws from the same
+# fixed sequence regardless of test order. Faker uses one shared, global stream,
+# so without this a factory's "random" value depends on how many Faker calls ran
+# earlier in the suite — making data order-dependent and specs flaky under some
+# seeds (e.g. an address factory landing on country "Canada"). Reseeding per
+# example makes the faked data deterministic AND independent of ordering.
 Faker::Config.random = Random.new(42)
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Faker::Config.random = Random.new(42)
+    # Faker's .unique generator remembers used values for the whole run; reseeding
+    # to the same stream would replay them and hit RetryLimitExceeded, so clear it.
+    Faker::UniqueGenerator.clear
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 spec-infra only (two after/before hooks + a factory-value pin); no app code — but touches all specs via the Faker hook, so worth a careful read

Hardens the spec suite against test-order pollution. Spec-only; no app code changes.

### 1. Reseed Faker per example (root fix for order-dependent faked data)
- Faker draws from **one shared global RNG stream**, so a factory's "random" value depends on how many Faker calls ran earlier in the suite — making data order-dependent and specs flaky under some seeds.
- `spec/support/faker.rb` now reseeds `Random.new(42)` in a `before(:each)` so every example draws the same fixed sequence regardless of order. Faker's `.unique` generator remembers used values for the whole run, so a bare reseed replays them and hits `RetryLimitExceeded` (that alone caused 1782 failures) — clearing it per example fixes that.
- Verified green on the full suite (system specs included) at seeds **11334** and **18114**: 6330 examples, 0 failures.

### 2. Reset `Current` (ActiveSupport::CurrentAttributes) between examples
- `Current.user` / `Current.source` is only auto-reset by the executor around real requests/jobs. Controller/view/service specs set it in the **test thread** with nothing to clear it, so a stale `Current` leaks into later examples and silently flips model behavior that branches on it — `Organization#affiliation_dates_locked` (`organization.rb:58`) and `AhoyTrackable` (`ahoy_trackable.rb:266`).
- Added `config.after { Current.reset }` beside the existing `travel_back` / `Warden.test_reset!` hooks, plus an `order: :defined` regression spec (red without the hook, green with it).

### 3. Pin address fields in `upsert_address_spec`
- The concrete flake that started this: at seed 62433 the factory's random country landed on `"Canada"` — the value the upsert sets — so `"Country"` dropped from the reported changes. Pinned the changed fields to fixed, distinct values. Now also covered by fix  but kept for clarity/robustness.

### Scope note
- I could **not** reproduce the originally-reported 11 failures (age-range / category / public-registration) from code + seed — seed 18114 was green across repeated runs and a full-suite leak detector found no residual `Current` or committed "AgeRange" `CategoryType`. Those look **environment-specific** (residual data in that workspace's test DB, or a selenium flake); `RAILS_ENV=test bin/rails db:reset` in that workspace is the likely remedy. The changes here fix the order-dependence hazards that *are* reproducible and real.
