### PR TITLE
Add sector & category tagging to grants

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -37,13 +37,13 @@ class GrantsController < ApplicationController
   def new
     @grant = Grant.new
     authorize! @grant
-    set_tag_collections
+    set_form_variables
   end
 
   def edit
     authorize! @grant
     set_scholarships
-    set_tag_collections
+    set_form_variables
   end
 
   def create
@@ -55,7 +55,7 @@ class GrantsController < ApplicationController
     if @grant.save
       redirect_to @grant, notice: "Grant was successfully created."
     else
-      set_tag_collections
+      set_form_variables
       render :new, status: :unprocessable_content
     end
   end
@@ -68,7 +68,7 @@ class GrantsController < ApplicationController
       redirect_to @grant, notice: "Grant was successfully updated.", status: :see_other
     else
       set_scholarships
-      set_tag_collections
+      set_form_variables
       render :edit, status: :unprocessable_content
     end
   end
@@ -134,8 +134,9 @@ class GrantsController < ApplicationController
                           .paginate(page: params[:page], per_page: 10)
   end
 
-  # Sector chips and the grouped category checkboxes on the grant form.
-  def set_tag_collections
+  # Sector chips, grouped category checkboxes, and the image upload fields on the
+  # grant form.
+  def set_form_variables
     @sectors = Sector.published.order(:name)
     @categories_grouped =
       Category
@@ -145,13 +146,18 @@ class GrantsController < ApplicationController
         .group_by(&:category_type)
         .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
         .sort_by { |type, _| type&.name.to_s.downcase }
+
+    @grant.build_primary_asset if @grant.primary_asset.blank?
+    @grant.gallery_assets.build
   end
 
   def grant_params
     params.require(:grant).permit(
       :name, :description, :amount_dollars, :amount_cents, :funder_sgid,
       :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks,
-      sector_ids: [], category_ids: []
+      sector_ids: [], category_ids: [],
+      primary_asset_attributes: [ :id, :file, :_destroy ],
+      gallery_assets_attributes: [ :id, :file, :_destroy ]
     )
   end
 end

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -37,11 +37,13 @@ class GrantsController < ApplicationController
   def new
     @grant = Grant.new
     authorize! @grant
+    set_tag_collections
   end
 
   def edit
     authorize! @grant
     set_scholarships
+    set_tag_collections
   end
 
   def create
@@ -53,6 +55,7 @@ class GrantsController < ApplicationController
     if @grant.save
       redirect_to @grant, notice: "Grant was successfully created."
     else
+      set_tag_collections
       render :new, status: :unprocessable_content
     end
   end
@@ -65,6 +68,7 @@ class GrantsController < ApplicationController
       redirect_to @grant, notice: "Grant was successfully updated.", status: :see_other
     else
       set_scholarships
+      set_tag_collections
       render :edit, status: :unprocessable_content
     end
   end
@@ -96,6 +100,11 @@ class GrantsController < ApplicationController
     scope = scope.where(funder_type: params[:funder_type]) if Grant::FUNDER_TYPES.include?(params[:funder_type])
     scope = scope.where(funder_id: params[:funder_id]) if params[:funder_id].present?
 
+    # Sector/category filters back the "View all grants" deep link from the
+    # taggings browse page (see TaggingsHelper#tagged_index_path).
+    scope = scope.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
+    scope = scope.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
+
     case params[:tasks]
     when "completed" then scope.all_tasks_completed
     when "outstanding" then scope.tasks_outstanding
@@ -125,10 +134,24 @@ class GrantsController < ApplicationController
                           .paginate(page: params[:page], per_page: 10)
   end
 
+  # Sector chips and the grouped category checkboxes on the grant form.
+  def set_tag_collections
+    @sectors = Sector.published.order(:name)
+    @categories_grouped =
+      Category
+        .includes(:category_type)
+        .published
+        .order(:position, :name)
+        .group_by(&:category_type)
+        .select { |type, _| type.nil? || (type.published? && !type.story_specific? && !type.profile_specific?) }
+        .sort_by { |type, _| type&.name.to_s.downcase }
+  end
+
   def grant_params
     params.require(:grant).permit(
       :name, :description, :amount_dollars, :amount_cents, :funder_sgid,
-      :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks
+      :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks,
+      sector_ids: [], category_ids: []
     )
   end
 end

--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -18,7 +18,8 @@ class TaggingsController < ApplicationController
       people: params[:people_page],
       organizations: params[:organizations_page],
       quotes: params[:quotes_page],
