### PR TITLE
Show 'None' instead of 0 in associated-records count badges

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -346,8 +346,9 @@ module ApplicationHelper
       count_tag = if hide_count
         "".html_safe
       else
+        count = collection.count
         content_tag(:span,
-                    number_with_delimiter(collection.count),
+                    count.zero? ? "None" : number_with_delimiter(count),
                     class: "ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white #{text} border #{border}")
       end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -627,6 +627,25 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#index_button" do
+    it "renders 'None' instead of a zero count" do
+      html = helper.index_button(Story.all)
+
+      expect(Story.count).to eq(0)
+      expect(html).to include("None")
+      expect(html).not_to include(">0<")
+    end
+
+    it "renders the delimited count when records exist" do
+      create_list(:story, 2)
+
+      html = helper.index_button(Story.all)
+
+      expect(html).to include(">2<")
+      expect(html).not_to include("None")
+    end
+  end
+
   describe "#badge_classes" do
     it "builds the pill recipe with the theme classes and default padding" do
       result = helper.badge_classes("bg-green-50 text-green-700 border-green-200")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line helper change to the shared count-badge renderer

## What
- The associated-records count badge now renders **"None"** instead of **"0"** when a record type has no associated records.

## Why
- A `0` badge looked like a clickable link to an empty index. "None" makes empty associations obvious at a glance.

## Where
- `index_button` helper (`app/helpers/application_helper.rb`) — the single source for the count badges in both the **person** and **organization** associated-records footers, so one edit covers both.
- Non-zero counts are unchanged (still delimited, e.g. `2`, `1,200`).

## Tests
- Added `#index_button` specs covering the zero → "None" and non-zero delimited-count cases.
