### PR TITLE
Licenses index: new/edit flows, richer filtering, CE-hours deep links

### DIFF
--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -7,4 +7,27 @@ class ProfessionalLicensesController < ApplicationController
       .paginate(page: params[:page], per_page: 25)
     render :professional_licenses_results if turbo_frame_request?
   end
+
+  def new
+    @professional_license = ProfessionalLicense.new(person_id: params[:person_id])
+    authorize! @professional_license
+  end
+
+  def create
+    @professional_license = ProfessionalLicense.new(professional_license_params)
+    @professional_license.created_by = current_user
+    authorize! @professional_license
+
+    if @professional_license.save
+      redirect_to professional_licenses_path, notice: "License added for #{@professional_license.person.full_name}."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def professional_license_params
+    params.require(:professional_license).permit(:person_id, :number, :kind, :issuing_state, :expires_on)
+  end
 end

--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -29,9 +29,32 @@ class ProfessionalLicensesController < ApplicationController
     end
   end
 
+  def edit
+    @professional_license = ProfessionalLicense.find(params[:id])
+    authorize! @professional_license
+  end
+
+  def update
+    @professional_license = ProfessionalLicense.find(params[:id])
+    authorize! @professional_license
+    @professional_license.updated_by = current_user
+
+    if @professional_license.update(license_edit_params)
+      redirect_to professional_licenses_path, notice: "License updated for #{@professional_license.person.full_name}."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def professional_license_params
     params.require(:professional_license).permit(:person_id, :number, :kind, :issuing_state, :expires_on)
+  end
+
+  # The registrant is fixed once a license exists — edits change the license
+  # fields only, never who it belongs to.
+  def license_edit_params
+    params.require(:professional_license).permit(:number, :kind, :issuing_state, :expires_on)
   end
 end

--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -1,10 +1,14 @@
 class ProfessionalLicensesController < ApplicationController
+  VALID_SORTS = %w[kind number].freeze
+
   def index
     authorize!
-    @professional_licenses = ProfessionalLicense.search_by_params(params)
+    scope = ProfessionalLicense.search_by_params(params)
       .includes(:person, :continuing_education_registrations)
-      .order(created_at: :desc)
-      .paginate(page: params[:page], per_page: 25)
+    @sort = VALID_SORTS.include?(params[:sort]) ? params[:sort] : nil
+    @sort_direction = params[:direction] == "asc" ? "asc" : "desc"
+    scope = @sort ? scope.order(@sort.to_sym => @sort_direction) : scope.order(created_at: :desc)
+    @professional_licenses = scope.paginate(page: params[:page], per_page: 25)
     render :professional_licenses_results if turbo_frame_request?
   end
 

--- a/app/decorators/professional_license_decorator.rb
+++ b/app/decorators/professional_license_decorator.rb
@@ -1,14 +1,17 @@
 class ProfessionalLicenseDecorator < ApplicationDecorator
   Badge = Struct.new(:label, :icon, :classes, keyword_init: true)
 
-  # Expiry pill: expired / expiring soon / valid, or unknown when no date is on file.
+  # Status pill combining validity + expiry date: active until / expired on, or
+  # unknown when no date is on file.
   def expiry_badge
-    return Badge.new(label: "No expiry on file", icon: "fa-regular fa-circle-question", classes: "bg-gray-50 text-gray-500 border-gray-200") if expires_on.blank?
-    return Badge.new(label: "Expired", icon: "fa-solid fa-circle-xmark", classes: "bg-red-50 text-red-700 border-red-200") if expired?
-    if expires_on <= 60.days.from_now.to_date
-      return Badge.new(label: "Expiring soon", icon: "fa-solid fa-triangle-exclamation", classes: "bg-amber-50 text-amber-700 border-amber-200")
+    return Badge.new(label: "No expiration date", icon: "fa-regular fa-circle-question", classes: "bg-gray-50 text-gray-500 border-gray-200") if expires_on.blank?
+
+    month_year = expires_on.strftime("%b %Y")
+    if expired?
+      Badge.new(label: "Expired (#{month_year})", icon: "fa-solid fa-circle-xmark", classes: "bg-red-50 text-red-700 border-red-200")
+    else
+      Badge.new(label: "Active (until #{month_year})", icon: "fa-solid fa-circle-check", classes: "bg-green-50 text-green-700 border-green-200")
     end
-    Badge.new(label: "Valid", icon: "fa-solid fa-circle-check", classes: "bg-green-50 text-green-700 border-green-200")
   end
 
   # CE hours issued against this license this calendar year — only registrations

--- a/app/decorators/professional_license_decorator.rb
+++ b/app/decorators/professional_license_decorator.rb
@@ -10,4 +10,26 @@ class ProfessionalLicenseDecorator < ApplicationDecorator
     end
     Badge.new(label: "Valid", icon: "fa-solid fa-circle-check", classes: "bg-green-50 text-green-700 border-green-200")
   end
+
+  # CE hours issued against this license this calendar year — only registrations
+  # whose certificate has been sent (in the current year) count.
+  def ce_hours_issued_this_year
+    issued_ce_hours { |registration| registration.certificate_sent_at.year == Date.current.year }
+  end
+
+  # CE hours issued against this license across all years.
+  def ce_hours_issued_all_years
+    issued_ce_hours
+  end
+
+  private
+
+  # Sum CE hours from registrations whose certificate has been sent, optionally
+  # narrowed by the given block. Whole totals drop the decimal.
+  def issued_ce_hours
+    issued = continuing_education_registrations.select { |registration| registration.certificate_sent_at.present? }
+    issued = issued.select { |registration| yield(registration) } if block_given?
+    total = issued.sum { |registration| registration.hours || 0 }
+    total == total.to_i ? total.to_i : total
+  end
 end