-      video_recordings: params[:video_recordings_page]
+      video_recordings: params[:video_recordings_page],
+      grants: params[:grants_page]
     }
 
     @grouped_tagged_items = TaggingSearchService.new(user: current_user).call(

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -33,7 +33,7 @@ class GrantDecorator < ApplicationDecorator
     object.remaining_cents <= 0
   end
 
-  # Whole-number percentage of the donation awarded in scholarships, clamped to
+  # Whole-number percentage of the grant awarded in scholarships, clamped to
   # 0–100, for rendering the allocation progress bar on the index.
   def allocation_percentage
     return 0 if object.amount_cents.to_i.zero?
@@ -41,7 +41,7 @@ class GrantDecorator < ApplicationDecorator
     ((object.scholarships_total_cents.to_d / object.amount_cents) * 100).clamp(0, 100).round
   end
 
-  # Whole-number percentage of the donation still unallocated, for the "Remaining"
+  # Whole-number percentage of the grant still unallocated, for the "Remaining"
   # bar on the index — full green when untouched, empty (grey track) when spent.
   def remaining_percentage
     100 - allocation_percentage
@@ -77,7 +77,7 @@ class GrantDecorator < ApplicationDecorator
     MoneyFormatter.compact_from_cents(object.remaining_cents)
   end
 
-  # Short human-readable total donation for the grant picker, e.g. "$10k".
+  # Short human-readable total funding amount for the grant picker, e.g. "$10k".
   def amount_compact
     MoneyFormatter.compact_from_cents(object.amount_cents)
   end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -1,4 +1,14 @@
 class GrantDecorator < ApplicationDecorator
+  # Title/detail back the shared taggings card (app/views/taggings/_tagged_item_card).
+  def title
+    object.name
+  end
+
+  def detail(length: nil)
+    text = object.description
+    length ? text&.truncate(length) : text
+  end
+
   def amount
     h.dollars_from_cents(object.amount_cents)
   end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,9 +1,29 @@
 class Grant < ApplicationRecord
+  include TagFilterable
+
   belongs_to :funder, polymorphic: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
 
   has_many :scholarships, dependent: :restrict_with_error
+
+  has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
+  has_many :sectors, through: :sectorable_items
+  has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
+  has_many :categories, through: :categorizable_items
+  has_many :category_types, through: :categories
+
+  # Grants have no publish lifecycle — they're admin-only and always visible to
+  # their audience. This no-op `published` scope satisfies the shared taggings
+  # machinery (the matrix heatmap, Sector/Category#has_published_taggings, and the
+  # tagged-index deep link), which calls `.published` on every TAGGABLE_META klass.
+  scope :published, ->(*) { all }
+
+  # Defer sector/category assignment on new records: the form submits sector_ids/
+  # category_ids, but the polymorphic join rows need the grant's id, so we stash
+  # them and attach after_create. Mirrors Workshop.
+  attr_accessor :pending_sector_ids, :pending_category_ids
+  after_create :assign_pending_associations
 
   FUNDER_TYPES = %w[Organization Person].freeze
 
@@ -119,7 +139,31 @@ class Grant < ApplicationRecord
     text_to_list(tasks)
   end
 
+  # Defer association assignment until after save on new records (see
+  # pending_* accessors above); update existing records directly.
+  def sector_ids=(ids)
+    new_record? ? @pending_sector_ids = ids : super
+  end
+
+  def category_ids=(ids)
+    new_record? ? @pending_category_ids = ids : super
+  end
+
   private
+
+  def assign_pending_associations
+    return unless @pending_sector_ids || @pending_category_ids
+
+    if @pending_sector_ids
+      self.sectors = Sector.where(id: @pending_sector_ids)
+      @pending_sector_ids = nil
+    end
+
+    if @pending_category_ids
+      self.categories = Category.where(id: @pending_category_ids)
+      @pending_category_ids = nil
+    end
+  end
 
   # A grant's amount can't be lowered below what has already been awarded against
   # it — the scholarships are committed, so the grant must at least cover them.

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,7 +1,7 @@
 class Grant < ApplicationRecord
   include TagFilterable
 
-  belongs_to :funder, polymorphic: true
+  belongs_to :funder, polymorphic: true, optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
 
@@ -38,7 +38,8 @@ class Grant < ApplicationRecord
 
   validates :name, presence: true
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
-  validates :funder_type, inclusion: { in: FUNDER_TYPES }
+  validates :funder_type, inclusion: { in: FUNDER_TYPES }, allow_nil: true
+  validate :funder_present
   validate :amount_covers_scholarships_already_issued
 
   scope :by_deadline, -> { order(Arel.sql("funds_allocation_deadline IS NULL, funds_allocation_deadline ASC")) }
@@ -159,6 +160,13 @@ class Grant < ApplicationRecord
   end
 
   private
+
+  # The funder is chosen through the virtual funder_sgid field, so attach the
+  # "no funder picked" error there — that's the input the form renders, so the
+  # error shows inline on the field, not just in the summary.
+  def funder_present
+    errors.add(:funder_sgid, "must be selected") if funder.blank?
+  end
 
   def assign_pending_associations
     return unless @pending_sector_ids || @pending_category_ids

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -13,6 +13,15 @@ class Grant < ApplicationRecord
   has_many :categories, through: :categorizable_items
   has_many :category_types, through: :categories
 
+  has_one :primary_asset, -> { where(type: "PrimaryAsset") },
+          as: :owner, class_name: "PrimaryAsset", dependent: :destroy
+  has_many :gallery_assets, -> { where(type: "GalleryAsset") },
+           as: :owner, class_name: "GalleryAsset", dependent: :destroy
+  has_many :assets, as: :owner, dependent: :destroy
+
+  accepts_nested_attributes_for :primary_asset, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :gallery_assets, reject_if: :all_blank, allow_destroy: true
+
   # Grants have no publish lifecycle — they're admin-only and always visible to
   # their audience. This no-op `published` scope satisfies the shared taggings
   # machinery (the matrix heatmap, Sector/Category#has_published_taggings, and the
@@ -47,11 +56,11 @@ class Grant < ApplicationRecord
   ALLOCATED_CENTS_SUBQUERY =
     "COALESCE((SELECT SUM(scholarships.amount_cents) FROM scholarships WHERE scholarships.grant_id = grants.id), 0)".freeze
 
-  # Grants that still have unallocated funds (donation amount exceeds the sum of
+  # Grants that still have unallocated funds (grant amount exceeds the sum of
   # scholarships drawn against them).
   scope :with_funds_remaining, -> { where("grants.amount_cents > #{ALLOCATED_CENTS_SUBQUERY}") }
 
-  # Grants whose full donation has been issued as scholarships (nothing left to
+  # Grants whose full amount has been issued as scholarships (nothing left to
   # award) — the complement of with_funds_remaining.
   scope :fully_issued, -> { where("grants.amount_cents <= #{ALLOCATED_CENTS_SUBQUERY}") }
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -40,7 +40,7 @@ class Organization < ApplicationRecord
   AGENCY_TYPE_OTHER = "Other"
   AGENCY_TYPES = [ "501c3/nonprofit", "For-profit", "Government agency", AGENCY_TYPE_OTHER ].freeze
 
-  # The organization that runs this app. A grant it donates is the org funding
+  # The organization that runs this app. A grant it self-funds is the org funding
   # itself, so reports count it as subsidy (unfunded), not external funding.
   # Identified by name via ORGANIZATION_NAME — the only marker available today.
   # Not memoized: the record can be created mid-process (seeds, tests).

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -44,6 +44,11 @@ class Tag
       icon: "🎬",
       path: -> { Rails.application.routes.url_helpers.video_recordings_path },
       klass: VideoRecording
+    },
+    grants: {
+      icon: "💰",
+      path: -> { Rails.application.routes.url_helpers.grants_path },
+      klass: Grant
     }
   }.freeze
 

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -110,7 +110,7 @@ class EventDashboard
   end
 
   # Scholarship dollars the org comps from its own pocket: awards with no grant,
