### PR TITLE
Open photo edit-form thumbnails and filenames in a new tab

### DIFF
--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -48,19 +48,23 @@
 
       <%# ---------- IMAGE ---------- %>
       <% if is_image && file.present? && file.try(:persisted?) %>
-        <%= image_tag file,
-                      id: image_dom_id,
-                      alt: "#{label}",
-                      data: { file_preview_target: "preview" },
-                      class: "w-32 h-32 object-cover border border-gray-300 shadow-sm #{rounded ? 'rounded-full' : ''}" %>
+        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer", class: "block" do %>
+          <%= image_tag file,
+                        id: image_dom_id,
+                        alt: "#{label}",
+                        data: { file_preview_target: "preview" },
+                        class: "w-32 h-32 object-cover border border-gray-300 shadow-sm #{rounded ? 'rounded-full' : ''}" %>
+        <% end %>
 
         <%# ---------- PDF PREVIEW ---------- %>
       <% elsif is_pdf && file.previewable? %>
-        <%= image_tag file.preview(resize_to_limit: [300, 300]),
-                      id: image_dom_id,
-                      alt: "#{label} PDF preview",
-                      data: { file_preview_target: "preview" },
-                      class: "w-32 h-32 object-contain border border-gray-300 shadow-sm" %>
+        <%= link_to url_for(file), target: "_blank", rel: "noopener noreferrer", class: "block" do %>
+          <%= image_tag file.preview(resize_to_limit: [300, 300]),
+                        id: image_dom_id,
+                        alt: "#{label} PDF preview",
+                        data: { file_preview_target: "preview" },
+                        class: "w-32 h-32 object-contain border border-gray-300 shadow-sm" %>
+        <% end %>
 
         <%# ---------- PLACEHOLDER ---------- %>
       <% else %>
@@ -80,7 +84,7 @@
       <div data-file-preview-target="filename"
            class="text-center text-sm text-gray-500 break-all max-w-[8rem]">
         <%= if blob.present? && blob.respond_to?(:persisted?) && blob.persisted?
-              link_to(blob.filename.to_s, url_for(file), class: "underline")
+              link_to(blob.filename.to_s, url_for(file), class: "underline", target: "_blank", rel: "noopener noreferrer")
             else
               "No file selected"
             end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup in one shared partial, no logic/backend changes

## What
- On photo **edit** forms, clicking an attached image's **thumbnail** (or PDF preview, or filename caption) now opens the full file in a **new tab**.

## Why
- The thumbnail wasn't clickable at all, and the filename link opened in the **same tab** — navigating the user off the edit form and discarding unsaved changes.

## Scope
- Single shared partial (`shared/_form_image_field.html.erb`), so every photo form gets it: stories, story ideas, workshops, grants, resources, video recordings, community news, events, org logos, avatars.
- Empty placeholder (no file yet) stays non-clickable; `file-preview` Stimulus behavior untouched.