### PR TITLE
Email submitter + admin FYI when a story idea is promoted to a story

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -76,6 +76,7 @@ class StoriesController < ApplicationController
         elsif params.dig(:library_asset, :new_assets).present?
           update_asset_owner(@story)
         end
+        notify_story_promoted if @story.story_idea.present?
         success = true
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved, ActiveRecord::RecordNotUnique => e
@@ -171,6 +172,22 @@ class StoriesController < ApplicationController
     @story.comments.select { |c| c.persisted? && c.body_changed? }.each do |c|
       c.updated_by = current_user
     end
+  end
+
+  # Promoting a story idea into a story emails the idea's submitter and an admin FYI.
+  def notify_story_promoted
+    NotificationServices::CreateNotification.call(
+      noticeable: @story,
+      kind: :story_promoted,
+      recipient_role: :person,
+      recipient_email: @story.story_idea.created_by.email,
+      notification_type: 0)
+    NotificationServices::CreateNotification.call(
+      noticeable: @story,
+      kind: :story_promoted_fyi,
+      recipient_role: :admin,
+      recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
+      notification_type: 0)
   end
 
   # Inline-logged communications are addressed to the story's credited author.

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -7,6 +7,8 @@ class NotificationMailerJob < ApplicationJob
     mailer_map = {
       "idea_submitted"       => ->(n) { NotificationMailer.idea_submitted(n) },
       "idea_submitted_fyi"   => ->(n) { NotificationMailer.idea_submitted_fyi(n) },
+      "story_promoted"       => ->(n) { NotificationMailer.story_promoted(n) },
+      "story_promoted_fyi"   => ->(n) { NotificationMailer.story_promoted_fyi(n) },
       "report_submitted_fyi" => ->(n) { NotificationMailer.report_submitted_fyi(n) },
       "workshop_log_submitted"     => ->(n) { NotificationMailer.workshop_log_submitted(n) },
       "workshop_log_submitted_fyi" => ->(n) { NotificationMailer.workshop_log_submitted_fyi(n) },

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -78,6 +78,27 @@ class NotificationMailer < ApplicationMailer
     )
   end
 
+  def story_promoted(notification)
+    @story = notification.noticeable.decorate
+    @story_idea = @story.story_idea
+    @user = @story_idea&.created_by || @story.created_by
+
+    mail(
+      to: notification.recipient_email,
+      subject: "#{SUBJECT_PREFIX} Your story idea is now a story"
+    )
+  end
+
+  def story_promoted_fyi(notification)
+    @story = notification.noticeable.decorate
+    @story_idea = @story.story_idea
+    @user = @story_idea&.created_by || @story.created_by
+
+    mail(
+      subject: "#{FYI_PREFIX} Story idea promoted to a story: #{@story.title}"
+    )
+  end
+
   def report_submitted_fyi(notification)
     @notification = notification
     @noticeable   = notification.noticeable

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -31,6 +31,8 @@ class Notification < ApplicationRecord
     bulk_payment_confirmation_fyi
     idea_submitted
     idea_submitted_fyi
+    story_promoted
+    story_promoted_fyi
     report_submitted
     report_submitted_fyi
     workshop_log_submitted
@@ -62,6 +64,7 @@ class Notification < ApplicationRecord
     FormSubmission
     Person
     Report
+    Story
     StoryIdea
     User
     WorkshopLog
@@ -78,6 +81,7 @@ class Notification < ApplicationRecord
     [ "Admin FYI: event scholarship registration cancelled", "[FYI] Event scholarship registration cancelled" ],
     [ "Admin FYI: bulk payment", "[FYI] New bulk payment" ],
     [ "Admin FYI: idea submitted", "submission by" ],
+    [ "Admin FYI: story promoted", "Story idea promoted" ],
     [ "Admin FYI: password reset", "[FYI] New password reset" ],
     [ "Admin FYI: workshop log submission", "New WorkshopLog submission" ],
     [ "Admin FYI: contact form submission", "contact form submission" ],
@@ -88,6 +92,7 @@ class Notification < ApplicationRecord
     [ "Event scholarship registration received", "Event scholarship registration received" ],
     [ "Bulk payment: confirmation", "Bulk payment received" ],
     [ "Idea: confirmation (all)", "has been received" ],
+    [ "Story: promotion confirmation", "is now a story" ],
     [ "Idea: confirmation: workshop log", "workshop log has been received" ],
     [ "User: confirm new email", "Confirm your new email address" ],
     [ "User: password reset", "Password reset request" ],

