### PR TITLE
Harden inline-communication spec against cocoon insertion race

### DIFF
--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -283,6 +283,10 @@ RSpec.describe "Event registration edit page", type: :system do
 
       within("section", text: "Registration communications") do
         click_on "Add communication"
+        # Wait for cocoon to insert the field and the paginated-fields controller
+        # to finish its re-render before typing, so the input node isn't swapped
+        # mid-fill (which raced as a stale-node error).
+        expect(page).to have_field("Subject")
         fill_in "Subject", with: "Called about parking"
       end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 test-only wait added to a system spec, no app code

### What is the goal of this PR and why is this important?
- Removes a flaky failure in the event-registration edit system spec that surfaced intermittently in the full suite.

### How did you approach the change?
- The inline "Add communication" Subject field is inserted by cocoon as a `paginated-fields` item, whose connection re-renders the list; typing immediately raced with that re-render and failed with a stale-node error (`Node with given id does not belong to the document`).
- Added `expect(page).to have_field("Subject")` between the click and the `fill_in` so Capybara waits for the inserted, settled field before typing. Test-only — no app code changed.

### UI Testing Checklist
- [ ] N/A — spec-only change.

### Anything else to add?
- Verified passing 3/3 in isolation and green across full-file runs.