### PR TITLE
Mint facilitator affiliations only from trainings; record the creating registration

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -615,7 +615,9 @@ class EventRegistrationsController < ApplicationController
       organization: organization,
       job_title: submitted_position(registration, organization),
       training_date: registration.event.start_date,
-      organization_address: address_result.address || sole_address(organization)
+      organization_address: address_result.address || sole_address(organization),
+      facilitator_training: registration.event.facilitator_training,
+      event_registration: registration
     )
 
     address_result

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -16,6 +16,10 @@ class Affiliation < ApplicationRecord
   belongs_to :person, touch: true
   # Which of the organization's addresses this person is affiliated with (optional).
   belongs_to :organization_address, class_name: "Address", optional: true
+  # The registration that auto-minted this affiliation, when it came from one. NULL
+  # for manually/historically created rows — reconciliation only sweeps rows that
+  # have this link.
+  belongs_to :event_registration, optional: true, inverse_of: :affiliations
 
   # Validations
   validates_presence_of :organization_id
@@ -72,6 +76,7 @@ class Affiliation < ApplicationRecord
 
   before_validation :skip_if_duplicate
   before_save :set_inactive_from_dates
+  before_update :clear_event_registration_on_org_change
   after_save :sync_organization_status_with_affiliations
   after_save :sync_organization_affiliation_dates
   after_destroy :sync_organization_status_with_affiliations
@@ -129,6 +134,14 @@ class Affiliation < ApplicationRecord
     scope = scope.where.not(id: id) if persisted?
 
     throw(:abort) if scope.exists?
+  end
+
+  # event_registration_id records the registration that created this affiliation for
+  # its original org. If an admin moves the affiliation to a different org, that link
+  # no longer applies, so clear it — a row with no link counts as manually created,
+  # which reconciliation leaves alone.
+  def clear_event_registration_on_org_change
+    self.event_registration_id = nil if organization_id_changed?
   end
 
   def set_inactive_from_dates

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -19,6 +19,9 @@ class EventRegistration < ApplicationRecord
   has_many :scholarships, -> { distinct },
     through: :allocations, source: :source, source_type: "Scholarship"
   has_many :checklist_completions, class_name: "EventRegistrationChecklistCompletion", dependent: :destroy
+  # Affiliations this registration auto-minted; keep them but drop the link if the
+  # registration is deleted (mirrors the FK's on_delete: :nullify).
+  has_many :affiliations, dependent: :nullify, inverse_of: :event_registration
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
   accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }

--- a/app/services/affiliation_services/create_from_registration.rb
+++ b/app/services/affiliation_services/create_from_registration.rb
@@ -4,7 +4,12 @@ module AffiliationServices
   #
   #   1. a "job affiliation" with the title the person typed on their form, when
   #      one was provided, and
-  #   2. a standing "facilitator affiliation" titled "Facilitator".
+  #   2. a standing "facilitator affiliation" titled "Facilitator" — but ONLY for
+  #      facilitator-training events (`facilitator_training: true`). A non-training
+  #      registration still gets its job affiliation; we don't mint a facilitator
+  #      affiliation off it, because being a facilitator is conferred by a training,
+  #      not by any org-linked event. (Manual/historical facilitator affiliations
+  #      are created directly, not through this service, so they're unaffected.)
   #
   # The facilitator affiliation is skipped only when the person already has an
   # active-or-pending affiliation titled exactly "Facilitator" with the
@@ -22,22 +27,24 @@ module AffiliationServices
   # (they may have been with the org for years before this training), and dating it
   # to registration would misrepresent that.
   class CreateFromRegistration
-    def self.call(person:, organization:, job_title: nil, training_date: nil, organization_address: nil)
-      new(person:, organization:, job_title:, training_date:, organization_address:).call
+    def self.call(person:, organization:, job_title: nil, training_date: nil, organization_address: nil, facilitator_training: true, event_registration: nil)
+      new(person:, organization:, job_title:, training_date:, organization_address:, facilitator_training:, event_registration:).call
     end
 
