### PR TITLE
Harden the file-upload answer type against forged, dropped, and oversized uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ This codebase (Rails 8.1)
 
 ### STI Models
 
-- **Asset** (inheritance column: `type`): PrimaryAsset, GalleryAsset, RichTextAsset, DownloadableAsset, ThumbnailAsset
+- **Asset** (inheritance column: `type`): PrimaryAsset, GalleryAsset, RichTextAsset, DownloadableAsset, ThumbnailAsset, FormUploadAsset
+  - The `type` column defaults to `"PrimaryAsset"`, which narrows `ACCEPTED_CONTENT_TYPES` to five image types — always name the type when building an Asset, or documents will fail validation. `FormUploadAsset` backs a respondent's file-upload form answer and takes Asset's full accepted-type list.
 - **Report**: MonthlyReport
 
 ### Polymorphic Associations

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -33,7 +33,7 @@ module Events
       @scholarship_form = @event.scholarship_form if @scholarship
       @continuing_education_form = @event.continuing_education_form
 
-      all_params = params.dig(:public_registration, :form_fields)&.to_unsafe_h || {}
+      all_params = merge_retained_uploads(params.dig(:public_registration, :form_fields)&.to_unsafe_h || {})
       registration_params, scholarship_params, continuing_education_params = split_form_params(all_params)
 
       @field_errors = validate_required_fields(registration_params)
@@ -96,6 +96,12 @@ module Events
         person = registration.registrant
       elsif params[:person_id].present?
         person = Person.find(params[:person_id])
+        # Unlike the registration slug — an unguessable token handed to the
+        # registrant — person ids are sequential, so this branch is not a
+        # capability. It exists as the admin-side fallback for registrations with
+        # no slug, so gate it on the same access as the event's other submission
+        # views (or on the viewer being that person).
+        authorize! @event, to: :form_submissions? unless current_user&.person_id == person.id
         registration = @event.event_registrations.find_by(registrant: person)
       else
         redirect_to event_path(@event), alert: "Registration not found."
@@ -131,6 +137,22 @@ module Events
     end
 
     private
+
+    # A file input can't be repopulated, so a form re-rendered after a validation
+    # error carries the already-uploaded blob's signed id in retained_uploads.
+    # An untouched file input still posts a blank value, so fall back to the
+    # retained id wherever the field itself came back empty.
+    def merge_retained_uploads(form_params)
+      retained = params.dig(:public_registration, :retained_uploads)&.to_unsafe_h || {}
+      return form_params if retained.blank?
+
+      retained.each do |field_id, signed_id|
+        next if signed_id.blank? || form_params[field_id].present?
+
+        form_params[field_id] = signed_id
+      end
+      form_params
+    end
 
     def credit_card_payment?(form_params)
       payment_method_field = @registration_form.form_fields.find_by(field_identifier: "payment_method")

