### PR TITLE
Add metadata/Stripe-charge-id search and amount range to payments index

### DIFF
--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
     this.element.addEventListener("input", (event) => {
       // skip submit on tom-select keyboard input
       const target = event.target;
-      if (target.type !== "text") return;
+      if (target.type !== "text" && target.type !== "number") return;
 
       const isTomSelect = target.closest(".ts-control");
 
@@ -70,7 +70,7 @@ export default class extends Controller {
     // are exactly what reset() restores — so resetting puts back the filters we
     // just cleared and "Clear filters" re-submits them.
     this.element
-      .querySelectorAll('input[type="text"], input[type="search"], input[type="date"]')
+      .querySelectorAll('input[type="text"], input[type="search"], input[type="date"], input[type="number"]')
       .forEach((input) => {
         input.value = "";
       });

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -42,7 +42,16 @@ class Payment < ApplicationRecord
     results = results.where(person_id: params[:person_id]) if params[:person_id].present?
     results = results.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     results = results.has_remaining(params[:has_remaining]) if params[:has_remaining].present? && params[:has_remaining] != "all"
+    results = results.matching_search(params[:search]) if params[:search].present?
+    results = results.where("amount_cents >= ?", (params[:amount_min].to_d * 100).to_i) if params[:amount_min].present?
+    results = results.where("amount_cents <= ?", (params[:amount_max].to_d * 100).to_i) if params[:amount_max].present?
     results
+  end
+
+  # Free-text search across the JSON metadata blob and the Stripe charge id.
+  def self.matching_search(query)
+    pattern = "%#{sanitize_sql_like(query)}%"
+    where("CAST(metadata AS CHAR) LIKE :q OR stripe_charge_id LIKE :q", q: pattern)
   end
 
   def payer

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -88,7 +88,7 @@
           class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
       </div>
 
-      <div class="md:col-span-4 flex gap-2 justify-end"><%= submit_tag "Search", class: "btn btn-primary" %><%= link_to "Clear filters", payments_path, class: "btn btn-secondary", data: { action: "collection#clearAndSubmit" } %></div>
+      <div class="md:col-span-4 flex gap-2 justify-end"><%= submit_tag "Search", class: "btn btn-primary" %><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
     </div>
   <% end %>
 </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -88,7 +88,7 @@
           class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
       </div>
 
-      <div class="md:col-span-4 flex gap-2 justify-end"><%= submit_tag "Search", class: "btn btn-primary" %><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
+      <div class="md:col-span-4 flex gap-2 justify-end"><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
     </div>
   <% end %>
 </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -12,38 +12,6 @@
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
       <div>
-        <label for="search" class="text-sm font-medium text-gray-500 mb-1 block">Search metadata / Stripe charge ID</label>
-
-        <%= text_field_tag "search", params[:search],
-          placeholder: "Search metadata or Stripe charge ID",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
-        <label for="amount_min" class="text-sm font-medium text-gray-500 mb-1 block">Min amount ($)</label>
-
-        <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
-          placeholder: "Min",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
-        <label for="amount_max" class="text-sm font-medium text-gray-500 mb-1 block">Max amount ($)</label>
-
-        <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
-          placeholder: "Max",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
-        <label for="type" class="text-sm font-medium text-gray-500 mb-1 block">Type</label>
-
-        <%= select_tag "type[]",
-          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
         <label for="person_id" class="text-sm font-medium text-gray-500 mb-1 block">Person</label>
 
         <%= select_tag "person_id",
@@ -69,6 +37,38 @@
             remote_select_model_value: "organization"
           },
           prompt: "Search for an organization" %>
+      </div>
+
+      <div>
+        <label for="search" class="text-sm font-medium text-gray-500 mb-1 block">Search metadata / Stripe charge ID</label>
+
+        <%= text_field_tag "search", params[:search],
+          placeholder: "Search metadata or Stripe charge ID",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="type" class="text-sm font-medium text-gray-500 mb-1 block">Payment method</label>
+
+        <%= select_tag "type[]",
+          options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="amount_min" class="text-sm font-medium text-gray-500 mb-1 block">Min amount ($)</label>
+
+        <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
+          placeholder: "Min",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="amount_max" class="text-sm font-medium text-gray-500 mb-1 block">Max amount ($)</label>
+
+        <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
+          placeholder: "Max",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
       </div>
 
       <div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -11,6 +11,30 @@
       collection_selected_class: selected_btn
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div class="md:col-span-2">
+        <label for="search" class="text-sm font-medium text-gray-500 mb-1 block">Search metadata / Stripe charge ID</label>
+
+        <%= text_field_tag "search", params[:search],
+          placeholder: "Search metadata or Stripe charge ID",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="amount_min" class="text-sm font-medium text-gray-500 mb-1 block">Min amount ($)</label>
+
+        <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
+          placeholder: "Min",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="amount_max" class="text-sm font-medium text-gray-500 mb-1 block">Max amount ($)</label>
+
+        <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
+          placeholder: "Max",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
       <div>
         <label for="type" class="text-sm font-medium text-gray-500 mb-1 block">Type</label>
 

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -11,7 +11,7 @@
       collection_selected_class: selected_btn
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-      <div class="md:col-span-2">
+      <div>
         <label for="search" class="text-sm font-medium text-gray-500 mb-1 block">Search metadata / Stripe charge ID</label>
 
         <%= text_field_tag "search", params[:search],
@@ -44,23 +44,6 @@
       </div>
 
       <div>
-        <label for="has_remaining" class="text-sm font-medium text-gray-500 mb-1 block">Amount Remaining</label>
-
-        <%= select_tag "has_remaining",
-          options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
-        <label for="payer_type" class="text-sm font-medium text-gray-500 mb-1 block">Payer Type</label>
-
-        <%= select_tag "payer_type",
-          options_for_select(["Person", "Organization"], params[:payer_type]),
-          include_blank: "All",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div>
         <label for="person_id" class="text-sm font-medium text-gray-500 mb-1 block">Person</label>
 
         <%= select_tag "person_id",
@@ -86,6 +69,23 @@
             remote_select_model_value: "organization"
           },
           prompt: "Search for an organization" %>
+      </div>
+
+      <div>
+        <label for="has_remaining" class="text-sm font-medium text-gray-500 mb-1 block">Amount Remaining</label>
+
+        <%= select_tag "has_remaining",
+          options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <div>
+        <label for="payer_type" class="text-sm font-medium text-gray-500 mb-1 block">Payer Type</label>
+
+        <%= select_tag "payer_type",
+          options_for_select(["Person", "Organization"], params[:payer_type]),
+          include_blank: "All",
+          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
       </div>
 
       <div class="md:col-span-4 flex gap-2 justify-end"><%= submit_tag "Search", class: "btn btn-primary" %><%= link_to "Clear filters", payments_path, class: "btn btn-secondary", data: { action: "collection#clearAndSubmit" } %></div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -1,6 +1,12 @@
-<!-- Filters -->
+<!-- Filters — field, label, and button styling modeled on the allocations search. -->
 <% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
 <% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
+<%# Grey the placeholder while the "All" option (rendered first) is the current
+    selection, so an unfiltered dropdown reads like a placeholder and a chosen value
+    reads in dark text — matching the events/allocations filter selects. %>
+<% placeholder_select_class = "#{field_class} has-[option:first-child:checked]:text-gray-400" %>
 
 <div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
   <%= form_tag payments_path, method: :get, class: "space-y-4",
@@ -12,12 +18,12 @@
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
       <div>
-        <label for="person_id" class="text-sm font-medium text-gray-500 mb-1 block">Person</label>
+        <label for="person_id" class="<%= label_class %>">Person</label>
 
         <%= select_tag "person_id",
           options_for_select(Person.where(id: params[:person_id]).map { |p| [p.full_name, p.id] }),
           include_blank: true,
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+          class: field_class,
           data: {
             controller: "remote-select",
             remote_select_model_value: "person"
@@ -26,12 +32,12 @@
       </div>
 
       <div>
-        <label for="organization_id" class="text-sm font-medium text-gray-500 mb-1 block">Organization</label>
+        <label for="organization_id" class="<%= label_class %>">Organization</label>
 
         <%= select_tag "organization_id",
           options_for_select(Organization.where(id: params[:organization_id]).map { |o| [o.name, o.id] }),
           include_blank: true,
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",
+          class: field_class,
           data: {
             controller: "remote-select",
             remote_select_model_value: "organization"
@@ -40,52 +46,52 @@
       </div>
 
       <div>
-        <label for="search" class="text-sm font-medium text-gray-500 mb-1 block">Search metadata / Stripe charge ID</label>
+        <label for="search" class="<%= label_class %>">Search metadata / Stripe charge ID</label>
 
         <%= text_field_tag "search", params[:search],
           placeholder: "Search metadata or Stripe charge ID",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: field_class %>
       </div>
 
       <div>
-        <label for="type" class="text-sm font-medium text-gray-500 mb-1 block">Payment method</label>
+        <label for="type" class="<%= label_class %>">Payment method</label>
 
         <%= select_tag "type[]",
           options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: placeholder_select_class %>
       </div>
 
       <div>
-        <label for="amount_min" class="text-sm font-medium text-gray-500 mb-1 block">Min amount ($)</label>
+        <label for="amount_min" class="<%= label_class %>">Min amount ($)</label>
 
         <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
           placeholder: "Min",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: field_class %>
       </div>
 
       <div>
-        <label for="amount_max" class="text-sm font-medium text-gray-500 mb-1 block">Max amount ($)</label>
+        <label for="amount_max" class="<%= label_class %>">Max amount ($)</label>
 
         <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
           placeholder: "Max",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: field_class %>
       </div>
 
       <div>
-        <label for="has_remaining" class="text-sm font-medium text-gray-500 mb-1 block">Amount Remaining</label>
+        <label for="has_remaining" class="<%= label_class %>">Amount remaining</label>
 
         <%= select_tag "has_remaining",
           options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: placeholder_select_class %>
       </div>
 
       <div>
-        <label for="payer_type" class="text-sm font-medium text-gray-500 mb-1 block">Payer Type</label>
+        <label for="payer_type" class="<%= label_class %>">Payer type</label>
 
         <%= select_tag "payer_type",
           options_for_select(["Person", "Organization"], params[:payer_type]),
           include_blank: "All",
-          class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500" %>
+          class: placeholder_select_class %>
       </div>
 
       <div class="md:col-span-4 flex gap-2 justify-end"><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -180,6 +180,68 @@ RSpec.describe Payment, type: :model do
         expect(result).to include(person_payment)
         expect(result).not_to include(org_payment)
       end
+
+      it "returns all payments when no filters are given" do
+        result = Payment.search_by_params({})
+        expect(result).to include(person_payment, org_payment)
+      end
+
+      describe "search (metadata / stripe charge id)" do
+        let!(:metadata_match) { create(:payment, metadata: { "note" => "reunion gala" }) }
+        let!(:stripe_match) { create(:payment, stripe_charge_id: "ch_ABC123") }
+        let!(:no_match) { create(:payment, metadata: { "note" => "something else" }) }
+
+        it "matches on metadata contents" do
+          result = Payment.search_by_params({ search: "reunion" })
+          expect(result).to include(metadata_match)
+          expect(result).not_to include(no_match, stripe_match)
+        end
+
+        it "matches on stripe charge id" do
+          result = Payment.search_by_params({ search: "ch_ABC" })
+          expect(result).to include(stripe_match)
+          expect(result).not_to include(no_match, metadata_match)
+        end
+
+        it "returns all payments when search is blank" do
+          result = Payment.search_by_params({ search: "" })
+          expect(result).to include(metadata_match, stripe_match, no_match)
+        end
+
+        it "escapes LIKE wildcards in the query" do
+          result = Payment.search_by_params({ search: "%" })
+          expect(result).not_to include(metadata_match, stripe_match, no_match)
+        end
+      end
+
+      describe "amount range" do
+        let!(:small) { create(:payment, amount_cents: 500) }
+        let!(:medium) { create(:payment, amount_cents: 1500) }
+        let!(:large) { create(:payment, amount_cents: 5000) }
+
+        it "filters by minimum dollar amount" do
+          result = Payment.search_by_params({ amount_min: "15" })
+          expect(result).to include(medium, large)
+          expect(result).not_to include(small)
+        end
+
+        it "filters by maximum dollar amount" do
+          result = Payment.search_by_params({ amount_max: "15" })
+          expect(result).to include(small, medium)
+          expect(result).not_to include(large)
+        end
+
+        it "filters by a min/max range" do
+          result = Payment.search_by_params({ amount_min: "10", amount_max: "20" })
+          expect(result).to include(medium)
+          expect(result).not_to include(small, large)
+        end
+
+        it "returns all payments when the range is blank" do
+          result = Payment.search_by_params({ amount_min: "", amount_max: "" })
+          expect(result).to include(small, medium, large)
+        end
+      end
     end
 
     describe ".has_remaining" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small filter additions to one model + one filter partial, covered by model specs

### What is the goal of this PR and why is this important?
- The payments index had no way to find a payment by its metadata, Stripe charge id, or amount.

### How did you approach the change?
- Extended `Payment.search_by_params` with a `search` filter (`CAST(metadata AS CHAR) LIKE ? OR stripe_charge_id LIKE ?`, wildcard-escaped) and `amount_min`/`amount_max` dollar→cents range filters — all no-ops when blank, so an empty form returns every row.
- Added a "Search metadata / Stripe charge ID" text box and min/max amount fields to the filter partial; they flow through the existing `collection` Stimulus controller and `payments_results` turbo frame.

### Anything else to add?
- Folded Stripe charge id into the same text box as metadata (one OR search) rather than a separate field.
- `metadata` is a MySQL JSON column, so search is a substring match over the serialized JSON, not key-scoped.