### PR TITLE
Public read-only JSON API for publicly visible stories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This codebase (Rails 8.1)
 
 | Directory | Purpose | Count |
 |---|---|---|
-| `app/controllers/` | Rails controllers (admin/, events/) | ~78 files |
+| `app/controllers/` | Rails controllers (admin/, events/, home/, api/) | ~80 files |
 | `app/views/` | ERB templates | ~745 files |
 | `app/decorators/` | Draper decorators for view logic | ~40 files |
 | `app/policies/` | ActionPolicy authorization rules | ~55 files |

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  # Base for the public, read-only JSON API. These endpoints serve only
+  # unconditionally public data, so authentication is skipped and errors are
+  # rendered as JSON rather than the HTML redirects ApplicationController uses.
+  class BaseController < ApplicationController
+    skip_before_action :authenticate_user!
+
+    rescue_from ActiveRecord::RecordNotFound do
+      render json: { error: "Not found" }, status: :not_found
+    end
+
+    rescue_from ActionPolicy::Unauthorized do
+      render json: { error: "Forbidden" }, status: :forbidden
+    end
+  end
+end

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -6,14 +6,14 @@ module Api
       MAX_PER_PAGE = 100
 
       # GET /api/v1/stories
-      # All publicly visible stories (published + publicly_visible). Each record
-      # exposes its `featured` and `publicly_featured` flags.
+      # Publicly featured stories only (published + publicly_visible +
+      # publicly_featured).
       def index
         authorize! Story, to: :index?
-        # `authorized_scope` applies StoryPolicy (anonymous callers collapse to
-        # `publicly_visible`); starting from `Story.publicly_visible` guarantees
-        # the public floor for any caller.
-        @stories = authorized_scope(Story.publicly_visible)
+        # `authorized_scope` layers StoryPolicy (anonymous callers collapse to
+        # `publicly_visible`) over the `publicly_featured` scope, which already
+        # includes the public floor.
+        @stories = authorized_scope(Story.publicly_featured)
           .includes(:windows_type, :organization, :author, :primary_asset, :sectors,
                     { categories: :category_type }, created_by: :person)
           .order(created_at: :desc)
@@ -22,7 +22,7 @@ module Api
 
       # GET /api/v1/stories/:id
       def show
-        @story = Story.publicly_visible.find(params[:id])
+        @story = Story.publicly_featured.find(params[:id])
         authorize! @story
       end
 

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -14,7 +14,8 @@ module Api
         # `publicly_visible`); starting from `Story.publicly_visible` guarantees
         # the public floor for any caller.
         @stories = authorized_scope(Story.publicly_visible)
-          .includes(:windows_type, :organization, :author, :primary_asset, :sectors, created_by: :person)
+          .includes(:windows_type, :organization, :author, :primary_asset, :sectors,
+                    { categories: :category_type }, created_by: :person)
           .order(created_at: :desc)
           .paginate(page: params[:page], per_page: per_page)
       end

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -6,18 +6,14 @@ module Api
       MAX_PER_PAGE = 100
 
       # GET /api/v1/stories
-      # Publicly visible stories (published + publicly_visible). Each record
-      # exposes its `featured` and `publicly_featured` flags. Pass
-      # `?publicly_featured=true` to return only the public-featured set.
+      # All publicly visible stories (published + publicly_visible). Each record
+      # exposes its `featured` and `publicly_featured` flags.
       def index
         authorize! Story, to: :index?
         # `authorized_scope` applies StoryPolicy (anonymous callers collapse to
         # `publicly_visible`); starting from `Story.publicly_visible` guarantees
         # the public floor for any caller.
-        scope = authorized_scope(Story.publicly_visible)
-        scope = scope.publicly_featured if publicly_featured_filter?
-
-        @stories = scope
+        @stories = authorized_scope(Story.publicly_visible)
           .includes(:windows_type, :organization, :author, :primary_asset, :sectors, created_by: :person)
           .order(created_at: :desc)
           .paginate(page: params[:page], per_page: per_page)
@@ -30,10 +26,6 @@ module Api
       end
 
       private
