### PR TITLE
Show event month/year after event name in noticeable labels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -384,7 +384,7 @@ module ApplicationHelper
   def noticeable_label(record)
     label = case record
     when EventRegistration
-      [ record.registrant&.name, record.event&.title ].compact_blank.join(" · ")
+      [ record.registrant&.name, event_title_with_month_year(record.event) ].compact_blank.join(" · ")
     when FormSubmission
       [ record.person&.name, record.form&.name ].compact_blank.join(" · ")
     else
@@ -392,6 +392,15 @@ module ApplicationHelper
     end
 
     label.presence || "##{record.id}"
+  end
+
+  # Event title with its month and year appended (e.g. "AWBW Facilitator
+  # Training (August 2026)") so a registration reads as which occurrence it's for.
+  def event_title_with_month_year(event)
+    return if event.blank?
+    return event.title if event.start_date.blank?
+
+    "#{event.title} (#{event.start_date.strftime('%B %Y')})"
   end
 
   def search_page(params)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -501,12 +501,12 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#noticeable_label" do
-    it "describes a registration by registrant and event" do
+    it "describes a registration by registrant and event, with the event's month and year" do
       person = create(:person, first_name: "Jane", last_name: "Doe")
-      event = create(:event, title: "Summer Workshop")
+      event = create(:event, title: "Summer Workshop", start_date: Time.zone.local(2026, 8, 14))
       registration = create(:event_registration, registrant: person, event: event)
 
-      expect(helper.noticeable_label(registration)).to eq("#{person.name} · Summer Workshop")
+      expect(helper.noticeable_label(registration)).to eq("#{person.name} · Summer Workshop (August 2026)")
     end
 
     it "describes a form submission by submitter and form" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one contained helper change with a spec; low blast radius

### What is the goal of this PR and why is this important?
- Registration notifications show the same, often-reused event title, so it's hard to tell *which* occurrence a notification is about.

### How did you approach the change?
- `noticeable_label` now appends the event's month and year after the title (e.g. `Jane Doe · AWBW Facilitator Training (August 2026)`) via a small `event_title_with_month_year` helper, falling back to the plain title when no `start_date` is set. This covers the notifications index and show pages, which both route through that helper.

### Anything else to add?
- Uses the app-wide `%B %Y` ("August 2026") convention already used by `{{event_month_year}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)