### PR TITLE
Auto-filtering activities index: person search + hyphen event search

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -5,6 +5,12 @@ module Admin
     def index
       authorize! :ahoy_activity, to: :index?
 
+      @person = Person.find_by(id: params[:person_id]) if params[:person_id].present?
+
+      # The full page renders only the header, filters, and an empty results frame;
+      # the frame's src request (turbo_frame_request?) loads the filtered rows.
+      return render :index unless turbo_frame_request?
+
       @users = params[:user_id].present? ? User.where(id: params[:user_id].to_s.split("--")) : nil
 
       page = params[:page].presence&.to_i || 1
@@ -23,9 +29,13 @@ module Admin
                             *prefixes.map { |p| "#{p}.%" })
       end
 
-      # Filter by event name
+      # Filter by event name. Split on any non-alphanumeric run so hyphens (and
+      # commas, dots, spaces) are interchangeable separators and each token must
+      # match — e.g. "account-auth" finds "auth.account_deactivated".
       if params[:event_name].present?
-        scope = scope.where("ahoy_events.name LIKE ?", "%#{Ahoy::Event.sanitize_sql_like(params[:event_name])}%")
+        params[:event_name].split(/[^a-z0-9]+/i).reject(&:blank?).each do |token|
+          scope = scope.where("ahoy_events.name LIKE ?", "%#{Ahoy::Event.sanitize_sql_like(token)}%")
+        end
       end
 
       # Filter by user (if viewing specific user activity)
@@ -72,30 +82,28 @@ module Admin
 
       # Filter to a person's full history: the person, their user, and every
       # associated record (see Analytics::PersonActivityEvents).
-      if params[:person_id].present?
-        person = Person.find_by(id: params[:person_id])
-        if person
-          @person = person
-          scope = scope.where(id: Analytics::PersonActivityEvents.new(person).relation.select(:id))
-          # Notifications aren't ahoy-tracked, so surface the person's
-          # communications straight from the notifications table.
-          email = person.communications_email
-          @person_communications = email.present? ?
-            Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc).limit(10) :
-            Notification.none
+      if @person
+        scope = scope.where(id: Analytics::PersonActivityEvents.new(@person).relation.select(:id))
+        # Notifications aren't ahoy-tracked, so surface the person's
+        # communications straight from the notifications table.
+        email = @person.communications_email
+        @person_communications = email.present? ?
+          Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc).limit(10) :
+          Notification.none
 
-          # Attendance sign-ins happen on a login-free public callout (no Current),
-          # so they aren't ahoy-tracked either — read the entries directly.
-          @person_time_entries = EventAttendanceTimeEntry
-            .where(event_registration_id: person.event_registrations.select(:id))
-            .includes(event_registration: :event)
-            .order(signed_in_at: :desc)
-            .limit(15)
-            .decorate
-        end
+        # Attendance sign-ins happen on a login-free public callout (no Current),
+        # so they aren't ahoy-tracked either — read the entries directly.
+        @person_time_entries = EventAttendanceTimeEntry
+          .where(event_registration_id: @person.event_registrations.select(:id))
+          .includes(event_registration: :event)
+          .order(signed_in_at: :desc)
+          .limit(15)
+          .decorate
       end
 
       @events = scope.paginate(page: page, per_page: per_page)
+
+      render :activity_results
     end
 
     def show

--- a/app/frontend/javascript/controllers/collection_controller.js
+++ b/app/frontend/javascript/controllers/collection_controller.js
@@ -17,7 +17,8 @@ export default class extends Controller {
         type === "checkbox" ||
         type === "radio" ||
         type === "select-one" ||
-        type === "select-multiple"
+        type === "select-multiple" ||
+        type === "date"
       ) {
         this.submitForm();
       }

