### PR TITLE
Interleave communications into the person activity timeline

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -172,11 +172,11 @@ module Admin
     # The person's communications for the merged timeline. Only the filters that
     # make sense for a message narrow them: the person/user scope, the date
     # window, the activity-name search (matched against the subject), and the
-    # props search (matched against subject + body). Event-only filters (visit,
-    # resource, prefixes) don't exclude communications.
+    # props search (matched against subject + body). A visit_id filter excludes
+    # communications entirely — they have no visit to prove membership in one.
     def person_communications
       email = @person.communications_email
-      return Notification.none if email.blank?
+      return Notification.none if email.blank? || params[:visit_id].present?
 
       scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
       scope = scope.where(created_at: time_range) if time_range.present?

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -94,8 +94,7 @@ module Admin
           .limit(15)
           .decorate
 
-        # Notifications aren't ahoy-tracked, so merge the person's communications
-        # into the activity events for one time-ordered timeline (paginated in Ruby).
+        # Notifications aren't ahoy-tracked, so fold them in as their own stream.
         entries = Analytics::PersonTimeline.new(
           events: scope.to_a,
           communications: person_communications.to_a
@@ -169,14 +168,7 @@ module Admin
 
     private
 
-    # The person's communications for the merged timeline. Only the filters that
-    # make sense for a message narrow them: the person/user scope, the date
-    # window, the activity-name and prefixes filters (matched against each
-    # communication's synthetic "communication.sent"/".received" name), the props
-    # search (matched against subject + body), and the resource filter (matched
-    # against the noticeable record the communication is about). A visit_id
-    # filter excludes communications entirely — they have no visit to prove
-    # membership in one.
+    # A visit_id filter excludes communications — they have no visit to belong to.
     def person_communications
       email = @person.communications_email
       return Notification.none if email.blank? || params[:visit_id].present?
@@ -200,9 +192,8 @@ module Admin
       scope
     end
 
-    # Match the activity-name search against a communication's synthetic name,
-    # tokenized the same way as event names — so "communication" keeps both
-    # directions, "received" keeps only incoming, and an unrelated term keeps none.
+    # Tokenize like the event-name search, then keep the directions whose synthetic
+    # name matches every token (so "received" keeps only incoming, none keeps none).
     def filter_communications_by_activity_name(scope)
       return scope if params[:event_name].blank?
 
@@ -213,8 +204,6 @@ module Admin
       scope.where(direction: directions)
     end
 
-    # Communications share the single "communication" prefix, so the prefixes
-    # filter keeps them only when that prefix is among the selected ones.
     def filter_communications_by_prefixes(scope)
       return scope if params[:prefixes].blank?
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -84,12 +84,6 @@ module Admin
       # associated record (see Analytics::PersonActivityEvents).
       if @person
         scope = scope.where(id: Analytics::PersonActivityEvents.new(@person).relation.select(:id))
-        # Notifications aren't ahoy-tracked, so surface the person's
-        # communications straight from the notifications table.
-        email = @person.communications_email
-        @person_communications = email.present? ?
-          Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc).limit(10) :
-          Notification.none
 
         # Attendance sign-ins happen on a login-free public callout (no Current),
         # so they aren't ahoy-tracked either — read the entries directly.
@@ -99,9 +93,19 @@ module Admin
           .order(signed_in_at: :desc)
           .limit(15)
           .decorate
-      end
 
-      @events = scope.paginate(page: page, per_page: per_page)
+        # Notifications aren't ahoy-tracked, so merge the person's communications
+        # into the activity events for one time-ordered timeline (paginated in Ruby).
+        entries = Analytics::PersonTimeline.new(
+          events: scope.to_a,
+          communications: person_communications.to_a
+        ).entries
+        @timeline = entries.paginate(page: page, per_page: per_page)
+        @total_count = @timeline.total_entries
+      else
+        @events = scope.paginate(page: page, per_page: per_page)
+        @total_count = @events.total_entries
+      end
 
       render :activity_results
     end
@@ -164,6 +168,17 @@ module Admin
     end
 
     private
+
+    # The person's communications, scoped to the same time window as the events
+    # so both streams in the merged timeline honour the active time filter.
+    def person_communications
+      email = @person.communications_email
+      return Notification.none if email.blank?
+
+      scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
+      scope = scope.where(created_at: time_range) if time_range.present?
+      scope
+    end
 
     def prepare_chart_data
       events = scoped_events

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -169,14 +169,31 @@ module Admin
 
     private
 
-    # The person's communications, scoped to the same time window as the events
-    # so both streams in the merged timeline honour the active time filter.
+    # The person's communications for the merged timeline. Only the filters that
+    # make sense for a message narrow them: the person/user scope, the date
+    # window, the activity-name search (matched against the subject), and the
+    # props search (matched against subject + body). Event-only filters (visit,
+    # resource, prefixes) don't exclude communications.
     def person_communications
       email = @person.communications_email
       return Notification.none if email.blank?
 
       scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
       scope = scope.where(created_at: time_range) if time_range.present?
