### PR TITLE
Flag bulk reminders & invites as bulk communications

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -450,6 +450,7 @@ class EventsController < ApplicationController
         recipient_email: event_registration.registrant.preferred_email,
         notification_type: 0,
         sender: current_user, # an admin sent these by hand from the reminders page
+        bulk: true,
         custom_message: custom_message.presence,
         custom_subject: custom_subject.presence
       )
@@ -913,7 +914,7 @@ class EventsController < ApplicationController
   # its own communication record, so there's no separate per-recipient notification
   # or admin FYI here.
   def send_bulk_invites(registrations)
-    invited = registrations.count { |reg| PersonInviter.call(person: reg.registrant, sender: current_user).invited }
+    invited = registrations.count { |reg| PersonInviter.call(person: reg.registrant, sender: current_user, bulk: true).invited }
 
     track_view("events.send_invites", { event_id: @event.id, recipient_count: invited })
     redirect_to registrants_event_path(@event), notice: "Portal invite (confirmation) emails are being sent to #{invited} #{'person'.pluralize(invited)}."

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -86,10 +86,12 @@ class NotificationDecorator < ApplicationDecorator
     pill(AUDIENCE_META[audience], **options)
   end
 
-  # Part of a bulk operation (bulk payment) — sent as part of a bulk or its admin
-  # FYI. Both bulk kinds start with "bulk_".
+  # Part of a bulk send, so the index can flag it with a "Bulk" pill. Two things
+  # count: the bulk_payment_* kinds (unambiguous from the kind alone), and any
+  # send explicitly marked via the `bulk` column — bulk reminders and invites,
+  # whose kind is shared with one-off sends.
   def bulk?
-    kind.to_s.start_with?("bulk_")
+    object.bulk? || kind.to_s.start_with?("bulk_")
   end
 
   # Every applicable flag pill for this communication, rendered together:

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -26,6 +26,9 @@ class DeviseMailer < Devise::Mailer
     # The invite sender arrives as a plain id in opts (GlobalID-safe for async
     # delivery); pull it out before super so Devise doesn't fold it into the headers.
     @confirmation_sender_id = opts.delete(:sender_id)
+    # Set when this confirmation is part of a bulk invite send, so the logged
+    # communication is flagged bulk. Pulled out before super for the same reason.
+    @confirmation_bulk = opts.delete(:bulk) { false }
     @record = record
     @token  = token
     @user = record
@@ -94,6 +97,7 @@ class DeviseMailer < Devise::Mailer
       kind: kind,
       notification_type: 1,
       sender: confirmation_sender, # the staff member who triggered it, when one did
+      bulk: @confirmation_bulk || false, # part of a bulk invite send (only ever set on confirmations)
       deliver: false # Devise already sent the email, so no need to deliver via the job
     )
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,11 +221,12 @@ class User < ApplicationRecord
   # notification it logs, since it has no request and no current_user. Passing an
   # id rather than stashing it on the record keeps it intact if the confirmation
   # is ever delivered async (the record round-trips through GlobalID; the opts don't).
-  def send_confirmation_instructions(sender: nil)
+  def send_confirmation_instructions(sender: nil, bulk: false)
     generate_confirmation_token! unless @raw_confirmation_token
     target = unconfirmed_email.presence || email
     opts = { to: target }
     opts[:sender_id] = sender.id if sender
+    opts[:bulk] = true if bulk
     send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
   end
 

--- a/app/services/notification_services/create_notification.rb
+++ b/app/services/notification_services/create_notification.rb
@@ -9,6 +9,7 @@ module NotificationServices
       custom_message: nil,
       custom_subject: nil,
       sender: nil,
+      bulk: false,
       deliver: true,
       persist_delivered_email: true
     )
@@ -21,7 +22,8 @@ module NotificationServices
         recipient_email: recipient_email,
         custom_message: custom_message,
         custom_subject: custom_subject,
-        sender: sender
+        sender: sender,
+        bulk: bulk
       )
       Rails.logger.info({
                           event: "notification.created",

--- a/app/services/person_inviter.rb
+++ b/app/services/person_inviter.rb
@@ -6,13 +6,14 @@
 class PersonInviter
   Result = Struct.new(:invited, :reason, keyword_init: true)
 
-  def self.call(person:, sender: nil)
-    new(person: person, sender: sender).call
+  def self.call(person:, sender: nil, bulk: false)
+    new(person: person, sender: sender, bulk: bulk).call
   end
 
-  def initialize(person:, sender: nil)
+  def initialize(person:, sender: nil, bulk: false)
     @person = person
     @sender = sender
+    @bulk = bulk
   end
 
   def call
@@ -50,6 +51,6 @@ class PersonInviter
     user.updated_by = @sender
     user.set_welcome_instructions_token!
     user.update!(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: @sender)
-    user.send_confirmation_instructions(sender: @sender)
+    user.send_confirmation_instructions(sender: @sender, bulk: @bulk)
   end
 end

--- a/db/migrate/20260813143231_add_bulk_to_notifications.rb
+++ b/db/migrate/20260813143231_add_bulk_to_notifications.rb
@@ -1,0 +1,15 @@
+class AddBulkToNotifications < ActiveRecord::Migration[8.0]
+  def up
+    return if column_exists?(:notifications, :bulk)
+
+    # Marks a communication that went out as part of a bulk send. The bulk_payment_*
+    # kinds are already unambiguous from their kind alone; this flag exists for the
+    # bulk sends whose kind is shared with one-off sends — bulk reminders
+    # (event_registration_reminder) and bulk invites (account_confirmation).
+    add_column :notifications, :bulk, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :notifications, :bulk, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_154855) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_143231) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -783,6 +783,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_154855) do
   end
 
   create_table "notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.boolean "bulk", default: false, null: false
     t.string "channel", default: "autoemail", null: false
     t.datetime "created_at", precision: nil, null: false
     t.text "custom_message"

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -170,6 +170,13 @@ RSpec.describe NotificationDecorator, type: :decorator do
       expect(html).not_to include("Incoming")
     end
 
