### PR TITLE
Add planned-giving flag to grants

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -100,6 +100,12 @@ class GrantsController < ApplicationController
     scope = scope.where(funder_type: params[:funder_type]) if Grant::FUNDER_TYPES.include?(params[:funder_type])
     scope = scope.where(funder_id: params[:funder_id]) if params[:funder_id].present?
 
+    scope = case params[:planned_giving]
+    when "yes" then scope.where(planned_giving: true)
+    when "no" then scope.where(planned_giving: false)
+    else scope
+    end
+
     # Sector/category filters back the "View all grants" deep link from the
     # taggings browse page (see TaggingsHelper#tagged_index_path).
     scope = scope.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -155,6 +155,7 @@ class GrantsController < ApplicationController
     params.require(:grant).permit(
       :name, :description, :amount_dollars, :amount_cents, :funder_sgid,
       :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks,
+      :planned_giving,
       sector_ids: [], category_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ]

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -33,6 +33,16 @@ class GrantDecorator < ApplicationDecorator
     object.remaining_cents <= 0
   end
 
+  # Amber pill flagging a grant as a Legacy scholarship (funded through planned
+  # giving). Renders nothing for ordinary grants, so callers can inline it.
+  def legacy_scholarship_badge
+    return unless object.planned_giving?
+
+    h.tag.span("Legacy scholarship",
+               class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800",
+               title: "Funded through planned giving")
+  end
+
   # Whole-number percentage of the grant awarded in scholarships, clamped to
   # 0–100, for rendering the allocation progress bar on the index.
   def allocation_percentage

--- a/app/views/grants/_filters.html.erb
+++ b/app/views/grants/_filters.html.erb
@@ -32,6 +32,13 @@
                      include_blank: "All",
                      class: field_class %>
     </div>
+    <div class="w-full md:w-40">
+      <%= label_tag :planned_giving, "Legacy scholarship", class: label_class %>
+      <%= select_tag :planned_giving,
+                     options_for_select([ [ "Legacy scholarships", "yes" ], [ "Other grants", "no" ] ], params[:planned_giving]),
+                     include_blank: "All",
+                     class: field_class %>
+    </div>
     <div class="w-full md:w-32">
       <%= label_tag :tasks, "Tasks completed", class: label_class %>
       <%= select_tag :tasks,

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -41,8 +41,8 @@
       <label class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm cursor-pointer hover:bg-gray-50 transition">
         <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
         <span>
-          <span class="block text-sm font-medium text-gray-800">Planned giving (aka Legacy Scholarship)</span>
-          <span class="block text-xs text-gray-500">Funded by a collection of individuals, usually to honor a loved one.</span>
+          <span class="block text-sm font-medium text-gray-800">Legacy scholarship</span>
+          <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate gift, or Healing heARTs Legacy Society gift — often to honor a loved one.</span>
         </span>
       </label>
     </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -3,10 +3,21 @@
   <%= render "shared/errors", resource: @grant if @grant.errors.any? %>
 
   <div class="space-y-6">
-    <div>
-      <%= f.input :name,
-                  label: "Grant name",
-                  input_html: { class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <%= f.input :name,
+                    label: "Grant name",
+                    input_html: { class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+      </div>
+      <div>
+        <%= f.label :amount_dollars, "Funding amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <div class="relative">
+          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">$</span>
+          <%= f.number_field :amount_dollars, step: 0.01, value: @grant.amount_dollars,
+                             class: "pl-7 w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+        </div>
+        <p class="mt-1 text-xs text-gray-500">Total scholarship amounts awarded from this grant cannot exceed this.</p>
+      </div>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -27,15 +38,13 @@
                     label: "Funder",
                     hint: "The organization or person funding the grant." %>
       </div>
-      <div>
-        <%= f.label :amount_dollars, "Funding amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <div class="relative">
-          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">$</span>
-          <%= f.number_field :amount_dollars, step: 0.01, value: @grant.amount_dollars,
-                             class: "pl-7 w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
-        </div>
-        <p class="mt-1 text-xs text-gray-500">Total scholarship amounts awarded from this grant cannot exceed this.</p>
-      </div>
+      <label class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm cursor-pointer hover:bg-gray-50 transition">
+        <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
+        <span>
+          <span class="block text-sm font-medium text-gray-800">Planned giving (aka Legacy Scholarship)</span>
+          <span class="block text-xs text-gray-500">Funded by a collection of individuals, usually to honor a loved one.</span>
+        </span>
+      </label>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -4,7 +4,10 @@
     rather than their formatted text. %>
 <tr class="group hover:bg-green-50/60 transition-colors duration-150">
   <td class="px-4 py-3.5 align-middle" data-sort-value="<%= grant.object.name.to_s.downcase %>">
-    <%= link_to grant.name, grant_path(grant), class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } %>
+    <div class="flex flex-wrap items-center gap-2">
+      <%= link_to grant.name, grant_path(grant), class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } %>
+      <%= grant.legacy_scholarship_badge %>
+    </div>
   </td>
   <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.funder_name.to_s.downcase %>"><%= grant_funder_badge(grant) %></td>
   <td class="px-4 py-3.5 align-middle text-sm font-medium text-gray-900 text-right tabular-nums" data-sort-value="<%= grant.object.amount_cents.to_i %>"><%= grant.amount %></td>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -18,9 +18,7 @@
       <div>
         <div class="flex items-center gap-2 flex-wrap">
           <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