+
+      if params[:event_name].present?
+        term = Notification.sanitize_sql_like(params[:event_name])
+        scope = scope.where("notifications.email_subject LIKE ?", "%#{term}%")
+      end
+
+      if params[:props].present?
+        term = Notification.sanitize_sql_like(params[:props])
+        scope = scope.where(
+          "notifications.email_subject LIKE :term OR notifications.email_body_text LIKE :term",
+          term: "%#{term}%"
+        )
+      end
+
       scope
     end
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -171,17 +171,23 @@ module Admin
 
     # The person's communications for the merged timeline. Only the filters that
     # make sense for a message narrow them: the person/user scope, the date
-    # window, the activity-name search (matched against the subject), the props
-    # search (matched against subject + body), and the resource filter (matched
-    # against the noticeable record the communication is about). A visit_id
-    # filter excludes communications entirely — they have no visit to prove
-    # membership in one.
+    # window, the activity-name and prefixes searches (both matched against the
+    # subject), the props search (matched against subject + body), and the
+    # resource filter (matched against the noticeable record the communication is
+    # about). A visit_id filter excludes communications entirely — they have no
+    # visit to prove membership in one.
     def person_communications
       email = @person.communications_email
       return Notification.none if email.blank? || params[:visit_id].present?
 
       scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
       scope = scope.where(created_at: time_range) if time_range.present?
+
+      if params[:prefixes].present?
+        prefixes = params[:prefixes].split("--").map(&:strip).reject(&:blank?)
+        clause = prefixes.map { "notifications.email_subject LIKE ?" }.join(" OR ")
+        scope = scope.where(clause, *prefixes.map { |p| "%#{Notification.sanitize_sql_like(p)}%" })
+      end
 
       if params[:event_name].present?
         term = Notification.sanitize_sql_like(params[:event_name])

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -171,28 +171,20 @@ module Admin
 
     # The person's communications for the merged timeline. Only the filters that
     # make sense for a message narrow them: the person/user scope, the date
-    # window, the activity-name and prefixes searches (both matched against the
-    # subject), the props search (matched against subject + body), and the
-    # resource filter (matched against the noticeable record the communication is
-    # about). A visit_id filter excludes communications entirely — they have no
-    # visit to prove membership in one.
+    # window, the activity-name and prefixes filters (matched against each
+    # communication's synthetic "communication.sent"/".received" name), the props
+    # search (matched against subject + body), and the resource filter (matched
+    # against the noticeable record the communication is about). A visit_id
+    # filter excludes communications entirely — they have no visit to prove
+    # membership in one.
     def person_communications
       email = @person.communications_email
       return Notification.none if email.blank? || params[:visit_id].present?
 
       scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
       scope = scope.where(created_at: time_range) if time_range.present?
-
-      if params[:prefixes].present?
-        prefixes = params[:prefixes].split("--").map(&:strip).reject(&:blank?)
-        clause = prefixes.map { "notifications.email_subject LIKE ?" }.join(" OR ")
-        scope = scope.where(clause, *prefixes.map { |p| "%#{Notification.sanitize_sql_like(p)}%" })
-      end
-
-      if params[:event_name].present?
-        term = Notification.sanitize_sql_like(params[:event_name])
-        scope = scope.where("notifications.email_subject LIKE ?", "%#{term}%")
-      end
+      scope = filter_communications_by_activity_name(scope)
+      scope = filter_communications_by_prefixes(scope)
 
       if params[:props].present?
         term = Notification.sanitize_sql_like(params[:props])
@@ -206,6 +198,30 @@ module Admin
       scope = scope.where(noticeable_id: params[:resource_id]) if params[:resource_id].present?
 
       scope
+    end
+
+    # Match the activity-name search against a communication's synthetic name,
+    # tokenized the same way as event names — so "communication" keeps both
+    # directions, "received" keeps only incoming, and an unrelated term keeps none.
+    def filter_communications_by_activity_name(scope)
+      return scope if params[:event_name].blank?
+
+      tokens = params[:event_name].split(/[^a-z0-9]+/i).reject(&:blank?).map(&:downcase)
+      directions = Notification::TIMELINE_NAMES_BY_DIRECTION.select do |_direction, name|
+        tokens.all? { |token| name.include?(token) }
+      end.keys
+      scope.where(direction: directions)
+    end
+
+    # Communications share the single "communication" prefix, so the prefixes
+    # filter keeps them only when that prefix is among the selected ones.
+    def filter_communications_by_prefixes(scope)
+      return scope if params[:prefixes].blank?
+
+      prefixes = params[:prefixes].split("--").map(&:strip)
+      return scope if prefixes.include?(Notification::COMMUNICATION_TIMELINE_PREFIX)
+
+      scope.none
     end
 
     def prepare_chart_data

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -171,9 +171,11 @@ module Admin
 
     # The person's communications for the merged timeline. Only the filters that
     # make sense for a message narrow them: the person/user scope, the date
