### PR TITLE
Activities: fix "See all user activity" link + text-box user search

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -41,6 +41,10 @@ module Admin
       # Filter by user (if viewing specific user activity)
       scope = scope.where(user: @users) if @users.present?
 
+      if params[:user_search].present?
+        scope = scope.where(user_id: User.activity_search(params[:user_search]).select(:id))
+      end
+
       # Time filter
       scope = scope.where(time: time_range) if time_range.present?
 
@@ -128,6 +132,10 @@ module Admin
       # Filter by user
       if params[:user_id].present?
         scope = scope.where(user_id: params[:user_id])
+      end
+
+      if params[:user_search].present?
+        scope = scope.where(user_id: User.activity_search(params[:user_search]).select(:id))
       end
 
       # Filter by visit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,21 @@ class User < ApplicationRecord
     { id: id, label: full_name_with_email }
   end
 
+  # Not limited to has_access (unlike remote_search) — the activity log spans deactivated and historical accounts.
+  def self.activity_search(query)
+    return none if query.blank?
+
+    pattern = "%#{sanitize_sql_like(query.to_s.strip)}%"
+    left_joins(:person).where(
+      "users.email LIKE :p OR users.first_name LIKE :p OR users.last_name LIKE :p OR " \
+      "people.first_name LIKE :p OR people.last_name LIKE :p OR people.legal_first_name LIKE :p OR " \
+      "people.email LIKE :p OR people.email_2 LIKE :p OR " \
+      "CONCAT(people.first_name, ' ', people.last_name) LIKE :p OR " \
+      "CONCAT(users.first_name, ' ', users.last_name) LIKE :p",
+      p: pattern
+    )
+  end
+
   def active_for_authentication?
     super && !inactive?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,7 @@ class User < ApplicationRecord
       "people.first_name LIKE :p OR people.last_name LIKE :p OR people.legal_first_name LIKE :p OR " \
       "people.email LIKE :p OR people.email_2 LIKE :p OR " \
       "CONCAT(people.first_name, ' ', people.last_name) LIKE :p OR " \
+      "CONCAT(people.legal_first_name, ' ', people.last_name) LIKE :p OR " \
       "CONCAT(users.first_name, ' ', users.last_name) LIKE :p",
       p: pattern
     )

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -61,13 +61,12 @@
 
             <div class="flex-1 min-w-0">
               <label class="block text-sm font-medium text-gray-600 mb-1">
-                Person
+                User
               </label>
-              <%= select_tag :person_id,
-                             @person ? options_for_select([ [ @person.name, @person.id ] ], @person.id) : nil,
-                             include_blank: "All people",
-                             data: { controller: "remote-select", remote_select_model_value: "person" },
-                             class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              <%= text_field_tag :user_search,
+                                 params[:user_search],
+                                 placeholder: "Name or email",
+                                 class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
             <div class="flex-1 min-w-0">
@@ -118,7 +117,7 @@
 
           <div class="flex items-center gap-3 mt-6 text-sm">
             <span class="text-gray-500">Quick:</span>