-    def initialize(person:, organization:, job_title: nil, training_date: nil, organization_address: nil)
+    def initialize(person:, organization:, job_title: nil, training_date: nil, organization_address: nil, facilitator_training: true, event_registration: nil)
       @person = person
       @organization = organization
       @job_title = job_title.presence&.strip
       @training_date = training_date
       @organization_address = organization_address
+      @facilitator_training = facilitator_training
+      @event_registration = event_registration
     end
 
     def call
       ActiveRecord::Base.transaction do
         create_job_affiliation
-        create_facilitator_affiliation
+        create_facilitator_affiliation if @facilitator_training
       end
     end
 
@@ -77,7 +84,8 @@ module AffiliationServices
         organization: @organization,
         title: title,
         start_date: start_date,
-        organization_address: @organization_address
+        organization_address: @organization_address,
+        event_registration: @event_registration
       )
     end
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -76,6 +76,12 @@ module EventRegistrationServices
         create_mailing_address(person) if field_value("mailing_city").present?
         create_phone_contact(person) if field_value("phone").present?
 
+        # Resolve the registration before creating affiliations so each one can record
+        # which registration created it. Capture `existing` first — the find_by must
+        # see prior state, not the row we're about to create.
+        existing = @event.event_registrations.find_by(registrant: person)
+        event_registration = existing || create_event_registration(person)
+
         organization = find_organization if field_value(ORGANIZATION_NAME_IDENTIFIER).present?
         if organization
           profile_changes = sync_organization_profile(organization).changes
@@ -84,12 +90,11 @@ module EventRegistrationServices
           # registrant just changed it — connect_organization records what, and to
           # what value, for the admin linking page's persistent note.
           @organization_autofill = profile_changes + address_result.changes
-          create_affiliation(person, organization, address_result.address)
+          create_affiliation(person, organization, address_result.address, event_registration)
         end
 
         assign_tags(person, organization)
 
-        existing = @event.event_registrations.find_by(registrant: person)
         if existing
           existing.update!(scholarship_requested: true) if @scholarship_requested
           create_ce_registration(existing, person)
@@ -111,7 +116,6 @@ module EventRegistrationServices
           return Result.new(success?: true, event_registration: existing, form_submission: submission, errors: [])
         end
 
-        event_registration = create_event_registration(person)
         create_ce_registration(event_registration, person)
         organization_link = connect_organization(event_registration, organization)
         submission = create_form_submission(person)
@@ -347,13 +351,15 @@ module EventRegistrationServices
       link
     end
 
-    def create_affiliation(person, organization, organization_address = nil)
+    def create_affiliation(person, organization, organization_address = nil, event_registration = nil)
       AffiliationServices::CreateFromRegistration.call(
         person: person,
         organization: organization,
         job_title: field_value(ORGANIZATION_POSITION_IDENTIFIER),
         training_date: @event.start_date,
-        organization_address: organization_address
+        organization_address: organization_address,
+        facilitator_training: @event.facilitator_training,
+        event_registration: event_registration
       )
     end
 

--- a/db/migrate/20260814022129_add_event_registration_to_affiliations.rb
+++ b/db/migrate/20260814022129_add_event_registration_to_affiliations.rb
@@ -1,0 +1,15 @@
+class AddEventRegistrationToAffiliations < ActiveRecord::Migration[8.1]
+  # Provenance link: the registration that auto-minted this affiliation. NULL means
+  # it was created manually/historically (not through CreateFromRegistration), which
+  # is how facilitator reconciliation tells auto-minted rows from ones to leave alone.
+  def up
+    return if column_exists?(:affiliations, :event_registration_id)
+
+    add_reference :affiliations, :event_registration, null: true, index: true,
+                  foreign_key: { on_delete: :nullify }
+  end
+
+  def down
+    remove_reference :affiliations, :event_registration, foreign_key: true if column_exists?(:affiliations, :event_registration_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_143231) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_022129) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -107,6 +107,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_143231) do
   create_table "affiliations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.date "end_date"
+    t.bigint "event_registration_id"
     t.string "filemaker_code"
     t.boolean "inactive", default: false, null: false
     t.bigint "organization_address_id"