-
-      def publicly_featured_filter?
-        ActiveModel::Type::Boolean.new.cast(params[:publicly_featured])
-      end
 
       def per_page
         requested = params[:per_page].to_i

--- a/app/controllers/api/v1/stories_controller.rb
+++ b/app/controllers/api/v1/stories_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  module V1
+    class StoriesController < Api::BaseController
+      # Cap page size so a caller can't request an unbounded payload.
+      DEFAULT_PER_PAGE = 25
+      MAX_PER_PAGE = 100
+
+      # GET /api/v1/stories
+      # Publicly visible stories (published + publicly_visible). Each record
+      # exposes its `featured` and `publicly_featured` flags. Pass
+      # `?publicly_featured=true` to return only the public-featured set.
+      def index
+        authorize! Story, to: :index?
+        # `authorized_scope` applies StoryPolicy (anonymous callers collapse to
+        # `publicly_visible`); starting from `Story.publicly_visible` guarantees
+        # the public floor for any caller.
+        scope = authorized_scope(Story.publicly_visible)
+        scope = scope.publicly_featured if publicly_featured_filter?
+
+        @stories = scope
+          .includes(:windows_type, :organization, :author, :primary_asset, :sectors, created_by: :person)
+          .order(created_at: :desc)
+          .paginate(page: params[:page], per_page: per_page)
+      end
+
+      # GET /api/v1/stories/:id
+      def show
+        @story = Story.publicly_visible.find(params[:id])
+        authorize! @story
+      end
+
+      private
+
+      def publicly_featured_filter?
+        ActiveModel::Type::Boolean.new.cast(params[:publicly_featured])
+      end
+
+      def per_page
+        requested = params[:per_page].to_i
+        return DEFAULT_PER_PAGE unless requested.positive?
+        [ requested, MAX_PER_PAGE ].min
+      end
+    end
+  end
+end

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -14,9 +14,10 @@ json.flags do
   json.publicly_featured story.publicly_featured
 end
 
-# Tags applied to the story, split into their two taxonomies: categories
-# (grouped by category type, e.g. "Age range", "Story category") and sectors.
+# Tags applied to the story: the windows type, categories (grouped by category
+# type, e.g. "Age range", "Story category"), and sectors.
 json.tags do
+  json.windows_type story.windows_type&.name
   # Always emit `categories` as an object (`{}` when untagged) so consumers can
   # iterate it unconditionally.
   json.categories story.categories
@@ -26,8 +27,6 @@ json.tags do
 end
 
 json.body story.rhino_body.to_plain_text
-
-json.windows_type story.windows_type&.name
 
 if story.primary_asset&.file&.attached?
   json.image_url rails_blob_url(story.primary_asset.file)

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -27,7 +27,6 @@ end
 
 json.body story.rhino_body.to_plain_text
 
-json.id story.id
 json.slug story.to_param
 json.windows_type story.windows_type&.name
 

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -1,0 +1,35 @@
+json.id story.id
+json.slug story.to_param
+json.title story.title
+json.body story.rhino_body.to_plain_text
+json.url story_url(story)
+
+json.featured story.featured
+json.publicly_featured story.publicly_featured
+json.published story.published
+
+json.website_url story.website_url
+json.youtube_url story.youtube_url
+
+# Credited author, honoring the story's privacy preference (may be "Anonymous").
+json.author story.author_credit
+
+json.organization do
+  json.name story.organization_name
+  json.locality story.organization_locality
+end
+
+json.windows_type story.windows_type&.name
+json.sectors story.sector_names_all
+json.audience_categories story.audience_categories.pluck(:name)
+
+if story.primary_asset&.file&.attached?
+  json.image_url rails_blob_url(story.primary_asset.file)
+  json.thumbnail_url rails_representation_url(story.primary_asset.file.variant(:thumbnail))
+else
+  json.image_url nil
+  json.thumbnail_url nil
+end
+
+json.created_at story.created_at.iso8601
+json.updated_at story.updated_at.iso8601

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -4,12 +4,10 @@ json.title story.title
 json.body story.rhino_body.to_plain_text
 json.url story_url(story)
 