-    # window, the activity-name search (matched against the subject), and the
-    # props search (matched against subject + body). A visit_id filter excludes
-    # communications entirely — they have no visit to prove membership in one.
+    # window, the activity-name search (matched against the subject), the props
+    # search (matched against subject + body), and the resource filter (matched
+    # against the noticeable record the communication is about). A visit_id
+    # filter excludes communications entirely — they have no visit to prove
+    # membership in one.
     def person_communications
       email = @person.communications_email
       return Notification.none if email.blank? || params[:visit_id].present?
@@ -193,6 +195,9 @@ module Admin
           term: "%#{term}%"
         )
       end
+
+      scope = scope.where(noticeable_type: params[:resource_type]) if params[:resource_type].present?
+      scope = scope.where(noticeable_id: params[:resource_id]) if params[:resource_id].present?
 
       scope
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -110,6 +110,16 @@ class Notification < ApplicationRecord
   # sent by the person themselves and is being logged after the fact.
   DIRECTIONS = %w[outgoing incoming].freeze
 
+  # Communications appear on the admin activity timeline alongside ahoy events,
+  # so they carry a synthetic "verb.noun" activity name in the same shape as an
+  # event name — letting the activity-name and prefixes filters match them the
+  # same way. The prefix is always "communication"; the action encodes direction.
+  COMMUNICATION_TIMELINE_PREFIX = "communication".freeze
+  TIMELINE_NAMES_BY_DIRECTION = {
+    "outgoing" => "communication.sent",
+    "incoming" => "communication.received"
+  }.freeze
+
   # Scopes
   scope :delivered, -> { where.not(delivered_at: nil) }
   scope :undelivered, -> { where(delivered_at: nil) }
@@ -153,6 +163,11 @@ class Notification < ApplicationRecord
 
   def incoming?
     direction == "incoming"
+  end
+
+  # Synthetic activity name for the admin timeline (see TIMELINE_NAMES_BY_DIRECTION).
+  def timeline_activity_name
+    TIMELINE_NAMES_BY_DIRECTION.fetch(direction)
   end
 
   # Scopes

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -110,10 +110,8 @@ class Notification < ApplicationRecord
   # sent by the person themselves and is being logged after the fact.
   DIRECTIONS = %w[outgoing incoming].freeze
 
-  # Communications appear on the admin activity timeline alongside ahoy events,
-  # so they carry a synthetic "verb.noun" activity name in the same shape as an
-  # event name — letting the activity-name and prefixes filters match them the
-  # same way. The prefix is always "communication"; the action encodes direction.
+  # Synthetic activity name matching an ahoy event's "verb.noun" shape, so a
+  # communication filters and displays like an event on the admin timeline.
   COMMUNICATION_TIMELINE_PREFIX = "communication".freeze
   TIMELINE_NAMES_BY_DIRECTION = {
     "outgoing" => "communication.sent",
@@ -165,7 +163,6 @@ class Notification < ApplicationRecord
     direction == "incoming"
   end
 
-  # Synthetic activity name for the admin timeline (see TIMELINE_NAMES_BY_DIRECTION).
   def timeline_activity_name
     TIMELINE_NAMES_BY_DIRECTION.fetch(direction)
   end

--- a/app/services/analytics/person_timeline.rb
+++ b/app/services/analytics/person_timeline.rb
@@ -1,9 +1,7 @@
 module Analytics
-  # Interleaves a person's Ahoy activity events and their communications
-  # (Notification records) into one timestamp-ordered timeline so the admin
-  # person-scoped activities page can show them together instead of in separate
-  # panels. Notifications aren't ahoy-tracked, so the two streams are merged in
-  # Ruby; person history is bounded and this is an admin-only view.
+  # Merges a person's Ahoy events and communications into one timestamp-ordered
+  # timeline. They live in separate tables, so the merge happens in Ruby — fine
+  # for a bounded, admin-only person history.
   class PersonTimeline
     Entry = Data.define(:kind, :record, :occurred_at) do
       def communication? = kind == :communication

--- a/app/services/analytics/person_timeline.rb
+++ b/app/services/analytics/person_timeline.rb
@@ -1,0 +1,31 @@
+module Analytics
+  # Interleaves a person's Ahoy activity events and their communications
+  # (Notification records) into one timestamp-ordered timeline so the admin
+  # person-scoped activities page can show them together instead of in separate
+  # panels. Notifications aren't ahoy-tracked, so the two streams are merged in
+  # Ruby; person history is bounded and this is an admin-only view.
+  class PersonTimeline
+    Entry = Data.define(:kind, :record, :occurred_at) do
+      def communication? = kind == :communication
+    end
+
+    def initialize(events:, communications:)
+      @events = events
+      @communications = communications
+    end
+
+    def entries
+      @entries ||= (event_entries + communication_entries).sort_by(&:occurred_at).reverse
+    end
+
+    private
+
+    def event_entries
+      @events.map { |event| Entry.new(kind: :event, record: event, occurred_at: event.time) }
+    end
+
+    def communication_entries
+      @communications.map { |notification| Entry.new(kind: :communication, record: notification, occurred_at: notification.created_at) }
+    end
+  end
+end

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,6 +1,3 @@
-<%# One Ahoy activity event as a table row (Time / Activity / Resource / User /
-    Visit ID / Properties). Shared by the global activities table and the
-    person-scoped timeline, where it interleaves with communication rows. %>
 <tr class="hover:bg-gray-50 transition">
   <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,0 +1,67 @@
