### PR TITLE
Replace payments time-period filter with a date range

### DIFF
--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
       if (
         type === "checkbox" ||
         type === "radio" ||
+        type === "date" ||
         type === "select-one" ||
         type === "select-multiple" ||
         type === "date"

--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -16,7 +16,6 @@ export default class extends Controller {
       if (
         type === "checkbox" ||
         type === "radio" ||
-        type === "date" ||
         type === "select-one" ||
         type === "select-multiple" ||
         type === "date"

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -2,8 +2,6 @@ class Payment < ApplicationRecord
   has_paper_trail
   PAYER_TYPES = %w[Person Organization].freeze
 
-  DEFAULT_DATE_RANGE = 1.month
-
   has_many :allocations, as: :source
   has_many :refunds, as: :refundable
   belongs_to :person, optional: true
@@ -53,14 +51,8 @@ class Payment < ApplicationRecord
     results = results.matching_search(params[:search]) if params[:search].present?
     results = results.where("amount_cents >= ?", (params[:amount_min].to_d * 100).to_i) if params[:amount_min].present?
     results = results.where("amount_cents <= ?", (params[:amount_max].to_d * 100).to_i) if params[:amount_max].present?
-    start_date = parse_date(params[:start_date]) || default_start_date
-    end_date = parse_date(params[:end_date]) || Date.current
-    results = results.created_between(start_date, end_date)
+    results = results.created_between(parse_date(params[:start_date]), parse_date(params[:end_date]))
     results
-  end
-
-  def self.default_start_date
-    DEFAULT_DATE_RANGE.ago.to_date
   end
 
   def self.parse_date(value)

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -2,14 +2,7 @@ class Payment < ApplicationRecord
   has_paper_trail
   PAYER_TYPES = %w[Person Organization].freeze
 
-  PERIOD_OPTIONS = {
-    "Past day" => "past_day",
-    "Past week" => "past_week",
-    "Past month" => "past_month",
-    "Past year" => "past_year",
-    "All time" => "all_time"
-  }.freeze
-  DEFAULT_PERIOD = "past_month".freeze
+  DEFAULT_DATE_RANGE = 1.month
 
   has_many :allocations, as: :source
   has_many :refunds, as: :refundable
@@ -43,14 +36,11 @@ class Payment < ApplicationRecord
     when "no" then where("amount_cents_remaining = 0")
     end
   }
-  scope :in_period, ->(period) {
-    window = case period
-    when "past_day" then 1.day.ago
-    when "past_week" then 1.week.ago
-    when "past_month" then 1.month.ago
-    when "past_year" then 1.year.ago
-    end
-    where(created_at: window..) if window
+  scope :created_between, ->(start_date, end_date) {
+    scope = all
+    scope = scope.where(created_at: start_date.beginning_of_day..) if start_date
+    scope = scope.where(created_at: ..end_date.end_of_day) if end_date
+    scope
   }
 
   def self.search_by_params(params)
@@ -63,8 +53,21 @@ class Payment < ApplicationRecord
     results = results.matching_search(params[:search]) if params[:search].present?
     results = results.where("amount_cents >= ?", (params[:amount_min].to_d * 100).to_i) if params[:amount_min].present?
     results = results.where("amount_cents <= ?", (params[:amount_max].to_d * 100).to_i) if params[:amount_max].present?
-    results = results.in_period(params[:period].presence || DEFAULT_PERIOD)
+    start_date = parse_date(params[:start_date]) || default_start_date
+    end_date = parse_date(params[:end_date]) || Date.current
+    results = results.created_between(start_date, end_date)
     results
+  end
+
+  def self.default_start_date
+    DEFAULT_DATE_RANGE.ago.to_date
+  end
+
+  def self.parse_date(value)
+    return if value.blank?
+    Date.parse(value)
+  rescue ArgumentError, TypeError
+    nil
   end
 
   # Free-text search across the JSON metadata blob and the Stripe charge id.

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -17,7 +17,7 @@
       collection_selected_class: selected_btn
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
-      <div class="md:col-span-3">
+      <div class="md:col-span-2">
         <label for="person_id" class="<%= label_class %>">Person</label>
 
         <%= select_tag "person_id",
@@ -31,7 +31,7 @@
           prompt: "Search for a person" %>
       </div>
 
-      <div class="md:col-span-3">
+      <div class="md:col-span-2">
         <label for="organization_id" class="<%= label_class %>">Organization</label>
 
         <%= select_tag "organization_id",
@@ -45,7 +45,7 @@
           prompt: "Search for an organization" %>
       </div>
 
-      <div class="md:col-span-4">
+      <div class="md:col-span-3">
         <label for="search" class="<%= label_class %>">Search metadata / Stripe charge ID</label>
 
         <%= text_field_tag "search", params[:search],
@@ -58,30 +58,6 @@
 
         <%= select_tag "type[]",
           options_for_select({ "All" => "", "Cash" => "CashPayment", "Check" => "CheckPayment", "Stripe" => "ExternalProcessorPayment" }, Array(params[:type]).first),
-          class: placeholder_select_class %>
-      </div>
-
-      <div class="md:col-span-2">
-        <label for="amount_min" class="<%= label_class %>">Min amount ($)</label>
-
-        <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
-          placeholder: "Min",
-          class: field_class %>
-      </div>
-
-      <div class="md:col-span-2">
-        <label for="amount_max" class="<%= label_class %>">Max amount ($)</label>
-
-        <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
-          placeholder: "Max",
-          class: field_class %>
-      </div>
-
-      <div class="md:col-span-3">
-        <label for="has_remaining" class="<%= label_class %>">Amount remaining</label>
-
-        <%= select_tag "has_remaining",
-          options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),
           class: placeholder_select_class %>
       </div>
 
@@ -108,7 +84,31 @@
           class: field_class %>
       </div>
 
-      <div class="md:col-span-12 flex gap-2 justify-end"><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
+      <div class="md:col-span-2">
+        <label for="amount_min" class="<%= label_class %>">Min amount ($)</label>
+
+        <%= number_field_tag "amount_min", params[:amount_min], min: 0, step: "0.01",
+          placeholder: "Min",
+          class: field_class %>
+      </div>
+
+      <div class="md:col-span-2">
+        <label for="amount_max" class="<%= label_class %>">Max amount ($)</label>
+
+        <%= number_field_tag "amount_max", params[:amount_max], min: 0, step: "0.01",
+          placeholder: "Max",
+          class: field_class %>
+      </div>
+
+      <div class="md:col-span-2">
+        <label for="has_remaining" class="<%= label_class %>">Amount remaining</label>
+
+        <%= select_tag "has_remaining",
+          options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),
+          class: placeholder_select_class %>
+      </div>
+
+      <div class="md:col-span-2 flex items-end justify-end"><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
     </div>
   <% end %>
 </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -71,14 +71,14 @@
       </div>
 
       <div class="md:col-span-2">
-        <label for="start_date" class="<%= label_class %>">Start date</label>
+        <label for="start_date" class="<%= label_class %>">Created from</label>
 
         <%= date_field_tag "start_date", params[:start_date].presence || Payment.default_start_date.to_s,
           class: field_class %>
       </div>
 
       <div class="md:col-span-2">
-        <label for="end_date" class="<%= label_class %>">End date</label>
+        <label for="end_date" class="<%= label_class %>">Created to</label>
 
         <%= date_field_tag "end_date", params[:end_date].presence || Date.current.to_s,
           class: field_class %>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -95,10 +95,16 @@
       </div>
 
       <div class="md:col-span-2">
-        <label for="period" class="<%= label_class %>">Time period</label>
+        <label for="start_date" class="<%= label_class %>">Start date</label>
 
-        <%= select_tag "period",
-          options_for_select(Payment::PERIOD_OPTIONS, params[:period].presence || Payment::DEFAULT_PERIOD),
+        <%= date_field_tag "start_date", params[:start_date].presence || Payment.default_start_date.to_s,
+          class: field_class %>
+      </div>
+
+      <div class="md:col-span-2">
+        <label for="end_date" class="<%= label_class %>">End date</label>
+
+        <%= date_field_tag "end_date", params[:end_date].presence || Date.current.to_s,
           class: field_class %>
       </div>
 

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -45,7 +45,7 @@
           prompt: "Search for an organization" %>
       </div>
 
-      <div class="md:col-span-3">
+      <div class="md:col-span-4">
         <label for="search" class="<%= label_class %>">Search metadata / Stripe charge ID</label>
 
         <%= text_field_tag "search", params[:search],
@@ -61,7 +61,7 @@
           class: placeholder_select_class %>
       </div>
 
-      <div class="md:col-span-3">
+      <div class="md:col-span-2">
         <label for="payer_type" class="<%= label_class %>">Payer type</label>
 
         <%= select_tag "payer_type",
@@ -108,7 +108,11 @@
           class: placeholder_select_class %>
       </div>
 
-      <div class="md:col-span-2 flex items-end justify-end"><%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %></div>
+      <div class="md:col-span-2 flex flex-col">
+        <span class="<%= label_class %>" aria-hidden="true">&nbsp;</span>
+
+        <%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline flex-1 w-full justify-center", data: { action: "collection#clearAndSubmit" } %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -73,14 +73,14 @@
       <div class="md:col-span-2">
         <label for="start_date" class="<%= label_class %>">Created from</label>
 
-        <%= date_field_tag "start_date", params[:start_date].presence || Payment.default_start_date.to_s,
+        <%= date_field_tag "start_date", params[:start_date],
           class: field_class %>
       </div>
 
       <div class="md:col-span-2">
         <label for="end_date" class="<%= label_class %>">Created to</label>
 
-        <%= date_field_tag "end_date", params[:end_date].presence || Date.current.to_s,
+        <%= date_field_tag "end_date", params[:end_date],
           class: field_class %>
       </div>
 

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -101,7 +101,7 @@
       </div>
 
       <div class="md:col-span-2">
-        <label for="has_remaining" class="<%= label_class %>">Amount remaining</label>
+        <label for="has_remaining" class="<%= label_class %>">Has unallocated</label>
 
         <%= select_tag "has_remaining",
           options_for_select({ "All" => "all", "Yes" => "yes", "No" => "no" }, params[:has_remaining] || "all"),

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1546,6 +1546,9 @@ if facilitator_training && registration_form
   # Demo 10: a registrant with more than one registration-form submission, each
   # naming a different org we don't have — exercises the per-submission "View
   # submission #N" links and one "Create and link" row per distinct submitted org.
+  # Each submission also carries a fake Stripe (ExternalProcessorPayment) so the
+  # payments index has Stripe rows to exercise its payment-method filter and
+  # metadata / charge-id search.
   if agency_field
     demo_multi = Person.create!(
       email: "orgchip.demo.10@seed.example.com",
@@ -1555,9 +1558,28 @@ if facilitator_training && registration_form
     EventRegistration.find_or_create_by!(event: facilitator_training, registrant: demo_multi) do |reg|
       reg.status = "registered"
     end
+    card_amount_cents = facilitator_training.cost_cents.to_i
+    card_amount_cents = 15_000 if card_amount_cents <= 0
     [ "Greenfield Survivor Services", "Harbor Light Counseling" ].each do |org_name|
       submission = FormSubmission.create!(person: demo_multi, form: registration_form, event: facilitator_training, role: "registration")
       submission.form_answers.create!(form_field: agency_field, submitted_answer: org_name, question_name_when_answered: agency_field.name)
+
+      stripe_payment = ExternalProcessorPayment.new(
+        person: demo_multi,
+        form_submission: submission,
+        amount_cents: card_amount_cents,
+        amount_cents_remaining: card_amount_cents,
+        currency: "usd",
+        external_origin: false,
+        stripe_charge_id: "ch_seed_reg_#{submission.id}",
+        metadata: {
+          "form_submission_id" => submission.id,
+          "event_id" => facilitator_training.id,
+          "organization_name" => org_name
+        }
+      )
+      stripe_payment.skip_pay_charge_validation = true
+      stripe_payment.save!
     end
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Payment, type: :model do
         end
       end
 
-      describe "time period" do
+      describe "date range" do
         let!(:recent) { create(:payment, created_at: 2.days.ago) }
         let!(:old) { create(:payment, created_at: 2.months.ago) }
 
@@ -253,18 +253,25 @@ RSpec.describe Payment, type: :model do
           expect(result).not_to include(old)
         end
 
-        it "honors an explicit period window" do
-          result = Payment.search_by_params({ period: "past_year" })
+        it "honors an explicit start date" do
+          result = Payment.search_by_params({ start_date: 3.months.ago.to_date.to_s })
           expect(result).to include(recent, old)
         end
 
-        it "returns the full history for all_time" do
-          result = Payment.search_by_params({ period: "all_time" })
-          expect(result).to include(recent, old)
+        it "honors an explicit end date" do
+          result = Payment.search_by_params({ start_date: 3.months.ago.to_date.to_s, end_date: 1.month.ago.to_date.to_s })
+          expect(result).to include(old)
+          expect(result).not_to include(recent)
         end
 
-        it "falls back to the default when period is blank" do
-          result = Payment.search_by_params({ period: "" })
+        it "falls back to the default start date when blank" do
+          result = Payment.search_by_params({ start_date: "", end_date: "" })
+          expect(result).to include(recent)
+          expect(result).not_to include(old)
+        end
+
+        it "ignores an unparseable date" do
+          result = Payment.search_by_params({ start_date: "not-a-date" })
           expect(result).to include(recent)
           expect(result).not_to include(old)
         end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -247,15 +247,15 @@ RSpec.describe Payment, type: :model do
         let!(:recent) { create(:payment, created_at: 2.days.ago) }
         let!(:old) { create(:payment, created_at: 2.months.ago) }
 
-        it "defaults to the past month, excluding older payments" do
+        it "returns all payments when no dates are given" do
           result = Payment.search_by_params({})
-          expect(result).to include(recent)
-          expect(result).not_to include(old)
+          expect(result).to include(recent, old)
         end
 
         it "honors an explicit start date" do
-          result = Payment.search_by_params({ start_date: 3.months.ago.to_date.to_s })
-          expect(result).to include(recent, old)
+          result = Payment.search_by_params({ start_date: 1.month.ago.to_date.to_s })
+          expect(result).to include(recent)
+          expect(result).not_to include(old)
         end
 
         it "honors an explicit end date" do
@@ -264,16 +264,14 @@ RSpec.describe Payment, type: :model do
           expect(result).not_to include(recent)
         end
 
-        it "falls back to the default start date when blank" do
+        it "returns all payments when the dates are blank" do
           result = Payment.search_by_params({ start_date: "", end_date: "" })
-          expect(result).to include(recent)
-          expect(result).not_to include(old)
+          expect(result).to include(recent, old)
         end
 
         it "ignores an unparseable date" do
           result = Payment.search_by_params({ start_date: "not-a-date" })
-          expect(result).to include(recent)
-          expect(result).not_to include(old)
+          expect(result).to include(recent, old)
         end
       end
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained filter-logic + view/JS/seed changes on the payments index

### What is the goal of this PR and why is this important?
The payments index "Time period" dropdown couldn't express an arbitrary window (e.g. one specific month). Replaces it with explicit **Created from** / **Created to** date fields and tidies the filter layout.

### How did you approach the change?
- Swapped the `period` select for two date fields; `search_by_params` now filters on `start_date`/`end_date` via a `created_between` scope. Both are optional — blank means unbounded (no default range).
- Reflowed the filter form into two aligned 12-col rows, relabeled "Amount remaining" → **Has unallocated**, and made the Clear filters button sit evenly with the inputs.
- Taught the `collection` Stimulus controller to auto-submit on date-input `change`, like the other filters.
- Seeded two fake Stripe (`ExternalProcessorPayment`) rows on the multi-submission org demo so the Stripe filter / charge-id search have data.

### Anything else to add?
Labels chosen for non-technical users ("from/to", "Created").
