### PR TITLE
Bulk reminder emails: hide the event-details box, with on-demand-aware defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ end
 - `prefetch_lazy` — Prefetch lazy-loaded content
 - `primary_tag` — Shared single-primary star for the sector and age-range cocoon chip editors (clears other stars, highlights via configurable classes, no reorder)
 - `print_options` — Print options toggle for analytics
-- `reminder_preview` — Live-preview a custom message in the reminder email as the admin types it on the bulk-reminder page
+- `reminder_preview` — Live-preview the reminder email as the admin composes it on the bulk-reminder page: custom message, subject, and the event-details box toggle (announced to screen readers)
 - `remote_select` — AJAX-powered select dropdown
 - `reveal_section` — Expand a collapsible section and scroll to it when loaded via matching URL hash
 - `rhino_source` — Rich text editor integration

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -390,11 +390,12 @@ class EventsController < ApplicationController
     # absent-vs-present logic as the message, so a bounce-back keeps the admin's
     # edit; a blank subject falls back to the default at send time.
     @custom_subject = params.key?(:custom_subject) ? params[:custom_subject].to_s : helpers.default_reminder_subject(@event)
+    @hide_event_card = hide_event_card_param
 
     if @sample_registration
       # Render in preview mode so the custom-message container is always present
       # in the markup for the live preview, even before any text is typed.
-      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, custom_subject: @custom_subject, preview: true)
+      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card, preview: true)
       @reminder_preview_html = mail.html_part&.body&.decoded
     end
   end
@@ -409,9 +410,10 @@ class EventsController < ApplicationController
     @event_registrations = selected_reminder_registrations
     @custom_message = params[:custom_message].to_s
     @custom_subject = params[:custom_subject].to_s
+    @hide_event_card = hide_event_card_param
 
     if @event_registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: ("1" if hide_event_card_param)), alert: "Please select at least one recipient."
       return
     end
 
@@ -421,7 +423,7 @@ class EventsController < ApplicationController
       return
     end
 
-    mail = EventMailer.event_registration_reminder(@event_registrations.first, custom_message: @custom_message, custom_subject: @custom_subject)
+    mail = EventMailer.event_registration_reminder(@event_registrations.first, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card)
     @reminder_subject = mail.subject
     @reminder_preview_html = mail.html_part&.body&.decoded
   end
@@ -431,7 +433,7 @@ class EventsController < ApplicationController
     registrations = selected_reminder_registrations
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s, hide_event_card: ("1" if hide_event_card_param)), alert: "Please select at least one recipient."
       return
     end
 
@@ -439,6 +441,7 @@ class EventsController < ApplicationController
 
     custom_message = params[:custom_message].to_s
     custom_subject = params[:custom_subject].to_s
+    hide_event_card = hide_event_card_param
 
     # Record an individual notification per recipient (delivered + persisted via
     # NotificationMailerJob), so each reminder shows up in that person's
@@ -453,7 +456,8 @@ class EventsController < ApplicationController
         sender: current_user, # an admin sent these by hand from the reminders page
         bulk: true,
         custom_message: custom_message.presence,
-        custom_subject: custom_subject.presence
+        custom_subject: custom_subject.presence,
+        hide_event_card: hide_event_card
       )
     end
 
@@ -461,7 +465,7 @@ class EventsController < ApplicationController
     # was sent. Roster passed as plain "Name <email>" labels so the delivery job
     # needs no record lookups.
     recipient_labels = registrations.map { |r| "#{r.registrant.full_name} <#{r.registrant.preferred_email}>" }
-    EventMailer.event_registration_reminder_fyi(@event, recipient_labels, custom_message: custom_message.presence).deliver_later
+    EventMailer.event_registration_reminder_fyi(@event, recipient_labels, custom_message: custom_message.presence, hide_event_card: hide_event_card).deliver_later
 
     track_view("events.send_reminder", { event_id: @event.id, recipient_count: registrations.size })
     redirect_to registrants_event_path(@event), notice: "Reminder emails are being sent to #{registrations.size} registrant#{'s' if registrations.size != 1}."
@@ -1003,6 +1007,11 @@ class EventsController < ApplicationController
     mail = DeviseMailer.confirmation_instructions(sample_user, "preview-token", preview: true)
     @invite_subject = mail.subject
     @reminder_preview_html = mail.html_part&.body&.decoded
+  end
+
+  # Whether the admin ticked "hide the event details box" on the compose page.
+  def hide_event_card_param
+    ActiveModel::Type::Boolean.new.cast(params[:hide_event_card]) || false
   end
 
   # The registrations the admin checked on the recipient picker, narrowed to those

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -385,12 +385,15 @@ class EventsController < ApplicationController
     # Pre-fill the editable message with the standard reminder sentence (days
     # resolved now). Absent param = first load → default; a present-but-blank
     # param = the admin cleared it (e.g. bounced back here) → respect the blank.
-    @custom_message = params.key?(:custom_message) ? params[:custom_message].to_s : helpers.default_reminder_message(days_until_event)
+    @custom_message = params.key?(:custom_message) ? params[:custom_message].to_s : helpers.default_reminder_message(days_until_event, event: @event)
     # Pre-fill the editable subject with the standard portal subject. Same
     # absent-vs-present logic as the message, so a bounce-back keeps the admin's
     # edit; a blank subject falls back to the default at send time.
     @custom_subject = params.key?(:custom_subject) ? params[:custom_subject].to_s : helpers.default_reminder_subject(@event)
-    @hide_event_card = hide_event_card_param
+    # Same absent-vs-present logic as the message: on-demand training defaults to
+    # hiding the box (its dates/times/cost describe nothing), but an explicit "0"
+    # from a bounce-back means the admin unticked it and we respect that.
+    @hide_event_card = params.key?(:hide_event_card) ? hide_event_card_param : @event.on_demand?
 
     if @sample_registration
       # Render in preview mode so the custom-message container is always present
@@ -413,7 +416,7 @@ class EventsController < ApplicationController
     @hide_event_card = hide_event_card_param
 
     if @event_registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: ("1" if hide_event_card_param)), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: (hide_event_card_param ? "1" : "0")), alert: "Please select at least one recipient."
       return
     end
 
@@ -433,7 +436,7 @@ class EventsController < ApplicationController
     registrations = selected_reminder_registrations
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s, hide_event_card: ("1" if hide_event_card_param)), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s, hide_event_card: (hide_event_card_param ? "1" : "0")), alert: "Please select at least one recipient."
       return
     end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -64,13 +64,19 @@ class NotificationsController < ApplicationController
     parent_id = @notification.id
     root_id = @notification.root_notification_id || @notification.id
 
