### PR TITLE
Person History card + Ahoy person filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `Analytics::LifecycleBuffer` — Thread-safe event buffer for batch tracking
 - `Analytics::EventBuilder` — Constructs analytics event payloads
 - `Analytics::AhoyTracker` — Coordinates ahoy event tracking
+- `Analytics::PersonActivityEvents` — Aggregates Ahoy events for a person, their user, and associated data (powers the person edit History card + `person_id` filter on the Ahoy activities index)
 
 ### Business Logic
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -83,6 +83,15 @@ module Admin
           @person_communications = email.present? ?
             Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc).limit(10) :
             Notification.none
+
+          # Attendance sign-ins happen on a login-free public callout (no Current),
+          # so they aren't ahoy-tracked either — read the entries directly.
+          @person_time_entries = EventAttendanceTimeEntry
+            .where(event_registration_id: person.event_registrations.select(:id))
+            .includes(event_registration: :event)
+            .order(signed_in_at: :desc)
+            .limit(15)
+            .decorate
         end
       end
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -77,6 +77,12 @@ module Admin
         if person
           @person = person
           scope = scope.where(id: Analytics::PersonActivityEvents.new(person).relation.select(:id))
+          # Notifications aren't ahoy-tracked, so surface the person's
+          # communications straight from the notifications table.
+          email = person.communications_email
+          @person_communications = email.present? ?
+            Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc).limit(10) :
+            Notification.none
         end
       end
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -70,6 +70,16 @@ module Admin
         scope = scope.where(resource_id: params[:resource_id])
       end
 
+      # Filter to a person's full history: the person, their user, and every
+      # associated record (see Analytics::PersonActivityEvents).
+      if params[:person_id].present?
+        person = Person.find_by(id: params[:person_id])
+        if person
+          @person = person
+          scope = scope.where(id: Analytics::PersonActivityEvents.new(person).relation.select(:id))
+        end
+      end
+
       @events = scope.paginate(page: page, per_page: per_page)
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -308,6 +308,7 @@ module ApplicationHelper
     form_submissions:    "fa-file-signature",
     payments:            "fa-money-check-dollar",
     topic_subscriptions: "fa-envelope-open-text",
+    memberships:         "fa-id-card",
     workshop_ideas:          "fa-lightbulb",
     workshop_variation_ideas: "fa-lightbulb"
   }.freeze

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -309,6 +309,7 @@ module ApplicationHelper
     payments:            "fa-money-check-dollar",
     topic_subscriptions: "fa-envelope-open-text",
     memberships:         "fa-id-card",
+    continuing_education_registrations: "fa-award",
     workshop_ideas:          "fa-lightbulb",
     workshop_variation_ideas: "fa-lightbulb"
   }.freeze

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -265,7 +265,7 @@ module AhoyTrackable
   def track_lifecycle_event(action, extra_properties = {})
     return unless Current.user || Current.source
     return if self.class.name.start_with?("Ahoy::")
-    return if self.class.name.in?(%w[ActiveStorage::Attachment ActiveStorage::Blob])
+    return if self.class.name.in?(%w[Notification ActiveStorage::Attachment ActiveStorage::Blob])
 
     # prevent nested tracking loops
     return if Thread.current[:_ahoy_tracking]

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -265,7 +265,7 @@ module AhoyTrackable
   def track_lifecycle_event(action, extra_properties = {})
     return unless Current.user || Current.source
     return if self.class.name.start_with?("Ahoy::")
-    return if self.class.name.in?(%w[Notification ActiveStorage::Attachment ActiveStorage::Blob])
+    return if self.class.name.in?(%w[ActiveStorage::Attachment ActiveStorage::Blob])
 
     # prevent nested tracking loops
     return if Thread.current[:_ahoy_tracking]

--- a/app/services/analytics/person_activity_events.rb
+++ b/app/services/analytics/person_activity_events.rb
@@ -61,6 +61,11 @@ module Analytics
         map["User"] = [ user.id ]
         map["WorkshopLog"] = user.workshop_logs.select(:id)
       end
+      # Notifications match the person by recipient email — mirrors the panel's
+      # "Communications (universal)" card, which now emits events (see AhoyTrackable).
+      if (email = @person.preferred_email).present?
+        map["Notification"] = Notification.email(email).select(:id)
+      end
       map
     end
 