--- a/app/views/admin/ahoy_activities/_count.html.erb
+++ b/app/views/admin/ahoy_activities/_count.html.erb
@@ -1,0 +1,4 @@
+<%# Rendered in the page header and replaced via turbo_stream from the results
+    view when the frame loads, so the total reflects the active filters. @events
+    is nil on the initial full-page render (the frame fills it in moments later). %>
+<span id="activities_count" class="text-sm text-gray-500 leading-none"><%= @events&.total_entries %> total</span>

--- a/app/views/admin/ahoy_activities/_count.html.erb
+++ b/app/views/admin/ahoy_activities/_count.html.erb
@@ -1,4 +1,4 @@
 <%# Rendered in the page header and replaced via turbo_stream from the results
     view when the frame loads, so the total reflects the active filters. @events
     is nil on the initial full-page render (the frame fills it in moments later). %>
-<span id="activities_count" class="text-sm text-gray-500 leading-none"><%= @events&.total_entries %> total</span>
+<span id="activities_count" class="text-sm leading-none text-gray-500"><%= @events&.total_entries %> total</span>

--- a/app/views/admin/ahoy_activities/_results_skeleton.html.erb
+++ b/app/views/admin/ahoy_activities/_results_skeleton.html.erb
@@ -1,0 +1,21 @@
+<%# Placeholder shown while the activity_results frame loads its filtered rows. %>
+<div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-x-auto">
+  <table class="min-w-full border-collapse">
+    <thead>
+      <tr class="border-b border-gray-200 bg-gray-50 animate-pulse">
+        <% 6.times do %>
+          <th class="px-4 py-3"><div class="h-3 w-16 rounded bg-gray-200"></div></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      <% 8.times do %>
+        <tr class="animate-pulse">
+          <% 6.times do %>
+            <td class="px-4 py-3.5"><div class="h-4 w-20 rounded bg-gray-100"></div></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/ahoy_activities/_results_skeleton.html.erb
+++ b/app/views/admin/ahoy_activities/_results_skeleton.html.erb
@@ -1,8 +1,8 @@
 <%# Placeholder shown while the activity_results frame loads its filtered rows. %>
-<div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-x-auto">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full border-collapse">
     <thead>
-      <tr class="border-b border-gray-200 bg-gray-50 animate-pulse">
+      <tr class="animate-pulse border-b border-gray-200 bg-gray-50">
         <% 6.times do %>
           <th class="px-4 py-3"><div class="h-3 w-16 rounded bg-gray-200"></div></th>
         <% end %>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -1,0 +1,152 @@