--- a/app/decorators/professional_license_decorator.rb
+++ b/app/decorators/professional_license_decorator.rb
@@ -1,14 +1,16 @@
 class ProfessionalLicenseDecorator < ApplicationDecorator
   Badge = Struct.new(:label, :icon, :classes, keyword_init: true)
 
-  # Status pill combining validity + expiry date: active until / expired on, or
-  # unknown when no date is on file.
+  # Status pill combining validity + expiry date: expired on / expiring soon /
+  # active until, or unknown when no date is on file.
   def expiry_badge
     return Badge.new(label: "No expiration date", icon: "fa-regular fa-circle-question", classes: "bg-gray-50 text-gray-500 border-gray-200") if expires_on.blank?
 
     month_year = expires_on.strftime("%b %Y")
     if expired?
       Badge.new(label: "Expired (#{month_year})", icon: "fa-solid fa-circle-xmark", classes: "bg-red-50 text-red-700 border-red-200")
+    elsif expires_on <= 60.days.from_now.to_date
+      Badge.new(label: "Expiring soon (#{month_year})", icon: "fa-solid fa-triangle-exclamation", classes: "bg-amber-50 text-amber-700 border-amber-200")
     else
       Badge.new(label: "Active (until #{month_year})", icon: "fa-solid fa-circle-check", classes: "bg-green-50 text-green-700 border-green-200")
     end

--- a/app/models/continuing_education_registration.rb
+++ b/app/models/continuing_education_registration.rb
@@ -39,17 +39,34 @@ class ContinuingEducationRegistration < ApplicationRecord
 
   scope :for_event, ->(event_id) { joins(:event_registration).where(event_registrations: { event_id: event_id }) }
   scope :for_registrant, ->(person_id) { joins(:event_registration).where(event_registrations: { registrant_id: person_id }) }
+  scope :for_license, ->(license_id) { where(professional_license_id: license_id) }
   scope :certificate_issued, -> { where.not(certificate_sent_at: nil) }
   scope :certificate_pending, -> { where(certificate_sent_at: nil) }
+  scope :issued_on_or_after, ->(date) { where(certificate_sent_at: date.beginning_of_day..) }
+  scope :issued_on_or_before, ->(date) { where(certificate_sent_at: ..date.end_of_day) }
 
-  # Drives the admin index filters (event, registrant, certificate status).
+  # Drives the admin index filters (event, registrant, license, certificate
+  # status, and issued-date range).
   def self.search_by_params(params)
     results = all
     results = results.for_event(params[:event_id]) if params[:event_id].present?
     results = results.for_registrant(params[:person_id]) if params[:person_id].present?
+    results = results.for_license(params[:professional_license_id]) if params[:professional_license_id].present?
     results = results.certificate_issued if params[:certificate] == "issued"
     results = results.certificate_pending if params[:certificate] == "pending"
+    if (from = parse_iso_date(params[:issued_from]))
+      results = results.issued_on_or_after(from)
+    end
+    if (to = parse_iso_date(params[:issued_to]))
+      results = results.issued_on_or_before(to)
+    end
     results
+  end
+
+  def self.parse_iso_date(value)
+    return if value.blank?
+    parts = Date._parse(value.to_s)
+    Date.new(parts[:year], parts[:mon], parts[:mday]) if parts[:year] && parts[:mon] && parts[:mday]
   end
 
   # Payment interface (allocations_sum / paid_in_full? / remaining_cost / …) comes from

--- a/app/models/professional_license.rb
+++ b/app/models/professional_license.rb
@@ -17,15 +17,18 @@ class ProfessionalLicense < ApplicationRecord
   # different kinds is allowed; only a duplicate (kind, number) pair is rejected.
   validates :number, uniqueness: { scope: [ :person_id, :kind ] }, allow_nil: true
 
-  scope :for_person, ->(person_id) { where(person_id: person_id) }
   scope :of_kind, ->(kind) { where(kind: kind) }
   scope :expired, -> { where.not(expires_on: nil).where("expires_on < ?", Date.current) }
   scope :not_expired, -> { where("expires_on IS NULL OR expires_on >= ?", Date.current) }
 
-  # Drives the admin index filters (registrant, kind, expiry status).
+  # Drives the admin index filters (registrant, kind, expiry status). The
+  # registrant filter is a free-text search over the holder's name (incl. legal
+  # first name) and email, reusing Person's remote-search columns.
   def self.search_by_params(params)
     results = all
-    results = results.for_person(params[:person_id]) if params[:person_id].present?
+    if params[:person_query].present?
+      results = results.where(person: Person.remote_search(params[:person_query]).reorder(nil))
+    end
     results = results.of_kind(params[:kind]) if params[:kind].present?
     results = results.expired if params[:expired] == "yes"
     results = results.not_expired if params[:expired] == "no"

--- a/app/views/continuing_education_registrations/_search_boxes.html.erb
+++ b/app/views/continuing_education_registrations/_search_boxes.html.erb
@@ -5,8 +5,11 @@
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 <% ce_event_ids = ContinuingEducationRegistration.joins(:event_registration).distinct.pluck(Arel.sql("event_registrations.event_id")) %>
 <% ce_events = Event.where(id: ce_event_ids).order(start_date: :desc) %>