--- a/app/services/analytics/person_activity_events.rb
+++ b/app/services/analytics/person_activity_events.rb
@@ -1,0 +1,78 @@
+module Analytics
+  # Collects every Ahoy event that belongs to a person's history: events about
+  # the person record itself, about their user account (both lifecycle and
+  # `auth.*` events), and about the associated records surfaced on the person's
+  # "Associated records" panel. Powers the person edit "History" card and the
+  # `person_id` filter on the admin Ahoy activities index.
+  class PersonActivityEvents
+    def initialize(person)
+      @person = person
+    end
+
+    def relation
+      scopes = resource_scopes
+      scopes << auth_scope if @person.user
+      return Ahoy::Event.none if scopes.empty?
+      scopes.reduce(:or)
+    end
+
+    def count
+      relation.count
+    end
+
+    private
+
+    def resource_scopes
+      resource_ids_by_type.map do |type, ids|
+        Ahoy::Event.where(resource_type: type, resource_id: ids)
+      end
+    end
+
+    # resource_type => ids (arrays or id-only subqueries). Mirrors the records in
+    # people/_associated_records plus the person's own nested records.
+    def resource_ids_by_type
+      map = {
+        "Person" => [ @person.id ],
+        "Affiliation" => @person.affiliations.select(:id),
+        "ProfessionalLicense" => @person.professional_licenses.select(:id),
+        "Membership" => @person.memberships.select(:id),
+        "Address" => @person.addresses.select(:id),
+        "ContactMethod" => @person.contact_methods.select(:id),
+        # Every comment connected to the person, not just profile comments —
+        # reuses PersonCommentAggregator so History and the comments page agree.
+        "Comment" => PersonCommentAggregator.new(@person).comments.reorder(nil).select(:id),
+        "EventRegistration" => @person.event_registrations.select(:id),
+        "FormSubmission" => @person.form_submissions.select(:id),
+        "Grant" => @person.grants.select(:id),
+        "Payment" => Payment.where(person_id: @person.id).select(:id),
+        "Scholarship" => @person.scholarships.select(:id),
+        "TopicSubscription" => @person.topic_subscriptions.select(:id),
+        "CommunityNews" => @person.community_news_as_author.select(:id),
+        "Resource" => @person.resources_as_author.select(:id),
+        "Story" => @person.stories_as_author.select(:id),
+        "StoryIdea" => StoryIdea.created_by_person(@person.id).select(:id),
+        "Workshop" => @person.workshops_as_author.select(:id),
+        "WorkshopIdea" => WorkshopIdea.created_by_person(@person.id).select(:id),
+        "WorkshopVariation" => @person.workshop_variations_as_author.select(:id),
+        "WorkshopVariationIdea" => WorkshopVariationIdea.created_by_person(@person.id).select(:id)
+      }
+      if (user = @person.user)
+        map["User"] = [ user.id ]
+        map["WorkshopLog"] = user.workshop_logs.select(:id)
+      end
+      map
+    end
+
+    # Auth events store the user under properties.record_id/record_type rather
+    # than the resource_type/resource_id columns, so they need a JSON match.
+    def auth_scope
+      Ahoy::Event
+        .where("ahoy_events.name LIKE 'auth.%'")
+        .where(
+          "CAST(JSON_EXTRACT(ahoy_events.properties, '$.record_id') AS UNSIGNED) = :id AND " \
+          "JSON_UNQUOTE(JSON_EXTRACT(ahoy_events.properties, '$.record_type')) = 'User'",
+          id: @person.user.id
+        )
+    end
+  end
+end

--- a/app/services/analytics/person_activity_events.rb
+++ b/app/services/analytics/person_activity_events.rb
@@ -61,11 +61,6 @@ module Analytics
         map["User"] = [ user.id ]
         map["WorkshopLog"] = user.workshop_logs.select(:id)
       end
-      # Notifications match the person by recipient email — mirrors the panel's
-      # "Communications (universal)" card, which now emits events (see AhoyTrackable).
-      if (email = @person.preferred_email).present?
-        map["Notification"] = Notification.email(email).select(:id)
-      end
       map
     end
 

--- a/app/services/analytics/person_activity_events.rb
+++ b/app/services/analytics/person_activity_events.rb
@@ -42,6 +42,7 @@ module Analytics
         # reuses PersonCommentAggregator so History and the comments page agree.
         "Comment" => PersonCommentAggregator.new(@person).comments.reorder(nil).select(:id),
         "EventRegistration" => @person.event_registrations.select(:id),