--- a/app/frontend/javascript/controllers/file_preview_controller.js
+++ b/app/frontend/javascript/controllers/file_preview_controller.js
@@ -9,6 +9,9 @@ const FILE_TYPE_ICONS = {
 
 export default class extends Controller {
     static targets = ["input", "preview", "placeholder", "filename"]
+    // 0 means no client-side limit; the server validates either way. Setting it
+    // stops an oversized file from being direct-uploaded before rejection.
+    static values = { maxSize: { type: Number, default: 0 } }
 
     connect() {
         this.handleUploadError = this.onUploadError.bind(this)
@@ -28,6 +31,13 @@ export default class extends Controller {
 
         this.clearError()
 
+        if (this.maxSizeValue > 0 && file.size > this.maxSizeValue) {
+            // Clearing the input keeps Active Storage from uploading it on submit
+            event.target.value = ""
+            this.showError(`That file is ${this.megabytes(file.size)} MB — the maximum is ${this.megabytes(this.maxSizeValue)} MB.`)
+            return
+        }
+
         // Update filename
         if (this.hasFilenameTarget) {
             this.filenameTarget.textContent = file.name
@@ -38,6 +48,10 @@ export default class extends Controller {
         } else {
             this.showFileIcon(file.type)
         }
+    }
+
+    megabytes(bytes) {
+        return Math.round((bytes / (1024 * 1024)) * 10) / 10
     }
 
     // Ensure a placeholder div exists (server may not render one when a persisted file exists)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -263,6 +263,16 @@ module ApplicationHelper
     end
   end
 
+  # Resolves the signed blob id a file-upload field carries back when its form is
+  # re-rendered after a validation error, so the form can show what is already
+  # uploaded rather than making the registrant pick the file again. nil when the
+  # value is missing or isn't a live signed id.
+  def retained_upload_blob(signed_id)
+    return if signed_id.blank?
+
+    ActiveStorage::Blob.find_signed(signed_id.to_s)
+  end
+
   # True when a dropdown field carries an "Other" option that the public form
   # strips (dropdowns have no free-text input). Checks the field's effective
   # options — dynamic sources (sectors/categories) as well as author-managed

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -14,6 +14,11 @@ class Asset < ApplicationRecord
     "application/vnd.oasis.opendocument.text" # Word document .odt
   ].freeze
 
+  # Ceiling on a single upload. Uploads now reach us from the public event
+  # registration form, so this is the backstop against one enormous file
+  # filling storage — generous enough for a photo or a scanned document.
+  MAX_FILE_SIZE = 25.megabytes
+
 
   # Form selection
   TYPES = %w[
@@ -61,6 +66,10 @@ class Asset < ApplicationRecord
     self::ACCEPTED_CONTENT_TYPES.map { |ct| CONTENT_TYPE_LABELS[ct] || ct }.join(", ")
   end
 
+  def self.max_file_size_label
+    ActiveSupport::NumberHelper.number_to_human_size(MAX_FILE_SIZE)
+  end
+
   belongs_to :owner, polymorphic: true, optional: true, touch: true
   belongs_to :report, optional: true
 
@@ -71,6 +80,7 @@ class Asset < ApplicationRecord
       saver: { quality: 80 }
   end
   validate :file_type
+  validate :file_size
 
   private
 
@@ -82,5 +92,12 @@ class Asset < ApplicationRecord
     unless allowed_types.include?(file.content_type)
       errors.add(:file, "type not accepted")
     end
+  end
+
+  def file_size
+    return unless file.attached?
+    return if file.byte_size.to_i <= MAX_FILE_SIZE
+
+    errors.add(:file, "is too large (maximum #{self.class.max_file_size_label})")
   end
 end

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -22,9 +22,21 @@ class FormAnswer < ApplicationRecord
   end
 
   # The attached upload, when this answer is a file-upload answer with a file on
-  # file. nil for text answers or an unanswered file question.
+  # file. nil for text answers or an unanswered file question. The attachment is
+  # authoritative for a file answer — submitted_answer only caches its name (see
+  # #sync_uploaded_filename!).
   def uploaded_file
     file = asset&.file
     file if file&.attached?
+  end
+
+  # Refresh the cached filename from the attachment. Every writer of a file
+  # answer's submitted_answer should go through here so the two can't drift —
+  # they did once, when a blank file param cleared the name off an answer whose
+  # file was still attached, and the presence checks that read submitted_answer
+  # (ScholarshipApplication#answered?, the scholarship card) then read the
+  # question as unanswered.
+  def sync_uploaded_filename!
+    update!(submitted_answer: uploaded_file&.filename.to_s)
   end
 end

--- a/app/models/form_upload_asset.rb
+++ b/app/models/form_upload_asset.rb
@@ -1,0 +1,13 @@
+# A file a respondent attached to a form answer, as opposed to an asset an
+# author picked for a Story/Workshop/Event. It takes Asset's full accepted-type
+# list — documents included — because the upload field offers those types.
+#
+# The distinct type matters: assets.type defaults to "PrimaryAsset", so building
+# an answer's asset without naming a type silently produces one, and PrimaryAsset
+# narrows ACCEPTED_CONTENT_TYPES to five image types. Every document the form
+# advertises would then fail validation and take the whole registration with it.
+#
+# Deliberately absent from Asset::TYPES — that list drives the author-facing
+# asset-type picker, and these are never chosen there.
+class FormUploadAsset < Asset
+end

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,6 +2,13 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
+    # Raised when a file-upload answer's value isn't a usable upload — a tampered,
+    # stale, or otherwise unverifiable direct-upload signed id. Rescued in #call so
+    # the registrant gets a form error instead of an unhandled exception.
+    UnreadableUpload = Class.new(StandardError)
+
+    UNREADABLE_UPLOAD_MESSAGE = "We couldn't read one of your uploaded files. Please choose it again."
+
     # Well-known field_identifier of the "magic" CE question seeded onto the
     # registration form. Answering it "Yes" creates a ContinuingEducationRegistration
     # (hours come from the event). Kept here so the seed, service, and specs agree.
@@ -127,6 +134,8 @@ module EventRegistrationServices
 
         Result.new(success?: true, event_registration: event_registration, form_submission: submission, errors: [])
       end
+    rescue UnreadableUpload => e
+      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
     rescue ActiveRecord::ValueTooLong => e
       Result.new(success?: false, event_registration: nil, errors: [ too_long_message(e) ])
     rescue ActiveRecord::RecordInvalid => e
@@ -535,16 +544,30 @@ module EventRegistrationServices
     # Attach the uploaded blob (a direct-upload signed id, or an uploaded file)
     # to the answer's Asset. The answer row is saved first so the polymorphic
     # owner id resolves; submitted_answer keeps the filename so text-only views,
-    # exports, and notifications still read. Asset enforces the content type on
-    # save, rolling back the whole submission on an unaccepted file.
+    # exports, and notifications still read. Asset enforces the content type and
+    # size on save, rolling back the whole submission on a rejected file.
     def attach_uploaded_file(record, raw_value)
-      record.update!(submitted_answer: "")
+      # An untouched file input still posts a blank value, so blank means "no new
+      # upload" — keep the file, and its filename, the answer already has.
+      record.update!(submitted_answer: record.uploaded_file&.filename.to_s)
       return if raw_value.blank?
 
       asset = record.asset || record.build_asset
-      asset.file.attach(raw_value)
+      asset.file.attach(upload_attachable(raw_value))
       asset.save!
       record.update!(submitted_answer: asset.file.filename.to_s)
+    end
+
+    # A direct upload arrives as a signed blob id. Handing the raw string to
+    # `attach` resolves it with find_signed!, which raises InvalidSignature or
+    # RecordNotFound on a tampered or stale id — neither is rescued here, so a
+    # forged param would 500 a public endpoint. Resolve it leniently instead and
+    # turn a miss into a form error. Anything else (a multipart UploadedFile,
+    # when the direct-upload JS didn't run) attaches as-is.
+    def upload_attachable(raw_value)
+      return raw_value unless raw_value.is_a?(String)
+
+      ActiveStorage::Blob.find_signed(raw_value) || raise(UnreadableUpload, UNREADABLE_UPLOAD_MESSAGE)
     end
 
     # Persist the answers to the separate scholarship form (when one is asked and a

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -543,19 +543,22 @@ module EventRegistrationServices
 
     # Attach the uploaded blob (a direct-upload signed id, or an uploaded file)
     # to the answer's Asset. The answer row is saved first so the polymorphic
-    # owner id resolves; submitted_answer keeps the filename so text-only views,
-    # exports, and notifications still read. Asset enforces the content type and
-    # size on save, rolling back the whole submission on a rejected file.
+    # owner id resolves; submitted_answer then caches the filename so text-only
+    # views, exports, and notifications still read. Asset enforces the content
+    # type and size on save, rolling back the whole submission on a rejected file.
     def attach_uploaded_file(record, raw_value)
       # An untouched file input still posts a blank value, so blank means "no new
       # upload" — keep the file, and its filename, the answer already has.
-      record.update!(submitted_answer: record.uploaded_file&.filename.to_s)
+      record.sync_uploaded_filename!
       return if raw_value.blank?
 
-      asset = record.asset || record.build_asset
+      # Named explicitly: assets.type defaults to "PrimaryAsset", which accepts
+      # only images, so a bare build_asset would reject every document type the
+      # upload field offers.
+      asset = record.asset || record.build_asset(type: FormUploadAsset.name)
       asset.file.attach(upload_attachable(raw_value))
       asset.save!
-      record.update!(submitted_answer: asset.file.filename.to_s)
+      record.sync_uploaded_filename!
     end
 
     # A direct upload arrives as a signed blob id. Handing the raw string to

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -179,7 +179,21 @@
         becomes a signed blob id, submitted as a normal param — so the form needs
         no multipart encoding and the persistence service attaches the blob.
         Reuses the file_preview controller (image thumbnail / file-type icon). %>
-    <div data-controller="file-preview">
+    <% retained_upload = retained_upload_blob(value) %>
+    <div data-controller="file-preview" data-file-preview-max-size-value="<%= Asset::MAX_FILE_SIZE %>">
+      <%# A file input can't be repopulated, so a re-render after a validation
+          error would otherwise discard a file the registrant already uploaded.
+          Carry its signed id back under its own param — a separate name because
+          an untouched file input still posts a blank value that would win on
+          duplicate keys — and let the controller fall back to it. %>
+      <% if retained_upload %>
+        <input type="hidden"
+               name="public_registration[retained_uploads][<%= field.id %>]"
+               value="<%= value %>">
+        <p class="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-gray-600">
+          <i class="fa-solid fa-paperclip"></i><%= retained_upload.filename %> already uploaded — choose another file to replace it.
+        </p>
+      <% end %>
       <input type="file"
              name="<%= field_name %>"
              id="<%= field_id %>"
@@ -188,9 +202,9 @@
              data-file-preview-target="input"
              data-action="change->file-preview#update"
              class="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 rounded-lg border <%= error_border %> bg-white px-2 py-2"
-             <%= "required" if field.required %>>
+             <%= "required" if field.required && retained_upload.nil? %>>
       <p data-file-preview-target="filename" class="mt-1.5 text-xs font-medium text-gray-600"></p>
-      <p class="mt-1 text-xs text-gray-400">Accepted: <%= Asset.accepted_types_label %></p>
+      <p class="mt-1 text-xs text-gray-400">Accepted: <%= Asset.accepted_types_label %> (max <%= Asset.max_file_size_label %>)</p>
       <img data-file-preview-target="preview"
            class="hidden mt-3 max-h-48 w-auto rounded-lg border border-gray-200 shadow-sm"
            alt="Selected file preview">

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -180,7 +180,7 @@
         no multipart encoding and the persistence service attaches the blob.
         Reuses the file_preview controller (image thumbnail / file-type icon). %>
     <% retained_upload = retained_upload_blob(value) %>
-    <div data-controller="file-preview" data-file-preview-max-size-value="<%= Asset::MAX_FILE_SIZE %>">
+    <div data-controller="file-preview" data-file-preview-max-size-value="<%= FormUploadAsset::MAX_FILE_SIZE %>">
       <%# A file input can't be repopulated, so a re-render after a validation
           error would otherwise discard a file the registrant already uploaded.
           Carry its signed id back under its own param — a separate name because
@@ -197,14 +197,14 @@
       <input type="file"
              name="<%= field_name %>"
              id="<%= field_id %>"
-             accept="<%= Asset.accept_attribute %>"
+             accept="<%= FormUploadAsset.accept_attribute %>"
              data-direct-upload-url="<%= rails_direct_uploads_path %>"
              data-file-preview-target="input"
              data-action="change->file-preview#update"
              class="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 rounded-lg border <%= error_border %> bg-white px-2 py-2"
              <%= "required" if field.required && retained_upload.nil? %>>
       <p data-file-preview-target="filename" class="mt-1.5 text-xs font-medium text-gray-600"></p>
-      <p class="mt-1 text-xs text-gray-400">Accepted: <%= Asset.accepted_types_label %> (max <%= Asset.max_file_size_label %>)</p>
+      <p class="mt-1 text-xs text-gray-400">Accepted: <%= FormUploadAsset.accepted_types_label %> (max <%= FormUploadAsset.max_file_size_label %>)</p>
       <img data-file-preview-target="preview"
            class="hidden mt-3 max-h-48 w-auto rounded-lg border border-gray-200 shadow-sm"
            alt="Selected file preview">

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -21,6 +21,32 @@ RSpec.describe Asset do
     # it { should validate_content_type_of(:file).rejecting("text/plain", "text/xml") }
   end
 
+  describe "file size" do
+    def asset_with_byte_size(bytes)
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+        filename: "sample.png", content_type: "image/png"
+      )
+      blob.update!(byte_size: bytes)
+      Asset.new.tap { |asset| asset.file.attach(blob) }
+    end
+
+    it "rejects a file over the maximum" do
+      asset = asset_with_byte_size(Asset::MAX_FILE_SIZE + 1)
+
+      expect(asset).not_to be_valid
+      expect(asset.errors[:file].join).to match(/too large/i)
+    end
+
+    it "accepts a file at the maximum" do
+      expect(asset_with_byte_size(Asset::MAX_FILE_SIZE)).to be_valid
+    end
+
+    it "labels the maximum for display" do
+      expect(Asset.max_file_size_label).to eq("25 MB")
+    end
+  end
+
   # it 'is valid with valid attributes' do
   #   # Note: Factory needs owner and/or report associations uncommented for create
   #   # expect(build(:image)).to be_valid

--- a/spec/models/form_answer_spec.rb
+++ b/spec/models/form_answer_spec.rb
@@ -27,6 +27,30 @@ RSpec.describe FormAnswer do
     end
   end
 
+  describe "#sync_uploaded_filename!" do
+    let(:form) { create(:form) }
+    let(:submission) { create(:form_submission, form: form) }
+    let(:answer) { create(:form_answer, form_submission: submission, submitted_answer: "stale.png") }
+
+    it "caches the attached file's name" do
+      answer.build_asset.tap do |asset|
+        asset.file.attach(io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+                          filename: "sample.png", content_type: "image/png")
+        asset.save!
+      end
+
+      answer.sync_uploaded_filename!
+
+      expect(answer.submitted_answer).to eq("sample.png")
+    end
+
+    it "clears the cache when there is no attachment" do
+      answer.sync_uploaded_filename!
+
+      expect(answer.submitted_answer).to eq("")
+    end
+  end
+
   describe "#name" do
     let(:form) { create(:form) }
     let(:form_field) { create(:form_field, form: form, name: "First Name") }

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -602,10 +602,108 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "POST create with a file upload" do
+    let!(:upload_field) do
+      create(:form_field, :file_upload, form: form, name: "Photo of your creation", required: true)
+    end
+    %w[first_name last_name primary_email].each do |identifier|
+      let!("#{identifier}_field".to_sym) do
+        create(:form_field, form: form, field_identifier: identifier, name: identifier.humanize, required: false)
+      end
+    end
+
+    def signed_id_for(fixture, content_type)
+      ActiveStorage::Blob.create_and_upload!(
+        io: File.open(Rails.root.join("spec/fixtures/files", fixture)),
+        filename: fixture, content_type: content_type
+      ).signed_id
+    end
+
+    def identity_answers
+      {
+        first_name_field.id.to_s => "Pat",
+        last_name_field.id.to_s => "Lee",
+        primary_email_field.id.to_s => "pat@example.com"
+      }
+    end
+
+    it "carries an already-uploaded file back into the form re-rendered after an error" do
+      signed_id = signed_id_for("sample.png", "image/png")
+
+      post event_public_registration_path(event),
+           params: { public_registration: { form_fields: identity_answers.merge(
+             essay_field.id.to_s => "too few",
+             upload_field.id.to_s => signed_id
+           ) } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(%(name="public_registration[retained_uploads][#{upload_field.id}]"))
+      expect(response.body).to include(signed_id)
+      expect(response.body).to include("sample.png")
+    end
+
+    # An untouched file input still posts a blank value, so the retained id is
+    # what keeps the earlier upload from being silently dropped.
+    it "attaches the retained upload when the file input comes back blank" do
+      signed_id = signed_id_for("sample.png", "image/png")
+
+      post event_public_registration_path(event),
+           params: { public_registration: {
+             form_fields: identity_answers.merge(
+               essay_field.id.to_s => "this answer has plenty of words",
+               upload_field.id.to_s => ""
+             ),
+             retained_uploads: { upload_field.id.to_s => signed_id }
+           } }
+
+      expect(response).to have_http_status(:redirect)
+      answer = FormAnswer.find_by(form_field: upload_field)
+      expect(answer.uploaded_file).to be_attached
+      expect(answer.submitted_answer).to eq("sample.png")
+    end
+
+    it "re-renders with an error instead of raising on an unusable signed id" do
+      post event_public_registration_path(event),
+           params: { public_registration: { form_fields: identity_answers.merge(
+             essay_field.id.to_s => "this answer has plenty of words",
+             upload_field.id.to_s => "not-a-signed-id"
+           ) } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to match(/uploaded file/i)
+    end
+  end
+
   describe "GET show" do
     let(:person) { create(:person) }
+    # The person_id lookup is the admin-side fallback for registrations that have
+    # no slug, so these view as staff. Public access is by slug — see below.
+    let(:admin) { create(:user, :admin) }
 
-    before { create(:form_submission, person: person, form: form, event: event) }
+    before do
+      create(:form_submission, person: person, form: form, event: event)
+      sign_in admin
+    end
+
+    context "when nobody is signed in" do
+      before { sign_out admin }
+
+      # Person ids are sequential, so this lookup would otherwise let anyone walk
+      # every registrant's answers (and now their uploaded files).
+      it "does not serve a registration looked up by person id" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "still serves the registrant's own slug link" do
+        registration = create(:event_registration, event: event, registrant: person)
+
+        get event_public_registration_path(event, reg: registration.slug)
+
+        expect(response).to have_http_status(:success)
+      end
+    end
 
     it "renders header and field-label HTML unescaped on the response page" do
       create(:form_field, form: form, answer_type: :group_header, name: "<strong>Your details</strong>")
@@ -704,10 +802,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
 
     context "when reached from the admin org-linking popup" do
-      let(:admin) { create(:user, :admin) }
       let!(:registration) { create(:event_registration, event: event, registrant: person) }
-
-      before { sign_in admin }
 
       it "shows a back link to the org popup, carrying its own return_to" do
         get event_public_registration_path(event, person_id: person.id,
@@ -725,10 +820,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
 
     context "when viewed from the admin registrants roster" do
-      let(:admin) { create(:user, :admin) }
       let!(:registration) { create(:event_registration, event: event, registrant: person) }
-
-      before { sign_in admin }
 
       it "returns the eyebrow to the registrant's row instead of the ticket" do
         get event_public_registration_path(event, person_id: person.id,

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -1007,5 +1007,51 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(result.success?).to be false
       expect(Person.find_by(email: "bad@example.com")).to be_nil
     end
+
+    it "rejects a file larger than Asset's maximum" do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+        filename: "huge.png", content_type: "image/png"
+      )
+      blob.update!(byte_size: Asset::MAX_FILE_SIZE + 1)
+      params = base_form_params(first_name: "Too", last_name: "Big", email: "big@example.com").merge(
+        upload_field.id.to_s => blob.signed_id
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.success?).to be false
+      expect(Person.find_by(email: "big@example.com")).to be_nil
+    end
+
+    # A tampered/expired signed id used to reach ActiveStorage's find_signed!,
+    # whose InvalidSignature isn't in this service's rescue list — a 500 on a
+    # public endpoint.
+    it "returns a form error rather than raising when the value isn't a usable signed id" do
+      params = base_form_params(first_name: "Bad", last_name: "Id", email: "badid@example.com").merge(
+        upload_field.id.to_s => "not-a-signed-id"
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.success?).to be false
+      expect(result.errors.join).to match(/uploaded file/i)
+      expect(Person.find_by(email: "badid@example.com")).to be_nil
+    end
+
+    it "keeps the file already on the answer when a re-submission leaves the field blank" do
+      params = base_form_params(first_name: "Re", last_name: "Sub", email: "resub@example.com").merge(
+        upload_field.id.to_s => signed_id_for("sample.png", "image/png")
+      )
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      result = described_class.call(event: event, registration_form: form,
+                                    form_params: params.merge(upload_field.id.to_s => ""))
+
+      expect(result.success?).to be true
+      answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(answer.uploaded_file).to be_attached
+      expect(answer.submitted_answer).to eq("sample.png")
+    end
   end
 end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -997,6 +997,24 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(answer.submitted_answer).to eq("")
     end
 
+    # assets.type defaults to "PrimaryAsset", so an unqualified build_asset yields
+    # a PrimaryAsset — five image types, no documents — while the form advertises
+    # the full Asset list. Every document type it offers has to actually save.
+    it "accepts every content type the upload field advertises" do
+      expect(FormUploadAsset::ACCEPTED_CONTENT_TYPES).to include("application/pdf")
+
+      params = base_form_params(first_name: "Doc", last_name: "Upload", email: "doc@example.com").merge(
+        upload_field.id.to_s => signed_id_for("sample.pdf", "application/pdf")
+      )
+
+      result = described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect(result.errors).to be_empty
+      answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(answer.uploaded_file.filename.to_s).to eq("sample.pdf")
+      expect(answer.asset).to be_a(FormUploadAsset)
+    end
+
     it "rejects a file whose content type Asset does not accept" do
       params = base_form_params(first_name: "Bad", last_name: "Type", email: "bad@example.com").merge(
         upload_field.id.to_s => signed_id_for("sample.txt", "text/plain")
@@ -1037,6 +1055,35 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(result.success?).to be false
       expect(result.errors.join).to match(/uploaded file/i)
       expect(Person.find_by(email: "badid@example.com")).to be_nil
+    end
+
+    # submitted_answer is only a cache of the attachment's name. Pinned across
+    # every transition so a second writer that skips FormAnswer#sync_uploaded_filename!
+    # fails here rather than silently desyncing the two.
+    it "keeps submitted_answer equal to the attached filename through upload, replace, and blank re-submit" do
+      params = base_form_params(first_name: "Sync", last_name: "Check", email: "sync@example.com")
+      in_sync = lambda do |result|
+        answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+        expect(answer.submitted_answer).to eq(answer.uploaded_file&.filename.to_s)
+        answer
+      end
+
+      uploaded = in_sync.call(described_class.call(
+        event: event, registration_form: form,
+        form_params: params.merge(upload_field.id.to_s => signed_id_for("sample.png", "image/png"))
+      ))
+      expect(uploaded.submitted_answer).to eq("sample.png")
+
+      replaced = in_sync.call(described_class.call(
+        event: event, registration_form: form,
+        form_params: params.merge(upload_field.id.to_s => signed_id_for("sample.pdf", "application/pdf"))
+      ))
+      expect(replaced.submitted_answer).to eq("sample.pdf")
+
+      blanked = in_sync.call(described_class.call(
+        event: event, registration_form: form, form_params: params.merge(upload_field.id.to_s => "")
+      ))
+      expect(blanked.submitted_answer).to eq("sample.pdf")
     end
 
     it "keeps the file already on the answer when a re-submission leaves the field blank" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 security + data-integrity fixes on the unauthenticated registration form, incl. an authz change and an STI type change

Follow-ups to #2136. Everything here is reachable from the public registration form, which is why it's worth a close read.

## Why

- **Documents the form advertises were rejected.** `assets.type` defaults to `"PrimaryAsset"`, so the bare `build_asset` produced one — narrowing `ACCEPTED_CONTENT_TYPES` to five image types while the field advertised Asset's full list. Uploading a PDF, DOC, DOCX, ODT, or even a GIF failed the whole registration with "File type not accepted". Now a named `FormUploadAsset`, with the view advertising that same class so the two can't drift.
- **Forged upload param 500'd a public endpoint.** A file-upload value that isn't a live signed id reached Active Storage's `find_signed!`, whose `InvalidSignature` isn't in `PublicRegistration`'s rescue list and has no `rescue_from`. Now resolved leniently and surfaced as a form error.
- **Re-registering wiped the stored filename.** `submitted_answer` was cleared before the blank guard. Active Storage's JS only disables file inputs that hold a file, so an untouched one still posts `""` — which blanked the filename while leaving the file attached, and `submitted_answer.present?` checks (`ScholarshipApplication#answered?`, the scholarship card's `answered` guard) then read the question as unanswered.
- **A validation error elsewhere on the form discarded an already-uploaded file.** File inputs can't be repopulated, and every other answer type round-trips its `value`. The signed id now comes back in `public_registration[retained_uploads][<field_id>]` — a separate param name, because a blank file input would win on duplicate keys — and the controller falls back to it.
- **No size cap.** `Asset` validated content type but not bytes, and the form is public. Capped at 25 MB, with a client-side guard so an oversized file isn't direct-uploaded before the server rejects it.
- **`person_id` on the registration show page was ungated.** Person ids are sequential, so unlike the registration slug that branch is not a capability — it's the admin-side fallback for registrations with no slug, and it now exposes uploaded files. It requires `EventPolicy#form_submissions?` (or being that person); slug access stays public.

## Notes for the reviewer

- `submitted_answer` is only a cache of the attachment's filename — the `Asset` is authoritative. `FormAnswer#sync_uploaded_filename!` is the single derivation, with a spec pinning the invariant across upload / replace / blank re-submit.
- `FormUploadAsset` is deliberately absent from `Asset::TYPES` — that list drives the author-facing asset-type picker and these are never chosen there.
- The size validation runs on every `Asset` save, matching the existing `file_type` validation — an already-oversized asset would block edits, same as an already-unaccepted content type does today.
- `file_preview_controller`'s new `maxSize` value defaults to `0` (no limit), so its other callers are unaffected.
- Existing `GET show` request specs now sign in as an admin, since they exercise the `person_id` path.

## Not in scope

Direct upload stores the blob before submit, so abandoned forms and rejected files leave unattached blobs and nothing reclaims them. Tracked separately in #2236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