+<%# Frame response for the activity_results turbo frame: the index controller
+    renders this (instead of the full index) on turbo_frame_request?. %>
+<%= turbo_frame_tag :activity_results do %>
+  <%= turbo_stream.replace "activities_count", partial: "count" %>
+
+  <%# Person-scoped view: notifications aren't ahoy events, so list the
+      person's communications here from the notifications table. %>
+  <% if @person && @person_communications.present? %>
+    <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
+          <i class="fa-solid fa-bell"></i>
+        </span>
+        <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
+        <%= link_to "View all",
+                    notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
+                    class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                    target: "_blank", rel: "noopener" %>
+      </div>
+      <div class="space-y-2 p-4">
+        <% @person_communications.each do |notification| %>
+          <%= render "notifications/notification_row", notification: notification, admin: true %>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
+  <%# Attendance sign-ins aren't ahoy-tracked (login-free public callout), so
+      list the entries directly, newest first. %>
+  <% if @person && @person_time_entries.present? %>
+    <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
+          <i class="fa-solid fa-clock"></i>
+        </span>
+        <h2 class="text-sm font-semibold text-gray-700">Attendance time entries</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
+          <tr>
+            <th class="px-4 py-2 text-left">Event</th>
+            <th class="px-4 py-2 text-left">Date</th>
+            <th class="px-4 py-2 text-left">In</th>
+            <th class="px-4 py-2 text-left">Out</th>
+            <th class="px-4 py-2 text-left">Duration</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <% @person_time_entries.each do |entry| %>
+            <tr>
+              <td class="px-4 py-2 text-gray-900"><%= entry.event_registration.event.title %></td>
+              <td class="px-4 py-2 text-gray-500"><%= entry.attendance_date&.strftime("%b %-d, %Y") %></td>
+              <td class="px-4 py-2 text-gray-500"><%= entry.signed_in_label %></td>
+              <td class="px-4 py-2 text-gray-500"><%= entry.signed_out_label %></td>
+              <td class="px-4 py-2 text-gray-500"><%= entry.duration_label %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  <% end %>
+
+  <!-- Activities Table -->
+  <div class="blur-on-submit bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
+    <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
+      <thead class="bg-gray-50 text-gray-600 uppercase tracking-wider text-xs">
+      <tr>
+        <th class="px-4 py-3 text-left rounded-tl-xl">Time</th>
+        <th class="px-4 py-3 text-left">Activity</th>
+        <th class="px-4 py-3 text-left">Resource</th>
+        <th class="px-4 py-3 text-left">User</th>
+        <th class="px-4 py-3 text-left">Visit ID</th>
+        <th class="px-4 py-3 text-left rounded-tr-xl">Properties</th>
+      </tr>
+      </thead>
+
+      <tbody class="divide-y divide-gray-100">
+      <% @events.each do |event| %>
+        <tr class="hover:bg-gray-50 transition">
+          <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
+            <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
+          </td>
+
+          <td data-label="Activity" class="px-4 py-3 font-medium text-gray-900">
+            <%= event.name %>
+          </td>
+
+          <td data-label="Resource" class="px-4 py-3 text-gray-500">
+            <%= event.properties["resource_title"].presence || "—" %>
+          </td>
+
+          <td data-label="User" class="px-4 py-3 text-gray-600">
+            <% if event.user %>
+              <%= link_to event.user.full_name,
+                          user_path(event.user),
+                          class: "text-indigo-600 hover:underline" %>
+            <% else %>
+              <span class="text-gray-400 italic">Guest</span>
+            <% end %>
+          </td>
+
+          <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
+            <%= event.visit_id %>
+          </td>
+
+          <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
+            <% if event.properties.present? && event.properties.any? %>
+              <%= link_to admin_activities_event_path(event),
+                          class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
+                <%= event.properties.size %> <%= "prop".pluralize(event.properties.size) %>
+              <% end %>
+              <%
+                props = event.properties.dup
+                display_props = []
+                # Combine polymorphic _type/_id pairs
+                props.keys.select { |k| k.end_with?("_type") }.each do |type_key|
+                  prefix = type_key.chomp("_type")
+                  id_key = "#{prefix}_id"
+                  if props.key?(id_key)
+                    display_props << [prefix, "#{props[type_key]}.find(#{props[id_key]})"]
+                    props.delete(type_key)
+                    props.delete(id_key)
+                  end
+                end
+                # Show resource_title first, then remaining props
+                if props.key?("resource_title")
+                  display_props.unshift(["resource_title", props.delete("resource_title")])
+                end
+                props.each do |key, value|
+                  display_props << [key, value.is_a?(Hash) ? value.to_json : value]
+                end
+              %>
+              <div class="hidden group-hover:block absolute z-50 right-0 top-full bg-gray-900 text-gray-100 text-xs rounded-lg shadow-lg px-3 py-3 max-h-64 overflow-y-auto" style="width: 400px;">
+                <% display_props.each do |key, value| %>
+                  <div class="py-1"><span class="text-indigo-300 font-semibold"><%= key %>:</span> <%= value.nil? ? "nil" : value.to_s.delete('"') %></div>
+                <% end %>
+              </div>
+            <% else %>
+              <span class="text-gray-300 italic">none</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Pagination -->
+  <div class="flex justify-center mt-8">
+    <%= tailwind_paginate @events %>
+  </div>
+<% end %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -42,7 +42,7 @@
           <div class="flex flex-wrap lg:flex-nowrap gap-4">
 
             <!-- Activity Name -->