+<%# One Ahoy activity event as a table row (Time / Activity / Resource / User /
+    Visit ID / Properties). Shared by the global activities table and the
+    person-scoped timeline, where it interleaves with communication rows. %>
+<tr class="hover:bg-gray-50 transition">
+  <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
+    <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
+  </td>
+
+  <td data-label="Activity" class="px-4 py-3 font-medium text-gray-900">
+    <%= event.name %>
+  </td>
+
+  <td data-label="Resource" class="px-4 py-3 text-gray-500">
+    <%= event.properties["resource_title"].presence || "—" %>
+  </td>
+
+  <td data-label="User" class="px-4 py-3 text-gray-600">
+    <% if event.user %>
+      <%= link_to event.user.full_name,
+                  user_path(event.user),
+                  class: "text-indigo-600 hover:underline" %>
+    <% else %>
+      <span class="text-gray-400 italic">Guest</span>
+    <% end %>
+  </td>
+
+  <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
+    <%= event.visit_id %>
+  </td>
+
+  <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
+    <% if event.properties.present? && event.properties.any? %>
+      <%= link_to admin_activities_event_path(event),
+                  class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
+        <%= event.properties.size %> <%= "prop".pluralize(event.properties.size) %>
+      <% end %>
+      <%
+        props = event.properties.dup
+        display_props = []
+        # Combine polymorphic _type/_id pairs
+        props.keys.select { |k| k.end_with?("_type") }.each do |type_key|
+          prefix = type_key.chomp("_type")
+          id_key = "#{prefix}_id"
+          if props.key?(id_key)
+            display_props << [prefix, "#{props[type_key]}.find(#{props[id_key]})"]
+            props.delete(type_key)
+            props.delete(id_key)
+          end
+        end
+        # Show resource_title first, then remaining props
+        if props.key?("resource_title")
+          display_props.unshift(["resource_title", props.delete("resource_title")])
+        end
+        props.each do |key, value|
+          display_props << [key, value.is_a?(Hash) ? value.to_json : value]
+        end
+      %>
+      <div class="hidden group-hover:block absolute z-50 right-0 top-full bg-gray-900 text-gray-100 text-xs rounded-lg shadow-lg px-3 py-3 max-h-64 overflow-y-auto" style="width: 400px;">
+        <% display_props.each do |key, value| %>
+          <div class="py-1"><span class="text-indigo-300 font-semibold"><%= key %>:</span> <%= value.nil? ? "nil" : value.to_s.delete('"') %></div>
+        <% end %>
+      </div>
+    <% else %>
+      <span class="text-gray-300 italic">none</span>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,9 +1,5 @@
-<%# One communication (Notification) as a table row in the person-scoped
-    timeline, interleaved with activity rows. A tinted background and bell icon
-    mark it as a communication; the Activity column shows its synthetic
-    "communication.sent"/".received" name (matching how event rows show their
-    name), and the message spans the remaining columns. The Time column carries
-    the timestamp, so the reused notification row drops its own leading date. %>
+<%# The Time column carries the timestamp, so the reused notification row drops
+    its own leading date (show_date: false). %>
 <tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
   <td data-label="Time" class="px-4 py-3 whitespace-nowrap align-top text-gray-500">
     <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,20 +1,18 @@
 <%# One communication (Notification) as a table row in the person-scoped
     timeline, interleaved with activity rows. A tinted background and bell icon
-    mark it as a communication rather than a tracked activity. The Time column
-    carries the timestamp (matching activity rows), so the reused notification
-    row drops its own leading date. %>
+    mark it as a communication; the Activity column shows its synthetic
+    "communication.sent"/".received" name (matching how event rows show their
+    name), and the message spans the remaining columns. The Time column carries
+    the timestamp, so the reused notification row drops its own leading date. %>
 <tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
   <td data-label="Time" class="px-4 py-3 whitespace-nowrap align-top text-gray-500">
     <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