-    # Create and send a new notification using the service
+    # Create and send a new notification using the service. Everything that shaped
+    # the original body travels with it so the resend is the same email, not a
+    # default-shaped one; only the provenance (sender, and `bulk` — a resend is an
+    # individual action, not part of the original batch) reflects the resend itself.
     new_notification = NotificationServices::CreateNotification.call(
       noticeable: @notification.noticeable,
       kind: @notification.kind,
       recipient_email: @notification.recipient_email,
       recipient_role: @notification.recipient_role,
       notification_type: @notification.notification_type,
+      custom_message: @notification.custom_message,
+      custom_subject: @notification.custom_subject,
+      hide_event_card: @notification.hide_event_card,
       sender: current_user, # a resend is an admin action — attribute it to them
       deliver: true,
       persist_delivered_email: true

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -42,10 +42,28 @@ class EventDecorator < ApplicationDecorator
     start_date.strftime("%B %d, %Y")
   end
 
+  # Subject pre-filled on the bulk reminder page and used as the send-time
+  # fallback, so the preview and the delivered email always agree. An on-demand
+  # event's start date bounds enrollment rather than naming a session, so putting
+  # it in the subject reads as "be there on August 7".
+  def default_reminder_subject(time_zone: Time.zone.name)
+    return "AWBW Portal: Reminder: #{title}" if on_demand? || start_date.blank?
+
+    "AWBW Portal: Reminder: #{title} – #{start_date.in_time_zone(time_zone).strftime("%B %-d, %Y")}"
+  end
+
   # Display in the viewer's TZ. Returns nil when no deadline is set.
   def ce_payment_due_deadline_display
     return if ce_payment_due_deadline.blank?
     ce_payment_due_deadline.in_time_zone(Time.zone).strftime("%-l:%M %p %Z on %B %-d, %Y")
+  end
+
+  # The date the training must be finished by (e.g. "August 30, 2026"). Nil when
+  # unset. Date-only, so no time or zone is applied — unlike the two payment
+  # deadlines below.
+  def completion_deadline_display
+    return if completion_deadline.blank?
+    completion_deadline.strftime("%B %-d, %Y")
   end
 
   # The ticket payment deadline in the viewer's TZ (e.g. "5:00 PM UTC on April 9,

--- a/app/frontend/javascript/controllers/reminder_preview_controller.js
+++ b/app/frontend/javascript/controllers/reminder_preview_controller.js
@@ -7,7 +7,7 @@ import { Controller } from "@hotwired/stimulus"
 // above the rendered email. The actual send re-sanitizes the message server-side,
 // so injecting the raw values here is only for the on-page preview.
 export default class extends Controller {
-  static targets = ["input", "message", "subjectInput", "subjectPreview"]
+  static targets = ["input", "message", "subjectInput", "subjectPreview", "eventCard", "eventCardToggle"]
 
   inputTargetConnected() {
     this.update()
@@ -25,6 +25,14 @@ export default class extends Controller {
     this.updateSubject()
   }
 
+  eventCardTargetConnected() {
+    this.toggleEventCard()
+  }
+
+  eventCardToggleTargetConnected() {
+    this.toggleEventCard()
+  }
+
   update() {
     if (!this.hasMessageTarget || !this.hasInputTarget) return
 
@@ -37,5 +45,11 @@ export default class extends Controller {
     if (!this.hasSubjectPreviewTarget || !this.hasSubjectInputTarget) return
 
     this.subjectPreviewTarget.textContent = this.subjectInputTarget.value.trim()
+  }
+
+  toggleEventCard() {
+    if (!this.hasEventCardTarget || !this.hasEventCardToggleTarget) return
+
+    this.eventCardTarget.style.display = this.eventCardToggleTarget.checked ? "none" : ""
   }
 }

--- a/app/frontend/javascript/controllers/reminder_preview_controller.js
+++ b/app/frontend/javascript/controllers/reminder_preview_controller.js
@@ -7,7 +7,7 @@ import { Controller } from "@hotwired/stimulus"
 // above the rendered email. The actual send re-sanitizes the message server-side,
 // so injecting the raw values here is only for the on-page preview.
 export default class extends Controller {
-  static targets = ["input", "message", "subjectInput", "subjectPreview", "eventCard", "eventCardToggle"]
+  static targets = ["input", "message", "subjectInput", "subjectPreview", "eventCard", "eventCardToggle", "cardStatus"]
 
   inputTargetConnected() {
     this.update()
@@ -26,11 +26,11 @@ export default class extends Controller {
   }
 
   eventCardTargetConnected() {
-    this.toggleEventCard()
+    this.syncEventCard()
   }
 
   eventCardToggleTargetConnected() {
-    this.toggleEventCard()
+    this.syncEventCard()
   }
 
   update() {
@@ -47,7 +47,19 @@ export default class extends Controller {
     this.subjectPreviewTarget.textContent = this.subjectInputTarget.value.trim()
   }
 
+  // Action handler. Announces as well as syncing — the connect callbacks use
+  // syncEventCard directly so the live region stays silent on page load.
   toggleEventCard() {
+    this.syncEventCard()
+
+    if (!this.hasCardStatusTarget || !this.hasEventCardToggleTarget) return
+
+    this.cardStatusTarget.textContent = this.eventCardToggleTarget.checked
+      ? "Event details box hidden from the email."
+      : "Event details box shown in the email."
+  }
+
+  syncEventCard() {
     if (!this.hasEventCardTarget || !this.hasEventCardToggleTarget) return
 
     this.eventCardTarget.style.display = this.eventCardToggleTarget.checked ? "none" : ""

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,17 +70,30 @@ module ApplicationHelper
   # Default text pre-filled into the editable reminder message on the bulk
   # reminder page (admins can edit or clear it). The day count is resolved when
   # the page renders — it's event-level, so the same for every recipient.
-  def default_reminder_message(days_until_event)
+  # Self-paced training gets its own copy: there's no meaningful day count, and
+  # its details box is hidden by default, so "the following event" would dangle
+  # with nothing under it. Naming the title inline keeps the email identifiable.
+  # Just "training", not "on-demand training" — these titles already say so
+  # ("On-Demand Training 2026"), and the pairing reads as a stutter.
+  def default_reminder_message(days_until_event, event: nil)
     organization = ENV.fetch("ORGANIZATION_NAME", "AWBW")
-    "This is a reminder that you're registered for the following #{organization} event#{reminder_days_phrase(days_until_event)}."
+    opening = if event&.on_demand?
+      "This is a reminder that you're registered for the #{organization} training <strong>#{ERB::Util.html_escape(event.title)}</strong>."
+    else
+      "This is a reminder that you're registered for the following #{organization} event#{reminder_days_phrase(days_until_event)}."
+    end
+    # Any event with a deadline states it here, in copy the admin can reword — the
+    # email template has no standalone deadline block, so this is the only place
+    # it appears and it can't land twice.
+    deadline = event&.decorate&.completion_deadline_display
+    [ opening, ("Please complete it by <strong>#{deadline}</strong>." if deadline) ].compact.join(" ")
   end
 
   # Default subject line pre-filled into the editable subject field on the bulk
   # reminder page (admins can edit it). Mirrors the mailer's fallback subject; the
   # event date is event-level, resolved here in the app default time zone.
   def default_reminder_subject(event)
-    date_suffix = event.start_date.present? ? " – #{event.start_date.in_time_zone.strftime('%B %-d, %Y')}" : ""
-    "AWBW Portal: Reminder: #{event.title}#{date_suffix}"
+    event.decorate.default_reminder_subject
   end
 
   # Tokens an admin can drop into a form header; each is filled from the event the

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -15,7 +15,7 @@ class NotificationMailerJob < ApplicationJob
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
       "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) },
-      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message, custom_subject: n.custom_subject) },
+      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message, custom_subject: n.custom_subject, hide_event_card: n.hide_event_card) },
       "bulk_payment_confirmation" => ->(n) { EventMailer.bulk_payment_confirmation(n.noticeable) },
       "bulk_payment_confirmation_fyi" => ->(n) { NotificationMailer.bulk_payment_confirmation_fyi(n) }
     }

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -65,14 +65,13 @@ class EventMailer < ApplicationMailer
     @organization_website = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 
     # Admins can override the subject from the bulk-reminder page; fall back to
-    # the standard portal subject when they left it blank.
-    date_suffix = @event.start_date.present? ? " – #{@event.start_date.in_time_zone(@time_zone).strftime('%B %-d, %Y')}" : ""
-    default_subject = "AWBW Portal: Reminder: #{@event.title}#{date_suffix}"
+    # the standard portal subject when they left it blank. Shared with the compose
+    # page's pre-fill so the preview and the delivered email can't drift apart.
     mail(
       to: @person.preferred_email,
       from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
-      subject: @custom_subject || default_subject
+      subject: @custom_subject || @event.default_reminder_subject(time_zone: @time_zone)
     )
   end
 

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -44,12 +44,15 @@ class EventMailer < ApplicationMailer
     )
   end
 
-  def event_registration_reminder(event_registration, custom_message: nil, custom_subject: nil, preview: false)
+  def event_registration_reminder(event_registration, custom_message: nil, custom_subject: nil, hide_event_card: false, preview: false)
     @event_registration = event_registration
     @event = event_registration.event.decorate
     @person = event_registration.registrant
     @custom_message = custom_message.presence
     @custom_subject = custom_subject.presence
+    # When true, the grey event-details card is dropped from the email — the admin
+    # chose to send a plainer message on the bulk-reminder page.
+    @hide_event_card = hide_event_card
     # When true, the HTML body always renders the custom-message container (even
     # when blank) with hooks the on-page preview's Stimulus controller fills in
     # live. Never set on a real send.
@@ -78,10 +81,12 @@ class EventMailer < ApplicationMailer
   # is passed as "Name <email>" labels (not records), so the job that delivers
   # this needs no extra lookups. The per-recipient reminders are tracked
   # notifications; this is just an at-a-glance heads-up for the team.
-  def event_registration_reminder_fyi(event, recipient_labels, custom_message: nil)
+  def event_registration_reminder_fyi(event, recipient_labels, custom_message: nil, hide_event_card: false)
     @event = event.decorate
     @recipient_labels = Array(recipient_labels)
     @custom_message = custom_message.presence
+    # Mirror what registrants received: drop the card from the admin copy too.
+    @hide_event_card = hide_event_card
     @notification_type = "Event registration reminder"
     @time_zone = Time.zone.name
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -65,7 +65,7 @@ class EventMailer < ApplicationMailer
     @organization_website = ENV.fetch("ORGANIZATION_WEBSITE", root_url)
 
     # Admins can override the subject from the bulk-reminder page; fall back to
-    # the standard portal subject (e.g. on a resend that carries no custom value).
+    # the standard portal subject when they left it blank.
     date_suffix = @event.start_date.present? ? " – #{@event.start_date.in_time_zone(@time_zone).strftime('%B %-d, %Y')}" : ""
     default_subject = "AWBW Portal: Reminder: #{@event.title}#{date_suffix}"
     mail(

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -155,6 +155,7 @@ class EventPolicy < ApplicationPolicy
                   :ce_payment_due_deadline_time,
                   :payment_due_deadline_date,
                   :payment_due_deadline_time,
+                  :completion_deadline,
                   :autoshow_cost,
                   :autoshow_date,
                   :autoshow_location,

--- a/app/services/builtin_callout_cards.rb
+++ b/app/services/builtin_callout_cards.rb
@@ -221,8 +221,17 @@ class BuiltinCalloutCards
              subtitle: "Unlocks after the training",
              href: registration_certificate_path(registration.slug),
              target: nil, trailing_icon: "fa-solid fa-arrow-right",
-             badge: "Available after the event",
+             badge: certificate_pending_badge,
              badge_classes: "bg-gray-100 text-gray-600 border border-gray-300")
+  end
+
+  # A completion deadline is the more actionable thing to badge — it tells the
+  # registrant what they owe, not just when the certificate turns up. Only the
+  # badge survives #card_for, which overwrites title and subtitle from the row.
+  def certificate_pending_badge
+    return "Available after the event" if event.completion_deadline.blank?
+
+    "Complete by #{ce_deadline_text(event.completion_deadline)}"
   end
 
   # Shown only when the registrant requested a scholarship. Its page surfaces the

--- a/app/services/notification_services/create_notification.rb
+++ b/app/services/notification_services/create_notification.rb
@@ -8,6 +8,7 @@ module NotificationServices
       notification_type:,
       custom_message: nil,
       custom_subject: nil,
+      hide_event_card: false,
       sender: nil,
       bulk: false,
       deliver: true,
@@ -22,6 +23,7 @@ module NotificationServices
         recipient_email: recipient_email,
         custom_message: custom_message,
         custom_subject: custom_subject,
+        hide_event_card: hide_event_card,
         sender: sender,
         bulk: bulk
       )

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -18,7 +18,18 @@
           style: "margin: 8px 0; font-size: 14px; line-height: 1.5;#{' display: none;' if @preview && @custom_message.blank?}" %>
   <% end %>
 