+<% scoped_license = ProfessionalLicense.find_by(id: params[:professional_license_id]) %>
 
 <div class="mb-6 p-4 bg-white border border-gray-200 rounded-xl shadow-sm">
+  <%= render "shared/filtered_to", record: scoped_license,
+        clear_path: continuing_education_registrations_path(request.query_parameters.except("professional_license_id")) %>
   <%= form_tag continuing_education_registrations_path, method: :get, class: "space-y-4",
     data: {
       controller: "collection",
@@ -14,6 +17,7 @@
       collection_unselected_class: default_btn,
       collection_selected_class: selected_btn
     }, autocomplete: "off" do %>
+    <%= hidden_field_tag "professional_license_id", params[:professional_license_id] if params[:professional_license_id].present? %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div>
         <label for="event_id" class="<%= label_class %>">Event</label>
@@ -41,6 +45,18 @@
         <%= select_tag "certificate",
           options_for_select({ "All" => "", "Issued" => "issued", "Not issued" => "pending" }, params[:certificate]),
           class: field_class %>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div>
+        <label for="issued_from" class="<%= label_class %>">Issued from</label>
+        <%= date_field_tag "issued_from", params[:issued_from], class: field_class %>
+      </div>
+
+      <div>
+        <label for="issued_to" class="<%= label_class %>">Issued to</label>
+        <%= date_field_tag "issued_to", params[:issued_to], class: field_class %>
       </div>
     </div>
 

--- a/app/views/professional_licenses/_form.html.erb
+++ b/app/views/professional_licenses/_form.html.erb
@@ -1,0 +1,61 @@
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
+
+<%= simple_form_for professional_license, html: { class: "space-y-4" } do |f| %>
+  <% if professional_license.errors.any? %>
+    <div class="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+      <ul class="list-disc list-inside">
+        <% professional_license.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% if professional_license.persisted? %>
+    <div>
+      <span class="<%= label_class %>">Registrant</span>
+      <p class="text-gray-900 font-medium">
+        <%= link_to professional_license.person.full_name, person_path(professional_license.person), class: "text-primary hover:text-primary-dark hover:underline", data: { turbo_frame: "_top" } %>
+      </p>
+    </div>
+  <% else %>
+    <div>
+      <label for="professional_license_person_id" class="<%= label_class %>">Registrant</label>
+      <%= f.collection_select :person_id,
+            (professional_license.person.present? ? [ professional_license.person ] : []),
+            :id, :full_name,
+            { include_blank: true },
+            { class: field_class,
+              prompt: "Search for a person",
+              data: { controller: "remote-select", remote_select_model_value: "person" } } %>
+    </div>
+  <% end %>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div>
+      <label for="professional_license_number" class="<%= label_class %>">License number</label>
+      <%= f.input_field :number, placeholder: "e.g. 90210", class: field_class %>
+    </div>
+
+    <div>
+      <label for="professional_license_kind" class="<%= label_class %>">Type</label>
+      <%= f.input_field :kind, placeholder: "e.g. LMFT", class: field_class %>
+    </div>
+
+    <div>
+      <label for="professional_license_issuing_state" class="<%= label_class %>">Issuing state</label>
+      <%= f.input_field :issuing_state, as: :select, collection: us_states, include_blank: true, class: field_class %>
+    </div>
+
+    <div>
+      <label for="professional_license_expires_on" class="<%= label_class %>">Expires</label>
+      <%= f.input_field :expires_on, as: :date, html5: true, class: field_class %>
+    </div>
+  </div>
+
+  <div class="flex gap-2 justify-end pt-2">
+    <%= link_to "Cancel", professional_licenses_path, class: "btn btn-secondary" %>
+    <%= f.button :submit, professional_license.persisted? ? "Save license" : "Add license", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/professional_licenses/_search_boxes.html.erb
+++ b/app/views/professional_licenses/_search_boxes.html.erb
@@ -3,7 +3,7 @@
 <% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
-<% kinds = ProfessionalLicense.where.not(kind: [ nil, "" ]).distinct.order(:kind).pluck(:kind) %>
+<% kinds = ProfessionalLicense.where.not(kind: [ nil, "" ]).distinct.order(:kind).limit(20).pluck(:kind) %>
 
 <div class="mb-6 p-4 bg-white border border-gray-200 rounded-xl shadow-sm">
   <%= form_tag professional_licenses_path, method: :get, class: "space-y-4",
@@ -15,16 +15,11 @@
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div>
-        <label for="person_id" class="<%= label_class %>">Registrant</label>
-        <%= select_tag "person_id",
-          options_for_select(Person.where(id: params[:person_id]).map { |p| [ p.full_name, p.id ] }, params[:person_id]),
-          include_blank: true,
+        <label for="person_query" class="<%= label_class %>">Registrant</label>
+        <%= text_field_tag "person_query", params[:person_query],
           class: field_class,
-          data: {
-            controller: "remote-select",
-            remote_select_model_value: "person"
-          },
-          prompt: "Search for a person" %>
+          placeholder: "Search by name or email",
+          autocomplete: "off" %>
       </div>
 
       <div>
@@ -36,9 +31,9 @@
       </div>
 
       <div>
-        <label for="expired" class="<%= label_class %>">Expiry</label>
+        <label for="expired" class="<%= label_class %>">Active</label>
         <%= select_tag "expired",
