### PR TITLE
Stabilize flaky workshops search spec

### DIFF
--- a/spec/system/workshops_spec.rb
+++ b/spec/system/workshops_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe "Workshops", type: :system do
 
         fill_in 'query', with: 'best workshop'
 
+        # The text filter auto-submits on a 400ms debounce while the checkbox
+        # submits immediately — let the debounced full-text reload settle before
+        # touching the dropdown, so the two Turbo-frame reloads can't overlap and
+        # leave an unfiltered frame under the assertions (flaky ~1 in 3, see #2214).
+        expect(page).to have_content(workshop_world.title)
+        expect(page).to have_content(workshop_mars.title)
+        expect(page).not_to have_content(workshop_hello.title)
+
         # Open the dropdown
         click_on "Windows audience"  # this clicks the <button> text/label
         check("windows_types_#{adult_window.id}")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 test-only sequencing fix, no app code changed

Closes #2214

### What is the goal of this PR and why is this important?
- `spec/system/workshops_spec.rb:22` fails ~1 run in 3 on the Windows-audience dropdown, unrelated to any branch — it gets blamed on whoever's PR hits it next.

### How did you approach the change?
- The filter form auto-submits text inputs on a 400ms debounce but checkboxes immediately, so the `query` fill and the checkbox `check` fired two overlapping Turbo-frame reloads; a debounced reload landing mid-assertion left the frame briefly unfiltered.
- Assert the intermediate filtered state after the text fill (draining the debounce) before opening the dropdown, so the two reloads can't overlap.

### Anything else to add?
- Test-only change. Ran the previously-flaky example 5× and the full file — green each time.