+        "ContinuingEducationRegistration" => ContinuingEducationRegistration.where(event_registration_id: @person.event_registrations.select(:id)).select(:id),
         "FormSubmission" => @person.form_submissions.select(:id),
         "Grant" => @person.grants.select(:id),
         "Payment" => Payment.where(person_id: @person.id).select(:id),

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -2,7 +2,13 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
 
       <div class="flex flex-wrap items-center gap-y-2 mb-2">
-        <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
+        <%# Scoped to a person (from their edit page's History card) — return there, not to Admin. %>
+        <% if @person %>
+          <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+            <i class="fas fa-arrow-left"></i>
+            <span><%= truncate(@person.name, length: 30) %></span>
+          <% end %>
+        <% elsif allowed_to?(:index?, with: Admin::HomePolicy) %>
           <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -149,6 +149,28 @@
         <% end %>
       </div>
 
+      <%# Person-scoped view: notifications aren't ahoy events, so list the
+          person's communications here from the notifications table. %>
+      <% if @person && @person_communications.present? %>
+        <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
+              <i class="fa-solid fa-bell"></i>
+            </span>
+            <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
+            <%= link_to "View all",
+                        notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
+                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                        target: "_blank", rel: "noopener" %>
+          </div>
+          <div class="space-y-2 p-4">
+            <% @person_communications.each do |notification| %>
+              <%= render "notifications/notification_row", notification: notification, admin: true %>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
       <!-- Activities Table -->
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
         <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -171,6 +171,41 @@
         </section>
       <% end %>
 
+      <%# Attendance sign-ins aren't ahoy-tracked (login-free public callout), so
+          list the entries directly, newest first. %>
+      <% if @person && @person_time_entries.present? %>
+        <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
+              <i class="fa-solid fa-clock"></i>
+            </span>
+            <h2 class="text-sm font-semibold text-gray-700">Attendance time entries</h2>
+          </div>
+          <table class="w-full text-sm">
+            <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
+              <tr>
+                <th class="px-4 py-2 text-left">Event</th>
+                <th class="px-4 py-2 text-left">Date</th>
+                <th class="px-4 py-2 text-left">In</th>
+                <th class="px-4 py-2 text-left">Out</th>
+                <th class="px-4 py-2 text-left">Duration</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+              <% @person_time_entries.each do |entry| %>
+                <tr>
+                  <td class="px-4 py-2 text-gray-900"><%= entry.event_registration.event.title %></td>
+                  <td class="px-4 py-2 text-gray-500"><%= entry.attendance_date&.strftime("%b %-d, %Y") %></td>
+                  <td class="px-4 py-2 text-gray-500"><%= entry.signed_in_label %></td>
+                  <td class="px-4 py-2 text-gray-500"><%= entry.signed_out_label %></td>
+                  <td class="px-4 py-2 text-gray-500"><%= entry.duration_label %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </section>
+      <% end %>
+
       <!-- Activities Table -->
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
         <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -17,7 +17,7 @@
   audience_values = Array(params[:audience]).reject(&:blank?).presence || default_audiences
   audience_labels = audience_values.filter_map { |v| audience_labels_map[v] }
 
-  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present?
+  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || @person.present?
 %>
 <div class="flex flex-wrap items-center gap-2">
   <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Filters applied</h3>
@@ -40,6 +40,12 @@
     <span class="inline-flex items-center px-3 py-1 rounded-full bg-purple-100 text-purple-800 font-medium">
       Props: <%= params[:props] %>
     </span>
+  <% end %>
+  <% if @person.present? %>
+    <%= link_to person_path(@person),
+                class: "inline-flex items-center px-3 py-1 rounded-full bg-blue-100 text-blue-800 font-medium hover:bg-blue-200" do %>
+      Person: <%= @person.name %>
+    <% end %>
   <% end %>
   <% unless any_filters %>
     <span class="text-gray-400">None</span>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -9,8 +9,7 @@
   <ul class="columns-1 sm:columns-2 md:columns-3 gap-x-6">
     <li class="break-inside-avoid mb-2"><%= index_button notifications, params: { email: email }, label: "#{t("communications.title")} (universal)" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