--- a/app/views/notification_mailer/story_promoted.html.erb
+++ b/app/views/notification_mailer/story_promoted.html.erb
@@ -1,0 +1,38 @@
+<h1>Your story has been shared</h1>
+
+<div style="margin-top: 36px; text-align: left;">
+  <p>
+    Hello <strong><%= @user.full_name %></strong>,
+  </p>
+
+  <p>
+    Wonderful news — the story idea you shared with us has been developed into a story.
+    Thank you for helping others see the healing power of art.
+  </p>
+
+  <div style="text-align: center; background-color: #f3f4f6; border-radius: 6px; padding: 24px; margin: 16px 0;">
+    <h2 style="font-size: 22px; font-weight: bold; color: #166534; margin: 0 0 8px; font-family: Lato, sans-serif;">
+      <%= @story.title %>
+    </h2>
+
+    <% if @story.windows_type.present? %>
+      <p style="font-size: 13px; color: #6b7280; margin: 0;">
+        <%= @story.windows_type.short_name %>
+      </p>
+    <% end %>
+  </div>
+</div>
+
+<% if @story.published? || @story.publicly_visible? %>
+  <p>
+    <%= link_to "View story",
+                polymorphic_url(@story),
+                style: "display:inline-block;
+                        padding:10px 16px;
+                        background:#2563eb;
+                        color:#ffffff;
+                        text-decoration:none;
+                        border-radius:6px;
+                        font-weight:bold;" %>
+  </p>
+<% end %>

--- a/app/views/notification_mailer/story_promoted.text.erb
+++ b/app/views/notification_mailer/story_promoted.text.erb
@@ -1,0 +1,18 @@
+Your story has been shared
+
+Hello <%= @user.full_name %>,
+
+Wonderful news — the story idea you shared with us has been developed into a story. Thank you for helping others see the healing power of art.
+
+<%= @story.title %>
+<% if @story.windows_type.present? %>
+(<%= @story.windows_type.short_name %>)
+<% end %>
+
+<% if @story.published? || @story.publicly_visible? %>
+View story:
+<%= polymorphic_url(@story) %>
+<% end %>
+
+--
+This is an automated message from AWBW.

--- a/app/views/notification_mailer/story_promoted_fyi.html.erb
+++ b/app/views/notification_mailer/story_promoted_fyi.html.erb
@@ -1,0 +1,48 @@
+<p style="margin-bottom: 6px;">
+  Story idea promoted to a story
+</p>
+
+<h1 style="margin: 0;">
+  <strong><%= @story.title %></strong>
+  <% if @story.windows_type.present? %>
+    <span style="font-weight: normal; color:#6b7280;">
+      (<%= @story.windows_type.short_name %>)
+    </span>
+  <% end %>
+</h1>
+
+<% if @user.present? %>
+  <p style="margin: 4px 0 16px; font-size: 13px; color: #6b7280;">
+    Idea submitted by <%= @user.full_name %>
+  </p>
+<% end %>
+
+<hr style="margin: 24px 0;">
+
+<% if @story.detail(length: nil).present? %>
+  <div style="text-align: left;">
+    <%= simple_format(@story.detail(length: nil)) %>
+  </div>
+<% end %>
+
+<hr style="margin: 24px 0;">
+
+<p>
+  <%= link_to "View story",
+              polymorphic_url(@story),
+              style: "display:inline-block;
+                      padding:10px 16px;
+                      background:#2563eb;
+                      color:#ffffff;
+                      text-decoration:none;
+                      border-radius:6px;
+                      font-weight:bold;" %>
+
+  <% if @story_idea.present? %>
+    <%= link_to "View original idea",
+                polymorphic_url(@story_idea),
+                style: "display:inline-block;background:#e5e7eb;color:#111827;
+                        text-decoration:none;padding:10px 16px;border-radius:6px;
+                        font-weight:bold;" %>
+  <% end %>
+</p>

--- a/app/views/notification_mailer/story_promoted_fyi.text.erb
+++ b/app/views/notification_mailer/story_promoted_fyi.text.erb
@@ -1,0 +1,27 @@
+Story idea promoted to a story
+==============================
+
+<%= @story.title %>
+<% if @story.windows_type.present? %>
+(<%= @story.windows_type.short_name %>)
+<% end %>
+
+<% if @user.present? %>
+Idea submitted by <%= @user.full_name %>
+<% end %>
+
+------------------------------------------------------------
+
+<% if @story.detail(length: nil).present? %>
+<%= @story.detail(length: nil) %>
+<% end %>
+
+------------------------------------------------------------
+
+View story:
+<%= polymorphic_url(@story) %>
+
+<% if @story_idea.present? %>
+View original idea:
+<%= polymorphic_url(@story_idea) %>
+<% end %>

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -274,6 +274,53 @@ RSpec.describe NotificationMailer, type: :mailer do
     end
   end
 