-  <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+  <%#
+    The grey event-details card. In preview the wrapper always renders (hidden
+    when the admin ticked "hide") so the reminder-preview controller can toggle it
+    live; a real send just omits it when hidden.
+  %>
+  <% if @preview %>
+    <div id="reminder-event-card" data-reminder-preview-target="eventCard" style="<%= "display: none;" if @hide_event_card %>">
+      <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+    </div>
+  <% elsif !@hide_event_card %>
+    <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+  <% end %>
 
   <%= render "ce_deadlines", event: @event %>
 </div>

--- a/app/views/event_mailer/event_registration_reminder.text.erb
+++ b/app/views/event_mailer/event_registration_reminder.text.erb
@@ -2,6 +2,7 @@ Event reminder Hello<%= @person.full_name %>,
 <% if @custom_message.present? %>
   <%= strip_tags(@custom_message).strip %>
 <% end %>
+<% unless @hide_event_card %>
 <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
   <%= @event.pre_title %>
 <% end %><%= @event.title %>
@@ -25,6 +26,7 @@ Event reminder Hello<%= @person.full_name %>,
 
 <% if @event.labelled_cost.present? %>
   <%= @event.labelled_cost %>
+<% end %>
 <% end %>
 <%= render "ce_deadlines", event: @event %>
 <% if @event_registration.slug.present? %>

--- a/app/views/event_mailer/event_registration_reminder_fyi.html.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.html.erb
@@ -27,7 +27,9 @@
     </div>
   <% end %>
 