@@ -119,6 +120,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_143231) do
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
+    t.index ["event_registration_id"], name: "index_affiliations_on_event_registration_id"
     t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_agency_id"], name: "index_affiliations_on_organization_agency_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
@@ -1773,6 +1775,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_143231) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "affiliations", "addresses", column: "organization_address_id", on_delete: :nullify
+  add_foreign_key "affiliations", "event_registrations", on_delete: :nullify
   add_foreign_key "affiliations", "organizations"
   add_foreign_key "affiliations", "organizations", column: "organization_agency_id"
   add_foreign_key "affiliations", "people"

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -270,4 +270,25 @@ RSpec.describe Affiliation do
       expect(op.reload.inactive).to be true
     end
   end
+
+  describe "the registration that created the affiliation" do
+    it "drops the link when the affiliation is moved to a different organization" do
+      registration = create(:event_registration)
+      affiliation = create(:affiliation, event_registration: registration)
+      other_org = create(:organization)
+
+      affiliation.update!(organization: other_org)
+
+      expect(affiliation.reload.event_registration_id).to be_nil
+    end
+
+    it "keeps the link when other attributes change" do
+      registration = create(:event_registration)
+      affiliation = create(:affiliation, event_registration: registration)
+
+      affiliation.update!(title: "Lead Facilitator")
+
+      expect(affiliation.reload.event_registration).to eq(registration)
+    end
+  end
 end

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -1007,6 +1007,10 @@ RSpec.describe "EventRegistrations", type: :request do
       end
 
       describe "POST /event_registrations/:id/select_organization" do
+        # The facilitator affiliation these link-flow examples assert is only minted
+        # off a facilitator-training event.
+        let(:event) { create(:event, title: "Test Event", facilitator_training: true) }
+
         it "links the org to the registration and the person, then returns to the edit page" do
           expect {
             post select_organization_event_registration_path(existing_registration),
@@ -1037,6 +1041,29 @@ RSpec.describe "EventRegistrations", type: :request do
 
           expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
             .to contain_exactly("Facilitator")
+        end
+
+        it "records the linking registration on the created affiliations" do
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(regular_user.person.affiliations.where(organization: organization).map(&:event_registration))
+            .to all(eq(existing_registration))
+        end
+
+        it "creates only the job affiliation for a non-facilitator-training event" do
+          existing_registration.event.update!(facilitator_training: false)
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: EventRegistrationServices::PublicRegistration::ORGANIZATION_POSITION_IDENTIFIER)
+          create(:event_form, :registration, event: event, form: reg_form)
+          submission = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Counselor")
+
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(regular_user.person.affiliations.where(organization: organization).pluck(:title))
+            .to contain_exactly("Counselor")
         end
 
         it "builds the org address from the submission and links the affiliations to it" do
@@ -1283,6 +1310,10 @@ RSpec.describe "EventRegistrations", type: :request do
       end
 
       describe "POST /event_registrations/:id/create_organization" do
+        # The facilitator affiliation these link-flow examples assert is only minted
+        # off a facilitator-training event.
+        let(:event) { create(:event, title: "Test Event", facilitator_training: true) }
+
         it "creates an org from the submitted name and links it" do
           create(:organization_status, name: "Active")
           reg_form = create(:form, name: "Reg form")

--- a/spec/services/affiliation_services/create_from_registration_spec.rb
+++ b/spec/services/affiliation_services/create_from_registration_spec.rb
@@ -26,6 +26,31 @@ RSpec.describe AffiliationServices::CreateFromRegistration do
     expect(titles).to contain_exactly("Facilitator")
   end
 
