### PR TITLE
Add User card to person associated records; drop zero-count badges

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -345,12 +345,12 @@ module ApplicationHelper
 
       label_tag = content_tag(:span, label, class: "font-medium #{text} truncate")
 
-      count_tag = if hide_count
+      count = collection.count
+      count_tag = if hide_count || count.zero?
         "".html_safe
       else
-        count = collection.count
         content_tag(:span,
-                    count.zero? ? "None" : number_with_delimiter(count),
+                    number_with_delimiter(count),
                     class: "ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white #{text} border #{border}")
       end
 

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -23,10 +23,10 @@
       <li class="break-inside-avoid mb-2">
         <%= link_to user_path(person.user),
                     data: { turbo_prefetch: false },
-                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
+                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
           <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-user"></i></span>
           <span class="font-medium text-gray-700 truncate">User</span>
-          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= number_with_delimiter(User.where(person_id: person.id).count) %></span>
+          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><%= number_with_delimiter(User.where(person_id: person.id).count) %></span>
         <% end %>
       </li>
     <% end %>
@@ -37,12 +37,10 @@
       <li class="break-inside-avoid mb-2">
         <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
                     data: { turbo_prefetch: false },
-                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
+                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
           <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
           <span class="font-medium text-gray-700 truncate">History</span>
-          <% unless history_count.zero? %>
-            <span class="ml-auto inline-flex items-center gap-1.5 min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i><%= number_with_delimiter(history_count) %></span>
-          <% end %>
+          <span class="ml-auto inline-flex items-center gap-1.5 min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i><% unless history_count.zero? %><%= number_with_delimiter(history_count) %><% end %></span>
         <% end %>
       </li>
     <% end %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -19,6 +19,17 @@
     <li class="break-inside-avoid mb-2"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
     <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Topic subscriptions" %></li>
     <li class="break-inside-avoid mb-2"><%= index_button(person.user&.workshop_logs || WorkshopLog.none, path: workshop_logs_person_path(person)) %></li>
+    <% if person.user %>
+      <li class="break-inside-avoid mb-2">
+        <%= link_to user_path(person.user),
+                    data: { turbo_prefetch: false },
+                    class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
+          <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-user"></i></span>
+          <span class="font-medium text-gray-700 truncate">User</span>
+          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= number_with_delimiter(User.where(person_id: person.id).count) %></span>
+        <% end %>
+      </li>
+    <% end %>
     <%# Aggregate Ahoy history (person + user + all associated data). Placed last
         so the column flow lands it in the otherwise-empty bottom-right cell. %>
     <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
@@ -29,7 +40,9 @@
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 transition-colors duration-200 shadow-sm" do %>
           <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
           <span class="font-medium text-gray-700 truncate">History</span>
-          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><%= history_count.zero? ? "None" : number_with_delimiter(history_count) %></span>
+          <% unless history_count.zero? %>
+            <span class="ml-auto inline-flex items-center gap-1.5 min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-gray-50 text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i><%= number_with_delimiter(history_count) %></span>
+          <% end %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -33,14 +33,13 @@
     <%# Aggregate Ahoy history (person + user + all associated data). Placed last
         so the column flow lands it in the otherwise-empty bottom-right cell. %>
     <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
-      <% history_count = Analytics::PersonActivityEvents.new(person).count %>
       <li class="break-inside-avoid mb-2">
         <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
                     data: { turbo_prefetch: false },
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
           <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
           <span class="font-medium text-gray-700 truncate">History</span>
-          <span class="ml-auto inline-flex items-center gap-1.5 min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i><% unless history_count.zero? %><%= number_with_delimiter(history_count) %><% end %></span>
+          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i></span>
         <% end %>
       </li>
     <% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -628,11 +628,11 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#index_button" do
-    it "renders 'None' instead of a zero count" do
+    it "renders no count badge for a zero count" do
       html = helper.index_button(Story.all)
 
       expect(Story.count).to eq(0)
-      expect(html).to include("None")
+      expect(html).not_to include("None")
       expect(html).not_to include(">0<")
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/helper change on the person associated-records cards

### What is the goal of this PR and why is this important?
- Give admins a one-click jump from a person to their linked user account.
- Stop the count pills reading "None" on empty relations — cleaner cards.
- Signal that these cards live on super-admin-only pages.

### How did you approach the change?
- Added a **User** card (icon + count) above History on the person associated-records partial, shown only when the person has a user, linking to the user show page.
- `index_button` and the History card now omit the badge entirely for a zero count instead of showing "None".
- Gave the User and History cards the `admin-only bg-blue-50` fill (these pages are super-admin only) and a persistent History badge with a magnifying-glass icon.

### Anything else to add?
- These cards render on the person edit page (and organizations views) via the shared partial.