-  <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+  <% unless @hide_event_card %>
+    <%= render "event_details_card", event: @event, time_zone: @time_zone %>
+  <% end %>
 
   <p style="font-size: 12px; color: #6b7280; margin: 8px 0 0;">
     Each registrant also received a personalized "View ticket" link.

--- a/app/views/event_mailer/event_registration_reminder_fyi.text.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.text.erb
@@ -9,7 +9,7 @@ Reminder content sent to each registrant:
 
 <% if @custom_message.present? %><%= strip_tags(@custom_message).strip %>
 
-<% end %><%= @event.title %>
+<% end %><% unless @hide_event_card %><%= @event.title %>
 <% Time.use_zone(@time_zone) do %><% if event_dates_detail_label(@event.object).present? %><%= event_dates_detail_label(@event.object) %>
 <% end %><% if event_times_label(@event.object).present? %><%= event_times_label(@event.object) %>
 <% end %><% end %><% if @event.labelled_cost.present? %>
@@ -18,6 +18,6 @@ Reminder content sent to each registrant:
 Location: <%= event_location_label(@event.object) %>
 <% end %><% if event_platform_label(@event.object).present? %>
 <%= event_platform_label(@event.object) %>
-<% end %>
+<% end %><% end %>
 
 Each registrant also received a personalized "View ticket" link.

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -169,6 +169,13 @@
                       class: "w-28 shrink-0 rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
               </div>
             </div>
+
+            <div>
+              <%= f.label :completion_deadline, "Complete training by", class: "block font-medium mb-1" %>
+              <%= f.text_field :completion_deadline, type: "date",
+                    class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+              <p class="text-xs text-gray-500 mt-1">The date registrants must finish the training by. Leave blank if there's no deadline.</p>
+            </div>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/views/events/callouts/certificate.html.erb
+++ b/app/views/events/callouts/certificate.html.erb
@@ -140,6 +140,14 @@
           </li>
         <% end %>
       </ul>
+      <%# An obligation on the registrant rather than an unlock condition, so it
+          sits below the checklist — a tick beside it would read as "already done". %>
+      <% if @event.completion_deadline %>
+        <p class="pt-2 border-t border-gray-200 text-gray-700">
+          <i class="fa-solid fa-hourglass-half text-gray-400"></i>
+          Complete this training by <strong><%= @event.decorate.completion_deadline_display %></strong>.
+        </p>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,7 +3,7 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : nil)), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
@@ -58,6 +58,14 @@
     <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
       <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Subject</p>
       <p class="text-sm font-medium text-gray-900"><%= @reminder_subject %></p>
+      <%# Name the omission explicitly — the preview below shows an absence, which
+          is easy to miss when you're scanning for what's there. %>
+      <% if @hide_event_card && !@invite_mode %>
+        <p class="text-xs text-gray-500 mt-1.5">
+          <i class="fa-solid fa-eye-slash text-gray-400"></i>
+          Event details box hidden — the date, time, cost, and location won't be in this email.
+        </p>
+      <% end %>
     </div>
     <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
       <%= raw @reminder_preview_html %>
@@ -77,7 +85,7 @@
       <%= hidden_field_tag :hide_event_card, (@hide_event_card ? "1" : "0") %>
     <% end %>
     <div class="flex justify-center gap-3">
-      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : nil)), class: "btn btn-secondary-outline" %>
+      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "btn btn-secondary-outline" %>
       <%= f.submit(@invite_mode ? "Send invites" : "Send reminder", class: "btn btn-primary") %>
     </div>
   <% end %>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,7 +3,7 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : nil)), class: "text-sm text-gray-500 hover:text-gray-700" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
@@ -71,12 +71,13 @@
     <% if @invite_mode %>
       <%= hidden_field_tag :mode, "invite" %>
     <% else %>
-      <%# Carry the composed subject/message through to the send untouched. %>
+      <%# Carry the composed subject/message and the hide-card choice through to the send untouched. %>
       <%= hidden_field_tag :custom_subject, @custom_subject %>
       <%= hidden_field_tag :custom_message, @custom_message %>
+      <%= hidden_field_tag :hide_event_card, (@hide_event_card ? "1" : "0") %>
     <% end %>
     <div class="flex justify-center gap-3">
-      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message), class: "btn btn-secondary-outline" %>
+      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : nil)), class: "btn btn-secondary-outline" %>
       <%= f.submit(@invite_mode ? "Send invites" : "Send reminder", class: "btn btn-primary") %>
     </div>
   <% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -102,7 +102,7 @@
             <div>
               <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
               <p class="text-gray-600 mb-2">
-                The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the "View ticket" button is always included.
+                The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like.
               </p>
               <%= text_area_tag :custom_message, @custom_message,
                     rows: 4,
@@ -122,6 +122,9 @@
               <p class="text-xs text-gray-400 mt-1.5 ml-6">
                 Leaves out the grey box with the event's date, time, cost, and location — send just your message and the "View ticket" button.
               </p>
+              <%# The toggle's only feedback is the preview below, which a screen
+                  reader never sees change. Announce it instead. %>
+              <p class="sr-only" role="status" aria-live="polite" data-reminder-preview-target="cardStatus"></p>
             </div>
           </div>
         </div>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -112,6 +112,17 @@
                 Accepts basic HTML — bold, italics, links, lists, and line breaks.
               </p>
             </div>
+            <div>
+              <label class="flex items-center gap-2 text-sm font-semibold text-gray-700">
+                <%= check_box_tag :hide_event_card, "1", @hide_event_card,
+                      class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500",
+                      data: { reminder_preview_target: "eventCardToggle", action: "reminder-preview#toggleEventCard" } %>
+                Hide the event details box
+              </label>
+              <p class="text-xs text-gray-400 mt-1.5 ml-6">
+                Leaves out the grey box with the event's date, time, cost, and location — send just your message and the "View ticket" button.
+              </p>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -102,7 +102,7 @@
             <div>
               <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
               <p class="text-gray-600 mb-2">
-                The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the event details and the "View ticket" button are always included.
+                The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like — the "View ticket" button is always included.
               </p>
               <%= text_area_tag :custom_message, @custom_message,
                     rows: 4,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -37,13 +37,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "343336d81aa87ab12862c5f9ca2b0f9ac4155488c053c1ce9c7ed27c456e3dba",
+      "fingerprint": "c0a7785bbcfe39ba0b0ec792dacfbf3b12596ef585e9eba974b6ed85ab106d30",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
       "file": "app/views/events/confirm_reminder.html.erb",