-          <% if @grant.planned_giving? %>
-            <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">Legacy scholarship</span>
-          <% end %>
+          <%= grant.legacy_scholarship_badge %>
         </div>
         <p class="text-gray-600 mt-1"><%= grant_funder_badge(grant) %></p>
       </div>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -16,7 +16,12 @@
     <% end %>
     <div class="flex items-start justify-between">
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
+        <div class="flex items-center gap-2 flex-wrap">
+          <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
+          <% if @grant.planned_giving? %>
+            <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">Planned giving</span>
+          <% end %>
+        </div>
         <p class="text-gray-600 mt-1"><%= grant_funder_badge(grant) %></p>
       </div>
       <% if allowed_to?(:edit?, @grant) %>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -19,7 +19,7 @@
         <div class="flex items-center gap-2 flex-wrap">
           <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
           <% if @grant.planned_giving? %>
-            <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">Planned giving</span>
+            <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">Legacy scholarship</span>
           <% end %>
         </div>
         <p class="text-gray-600 mt-1"><%= grant_funder_badge(grant) %></p>

--- a/db/migrate/20260814230559_add_planned_giving_to_grants.rb
+++ b/db/migrate/20260814230559_add_planned_giving_to_grants.rb
@@ -1,0 +1,9 @@
+class AddPlannedGivingToGrants < ActiveRecord::Migration[8.1]
+  def up
+    add_column :grants, :planned_giving, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :grants, :planned_giving, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -715,6 +715,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
     t.date "funds_allocation_deadline"
     t.date "funds_received_on"
     t.string "name", null: false
+    t.boolean "planned_giving", default: false, null: false
     t.text "tasks"
     t.datetime "updated_at", null: false
     t.bigint "updated_by_id"

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -132,4 +132,15 @@ RSpec.describe GrantDecorator, type: :decorator do
       expect(grant.decorate).not_to be_fully_allocated
     end
   end
+
+  describe "#legacy_scholarship_badge" do
+    it "renders a Legacy scholarship pill for planned-giving grants" do
+      badge = create(:grant, :planned_giving).decorate.legacy_scholarship_badge
+      expect(badge).to include("Legacy scholarship")
+    end
+
+    it "renders nothing for ordinary grants" do
+      expect(create(:grant).decorate.legacy_scholarship_badge).to be_nil
+    end
+  end
 end

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     trait :donated_by_person do
       association :funder, factory: :person
     end
+
+    trait :planned_giving do
+      planned_giving { true }
+    end
   end
 end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Grant, type: :model do
     end
   end
 
+  describe "planned_giving" do
+    it "defaults to false" do
+      expect(Grant.new.planned_giving).to be(false)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("Org grant")
       end
 
+      it "filters by legacy scholarship (planned giving)" do
+        legacy = create(:grant, :planned_giving, name: "Legacy fund")
+        ordinary = create(:grant, name: "Ordinary fund")
+
+        get grants_url(planned_giving: "yes"), headers: frame_headers
+        expect(response.body).to include("Legacy fund")
+        expect(response.body).not_to include("Ordinary fund")
+
+        get grants_url(planned_giving: "no"), headers: frame_headers
+        expect(response.body).to include("Ordinary fund")
+        expect(response.body).not_to include("Legacy fund")
+      end
+
       it "filters by grant name" do
         create(:grant, name: "Healing Arts Fund")
         create(:grant, name: "Music Therapy Grant")

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -227,6 +227,12 @@ RSpec.describe "/grants", type: :request do
           expect(Grant.last.primary_asset.file).to be_attached
         end
 
+        it "flags the grant as planned giving when checked" do
+          post grants_url, params: { grant: valid_attributes.merge(planned_giving: "1") }
+
+          expect(Grant.last).to be_planned_giving
+        end
+
         it "attaches the selected sectors and categories" do
           sector = create(:sector, :published)
           category = create(:category, :published)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one new boolean column + form/show/index wiring, low blast radius

## What
- Add a `planned_giving` boolean to grants (default `false`, `null: false`).
- **Form:** toggle beside the funder; top rows reflow to name · amount, then funder · legacy scholarship.
- **Show + index:** amber "Legacy scholarship" badge (shared `GrantDecorator#legacy_scholarship_badge`).
- **Index filter:** "Legacy scholarship" select — Legacy scholarships / Other grants / All.
- Permit the param; factory trait + model/request/decorator specs.

## Why
- Flags a grant as a **Legacy scholarship** — AWBW's planned-giving product (awbw.org/planned-giving), funded by a collection of individuals, usually to honor a loved one — so those grants can be told apart and filtered.
- Column named `planned_giving` (the giving mechanism) to avoid colliding with the `Scholarship` model; UI uses AWBW's product term "Legacy scholarship".