-    <%# No CE registrations index yet — placeholder card surfaces the count; wire up the path once the index exists. %>
-    <li class="break-inside-avoid mb-2"><%= index_button ContinuingEducationRegistration.where(event_registration_id: person.event_registrations.select(:id)), path: "#", label: "CE registrations (placeholder)" %></li>
+    <li class="break-inside-avoid mb-2"><%= index_button ContinuingEducationRegistration.for_registrant(person.id), params: { person_id: person.id }, label: "CE registrations" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
     <% if Membership.enabled? %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -9,6 +9,8 @@
   <ul class="columns-1 sm:columns-2 md:columns-3 gap-x-6">
     <li class="break-inside-avoid mb-2"><%= index_button notifications, params: { email: email }, label: "#{t("communications.title")} (universal)" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
+    <%# No CE registrations index yet — placeholder card surfaces the count; wire up the path once the index exists. %>
+    <li class="break-inside-avoid mb-2"><%= index_button ContinuingEducationRegistration.where(event_registration_id: person.event_registrations.select(:id)), path: "#", label: "CE registrations (placeholder)" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
     <% if Membership.enabled? %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -11,9 +11,12 @@
     <li class="break-inside-avoid mb-2"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
+    <% if Membership.enabled? %>
+      <li class="break-inside-avoid mb-2"><%= index_button person.memberships, path: person_memberships_path(person) %></li>
+    <% end %>
     <li class="break-inside-avoid mb-2"><%= index_button Payment.where(person_id: person.id), params: { person_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Subscriptions" %></li>
+    <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Topic subscriptions" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button(person.user&.workshop_logs || WorkshopLog.none, path: workshop_logs_person_path(person)) %></li>
     <%# Aggregate Ahoy history (person + user + all associated data). Placed last
         so the column flow lands it in the otherwise-empty bottom-right cell. %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -22,13 +22,14 @@
     <%# Aggregate Ahoy history (person + user + all associated data). Placed last
         so the column flow lands it in the otherwise-empty bottom-right cell. %>
     <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+      <% history_count = Analytics::PersonActivityEvents.new(person).count %>
       <li class="break-inside-avoid mb-2">
         <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
                     data: { turbo_prefetch: false },
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
           <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
           <span class="font-medium text-gray-700 truncate">History</span>
-          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= number_with_delimiter(Analytics::PersonActivityEvents.new(person).count) %></span>
+          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= history_count.zero? ? "None" : number_with_delimiter(history_count) %></span>
         <% end %>
       </li>
     <% end %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -15,6 +15,19 @@
     <li class="break-inside-avoid mb-2"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Subscriptions" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button(person.user&.workshop_logs || WorkshopLog.none, path: workshop_logs_person_path(person)) %></li>
+    <%# Aggregate Ahoy history (person + user + all associated data). Placed last
+        so the column flow lands it in the otherwise-empty bottom-right cell. %>
+    <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+      <li class="break-inside-avoid mb-2">
+        <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
+                    data: { turbo_prefetch: false },
+                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
+          <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
+          <span class="font-medium text-gray-700 truncate">History</span>
+          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= number_with_delimiter(Analytics::PersonActivityEvents.new(person).count) %></span>
+        <% end %>
+      </li>
+    <% end %>
   </ul>
 </div>
 

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -34,6 +34,7 @@ module DomainTheme
     comments:                 :purple,
     topic_subscriptions:      :stone,
     topic_subscription_types: :stone,
+    memberships:              :orange,
 
     # Event dashboard cards
     payments:                 :green,

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -40,6 +40,7 @@ module DomainTheme
     payments:                 :green,
     scholarships:             :fuchsia,
     continuing_education:     :teal,
+    continuing_education_registrations: :teal,
     bulk_payments:            :amber,
     event_dashboard:          :indigo,
     addresses:                :slate,

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,6 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe Notification do
+  describe "Ahoy lifecycle tracking" do
+    after { Current.reset }
+
+    it "tracks a create.notification event when created in a user context" do
+      allow(Analytics::LifecycleBuffer).to receive(:push)
+      noticeable = create(:user)
+      Current.user = create(:user)
+
+      create(:notification, noticeable: noticeable)
+
+      expect(Analytics::LifecycleBuffer).to have_received(:push)
+        .with(hash_including(name: "create.notification"))
+    end
+
+    it "does not track without a current user or source" do
+      Current.reset
+      allow(Analytics::LifecycleBuffer).to receive(:push)
+
+      create(:notification)
+
+      expect(Analytics::LifecycleBuffer).not_to have_received(:push)
+        .with(hash_including(name: "create.notification"))
+    end
+  end
+
   describe 'associations' do
     it { should belong_to(:noticeable).optional }
     it { should belong_to(:parent_notification).class_name('Notification').optional }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -4,22 +4,15 @@ RSpec.describe Notification do
   describe "Ahoy lifecycle tracking" do
     after { Current.reset }
 
-    it "tracks a create.notification event when created in a user context" do
+    # Notifications are intentionally excluded from AhoyTrackable — they're
+    # already a durable, timestamped log, so ahoy events would be redundant.
+    # The activities page surfaces them from the notifications table instead.
+    it "does not emit ahoy lifecycle events, even in a user context" do
       allow(Analytics::LifecycleBuffer).to receive(:push)
       noticeable = create(:user)
       Current.user = create(:user)
 
       create(:notification, noticeable: noticeable)
-
-      expect(Analytics::LifecycleBuffer).to have_received(:push)
-        .with(hash_including(name: "create.notification"))
-    end
-
-    it "does not track without a current user or source" do
-      Current.reset
-      allow(Analytics::LifecycleBuffer).to receive(:push)
-
-      create(:notification)
 
       expect(Analytics::LifecycleBuffer).not_to have_received(:push)
         .with(hash_including(name: "create.notification"))

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -210,6 +210,15 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Person: #{person.name}")
       end
+
+      it "shows a back-to-person eyebrow (not Admin) when scoped to a person" do
+        person = create(:person, first_name: "Ada", last_name: "Lovelace")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(edit_person_path(person))
+      end
     end
 
     describe "GET /admin/activities/visits" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -230,6 +230,19 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include("Communications")
         expect(response.body).to include("Comms row marker xyz")
       end
+
+      it "surfaces the person's attendance time entries on the activities page" do
+        person = create(:person)
+        event = create(:event, title: "Attendance marker event")
+        registration = create(:event_registration, registrant: person, event: event)
+        create(:event_attendance_time_entry, event_registration: registration)
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Attendance time entries")
+        expect(response.body).to include("Attendance marker event")
+      end
     end
 
     describe "GET /admin/activities/visits" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -174,6 +174,42 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include("create.bookmark")
         expect(response.body).not_to include("auth.login")
       end
+
+      it "filters by person_id to the person, their user, and associated data" do
+        person = create(:person)
+        payment = create(:payment, person: person)
+        unrelated_person = create(:person)
+
+        create(:ahoy_event, name: "update.person", visit: visit_for_admin,
+                            resource_type: "Person", resource_id: person.id, time: 1.day.ago,
+                            properties: { "resource_type" => "Person", "resource_id" => person.id, "resource_title" => "person_history_row" })
+        create(:ahoy_event, name: "update.user", visit: visit_for_admin,
+                            resource_type: "User", resource_id: person.user.id, time: 1.day.ago,
+                            properties: { "resource_type" => "User", "resource_id" => person.user.id, "resource_title" => "user_history_row" })
+        create(:ahoy_event, name: "create.payment", visit: visit_for_admin,
+                            resource_type: "Payment", resource_id: payment.id, time: 1.day.ago,
+                            properties: { "resource_type" => "Payment", "resource_id" => payment.id, "resource_title" => "payment_history_row" })
+        create(:ahoy_event, name: "update.person", visit: visit_for_admin,
+                            resource_type: "Person", resource_id: unrelated_person.id, time: 1.day.ago,
+                            properties: { "resource_type" => "Person", "resource_id" => unrelated_person.id, "resource_title" => "unrelated_history_row" })
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("person_history_row")
+        expect(response.body).to include("user_history_row")
+        expect(response.body).to include("payment_history_row")
+        expect(response.body).not_to include("unrelated_history_row")
+      end
+
+      it "surfaces a person chip in the applied filters when person_id is set" do
+        person = create(:person, first_name: "Ada", last_name: "Lovelace")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Person: #{person.name}")
+      end
     end
 
     describe "GET /admin/activities/visits" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -219,6 +219,17 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(edit_person_path(person))
       end
+
+      it "surfaces the person's communications (notifications) on the activities page" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email, email_subject: "Comms row marker xyz")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Communications")
+        expect(response.body).to include("Comms row marker xyz")
+      end
     end
 
     describe "GET /admin/activities/visits" do

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Analytics::PersonActivityEvents do
       expect(described_class.new(person).relation).to include(target)
     end
 