-  # plus awards from a grant the org donated to itself (AWBW) — that's subsidy,
+  # plus awards from a grant the org (AWBW) self-funded — that's subsidy,
   # not external funding.
   def unfunded_scholarship_cents
     unfunded_scholarships.sum(:amount_cents)
@@ -1263,12 +1263,12 @@ class EventDashboard
     scholarships.externally_funded(self_funded_grant_ids)
   end
 
-  # Org-subsidized = no grant, or a grant the org (AWBW) donated to itself.
+  # Org-subsidized = no grant, or a grant the org (AWBW) self-funded.
   def unfunded_scholarships
     scholarships.org_subsidized(self_funded_grant_ids)
   end
 
-  # Ids of grants the org donated to itself; memoized so the funded/unfunded split
+  # Ids of grants the org self-funded; memoized so the funded/unfunded split
   # doesn't re-run Grant.self_funded_ids (an Organization.awbw + pluck) per call.
   def self_funded_grant_ids
     @self_funded_grant_ids ||= Grant.self_funded_ids

--- a/app/services/event_scholarship_report.rb
+++ b/app/services/event_scholarship_report.rb
@@ -5,7 +5,7 @@
 #
 # Funded vs unfunded follows the app-wide convention (see EventDashboard):
 # funded = backed by an external grant; unfunded = no grant, or a grant the org
-# (AWBW) donated to itself. Alongside the money it carries a trainee headcount —
+# (AWBW) self-funded. Alongside the money it carries a trainee headcount —
 # people who ATTENDED — split by delivery format: scheduled instructor-led
 # sessions total under "Live" and self-paced ones (event.on_demand?) under
 # "On-demand".

--- a/app/services/tagging_search_service.rb
+++ b/app/services/tagging_search_service.rb
@@ -85,7 +85,17 @@ class TaggingSearchService
                    .category_names_all(category_names_all)
                    .order(:position, :title)
                    .paginate(page: pages[:video_recordings] || 1, per_page: number_of_items_per_page)
-                   .decorate
+                   .decorate,
+
+      # Admin-only: authorized_scope resolves to none for non-admins, so grants
+      # only surface here for admins.
+      grants: authorized_scope(Grant.all)
+                .includes(:sectors, :categories)
+                .sector_names_all(sector_names_all)
+                .category_names_all(category_names_all)
+                .by_deadline
+                .paginate(page: pages[:grants] || 1, per_page: number_of_items_per_page)
+                .decorate
     }
   end
 

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -82,7 +82,16 @@
                   input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
     </div>
 
-    <div class="space-y-6">
+    <div data-controller="dropdown">
+      <button type="button"
+              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              data-action="dropdown#toggle"
+              data-dropdown-payload-param='[{"grant_tag_fields":"hidden"}, {"grant_tag_fields_chevron":"rotate-180"}]'>
+        <span>Sectors &amp; categories</span>
+        <i id="grant_tag_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
+      </button>
+
+      <div id="grant_tag_fields" class="hidden mt-4 space-y-6">
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
         <h3 class="text-base font-semibold text-gray-800 mb-3">Sectors</h3>
         <div class="flex flex-wrap gap-3">