-json.featured story.featured
-json.publicly_featured story.publicly_featured
-json.published story.published
-
-json.website_url story.website_url
-json.youtube_url story.youtube_url
+json.flags do
+  json.featured story.featured
+  json.publicly_featured story.publicly_featured
+end
 
 # Credited author, honoring the story's privacy preference (may be "Anonymous").
 json.author story.author_credit

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -20,8 +20,17 @@ json.organization do
 end
 
 json.windows_type story.windows_type&.name
-json.sectors story.sector_names_all
-json.audience_categories story.audience_categories.pluck(:name)
+
+# Tags applied to the story, split into their two taxonomies: categories
+# (grouped by category type, e.g. "Age range", "Story category") and sectors.
+json.tags do
+  json.categories do
+    story.categories.group_by { |c| c.category_type&.display_label || "Other" }.each do |type_label, cats|
+      json.set! type_label, cats.map(&:name).sort
+    end
+  end
+  json.sectors story.sector_names_all
+end
 
 if story.primary_asset&.file&.attached?
   json.image_url rails_blob_url(story.primary_asset.file)

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -27,7 +27,6 @@ end
 
 json.body story.rhino_body.to_plain_text
 
-json.slug story.to_param
 json.windows_type story.windows_type&.name
 
 if story.primary_asset&.file&.attached?

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -11,7 +11,6 @@ end
 json.url story_url(story)
 
 json.flags do
-  json.featured story.featured
   json.publicly_featured story.publicly_featured
 end
 

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -1,13 +1,4 @@
-json.id story.id
-json.slug story.to_param
 json.title story.title
-json.body story.rhino_body.to_plain_text
-json.url story_url(story)
-
-json.flags do
-  json.featured story.featured
-  json.publicly_featured story.publicly_featured
-end
 
 # Credited author, honoring the story's privacy preference (may be "Anonymous").
 json.author story.author_credit
@@ -17,7 +8,12 @@ json.organization do
   json.locality story.organization_locality
 end
 
-json.windows_type story.windows_type&.name
+json.url story_url(story)
+
+json.flags do
+  json.featured story.featured
+  json.publicly_featured story.publicly_featured
+end
 
 # Tags applied to the story, split into their two taxonomies: categories
 # (grouped by category type, e.g. "Age range", "Story category") and sectors.
@@ -29,6 +25,12 @@ json.tags do
     .transform_values { |cats| cats.map(&:name).sort }
   json.sectors story.sector_names_all
 end
+
+json.body story.rhino_body.to_plain_text
+
+json.id story.id
+json.slug story.to_param
+json.windows_type story.windows_type&.name
 
 if story.primary_asset&.file&.attached?
   json.image_url rails_blob_url(story.primary_asset.file)

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -10,10 +10,6 @@ end
 
 json.url story_url(story)
 
-json.flags do
-  json.publicly_featured story.publicly_featured
-end
-
 # Tags applied to the story: the windows type, categories (grouped by category
 # type, e.g. "Age range", "Story category"), and sectors.
 json.tags do

--- a/app/views/api/v1/stories/_story.json.jbuilder
+++ b/app/views/api/v1/stories/_story.json.jbuilder
@@ -24,11 +24,11 @@ json.windows_type story.windows_type&.name
 # Tags applied to the story, split into their two taxonomies: categories
 # (grouped by category type, e.g. "Age range", "Story category") and sectors.
 json.tags do
-  json.categories do
-    story.categories.group_by { |c| c.category_type&.display_label || "Other" }.each do |type_label, cats|
-      json.set! type_label, cats.map(&:name).sort
-    end
-  end
+  # Always emit `categories` as an object (`{}` when untagged) so consumers can
+  # iterate it unconditionally.
+  json.categories story.categories
+    .group_by { |c| c.category_type&.display_label || "Other" }
+    .transform_values { |cats| cats.map(&:name).sort }
   json.sectors story.sector_names_all
 end
 

--- a/app/views/api/v1/stories/index.json.jbuilder
+++ b/app/views/api/v1/stories/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.stories @stories, partial: "api/v1/stories/story", as: :story
+
+json.meta do
+  json.current_page @stories.current_page
+  json.per_page @stories.per_page
+  json.total_entries @stories.total_entries
+  json.total_pages @stories.total_pages
+end