-          options_for_select({ "All" => "", "Expired" => "yes", "Not expired" => "no" }, params[:expired]),
+          options_for_select({ "All" => "", "Active" => "no", "Expired" => "yes" }, params[:expired]),
           class: field_class %>
       </div>
     </div>

--- a/app/views/professional_licenses/_search_boxes.html.erb
+++ b/app/views/professional_licenses/_search_boxes.html.erb
@@ -13,8 +13,8 @@
       collection_unselected_class: default_btn,
       collection_selected_class: selected_btn
     }, autocomplete: "off" do %>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div>
+    <div class="flex flex-wrap md:flex-nowrap items-end gap-4">
+      <div class="flex-1 min-w-[200px]">
         <label for="person_query" class="<%= label_class %>">Registrant</label>
         <%= text_field_tag "person_query", params[:person_query],
           class: field_class,
@@ -22,7 +22,7 @@
           autocomplete: "off" %>
       </div>
 
-      <div>
+      <div class="min-w-[150px]">
         <label for="kind" class="<%= label_class %>">Type</label>
         <%= select_tag "kind",
           options_for_select(kinds, params[:kind]),
@@ -30,17 +30,16 @@
           class: field_class %>
       </div>
 
-      <div>
+      <div class="min-w-[150px]">
         <label for="expired" class="<%= label_class %>">Active</label>
         <%= select_tag "expired",
           options_for_select({ "All" => "", "Active" => "no", "Expired" => "yes" }, params[:expired]),
           class: field_class %>
       </div>
-    </div>
 
-    <div class="md:col-span-3 flex gap-2 justify-end">
-      <%= submit_tag "Search", class: "btn btn-primary" %>
-      <%= link_to "Clear filters", professional_licenses_path, class: "btn btn-secondary", data: { action: "collection#clearAndSubmit" } %>
+      <div class="ml-auto">
+        <%= link_to "Clear filters", professional_licenses_path, class: "btn btn-utility", data: { action: "collection#clearAndSubmit" } %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -12,8 +12,8 @@
       <i class="fa-solid fa-id-card"></i>
     </span>
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">New license</h1>
-      <p class="text-gray-600 mt-1">Pick a registrant and record their professional license</p>
+      <h1 class="text-2xl font-semibold text-gray-900">Edit license</h1>
+      <p class="text-gray-600 mt-1">Update this registrant's professional license</p>
     </div>
   </div>
 

--- a/app/views/professional_licenses/index.html.erb
+++ b/app/views/professional_licenses/index.html.erb
@@ -8,6 +8,12 @@
     <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>
 
+  <div class="flex justify-end mb-6">
+    <%= link_to new_professional_license_path, class: "btn btn-primary" do %>
+      <i class="fa-solid fa-plus text-xs"></i> New license
+    <% end %>
+  </div>
+
   <div class="flex items-center gap-3 mb-6">
     <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
       <i class="fa-solid fa-id-card"></i>

--- a/app/views/professional_licenses/new.html.erb
+++ b/app/views/professional_licenses/new.html.erb
@@ -1,0 +1,74 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+<% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
+
+<div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="mb-6">
+    <%= link_to professional_licenses_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
+    <% end %>
+  </div>
+
+  <div class="flex items-center gap-3 mb-6">
+    <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
+      <i class="fa-solid fa-id-card"></i>
+    </span>
+    <div>
+      <h1 class="text-2xl font-semibold text-gray-900">New license</h1>
+      <p class="text-gray-600 mt-1">Pick a registrant and record their professional license</p>
+    </div>
+  </div>
+
+  <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+    <%= simple_form_for @professional_license, html: { class: "space-y-4" } do |f| %>
+      <% if @professional_license.errors.any? %>
+        <div class="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          <ul class="list-disc list-inside">
+            <% @professional_license.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div>
+        <label for="professional_license_person_id" class="<%= label_class %>">Registrant</label>
+        <%= f.collection_select :person_id,
+              (@professional_license.person.present? ? [ @professional_license.person ] : []),
+              :id, :full_name,
+              { include_blank: true },
+              { class: field_class,
+                prompt: "Search for a person",
+                data: { controller: "remote-select", remote_select_model_value: "person" } } %>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label for="professional_license_number" class="<%= label_class %>">License number</label>
+          <%= f.input_field :number, placeholder: "e.g. 90210", class: field_class %>
+        </div>
+
+        <div>
+          <label for="professional_license_kind" class="<%= label_class %>">Type</label>
+          <%= f.input_field :kind, placeholder: "e.g. LMFT", class: field_class %>
+        </div>
+
+        <div>
+          <label for="professional_license_issuing_state" class="<%= label_class %>">Issuing state</label>
+          <%= f.input_field :issuing_state, as: :select, collection: us_states, include_blank: true, class: field_class %>
+        </div>
+
+        <div>
+          <label for="professional_license_expires_on" class="<%= label_class %>">Expires</label>
+          <%= f.input_field :expires_on, as: :date, html5: true, class: field_class %>
+        </div>
+      </div>
+
+      <div class="flex gap-2 justify-end pt-2">
+        <%= link_to "Cancel", professional_licenses_path, class: "btn btn-secondary" %>
+        <%= f.button :submit, "Add license", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/professional_licenses/professional_licenses_results.html.erb
+++ b/app/views/professional_licenses/professional_licenses_results.html.erb
@@ -36,14 +36,10 @@
                 </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm">
                   <% type_number = [ license.kind.presence, license.number.presence ].compact.join(" ").presence || "License (details pending)" %>