+    it "shows a Bulk pill for a send flagged via the bulk column, even when its kind isn't bulk_" do
+      html = build_stubbed(:notification, :bulk, kind: "event_registration_reminder", recipient_role: "person").decorate.flag_badges
+      expect(html).to include("Bulk")
+      expect(html).not_to include("FYI")
+      expect(html).not_to include("Incoming")
+    end
+
     it "renders nothing for a plain message to the person" do
       expect(build_stubbed(:notification, recipient_role: "person").decorate.flag_badges).to eq("")
     end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     trait :incoming do
       direction { "incoming" }
     end
+
+    trait :bulk do
+      bulk { true }
+    end
   end
 end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe DeviseMailer, type: :mailer do
 
         described_class.confirmation_instructions(user, token).deliver_now
       end
+
+      it "flags the notification bulk when the invite is part of a bulk send" do
+        expect(NotificationServices::CreateNotification).to receive(:call).with(
+          hash_including(kind: "account_confirmation", bulk: true)
+        ).and_return(notification)
+
+        described_class.confirmation_instructions(user, token, bulk: true).deliver_now
+      end
+
+      it "leaves a one-off invite unflagged" do
+        expect(NotificationServices::CreateNotification).to receive(:call).with(
+          hash_including(kind: "account_confirmation", bulk: false)
+        ).and_return(notification)
+
+        described_class.confirmation_instructions(user, token).deliver_now
+      end
     end
 
     context "when sending confirmation for email change (reconfirmation)" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -489,5 +489,28 @@ RSpec.describe User do
           .with(user, anything, hash_excluding(:sender_id))
       end
     end
+
+    context "when part of a bulk invite send" do
+      let(:user) { create(:user, confirmed_at: nil) }
+
+      before do
+        user
+        allow(DeviseMailer).to receive(:confirmation_instructions).and_return(mock_mail)
+      end
+
+      it "passes bulk through the mailer opts so the logged communication is flagged" do
+        user.send_confirmation_instructions(bulk: true)
+
+        expect(DeviseMailer).to have_received(:confirmation_instructions)
+          .with(user, anything, hash_including(bulk: true))
+      end
+
+      it "omits bulk for a one-off invite" do
+        user.send_confirmation_instructions
+
+        expect(DeviseMailer).to have_received(:confirmation_instructions)
+          .with(user, anything, hash_excluding(:bulk))
+      end
+    end
   end
 end

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -123,5 +123,13 @@ RSpec.describe "Events::BulkReminders", type: :request do
       # carry a sender so the index/show page name the admin.
       expect(reminders.map(&:sender_id)).not_to include(nil)
     end
+
+    it "flags each reminder as bulk so the index marks it with a Bulk pill" do
+      post send_reminder_event_path(event), params: { registration_ids: [ jane.id, sam.id ] }
+
+      reminders = Notification.where(kind: "event_registration_reminder")
+      expect(reminders.count).to eq(2)
+      expect(reminders).to all(be_bulk)
+    end
   end
 end

--- a/spec/services/person_inviter_spec.rb
+++ b/spec/services/person_inviter_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe PersonInviter do
         .and change(User, :count).by(0)
     end
 
+    it "forwards the bulk flag so a bulk invite is logged as bulk" do
+      user = create(:user, :unconfirmed, email: "pending@example.com")
+      person = create(:person, user: user)
+
+      expect(user).to receive(:send_confirmation_instructions).with(sender: sender, bulk: true)
+
+      described_class.call(person: person, sender: sender, bulk: true)
+    end
+
     it "skips a person who already has a confirmed account" do
       person = create(:person) # factory associates a confirmed user
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small marker threaded through three send paths, plus a null:false gotcha in the shared Devise mailer

## Why
The **Bulk** pill in the communications index derives from `NotificationDecorator#bulk?`, which only matched `kind.start_with?("bulk_")` — i.e. the `bulk_payment_*` kinds. Bulk **reminders** (`event_registration_reminder`) and bulk **invites** (`account_confirmation`) share their kind with one-off sends, so they were indistinguishable from individual messages.

## What
- Add a `bulk` boolean column on `notifications` (`default: false, null: false`).
- Set it in the two paths whose kind is ambiguous: the reminder loop (`events#send_reminder`) and the invite path, threaded `send_bulk_invites → PersonInviter → User#send_confirmation_instructions → DeviseMailer → create_notification_record`.
- `bulk?` now reads `object.bulk? || kind.start_with?("bulk_")`, so bulk-payment sends keep flagging with **no backfill**.

## Notes
- `DeviseMailer#create_notification_record` is shared by reset-password/unlock, where `@confirmation_bulk` is never set — coerced with `|| false` so it doesn't write `nil` into the `null: false` column.
- No admin FYI is flagged for reminders/invites — neither creates a per-batch `Notification` (reminders send an FYI *mailer* only; invites log per-recipient).