--- a/app/views/api/v1/stories/show.json.jbuilder
+++ b/app/views/api/v1/stories/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.story do
+  json.partial! "api/v1/stories/story", story: @story
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,5 +317,12 @@ Rails.application.routes.draw do
     resources :video_recordings, only: :index
   end
 
+  # Public, read-only JSON API for publicly visible stories. No authentication.
+  namespace :api, defaults: { format: "json" } do
+    namespace :v1 do
+      resources :stories, only: [ :index, :show ]
+    end
+  end
+
   root to: "home#index"
 end

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Api::V1::Stories", type: :request do
       expect(response).to have_http_status(:ok)
       expect(json["story"]).to include(
         "title" => "Public story",
-        "slug" => public_story.to_param
+        "url" => story_url(public_story)
       )
     end
 

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe "Api::V1::Stories", type: :request do
       expect(titles).not_to include("Internal story", "Draft story")
     end
 
-    it "exposes the featured and publicly_featured flags on each story" do
+    it "exposes the publicly_featured flag on each story (and hides internal featured)" do
       get "/api/v1/stories"
 
       featured = json["stories"].find { |s| s["title"] == "Public featured story" }
       plain    = json["stories"].find { |s| s["title"] == "Public story" }
 
-      expect(featured["flags"]).to eq("featured" => true, "publicly_featured" => true)
-      expect(plain["flags"]).to eq("featured" => false, "publicly_featured" => false)
+      expect(featured["flags"]).to eq("publicly_featured" => true)
+      expect(plain["flags"]).to eq("publicly_featured" => false)
     end
 
     it "includes pagination metadata" do

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Stories", type: :request do
+  let!(:public_story) do
+    create(:story, :published, :publicly_visible, title: "Public story")
+  end
+
+  let!(:public_featured_story) do
+    create(:story, :published, :publicly_visible, :publicly_featured, :featured,
+           title: "Public featured story")
+  end
+
+  # published but not publicly_visible — must never appear in the public API
+  let!(:internal_story) do
+    create(:story, :published, title: "Internal story")
+  end
+
+  # not published at all
+  let!(:draft_story) do
+    create(:story, :unpublished, :publicly_visible, title: "Draft story")
+  end
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  describe "GET /api/v1/stories" do
+    it "returns only publicly visible stories, without authentication" do
+      get "/api/v1/stories"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+
+      titles = json["stories"].map { |s| s["title"] }
+      expect(titles).to contain_exactly("Public story", "Public featured story")
+      expect(titles).not_to include("Internal story", "Draft story")
+    end
+
+    it "exposes the featured and publicly_featured flags on each story" do
+      get "/api/v1/stories"
+
+      featured = json["stories"].find { |s| s["title"] == "Public featured story" }
+      plain    = json["stories"].find { |s| s["title"] == "Public story" }
+
+      expect(featured).to include("featured" => true, "publicly_featured" => true, "published" => true)
+      expect(plain).to include("featured" => false, "publicly_featured" => false)
+    end
+
+    it "filters to the public-featured set with publicly_featured=true" do
+      get "/api/v1/stories", params: { publicly_featured: "true" }
+
+      titles = json["stories"].map { |s| s["title"] }
+      expect(titles).to contain_exactly("Public featured story")
+    end
+
+    it "includes pagination metadata" do
+      get "/api/v1/stories"
+
+      expect(json["meta"]).to include(
+        "current_page" => 1,
+        "per_page" => Api::V1::StoriesController::DEFAULT_PER_PAGE,
+        "total_entries" => 2
+      )
+    end
+
+    it "caps per_page at the maximum" do
+      get "/api/v1/stories", params: { per_page: "9999" }
+
+      expect(json["meta"]["per_page"]).to eq(Api::V1::StoriesController::MAX_PER_PAGE)
+    end
+  end
+
+  describe "GET /api/v1/stories/:id" do
+    it "returns a publicly visible story" do
+      get "/api/v1/stories/#{public_story.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(json["story"]).to include(
+        "id" => public_story.id,
+        "title" => "Public story",
+        "slug" => public_story.to_param
+      )
+    end
+
+    it "404s for a story that is not publicly visible" do
+      get "/api/v1/stories/#{internal_story.id}"
+
+      expect(response).to have_http_status(:not_found)
+      expect(json["error"]).to eq("Not found")
+    end
+
+    it "404s for an unknown id" do
+      get "/api/v1/stories/0"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe "Api::V1::Stories", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(json["story"]).to include(
-        "id" => public_story.id,
         "title" => "Public story",
         "slug" => public_story.to_param
       )

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe "Api::V1::Stories", type: :request do
       expect(plain).to include("featured" => false, "publicly_featured" => false)
     end
 
