### PR TITLE
Use :unprocessable_content over deprecated :unprocessable_entity

### DIFF
--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -19,7 +19,7 @@ class AffiliationsController < ApplicationController
           render turbo_stream: turbo_stream.remove("affiliation_#{affiliation.id}")
         else
           render turbo_stream: turbo_stream.replace("flash_now", partial: "shared/flash_messages"),
-                 status: :unprocessable_entity
+                 status: :unprocessable_content
         end
       end
       format.html do

--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -64,7 +64,7 @@ module Dedupable
   rescue ActionPolicy::Unauthorized
     raise
   rescue StandardError => e
-    render json: { error: e.message }, status: :unprocessable_entity
+    render json: { error: e.message }, status: :unprocessable_content
   end
 
   def dedupe_perform

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -544,7 +544,7 @@ class EventsController < ApplicationController
       message = @event.errors.full_messages.to_sentence.presence || "Event could not be destroyed."
       respond_to do |format|
         format.html { redirect_to event_path(@event), status: :see_other, alert: message }
-        format.json { render json: { errors: @event.errors.full_messages }, status: :unprocessable_entity }
+        format.json { render json: { errors: @event.errors.full_messages }, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -43,7 +43,7 @@ class NotificationsController < ApplicationController
     if @person && @notification.save
       redirect_to notifications_path, notice: "Communication logged."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -36,7 +36,7 @@ class RegistrationTicketCalloutsController < ApplicationController
     if @callout.update(callout_params)
       head :ok
     else
-      head :unprocessable_entity
+      head :unprocessable_content
     end
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   config.sign_in_after_reset_password = true
 
   # Use Turbo-compatible HTTP status codes
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # Configure the class responsible to send e-mails.

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "Notifications", type: :request do
           post notifications_path, params: valid_params.except(:person_id)
         }.not_to change(Notification, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("Select a person")
       end
 
@@ -199,7 +199,7 @@ RSpec.describe "Notifications", type: :request do
           post notifications_path, params: valid_params.deep_merge(notification: { email_subject: "" })
         }.not_to change(Notification, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 mechanical status-symbol rename, no behavior change

### What is the goal of this PR and why is this important?
- Rack deprecated the `:unprocessable_entity` status symbol and warns on every use; the suite surfaced these warnings.

### How did you approach the change?
- Replaced every `:unprocessable_entity` with `:unprocessable_content` across controllers, the Dedupable concern, the Devise initializer, and the notifications request spec. Both symbols map to HTTP 422, so responses are unchanged.

### UI Testing Checklist
- N/A — no UI changes.

### Anything else to add?
- Rubocop and Brakeman pass (run on push).