### PR TITLE
Add test + click affordances for new-tab image previews

### DIFF
--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -86,7 +86,7 @@
       <div data-file-preview-target="filename"
            class="text-center text-sm text-gray-500 break-all max-w-[8rem]">
         <%= if blob.present? && blob.respond_to?(:persisted?) && blob.persisted?
-              link_to(blob.filename.to_s, url_for(file), class: "underline", target: "_blank", rel: "noopener noreferrer")
+              link_to(blob.filename.to_s, url_for(file), class: "underline cursor-zoom-in", target: "_blank", rel: "noopener noreferrer", title: "Open in a new tab")
             else
               "No file selected"
             end

--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -86,7 +86,7 @@
       <div data-file-preview-target="filename"
            class="text-center text-sm text-gray-500 break-all max-w-[8rem]">
         <%= if blob.present? && blob.respond_to?(:persisted?) && blob.persisted?
-              link_to(blob.filename.to_s, url_for(file), class: "underline cursor-zoom-in", target: "_blank", rel: "noopener noreferrer", title: "Open in a new tab")
+              link_to(blob.filename.to_s, url_for(file), class: "underline cursor-zoom-in", target: "_blank", rel: "noopener noreferrer", title: "Open image in a new tab")
             else
               "No file selected"
             end

--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -48,22 +48,24 @@
 
       <%# ---------- IMAGE ---------- %>
       <% if is_image && file.present? && file.try(:persisted?) %>
-        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer", class: "block" do %>
+        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer",
+                    title: "Open image in a new tab", class: "block cursor-zoom-in" do %>
           <%= image_tag file,
                         id: image_dom_id,
                         alt: "#{label}",
                         data: { file_preview_target: "preview" },
-                        class: "w-32 h-32 object-cover border border-gray-300 shadow-sm #{rounded ? 'rounded-full' : ''}" %>
+                        class: "w-32 h-32 object-cover border border-gray-300 shadow-sm hover:opacity-90 transition-opacity #{rounded ? 'rounded-full' : ''}" %>
         <% end %>
 
         <%# ---------- PDF PREVIEW ---------- %>
       <% elsif is_pdf && file.previewable? %>
-        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer", class: "block" do %>
+        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer",
+                    title: "Open PDF in a new tab", class: "block cursor-zoom-in" do %>
           <%= image_tag file.preview(resize_to_limit: [300, 300]),
                         id: image_dom_id,
                         alt: "#{label} PDF preview",
                         data: { file_preview_target: "preview" },
-                        class: "w-32 h-32 object-contain border border-gray-300 shadow-sm" %>
+                        class: "w-32 h-32 object-contain border border-gray-300 shadow-sm hover:opacity-90 transition-opacity" %>
         <% end %>
 
         <%# ---------- PLACEHOLDER ---------- %>

--- a/spec/views/shared/_form_image_field.html.erb_spec.rb
+++ b/spec/views/shared/_form_image_field.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "shared/_form_image_field", type: :view do
+  let(:asset) { create(:primary_asset, :with_file) }
+  let(:builder) { SimpleForm::FormBuilder.new(:primary_asset, asset, view, {}) }
+
+  before do
+    render partial: "shared/form_image_field", locals: { f: builder, label: "Primary" }
+  end
+
+  it "opens the image preview in a new tab so editors don't lose unsaved work" do
+    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer'] img[alt='Primary']")
+  end
+
+  it "opens the filename download link in a new tab too" do
+    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer']", text: "missing.png")
+  end
+end

--- a/spec/views/shared/_form_image_field.html.erb_spec.rb
+++ b/spec/views/shared/_form_image_field.html.erb_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "shared/_form_image_field", type: :view do
   end
 
   it "opens the image preview in a new tab so editors don't lose unsaved work" do
-    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer'] img[alt='Primary']")
+    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer'].cursor-zoom-in img[alt='Primary']")
   end
 
-  it "opens the filename download link in a new tab too" do
-    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer']", text: "missing.png")
+  it "opens the filename download link in a new tab too, with the same zoom cursor" do
+    expect(rendered).to have_css("a[target='_blank'][rel='noopener noreferrer'].cursor-zoom-in", text: "missing.png")
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small follow-up to #2224: one test + cosmetic affordances on the shared photo form partial

### What is the goal of this PR and why is this important?
- The new-tab behavior for edit-form image/PDF thumbnails already shipped in #2224 — this fills the two gaps that PR left:
  - **A regression test** locking in that both the thumbnail and the filename link open in a new tab (main currently has no coverage for it).
  - **Click affordances** so the thumbnail reads as clickable: zoom cursor, `title` tooltip, and a hover fade.

### How did you approach the change?
- Rebased onto main; dropped the now-redundant duplicate implementation and kept only the deltas on top of #2224.
- Kept #2224's stronger `rel="noopener noreferrer"`.
- Added `spec/views/shared/_form_image_field.html.erb_spec.rb`.

### Anything else to add?
- Applies to every photo edit form that reuses `shared/_form_image_field` (stories, story ideas, workshops, grants, resources, etc.).