### PR TITLE
Make story carousels full width and clarify primary-photo picker

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -69,6 +69,10 @@ class Asset < ApplicationRecord
       resize_to_limit: [ 256, 256 ],
       format: :webp,
       saver: { quality: 80 }
+    attachable.variant :card,
+      resize_to_limit: [ 1200, 1200 ],
+      format: :webp,
+      saver: { quality: 80 }
   end
   validate :file_type
 

--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -89,11 +89,17 @@ class DisplayImagePresenter
       resolve_previewable
     elsif @variant == :hero
       @file
+    elsif large_display?
+      @file.variant(:card)
     elsif use_thumbnail?
       @file.variant(:thumbnail)
     else
       @file
     end
+  end
+
+  def large_display?
+    @width == "full" && @file.variable?
   end
 
   def resolve_previewable

--- a/app/views/assets/_display_assets_carousel.html.erb
+++ b/app/views/assets/_display_assets_carousel.html.erb
@@ -7,7 +7,7 @@
 %>
 <% if assets.any? %>
   <div data-controller="carousel"
-       class="relative swiper my-6 max-w-2xl mx-auto"
+       class="relative swiper my-6 w-full"
        data-carousel-options-value='{ "loop": false, "spaceBetween": 16, "slidesPerView": 1, "breakpoints": {} }'>
     <div class="swiper-wrapper">
       <% assets.each_with_index do |asset, idx| %>

--- a/app/views/assets/_primary_image_picker.html.erb
+++ b/app/views/assets/_primary_image_picker.html.erb
@@ -11,6 +11,6 @@
 
     <%= hidden_field_tag :owner_sgid, owner.to_sgid.to_s, autocomplete: "off" %>
 
-    <button data-action="asset-picker#openFileDialog" type="button" class="admin-only hidden md:flex bg-blue-100 text-gray-700 rounded-full p-2 shadow hover:bg-blue-200 transition items-center"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change photo</span></button>
+    <button data-action="asset-picker#openFileDialog" type="button" class="admin-only hidden md:flex bg-blue-100 text-gray-700 rounded-full p-2 shadow hover:bg-blue-200 transition items-center"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change primary photo</span></button>
   <% end %>
 <% end %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -52,7 +52,7 @@
         <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
-        <div id="hero-image" class="relative max-w-2xl mx-auto">
+        <div id="hero-image" class="relative">
           <%= render "assets/display_assets_carousel", resource: @story %>
           <div class="absolute top-8 right-2 z-40">
             <%= render "assets/primary_image_picker", owner: @story %>

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe DisplayImagePresenter do
         expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
       end
 
+      it "uses the larger card variant for a full-width display" do
+        result = described_class.call(file: file, variant: :index, width: "full", height: "full", view_context: view_context)
+        expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
+        expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 1200, 1200 ])
+      end
+
       it "builds alt text with filename" do
         result = described_class.call(file: file, idx: 0, item_type: "Main", view_context: view_context)
         expect(result.alt_text).to include("missing.png")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, guarded logic change (new image variant used only for full-width displays) plus view/copy tweaks

### What is the goal of this PR and why is this important?
The story and story-share carousels were capped at `max-w-2xl`, so the image looked small on wide layouts. This lets them fill their container while staying crisp, and makes the admin photo picker read correctly across carousel slides.

### How did you approach the change?
Dropped the `max-w-2xl` cap so the carousel is full width, and added a 1200px `:card` Active Storage variant that the presenter serves for full-width displays (`width: "full"`) instead of upscaling the 256px thumbnail — small index thumbnails are unchanged. Relabeled the overlay button "Change primary photo" since it always sets the primary image, not whichever slide is showing.

### UI Testing Checklist
- [ ] Story page (`stories/show`) carousel spans the card full width and the image stays sharp
- [ ] Story-share page (`story_shares/show`) carousel fills its column
- [ ] Admin "Change primary photo" button still opens the file dialog and updates the primary image

### Anything else to add?
The carousel partial is shared, so the workshop-variation show page also becomes full width.