-                  <% if license.person %>
-                    <%= link_to edit_person_path(license.person), title: "Edit license", data: { turbo_frame: "_top" },
-                          class: "inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 hover:bg-gray-100 px-2 py-1 text-gray-700 transition-colors" do %>
-                      <span><%= type_number %></span>
-                      <i class="fa-solid fa-pen text-[0.65rem] text-gray-400"></i>
-                    <% end %>
-                  <% else %>
-                    <span class="text-gray-700"><%= type_number %></span>
+                  <%= link_to edit_professional_license_path(license), title: "Edit license", data: { turbo_frame: "_top" },
+                        class: "inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 hover:bg-gray-100 px-2 py-1 text-gray-700 transition-colors" do %>
+                    <span><%= type_number %></span>
+                    <i class="fa-solid fa-pen text-[0.65rem] text-gray-400"></i>
                   <% end %>
                 </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.issuing_state.presence || "—" %></td>
@@ -51,8 +47,26 @@
                 <td class="px-4 py-3 whitespace-nowrap text-sm">
                   <%= render "shared/badge", label: status.label, classes: status.classes, icon: status.icon %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= decorated.ce_hours_issued_this_year %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= decorated.ce_hours_issued_all_years %></td>
+                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums">
+                  <% this_year = decorated.ce_hours_issued_this_year %>
+                  <% if this_year.positive? %>
+                    <%= link_to this_year,
+                          continuing_education_registrations_path(professional_license_id: license.id, certificate: "issued", issued_from: Date.current.beginning_of_year, issued_to: Date.current.end_of_year),
+                          class: "text-primary hover:text-primary-dark hover:underline", data: { turbo_frame: "_top" } %>
+                  <% else %>
+                    <%= this_year %>
+                  <% end %>
+                </td>
+                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums">
+                  <% all_years = decorated.ce_hours_issued_all_years %>
+                  <% if all_years.positive? %>
+                    <%= link_to all_years,
+                          continuing_education_registrations_path(professional_license_id: license.id, certificate: "issued"),
+                          class: "text-primary hover:text-primary-dark hover:underline", data: { turbo_frame: "_top" } %>
+                  <% else %>
+                    <%= all_years %>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/professional_licenses/professional_licenses_results.html.erb
+++ b/app/views/professional_licenses/professional_licenses_results.html.erb
@@ -1,3 +1,5 @@
+<% sort_base = params.permit(:person_query, :kind, :expired).to_h.symbolize_keys %>
+<% sort_link = sort_header_link(frame: "professional_licenses_results", path: ->(p) { professional_licenses_path(p) }, base: sort_base) %>
 <%= turbo_frame_tag :professional_licenses_results do %>
   <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit">
     <% if @professional_licenses.any? %>
@@ -10,13 +12,13 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Registrant</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Number</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">State</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expires</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">CE</th>
+              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Registrant</th>
+              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"><%= sort_link.call("kind", "Type") %> / <%= sort_link.call("number", "Number") %></th>
+              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">State</th>
+              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expires</th>
+              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th class="px-4 py-3 align-bottom text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">CE hours issued<br>(this year)</th>
+              <th class="px-4 py-3 align-bottom text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">CE hours issued<br>(all years)</th>
             </tr>
           </thead>
 
@@ -27,19 +29,30 @@
               <tr class="hover:bg-gray-50 transition-colors duration-150">
                 <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">
                   <% if license.person %>
-                    <%= link_to license.person.full_name, edit_person_path(license.person), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top" } %>
+                    <%= link_to license.person.full_name, person_path(license.person), class: "text-primary hover:text-primary-dark hover:underline", data: { turbo_frame: "_top" } %>
                   <% else %>
                     <span class="text-gray-400">—</span>
                   <% end %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.kind.presence || "—" %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.number.presence || "—" %></td>
+                <td class="px-4 py-3 whitespace-nowrap text-sm">
+                  <% type_number = [ license.kind.presence, license.number.presence ].compact.join(" ").presence || "License (details pending)" %>
+                  <% if license.person %>
+                    <%= link_to edit_person_path(license.person), title: "Edit license", data: { turbo_frame: "_top" },
+                          class: "inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 hover:bg-gray-100 px-2 py-1 text-gray-700 transition-colors" do %>
+                      <span><%= type_number %></span>
+                      <i class="fa-solid fa-pen text-[0.65rem] text-gray-400"></i>
+                    <% end %>
+                  <% else %>
+                    <span class="text-gray-700"><%= type_number %></span>
+                  <% end %>
+                </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.issuing_state.presence || "—" %></td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.expires_on&.to_fs(:long) || "—" %></td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm">
                   <%= render "shared/badge", label: status.label, classes: status.classes, icon: status.icon %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= license.continuing_education_registrations.size %></td>
+                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= decorated.ce_hours_issued_this_year %></td>
+                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= decorated.ce_hours_issued_all_years %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/professional_licenses/professional_licenses_results.html.erb
+++ b/app/views/professional_licenses/professional_licenses_results.html.erb
@@ -15,7 +15,6 @@
               <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Registrant</th>
               <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"><%= sort_link.call("kind", "Type") %> / <%= sort_link.call("number", "Number") %></th>
               <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">State</th>
-              <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expires</th>
               <th class="px-4 py-3 align-bottom text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
               <th class="px-4 py-3 align-bottom text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">CE hours issued<br>(this year)</th>
               <th class="px-4 py-3 align-bottom text-right text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">CE hours issued<br>(all years)</th>
