### PR TITLE
Remove obsolete comments-association workaround from age ranges spec

### DIFF
--- a/spec/tasks/convert_age_ranges_spec.rb
+++ b/spec/tasks/convert_age_ranges_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe "data:convert_age_ranges" do
 
   before do
     Rake::Task["data:convert_age_ranges"].reenable
-
-    # The has_many :comments association is added in a separate PR.
-    # Define it here so the rake task can run in isolation.
-    unless Workshop.reflect_on_association(:comments)
-      Workshop.has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
-    end
   end
 
   let!(:age_range_type) { create(:category_type, name: "AgeRange") }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 test-only cleanup removing dead workaround code

### What is the goal of this PR and why is this important?
- The `data:convert_age_ranges` spec dynamically defined `Workshop.has_many :comments` in a `before` block, working around a time when the association didn't exist on the model.
- The association now lives on `Workshop` (workshop.rb:32), so redefining it in the spec was redundant and a source of flakiness.

### How did you approach the change?
- Deleted the workaround; the spec relies on the model's real association.