### PR TITLE
Overlay story Change photo button + admin tint

### DIFF
--- a/app/views/assets/_primary_image_picker.html.erb
+++ b/app/views/assets/_primary_image_picker.html.erb
@@ -11,6 +11,6 @@
 
     <%= hidden_field_tag :owner_sgid, owner.to_sgid.to_s, autocomplete: "off" %>
 
-    <button data-action="asset-picker#openFileDialog" type="button" class="hidden md:flex bg-white text-gray-700 rounded-full p-2 shadow hover:bg-gray-100 transition items-center"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change photo</span></button>
+    <button data-action="asset-picker#openFileDialog" type="button" class="admin-only hidden md:flex bg-blue-100 text-gray-700 rounded-full p-2 shadow hover:bg-blue-200 transition items-center"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change photo</span></button>
   <% end %>
 <% end %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -49,14 +49,14 @@
           <% end %>
         </div>
 
-        <div class="flex justify-end">
-          <%= render "assets/primary_image_picker", owner: @story %>
-        </div>
         <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
-        <div id="hero-image">
+        <div id="hero-image" class="relative max-w-2xl mx-auto">
           <%= render "assets/display_assets_carousel", resource: @story %>
+          <div class="absolute top-8 right-2 z-40">
+            <%= render "assets/primary_image_picker", owner: @story %>
+          </div>
         </div>
 
         <!-- Story Body Text -->


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup — overlay placement + a Tailwind class swap on a shared partial, no logic or data changes

## Why
The admin-only "Change photo" picker sat in its own flow block above the story hero, reserving empty vertical space at the top of the page for no non-admin benefit.

## What
- **Stories show** — overlay the picker on the hero's top-right corner instead of a flow block above it. Rebased onto main's carousel redesign: `#hero-image` is constrained to the carousel's width (`relative max-w-2xl mx-auto`) so the button lands on the image's top-right rather than floating far right, offset below the carousel's `my-6`, at `z-40` (above the carousel's prev/next controls). Still nothing rendered for non-admins.
- **Picker button** — swap `bg-white … hover:bg-gray-100` → `admin-only bg-blue-100 … hover:bg-blue-200` so it reads as an admin control, matching the Edit link convention.

## Notes
- Button lives in the shared `assets/_primary_image_picker` partial, so the **admin tint also applies to the workshop header and resource show** pages. It stays admin-only everywhere; only the story page got the overlay placement.
- Overlay button is `hidden md:flex` (unchanged) — only shows at `md`+ widths.