-            <% safe_params = params.slice(:event_name, :visit_id, :props, :person_id, :from, :to).to_unsafe_h %>
+            <% safe_params = params.slice(:event_name, :visit_id, :props, :person_id, :user_search, :from, :to).to_unsafe_h %>
             <%= link_to "24h",
                         url_for(safe_params.merge(from: 1.day.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -33,15 +33,10 @@
               <label class="block text-sm font-medium text-gray-600 mb-1">
                 User
               </label>
-              <%= select_tag :user_id,
-                             options_from_collection_for_select(
-                               User.where(id: Ahoy::Visit.select(:user_id).distinct).order(:first_name, :last_name),
-                               :id,
-                               :full_name,
-                               params[:user_id]
-                             ),
-                             include_blank: "All Users",
-                             class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              <%= text_field_tag :user_search,
+                                 params[:user_search],
+                                 placeholder: "Name or email",
+                                 class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
             </div>
 
             <!-- Audience -->
@@ -85,7 +80,7 @@
           <!-- Quick Ranges -->
           <div class="flex items-center gap-3 mt-6 text-sm">
             <span class="text-gray-500">Quick:</span>
-            <% safe_params = params.slice(:user_id, :from, :to).to_unsafe_h %>
+            <% safe_params = params.slice(:user_id, :user_search, :from, :to).to_unsafe_h %>
             <%= link_to "24h",
                         url_for(safe_params.merge(from: 1.day.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -21,7 +21,7 @@
   user_ids = params[:user_id].to_s.split("--").reject(&:blank?)
   filtered_users = user_ids.any? ? User.where(id: user_ids) : User.none
 
-  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || @person.present? || filtered_users.exists?
+  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || params[:user_search].present? || @person.present? || filtered_users.exists?
 %>
 <div class="flex flex-wrap items-center gap-2">
   <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Filters applied</h3>
@@ -43,6 +43,11 @@
   <% if params[:props].present? %>
     <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800">
       Properties: <%= params[:props] %>
+    </span>
+  <% end %>
+  <% if params[:user_search].present? %>
+    <span class="inline-flex items-center rounded-full bg-green-100 px-3 py-1 font-medium text-green-800">
+      User: <%= params[:user_search] %>
     </span>
   <% end %>
   <% if @person.present? %>

--- a/app/views/users/sections/_account_activity.html.erb
+++ b/app/views/users/sections/_account_activity.html.erb
@@ -2,8 +2,10 @@
   <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
     <div class="flex items-center justify-between mb-3">
       <h4 class="text-sm font-semibold uppercase text-gray-700">Account activity</h4>
+      <%# all_time + every audience (like the person "History" card) so staff and older events aren't dropped by the index defaults. %>
+      <% history_scope = user.person_id ? { person_id: user.person_id } : { user_id: user.id } %>
       <%= link_to "See all user activity",
-                  admin_activities_events_path(user_id: user.id),
+                  admin_activities_events_path(**history_scope, time_period: "all_time", audience: %w[visitors users staff]),
                   class: "text-xs text-gray-500 hover:text-blue-600",
                   data: { turbo_frame: "_top" } %>
     </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -348,6 +348,45 @@ RSpec.describe User do
     end
   end
 
+  describe ".activity_search" do
+    let!(:target) do
+      create(:user, :with_person, email: "rudy-login@example.com").tap do |u|
+        u.person.update!(
+          first_name: "Rudy", last_name: "Hernandez",
+          legal_first_name: "Rudolfo",
+          email: "rudy@example.com", email_2: "rudy.alt@example.com"
+        )
+      end
+    end
+    let!(:other) { create(:user, :with_person, email: "someone-else@example.com") }
+
+    it "returns none for a blank query" do
+      expect(User.activity_search("")).to eq(User.none)
+    end
+
+    it "matches on person last name" do
+      expect(User.activity_search("Hernandez")).to include(target)
+      expect(User.activity_search("Hernandez")).not_to include(other)
+    end
+
+    it "matches on legal first name" do
+      expect(User.activity_search("Rudolfo")).to include(target)
+    end
+
+    it "matches on the person's primary and secondary email" do
+      expect(User.activity_search("rudy@example.com")).to include(target)
+      expect(User.activity_search("rudy.alt@example.com")).to include(target)
+    end
+
+    it "matches on the user's login email" do
+      expect(User.activity_search("rudy-login@example.com")).to include(target)
+    end
+
+    it "matches on the full name" do
+      expect(User.activity_search("Rudy Hernandez")).to include(target)
+    end
+  end
+
   describe "#track_password_changed" do
     let(:user) { create(:user, password: "original_password") }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -385,6 +385,10 @@ RSpec.describe User do
     it "matches on the full name" do
       expect(User.activity_search("Rudy Hernandez")).to include(target)
     end
+
+    it "matches on the legal first name with last name" do
+      expect(User.activity_search("Rudolfo Hernandez")).to include(target)
+    end
   end
 
   describe "#track_password_changed" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -192,6 +192,30 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("create.bookmark")
       end
 
+      it "filters events by free-text user search across person and user fields" do
+        rudy = create(:user, :with_person, email: "rudy-login@example.com")
+        rudy.person.update!(
+          first_name: "Rudy", last_name: "Hernandez",
+          legal_first_name: "Rudolfo",
+          email: "rudy@example.com", email_2: "rudy.alt@example.com"
+        )
+        rudy_visit = create(:ahoy_visit, user: rudy, started_at: 1.day.ago)
+        create(:ahoy_event, name: "view.workshop", user: rudy, visit: rudy_visit,
+               time: 1.day.ago, properties: { "resource_title" => "rudy_activity_marker" })
+
+        other = create(:user, :with_person)
+        other_visit = create(:ahoy_visit, user: other, started_at: 1.day.ago)
+        create(:ahoy_event, name: "view.workshop", user: other, visit: other_visit,
+               time: 1.day.ago, properties: { "resource_title" => "other_activity_marker" })
+
+        %w[Hernandez Rudolfo rudy.alt@example.com rudy-login@example.com].each do |term|
+          get index_path, params: { user_search: term, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+          expect(response.body).to include("rudy_activity_marker"), "expected #{term.inspect} to match Rudy"
+          expect(response.body).not_to include("other_activity_marker")
+        end
+      end
+
       it "filters by person_id to the person, their user, and associated data" do
         person = create(:person)
         payment = create(:payment, person: person)
@@ -288,6 +312,22 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(visit_for_user.id.to_s)
+      end
+
+      it "filters visits by free-text user search" do
+        rudy = create(:user, :with_person)
+        rudy.person.update!(first_name: "Rudy", last_name: "Hernandez")
+        create(:ahoy_visit, user: rudy, started_at: 1.day.ago)
+
+        other = create(:user, :with_person)
+        other.person.update!(first_name: "Zoltan", last_name: "Nonmatch")
+        create(:ahoy_visit, user: other, started_at: 1.day.ago)
+
+        get visits_path, params: { user_search: "Hernandez", time_period: "all_time", audience: %w[visitors users staff] }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Rudy Hernandez")
+        expect(response.body).not_to include("Zoltan Nonmatch")
       end
 
       it "filters visits by from/to dates" do

--- a/spec/views/users/sections/_account_activity.html.erb_spec.rb
+++ b/spec/views/users/sections/_account_activity.html.erb_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe "users/sections/_account_activity", type: :view do
   end
 
   # The card shows resource-based history (auth + user-record events about this
-  # user), unbounded by time and audience. "See all user activity" must land on
-  # the same full history — so it uses the person-scoped path with all_time and
-  # every audience, matching the person edit "History" card. Passing a bare
-  # user_id (actor FK) with the past-month + visitors/users defaults silently
-  # drops staff users and older events, returning zero for a super_user.
+  # user), with no time limit and every audience included. "See all user
+  # activity" must land on that same full history — so it links with
+  # time_period=all_time and all three audiences, matching the person edit
+  # "History" card. A bare user_id (actor FK) instead inherits the index's
+  # past-month + visitors/users defaults, which drop staff and older events —
+  # returning zero for a super_user.
   context "when the user has a person" do
     let(:user) { create(:user, :with_person) }
 
@@ -36,7 +37,7 @@ RSpec.describe "users/sections/_account_activity", type: :view do
   context "when the user has no person" do
     let(:user) { create(:user, person: nil) }
 
-    it "falls back to the user filter, still unbounded and across all audiences" do
+    it "falls back to the user filter, still with all_time and all audiences" do
       render_partial(user)
 
       expect(rendered).to have_link(

--- a/spec/views/users/sections/_account_activity.html.erb_spec.rb
+++ b/spec/views/users/sections/_account_activity.html.erb_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "users/sections/_account_activity", type: :view do
+  def render_partial(user)
+    render partial: "users/sections/account_activity",
+           locals: {
+             user: user,
+             account_events: Ahoy::Event.none.paginate(page: 1),
+             by_user_options: []
+           }
+  end
+
+  # The card shows resource-based history (auth + user-record events about this
+  # user), unbounded by time and audience. "See all user activity" must land on
+  # the same full history — so it uses the person-scoped path with all_time and
+  # every audience, matching the person edit "History" card. Passing a bare
+  # user_id (actor FK) with the past-month + visitors/users defaults silently
+  # drops staff users and older events, returning zero for a super_user.
+  context "when the user has a person" do
+    let(:user) { create(:user, :with_person) }
+
+    it "links 'See all user activity' to the person's full history" do
+      render_partial(user)
+
+      expect(rendered).to have_link(
+        "See all user activity",
+        href: admin_activities_events_path(
+          person_id: user.person_id,
+          time_period: "all_time",
+          audience: %w[visitors users staff]
+        )
+      )
+    end
+  end
+
+  context "when the user has no person" do
+    let(:user) { create(:user, person: nil) }
+
+    it "falls back to the user filter, still unbounded and across all audiences" do
+      render_partial(user)
+
+      expect(rendered).to have_link(
+        "See all user activity",
+        href: admin_activities_events_path(
+          user_id: user.id,
+          time_period: "all_time",
+          audience: %w[visitors users staff]
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained filter logic across the activities index + visits, well covered by request/model specs

### Goal
Two things on the admin **Activities** area:
1. The user show page's **"See all user activity"** link returned **0** for a staff user while the Account activity card showed full history.
2. Filter the activity log by typing a name/email, matching any account (incl. deactivated/historical).

### Changes

#### Link fix
Point **"See all user activity"** at the same resource-based history the person edit **"History"** card uses: `time_period=all_time`, all audiences, `person_id` when the user has a person (falls back to `user_id`). The bare `user_id` link had inherited the index's past-month + visitors/users defaults, dropping staff and older events.

#### Text-box user search
Replace the index's remote person picker (from #2229) — and the Visits dropdown — with a plain **text box** that searches across the actor's own and their person's fields: first / last / legal-first name, email, email_2, and user email (+ full-name). Filters events/visits by matching `user_id`; auto-submits via the existing `collection` controller. `person_id` history filtering stays for the programmatic links above.

### Tests
- Partial view spec for the link params.
- Request specs: events search (name/legal-first/email_2/login-email, with exclusion) and visits search; `User.activity_search` model spec.