-            <div class="flex-1 min-w-0">
+            <div class="flex-[2] min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Activity name
               </label>
@@ -52,21 +52,10 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- Visit ID -->
-            <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
-                Visit ID
-              </label>
-              <%= number_field_tag :visit_id,
-                                   params[:visit_id],
-                                   placeholder: "e.g. 42",
-                                   class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
-            </div>
-
             <!-- Props -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
-                Props
+                Properties
               </label>
               <%= text_field_tag :props,
                                  params[:props],
@@ -122,6 +111,17 @@
               <%= date_field_tag :to,
                                  params[:to],
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm" %>
+            </div>
+
+            <!-- Visit ID -->
+            <div class="flex-none w-24">
+              <label class="block text-sm font-medium text-gray-600 mb-1">
+                Visit ID
+              </label>
+              <%= number_field_tag :visit_id,
+                                   params[:visit_id],
+                                   placeholder: "e.g. 42",
+                                   class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
           </div>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -2,7 +2,8 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
 
       <div class="flex flex-wrap items-center gap-y-2 mb-2">
-        <%# Scoped to a person (from their edit page's History card) — return there, not to Admin. %>
+        <%# Scoped to a person (from their edit page's History card, or the filter) —
+            return to that person, not the generic Admin default. %>
         <% if @person %>
           <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
             <i class="fas fa-arrow-left"></i>
@@ -22,7 +23,7 @@
       <!-- Page Header -->
       <div class="flex items-baseline gap-3 mb-6 leading-none">
         <h1 class="text-2xl font-semibold text-gray-900 leading-none">Activities</h1>
-        <span class="text-sm text-gray-500 leading-none"><%= @events.count %> total</span>
+        <%= render "count" %>
       </div>
 
       <div class="mb-6 text-sm min-h-10">
@@ -31,7 +32,12 @@
 
       <!-- Filters -->
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mb-6">
-        <%= form_with url: request.path, method: :get, local: true do %>
+        <%# Selects submit on change and the text boxes debounce-submit as you type,
+            all into the activity_results frame — the filter form stays put (and
+            focused) while just the rows swap. %>
+        <%= form_with url: request.path, method: :get,
+              data: { controller: "collection", turbo_frame: "activity_results" },
+              autocomplete: "off" do %>
 
           <div class="flex flex-wrap lg:flex-nowrap gap-4">
 
@@ -42,7 +48,7 @@
               </label>
               <%= text_field_tag :event_name,
                                  params[:event_name],
-                                 placeholder: "e.g. Viewed Workshop",
+                                 placeholder: "e.g. view workshop, account-auth",
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
@@ -68,19 +74,15 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- User Filter -->
+            <!-- Person Filter -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
-                User
+                Person
               </label>
-              <%= select_tag :user_id,
-                             options_from_collection_for_select(
-                               User.where(id: Ahoy::Visit.select(:user_id).distinct).order(:first_name, :last_name),
-                               :id,
-                               :full_name,
-                               params[:user_id]
-                             ),
-                             include_blank: "All Users",
+              <%= select_tag :person_id,
+                             @person ? options_for_select([ [ @person.name, @person.id ] ], @person.id) : nil,
+                             include_blank: "All people",
+                             data: { controller: "remote-select", remote_select_model_value: "person" },
                              class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
@@ -127,7 +129,7 @@
           <!-- Quick Ranges -->
           <div class="flex items-center gap-3 mt-6 text-sm">
             <span class="text-gray-500">Quick:</span>