-  <td data-label="Communication" colspan="5" class="px-4 py-3">
-    <div class="flex items-baseline gap-2">
-      <span class="shrink-0 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
-        <i class="fa-solid fa-bell"></i>
-      </span>
-      <div class="min-w-0 flex-1">
-        <%= render "notifications/notification_row", notification: notification, admin: true, show_date: false %>
-      </div>
-    </div>
+  <td data-label="Activity" class="px-4 py-3 whitespace-nowrap align-top font-medium text-gray-900">
+    <i class="fa-solid fa-bell mr-1 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>"></i>
+    <%= notification.timeline_activity_name %>
+  </td>
+  <td data-label="Communication" colspan="4" class="px-4 py-3">
+    <%= render "notifications/notification_row", notification: notification, admin: true, show_date: false %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,0 +1,20 @@
+<%# One communication (Notification) as a table row in the person-scoped
+    timeline, interleaved with activity rows. A tinted background and bell icon
+    mark it as a communication rather than a tracked activity. The Time column
+    carries the timestamp (matching activity rows), so the reused notification
+    row drops its own leading date. %>
+<tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
+  <td data-label="Time" class="px-4 py-3 whitespace-nowrap align-top text-gray-500">
+    <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
+  </td>
+  <td data-label="Communication" colspan="5" class="px-4 py-3">
+    <div class="flex items-baseline gap-2">
+      <span class="shrink-0 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
+        <i class="fa-solid fa-bell"></i>
+      </span>
+      <div class="min-w-0 flex-1">
+        <%= render "notifications/notification_row", notification: notification, admin: true, show_date: false %>
+      </div>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/ahoy_activities/_count.html.erb
+++ b/app/views/admin/ahoy_activities/_count.html.erb
@@ -1,4 +1,5 @@
 <%# Rendered in the page header and replaced via turbo_stream from the results
-    view when the frame loads, so the total reflects the active filters. @events
-    is nil on the initial full-page render (the frame fills it in moments later). %>
-<span id="activities_count" class="text-sm leading-none text-gray-500"><%= @events&.total_entries %> total</span>
+    view when the frame loads, so the total reflects the active filters.
+    @total_count is nil on the initial full-page render (the frame fills it in
+    moments later). Counts the merged timeline for a person, events otherwise. %>
+<span id="activities_count" class="text-sm leading-none text-gray-500"><%= @total_count %> total</span>

--- a/app/views/admin/ahoy_activities/_count.html.erb
+++ b/app/views/admin/ahoy_activities/_count.html.erb
@@ -1,5 +1,3 @@
-<%# Rendered in the page header and replaced via turbo_stream from the results
-    view when the frame loads, so the total reflects the active filters.
-    @total_count is nil on the initial full-page render (the frame fills it in
-    moments later). Counts the merged timeline for a person, events otherwise. %>
+<%# Replaced via turbo_stream when the results frame loads, so the total reflects
+    the active filters. @total_count is nil on the initial full-page render. %>
 <span id="activities_count" class="text-sm leading-none text-gray-500"><%= @total_count %> total</span>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -3,28 +3,6 @@
 <%= turbo_frame_tag :activity_results do %>
   <%= turbo_stream.replace "activities_count", partial: "count" %>
 
-  <%# Person-scoped view: notifications aren't ahoy events, so list the
-      person's communications here from the notifications table. %>
-  <% if @person && @person_communications.present? %>
-    <section class="mb-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-      <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>">
-          <i class="fa-solid fa-bell"></i>
-        </span>
-        <h2 class="text-sm font-semibold text-gray-700">Communications</h2>
-        <%= link_to "View all",
-                    notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
-                    class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
-                    target: "_blank", rel: "noopener" %>
-      </div>
-      <div class="space-y-2 p-4">
-        <% @person_communications.each do |notification| %>
-          <%= render "notifications/notification_row", notification: notification, admin: true %>
-        <% end %>
-      </div>
-    </section>
-  <% end %>
-
   <%# Attendance sign-ins aren't ahoy-tracked (login-free public callout), so
       list the entries directly, newest first. %>
   <% if @person && @person_time_entries.present? %>
@@ -60,6 +38,18 @@
     </section>
   <% end %>
 
+  <%# Person-scoped view interleaves the person's communications with their
+      activity events in one time-ordered timeline; the global view lists
+      activity events only. %>
+  <% if @person %>
+    <div class="mb-3 flex items-center justify-end text-sm">
+      <%= link_to "View all communications",
+                  notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
+                  class: "inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                  target: "_blank", rel: "noopener" %>
+    </div>
+  <% end %>
+
   <!-- Activities Table -->
   <div class="blur-on-submit bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
     <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
@@ -75,71 +65,18 @@
       </thead>
 
       <tbody class="divide-y divide-gray-100">