@@ -122,6 +131,7 @@
           </div>
         </div>
       <% end %>
+      </div>
     </div>
   </div>
 

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -9,27 +9,26 @@
                   input_html: { class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
     </div>
 
-    <div>
-      <% funder_label_data = @grant.funder&.compound_search_label %>
-      <%= f.input :funder_sgid,
-                  collection: funder_label_data ? [ [ funder_label_data[:label], funder_label_data[:id] ] ] : [],
-                  selected: funder_label_data&.dig(:id),
-                  required: true,
-                  input_html: {
-                    class: "bg-white",
-                    data: {
-                      controller: "remote-select",
-                      remote_select_model_value: "person_or_organization"
-                    }
-                  },
-                  prompt: "Search organizations and people",
-                  label: "Funder",
-                  hint: "The organization or person donating the funds." %>
-    </div>
-
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <div>
-        <%= f.label :amount_dollars, "Donation amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <% funder_label_data = @grant.funder&.compound_search_label %>
+        <%= f.input :funder_sgid,
+                    collection: funder_label_data ? [ [ funder_label_data[:label], funder_label_data[:id] ] ] : [],
+                    selected: funder_label_data&.dig(:id),
+                    required: true,
+                    input_html: {
+                      class: "bg-white",
+                      data: {
+                        controller: "remote-select",
+                        remote_select_model_value: "person_or_organization"
+                      }
+                    },
+                    prompt: "Search organizations and people",
+                    label: "Funder",
+                    hint: "The organization or person funding the grant." %>
+      </div>
+      <div>
+        <%= f.label :amount_dollars, "Funding amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
         <div class="relative">
           <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">$</span>
           <%= f.number_field :amount_dollars, step: 0.01, value: @grant.amount_dollars,
@@ -37,6 +36,9 @@
         </div>
         <p class="mt-1 text-xs text-gray-500">Total scholarship amounts awarded from this grant cannot exceed this.</p>
       </div>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <div>
         <%= f.input :funds_received_on,
                     label: "Funds received on",
@@ -47,39 +49,56 @@
                       class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
                     } %>
       </div>
+      <div>
+        <%= f.input :funds_allocation_deadline,
+                    label: "Funds allocation deadline",
+                    as: :string,
+                    input_html: {
+                      type: "date",
+                      value: @grant.funds_allocation_deadline&.strftime("%Y-%m-%d"),
+                      class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
+                    } %>
+      </div>
     </div>
 
-    <div>
-      <%= f.input :funds_allocation_deadline,
-                  label: "Funds allocation deadline",
-                  as: :string,
-                  input_html: {
-                    type: "date",
-                    value: @grant.funds_allocation_deadline&.strftime("%Y-%m-%d"),
-                    class: "w-full sm:w-1/2 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm"
-                  } %>
-    </div>
+    <%# Collapse the free-text fields once a grant is fully documented; keep them
+        open while any is still blank so nothing goes unnoticed on a new grant. %>
+    <% details_filled = @grant.description.present? && @grant.eligibility_criteria.present? && @grant.tasks.present? %>
+    <div data-controller="dropdown">
+      <button type="button"
+              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              data-action="dropdown#toggle"
+              data-dropdown-payload-param='[{"grant_detail_fields":"hidden"}, {"grant_detail_fields_show_label":"hidden"}, {"grant_detail_fields_hide_label":"hidden"}, {"grant_detail_fields_chevron":"rotate-180"}]'>
+        <span>
+          <span id="grant_detail_fields_show_label" class="<%= "hidden" unless details_filled %>">Description, criteria &amp; tasks</span>
+          <span id="grant_detail_fields_hide_label" class="<%= "hidden" if details_filled %>">Hide description, criteria &amp; tasks</span>
+        </span>
+        <i id="grant_detail_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 <%= "rotate-180" unless details_filled %>"></i>
+      </button>
 