@@ -43,7 +42,6 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.issuing_state.presence || "—" %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= license.expires_on&.to_fs(:long) || "—" %></td>
                 <td class="px-4 py-3 whitespace-nowrap text-sm">
                   <%= render "shared/badge", label: status.label, classes: status.classes, icon: status.icon %>
                 </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,9 +151,9 @@ Rails.application.routes.draw do
     member { patch :toggle_certificate }
     resources :comments, only: [ :create, :update ]
   end
-  # Licenses are edited inline on the person + CE forms; this is the admin-only
-  # browse index plus a standalone "new license" flow that picks a registrant.
-  resources :professional_licenses, only: [ :index, :new, :create ]
+  # The admin-only browse index plus standalone new/edit flows. (Licenses can
+  # also be edited inline on the person + CE forms.)
+  resources :professional_licenses, only: [ :index, :new, :create, :edit, :update ]
   resources :discounts, only: [ :create, :show, :destroy ] do
     collection do
       post :allocation_form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,9 +151,9 @@ Rails.application.routes.draw do
     member { patch :toggle_certificate }
     resources :comments, only: [ :create, :update ]
   end
-  # Licenses are created/edited inline on the person + CE forms; this is the
-  # admin-only browse index.
-  resources :professional_licenses, only: [ :index ]
+  # Licenses are edited inline on the person + CE forms; this is the admin-only
+  # browse index plus a standalone "new license" flow that picks a registrant.
+  resources :professional_licenses, only: [ :index, :new, :create ]
   resources :discounts, only: [ :create, :show, :destroy ] do
     collection do
       post :allocation_form

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -758,9 +758,9 @@ registrations_data = []
 if facilitator_training
   facilitator_training.update!(ce_hours_offered: 12, ce_hours_cost_cents: 12_000)
   [
-    { person: amy_person, status: "registered", scholarship_requested: true, w9_requested: true, invoice_requested: true, ce_credit_requested: true, ce_license_number: "LMFT 90210" },
+    { person: amy_person, status: "registered", scholarship_requested: true, w9_requested: true, invoice_requested: true, ce_credit_requested: true, ce_license_kind: "LMFT", ce_license_number: "90210" },
     { person: maria_j, status: "registered", invoice_requested: true, ce_credit_requested: true, intends_to_pay: true },
-    { person: anna_g, status: "attended", ce_credit_requested: true, intends_to_pay: true, ce_license_number: "LCSW 11223", ce_status: "issued" },
+    { person: anna_g, status: "attended", ce_credit_requested: true, intends_to_pay: true, ce_license_kind: "LCSW", ce_license_number: "11223", ce_status: "issued" },
     { person: mario_j, status: "registered" },
     { person: kim_d, status: "cancelled" },
     { person: aisha_person, status: "registered", intends_to_pay: true }
@@ -778,7 +778,7 @@ end
 if trauma_training
   trauma_training.update!(ce_hours_offered: 18, ce_hours_cost_cents: 15_000)
   [
-    { person: sarah_s, status: "registered", invoice_requested: true, ce_credit_requested: true, ce_license_number: "LPCC 44556" },
+    { person: sarah_s, status: "registered", invoice_requested: true, ce_credit_requested: true, ce_license_kind: "LPCC", ce_license_number: "44556" },
     { person: jessica_b, status: "registered", scholarship_requested: true, ce_credit_requested: true },
     { person: angel_g, status: "registered" },
     { person: linda_w, status: "no_show" }
@@ -853,7 +853,7 @@ registrations_data.each do |data|
   # CE opt-in becomes a ContinuingEducationRegistration against the registrant's
   # license (a placeholder when no number is seeded). Hours come from the event.
   if data[:ce_credit_requested] && registration.continuing_education_registrations.none?
-    license = ProfessionalLicense.find_or_create_for(person: data[:person], number: data[:ce_license_number])
+    license = ProfessionalLicense.find_or_create_for(person: data[:person], number: data[:ce_license_number], kind: data[:ce_license_kind])
     ce_registration = registration.continuing_education_registrations.create!(professional_license: license)
     # "issued" in the seed data means the CE certificate was delivered.
     ce_registration.mark_certificate_sent! if data[:ce_status] == "issued"

--- a/spec/decorators/professional_license_decorator_spec.rb
+++ b/spec/decorators/professional_license_decorator_spec.rb
@@ -1,6 +1,23 @@
 require "rails_helper"
 
 RSpec.describe ProfessionalLicenseDecorator do
+  describe "#expiry_badge" do
+    it "reads as no expiration date when none is on file" do
+      badge = build(:professional_license, expires_on: nil).decorate.expiry_badge
+      expect(badge.label).to eq("No expiration date")
+    end
+
+    it "reads as active with the future expiry month" do
+      badge = build(:professional_license, expires_on: Date.new(2099, 4, 10)).decorate.expiry_badge
+      expect(badge.label).to eq("Active (until Apr 2099)")
+    end
+
+    it "reads as expired with the past expiry month" do
+      badge = build(:professional_license, expires_on: Date.new(2024, 4, 10)).decorate.expiry_badge
+      expect(badge.label).to eq("Expired (Apr 2024)")
+    end
+  end
+
   describe "CE hours issued" do
     let(:person) { create(:person) }
     let(:license) { create(:professional_license, person: person) }

--- a/spec/decorators/professional_license_decorator_spec.rb
+++ b/spec/decorators/professional_license_decorator_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ProfessionalLicenseDecorator do
+  describe "CE hours issued" do
+    let(:person) { create(:person) }
+    let(:license) { create(:professional_license, person: person) }
+
+    def register(hours:, sent_at:)
+      registration = create(:event_registration, registrant: person)
+      create(:continuing_education_registration,
+        event_registration: registration,
+        professional_license: license,
+        hours: hours,
+        certificate_sent_at: sent_at)
+    end
+
+    it "sums only issued certificates, splitting this year from all years" do
+      register(hours: 6, sent_at: Time.current)
+      register(hours: 4, sent_at: 2.years.ago)
+      register(hours: 12, sent_at: nil)
+
+      expect(license.decorate.ce_hours_issued_this_year).to eq(6)
+      expect(license.decorate.ce_hours_issued_all_years).to eq(10)
+    end
+
+    it "returns 0 when nothing has been issued" do
+      register(hours: 6, sent_at: nil)
+
+      expect(license.decorate.ce_hours_issued_this_year).to eq(0)
+      expect(license.decorate.ce_hours_issued_all_years).to eq(0)
+    end
+
+    it "keeps a fractional total" do
+      register(hours: 1.5, sent_at: Time.current)
+
+      expect(license.decorate.ce_hours_issued_all_years).to eq(1.5)
+    end
+  end
+end

--- a/spec/decorators/professional_license_decorator_spec.rb
+++ b/spec/decorators/professional_license_decorator_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe ProfessionalLicenseDecorator do
       expect(badge.label).to eq("Active (until Apr 2099)")
     end
 
+    it "flags a soon-to-expire license with its month" do
+      badge = build(:professional_license, expires_on: 30.days.from_now.to_date).decorate.expiry_badge
+      expect(badge.label).to start_with("Expiring soon (")
+    end
+
     it "reads as expired with the past expiry month" do
       badge = build(:professional_license, expires_on: Date.new(2024, 4, 10)).decorate.expiry_badge
       expect(badge.label).to eq("Expired (Apr 2024)")

--- a/spec/models/continuing_education_registration_spec.rb
+++ b/spec/models/continuing_education_registration_spec.rb
@@ -284,4 +284,45 @@ RSpec.describe ContinuingEducationRegistration, type: :model do
       expect(ce_reg.payment_status_label).to eq("Paid")
     end
   end
+
+  describe ".search_by_params" do
+    let(:person) { create(:person) }
+    let(:license) { create(:professional_license, person: person) }
+
+    def ce_reg(license:, certificate_sent_at: nil)
+      registration = create(:event_registration, registrant: license.person)
+      create(:continuing_education_registration,
+        event_registration: registration,
+        professional_license: license,
+        certificate_sent_at: certificate_sent_at)
+    end
+
+    it "filters to a single license" do
+      mine = ce_reg(license: license)
+      other = ce_reg(license: create(:professional_license))
+
+      results = ContinuingEducationRegistration.search_by_params(professional_license_id: license.id)
+
+      expect(results).to include(mine)
+      expect(results).not_to include(other)
+    end
+
+    it "filters by issued-on date range" do
+      in_range = ce_reg(license: license, certificate_sent_at: Date.new(2026, 6, 15).noon)
+      before_range = ce_reg(license: license, certificate_sent_at: Date.new(2025, 12, 31).noon)
+
+      results = ContinuingEducationRegistration.search_by_params(issued_from: "2026-01-01", issued_to: "2026-12-31")
+
+      expect(results).to include(in_range)
+      expect(results).not_to include(before_range)
+    end
+
+    it "ignores an unparseable date" do
+      reg = ce_reg(license: license, certificate_sent_at: Time.current)
+
+      results = ContinuingEducationRegistration.search_by_params(issued_from: "not-a-date")
+
+      expect(results).to include(reg)
+    end
+  end
 end

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -43,11 +43,57 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include("555")
       expect(response.body).not_to include("222")
     end
+
+    it "renders the new license form" do
+      get new_professional_license_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("New license")
+    end
+
+    it "creates a license for the selected person" do
+      expect do
+        post professional_licenses_path, params: {
+          professional_license: { person_id: person.id, number: "777", kind: "LCSW", issuing_state: "CA" }
+        }
+      end.to change(ProfessionalLicense, :count).by(1)
+
+      expect(response).to redirect_to(professional_licenses_path)
+      created = ProfessionalLicense.order(:created_at).last
+      expect(created.person).to eq(person)
+      expect(created.number).to eq("777")
+      expect(created.created_by).to eq(admin)
+    end
+
+    it "re-renders new when the person is missing" do
+      expect do
+        post professional_licenses_path, params: {
+          professional_license: { number: "888", kind: "LMFT" }
+        }
+      end.not_to change(ProfessionalLicense, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
   end
 
   it "forbids non-admins" do
     sign_in create(:user)
     get professional_licenses_path
+    expect(response).not_to have_http_status(:ok)
+  end
+
+  it "forbids non-admins from the new license form" do
+    sign_in create(:user)
+    get new_professional_license_path
+    expect(response).not_to have_http_status(:ok)
+  end
+
+  it "forbids non-admins from creating a license for another person" do
+    sign_in create(:user)
+    expect do
+      post professional_licenses_path, params: {
+        professional_license: { person_id: person.id, number: "999", kind: "LMFT" }
+      }
+    end.not_to change(ProfessionalLicense, :count)
     expect(response).not_to have_http_status(:ok)
   end
 end

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -106,6 +106,36 @@ RSpec.describe "ProfessionalLicenses", type: :request do
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it "renders the edit license form" do
+      get edit_professional_license_path(license)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Edit license")
+      expect(response.body).to include(person.full_name)
+    end
+
+    it "updates the license fields" do
+      patch professional_license_path(license), params: {
+        professional_license: { number: "556", kind: "LCSW", issuing_state: "NY" }
+      }
+
+      expect(response).to redirect_to(professional_licenses_path)
+      license.reload
+      expect(license.number).to eq("556")
+      expect(license.kind).to eq("LCSW")
+      expect(license.issuing_state).to eq("NY")
+      expect(license.person).to eq(person)
+    end
+
+    it "does not let the registrant be reassigned on update" do
+      other = create(:person)
+
+      patch professional_license_path(license), params: {
+        professional_license: { person_id: other.id, number: "556" }
+      }
+
+      expect(license.reload.person).to eq(person)
+    end
   end
 
   it "forbids non-admins" do
@@ -128,5 +158,14 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       }
     end.not_to change(ProfessionalLicense, :count)
     expect(response).not_to have_http_status(:ok)
+  end
+
+  it "forbids non-admins from editing another person's license" do
+    sign_in create(:user)
+    get edit_professional_license_path(license)
+    expect(response).not_to have_http_status(:ok)
+
+    patch professional_license_path(license), params: { professional_license: { number: "000" } }
+    expect(license.reload.number).to eq("555")
   end
 end

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).not_to include("999")
     end
 
+    it "filters by registrant name" do
+      holder = create(:person, first_name: "Zephyrina", last_name: "Aldercott")
+      create(:professional_license, person: holder, number: "444")
+
+      get professional_licenses_path(person_query: "Zephyrina"),
+        headers: { "Turbo-Frame" => "professional_licenses_results" }
+
+      expect(response.body).to include("444")
+      expect(response.body).not_to include("555")
+    end
+
+    it "filters by registrant email" do
+      holder = create(:person, email: "unique-holder@example.com")
+      create(:professional_license, person: holder, number: "333")
+
+      get professional_licenses_path(person_query: "unique-holder@example.com"),
+        headers: { "Turbo-Frame" => "professional_licenses_results" }
+
+      expect(response.body).to include("333")
+      expect(response.body).not_to include("555")
+    end
+
     it "filters by expiry status" do
       license.update!(expires_on: 1.year.ago.to_date)
       current = create(:professional_license, number: "222", expires_on: 1.year.from_now.to_date)

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).not_to include("222")
     end
 
