### PR TITLE
Link communications People column to the contact's profile

### DIFF
--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -85,15 +85,27 @@ class NotificationDecorator < ApplicationDecorator
     contact_person if incoming?
   end
 
+  # The contact's email for each side, mirroring to_person/from_person — always
+  # recipient_email, on whichever side the contact sits. nil on the staff/portal
+  # side, which is a person's name (or "AWBW Portal"), not an address.
+  def to_email
+    recipient_email unless incoming?
+  end
+
+  def from_email
+    recipient_email if incoming?
+  end
+
   # People-column value for the index: the name linked to the person's profile
-  # when we've resolved them, plain text (email on hover) otherwise. The AWBW
-  # Portal and unmatched raw emails have no person, so they render unlinked.
+  # when we've resolved them, a mailto link when we only have their email, plain
+  # text otherwise. The AWBW Portal (and any staff name) has no address, so it
+  # renders unlinked.
   def to_value
-    people_value(to_name, to_person, to_title)
+    people_value(to_name, to_person, to_email, to_title)
   end
 
   def from_value
-    people_value(from_name, from_person, from_title)
+    people_value(from_name, from_person, from_email, from_title)
   end
 
   # "incoming" (the person wrote to us), "fyi" (an admin FYI copy), or nil for a
@@ -162,15 +174,14 @@ class NotificationDecorator < ApplicationDecorator
 
   private
 
-  # Links the value to the person's profile when we have one, otherwise a plain
-  # span. Either way the email (when resolved) stays available on hover.
-  def people_value(name, person, title)
-    return h.content_tag(:span, name, title: title) unless person
+  # Links the value to the person's profile when we have one, to a mailto when we
+  # only have their email, otherwise a plain span. The profile link keeps the
+  # email available on hover (title).
+  def people_value(name, person, email, title)
+    return h.link_to(name, h.person_path(person), title: title, data: { turbo_frame: "_top" }, class: "hover:underline") if person
+    return h.mail_to(email, name, class: "hover:underline") if email.present?
 
-    h.link_to name, h.person_path(person),
-      title: title,
-      data: { turbo_frame: "_top" },
-      class: "hover:underline"
+    h.content_tag(:span, name, title: title)
   end
 
   # Renders a coloured label pill from a *_META entry. Returns "" for a nil

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -74,6 +74,28 @@ class NotificationDecorator < ApplicationDecorator
     incoming? ? nil : contact_hover
   end
 
+  # The contact Person sits on the To side of an outgoing communication and the
+  # From side of an incoming one; the opposite side is staff or the AWBW Portal,
+  # which has no person to link to. nil when the contact isn't on file either.
+  def to_person
+    contact_person unless incoming?
+  end
+
+  def from_person
+    contact_person if incoming?
+  end
+
+  # People-column value for the index: the name linked to the person's profile
+  # when we've resolved them, plain text (email on hover) otherwise. The AWBW
+  # Portal and unmatched raw emails have no person, so they render unlinked.
+  def to_value
+    people_value(to_name, to_person, to_title)
+  end
+
+  def from_value
+    people_value(from_name, from_person, from_title)
+  end
+
   # "incoming" (the person wrote to us), "fyi" (an admin FYI copy), or nil for a
   # regular message to the person (the norm — no pill). Drives the audience pill.
   def audience
@@ -139,6 +161,17 @@ class NotificationDecorator < ApplicationDecorator
   end
 
   private