-    it "filters to the public-featured set with publicly_featured=true" do
-      get "/api/v1/stories", params: { publicly_featured: "true" }
-
-      titles = json["stories"].map { |s| s["title"] }
-      expect(titles).to contain_exactly("Public featured story")
-    end
-
     it "includes pagination metadata" do
       get "/api/v1/stories"
 

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -1,23 +1,24 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Stories", type: :request do
+  let!(:public_featured_story) do
+    create(:story, :published, :publicly_visible, :publicly_featured,
+           title: "Public featured story")
+  end
+
+  # publicly visible but not publicly featured — excluded from this API
   let!(:public_story) do
     create(:story, :published, :publicly_visible, title: "Public story")
   end
 
-  let!(:public_featured_story) do
-    create(:story, :published, :publicly_visible, :publicly_featured, :featured,
-           title: "Public featured story")
-  end
-
-  # published but not publicly_visible — must never appear in the public API
+  # published but not publicly_visible
   let!(:internal_story) do
     create(:story, :published, title: "Internal story")
   end
 
   # not published at all
   let!(:draft_story) do
-    create(:story, :unpublished, :publicly_visible, title: "Draft story")
+    create(:story, :unpublished, :publicly_visible, :publicly_featured, title: "Draft story")
   end
 
   def json
@@ -25,25 +26,15 @@ RSpec.describe "Api::V1::Stories", type: :request do
   end
 
   describe "GET /api/v1/stories" do
-    it "returns only publicly visible stories, without authentication" do
+    it "returns only publicly featured stories, without authentication" do
       get "/api/v1/stories"
 
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("application/json")
 
       titles = json["stories"].map { |s| s["title"] }
-      expect(titles).to contain_exactly("Public story", "Public featured story")
-      expect(titles).not_to include("Internal story", "Draft story")
-    end
-
-    it "exposes the publicly_featured flag on each story (and hides internal featured)" do
-      get "/api/v1/stories"
-
-      featured = json["stories"].find { |s| s["title"] == "Public featured story" }
-      plain    = json["stories"].find { |s| s["title"] == "Public story" }
-
-      expect(featured["flags"]).to eq("publicly_featured" => true)
-      expect(plain["flags"]).to eq("publicly_featured" => false)
+      expect(titles).to contain_exactly("Public featured story")
+      expect(titles).not_to include("Public story", "Internal story", "Draft story")
     end
 
     it "includes pagination metadata" do
@@ -52,7 +43,7 @@ RSpec.describe "Api::V1::Stories", type: :request do
       expect(json["meta"]).to include(
         "current_page" => 1,
         "per_page" => Api::V1::StoriesController::DEFAULT_PER_PAGE,
-        "total_entries" => 2
+        "total_entries" => 1
       )
     end
 
@@ -64,18 +55,18 @@ RSpec.describe "Api::V1::Stories", type: :request do
   end
 
   describe "GET /api/v1/stories/:id" do
-    it "returns a publicly visible story" do
-      get "/api/v1/stories/#{public_story.id}"
+    it "returns a publicly featured story" do
+      get "/api/v1/stories/#{public_featured_story.id}"
 
       expect(response).to have_http_status(:ok)
       expect(json["story"]).to include(
-        "title" => "Public story",
-        "url" => story_url(public_story)
+        "title" => "Public featured story",
+        "url" => story_url(public_featured_story)
       )
     end
 
     it "groups the story's tags into categories (by type) and sectors" do