-      "line": 58,
+      "line": 63,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "EventMailer.event_registration_reminder(selected_reminder_registrations.first, :custom_message => params[:custom_message].to_s, :custom_subject => params[:custom_subject].to_s).html_part.body.decoded",
+      "code": "EventMailer.event_registration_reminder(selected_reminder_registrations.first, :custom_message => params[:custom_message].to_s, :custom_subject => params[:custom_subject].to_s, :hide_event_card => hide_event_card_param).html_part.body.decoded",
       "render_path": [
         {
           "type": "controller",

--- a/db/migrate/20260814201638_add_hide_event_card_to_notifications.rb
+++ b/db/migrate/20260814201638_add_hide_event_card_to_notifications.rb
@@ -1,0 +1,14 @@
+class AddHideEventCardToNotifications < ActiveRecord::Migration[8.0]
+  def up
+    return if column_exists?(:notifications, :hide_event_card)
+
+    # When true, the bulk reminder email (event_registration_reminder) omits the
+    # grey event-details card. Set per-send from the compose page; defaults false
+    # so existing/resent reminders keep showing the card.
+    add_column :notifications, :hide_event_card, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :notifications, :hide_event_card, if_exists: true
+  end
+end

--- a/db/migrate/20260814201638_add_hide_event_card_to_notifications.rb
+++ b/db/migrate/20260814201638_add_hide_event_card_to_notifications.rb
@@ -4,7 +4,7 @@ class AddHideEventCardToNotifications < ActiveRecord::Migration[8.0]
 
     # When true, the bulk reminder email (event_registration_reminder) omits the
     # grey event-details card. Set per-send from the compose page; defaults false
-    # so existing/resent reminders keep showing the card.
+    # so existing reminders keep showing the card. Resends carry the stored value.
     add_column :notifications, :hide_event_card, :boolean, default: false, null: false
   end
 

--- a/db/migrate/20260815114533_add_completion_deadline_to_events.rb
+++ b/db/migrate/20260815114533_add_completion_deadline_to_events.rb
@@ -1,0 +1,14 @@
+class AddCompletionDeadlineToEvents < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:events, :completion_deadline)
+
+    # The date a registrant must finish the training by. Date-only (like
+    # ce_hours_request_deadline) — "complete by August 30" needs no time of day.
+    # Not on-demand-specific: a live event with post-work can carry one too.
+    add_column :events, :completion_deadline, :date
+  end
+
+  def down
+    remove_column :events, :completion_deadline, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_201638) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -546,6 +546,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_201638) do
     t.decimal "ce_hours_offered", precision: 5, scale: 2
     t.date "ce_hours_request_deadline"
     t.datetime "ce_payment_due_deadline"
+    t.date "completion_deadline"
     t.integer "cost_cents"
     t.datetime "created_at", null: false
     t.integer "created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_022129) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_201638) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -798,6 +798,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_022129) do
     t.datetime "error_at"
     t.string "error_class"
     t.text "error_message"
+    t.boolean "hide_event_card", default: false, null: false
     t.string "kind", null: false
     t.integer "noticeable_id"
     t.string "noticeable_type"

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -485,6 +485,19 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#completion_deadline_display" do
+    # Date-only, so no time or zone — unlike the two payment deadlines above.
+    it "renders the deadline as a plain date, e.g. 'August 30, 2026'" do
+      event = build(:event, completion_deadline: Date.new(2026, 8, 30)).decorate
+      expect(event.completion_deadline_display).to eq("August 30, 2026")
+    end
+
+    it "is nil when no deadline is set" do
+      event = build(:event, completion_deadline: nil).decorate
+      expect(event.completion_deadline_display).to be_nil
+    end
+  end
+
   describe "#times" do
     it "shows a multi-day event as a date range with a single daily time range" do
       event = build(:event, start_date: Time.zone.local(2026, 4, 21, 9), end_date: Time.zone.local(2026, 4, 23, 16, 30)).decorate

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -399,6 +399,58 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.default_reminder_message(nil))
         .to eq("This is a reminder that you're registered for the following A Window Between Worlds event.")
     end
+
+    # Self-paced training has no session date, and admins hide the details box for
+    # it — so "the following event" would point at nothing. The copy carries the
+    # title itself instead, and drops the day count.
+    it "names an on-demand event inline instead of pointing at the details box" do
+      event = build(:event, title: "Trauma-Informed Basics", on_demand: true)
+      expect(helper.default_reminder_message(60, event: event))
+        .to eq("This is a reminder that you're registered for the A Window Between Worlds training <strong>Trauma-Informed Basics</strong>.")
+    end
+
+    # These titles already carry the format ("On-Demand Training 2026"), so the
+    # copy says "training" and lets the title speak for itself.
+    it "does not repeat 'on-demand' ahead of a title that already says it" do
+      event = build(:event, title: "On-Demand Training 2026", on_demand: true)
+      expect(helper.default_reminder_message(nil, event: event))
+        .to eq("This is a reminder that you're registered for the A Window Between Worlds training <strong>On-Demand Training 2026</strong>.")
+    end
+
+    it "escapes HTML in an on-demand event title" do
+      event = build(:event, title: "Art & <Healing>", on_demand: true)
+      expect(helper.default_reminder_message(nil, event: event)).to include("Art &amp; &lt;Healing&gt;")
+    end
+
+    it "keeps the live-event copy when the event is not on-demand" do
+      event = build(:event, title: "Healing Workshop", on_demand: false)
+      expect(helper.default_reminder_message(60, event: event))
+        .to eq("This is a reminder that you're registered for the following A Window Between Worlds event in <strong>60 days</strong>.")
+    end
+
+    # Every event with a deadline carries it in the editable copy, so admins can
+    # reword it. There is no standalone block in the email template.
+    it "adds the completion deadline to an on-demand event's copy" do
+      event = build(:event, title: "On-Demand Training 2026", on_demand: true, completion_deadline: Date.new(2026, 8, 30))
+      expect(helper.default_reminder_message(nil, event: event))
+        .to eq("This is a reminder that you're registered for the A Window Between Worlds training <strong>On-Demand Training 2026</strong>. Please complete it by <strong>August 30, 2026</strong>.")
+    end
+
+    it "leaves the deadline sentence out when an on-demand event has no deadline" do
+      event = build(:event, title: "On-Demand Training 2026", on_demand: true, completion_deadline: nil)
+      expect(helper.default_reminder_message(nil, event: event)).not_to include("Please complete it by")
+    end
+
+    it "adds the completion deadline to a live event's copy too" do
+      event = build(:event, title: "Healing Workshop", on_demand: false, completion_deadline: Date.new(2026, 8, 30))
+      expect(helper.default_reminder_message(60, event: event))
+        .to eq("This is a reminder that you're registered for the following A Window Between Worlds event in <strong>60 days</strong>. Please complete it by <strong>August 30, 2026</strong>.")
+    end
+
+    it "leaves the deadline sentence out when a live event has no deadline" do
+      event = build(:event, title: "Healing Workshop", on_demand: false, completion_deadline: nil)
+      expect(helper.default_reminder_message(60, event: event)).not_to include("Please complete it by")
+    end
   end
 
   describe "#default_reminder_subject" do
@@ -410,6 +462,14 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it "omits the date suffix when the event has no start date" do
       event = build(:event, title: "Healing Workshop", start_date: nil)