+    it "sorts by license number" do
+      holder = create(:person)
+      create(:professional_license, person: holder, kind: "LMFT", number: "111")
+      create(:professional_license, person: holder, kind: "LMFT", number: "999")
+
+      get professional_licenses_path(person_query: holder.full_name, sort: "number", direction: "asc"),
+        headers: { "Turbo-Frame" => "professional_licenses_results" }
+
+      expect(response.body.index("111")).to be < response.body.index("999")
+    end
+
     it "renders the new license form" do
       get new_professional_license_path
       expect(response).to have_http_status(:ok)

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/payments/edit.html.erb"                 => "admin-only bg-blue-100",
     "app/views/professional_licenses/index.html.erb"   => "admin-only bg-blue-100",
     "app/views/professional_licenses/new.html.erb"     => "admin-only bg-blue-100",
+    "app/views/professional_licenses/edit.html.erb"    => "admin-only bg-blue-100",
     "app/views/workshop_variations/edit.html.erb"      => "admin-only bg-blue-100",
     "app/views/workshops/edit.html.erb"                => "admin-only bg-blue-100",
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -225,6 +225,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/grants/edit.html.erb"                   => "admin-only bg-blue-100",
     "app/views/payments/edit.html.erb"                 => "admin-only bg-blue-100",
     "app/views/professional_licenses/index.html.erb"   => "admin-only bg-blue-100",