+
+  # Links the value to the person's profile when we have one, otherwise a plain
+  # span. Either way the email (when resolved) stays available on hover.
+  def people_value(name, person, title)
+    return h.content_tag(:span, name, title: title) unless person
+
+    h.link_to name, h.person_path(person),
+      title: title,
+      data: { turbo_frame: "_top" },
+      class: "hover:underline"
+  end
 
   # Renders a coloured label pill from a *_META entry. Returns "" for a nil
   # entry. A caller-supplied `class:` is appended to the pill's own styling

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -35,9 +35,9 @@
       <!--          </td>-->
 
       <!-- People (To on top; From/To values flip for incoming — the person sent it.
-           Names shown when the email is on file, with the email on hover, and the
-           value linked to the person's profile — except the AWBW Portal, which
-           has no person to go to.) -->
+           A value links to the person's profile when the email is on file (name
+           shown, email on hover), otherwise a mailto for the raw email. The AWBW
+           Portal has no address, so it stays plain text.) -->
       <td class="px-4 py-3 text-gray-700">
         <div><span class="text-xs uppercase text-gray-500">To:</span> <%= n.to_value %></div>
         <div class="text-[10px] text-gray-400">

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -35,11 +35,13 @@
       <!--          </td>-->
 
       <!-- People (To on top; From/To values flip for incoming — the person sent it.
-           Names shown when the email is on file, with the email on hover.) -->
+           Names shown when the email is on file, with the email on hover, and the
+           value linked to the person's profile — except the AWBW Portal, which
+           has no person to go to.) -->
       <td class="px-4 py-3 text-gray-700">
-        <div><span class="text-xs uppercase text-gray-500">To:</span> <span title="<%= n.to_title %>"><%= n.to_name %></span></div>
+        <div><span class="text-xs uppercase text-gray-500">To:</span> <%= n.to_value %></div>
         <div class="text-[10px] text-gray-400">
-          <span class="uppercase">From:</span> <span title="<%= n.from_title %>"><%= n.from_name %></span>
+          <span class="uppercase">From:</span> <%= n.from_value %>
         </div>
       </td>
 

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -110,6 +110,31 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
   end
 
+  describe "#to_person / #from_person" do
+    it "puts the contact on the To side of an outgoing communication" do
+      person = create(:person, email: "kim@example.com")
+      decorated = create(:notification, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.to_person).to eq(person)
+      expect(decorated.from_person).to be_nil
+    end
+
+    it "puts the contact on the From side of an incoming communication" do
+      person = create(:person, email: "kim@example.com")
+      decorated = create(:notification, :incoming, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.from_person).to eq(person)
+      expect(decorated.to_person).to be_nil
+    end
+
+    it "has no person when the contact isn't on file" do
+      decorated = build_stubbed(:notification, recipient_email: "stranger@example.com").decorate
+
+      expect(decorated.to_person).to be_nil
+      expect(decorated.from_person).to be_nil
+    end
+  end
+
   describe "#audience" do
     it "is incoming for a communication the person sent" do
       expect(build_stubbed(:notification, :incoming).decorate.audience).to eq("incoming")

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -135,6 +135,28 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
   end
 
+  describe "#to_value / #from_value" do
+    it "links the resolved contact to their profile" do
+      person = create(:person, email: "kim@example.com")
+      decorated = create(:notification, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.to_value).to include("href=\"#{Rails.application.routes.url_helpers.person_path(person)}\"")
+    end
+
+    it "links an unresolved contact email as a mailto" do
+      decorated = build_stubbed(:notification, recipient_email: "stranger@example.com").decorate
+
+      expect(decorated.to_value).to include("href=\"mailto:stranger@example.com\"")
+    end
+
+    it "leaves the AWBW Portal side as plain text, not a link" do
+      decorated = build_stubbed(:notification, sender: nil, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.from_value).to include("AWBW Portal")
+      expect(decorated.from_value).not_to include("<a")
+    end
+  end
+
   describe "#audience" do
     it "is incoming for a communication the person sent" do
       expect(build_stubbed(:notification, :incoming).decorate.audience).to eq("incoming")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small decorator/view change adding profile/mailto links in the communications index

### What is the goal of this PR and why is this important?
- On the communications (notifications) index, the **To:**/**From:** values were dead text — no way to reach the person a communication was with.

### How did you approach the change?
- Resolve the contact `Person` per side (To for outgoing, From for incoming) in `NotificationDecorator` and link the value to their profile, keeping the email on hover.
- When the email has no `Person` on file (common for contact-form/portal contacts), fall back to a `mailto:` link so every real address still has a hover affordance; **AWBW Portal** and staff names have no address and stay plain text.

### UI Testing Checklist
- [ ] Communications index: a value with a matching person links to that profile (email on hover); an unmatched email is a mailto; "AWBW Portal" is plain text.

### Anything else to add?
- Staff senders (a `User`, not a `Person`) are intentionally left unlinked — there's no person profile to route to.