+    it "includes events about the person's continuing education registrations" do
+      registration = create(:event_registration, registrant: person)
+      ce = create(:continuing_education_registration, event_registration: registration)
+      target = event(resource_type: "ContinuingEducationRegistration", resource_id: ce.id,
+                     name: "update.continuing_education_registration")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
     it "includes events about comments connected to the person's associated records" do
       scholarship = create(:scholarship, recipient: person)
       comment = create(:comment, commentable: scholarship)

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Analytics::PersonActivityEvents do
       expect(described_class.new(person).relation).to include(target)
     end
 
+    it "includes events about notifications sent to the person's email" do
+      notification = create(:notification, recipient_email: person.preferred_email)
+      target = event(resource_type: "Notification", resource_id: notification.id, name: "create.notification")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
     it "includes events about the person's continuing education registrations" do
       registration = create(:event_registration, registrant: person)
       ce = create(:continuing_education_registration, event_registration: registration)

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe Analytics::PersonActivityEvents do
       expect(described_class.new(person).relation).to include(target)
     end
 
-    it "includes events about notifications sent to the person's email" do
-      notification = create(:notification, recipient_email: person.preferred_email)
-      target = event(resource_type: "Notification", resource_id: notification.id, name: "create.notification")
-      expect(described_class.new(person).relation).to include(target)
-    end
-
     it "includes events about the person's continuing education registrations" do
       registration = create(:event_registration, registrant: person)
       ce = create(:continuing_education_registration, event_registration: registration)

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Analytics::PersonActivityEvents do
+  let(:person) { create(:person) }
+  let(:visit) { create(:ahoy_visit) }
+
+  def event(resource_type:, resource_id:, name: "update.record", properties: {})
+    create(
+      :ahoy_event,
+      visit: visit,
+      name: name,
+      resource_type: resource_type,
+      resource_id: resource_id,
+      properties: { "resource_type" => resource_type, "resource_id" => resource_id }.merge(properties)
+    )
+  end
+
+  describe "#relation" do
+    it "includes events about the person record" do
+      target = event(resource_type: "Person", resource_id: person.id, name: "update.person")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
+    it "includes lifecycle events about the person's user account" do
+      target = event(resource_type: "User", resource_id: person.user.id, name: "update.user")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
+    it "includes auth events for the person's user (matched via JSON record_id)" do
+      target = create(
+        :ahoy_event,
+        visit: visit,
+        name: "auth.login",
+        resource_type: nil,
+        resource_id: nil,
+        properties: { "record_id" => person.user.id, "record_type" => "User" }
+      )
+      expect(described_class.new(person).relation).to include(target)
+    end
+
+    it "includes events about associated data (e.g. the person's payments)" do
+      payment = create(:payment, person: person)
+      target = event(resource_type: "Payment", resource_id: payment.id, name: "create.payment")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
+    it "includes events about comments connected to the person's associated records" do
+      scholarship = create(:scholarship, recipient: person)
+      comment = create(:comment, commentable: scholarship)
+      target = event(resource_type: "Comment", resource_id: comment.id, name: "create.comment")
+      expect(described_class.new(person).relation).to include(target)
+    end
+
+    it "excludes events unrelated to the person" do
+      unrelated_person = create(:person)
+      other = event(resource_type: "Person", resource_id: unrelated_person.id, name: "update.person")
+      auth_for_other = create(
+        :ahoy_event,
+        visit: visit,
+        name: "auth.login",
+        properties: { "record_id" => unrelated_person.user.id, "record_type" => "User" }
+      )
+
+      relation = described_class.new(person).relation
+      expect(relation).not_to include(other)
+      expect(relation).not_to include(auth_for_other)
+    end
+
+    it "returns no events when the person has none" do
+      event(resource_type: "Workshop", resource_id: 999, name: "view.workshop")
+      expect(described_class.new(person).relation).to be_empty
+    end
+  end
+
+  describe "#count" do
+    it "counts the person's, their user's, and associated data's events" do
+      event(resource_type: "Person", resource_id: person.id, name: "update.person")
+      event(resource_type: "User", resource_id: person.user.id, name: "update.user")
+      payment = create(:payment, person: person)
+      event(resource_type: "Payment", resource_id: payment.id, name: "create.payment")
+      event(resource_type: "Person", resource_id: create(:person).id, name: "update.person")
+
+      expect(described_class.new(person).count).to eq(3)
+    end
+  end
+end