+      expect(helper.default_reminder_subject(event))
+        .to eq("AWBW Portal: Reminder: Healing Workshop")
+    end
+
+    # A start date on self-paced training is an enrollment boundary, not a session
+    # time — putting it in the subject reads as "be there on August 7".
+    it "omits the date suffix for an on-demand event that has a start date" do
+      event = build(:event, title: "Healing Workshop", start_date: Time.zone.local(2026, 8, 7, 18, 0), on_demand: true)
       expect(helper.default_reminder_subject(event))
         .to eq("AWBW Portal: Reminder: Healing Workshop")
     end

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -267,6 +267,35 @@ RSpec.describe EventMailer, type: :mailer do
         expect(mail.html_part.body.encoded).to include("reminder-custom-message")
       end
     end
+
+    context "with the event card hidden" do
+      let(:event) { create(:event, title: "Confidential Retreat") }
+      let(:event_registration) { create(:event_registration, event: event) }
+      let(:mail) { described_class.event_registration_reminder(event_registration, hide_event_card: true) }
+
+      it "renders without raising" do
+        expect { mail.deliver_now }.not_to raise_error
+      end
+
+      it "omits the grey event-details card from the HTML body" do
+        # #166534 is the card's green event-title colour — present only inside the card.
+        expect(mail.html_part.body.encoded).not_to include("#166534")
+        expect(mail.html_part.body.encoded).not_to include("Confidential Retreat")
+      end
+
+      it "omits the event details from the plain-text body" do
+        expect(mail.text_part.body.encoded).not_to include("Confidential Retreat")
+      end
+
+      context "in preview mode" do
+        let(:mail) { described_class.event_registration_reminder(event_registration, hide_event_card: true, preview: true) }
+
+        it "still renders the card markup (hidden), so the live toggle can reveal it" do
+          expect(mail.html_part.body.encoded).to include("reminder-event-card")
+          expect(mail.html_part.body.encoded).to include("#166534")
+        end
+      end
+    end
   end
 
   describe "#event_registration_reminder_fyi" do
@@ -301,6 +330,20 @@ RSpec.describe EventMailer, type: :mailer do
     it "uses the singular noun for a single recipient" do
       mail = described_class.event_registration_reminder_fyi(event, [ "Alex Rivera <alex@example.org>" ])
       expect(mail.subject).to include("1 registrant ")
+    end
+
+    context "with the event card hidden" do
+      let(:mail) { described_class.event_registration_reminder_fyi(event, recipient_labels, hide_event_card: true) }
+
+      it "omits the event-details card, matching what registrants received" do
+        # #166534 is the card's green event-title colour — present only inside the card.
+        expect(mail.html_part.body.encoded).not_to include("#166534")
+      end
+
+      it "still names the event and lists recipients" do
+        expect(mail.html_part.body.encoded).to include("Art Workshop")
+        expect(mail.html_part.body.encoded).to include("Alex Rivera")
+      end
     end
   end
 end

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -235,6 +235,43 @@ RSpec.describe EventMailer, type: :mailer do
       end
     end
 
+    # The deadline reaches registrants through the composed message (see
+    # ApplicationHelper#default_reminder_message), not a template block — so it
+    # survives the event-details card being hidden, which is the on-demand case.
+    context "when the event has a completion deadline" do
+      let(:event) { create(:event, completion_deadline: Date.new(2026, 8, 30)) }
+      let(:event_registration) { create(:event_registration, event: event) }
+      let(:mail) do
+        described_class.event_registration_reminder(
+          event_registration,
+          custom_message: "Please complete it by <strong>August 30, 2026</strong>.",
+          hide_event_card: true
+        )
+      end
+
+      it "carries the deadline in the HTML body with the card hidden" do
+        expect(mail.html_part.body.encoded).to include("August 30, 2026")
+      end
+
+      it "carries the deadline in the plain-text body with the card hidden" do
+        expect(mail.text_part.body.encoded).to include("August 30, 2026")
+      end
+
+      it "states it exactly once" do
+        expect(mail.html_part.body.encoded.scan("August 30, 2026").size).to eq(1)
+      end
+    end
+
+    context "for an on-demand event" do
+      let(:event) { create(:event, title: "Self-Paced Training", start_date: Time.zone.local(2026, 8, 7, 18, 0), on_demand: true) }
+      let(:event_registration) { create(:event_registration, event: event) }
+
+      # Matches the subject the compose page pre-fills, so preview and send agree.
+      it "omits the date from the default subject" do
+        expect(mail.subject).to eq("AWBW Portal: Reminder: Self-Paced Training")
+      end
+    end
+
     context "with a custom message" do
       let(:mail) { described_class.event_registration_reminder(event_registration, custom_message: custom_message) }
       let(:custom_message) { "Please bring <strong>your art supplies</strong>." }

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -327,6 +327,10 @@ RSpec.describe EventMailer, type: :mailer do
       expect(mail.html_part.body.encoded).to include("Art Workshop")
     end
 
+    it "includes the event details in the plain-text body" do
+      expect(mail.text_part.body.encoded).to include(event.decorate.labelled_cost)
+    end
+
     it "uses the singular noun for a single recipient" do
       mail = described_class.event_registration_reminder_fyi(event, [ "Alex Rivera <alex@example.org>" ])
       expect(mail.subject).to include("1 registrant ")
@@ -343,6 +347,17 @@ RSpec.describe EventMailer, type: :mailer do
       it "still names the event and lists recipients" do
         expect(mail.html_part.body.encoded).to include("Art Workshop")
         expect(mail.html_part.body.encoded).to include("Alex Rivera")
+      end
+
+      it "omits the event details from the plain-text body" do
+        expect(mail.text_part.body.encoded).not_to include(event.decorate.labelled_cost)
+      end
+
+      # The event title sits inside the hidden section too, so this guards the
+      # summary line above it from being swallowed along with the card.
+      it "still names the event and lists recipients in the plain-text body" do
+        expect(mail.text_part.body.encoded).to include("Art Workshop")
+        expect(mail.text_part.body.encoded).to include("Alex Rivera <alex@example.org>")
       end
     end
   end

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
     it "redirects back to the picker when nothing is selected" do
       post send_reminder_event_path(event), params: { mode: "invite", registration_ids: [] }
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, mode: "invite", custom_message: "", custom_subject: ""))
+      expect(response).to redirect_to(preview_reminder_event_path(event, mode: "invite", custom_message: "", custom_subject: "", hide_event_card: "0"))
       expect(flash[:alert]).to be_present
     end
   end

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe "Events::BulkReminders", type: :request do
       expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: ""))
       expect(flash[:alert]).to be_present
     end
+
+    # #166534 is the grey card's green event-title colour — present only inside the box.
+    it "hides the event-details box in the preview when the box is checked" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ], hide_event_card: "1" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("#166534")
+    end
+
+    it "shows the event-details box in the preview by default" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+
+      expect(response.body).to include("#166534")
+    end
   end
 
   describe "editing a registration from the picker" do
@@ -130,6 +144,65 @@ RSpec.describe "Events::BulkReminders", type: :request do
       reminders = Notification.where(kind: "event_registration_reminder")
       expect(reminders.count).to eq(2)
       expect(reminders).to all(be_bulk)