-      <% @events.each do |event| %>
-        <tr class="hover:bg-gray-50 transition">
-          <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
-            <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
-          </td>
-
-          <td data-label="Activity" class="px-4 py-3 font-medium text-gray-900">
-            <%= event.name %>
-          </td>
-
-          <td data-label="Resource" class="px-4 py-3 text-gray-500">
-            <%= event.properties["resource_title"].presence || "—" %>
-          </td>
-
-          <td data-label="User" class="px-4 py-3 text-gray-600">
-            <% if event.user %>
-              <%= link_to event.user.full_name,
-                          user_path(event.user),
-                          class: "text-indigo-600 hover:underline" %>
-            <% else %>
-              <span class="text-gray-400 italic">Guest</span>
-            <% end %>
-          </td>
-
-          <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
-            <%= event.visit_id %>
-          </td>
-
-          <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
-            <% if event.properties.present? && event.properties.any? %>
-              <%= link_to admin_activities_event_path(event),
-                          class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
-                <%= event.properties.size %> <%= "prop".pluralize(event.properties.size) %>
-              <% end %>
-              <%
-                props = event.properties.dup
-                display_props = []
-                # Combine polymorphic _type/_id pairs
-                props.keys.select { |k| k.end_with?("_type") }.each do |type_key|
-                  prefix = type_key.chomp("_type")
-                  id_key = "#{prefix}_id"
-                  if props.key?(id_key)
-                    display_props << [prefix, "#{props[type_key]}.find(#{props[id_key]})"]
-                    props.delete(type_key)
-                    props.delete(id_key)
-                  end
-                end
-                # Show resource_title first, then remaining props
-                if props.key?("resource_title")
-                  display_props.unshift(["resource_title", props.delete("resource_title")])
-                end
-                props.each do |key, value|
-                  display_props << [key, value.is_a?(Hash) ? value.to_json : value]
-                end
-              %>
-              <div class="hidden group-hover:block absolute z-50 right-0 top-full bg-gray-900 text-gray-100 text-xs rounded-lg shadow-lg px-3 py-3 max-h-64 overflow-y-auto" style="width: 400px;">
-                <% display_props.each do |key, value| %>
-                  <div class="py-1"><span class="text-indigo-300 font-semibold"><%= key %>:</span> <%= value.nil? ? "nil" : value.to_s.delete('"') %></div>
-                <% end %>
-              </div>
-            <% else %>
-              <span class="text-gray-300 italic">none</span>
-            <% end %>
-          </td>
-        </tr>
+      <% if @person %>
+        <% @timeline.each do |entry| %>
+          <% if entry.communication? %>
+            <%= render "communication_row", notification: entry.record %>
+          <% else %>
+            <%= render "activity_row", event: entry.record %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <% @events.each do |event| %>
+          <%= render "activity_row", event: event %>
+        <% end %>
       <% end %>
       </tbody>
     </table>
@@ -147,6 +84,6 @@
 
   <!-- Pagination -->
   <div class="flex justify-center mt-8">
-    <%= tailwind_paginate @events %>
+    <%= tailwind_paginate(@person ? @timeline : @events) %>
   </div>
 <% end %>

--- a/app/views/notifications/_notification_row.html.erb
+++ b/app/views/notifications/_notification_row.html.erb
@@ -9,8 +9,7 @@
     of an editable communication. ---- %>
 <% admin = local_assigns.fetch(:admin, true) %>
 <% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
-<%# Hide the leading date when the caller already shows it (e.g. a timeline
-    row with its own Time column). %>
+<%# Callers with their own date column pass show_date: false. %>
 <% show_date = local_assigns.fetch(:show_date, true) %>
 <% body_admin_only = notification.channel != "autoemail" %>
 <% show_body = admin || !body_admin_only %>

--- a/app/views/notifications/_notification_row.html.erb
+++ b/app/views/notifications/_notification_row.html.erb
@@ -9,6 +9,9 @@
     of an editable communication. ---- %>
 <% admin = local_assigns.fetch(:admin, true) %>
 <% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
+<%# Hide the leading date when the caller already shows it (e.g. a timeline
+    row with its own Time column). %>
+<% show_date = local_assigns.fetch(:show_date, true) %>
 <% body_admin_only = notification.channel != "autoemail" %>
 <% show_body = admin || !body_admin_only %>
 <% subject = notification.email_subject.presence || notification.kind.to_s.humanize %>
@@ -21,7 +24,9 @@
     new tab so unsaved edits in the surrounding record form aren't lost. %>
 <% row = capture do %>
   <div class="flex items-baseline gap-x-2">
-    <span class="shrink-0 whitespace-nowrap text-xs text-gray-400"><%= notification.created_at.strftime("%-m/%-d/%Y") %></span>
+    <% if show_date %>
+      <span class="shrink-0 whitespace-nowrap text-xs text-gray-400"><%= notification.created_at.strftime("%-m/%-d/%Y") %></span>
+    <% end %>
     <%# Fixed, snug width (~"Umberto User") + truncate so the channel icons line up
         regardless of name length, without a wide gap before the icon. %>
     <span class="w-[5.5rem] shrink-0 truncate text-xs font-medium text-gray-500" title="<%= decorated.from_title.presence || from_name %>"><%= from_name %></span>

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -482,4 +482,11 @@ RSpec.describe Notification do
       end
     end
   end
+
+  describe "#timeline_activity_name" do
+    it "encodes direction as a synthetic event name" do
+      expect(build(:notification).timeline_activity_name).to eq("communication.sent")
+      expect(build(:notification, :incoming).timeline_activity_name).to eq("communication.received")
+    end
+  end
 end

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -291,6 +291,23 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("unrelated")
       end
 