--- a/spec/views/people/edit.html.erb_spec.rb
+++ b/spec/views/people/edit.html.erb_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "people/edit", type: :view do
     expect(rendered).to have_link("Memberships", href: person_memberships_path(person))
   end
 
-  it "shows a placeholder CE registrations card in associated records" do
-    expect(rendered).to have_content("CE registrations (placeholder)")
+  it "shows a CE registrations card linking to the filtered index" do
+    expect(rendered).to have_link("CE registrations", href: continuing_education_registrations_path(person_id: person.id))
   end
 
   context "when person has an associated user" do

--- a/spec/views/people/edit.html.erb_spec.rb
+++ b/spec/views/people/edit.html.erb_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe "people/edit", type: :view do
     )
   end
 
+  it "shows Topic subscriptions and Memberships cards in associated records" do
+    expect(rendered).to have_link("Topic subscriptions")
+    expect(rendered).to have_link("Memberships", href: person_memberships_path(person))
+  end
+
   context "when person has an associated user" do
     it "displays the user's email as read-only" do
       expect(rendered).to have_content(person.user.email)

--- a/spec/views/people/edit.html.erb_spec.rb
+++ b/spec/views/people/edit.html.erb_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe "people/edit", type: :view do
     expect(rendered).to have_link('Home', href: root_path)
   end
 