-    <div>
-      <%= f.input :description,
-                  as: :text,
-                  input_html: { rows: 4, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
-    </div>
+      <div id="grant_detail_fields" class="mt-4 space-y-6 <%= "hidden" if details_filled %>">
+        <div>
+          <%= f.input :description,
+                      as: :text,
+                      input_html: { rows: 4, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
 
-    <div>
-      <%= f.input :eligibility_criteria,
-                  label: "Eligibility criteria",
-                  hint: "One criterion per line.",
-                  as: :text,
-                  input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
-    </div>
+        <div>
+          <%= f.input :eligibility_criteria,
+                      label: "Eligibility criteria",
+                      hint: "One criterion per line.",
+                      as: :text,
+                      input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
 
-    <div>
-      <%= f.input :tasks,
-                  label: "Tasks to complete",
-                  hint: "One task per line.",
-                  as: :text,
-                  input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        <div>
+          <%= f.input :tasks,
+                      label: "Tasks to complete",
+                      hint: "One task per line.",
+                      as: :text,
+                      input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+        </div>
+      </div>
     </div>
 
     <div data-controller="dropdown">
@@ -131,6 +150,20 @@
           </div>
         </div>
       <% end %>
+      </div>
+    </div>
+
+    <div data-controller="dropdown">
+      <button type="button"
+              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              data-action="dropdown#toggle"
+              data-dropdown-payload-param='[{"grant_photo_fields":"hidden"}, {"grant_photo_fields_chevron":"rotate-180"}]'>
+        <span>Photos</span>
+        <i id="grant_photo_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
+      </button>
+
+      <div id="grant_photo_fields" class="hidden mt-4">
+        <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
       </div>
     </div>
   </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -64,9 +64,9 @@
     <%# Collapse the free-text fields once a grant is fully documented; keep them
         open while any is still blank so nothing goes unnoticed on a new grant. %>
     <% details_filled = @grant.description.present? && @grant.eligibility_criteria.present? && @grant.tasks.present? %>
-    <div data-controller="dropdown">
+    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
       <button type="button"
-              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_detail_fields":"hidden"}, {"grant_detail_fields_show_label":"hidden"}, {"grant_detail_fields_hide_label":"hidden"}, {"grant_detail_fields_chevron":"rotate-180"}]'>
         <span>
@@ -76,7 +76,7 @@
         <i id="grant_detail_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 <%= "rotate-180" unless details_filled %>"></i>
       </button>
 
-      <div id="grant_detail_fields" class="mt-4 space-y-6 <%= "hidden" if details_filled %>">
+      <div id="grant_detail_fields" class="border-t border-gray-200 p-4 space-y-6 <%= "hidden" if details_filled %>">
         <div>
           <%= f.input :description,
                       as: :text,
@@ -101,16 +101,16 @@
       </div>
     </div>
 
-    <div data-controller="dropdown">
+    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
       <button type="button"
-              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_tag_fields":"hidden"}, {"grant_tag_fields_chevron":"rotate-180"}]'>
         <span>Sectors &amp; categories</span>
         <i id="grant_tag_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
       </button>
 
-      <div id="grant_tag_fields" class="hidden mt-4 space-y-6">
+      <div id="grant_tag_fields" class="hidden border-t border-gray-200 p-4 space-y-6">
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
         <h3 class="text-base font-semibold text-gray-800 mb-3">Sectors</h3>
         <div class="flex flex-wrap gap-3">
@@ -153,16 +153,16 @@
       </div>
     </div>
 
-    <div data-controller="dropdown">
+    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
       <button type="button"
-              class="w-full flex items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-3 text-left text-sm font-medium text-gray-800 shadow-sm hover:bg-gray-50 transition"
+              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_photo_fields":"hidden"}, {"grant_photo_fields_chevron":"rotate-180"}]'>
         <span>Photos</span>
         <i id="grant_photo_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
       </button>
 
-      <div id="grant_photo_fields" class="hidden mt-4">
+      <div id="grant_photo_fields" class="hidden border-t border-gray-200 p-4">
         <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
       </div>
     </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -52,6 +52,7 @@
       <div>
         <%= f.input :funds_allocation_deadline,
                     label: "Funds allocation deadline",
+                    hint: "Award this grant's full amount in scholarships by this date.",
                     as: :string,
                     input_html: {
                       type: "date",

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -81,6 +81,48 @@
                   as: :text,
                   input_html: { rows: 5, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
     </div>
+
+    <div class="space-y-6">
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+        <h3 class="text-base font-semibold text-gray-800 mb-3">Sectors</h3>
+        <div class="flex flex-wrap gap-3">
+          <% @sectors.each do |sector| %>
+            <% id = "grant_sector_ids_#{sector.id}" %>
+            <label for="<%= id %>"
+                   class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+              <%= hidden_field_tag "grant[sector_ids][]", "" %>
+              <%= check_box_tag "grant[sector_ids][]",
+                                sector.id,
+                                @grant.sector_ids.include?(sector.id),
+                                id: id,
+                                class: "h-4 w-4 text-blue-600 rounded" %>
+              <span class="text-sm text-gray-700 whitespace-nowrap"><%= sector.name %></span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+
+      <% @categories_grouped.each do |type, cats| %>
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+          <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type ? type.name.underscore.humanize : "Other" %></h3>
+          <div class="flex flex-wrap gap-3">
+            <% cats.each do |category| %>
+              <% id = "grant_category_ids_#{category.id}" %>
+              <label for="<%= id %>"
+                     class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                <%= hidden_field_tag "grant[category_ids][]", "" %>
+                <%= check_box_tag "grant[category_ids][]",
+                                  category.id,
+                                  @grant.category_ids.include?(category.id),
+                                  id: id,
+                                  class: "h-4 w-4 text-blue-600 rounded" %>
+                <span class="text-sm text-gray-700 whitespace-nowrap"><%= category.name %></span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 
   <div class="action-buttons mt-8 flex justify-center gap-3">

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -18,7 +18,7 @@
             <%= Grant.model_name.human.pluralize %>
             <%= render "count" %>
           </h2>
-          <p class="text-gray-600 mt-1">Funds donated by organizations and people, from which scholarships are awarded.</p>
+          <p class="text-gray-600 mt-1">Funds provided by organizations and people, from which scholarships are awarded.</p>
         </div>
       </div>
 

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -25,11 +25,18 @@
     </div>
   </div>
 
+  <!-- Photos -->
+  <% if @grant.primary_asset&.file&.attached? || @grant.gallery_assets.any? { |asset| asset.file.attached? } %>
+    <div class="bg-white rounded-lg shadow p-5">
+      <%= render "assets/display_assets", resource: @grant, link: true %>
+    </div>
+  <% end %>
+
   <!-- Budget summary -->
   <div class="bg-white rounded-lg shadow p-5">
     <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
       <div>
-        <dt class="text-sm font-medium text-gray-500">Donation amount</dt>
+        <dt class="text-sm font-medium text-gray-500">Funding amount</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900"><%= grant.amount %></dd>
       </div>
       <div>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -70,9 +70,18 @@
   <% grant_sectors = @grant.sectors.order(:name) %>
   <% grant_categories = @grant.categories.includes(:category_type).order(Arel.sql("category_types.name, categories.position, categories.name")) %>
   <% if grant_sectors.any? || grant_categories.any? %>
-    <div class="bg-white rounded-lg shadow p-5">
-      <h2 class="text-lg font-semibold text-gray-900 mb-3">Tags</h2>
-      <div class="flex flex-wrap gap-2">
+    <% tag_count = grant_sectors.size + grant_categories.size %>
+    <div class="bg-white rounded-lg shadow p-5" data-controller="dropdown">
+      <button type="button"
+              class="inline-flex items-center gap-2 text-lg font-semibold text-gray-900 hover:text-gray-700 cursor-pointer transition"
+              data-action="dropdown#toggle"
+              data-dropdown-payload-param='[{"grant_tags_content":"hidden"}, {"grant_tags_show_label":"hidden"}, {"grant_tags_hide_label":"hidden"}, {"grant_tags_chevron":"rotate-180"}]'>
+        <i id="grant_tags_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
+        <span id="grant_tags_show_label">Tags (<%= tag_count %>)</span>
+        <span id="grant_tags_hide_label" class="hidden">Hide tags (<%= tag_count %>)</span>
+      </button>
+
+      <div id="grant_tags_content" class="hidden mt-4 flex flex-wrap gap-2">
         <% grant_sectors.each do |sector| %>
           <%= render "sectors/tagging_label", sector: sector %>
         <% end %>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -66,6 +66,23 @@
     <% end %>
   </div>
 
+  <!-- Tags -->
+  <% grant_sectors = @grant.sectors.order(:name) %>
+  <% grant_categories = @grant.categories.includes(:category_type).order(Arel.sql("category_types.name, categories.position, categories.name")) %>
+  <% if grant_sectors.any? || grant_categories.any? %>
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Tags</h2>
+      <div class="flex flex-wrap gap-2">
+        <% grant_sectors.each do |sector| %>
+          <%= render "sectors/tagging_label", sector: sector %>
+        <% end %>
+        <% grant_categories.each do |category| %>
+          <%= render "categories/tagging_label", category: category %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <!-- Eligibility criteria -->
   <div class="bg-white rounded-lg shadow p-5">
     <h2 class="text-lg font-semibold text-gray-900 mb-2">Eligibility criteria</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
     none_for_story_idea: "No communications for this story idea yet."
   activerecord:
     attributes:
+      grant:
+        funder_sgid: "Funder"
       workshop_variation:
         rhino_body: "Details"
       workshop_variation_idea:

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -8,6 +8,16 @@ FactoryBot.define do
     eligibility_criteria { "Must be a current facilitator\nMust serve a partner organization" }
     tasks { "Submit application form\nComplete intake interview" }
 
+    transient do
+      categories { [] }
+      sectors { [] }
+    end
+
+    after(:create) do |grant, evaluator|
+      evaluator.sectors.each { |sector| grant.sectors << sector unless grant.sectors.include?(sector) }
+      evaluator.categories.each { |category| grant.categories << category unless grant.categories.include?(category) }
+    end
+
     trait :donated_by_person do
       association :funder, factory: :person
     end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -6,6 +6,47 @@ RSpec.describe Grant, type: :model do
     it { is_expected.to belong_to(:created_by).class_name("User").optional }
     it { is_expected.to belong_to(:updated_by).class_name("User").optional }
     it { is_expected.to have_many(:scholarships).dependent(:restrict_with_error) }
+    it { is_expected.to have_many(:sectorable_items).dependent(:destroy) }
+    it { is_expected.to have_many(:sectors).through(:sectorable_items) }
+    it { is_expected.to have_many(:categorizable_items).dependent(:destroy) }
+    it { is_expected.to have_many(:categories).through(:categorizable_items) }
+  end
+
+  describe "tagging" do
+    let(:sector) { create(:sector) }
+    let(:category) { create(:category) }
+
+    it "attaches sectors and categories assigned by id on a new record" do
+      grant = create(:grant, sector_ids: [ sector.id ], category_ids: [ category.id ])
+
+      expect(grant.reload.sectors).to contain_exactly(sector)
+      expect(grant.categories).to contain_exactly(category)
+    end
+
+    it "updates sectors and categories by id on an existing record" do
+      grant = create(:grant, sectors: [ sector ])
+      other_sector = create(:sector)
+
+      grant.update!(sector_ids: [ other_sector.id ], category_ids: [ category.id ])
+
+      expect(grant.reload.sectors).to contain_exactly(other_sector)
+      expect(grant.categories).to contain_exactly(category)
+    end
+
+    describe ".sector_names_all / .category_names_all" do
+      it "finds grants carrying the given tags" do
+        tagged = create(:grant, sectors: [ sector ], categories: [ category ])
+        create(:grant)
+
+        expect(Grant.sector_names_all(sector.name)).to contain_exactly(tagged)
+        expect(Grant.category_names_all(category.name)).to contain_exactly(tagged)
+      end
+    end
+
+    it "responds to a no-op published scope covering every grant" do
+      grant = create(:grant)
+      expect(Grant.published).to include(grant)
+    end
   end
 
   describe "validations" do

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Grant, type: :model do
   describe "associations" do
-    it { is_expected.to belong_to(:funder) }
+    it { is_expected.to belong_to(:funder).optional }
     it { is_expected.to belong_to(:created_by).class_name("User").optional }
     it { is_expected.to belong_to(:updated_by).class_name("User").optional }
     it { is_expected.to have_many(:scholarships).dependent(:restrict_with_error) }
@@ -59,6 +59,14 @@ RSpec.describe Grant, type: :model do
 
     it "is valid with a person funder" do
       expect(build(:grant, :donated_by_person)).to be_valid
+    end
+
+    it "attaches the missing-funder error to funder_sgid so the form field shows it" do
+      grant = build(:grant, funder: nil)
+
+      expect(grant).not_to be_valid
+      expect(grant.errors[:funder_sgid]).to include("must be selected")
+      expect(grant.errors.full_messages).to include("Funder must be selected")
     end
 
     describe "amount cannot drop below scholarships already issued" do

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -119,6 +119,21 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("All done")
       end
 
+      it "filters by sector and category tags for the taggings deep link" do
+        sector = create(:sector, :published, name: "Homelessness")
+        category = create(:category, :published, name: "Ages 10-13")
+        tagged = create(:grant, name: "Tagged grant", sectors: [ sector ], categories: [ category ])
+        create(:grant, name: "Untagged grant")
+
+        get grants_url(sector_names_all: sector.name), headers: frame_headers
+        expect(response.body).to include("Tagged grant")
+        expect(response.body).not_to include("Untagged grant")
+
+        get grants_url(category_names_all: category.name), headers: frame_headers
+        expect(response.body).to include("Tagged grant")
+        expect(response.body).not_to include("Untagged grant")
+      end
+
       it "scopes to a single funder via funder_id and names it in the banner" do
         funder = create(:person, first_name: "Dana", last_name: "Funder")
         create(:grant, name: "Dana Fund", funder: funder)
@@ -140,6 +155,16 @@ RSpec.describe "/grants", type: :request do
       it "renders a successful response" do
         get grant_url(create(:grant))
         expect(response).to be_successful
+      end
+
+      it "shows the grant's sector and category tags" do
+        sector = create(:sector, :published, name: "Domestic Violence")
+        category = create(:category, :published, name: "Ages 6-9")
+        grant = create(:grant, sectors: [ sector ], categories: [ category ])
+
+        get grant_url(grant)
+        expect(response.body).to include("Domestic Violence")
+        expect(response.body).to include("Ages 6-9")
       end
     end
 
@@ -174,6 +199,19 @@ RSpec.describe "/grants", type: :request do
           post grants_url, params: { grant: valid_attributes }
           expect(response).to redirect_to(grant_url(Grant.last))
         end
+
+        it "attaches the selected sectors and categories" do
+          sector = create(:sector, :published)
+          category = create(:category, :published)
+
+          post grants_url, params: {
+            grant: valid_attributes.merge(sector_ids: [ sector.id ], category_ids: [ category.id ])
+          }
+
+          grant = Grant.last
+          expect(grant.sectors).to contain_exactly(sector)
+          expect(grant.categories).to contain_exactly(category)
+        end
       end
 
       context "with invalid parameters" do
@@ -202,6 +240,20 @@ RSpec.describe "/grants", type: :request do
         grant = create(:grant)
         patch grant_url(grant), params: { grant: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "replaces the grant's sectors and categories" do
+        old_sector = create(:sector, :published)
+        grant = create(:grant, sectors: [ old_sector ])
+        new_sector = create(:sector, :published)
+        category = create(:category, :published)
+
+        patch grant_url(grant), params: {
+          grant: valid_attributes.merge(sector_ids: [ new_sector.id ], category_ids: [ category.id ])
+        }
+
+        expect(grant.reload.sectors).to contain_exactly(new_sector)
+        expect(grant.categories).to contain_exactly(category)
       end
     end
 

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -157,6 +157,19 @@ RSpec.describe "/grants", type: :request do
         expect(response).to be_successful
       end
 
+      it "shows an uploaded primary photo" do
+        grant = create(:grant)
+        grant.create_primary_asset!.file.attach(
+          io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+          filename: "sample.png",
+          content_type: "image/png"
+        )
+
+        get grant_url(grant)
+        expect(response).to be_successful
+        expect(response.body).to include("sample")
+      end
+
       it "shows the grant's sector and category tags" do
         sector = create(:sector, :published, name: "Domestic Violence")
         category = create(:category, :published, name: "Ages 6-9")
@@ -198,6 +211,20 @@ RSpec.describe "/grants", type: :request do
         it "redirects to the created grant" do
           post grants_url, params: { grant: valid_attributes }
           expect(response).to redirect_to(grant_url(Grant.last))
+        end
+
+        it "attaches an uploaded primary photo" do
+          expect {
+            post grants_url, params: {
+              grant: valid_attributes.merge(
+                primary_asset_attributes: {
+                  file: fixture_file_upload("spec/fixtures/files/sample.png", "image/png")
+                }
+              )
+            }
+          }.to change(Grant, :count).by(1)
+
+          expect(Grant.last.primary_asset.file).to be_attached
         end
 
         it "attaches the selected sectors and categories" do

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -252,6 +252,15 @@ RSpec.describe "/grants", type: :request do
           post grants_url, params: { grant: invalid_attributes }
           expect(response).to have_http_status(:unprocessable_content)
         end
+
+        it "surfaces the missing-funder error on the funder field, not just the summary" do
+          post grants_url, params: { grant: invalid_attributes }
+
+          # simple_form wraps the funder_sgid input with the error class when the
+          # attribute has an error, so the message renders inline on the field.
+          expect(response.body).to include("Funder must be selected")
+          expect(response.body).to include("must be selected")
+        end
       end
     end
 

--- a/spec/requests/taggings_spec.rb
+++ b/spec/requests/taggings_spec.rb
@@ -84,6 +84,23 @@ RSpec.describe "Taggings index", type: :request do
     end
   end
 
+  describe "grants (admin-only)" do
+    let!(:admin) { create(:user, :admin) }
+    let!(:grant) { create(:grant, name: "Youth Healing Fund", sectors: [ sector_2 ]) }
+
+    it "shows a matching grant card to an admin" do
+      sign_in admin
+      get taggings_path(sector_names_all: sector_2.name)
+      expect(response.body).to include("Youth Healing Fund")
+      expect(response.body).to include(grant_path(grant))
+    end
+
+    it "hides grants from a regular signed-in user" do
+      get taggings_path(sector_names_all: sector_2.name)
+      expect(response.body).not_to include("Youth Healing Fund")
+    end
+  end
+
   describe "edit buttons for non-admins" do
     it "does not show edit buttons to a regular signed-in user" do
       get taggings_path(sector_names_all: sector_2.name)

--- a/spec/services/tagging_search_service_spec.rb
+++ b/spec/services/tagging_search_service_spec.rb
@@ -111,6 +111,33 @@ RSpec.describe TaggingSearchService do
       end
     end
 
+    context "with grants (admin-only)" do
+      let!(:admin) { create(:user, :admin) }
+      let!(:grant) { create(:grant, name: "Youth Fund", sectors: [ sector ]) }
+
+      it "returns matching grants for an admin" do
+        results = described_class.new(user: admin).call(
+          sector_names_all: "Youth",
+          category_names_all: nil,
+          pages: {},
+          number_of_items_per_page: 9
+        )
+
+        expect(results[:grants].map(&:name)).to include("Youth Fund")
+      end
+
+      it "hides grants from non-admins" do
+        results = described_class.new(user: user).call(
+          sector_names_all: "Youth",
+          category_names_all: nil,
+          pages: {},
+          number_of_items_per_page: 9
+        )
+
+        expect(results[:grants]).to be_empty
+      end
+    end
+
     context "as a guest (nil user)" do
       it "returns only publicly visible results" do
         results = described_class.new(user: nil).call(


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained model/view wiring across the grant feature (tagging, photos, form polish) plus a scoped terminology cleanup

### What is the goal of this PR and why is this important?
- Grants can be tagged by sector and thematic category (like workshops/stories), findable from the taggings browse page.
- Grants gain primary + gallery photos.
- Grant form is tidied and terminology moves from "donation" to "funding".

### How did you approach the change?
**Tagging**
- `Grant` gains polymorphic `sectors`/`categories` + `TagFilterable`; new-record `sector_ids=`/`category_ids=` defer to `after_create` (mirrors `Workshop`).
- Registered in `Tag::TAGGABLE_META`, `TaggingSearchService`, taggings `pages`. Admin-only via `authorized_scope`, so grants never surface publicly; matrix already gates on `matrix?`. No-op `published` scope satisfies the shared machinery.
- Grants index honors `sector_names_all`/`category_names_all` for the "View all grants" deep link.

**Photos** — primary + gallery assets via the `CommunityNews` pattern (`shared/form_image_fields`, `assets/display_assets`). No migration (polymorphic assets table).

**Form & display**
- Sectors/categories, description+criteria+tasks, and photos each collapse behind a toggle. The detail toggle starts collapsed only when all three fields are filled.
- Funder pairs with Funding amount on one row; received-on with deadline on the next.
- Tag chips + photos render on the grant show page (tags behind a toggle).

**Terminology** — user-facing "Donation amount" → "Funding amount"; grant-domain code/comment wording "donation"/"donated" → grant/funding (`self-funded` for AWBW's own grants). Deliberately left alone: the real charitable-donation checkout flow, the `Fundraising/Donor Engagement` sector name, and external "Donate" marketing links.

### Anything else to add?
- Because sectors are a shared vocabulary, a sector/category tagged only on a grant can appear in the public tag list (empty result) — never exposes grant data itself.