+    end
+
+    it "records the hide-event-card choice on each reminder when checked" do
+      post send_reminder_event_path(event), params: { registration_ids: [ jane.id, sam.id ], hide_event_card: "1" }
+
+      reminders = Notification.where(kind: "event_registration_reminder")
+      expect(reminders.count).to eq(2)
+      expect(reminders.map(&:hide_event_card)).to all(be(true))
+    end
+
+    it "defaults hide_event_card to false when the box is left unchecked" do
+      post send_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+
+      expect(Notification.where(kind: "event_registration_reminder").map(&:hide_event_card)).to all(be(false))
+    end
+
+    # End-to-end: checking the box on the page must carry through the async delivery
+    # job into the email that actually lands in the registrant's inbox.
+    it "hides the box in the delivered email when the box is checked" do
+      perform_enqueued_jobs do
+        post send_reminder_event_path(event), params: { registration_ids: [ jane.id ], hide_event_card: "1" }
+      end
+
+      reminder = ActionMailer::Base.deliveries.find { |m| m.to == [ jane.registrant.preferred_email ] }
+      expect(reminder).to be_present
+      # #166534 is the grey card's green event-title colour — gone once the box is hidden.
+      expect(reminder.html_part.body.encoded).not_to include("#166534")
+    end
+
+    it "keeps the box in the delivered email when the box is left unchecked" do
+      perform_enqueued_jobs do
+        post send_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+      end
+
+      reminder = ActionMailer::Base.deliveries.find { |m| m.to == [ jane.registrant.preferred_email ] }
+      expect(reminder.html_part.body.encoded).to include("#166534")
+    end
+  end
+
+  describe "the compose page" do
+    it "offers a checkbox to hide the event details box" do
+      get preview_reminder_event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("hide_event_card")
+      expect(response.body).to include("Hide the event details")
+    end
+
+    it "reflects a carried-over hidden choice: checkbox ticked and the card pre-hidden in the live preview" do
+      get preview_reminder_event_path(event, hide_event_card: "1")
+
+      expect(response).to have_http_status(:ok)
+      html = Nokogiri::HTML(response.body)
+      expect(html.at_css("#hide_event_card")["checked"]).to be_present
+      # In preview the card stays in the DOM but rendered hidden, so the Stimulus
+      # toggle can reveal it live without a round-trip.
+      card = html.at_css("#reminder-event-card")
+      expect(card).to be_present
+      expect(card["style"]).to include("display: none")
     end
   end
 end

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -73,10 +73,12 @@ RSpec.describe "Events::BulkReminders", type: :request do
       expect(response.body).to include("value=\"#{jane.id}\"")
     end
 
+    # hide_event_card rides along explicitly rather than being omitted when false,
+    # so the bounce-back can't be re-defaulted by the event's on-demand flag.
     it "redirects back to the picker when nothing is selected" do
       post confirm_reminder_event_path(event), params: { registration_ids: [] }
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: ""))
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0"))
       expect(flash[:alert]).to be_present
     end
 
@@ -203,6 +205,92 @@ RSpec.describe "Events::BulkReminders", type: :request do
       card = html.at_css("#reminder-event-card")
       expect(card).to be_present
       expect(card["style"]).to include("display: none")
+    end
+
+    it "says on the confirm page when the details box is hidden" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ], hide_event_card: "1" }
+
+      expect(response.body).to include("Event details box hidden")
+    end
+
+    it "says nothing about the box on the confirm page when it is shown" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+
+      expect(response.body).not_to include("Event details box hidden")
+    end
+
+    # Gated on the event carrying a deadline, not on it being on-demand.
+    it "puts the completion deadline in the pre-filled message for a live event" do
+      event.update!(completion_deadline: Date.new(2026, 8, 30))
+
+      get preview_reminder_event_path(event)
+
+      message = Nokogiri::HTML(response.body).at_css("#custom_message").text
+      expect(message).to include("Please complete it by <strong>August 30, 2026</strong>.")
+    end
+
+    it "leaves the deadline out of the pre-filled message when the event has none" do
+      get preview_reminder_event_path(event)
+
+      message = Nokogiri::HTML(response.body).at_css("#custom_message").text
+      expect(message).not_to include("Please complete it by")
+    end
+  end
+
+  # Self-paced training has no session date, time, or "see you there" — the grey
+  # box is wrong for it on every send, so the page defaults to hiding it.
+  describe "the compose page for an on-demand event" do
+    let(:event) { create(:event, title: "Self-Paced Training", on_demand: true, cost_cents: 10_000) }
+
+    it "pre-checks the hide box and pre-hides the card in the live preview" do
+      get preview_reminder_event_path(event)
+
+      html = Nokogiri::HTML(response.body)
+      expect(html.at_css("#hide_event_card")["checked"]).to be_present
+      expect(html.at_css("#reminder-event-card")["style"]).to include("display: none")
+    end
+
+    it "respects an explicit choice to show the box" do
+      get preview_reminder_event_path(event, hide_event_card: "0")
+
+      html = Nokogiri::HTML(response.body)
+      expect(html.at_css("#hide_event_card")["checked"]).to be_nil
+      expect(html.at_css("#reminder-event-card")["style"].to_s).not_to include("display: none")
+    end
+
+    # Without the box, nothing else in the body names the event, so the pre-filled
+    # message has to carry the title.
+    it "names the event in the pre-filled message" do
+      get preview_reminder_event_path(event)
+
+      message = Nokogiri::HTML(response.body).at_css("#custom_message").text
+      expect(message).to include("training <strong>Self-Paced Training</strong>")
+    end
+
+    it "puts the completion deadline in the pre-filled message when the event has one" do
+      event.update!(completion_deadline: Date.new(2026, 8, 30))
+
+      get preview_reminder_event_path(event)
+
+      message = Nokogiri::HTML(response.body).at_css("#custom_message").text
+      expect(message).to include("Please complete it by <strong>August 30, 2026</strong>.")
+    end
+
+    it "leaves the date out of the pre-filled subject" do
+      get preview_reminder_event_path(event)
+
+      subject_value = Nokogiri::HTML(response.body).at_css("#custom_subject")["value"]
+      expect(subject_value).to eq("AWBW Portal: Reminder: Self-Paced Training")
+    end
+
+    # The bounce-back carries the choice as an explicit 0, otherwise the on-demand
+    # default would silently re-check the box the admin just cleared.
+    it "keeps the box unchecked through an empty-recipient bounce-back" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [], hide_event_card: "0" }
+
+      expect(response.headers["Location"]).to include("hide_event_card=0")
+      follow_redirect!
+      expect(Nokogiri::HTML(response.body).at_css("#hide_event_card")["checked"]).to be_nil
     end
   end
 end

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -619,6 +619,26 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).not_to include("This certifies that")
     end
 