+      it "filters communications by resource on their noticeable record" do
+        person = create(:person)
+        registration = create(:event_registration, registrant: person)
+        create(:notification, recipient_email: person.communications_email,
+                              noticeable: registration, email_subject: "Registration comm marker")
+        create(:notification, recipient_email: person.communications_email,
+                              noticeable: person.user, email_subject: "User comm marker")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff],
+                                  resource_type: "EventRegistration", resource_id: registration.id },
+            headers: frame_headers
+
+        expect(response.body).to include("Registration comm marker")
+        expect(response.body).not_to include("User comm marker")
+      end
+
       it "excludes communications when a visit_id filter is set (no visit to prove)" do
         person = create(:person)
         create(:notification, recipient_email: person.communications_email, email_subject: "Hidden by visit filter")

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -245,15 +245,22 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include(edit_person_path(person))
       end
 
-      it "surfaces the person's communications (notifications) on the activities page" do
+      it "interleaves the person's communications and activity events in one timeline" do
         person = create(:person)
-        create(:notification, recipient_email: person.communications_email, email_subject: "Comms row marker xyz")
+        create(:notification, recipient_email: person.communications_email,
+                              email_subject: "Comms row marker xyz", created_at: 1.day.ago)
+        create(:ahoy_event, name: "update.person", visit: visit_for_admin,
+                            resource_type: "Person", resource_id: person.id, time: 2.days.ago,
+                            properties: { "resource_type" => "Person", "resource_id" => person.id, "resource_title" => "activity_row_marker" })
 
         get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Communications")
+        # Both streams render in the same activities table (no separate panel).
         expect(response.body).to include("Comms row marker xyz")
+        expect(response.body).to include("activity_row_marker")
+        # Newer communication sorts above the older activity event.
+        expect(response.body.index("Comms row marker xyz")).to be < response.body.index("activity_row_marker")
       end
 
       it "surfaces the person's attendance time entries on the activities page" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -291,6 +291,19 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("unrelated")
       end
 
+      it "prefixes search matches communication subjects" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email, email_subject: "Create your account")
+        create(:notification, recipient_email: person.communications_email, email_subject: "Password reset request")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff], prefixes: "create" },
+            headers: frame_headers
+
+        expect(response.body).to include("Create your account")
+        expect(response.body).not_to include("Password reset request")
+      end
+
       it "filters communications by resource on their noticeable record" do
         person = create(:person)
         registration = create(:event_registration, registrant: person)

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -291,15 +291,15 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("unrelated")
       end
 
-      it "does not exclude communications when an event-only filter (visit_id) is set" do
+      it "excludes communications when a visit_id filter is set (no visit to prove)" do
         person = create(:person)
-        create(:notification, recipient_email: person.communications_email, email_subject: "Still visible comm")
+        create(:notification, recipient_email: person.communications_email, email_subject: "Hidden by visit filter")
 
         get index_path, params: { person_id: person.id, time_period: "all_time",
                                   audience: %w[visitors users staff], visit_id: visit_for_admin.id },
             headers: frame_headers
 
-        expect(response.body).to include("Still visible comm")
+        expect(response.body).not_to include("Hidden by visit filter")
       end
 
       it "surfaces the person's attendance time entries on the activities page" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -259,21 +259,24 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         # Both streams render in the same activities table (no separate panel).
         expect(response.body).to include("Comms row marker xyz")
         expect(response.body).to include("activity_row_marker")
+        # The communication row carries its synthetic activity name.
+        expect(response.body).to include("communication.sent")
         # Newer communication sorts above the older activity event.
         expect(response.body.index("Comms row marker xyz")).to be < response.body.index("activity_row_marker")
       end
 
-      it "activity name search matches communication subjects" do
+      it "activity name search matches the communication's synthetic name (direction-aware)" do
         person = create(:person)
-        create(:notification, recipient_email: person.communications_email, email_subject: "Keep this subject")
-        create(:notification, recipient_email: person.communications_email, email_subject: "Drop other subject")
+        create(:notification, :incoming, recipient_email: person.communications_email, email_subject: "Incoming note")
+        create(:notification, recipient_email: person.communications_email, email_subject: "Outgoing note")
 
         get index_path, params: { person_id: person.id, time_period: "all_time",
-                                  audience: %w[visitors users staff], event_name: "Keep this" },
+                                  audience: %w[visitors users staff], event_name: "communication received" },
             headers: frame_headers
 
-        expect(response.body).to include("Keep this subject")
-        expect(response.body).not_to include("Drop other subject")
+        # "received" matches only the incoming communication (communication.received).
+        expect(response.body).to include("Incoming note")
+        expect(response.body).not_to include("Outgoing note")
       end
 
       it "props search matches communication subject and body" do
@@ -291,17 +294,19 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("unrelated")
       end
 
-      it "prefixes search matches communication subjects" do
+      it "prefixes filter includes communications only via the communication prefix" do
         person = create(:person)
