### PR TITLE
Reorder onboarding matrix: attendance beside day columns, email last

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -113,8 +113,8 @@ module EventsHelper
     (1..event.day_count).each do |day|
       columns << { key: "completed_day_#{day}", label: "Day #{day}", kind: :checkbox, field: "completed_day_#{day}", sortable: true, align: "center", toggle: "days" }
     end
+    columns << { key: "attendance", label: "Event attendance", kind: :attendance, sortable: true, align: "center", toggle: "attendance" }
     columns += [
-      { key: "email", label: "Email", kind: :email, sortable: true, align: "left" },
       { key: "program", label: "Organization", kind: :program, sortable: true, align: "left", toggle: "program" },
       { key: "program_type", label: "Program type", kind: :program_type, sortable: true, align: "center", toggle: "program_type" }
     ]
@@ -139,7 +139,7 @@ module EventsHelper
     end
     columns << { key: "flagged_comments", label: "Flagged comments", kind: :flagged_comments, sortable: true, align: "center", toggle: "flagged_comments" }
     columns << { key: "comments", label: "Comments", kind: :comments, sortable: true, align: "left", toggle: "comments" }
-    columns << { key: "attendance", label: "Event attendance", kind: :attendance, sortable: true, align: "center", toggle: "attendance" }
+    columns << { key: "email", label: "Email", kind: :email, sortable: true, align: "left" }
     columns
   end
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 column-order-only change in one helper, no logic touched

### What is the goal of this PR and why is this important?
Reorder the event onboarding matrix so "Event attendance" sits right after the per-day completion columns (where it reads naturally against Day 1 / Day 2), and move "Email" to the far-right as reference detail.

### How did you approach the change?
Both the header and each row render from `onboarding_columns`, so repositioning the two column definitions there moves them consistently everywhere — no view changes needed.

### UI Testing Checklist
- [ ] Onboarding matrix shows Event attendance immediately right of the Day N columns
- [ ] Email is the last column
- [ ] Column show/hide toggles and sorting still work for both

### Anything else to add?
Column-order-only; no behavior or data changes.