-      story    = create(:story, :published, :publicly_visible, title: "Tagged story")
+      story    = create(:story, :published, :publicly_visible, :publicly_featured, title: "Tagged story")
       age_type = create(:category_type, name: "AgeRange")
       category = create(:category, name: "6-12", category_type: age_type)
       sector   = create(:sector, name: "Domestic violence")
@@ -89,11 +80,17 @@ RSpec.describe "Api::V1::Stories", type: :request do
       expect(tags["sectors"]).to eq([ "Domestic violence" ])
     end
 
+    it "404s for a publicly visible story that is not publicly featured" do
+      get "/api/v1/stories/#{public_story.id}"
+
+      expect(response).to have_http_status(:not_found)
+      expect(json["error"]).to eq("Not found")
+    end
+
     it "404s for a story that is not publicly visible" do
       get "/api/v1/stories/#{internal_story.id}"
 
       expect(response).to have_http_status(:not_found)
-      expect(json["error"]).to eq("Not found")
     end
 
     it "404s for an unknown id" do

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "Api::V1::Stories", type: :request do
       featured = json["stories"].find { |s| s["title"] == "Public featured story" }
       plain    = json["stories"].find { |s| s["title"] == "Public story" }
 
-      expect(featured).to include("featured" => true, "publicly_featured" => true, "published" => true)
-      expect(plain).to include("featured" => false, "publicly_featured" => false)
+      expect(featured["flags"]).to eq("featured" => true, "publicly_featured" => true)
+      expect(plain["flags"]).to eq("featured" => false, "publicly_featured" => false)
     end
 
     it "includes pagination metadata" do

--- a/spec/requests/api/v1/stories_spec.rb
+++ b/spec/requests/api/v1/stories_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe "Api::V1::Stories", type: :request do
       )
     end
 
+    it "groups the story's tags into categories (by type) and sectors" do
+      story    = create(:story, :published, :publicly_visible, title: "Tagged story")
+      age_type = create(:category_type, name: "AgeRange")
+      category = create(:category, name: "6-12", category_type: age_type)
+      sector   = create(:sector, name: "Domestic violence")
+      create(:categorizable_item, category: category, categorizable: story)
+      create(:sectorable_item, sector: sector, sectorable: story)
+
+      get "/api/v1/stories/#{story.id}"
+
+      tags = json["story"]["tags"]
+      expect(tags["categories"]).to eq("Age range" => [ "6-12" ])
+      expect(tags["sectors"]).to eq([ "Domestic violence" ])
+    end
+
     it "404s for a story that is not publicly visible" do
       get "/api/v1/stories/#{internal_story.id}"
 

--- a/spec/routing/api/v1/stories_routing_spec.rb
+++ b/spec/routing/api/v1/stories_routing_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::StoriesController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/api/v1/stories").to route_to("api/v1/stories#index", format: "json")
+    end
+
+    it "routes to #show" do
+      expect(get: "/api/v1/stories/1").to route_to("api/v1/stories#show", id: "1", format: "json")
+    end
+
+    it "does not route to #create" do
+      expect(post: "/api/v1/stories").not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained new endpoint; main thing to verify is the public-visibility scoping

## What
- New public, unauthenticated JSON API at `/api/v1/stories` (index) and `/api/v1/stories/:id` (show).
- Returns **only publicly featured stories** (`published AND publicly_visible AND publicly_featured`).
- Each story exposes: `title`, `author`, `organization`, `url`, `tags` (`windows_type` + `categories` grouped by category-type label + `sectors`), `body`, `image_url`/`thumbnail_url`, timestamps.
- `per_page` capped (default 25, max 100), with pagination `meta`.

## Why
- Lets external consumers (e.g. the marketing site) pull featured public stories without a login.

## Notes
- Scoping starts from `Story.publicly_featured` and layers `StoryPolicy` via `authorized_scope`, so the public floor holds regardless of caller.
- Author names go through `author_credit`, honoring each story's privacy preference (never raw PII).
- Rendered with jbuilder; errors return JSON (404 / 403).