+    # An obligation on the registrant, not an unlock condition — so it sits below
+    # the checklist rather than in it, where a tick would imply it was already met.
+    it "states the completion deadline on the pending page when the event has one" do
+      registration.update!(status: "registered")
+      event.update!(completion_deadline: Date.new(2026, 8, 30))
+
+      get registration_certificate_path(registration.slug)
+
+      expect(response.body).to include("Complete this training by")
+      expect(response.body).to include("August 30, 2026")
+    end
+
+    it "says nothing about a deadline on the pending page when the event has none" do
+      registration.update!(status: "registered")
+
+      get registration_certificate_path(registration.slug)
+
+      expect(response.body).not_to include("Complete this training by")
+    end
+
     it "adds the CE accreditation clause once CE credit is registered and paid" do
       event.update!(ce_hours_offered: 6)
       license = create(:professional_license, person: registration.registrant, number: "LIC-1")

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1085,6 +1085,11 @@ RSpec.describe "Events", type: :request do
         expect(event.reload.facilitator_training).to be(true)
       end
 
+      it "persists the training completion deadline" do
+        patch event_path(event), params: { event: { completion_deadline: "2026-08-30" } }
+        expect(event.reload.completion_deadline).to eq(Date.new(2026, 8, 30))
+      end
+
       it "persists the registration detail hints" do
         patch event_path(event), params: { event: {
           hint_dates: "must attend both days",
@@ -3748,7 +3753,7 @@ RSpec.describe "Events", type: :request do
         post send_reminder_event_path(event), params: { registration_ids: [] }
       }.not_to change(Notification, :count)
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: ""))
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0"))
     end
 
     it "logs an Ahoy event with the recipient count on a successful send" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -403,6 +403,47 @@ RSpec.describe "Notifications", type: :request do
         expect(Notification.last.sender).to eq(admin)
       end
 
+      # A resend is meant to put the same email back in the inbox, so everything
+      # that shaped the original body and subject has to travel with it.
+      context "with a composed bulk reminder" do
+        let(:reminder) do
+          create(:notification, :bulk,
+                 kind: "event_registration_reminder",
+                 noticeable: create(:event_registration),
+                 recipient_role: :person,
+                 custom_message: "See you tomorrow!",
+                 custom_subject: "Reminder: see you tomorrow",
+                 hide_event_card: true)
+        end
+
+        it "carries the composed message, subject, and hide-card choice onto the resent copy" do
+          post resend_notification_path(reminder)
+
+          resent = Notification.last
+          expect(resent.custom_message).to eq("See you tomorrow!")
+          expect(resent.custom_subject).to eq("Reminder: see you tomorrow")
+          expect(resent.hide_event_card).to be(true)
+        end
+
+        it "delivers the same email the registrant originally received" do
+          perform_enqueued_jobs { post resend_notification_path(reminder) }
+
+          mail = ActionMailer::Base.deliveries.last
+          expect(mail.subject).to eq("Reminder: see you tomorrow")
+          expect(mail.html_part.body.encoded).to include("See you tomorrow!")
+          # #166534 is the event-details card's green title colour — hidden here.
+          expect(mail.html_part.body.encoded).not_to include("#166534")
+        end
+
+        # The copy is a fresh, individually-triggered send, so it isn't part of
+        # the original batch and shouldn't wear the "Bulk" pill.
+        it "does not mark the resent copy as bulk" do
+          post resend_notification_path(reminder)
+
+          expect(Notification.last).not_to be_bulk
+        end
+      end
+
       it "tracks resend chain correctly when resending a resent notification" do
         # Create first resend
         first_resend = nil

--- a/spec/services/builtin_callout_cards_spec.rb
+++ b/spec/services/builtin_callout_cards_spec.rb
@@ -291,6 +291,17 @@ RSpec.describe BuiltinCalloutCards do
       expect(card.badge).to eq("Available after the event")
     end
 
+    # The deadline goes in the badge, not the subtitle: card_for overwrites title
+    # and subtitle with the admin row's values, so a subtitle would be discarded.
+    it "badges the pending certificate with the completion deadline when the event has one" do
+      event.update!(completion_deadline: Date.new(2026, 8, 30))
+      callout = create(:registration_ticket_callout, event:, builtin_key: "certificate",
+        title: "Certificate of completion", subtitle: "View and download your certificate")
+
+      card = described_class.new(registration).card_for(callout)
+      expect(card.badge).to eq("Complete by Aug 30")
+    end
+
     it "returns nil for a behavioral card that truly can't apply (no videoconference URL)" do
       callout = create(:registration_ticket_callout, event:, builtin_key: "videoconference",
         title: "Videoconference")


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new events column plus changes to the default subject/body of every bulk reminder

### What is the goal of this PR and why is this important?
Admins asked to drop the grey event-details card from a bulk email for an **On-Demand (self-paced) training** — its date, time and cost describe nothing for a course you take whenever you like. This adds the checkbox to do that, then makes the whole flow on-demand aware so nobody has to remember to tick it, and adds the "finish the training by" date they were retyping into every message.

### How did you approach the change?
- **Per-send checkbox** — threads compose → confirm → persisted `Notification` (`hide_event_card`) → delivery job → sent email and admin FYI copy, so the delivered email matches the preview.
- **On-demand defaults** — `on_demand` events pre-tick the box, name the training inline in the stock copy (there's no box for "the following event" to point at), and drop the start date from the default subject, since it bounds enrollment rather than naming a session. The empty-recipient bounce-back now passes an explicit `0` so the default can't re-tick a box the admin just cleared.
- **`events.completion_deadline`** (new, nullable `date`) — surfaces through the editable stock copy, and badges the pending certificate card. It goes in the badge because `BuiltinCalloutCards#card_for` overwrites title and subtitle from the admin's row, so a subtitle would be silently discarded.
- **Resend fidelity** — resending a bulk reminder carries the original message, subject and hide-card choice, so it reproduces the same email instead of a default-shaped one. `bulk` deliberately does not carry over: a resend is an individual action, not part of the original batch.
- The default reminder subject was duplicated in the compose helper and the mailer, with **different time zones**; both now call one `EventDecorator` method so preview and delivery can't disagree.

### UI Testing Checklist
- [ ] Compose a bulk reminder, tick "Hide the event details box" — the live preview drops the grey box; the confirm page says it's hidden
- [ ] Send it — the received email has no event-details box (HTML **and** plain text)
- [ ] Leave it unticked — the box appears as before
- [ ] Open the compose page for an On-Demand event — box pre-hidden, message names the training, subject has no date
- [ ] Untick it there, submit with no recipients selected — the bounce-back keeps it unticked
- [ ] Set "Complete training by" on an event — the date appears in the pre-filled message and on the pending certificate card badge
- [ ] Resend a hidden-box reminder — same message, subject, and hidden box

### Anything else to add?
The completion deadline lives in the **editable** stock copy rather than a template block, so it's frozen into `custom_message` at send time: clearing the message drops it, and a resend replays the wording from when it was composed. That's the tradeoff of making it admin-editable; a `custom_message.blank?` fallback block could cover message-less sends if we want one later.

Hiding the box also omits the event details from the plain-text part, and from the admin FYI copy, so all three stay consistent with what registrants received.

**Found while in here, not fixed:** the `autoshow_date` / `autoshow_time` / `autoshow_cost` / `autoshow_location` flags are honoured on the public event page but ignored by every email — untick "Cost" on an event and it still ships in reminders. Worth its own ticket.