+    "app/views/professional_licenses/new.html.erb"     => "admin-only bg-blue-100",
     "app/views/workshop_variations/edit.html.erb"      => "admin-only bg-blue-100",
     "app/views/workshops/edit.html.erb"                => "admin-only bg-blue-100",
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained CRUD + filter/decorator logic across the licenses and CE-registration indexes, well covered by specs

## Why
The admin licenses index was browse-only with thin filters/columns. This makes it a place you can actually work from — create, edit, filter, and jump to the CE detail behind each hour total.

## What
**Licenses index**
- **New + Edit flows** — standalone `new`/`create`/`edit`/`update` (shared `_form`). Create picks the registrant via the `remote-select` picker; edit keeps the registrant fixed and changes license fields only. The Type/Number edit chip links to the edit page.
- **Registrant filter** — plain text search over name (incl. legal first name) + email (`Person.remote_search`); dropped the redundant Search button (the `collection` controller autosubmits); Clear filters moved inline (`btn btn-utility`).
- **Type filter** capped at 20 kinds; **Active** filter (All / Active / Expired).
- **CE hours issued** — replaced the CE count with issued-certificate hour totals (`ProfessionalLicenseDecorator`), split into this-year / all-years columns (two-row headers). Each total deep-links to the CE index filtered to that license (this-year scoped to the current year).
- **Registrant name** is a hoverable link to the person profile.

**CE registrations index**
- Added a `professional_license_id` filter and an **Issued from / Issued to** date-range filter (scopes + safe ISO parsing), a "Filtered to <license>" banner, and hidden-field carry across autosubmits.

**Seeds** — license acronyms seed into `kind`, numeric part into `number`.