-            <% safe_params = params.slice(:event_name, :visit_id, :props, :user_id, :from, :to).to_unsafe_h %>
+            <% safe_params = params.slice(:event_name, :visit_id, :props, :person_id, :from, :to).to_unsafe_h %>
             <%= link_to "24h",
                         url_for(safe_params.merge(from: 1.day.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>
@@ -139,160 +141,18 @@
             <%= link_to "30d",
                         url_for(safe_params.merge(from: 30.days.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>
-          </div>
 
-          <div class="mt-6">
-            <%= submit_tag "Filter",
-                           class: "bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition" %>
+            <%= link_to "Clear filters", request.path,
+                        class: "ml-auto text-gray-500 hover:text-gray-700",
+                        data: { action: "collection#clearAndSubmit" } %>
           </div>
 
         <% end %>
       </div>
 
-      <%# Person-scoped view: notifications aren't ahoy events, so list the
-          person's communications here from the notifications table. %>
-      <% if @person && @person_communications.present? %>
-        <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-          <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
-              <i class="fa-solid fa-bell"></i>
-            </span>
-            <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
-            <%= link_to "View all",
-                        notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
-                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
-                        target: "_blank", rel: "noopener" %>
-          </div>
-          <div class="space-y-2 p-4">
-            <% @person_communications.each do |notification| %>
-              <%= render "notifications/notification_row", notification: notification, admin: true %>
-            <% end %>
-          </div>
-        </section>
+      <%# Results load in a turbo frame so the filter form (outside the frame) can
+          swap just the rows — keeping the search inputs focused as you type. %>
+      <%= turbo_frame_tag :activity_results, src: admin_activities_events_path(request.query_parameters), data: { turbo: "temporary" } do %>
+        <%= render "results_skeleton" %>
       <% end %>
-
-      <%# Attendance sign-ins aren't ahoy-tracked (login-free public callout), so
-          list the entries directly, newest first. %>
-      <% if @person && @person_time_entries.present? %>
-        <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-          <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
-              <i class="fa-solid fa-clock"></i>
-            </span>
-            <h2 class="text-sm font-semibold text-gray-700">Attendance time entries</h2>
-          </div>
-          <table class="w-full text-sm">
-            <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-500">
-              <tr>
-                <th class="px-4 py-2 text-left">Event</th>
-                <th class="px-4 py-2 text-left">Date</th>
-                <th class="px-4 py-2 text-left">In</th>
-                <th class="px-4 py-2 text-left">Out</th>
-                <th class="px-4 py-2 text-left">Duration</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100">
-              <% @person_time_entries.each do |entry| %>
-                <tr>
-                  <td class="px-4 py-2 text-gray-900"><%= entry.event_registration.event.title %></td>
-                  <td class="px-4 py-2 text-gray-500"><%= entry.attendance_date&.strftime("%b %-d, %Y") %></td>
-                  <td class="px-4 py-2 text-gray-500"><%= entry.signed_in_label %></td>
-                  <td class="px-4 py-2 text-gray-500"><%= entry.signed_out_label %></td>
-                  <td class="px-4 py-2 text-gray-500"><%= entry.duration_label %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </section>
-      <% end %>
-
-      <!-- Activities Table -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
-        <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
-          <thead class="bg-gray-50 text-gray-600 uppercase tracking-wider text-xs">
-          <tr>
-            <th class="px-4 py-3 text-left rounded-tl-xl">Time</th>
-            <th class="px-4 py-3 text-left">Activity</th>
-            <th class="px-4 py-3 text-left">Resource</th>
-            <th class="px-4 py-3 text-left">User</th>
-            <th class="px-4 py-3 text-left">Visit ID</th>
-            <th class="px-4 py-3 text-left rounded-tr-xl">Properties</th>
-          </tr>
-          </thead>
-
-          <tbody class="divide-y divide-gray-100">
-          <% @events.each do |event| %>
-            <tr class="hover:bg-gray-50 transition">
-              <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
-                <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
-              </td>
-
-              <td data-label="Activity" class="px-4 py-3 font-medium text-gray-900">
-                <%= event.name %>
-              </td>
-
-              <td data-label="Resource" class="px-4 py-3 text-gray-500">
-                <%= event.properties["resource_title"].presence || "—" %>
-              </td>
-
-              <td data-label="User" class="px-4 py-3 text-gray-600">
-                <% if event.user %>
-                  <%= link_to event.user.full_name,
-                              user_path(event.user),
-                              class: "text-indigo-600 hover:underline" %>
-                <% else %>
-                  <span class="text-gray-400 italic">Guest</span>
-                <% end %>
-              </td>
-
-              <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
-                <%= event.visit_id %>
-              </td>
-
-              <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
-                <% if event.properties.present? && event.properties.any? %>
-                  <%= link_to admin_activities_event_path(event),
-                              class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
-                    <%= event.properties.size %> <%= "prop".pluralize(event.properties.size) %>
-                  <% end %>
-                  <%
-                    props = event.properties.dup
-                    display_props = []
-                    # Combine polymorphic _type/_id pairs
-                    props.keys.select { |k| k.end_with?("_type") }.each do |type_key|
-                      prefix = type_key.chomp("_type")
-                      id_key = "#{prefix}_id"
-                      if props.key?(id_key)
-                        display_props << [prefix, "#{props[type_key]}.find(#{props[id_key]})"]
-                        props.delete(type_key)
-                        props.delete(id_key)
-                      end
-                    end
-                    # Show resource_title first, then remaining props
-                    if props.key?("resource_title")
-                      display_props.unshift(["resource_title", props.delete("resource_title")])
-                    end
-                    props.each do |key, value|
-                      display_props << [key, value.is_a?(Hash) ? value.to_json : value]
-                    end
-                  %>
-                  <div class="hidden group-hover:block absolute z-50 right-0 top-full bg-gray-900 text-gray-100 text-xs rounded-lg shadow-lg px-3 py-3 max-h-64 overflow-y-auto" style="width: 400px;">
-                    <% display_props.each do |key, value| %>
-                      <div class="py-1"><span class="text-indigo-300 font-semibold"><%= key %>:</span> <%= value.nil? ? "nil" : value.to_s.delete('"') %></div>
-                    <% end %>
-                  </div>
-                <% else %>
-                  <span class="text-gray-300 italic">none</span>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
-      </div>
-
-      <!-- Pagination -->
-      <div class="flex justify-center mt-8">
-        <%= tailwind_paginate @events %>
-      </div>
 </div>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -20,7 +20,6 @@
         </div>
       </div>
 
-      <!-- Page Header -->
       <div class="flex items-baseline gap-3 mb-6 leading-none">
         <h1 class="text-2xl font-semibold text-gray-900 leading-none">Activities</h1>
         <%= render "count" %>
@@ -30,7 +29,6 @@
         <%= render "admin/shared/active_filters_subheader" %>
       </div>
 
-      <!-- Filters -->
       <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mb-6">
         <%# Selects submit on change and the text boxes debounce-submit as you type,
             all into the activity_results frame — the filter form stays put (and
@@ -41,7 +39,6 @@
 
           <div class="flex flex-wrap lg:flex-nowrap gap-4">
 
-            <!-- Activity Name -->
             <div class="flex-[2] min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Activity name
@@ -52,7 +49,6 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- Props -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Properties
@@ -63,7 +59,6 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- Person Filter -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Person
@@ -75,12 +70,10 @@
                              class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- Audience -->
             <div class="flex-1 min-w-0">
               <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
             </div>
 
-            <!-- Time Period -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Time Period
@@ -93,7 +86,6 @@
                              class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
-            <!-- Date From -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 From
@@ -103,7 +95,6 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm" %>
             </div>
 
-            <!-- Date To -->
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 To
@@ -113,7 +104,6 @@
                                  class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm" %>
             </div>
 
-            <!-- Visit ID -->
             <div class="flex-none w-24">
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 Visit ID
@@ -126,7 +116,6 @@
 
           </div>
 
-          <!-- Quick Ranges -->
           <div class="flex items-center gap-3 mt-6 text-sm">
             <span class="text-gray-500">Quick:</span>
             <% safe_params = params.slice(:event_name, :visit_id, :props, :person_id, :from, :to).to_unsafe_h %>

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -42,7 +42,7 @@
   <% end %>
   <% if params[:props].present? %>
     <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800">
-      Props: <%= params[:props] %>
+      Properties: <%= params[:props] %>
     </span>
   <% end %>
   <% if @person.present? %>

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -17,27 +17,31 @@
   audience_values = Array(params[:audience]).reject(&:blank?).presence || default_audiences
   audience_labels = audience_values.filter_map { |v| audience_labels_map[v] }
 
-  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || @person.present?
+  # user_id supports multiple ids joined by "--" (see AhoyActivitiesController).
+  user_ids = params[:user_id].to_s.split("--").reject(&:blank?)
+  filtered_users = user_ids.any? ? User.where(id: user_ids) : User.none
+
+  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || @person.present? || filtered_users.exists?
 %>
 <div class="flex flex-wrap items-center gap-2">
-  <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Filters applied</h3>
+  <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Filters applied</h3>
   <% if time_label %>
-    <span class="inline-flex items-center px-3 py-1 rounded-full bg-indigo-100 text-indigo-800 font-medium">
+    <span class="inline-flex items-center rounded-full bg-indigo-100 px-3 py-1 font-medium text-indigo-800">
       <%= time_label %>
     </span>
   <% end %>
   <% audience_labels.each do |label| %>
-    <span class="inline-flex items-center px-3 py-1 rounded-full bg-pink-100 text-pink-800 font-medium">
+    <span class="inline-flex items-center rounded-full bg-pink-100 px-3 py-1 font-medium text-pink-800">
       <%= label %>
     </span>
   <% end %>
   <% if params[:visit_id].present? %>
-    <span class="inline-flex items-center px-3 py-1 rounded-full bg-yellow-100 text-yellow-800 font-medium">
+    <span class="inline-flex items-center rounded-full bg-yellow-100 px-3 py-1 font-medium text-yellow-800">
       Visit: <%= params[:visit_id] %>
     </span>
   <% end %>
   <% if params[:props].present? %>
-    <span class="inline-flex items-center px-3 py-1 rounded-full bg-purple-100 text-purple-800 font-medium">
+    <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800">
       Props: <%= params[:props] %>
     </span>
   <% end %>
@@ -45,6 +49,12 @@
     <%= link_to person_path(@person),
                 class: "inline-flex items-center px-3 py-1 rounded-full bg-blue-100 text-blue-800 font-medium hover:bg-blue-200" do %>
       Person: <%= @person.name %>
+    <% end %>
+  <% end %>
+  <% filtered_users.each do |user| %>
+    <%= link_to user_path(user),
+                class: "inline-flex items-center px-3 py-1 rounded-full bg-green-100 text-green-800 font-medium hover:bg-green-200" do %>
+      User: <%= user.full_name %>
     <% end %>
   <% end %>
   <% unless any_filters %>

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -219,6 +219,14 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("unrelated_history_row")
       end
 
+      it "surfaces a user chip in the applied filters when user_id is set" do
+        get index_path, params: { user_id: user.id, time_period: "all_time" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("User: #{user.full_name}")
+        expect(response.body).to include(user_path(user))
+      end
+
       it "surfaces a person chip in the applied filters when person_id is set" do
         person = create(:person, first_name: "Ada", last_name: "Lovelace")
 

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
   let(:visits_path) { admin_activities_visits_path }   # GET /admin/activities/visits
   let(:charts_path) { admin_activities_charts_path }   # GET /admin/activities/charts
 
+  # The events index lazy-loads its rows in a turbo frame, so row/section
+  # assertions must issue the frame request (Turbo-Frame header) the browser sends.
+  let(:frame_headers) { { "Turbo-Frame" => "activity_results" } }
+
   # ============================================================
   # AS A GUEST
   # ============================================================
@@ -133,7 +137,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
       end
 
       it "filters by prefixes=auth" do
-        get index_path, params: { prefixes: "auth" }
+        get index_path, params: { prefixes: "auth" }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("auth.login")
@@ -141,7 +145,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
       end
 
       it "filters by visit_id" do
-        get index_path, params: { visit_id: visit_for_user.id }
+        get index_path, params: { visit_id: visit_for_user.id }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("create.bookmark")
@@ -152,7 +156,8 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
             params: {
               from: 3.days.ago.to_date.to_s,
               to: 1.day.ago.to_date.to_s
-            }
+            },
+            headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("create.bookmark")
@@ -160,7 +165,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
       end
 
       it "filters by event name" do
-        get index_path, params: { event_name: "auth.login", time_period: "all_time" }
+        get index_path, params: { event_name: "auth.login", time_period: "all_time" }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("auth.login")
@@ -168,11 +173,23 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
       end
 
       it "filters by partial event name" do
-        get index_path, params: { event_name: "bookmark", time_period: "all_time" }
+        get index_path, params: { event_name: "bookmark", time_period: "all_time" }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("create.bookmark")
         expect(response.body).not_to include("auth.login")
+      end
+
+      it "filters by hyphen-separated tokens in any order (account-auth)" do
+        create(:ahoy_event, name: "auth.account_deactivated", user: nil,
+                            visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
+                            time: 1.day.ago, properties: {})
+
+        get index_path, params: { event_name: "account-auth", time_period: "all_time" }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("auth.account_deactivated")
+        expect(response.body).not_to include("create.bookmark")
       end
 
       it "filters by person_id to the person, their user, and associated data" do
@@ -193,7 +210,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
                             resource_type: "Person", resource_id: unrelated_person.id, time: 1.day.ago,
                             properties: { "resource_type" => "Person", "resource_id" => unrelated_person.id, "resource_title" => "unrelated_history_row" })
 
-        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("person_history_row")
@@ -224,7 +241,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         person = create(:person)
         create(:notification, recipient_email: person.communications_email, email_subject: "Comms row marker xyz")
 
-        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Communications")
@@ -237,7 +254,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         registration = create(:event_registration, registrant: person, event: event)
         create(:event_attendance_time_entry, event_registration: registration)
 
-        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Attendance time entries")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic on one admin page plus an additive shared-controller/partial tweak

## Why
The `/admin/activities/events` page lagged the other index pages: filters only applied behind a **Filter** button, the user filter was a plain dropdown, and event-name search was a literal substring match. This makes it behave like the rest.

## What
### Auto-apply filters (lazy turbo frame)
- Rows now load in an `activity_results` turbo frame; the filter form sits outside it and is driven by the `collection` controller.
- Selects/dates submit on change, text inputs debounce-submit — no Filter button; added a **Clear filters** link.
- Form stays put (and focused) while just the rows swap.

### Person remote search
- Replaced the user `<select>` with a `remote-select` person search, reusing the existing `person_id` filtering (searches the associated person).

### Hyphen-friendly event search
- Event-name search splits on any non-alphanumeric run and ANDs the tokens, so separators are interchangeable and order-independent — `account-auth` finds `auth.account_deactivated`.

### Applied-filter chips
- The `user_id` filter is still honored server-side (e.g. the "view activity" link from a user's account page). Since the picker now searches people, that scope is surfaced as a **User: …** chip in "Filters applied" (multi-id aware). Driven by params, so the shared subheader also chips the visits page's user filter.

### Shared controller
- `collection` controller also submits on `date` input change (additive; only affects forms with date inputs).

## Notes
- Request specs that assert on rendered rows/person sections now issue the frame request (`Turbo-Frame` header), matching the pattern used by the other lazy indexes.
- New view classes conform to the automated Tailwind class ordering (`ai/tw-sort`, #2175).