+  it "shows a History card linking to the person's full Ahoy activity" do
+    expect(rendered).to have_link(
+      "History",
+      href: admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff])
+    )
+  end
+
   context "when person has an associated user" do
     it "displays the user's email as read-only" do
       expect(rendered).to have_content(person.user.email)

--- a/spec/views/people/edit.html.erb_spec.rb
+++ b/spec/views/people/edit.html.erb_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe "people/edit", type: :view do
     expect(rendered).to have_link("Memberships", href: person_memberships_path(person))
   end
 
+  it "shows a placeholder CE registrations card in associated records" do
+    expect(rendered).to have_content("CE registrations (placeholder)")
+  end
+
   context "when person has an associated user" do
     it "displays the user's email as read-only" do
       expect(rendered).to have_content(person.user.email)


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new service + controller filter aggregating many associations, plus admin view changes

### What is the goal of this PR and why is this important?
Give admins one entry point to a person's full audit trail. A new **History** card on person edit surfaces a count and links to the Ahoy activities index, scoped to that person.

### How did you approach the change?
- **`Analytics::PersonActivityEvents`** aggregates every Ahoy event for the person, their user account (lifecycle **and** `auth.*`, matched via the JSON `record_id` those events use), continuing-education registrations, and all associated data. Comments reuse **`PersonCommentAggregator`** so History and the comments page stay in lockstep.
- **`AhoyActivitiesController#index`** gains a `person_id` filter (expanded server-side by the service), a **`Person: <name>` chip** in the applied-filters subheader, and a **back-to-person eyebrow** (instead of the generic Admin link) when person-scoped.
- **Not-ahoy-tracked data surfaced directly** on the person-scoped activities view, since ahoy would be redundant *and* incomplete for both:
  - **Communications** — notifications are already a timestamped log; read from the notifications table (reusing `notification_row`).
  - **Attendance time entries** — self-service sign-ins happen on a login-free public callout (no `Current`), so ahoy would only capture staff edits; read the entries directly.
- **Associated-records cards**: History card fills the empty bottom-right grid cell (admin-only); added **Memberships** (gated on `Membership.enabled?`) and a **CE registrations** card (links to the admin CE index added in #2208, filtered by person); relabeled **"Subscriptions" → "Topic subscriptions"**.

### Anything else to add?
- Rebased on main; CE card links to #2208's browse index; History card's zero-count shows "None" to match #2211.
- The History link opens the index with `time_period=all_time` and all audiences, since the index otherwise defaults to *past month* and *excludes admins* — hiding most staff-made edits.
- **Membership ≠ TopicSubscription**: Membership is the annual paid-membership model; the "Topic subscriptions" card is `topic_subscriptions`.
- Full system suite not yet run (targeted specs green).