+  describe "#story_promoted" do
+    let(:submitter) { create(:user, email: "submitter@example.com") }
+    let(:story_idea) { create(:story_idea, created_by: submitter) }
+    let(:story) { create(:story, :published, story_idea: story_idea, title: "A Healing Story") }
+    let(:notification) do
+      create(:notification, kind: "story_promoted", noticeable: story,
+             recipient_role: "person", recipient_email: submitter.email)
+    end
+
+    it "renders without raising" do
+      expect { described_class.story_promoted(notification).deliver_now }.not_to raise_error
+    end
+
+    it "sends to the idea's submitter" do
+      expect(described_class.story_promoted(notification).to).to eq([ submitter.email ])
+    end
+
+    it "names the story and greets the submitter" do
+      body = described_class.story_promoted(notification).body.encoded
+      expect(body).to include("A Healing Story")
+      expect(body).to include(submitter.full_name)
+    end
+  end
+
+  describe "#story_promoted_fyi" do
+    let(:submitter) { create(:user) }
+    let(:story_idea) { create(:story_idea, created_by: submitter) }
+    let(:story) { create(:story, story_idea: story_idea, title: "A Healing Story") }
+    let(:notification) do
+      create(:notification, kind: "story_promoted_fyi", noticeable: story,
+             recipient_role: "admin",
+             recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"))
+    end
+
+    it "renders without raising" do
+      expect { described_class.story_promoted_fyi(notification).deliver_now }.not_to raise_error
+    end
+
+    it "goes to the admin mailbox" do
+      expect(described_class.story_promoted_fyi(notification).to).to eq([ ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org") ])
+    end
+
+    it "names the story in the subject" do
+      expect(described_class.story_promoted_fyi(notification).subject).to include("A Healing Story")
+    end
+  end
+
   describe "#reset_password_fyi" do
     let(:user) { create(:user, email: "user@example.com") }
     let(:notification) { create(:notification, kind: "reset_password_fyi", noticeable: user) }

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -264,6 +264,31 @@ RSpec.describe "/stories", type: :request do
 
         expect(Story.last.author).to eq(facilitator)
       end
+
+      context "when promoting a story idea into a story" do
+        let(:submitter) { create(:user, email: "submitter@example.com") }
+        let(:story_idea) { create(:story_idea, created_by: submitter) }
+
+        it "notifies the idea's submitter and an admin" do
+          expect {
+            post stories_url, params: { story: base_attributes.merge(story_idea_id: story_idea.id) }
+          }.to change(Notification, :count).by(2)
+
+          person_note = Notification.find_by(kind: "story_promoted")
+          expect(person_note.recipient_role).to eq("person")
+          expect(person_note.recipient_email).to eq(submitter.email)
+
+          admin_note = Notification.find_by(kind: "story_promoted_fyi")
+          expect(admin_note.recipient_role).to eq("admin")
+          expect(admin_note.recipient_email).to eq(ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"))
+        end
+      end
+
+      it "does not send promotion emails when no story idea is linked" do
+        expect {
+          post stories_url, params: { story: base_attributes }
+        }.not_to change(Notification, :count)
+      end
     end
 
     describe "comments and communications on the edit page" do

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -82,6 +82,33 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.idea_submitted_fyi(notification)
   end
 
+  def story_promoted
+    story = Story.where.not(story_idea_id: nil).first || Story.first
+    user = story&.story_idea&.created_by || story&.created_by || User.first
+    notification = find_valid_notification("story_promoted") ||
+      Notification.create!(
+        noticeable: story,
+        notification_type: 0,
+        kind: "story_promoted",
+        recipient_role: "person",
+        recipient_email: user&.email || "preview@example.com"
+      )
+    NotificationMailer.story_promoted(notification)
+  end
+
+  def story_promoted_fyi
+    story = Story.where.not(story_idea_id: nil).first || Story.first
+    notification = find_valid_notification("story_promoted_fyi") ||
+      Notification.create!(
+        noticeable: story,
+        notification_type: 0,
+        kind: "story_promoted_fyi",
+        recipient_role: "admin",
+        recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+      )
+    NotificationMailer.story_promoted_fyi(notification)
+  end
+
   def report_submitted_fyi
     notification = find_valid_notification("report_submitted_fyi") ||
       Notification.create!(


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained addition of two notification kinds + a create-flow trigger, following the existing idea_submitted pattern

### What is the goal of this PR and why is this important?
- Promoting a story idea into a story (creating a `Story` from a `StoryIdea`) previously sent **no** emails.
- Now it emails the idea's **submitter** ("your story idea is now a story") and sends an **admin FYI**, mirroring the existing `idea_submitted` / `idea_submitted_fyi` flow.

### How did you approach the change?
- New notification kinds `story_promoted` / `story_promoted_fyi` (KINDS + `NotificationMailerJob` map).
- `StoriesController#create` fires both via `NotificationServices::CreateNotification` when the new story has a `story_idea` — submitter goes to `story_idea.created_by.email`, FYI to `REPLY_TO_EMAIL`.
- Added the two `NotificationMailer` methods, four views (html + text), previews, and mailer + request specs.
- Added `Story` to `NOTICEABLE_TYPES` and topic entries so the new emails are filterable/searchable on the notifications index.

### Anything else to add?
- Person's "View story" button is shown only when the story is published/publicly visible, so submitters never hit a link they can't open.