### PR TITLE
Overlay workshop "Change photo" on the hero image

### DIFF
--- a/app/views/workshops/_show_header.html.erb
+++ b/app/views/workshops/_show_header.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full aspect-[3/2] sm:aspect-[21/9] lg:aspect-[24/9] overflow-hidden rounded-xl print:hidden">
+<div class="relative w-full aspect-[3/2] sm:aspect-[21/9] lg:aspect-[24/9] overflow-hidden rounded-xl print:hidden">
   <!-- Background image -->
   <div id="hero-image"><%= render "assets/display_image",
                 resource: workshop,
@@ -7,20 +7,20 @@
                 link_to_object: false,
                 file: workshop.display_image,
                 variant: :hero %></div>
+  <div class="absolute top-8 right-2 z-40">
+    <%= render "assets/primary_image_picker", owner: workshop %>
+  </div>
 </div>
 <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
   <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
 </div>
 <!-- Title + meta -->
-<div class="flex justify-between px-8 py-4 my-2 border-md bg-primary rounded-xl">
-  <div>
-    <h1 class="text-3xl md:text-4xl font-bold text-white">
-      <%= workshop.title %>
-      <% unless workshop.published %>
-        <span class="text-red-300 text-lg">(Unpublished)</span>
-      <% end %>
-    </h1>
-    <div class="flex flex-wrap gap-4 text-sm text-gray-200 mt-3"><span>Author: <%= credited_author_link(workshop, class: "hover:underline") %></span><span>Category: <%= workshop.windows_type&.short_name %></span><span>Added: <%= workshop.date %></span></div>
-  </div>
-  <%= render "assets/primary_image_picker", owner: workshop %>
+<div class="px-8 py-4 my-2 border-md bg-primary rounded-xl">
+  <h1 class="text-3xl md:text-4xl font-bold text-white">
+    <%= workshop.title %>
+    <% unless workshop.published %>
+      <span class="text-red-300 text-lg">(Unpublished)</span>
+    <% end %>
+  </h1>
+  <div class="flex flex-wrap gap-4 text-sm text-gray-200 mt-3"><span>Author: <%= credited_author_link(workshop, class: "hover:underline") %></span><span>Category: <%= workshop.windows_type&.short_name %></span><span>Added: <%= workshop.date %></span></div>
 </div>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup move, no logic or data changes

## What & why

- Overlay the workshop "Change photo" picker on the hero image (top-right) instead of inside the `bg-primary` title banner, so it matches the story show page.
- On the dark banner the light `bg-blue-100` pill read as a plain white button; overlaying it on the image keeps admin controls consistent across show pages.

Same `assets/_primary_image_picker` partial as before — only its placement changed (added `relative` to the hero wrapper + an `absolute` overlay; simplified the banner to just title/meta).