+  describe "a non-facilitator-training event" do
+    it "creates only the job affiliation, not a facilitator affiliation" do
+      described_class.call(person: person, organization: organization,
+                           job_title: "Counselor", facilitator_training: false)
+
+      expect(titles).to contain_exactly("Counselor")
+    end
+
+    it "creates no affiliations when no job title is given" do
+      described_class.call(person: person, organization: organization,
+                           job_title: nil, facilitator_training: false)
+
+      expect(titles).to be_empty
+    end
+
+    it "leaves an existing facilitator affiliation alone rather than ending it" do
+      create(:affiliation, person: person, organization: organization, title: "Facilitator")
+
+      described_class.call(person: person, organization: organization,
+                           job_title: "Counselor", facilitator_training: false)
+
+      expect(titles).to contain_exactly("Counselor", "Facilitator")
+    end
+  end
+
   it "still adds a Facilitator affiliation alongside a facilitator-ish job title" do
     described_class.call(person: person, organization: organization, job_title: "Lead Facilitator")
 
@@ -134,6 +159,34 @@ RSpec.describe AffiliationServices::CreateFromRegistration do
       described_class.call(person: person, organization: organization)
 
       expect(facilitator.reload.organization_address).to be_nil
+    end
+  end
+
+  describe "recording the registration that created the affiliation" do
+    let(:registration) { create(:event_registration) }
+
+    it "stamps the event_registration onto every row it creates" do
+      described_class.call(person: person, organization: organization,
+                           job_title: "Counselor", event_registration: registration)
+
+      created = person.affiliations.where(organization: organization)
+      expect(created.pluck(:title)).to contain_exactly("Counselor", "Facilitator")
+      expect(created.map(&:event_registration)).to all(eq(registration))
+    end
+
+    it "leaves the link nil when no registration is given" do
+      described_class.call(person: person, organization: organization, job_title: "Counselor")
+
+      expect(person.affiliations.where(organization: organization).map(&:event_registration)).to all(be_nil)
+    end
+
+    it "does not stamp an existing (manual) affiliation it only backfills" do
+      manual = create(:affiliation, person: person, organization: organization, title: "Facilitator")
+
+      described_class.call(person: person, organization: organization,
+                           job_title: "Counselor", event_registration: registration)
+
+      expect(manual.reload.event_registration).to be_nil
     end
   end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
   end
 
   describe "affiliation creation" do
+    # A facilitator affiliation is only minted off a facilitator-training event.
+    let(:event) { create(:event, :published, :publicly_visible, facilitator_training: true) }
     let!(:organization) { create(:organization, name: "Helping Hands") }
 
     def register_with(position:)
@@ -75,6 +77,23 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       person = register_with(position: "Counselor")
 
       expect(person.affiliations.where(organization: organization).map(&:organization_address)).to all(be_nil)
+    end
+
+    it "creates only the job affiliation for a non-facilitator-training event" do
+      event.update!(facilitator_training: false)
+
+      person = register_with(position: "Counselor")
+
+      expect(person.affiliations.where(organization: organization).pluck(:title))
+        .to contain_exactly("Counselor")
+    end
+
+    it "links the created affiliations to the resulting registration" do
+      person = register_with(position: "Counselor")
+
+      registration = event.event_registrations.find_by(registrant: person)
+      expect(person.affiliations.where(organization: organization).map(&:event_registration))
+        .to all(eq(registration))
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 changes affiliation-creation semantics + adds an FK the reconciler will depend on

### What is the goal of this PR and why is this important?
- Facilitator affiliations are conceptually about **facilitator trainings** — a non-training registration should no longer mint one (it gets a job affiliation only).
- Adds `affiliations.event_registration_id` so the upcoming reconciliation can tell **auto-minted** rows (in scope) from **manual/historical** ones (left alone). NULL = manual.

### How did you approach the change?
- `CreateFromRegistration` takes `facilitator_training:` and skips the facilitator affiliation when false; both callers pass `event.facilitator_training`.
- New nullable FK (`on_delete: :nullify`), stamped only on rows the service **creates** (not on backfilled/manual rows). Public path reordered so the registration is resolved before affiliations are minted.
- The FK is provenance + an auto/manual **gate** only — it is deliberately *not* the completion signal, since creation dedupes and one affiliation can be backed by multiple registrations.
- Guard: clear the FK if an affiliation is moved to a different org, so it never claims a registration for the wrong org.

### Anything else to add?
- Reconciler itself is **not** in this PR — this lays the groundwork (gating + the link).