### PR TITLE
Show story images as a hero-first carousel

### DIFF
--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -56,7 +56,7 @@
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
         <div id="hero-image">
-          <%= render "assets/display_assets", resource: @story, link: true %>
+          <%= render "assets/display_assets_carousel", resource: @story %>
         </div>
 
         <!-- Story Body Text -->

--- a/app/views/story_shares/show.html.erb
+++ b/app/views/story_shares/show.html.erb
@@ -44,12 +44,8 @@
 
       <%= render "tag_chips", story: @story %>
 
-      <!-- Story image -->
-      <% if @story.primary_asset&.file&.attached? || @story.gallery_assets.any? %>
-        <div class="mb-8 rounded-lg overflow-hidden bg-black">
-          <%= image_tag @story.display_image, alt: @story.title, class: "w-full h-auto" %>
-        </div>
-      <% end %>
+      <!-- Story images -->
+      <%= render "assets/display_assets_carousel", resource: @story %>
 
       <!-- Body -->
       <div class="prose prose-lg max-w-none text-gray-700 mb-10">
@@ -61,13 +57,6 @@
         <div class="aspect-video mb-10">
           <iframe src="<%= embed_url %>" class="w-full h-full rounded-lg"
                   title="<%= @story.title %> video" allowfullscreen loading="lazy"></iframe>
-        </div>
-      <% end %>
-
-      <!-- Additional artwork gallery -->
-      <% if @story.assets.count > 1 %>
-        <div class="mb-10">
-          <%= render "assets/display_assets", resource: @story, link: true %>
         </div>
       <% end %>
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only swap to a shared carousel partial, no logic or data changes

### What is the goal of this PR and why is this important?
Both the public story share page and the internal story show page rendered the hero image, then the body text, then the primary asset again alongside the gallery — showing the hero twice. This makes all of a story's images read as one gallery instead of a duplicated hero.

### How did you approach the change?
Replaced the direct hero render and the separate `display_assets` gallery on both pages with the existing `assets/_display_assets_carousel` partial, which builds a single hero-first carousel (primary + gallery) wired to the Swiper `carousel` controller. The `#hero-image` wrapper is kept on the internal page so the upload blur/fade in `asset_picker_controller.js` still works.

### UI Testing Checklist
- [ ] Story share page (`/story_shares/:id`) shows one carousel starting with the hero; body text appears once
- [ ] Internal story page (`/stories/:id`) shows the same carousel; prev/next arrows appear only with multiple images
- [ ] Single-image and no-image stories render cleanly
- [ ] Uploading a new primary image on the internal page still blurs/fades the hero region

### Anything else to add?
View-only. Existing story view + share request specs pass.