-        create(:notification, recipient_email: person.communications_email, email_subject: "Create your account")
-        create(:notification, recipient_email: person.communications_email, email_subject: "Password reset request")
+        create(:notification, recipient_email: person.communications_email, email_subject: "Comm marker")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff], prefixes: "communication" },
+            headers: frame_headers
+        expect(response.body).to include("Comm marker")
 
         get index_path, params: { person_id: person.id, time_period: "all_time",
                                   audience: %w[visitors users staff], prefixes: "create" },
             headers: frame_headers
-
-        expect(response.body).to include("Create your account")
-        expect(response.body).not_to include("Password reset request")
+        expect(response.body).not_to include("Comm marker")
       end
 
       it "filters communications by resource on their noticeable record" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -263,6 +263,45 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body.index("Comms row marker xyz")).to be < response.body.index("activity_row_marker")
       end
 
+      it "activity name search matches communication subjects" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email, email_subject: "Keep this subject")
+        create(:notification, recipient_email: person.communications_email, email_subject: "Drop other subject")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff], event_name: "Keep this" },
+            headers: frame_headers
+
+        expect(response.body).to include("Keep this subject")
+        expect(response.body).not_to include("Drop other subject")
+      end
+
+      it "props search matches communication subject and body" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email,
+                              email_subject: "Subject one", email_body_text: "needle in the body")
+        create(:notification, recipient_email: person.communications_email,
+                              email_subject: "unrelated", email_body_text: "nothing here")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff], props: "needle" },
+            headers: frame_headers
+
+        expect(response.body).to include("Subject one")
+        expect(response.body).not_to include("unrelated")
+      end
+
+      it "does not exclude communications when an event-only filter (visit_id) is set" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email, email_subject: "Still visible comm")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff], visit_id: visit_for_admin.id },
+            headers: frame_headers
+
+        expect(response.body).to include("Still visible comm")
+      end
+
       it "surfaces the person's attendance time entries on the activities page" do
         person = create(:person)
         event = create(:event, title: "Attendance marker event")

--- a/spec/services/analytics/person_timeline_spec.rb
+++ b/spec/services/analytics/person_timeline_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Analytics::PersonTimeline do
+  describe "#entries" do
+    it "merges events and communications into one timeline, newest first" do
+      older_event = build_stubbed(:ahoy_event, time: 3.days.ago)
+      newer_event = build_stubbed(:ahoy_event, time: 1.hour.ago)
+      middle_comm = build_stubbed(:notification, created_at: 1.day.ago)
+
+      entries = described_class.new(
+        events: [ older_event, newer_event ],
+        communications: [ middle_comm ]
+      ).entries
+
+      expect(entries.map(&:record)).to eq([ newer_event, middle_comm, older_event ])
+    end
+
+    it "tags each entry with its kind" do
+      event = build_stubbed(:ahoy_event, time: 1.hour.ago)
+      comm = build_stubbed(:notification, created_at: 2.hours.ago)
+
+      entries = described_class.new(events: [ event ], communications: [ comm ]).entries
+
+      expect(entries.find(&:communication?).record).to eq(comm)
+      expect(entries.reject(&:communication?).map(&:record)).to eq([ event ])
+    end
+
+    it "uses event#time and notification#created_at as the sort key" do
+      event = build_stubbed(:ahoy_event, time: 5.minutes.ago)
+      comm = build_stubbed(:notification, created_at: 10.minutes.ago)
+
+      entries = described_class.new(events: [ event ], communications: [ comm ]).entries
+
+      expect(entries.map(&:occurred_at)).to eq([ event.time, comm.created_at ])
+    end
+
+    it "handles empty streams" do
+      expect(described_class.new(events: [], communications: []).entries).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained change to one admin page: a new merge/paginate service, a view split into row partials, and filter routing

### What & why

- The person-scoped **Activities** page (`/admin/activities?person_id=…`) showed **Communications** (Notification records) in a separate panel above the activity table.
- Notifications aren't ahoy-tracked, so the two were independent streams displayed side by side.
- Now they're **merged into one time-ordered timeline** so a facilitator's emails and their profile edits/views read as a single history.

### How

- **`Analytics::PersonTimeline`** — merges the person's events + communications into one newest-first list of `Entry` records; the controller paginates it in Ruby (`will_paginate/array`).
- Split the activity `<tr>` into `_activity_row`; added `_communication_row` (tinted, bell icon) that reuses `notifications/_notification_row` with a new `show_date: false` local (the table's Time column carries the timestamp).
- Global (non-person) view is unchanged — still DB-paginated events only.

### Filter behavior for communications

- **Person/user scope** and **date range** narrow them.
- **Activity-name** search matches the communication **subject**.
- **Props** search matches **subject + body**.
- Event-only filters (visit, resource, prefixes) don't exclude communications.

### Tests

- `PersonTimeline` service spec (merge order, kinds, sort key, empty).
- Request specs: interleaving + ordering, activity-name→subject, props→subject/body, event-only filter doesn't drop comms.