### PR TITLE
Affiliation edit gear: standalone editor with comments + reassign

### DIFF
--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -20,6 +20,17 @@ class AffiliationsController < ApplicationController
 
   def destroy
     authorize! @affiliation, to: :destroy?
+
+    if params[:return_to].present?
+      if @affiliation.destroy
+        redirect_to affiliation_return_path(anchor: "affiliations"),
+                    notice: "Affiliation was removed.", status: :see_other
+      else
+        redirect_to edit_affiliation_path(@affiliation), alert: "Unable to remove affiliation."
+      end
+      return
+    end
+
     affiliation = Affiliation.find(params[:id])
     person = affiliation.person
     destroyed = affiliation.destroy
@@ -58,9 +69,9 @@ class AffiliationsController < ApplicationController
     )
   end
 
-  # Return to whichever edit page the gear was clicked from, scrolled to the row.
-  def affiliation_return_path
-    anchor = helpers.dom_id(@affiliation)
+  # Return to whichever edit page the gear was clicked from, scrolled to the row
+  # (or the affiliations section after a delete removes the row).
+  def affiliation_return_path(anchor: helpers.dom_id(@affiliation))
     case params[:return_to]
     when "person"
       edit_person_path(params[:origin_id], anchor: anchor)

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -1,5 +1,22 @@
 class AffiliationsController < ApplicationController
-  before_action :set_affiliation, only: %i[ destroy ]
+  before_action :set_affiliation, only: %i[ edit update destroy ]
+
+  def edit
+    authorize! @affiliation
+  end
+
+  def update
+    authorize! @affiliation
+    @affiliation.assign_attributes(affiliation_params)
+    @affiliation.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
+    @affiliation.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
+
+    if @affiliation.save
+      redirect_to affiliation_return_path, notice: "Affiliation was successfully updated.", status: :see_other
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
 
   def destroy
     authorize! @affiliation, to: :destroy?
@@ -32,5 +49,25 @@ class AffiliationsController < ApplicationController
 
   def set_affiliation
     @affiliation = Affiliation.find(params[:id])
+  end
+
+  def affiliation_params
+    params.require(:affiliation).permit(
+      :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
+    )
+  end
+
+  # Return to whichever edit page the gear was clicked from, scrolled to the row.
+  def affiliation_return_path
+    anchor = helpers.dom_id(@affiliation)
+    case params[:return_to]
+    when "person"
+      edit_person_path(params[:origin_id], anchor: anchor)
+    when "organization"
+      edit_organization_path(params[:origin_id], anchor: anchor)
+    else
+      edit_affiliation_path(@affiliation)
+    end
   end
 end

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -64,7 +64,7 @@ class AffiliationsController < ApplicationController
 
   def affiliation_params
     params.require(:affiliation).permit(
-      :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
+      :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact, :organization_address_id,
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
     )
   end

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -19,6 +19,7 @@ class CommentDecorator < ApplicationDecorator
     when TopicSubscription then h.edit_topic_subscription_path(commentable)
     when Story then h.edit_story_path(commentable)
     when StoryIdea then h.edit_story_idea_path(commentable)
+    when Affiliation then h.edit_affiliation_path(commentable)
     end
   end
 
@@ -34,6 +35,7 @@ class CommentDecorator < ApplicationDecorator
     when TopicSubscription then :topic_subscriptions
     when Story then :stories
     when StoryIdea then :story_ideas
+    when Affiliation then :organizations
     else :comments
     end
   end

--- a/app/frontend/javascript/controllers/address_select_controller.js
+++ b/app/frontend/javascript/controllers/address_select_controller.js
@@ -42,6 +42,7 @@ export default class extends Controller {
     const option = event.currentTarget;
     this.inputTarget.value = option.dataset.value;
     this.labelTarget.textContent = option.dataset.label;
+    this.inputTarget.dispatchEvent(new Event("change", { bubbles: true }));
     this.close();
   }
 

--- a/app/frontend/javascript/controllers/address_select_controller.js
+++ b/app/frontend/javascript/controllers/address_select_controller.js
@@ -1,10 +1,10 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Compact numbered address picker for the affiliation editor row. The trigger
-// button shows only the selected address's number (or a dash); the panel lists
-// each address with its full one-line text. Selecting an option writes the
-// address id into a hidden field so it saves as the affiliation's
-// organization_address_id.
+// Numbered address picker for the affiliation editor row. The trigger button
+// shows the selected address's number and name (truncated to the column width,
+// or a dash when none); the panel lists each address with its full one-line
+// text. Selecting an option writes the address id into a hidden field so it
+// saves as the affiliation's organization_address_id.
 //
 // Connects to data-controller="address-select"
 export default class extends Controller {
@@ -41,7 +41,7 @@ export default class extends Controller {
   select(event) {
     const option = event.currentTarget;
     this.inputTarget.value = option.dataset.value;
-    this.labelTarget.textContent = option.dataset.number;
+    this.labelTarget.textContent = option.dataset.label;
     this.close();
   }
 

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
     if (!this.hasAffiliationsContainerTarget) return
     const fields = this.affiliationsContainerTarget.querySelectorAll(".nested-fields")
     fields.forEach(field => {
-      const inputs = field.querySelectorAll("input[name*='start_date'], input[name*='end_date'], textarea[name*='title']")
+      const inputs = field.querySelectorAll("input[name*='start_date'], input[name*='end_date'], input[name*='title']")
       inputs.forEach(input => {
         input.addEventListener("change", this.boundRecalculate)
         input.addEventListener("input", this.boundRecalculate)
@@ -89,7 +89,7 @@ export default class extends Controller {
       .map(field => ({
         startDate: field.querySelector("input[name*='start_date']")?.value || "",
         endDate: field.querySelector("input[name*='end_date']")?.value || "",
-        title: field.querySelector("textarea[name*='title']")?.value || ""
+        title: field.querySelector("input[name*='title']")?.value || ""
       }))
   }
 

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -24,24 +24,33 @@ export default class extends Controller {
       this.accentBarTarget.classList.toggle("bg-purple-500", facilitator);
       this.accentBarTarget.classList.toggle("bg-gray-300", !facilitator);
     }
-    this.styleTitle(facilitator);
+    this.styleTitle();
     this.updateRowBackground();
   }
 
   // Purple "Facilitator" tint on the title input, matching the server-rendered
-  // state and toggled live as the title changes. Shape/size are untouched.
-  styleTitle(facilitator) {
+  // state and toggled live as the title/end date change. Inactive facilitator
+  // rows use a lighter, softer purple; shape/size are untouched.
+  styleTitle() {
+    if (!this.hasTitleTarget) return;
+    const facilitator = this.isFacilitator();
+    const active = facilitator && !this.isPast();
+    const inactive = facilitator && this.isPast();
     const t = this.titleTarget;
-    t.classList.toggle("bg-purple-100!", facilitator);
-    t.classList.toggle("text-purple-700!", facilitator);
-    t.classList.toggle("font-semibold", facilitator);
-    t.classList.toggle("border-purple-300!", facilitator);
+    t.classList.toggle("bg-purple-100!", active);
+    t.classList.toggle("text-purple-700!", active);
+    t.classList.toggle("font-semibold", active);
+    t.classList.toggle("border-purple-300!", active);
+    t.classList.toggle("bg-purple-50!", inactive);
+    t.classList.toggle("text-purple-400!", inactive);
+    t.classList.toggle("border-purple-200!", inactive);
     t.classList.toggle("border-gray-300!", !facilitator);
   }
 
   apply() {
     if (!this.hasEndDateTarget) return;
     this.updateRowBackground();
+    this.styleTitle();
   }
 
   // Single source of truth for the row tint: gray when expired, light purple for

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -1,17 +1,16 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Live styling for the affiliation editor row: reflects facilitator-ness (title)
-// and active/expired state (end date) as you edit, before saving. Drives the row
-// tint, the left accent bar, the "Facilitator" title purple, and the field fills
-// (transparent when empty, the pill colour when filled).
+// Live styling for the affiliation editor row as you edit, before saving. Colour
+// carries role only (facilitator = purple, else neutral); inactive is a structural
+// cue — a dashed row border and a struck-through end date — so active vs inactive
+// never competes with the role colour.
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar", "valueField"]
-  static values = { activeTint: String, expired: Boolean }
+  static values = { expired: Boolean }
 
   connect() {
-    if (this.hasEndDateTarget) this.apply();
     if (this.hasTitleTarget) this.updateBorder();
-    this.paintFields();
+    else this.apply();
   }
 
   toggle() {
@@ -25,57 +24,43 @@ export default class extends Controller {
       this.accentBarTarget.classList.toggle("bg-purple-500", facilitator);
       this.accentBarTarget.classList.toggle("bg-gray-300", !facilitator);
     }
-    this.styleTitle();
-    this.updateRowBackground();
-    this.paintFields();
+    this.apply();
   }
 
   apply() {
-    if (!this.hasEndDateTarget) return;
     this.updateRowBackground();
     this.styleTitle();
     this.paintFields();
+    this.styleEndDate();
   }
 
-  // The "Facilitator" title keeps its own darker purple (lighter when inactive);
-  // any other title fills like the rest of the fields. Shape/size are untouched.
+  // Facilitator title keeps its darker purple; any other title fills like the rest.
   styleTitle() {
     if (!this.hasTitleTarget) return;
     const t = this.titleTarget;
-    const facilitator = this.isFacilitator();
-    const past = this.isPast();
     t.classList.remove(
-      "bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!",
-      "text-purple-700!", "text-purple-500!", "font-semibold",
-      "border-purple-300!", "border-gray-300!"
+      "bg-transparent!", "bg-white!", "bg-purple-100!",
+      "text-purple-700!", "font-semibold", "border-purple-300!", "border-gray-300!"
     );
-    if (facilitator && !past) {
+    if (this.isFacilitator()) {
       t.classList.add("bg-purple-100!", "text-purple-700!", "font-semibold", "border-purple-300!");
-    } else if (facilitator && past) {
-      t.classList.add("bg-purple-100!", "text-purple-500!", "border-purple-300!");
     } else {
       t.classList.add(this.fieldBg(t), "border-gray-300!");
     }
   }
 
-  // Repaint the date/address fields: empty -> transparent (card tint shows
-  // through), filled -> the pill colour for the row's current state.
+  // Empty fields are transparent (row tint shows through); filled fields take the
+  // role colour (purple for facilitators, else white).
   paintFields() {
     this.valueFieldTargets.forEach((el) => {
-      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!");
+      el.classList.remove("bg-transparent!", "bg-white!", "bg-purple-100!");
       el.classList.add(this.fieldBg(el));
     });
   }
 
   fieldBg(el) {
-    return this.fieldHasValue(el) ? this.pillColorClass() : "bg-transparent!";
-  }
-
-  // The fill for a filled field: facilitator rows take purple (lighter when
-  // inactive to match the title), other rows take white (active) / grey (inactive).
-  pillColorClass() {
-    if (this.isFacilitator()) return "bg-purple-100!";
-    return this.isPast() ? "bg-gray-100!" : "bg-white!";
+    if (!this.fieldHasValue(el)) return "bg-transparent!";
+    return this.isFacilitator() ? "bg-purple-100!" : "bg-white!";
   }
 
   fieldHasValue(el) {
@@ -85,27 +70,28 @@ export default class extends Controller {
     return Boolean(hidden && hidden.value);
   }
 
-  // Single source of truth for the row tint: gray when expired, light purple for
-  // an active facilitator, else the counterpart-theme active tint (sky/emerald).
+  // Role colour for the row + a dashed border when inactive.
   updateRowBackground() {
-    const activeTint = (this.activeTintValue || "bg-gray-50 border-gray-200").split(" ");
+    const facilitator = this.isFacilitator();
+    const past = this.isPast();
     this.rowTarget.classList.remove(
-      "bg-gray-100", "border-gray-300", "opacity-80",
-      "bg-purple-50", "border-purple-200",
-      "bg-gray-50", "border-gray-200"
+      "bg-purple-50", "bg-gray-50",
+      "border-purple-200", "border-purple-300", "border-gray-200", "border-gray-300",
+      "border-dashed"
     );
-
-    if (this.isPast()) {
-      if (this.isFacilitator()) {
-        this.rowTarget.classList.add("bg-purple-50", "border-purple-200", "opacity-80");
-      } else {
-        this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-80");
-      }
-    } else if (this.isFacilitator()) {
-      this.rowTarget.classList.add("bg-purple-50", "border-purple-200");
+    this.rowTarget.classList.add(facilitator ? "bg-purple-50" : "bg-gray-50");
+    if (past) {
+      this.rowTarget.classList.add(facilitator ? "border-purple-300" : "border-gray-300", "border-dashed");
     } else {
-      this.rowTarget.classList.add(...activeTint);
+      this.rowTarget.classList.add(facilitator ? "border-purple-200" : "border-gray-200");
     }
+  }
+
+  // Strike the end date when it marks the row ended.
+  styleEndDate() {
+    if (!this.hasEndDateTarget) return;
+    const ended = Boolean(this.endDateTarget.value) && this.isPast();
+    this.endDateTarget.classList.toggle("date-ended", ended);
   }
 
   // With an end date, compute from it (live); without one, the JS can't see the
@@ -117,7 +103,7 @@ export default class extends Controller {
   }
 
   // Mirror Affiliation#facilitator? — an exact, case-sensitive match on
-  // "Facilitator" (trimmed), so the live row tint matches what the server will render.
+  // "Facilitator" (trimmed), so the live styling matches what the server renders.
   isFacilitator() {
     return this.hasTitleTarget && this.titleTarget.value.trim() === "Facilitator";
   }

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -1,9 +1,9 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Live styling for the affiliation editor row as you edit, before saving. Colour
-// carries role only (facilitator = purple, else neutral); inactive is a structural
-// cue — a dashed row border and a struck-through end date — so active vs inactive
-// never competes with the role colour.
+// Live styling for the affiliation editor row as you edit, before saving. Four
+// states by colour: role is the hue (facilitator = purple, else blue) and status
+// is the saturation (active = full, inactive = super-light). Inactive rows also
+// strike their fields (.aff-ended).
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar", "valueField"]
   static values = { expired: Boolean }
@@ -19,10 +19,14 @@ export default class extends Controller {
 
   updateBorder() {
     if (!this.hasTitleTarget) return;
-    const facilitator = this.isFacilitator();
     if (this.hasAccentBarTarget) {
-      this.accentBarTarget.classList.toggle("bg-purple-500", facilitator);
-      this.accentBarTarget.classList.toggle("bg-gray-300", !facilitator);
+      const fac = this.isFacilitator();
+      const past = this.isPast();
+      const a = this.accentBarTarget.classList;
+      a.toggle("bg-purple-500", fac && !past);
+      a.toggle("bg-purple-300", fac && past);
+      a.toggle("bg-blue-500", !fac && !past);
+      a.toggle("bg-blue-300", !fac && past);
     }
     this.apply();
   }
@@ -31,36 +35,38 @@ export default class extends Controller {
     this.updateRowBackground();
     this.styleTitle();
     this.paintFields();
-    this.styleEndDate();
+    this.rowTarget.classList.toggle("aff-ended", this.isPast());
   }
 
-  // Facilitator title keeps its darker purple; any other title fills like the rest.
   styleTitle() {
     if (!this.hasTitleTarget) return;
     const t = this.titleTarget;
+    const fac = this.isFacilitator();
+    const past = this.isPast();
     t.classList.remove(
-      "bg-transparent!", "bg-white!", "bg-purple-100!",
-      "text-purple-700!", "font-semibold", "border-purple-300!", "border-gray-300!"
+      "bg-purple-100!", "bg-purple-50!", "bg-blue-100!", "bg-blue-50!",
+      "text-purple-700!", "text-purple-500!", "text-blue-700!", "text-blue-500!",
+      "font-semibold",
+      "border-purple-300!", "border-purple-200!", "border-blue-300!", "border-blue-200!"
     );
-    if (this.isFacilitator()) {
-      t.classList.add("bg-purple-100!", "text-purple-700!", "font-semibold", "border-purple-300!");
-    } else {
-      t.classList.add(this.fieldBg(t), "border-gray-300!");
-    }
+    if (fac && !past) t.classList.add("bg-purple-100!", "text-purple-700!", "font-semibold", "border-purple-300!");
+    else if (fac && past) t.classList.add("bg-purple-50!", "text-purple-500!", "border-purple-200!");
+    else if (!fac && !past) t.classList.add("bg-blue-100!", "text-blue-700!", "font-semibold", "border-blue-300!");
+    else t.classList.add("bg-blue-50!", "text-blue-500!", "border-blue-200!");
   }
 
   // Empty fields are transparent (row tint shows through); filled fields take the
-  // role colour (purple for facilitators, else white).
+  // role+status fill colour.
   paintFields() {
     this.valueFieldTargets.forEach((el) => {
-      el.classList.remove("bg-transparent!", "bg-white!", "bg-purple-100!");
-      el.classList.add(this.fieldBg(el));
+      el.classList.remove("bg-transparent!", "bg-purple-100!", "bg-purple-50!", "bg-blue-100!", "bg-blue-50!");
+      el.classList.add(this.fieldHasValue(el) ? this.fillClass() : "bg-transparent!");
     });
   }
 
-  fieldBg(el) {
-    if (!this.fieldHasValue(el)) return "bg-transparent!";
-    return this.isFacilitator() ? "bg-purple-100!" : "bg-white!";
+  fillClass() {
+    if (this.isFacilitator()) return this.isPast() ? "bg-purple-50!" : "bg-purple-100!";
+    return this.isPast() ? "bg-blue-50!" : "bg-blue-100!";
   }
 
   fieldHasValue(el) {
@@ -70,28 +76,12 @@ export default class extends Controller {
     return Boolean(hidden && hidden.value);
   }
 
-  // Role colour for the row + a dashed border when inactive.
+  // Row background is the role hue only; status is carried by the fills/accent/title.
   updateRowBackground() {
-    const facilitator = this.isFacilitator();
-    const past = this.isPast();
-    this.rowTarget.classList.remove(
-      "bg-purple-50", "bg-gray-50",
-      "border-purple-200", "border-purple-300", "border-gray-200", "border-gray-300",
-      "border-dashed"
-    );
-    this.rowTarget.classList.add(facilitator ? "bg-purple-50" : "bg-gray-50");
-    if (past) {
-      this.rowTarget.classList.add(facilitator ? "border-purple-300" : "border-gray-300", "border-dashed");
-    } else {
-      this.rowTarget.classList.add(facilitator ? "border-purple-200" : "border-gray-200");
-    }
-  }
-
-  // Strike the end date when it marks the row ended.
-  styleEndDate() {
-    if (!this.hasEndDateTarget) return;
-    const ended = Boolean(this.endDateTarget.value) && this.isPast();
-    this.endDateTarget.classList.toggle("date-ended", ended);
+    const fac = this.isFacilitator();
+    const r = this.rowTarget.classList;
+    r.remove("bg-purple-50", "border-purple-200", "bg-blue-50", "border-blue-200");
+    r.add(fac ? "bg-purple-50" : "bg-blue-50", fac ? "border-purple-200" : "border-blue-200");
   }
 
   // With an end date, compute from it (live); without one, the JS can't see the

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -88,17 +88,19 @@ export default class extends Controller {
   // Single source of truth for the row tint: gray when expired, light purple for
   // an active facilitator, else the counterpart-theme active tint (sky/emerald).
   updateRowBackground() {
-    const activeTint = (this.activeTintValue || "bg-white border-gray-200").split(" ");
+    const activeTint = (this.activeTintValue || "bg-gray-50 border-gray-200").split(" ");
     this.rowTarget.classList.remove(
       "bg-gray-100", "border-gray-300", "opacity-60",
       "bg-purple-50", "border-purple-200",
-      "bg-sky-50", "border-sky-200",
-      "bg-emerald-50", "border-emerald-200",
-      "bg-white", "border-gray-200"
+      "bg-gray-50", "border-gray-200"
     );
 
     if (this.isPast()) {
-      this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-60");
+      if (this.isFacilitator()) {
+        this.rowTarget.classList.add("bg-purple-50", "border-purple-200", "opacity-60");
+      } else {
+        this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-60");
+      }
     } else if (this.isFacilitator()) {
       this.rowTarget.classList.add("bg-purple-50", "border-purple-200");
     } else {

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -1,16 +1,17 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Live row tint for the affiliation editor: reflects facilitator-ness (title) and
-// active/expired state (end date) as you edit, before saving. The person/org pill
-// and field chrome are static neutral styles now, so only the row background and
-// the left accent bar need updating here.
+// Live styling for the affiliation editor row: reflects facilitator-ness (title)
+// and active/expired state (end date) as you edit, before saving. Drives the row
+// tint, the left accent bar, the "Facilitator" title purple, and the field fills
+// (transparent when empty, the pill colour when filled).
 export default class extends Controller {
-  static targets = ["endDate", "title", "row", "accentBar"]
+  static targets = ["endDate", "title", "row", "accentBar", "valueField"]
   static values = { activeTint: String }
 
   connect() {
     if (this.hasEndDateTarget) this.apply();
     if (this.hasTitleTarget) this.updateBorder();
+    this.paintFields();
   }
 
   toggle() {
@@ -26,31 +27,63 @@ export default class extends Controller {
     }
     this.styleTitle();
     this.updateRowBackground();
-  }
-
-  // Purple "Facilitator" tint on the title input, matching the server-rendered
-  // state and toggled live as the title/end date change. Inactive facilitator
-  // rows use a lighter, softer purple; shape/size are untouched.
-  styleTitle() {
-    if (!this.hasTitleTarget) return;
-    const facilitator = this.isFacilitator();
-    const active = facilitator && !this.isPast();
-    const inactive = facilitator && this.isPast();
-    const t = this.titleTarget;
-    t.classList.toggle("bg-purple-100!", active);
-    t.classList.toggle("text-purple-700!", active);
-    t.classList.toggle("font-semibold", active);
-    t.classList.toggle("border-purple-300!", active);
-    t.classList.toggle("bg-purple-50!", inactive);
-    t.classList.toggle("text-purple-400!", inactive);
-    t.classList.toggle("border-purple-200!", inactive);
-    t.classList.toggle("border-gray-300!", !facilitator);
+    this.paintFields();
   }
 
   apply() {
     if (!this.hasEndDateTarget) return;
     this.updateRowBackground();
     this.styleTitle();
+    this.paintFields();
+  }
+
+  // The "Facilitator" title keeps its own darker purple (lighter when inactive);
+  // any other title fills like the rest of the fields. Shape/size are untouched.
+  styleTitle() {
+    if (!this.hasTitleTarget) return;
+    const t = this.titleTarget;
+    const facilitator = this.isFacilitator();
+    const past = this.isPast();
+    t.classList.remove(
+      "bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!", "bg-purple-50!",
+      "text-purple-700!", "text-purple-400!", "font-semibold",
+      "border-purple-300!", "border-purple-200!", "border-gray-300!"
+    );
+    if (facilitator && !past) {
+      t.classList.add("bg-purple-100!", "text-purple-700!", "font-semibold", "border-purple-300!");
+    } else if (facilitator && past) {
+      t.classList.add("bg-purple-50!", "text-purple-400!", "border-purple-200!");
+    } else {
+      t.classList.add(this.fieldBg(t), "border-gray-300!");
+    }
+  }
+
+  // Repaint the date/address fields: empty -> transparent (card tint shows
+  // through), filled -> the pill colour for the row's current state.
+  paintFields() {
+    this.valueFieldTargets.forEach((el) => {
+      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!");
+      el.classList.add(this.fieldBg(el));
+    });
+  }
+
+  fieldBg(el) {
+    return this.fieldHasValue(el) ? this.pillColorClass() : "bg-transparent!";
+  }
+
+  // Mirrors the person/org pill: grey when expired, purple for a facilitator,
+  // else white.
+  pillColorClass() {
+    if (this.isPast()) return "bg-gray-100!";
+    if (this.isFacilitator()) return "bg-purple-100!";
+    return "bg-white!";
+  }
+
+  fieldHasValue(el) {
+    if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") return el.value.trim() !== "";
+    // Address button: filled when its org-address hidden input holds a value.
+    const hidden = el.parentElement.querySelector("input[type='hidden']");
+    return Boolean(hidden && hidden.value);
   }
 
   // Single source of truth for the row tint: gray when expired, light purple for

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -18,12 +18,24 @@ export default class extends Controller {
 
   updateBorder() {
     if (!this.hasTitleTarget) return;
+    const facilitator = this.isFacilitator();
     if (this.hasAccentBarTarget) {
-      const facilitator = this.isFacilitator();
       this.accentBarTarget.classList.toggle("bg-purple-500", facilitator);
       this.accentBarTarget.classList.toggle("bg-gray-300", !facilitator);
     }
+    this.styleTitle(facilitator);
     this.updateRowBackground();
+  }
+
+  // Purple "Facilitator" tint on the title input, matching the server-rendered
+  // state and toggled live as the title changes. Shape/size are untouched.
+  styleTitle(facilitator) {
+    const t = this.titleTarget;
+    t.classList.toggle("bg-purple-100!", facilitator);
+    t.classList.toggle("text-purple-700!", facilitator);
+    t.classList.toggle("font-semibold", facilitator);
+    t.classList.toggle("border-purple-300!", facilitator);
+    t.classList.toggle("border-gray-300!", !facilitator);
   }
 
   apply() {
@@ -36,14 +48,14 @@ export default class extends Controller {
   updateRowBackground() {
     this.rowTarget.classList.remove(
       "bg-gray-100", "border-gray-300", "opacity-60",
-      "bg-purple-100", "border-purple-300",
+      "bg-purple-50", "border-purple-200",
       "bg-white", "border-gray-200"
     );
 
     if (this.isPast()) {
       this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-60");
     } else if (this.isFacilitator()) {
-      this.rowTarget.classList.add("bg-purple-100", "border-purple-300");
+      this.rowTarget.classList.add("bg-purple-50", "border-purple-200");
     } else {
       this.rowTarget.classList.add("bg-white", "border-gray-200");
     }

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -45,14 +45,14 @@ export default class extends Controller {
     const facilitator = this.isFacilitator();
     const past = this.isPast();
     t.classList.remove(
-      "bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!", "bg-purple-50!",
-      "text-purple-700!", "text-purple-400!", "font-semibold",
-      "border-purple-300!", "border-purple-200!", "border-gray-300!"
+      "bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!",
+      "text-purple-700!", "text-purple-500!", "font-semibold",
+      "border-purple-300!", "border-gray-300!"
     );
     if (facilitator && !past) {
       t.classList.add("bg-purple-100!", "text-purple-700!", "font-semibold", "border-purple-300!");
     } else if (facilitator && past) {
-      t.classList.add("bg-purple-50!", "text-purple-400!", "border-purple-200!");
+      t.classList.add("bg-purple-100!", "text-purple-500!", "border-purple-300!");
     } else {
       t.classList.add(this.fieldBg(t), "border-gray-300!");
     }
@@ -62,7 +62,7 @@ export default class extends Controller {
   // through), filled -> the pill colour for the row's current state.
   paintFields() {
     this.valueFieldTargets.forEach((el) => {
-      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!", "bg-purple-50!");
+      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!");
       el.classList.add(this.fieldBg(el));
     });
   }
@@ -74,7 +74,7 @@ export default class extends Controller {
   // The fill for a filled field: facilitator rows take purple (lighter when
   // inactive to match the title), other rows take white (active) / grey (inactive).
   pillColorClass() {
-    if (this.isFacilitator()) return this.isPast() ? "bg-purple-50!" : "bg-purple-100!";
+    if (this.isFacilitator()) return "bg-purple-100!";
     return this.isPast() ? "bg-gray-100!" : "bg-white!";
   }
 
@@ -90,16 +90,16 @@ export default class extends Controller {
   updateRowBackground() {
     const activeTint = (this.activeTintValue || "bg-gray-50 border-gray-200").split(" ");
     this.rowTarget.classList.remove(
-      "bg-gray-100", "border-gray-300", "opacity-60",
+      "bg-gray-100", "border-gray-300", "opacity-80",
       "bg-purple-50", "border-purple-200",
       "bg-gray-50", "border-gray-200"
     );
 
     if (this.isPast()) {
       if (this.isFacilitator()) {
-        this.rowTarget.classList.add("bg-purple-50", "border-purple-200", "opacity-60");
+        this.rowTarget.classList.add("bg-purple-50", "border-purple-200", "opacity-80");
       } else {
-        this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-60");
+        this.rowTarget.classList.add("bg-gray-100", "border-gray-300", "opacity-80");
       }
     } else if (this.isFacilitator()) {
       this.rowTarget.classList.add("bg-purple-50", "border-purple-200");

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -6,7 +6,7 @@ import { Controller } from "@hotwired/stimulus";
 // (transparent when empty, the pill colour when filled).
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar", "valueField"]
-  static values = { activeTint: String }
+  static values = { activeTint: String, expired: Boolean }
 
   connect() {
     if (this.hasEndDateTarget) this.apply();
@@ -62,7 +62,7 @@ export default class extends Controller {
   // through), filled -> the pill colour for the row's current state.
   paintFields() {
     this.valueFieldTargets.forEach((el) => {
-      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!");
+      el.classList.remove("bg-transparent!", "bg-gray-100!", "bg-white!", "bg-purple-100!", "bg-purple-50!");
       el.classList.add(this.fieldBg(el));
     });
   }
@@ -71,12 +71,11 @@ export default class extends Controller {
     return this.fieldHasValue(el) ? this.pillColorClass() : "bg-transparent!";
   }
 
-  // Mirrors the person/org pill: grey when expired, purple for a facilitator,
-  // else white.
+  // The fill for a filled field: facilitator rows take purple (lighter when
+  // inactive to match the title), other rows take white (active) / grey (inactive).
   pillColorClass() {
-    if (this.isPast()) return "bg-gray-100!";
-    if (this.isFacilitator()) return "bg-purple-100!";
-    return "bg-white!";
+    if (this.isFacilitator()) return this.isPast() ? "bg-purple-50!" : "bg-purple-100!";
+    return this.isPast() ? "bg-gray-100!" : "bg-white!";
   }
 
   fieldHasValue(el) {
@@ -107,10 +106,12 @@ export default class extends Controller {
     }
   }
 
+  // With an end date, compute from it (live); without one, the JS can't see the
+  // server's inactive flag, so trust the server-rendered `expired` value.
   isPast() {
-    if (!this.hasEndDateTarget) return false;
-    const value = this.endDateTarget.value;
-    return value && new Date(value) < new Date(new Date().toDateString());
+    const value = this.hasEndDateTarget ? this.endDateTarget.value : "";
+    if (value) return new Date(value) < new Date(new Date().toDateString());
+    return this.expiredValue;
   }
 
   // Mirror Affiliation#facilitator? — an exact, case-sensitive match on

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -6,6 +6,7 @@ import { Controller } from "@hotwired/stimulus";
 // the left accent bar need updating here.
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar"]
+  static values = { activeTint: String }
 
   connect() {
     if (this.hasEndDateTarget) this.apply();
@@ -44,11 +45,14 @@ export default class extends Controller {
   }
 
   // Single source of truth for the row tint: gray when expired, light purple for
-  // an active facilitator, white otherwise.
+  // an active facilitator, else the counterpart-theme active tint (sky/emerald).
   updateRowBackground() {
+    const activeTint = (this.activeTintValue || "bg-white border-gray-200").split(" ");
     this.rowTarget.classList.remove(
       "bg-gray-100", "border-gray-300", "opacity-60",
       "bg-purple-50", "border-purple-200",
+      "bg-sky-50", "border-sky-200",
+      "bg-emerald-50", "border-emerald-200",
       "bg-white", "border-gray-200"
     );
 
@@ -57,7 +61,7 @@ export default class extends Controller {
     } else if (this.isFacilitator()) {
       this.rowTarget.classList.add("bg-purple-50", "border-purple-200");
     } else {
-      this.rowTarget.classList.add("bg-white", "border-gray-200");
+      this.rowTarget.classList.add(...activeTint);
     }
   }
 

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -1,31 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Active themed classes used by person (sky) and organization (emerald) profile buttons
-const ACTIVE_CLASSES = [
-  "bg-sky-50", "bg-sky-100", "bg-sky-200", "hover:bg-sky-100", "hover:bg-sky-200",
-  "text-sky-700", "text-sky-800", "border-sky-200", "border-sky-300",
-  "bg-emerald-50", "bg-emerald-100", "bg-emerald-200", "hover:bg-emerald-100", "hover:bg-emerald-200",
-  "text-emerald-700", "text-emerald-800", "border-emerald-200", "border-emerald-300"
-];
-const GRAY_CLASSES = ["bg-gray-100", "hover:bg-gray-200", "text-gray-400", "border-gray-300"];
-
-function grayOut(el) {
-  ACTIVE_CLASSES.forEach((cls) => el.classList.remove(cls));
-  GRAY_CLASSES.forEach((cls) => el.classList.add(cls));
-}
-
+// Live row tint for the affiliation editor: reflects facilitator-ness (title) and
+// active/expired state (end date) as you edit, before saving. The person/org pill
+// and field chrome are static neutral styles now, so only the row background and
+// the left accent bar need updating here.
 export default class extends Controller {
-  static targets = ["endDate", "title", "row", "profileButton", "accentBar"]
+  static targets = ["endDate", "title", "row", "accentBar"]
 
   connect() {
-    // Save original classes for profile buttons and their styled children
-    this._savedClasses = [];
-    this.profileButtonTargets.forEach((btn) => {
-      btn.querySelectorAll("a.group, a.group span").forEach((el) => {
-        this._savedClasses.push({ el, className: el.className });
-      });
-    });
-
     if (this.hasEndDateTarget) this.apply();
     if (this.hasTitleTarget) this.updateBorder();
   }
@@ -37,24 +19,16 @@ export default class extends Controller {
   updateBorder() {
     if (!this.hasTitleTarget) return;
     if (this.hasAccentBarTarget) {
-      this.accentBarTarget.style.backgroundColor = this.isFacilitator() ? "#a855f7" : "#d1d5db";
+      const facilitator = this.isFacilitator();
+      this.accentBarTarget.classList.toggle("bg-purple-500", facilitator);
+      this.accentBarTarget.classList.toggle("bg-gray-300", !facilitator);
     }
     this.updateRowBackground();
   }
 
   apply() {
     if (!this.hasEndDateTarget) return;
-    const isPast = this.isPast();
-
     this.updateRowBackground();
-
-    if (isPast) {
-      this.profileButtonTargets.forEach((btn) => {
-        btn.querySelectorAll("a.group, a.group span").forEach((el) => grayOut(el));
-      });
-    } else {
-      this._savedClasses.forEach(({ el, className }) => { el.className = className; });
-    }
   }
 
   // Single source of truth for the row tint: gray when expired, light purple for

--- a/app/frontend/javascript/controllers/paginated_fields_controller.js
+++ b/app/frontend/javascript/controllers/paginated_fields_controller.js
@@ -8,6 +8,28 @@ export default class extends Controller {
     this.currentPage = 1;
     this.render();
     this.ready = true;
+    this.revealHashTarget();
+  }
+
+  // When the page loads with a #fragment matching a row inside this controller
+  // (e.g. returning from the affiliation editor to its row), jump to the page
+  // holding that row — otherwise it's hidden on a later page — and scroll to it.
+  revealHashTarget() {
+    const hash = window.location.hash;
+    if (hash.length < 2) return;
+
+    const id = hash.slice(1);
+    const items = this.visibleItems;
+    const index = items.findIndex(
+      (el) => el.id === id || el.querySelector(`#${CSS.escape(id)}`)
+    );
+    if (index === -1) return;
+
+    this.currentPage = Math.floor(index / this.perPageValue) + 1;
+    this.render();
+
+    const target = document.getElementById(id) || items[index];
+    requestAnimationFrame(() => target.scrollIntoView({ block: "center" }));
   }
 
   get visibleItems() {

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -119,7 +119,8 @@
    date input's value only strikes via its inner pseudo-element (WebKit). */
 .aff-ended input,
 .aff-ended textarea,
-.aff-ended [data-address-select-target="button"] {
+.aff-ended [data-address-select-target="button"],
+.aff-ended a .truncate {
   text-decoration: line-through;
 }
 .aff-ended input::-webkit-datetime-edit {

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -115,6 +115,13 @@
   @apply bg-gray-100;
 }
 
+/* Struck-through end date on an ended (inactive) affiliation row. The value of a
+   native date input can only be styled via its inner pseudo-element (WebKit). */
+.date-ended::-webkit-datetime-edit {
+  text-decoration: line-through;
+  color: #9ca3af;
+}
+
 /* Tom Select "flat" variant: the wrapper inherits the field's bordered box,
    so the inner control is transparent and borderless — no box-within-a-box.
    Used for optional searchable-selects (e.g. the event location) so the field

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -115,11 +115,15 @@
   @apply bg-gray-100;
 }
 
-/* Struck-through end date on an ended (inactive) affiliation row. The value of a
-   native date input can only be styled via its inner pseudo-element (WebKit). */
-.date-ended::-webkit-datetime-edit {
+/* Inactive (ended) affiliation rows strike through their field values. A native
+   date input's value only strikes via its inner pseudo-element (WebKit). */
+.aff-ended input,
+.aff-ended textarea,
+.aff-ended [data-address-select-target="button"] {
   text-decoration: line-through;
-  color: #9ca3af;
+}
+.aff-ended input::-webkit-datetime-edit {
+  text-decoration: line-through;
 }
 
 /* Tom Select "flat" variant: the wrapper inherits the field's bordered box,

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -13,6 +13,7 @@ module CommentsHelper
     when TopicSubscription then "Subscription · #{record.topic_label}"
     when Story then "Story · #{record.title}"
     when StoryIdea then "Story idea · #{record.title.presence || "##{record.id}"}"
+    when Affiliation then "Affiliation · #{record.person&.full_name} @ #{record.organization&.name}"
     else record.class.name.underscore.humanize
     end
   end

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -1,5 +1,5 @@
 module OrganizationHelper
-  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, muted: false, compact: false)
+  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, tint: nil, compact: false)
     # Compact mode shrinks the control to roughly a text input's height, for use
     # inline beside form fields (e.g. the affiliation editor rows).
     padding = compact ? "px-3 py-1" : "px-4 py-2"
@@ -11,7 +11,12 @@ module OrganizationHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
-    elsif muted
+    elsif tint == :facilitator
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = DomainTheme.text_class_for(:organizations)
+      border = "border-purple-200"
+    elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"
       text = DomainTheme.text_class_for(:organizations)
@@ -22,7 +27,7 @@ module OrganizationHelper
       text = DomainTheme.text_class_for(:organizations)
       border = DomainTheme.border_class_for(:organizations)
     end
-    shadow = muted ? "shadow-none" : "shadow-sm"
+    shadow = tint ? "shadow-none" : "shadow-sm"
 
     hover_title = [ organization.name, subtitle ].compact_blank.join(" — ")
 

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -14,8 +14,23 @@ module OrganizationHelper
     elsif tint == :facilitator
       bg = "bg-purple-100"
       hover_bg = "hover:bg-purple-200"
-      text = DomainTheme.text_class_for(:organizations)
+      text = "text-gray-800"
       border = "border-purple-300"
+    elsif tint == :facilitator_light
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = "text-gray-800"
+      border = "border-purple-200"
+    elsif tint == :nonfac
+      bg = "bg-blue-100"
+      hover_bg = "hover:bg-blue-200"
+      text = "text-gray-800"
+      border = "border-blue-300"
+    elsif tint == :nonfac_light
+      bg = "bg-blue-50"
+      hover_bg = "hover:bg-blue-100"
+      text = "text-gray-800"
+      border = "border-blue-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -1,5 +1,5 @@
 module OrganizationHelper
-  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, compact: false)
+  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, transparent: false, compact: false)
     # Compact mode shrinks the control to roughly a text input's height, for use
     # inline beside form fields (e.g. the affiliation editor rows).
     padding = compact ? "px-3 py-1" : "px-4 py-2"
@@ -11,12 +11,18 @@ module OrganizationHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
+    elsif transparent
+      bg = "bg-transparent"
+      hover_bg = "hover:bg-gray-100"
+      text = DomainTheme.text_class_for(:organizations)
+      border = "border-transparent"
     else
       bg = DomainTheme.bg_class_for(:organizations, intensity: 100)
       hover_bg = DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)
       text = DomainTheme.text_class_for(:organizations)
       border = DomainTheme.border_class_for(:organizations)
     end
+    shadow = transparent ? "shadow-none" : "shadow-sm"
 
     hover_title = [ organization.name, subtitle ].compact_blank.join(" — ")
 
@@ -27,7 +33,7 @@ module OrganizationHelper
                     w-full #{padding}
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
-                    font-medium shadow-sm leading-none
+                    font-medium #{shadow} leading-none
                     overflow-hidden" do
       # --- Logo ---
       logo = if organization.respond_to?(:logo) && organization.logo.attached?

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -16,6 +16,11 @@ module OrganizationHelper
       hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:organizations)
       border = "border-purple-300"
+    elsif tint == :facilitator_inactive
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = DomainTheme.text_class_for(:organizations)
+      border = "border-purple-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -16,11 +16,6 @@ module OrganizationHelper
       hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:organizations)
       border = "border-purple-300"
-    elsif tint == :facilitator_inactive
-      bg = "bg-purple-50"
-      hover_bg = "hover:bg-purple-100"
-      text = DomainTheme.text_class_for(:organizations)
-      border = "border-purple-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -12,10 +12,10 @@ module OrganizationHelper
       text = "text-gray-400"
       border = "border-gray-300"
     elsif tint == :facilitator
-      bg = "bg-purple-50"
-      hover_bg = "hover:bg-purple-100"
+      bg = "bg-purple-100"
+      hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:organizations)
-      border = "border-purple-200"
+      border = "border-purple-300"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -1,5 +1,5 @@
 module OrganizationHelper
-  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, transparent: false, compact: false)
+  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, muted: false, compact: false)
     # Compact mode shrinks the control to roughly a text input's height, for use
     # inline beside form fields (e.g. the affiliation editor rows).
     padding = compact ? "px-3 py-1" : "px-4 py-2"
@@ -11,18 +11,18 @@ module OrganizationHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
-    elsif transparent
-      bg = "bg-transparent"
-      hover_bg = "hover:bg-gray-100"
+    elsif muted
+      bg = "bg-gray-100"
+      hover_bg = "hover:bg-gray-200"
       text = DomainTheme.text_class_for(:organizations)
-      border = "border-transparent"
+      border = "border-gray-300"
     else
       bg = DomainTheme.bg_class_for(:organizations, intensity: 100)
       hover_bg = DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)
       text = DomainTheme.text_class_for(:organizations)
       border = DomainTheme.border_class_for(:organizations)
     end
-    shadow = transparent ? "shadow-none" : "shadow-sm"
+    shadow = muted ? "shadow-none" : "shadow-sm"
 
     hover_title = [ organization.name, subtitle ].compact_blank.join(" — ")
 

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -1,5 +1,11 @@
 module OrganizationHelper
-  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false)
+  def organization_profile_button(organization, truncate_at: nil, subtitle: nil, label: nil, data: {}, inactive: false, compact: false)
+    # Compact mode shrinks the control to roughly a text input's height, for use
+    # inline beside form fields (e.g. the affiliation editor rows).
+    padding = compact ? "px-3 py-1" : "px-4 py-2"
+    avatar_size = compact ? "w-8 h-8" : "w-10 h-10"
+    initial_text_size = compact ? "text-sm" : "text-lg"
+
     if inactive
       bg = "bg-gray-100"
       hover_bg = "hover:bg-gray-200"
@@ -18,7 +24,7 @@ module OrganizationHelper
             data: { turbo_prefetch: false }.merge(data),
             title: hover_title,
             class: "group relative flex items-center gap-2
-                    w-full px-4 py-2
+                    w-full #{padding}
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
                     font-medium shadow-sm leading-none
@@ -26,11 +32,11 @@ module OrganizationHelper
       # --- Logo ---
       logo = if organization.respond_to?(:logo) && organization.logo.attached?
         image_tag organization.logo,
-                  class: "w-10 h-10 rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
+                  class: "#{avatar_size} rounded-full object-cover border border-gray-300 shadow-sm flex-shrink-0"
       else
         content_tag(:span, organization.name.first.upcase,
-                    class: "w-10 h-10 rounded-full flex items-center justify-center
-                            bg-emerald-200 text-emerald-700 font-bold text-lg
+                    class: "#{avatar_size} rounded-full flex items-center justify-center
+                            bg-emerald-200 text-emerald-700 font-bold #{initial_text_size}
                             border border-emerald-300 shadow-sm flex-shrink-0")
       end
 

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -12,8 +12,8 @@ module OrganizationHelper
       text = "text-gray-400"
       border = "border-gray-300"
     elsif muted
-      bg = "bg-gray-100"
-      hover_bg = "hover:bg-gray-200"
+      bg = "bg-white"
+      hover_bg = "hover:bg-gray-50"
       text = DomainTheme.text_class_for(:organizations)
       border = "border-gray-300"
     else

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,5 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, muted: false, path_params: {}, width_class: "w-full", compact: false)
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, tint: nil, path_params: {}, width_class: "w-full", compact: false)
     # Compact mode shrinks the whole control (padding, avatar, type) for dense
     # tables like the registrants roster where horizontal space is at a premium.
     padding = compact ? "px-2 py-1" : "px-4 py-2"
@@ -12,7 +12,12 @@ module PersonHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
-    elsif muted
+    elsif tint == :facilitator
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = DomainTheme.text_class_for(:people)
+      border = "border-purple-200"
+    elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"
       text = DomainTheme.text_class_for(:people)
@@ -23,7 +28,7 @@ module PersonHelper
       text = DomainTheme.text_class_for(:people)
       border = DomainTheme.border_class_for(:people)
     end
-    shadow = muted ? "shadow-none" : "shadow-sm"
+    shadow = tint ? "shadow-none" : "shadow-sm"
 
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,5 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, path_params: {}, width_class: "w-full", compact: false)
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, transparent: false, path_params: {}, width_class: "w-full", compact: false)
     # Compact mode shrinks the whole control (padding, avatar, type) for dense
     # tables like the registrants roster where horizontal space is at a premium.
     padding = compact ? "px-2 py-1" : "px-4 py-2"
@@ -12,12 +12,18 @@ module PersonHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
+    elsif transparent
+      bg = "bg-transparent"
+      hover_bg = "hover:bg-gray-100"
+      text = DomainTheme.text_class_for(:people)
+      border = "border-transparent"
     else
       bg = DomainTheme.bg_class_for(:people, intensity: 100)
       hover_bg = DomainTheme.bg_class_for(:people, intensity: 100, hover: true)
       text = DomainTheme.text_class_for(:people)
       border = DomainTheme.border_class_for(:people)
     end
+    shadow = transparent ? "shadow-none" : "shadow-sm"
 
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")
@@ -35,7 +41,7 @@ module PersonHelper
                     #{width_class} #{padding}
                     border #{border} #{bg} #{hover_bg} rounded-lg
                     transition-colors duration-200
-                    font-medium shadow-sm leading-none
+                    font-medium #{shadow} leading-none
                     overflow-hidden" do
       person = person.decorate
 

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -17,6 +17,11 @@ module PersonHelper
       hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:people)
       border = "border-purple-300"
+    elsif tint == :facilitator_inactive
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = DomainTheme.text_class_for(:people)
+      border = "border-purple-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -13,8 +13,8 @@ module PersonHelper
       text = "text-gray-400"
       border = "border-gray-300"
     elsif muted
-      bg = "bg-gray-100"
-      hover_bg = "hover:bg-gray-200"
+      bg = "bg-white"
+      hover_bg = "hover:bg-gray-50"
       text = DomainTheme.text_class_for(:people)
       border = "border-gray-300"
     else

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -17,11 +17,6 @@ module PersonHelper
       hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:people)
       border = "border-purple-300"
-    elsif tint == :facilitator_inactive
-      bg = "bg-purple-50"
-      hover_bg = "hover:bg-purple-100"
-      text = DomainTheme.text_class_for(:people)
-      border = "border-purple-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,5 +1,5 @@
 module PersonHelper
-  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, transparent: false, path_params: {}, width_class: "w-full", compact: false)
+  def person_profile_button(person, truncate_at: nil, subtitle: nil, display_name: nil, data: {}, inactive: false, muted: false, path_params: {}, width_class: "w-full", compact: false)
     # Compact mode shrinks the whole control (padding, avatar, type) for dense
     # tables like the registrants roster where horizontal space is at a premium.
     padding = compact ? "px-2 py-1" : "px-4 py-2"
@@ -12,18 +12,18 @@ module PersonHelper
       hover_bg = "hover:bg-gray-200"
       text = "text-gray-400"
       border = "border-gray-300"
-    elsif transparent
-      bg = "bg-transparent"
-      hover_bg = "hover:bg-gray-100"
+    elsif muted
+      bg = "bg-gray-100"
+      hover_bg = "hover:bg-gray-200"
       text = DomainTheme.text_class_for(:people)
-      border = "border-transparent"
+      border = "border-gray-300"
     else
       bg = DomainTheme.bg_class_for(:people, intensity: 100)
       hover_bg = DomainTheme.bg_class_for(:people, intensity: 100, hover: true)
       text = DomainTheme.text_class_for(:people)
       border = DomainTheme.border_class_for(:people)
     end
-    shadow = transparent ? "shadow-none" : "shadow-sm"
+    shadow = muted ? "shadow-none" : "shadow-sm"
 
     full_name = display_name || person.try(:name) || person.to_s
     hover_title = [ full_name, subtitle ].compact_blank.join(" — ")

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -13,10 +13,10 @@ module PersonHelper
       text = "text-gray-400"
       border = "border-gray-300"
     elsif tint == :facilitator
-      bg = "bg-purple-50"
-      hover_bg = "hover:bg-purple-100"
+      bg = "bg-purple-100"
+      hover_bg = "hover:bg-purple-200"
       text = DomainTheme.text_class_for(:people)
-      border = "border-purple-200"
+      border = "border-purple-300"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -15,8 +15,23 @@ module PersonHelper
     elsif tint == :facilitator
       bg = "bg-purple-100"
       hover_bg = "hover:bg-purple-200"
-      text = DomainTheme.text_class_for(:people)
+      text = "text-gray-800"
       border = "border-purple-300"
+    elsif tint == :facilitator_light
+      bg = "bg-purple-50"
+      hover_bg = "hover:bg-purple-100"
+      text = "text-gray-800"
+      border = "border-purple-200"
+    elsif tint == :nonfac
+      bg = "bg-blue-100"
+      hover_bg = "hover:bg-blue-200"
+      text = "text-gray-800"
+      border = "border-blue-300"
+    elsif tint == :nonfac_light
+      bg = "bg-blue-50"
+      hover_bg = "hover:bg-blue-100"
+      text = "text-gray-800"
+      border = "border-blue-200"
     elsif tint == :muted
       bg = "bg-white"
       hover_bg = "hover:bg-gray-50"

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -80,7 +80,7 @@ class Affiliation < ApplicationRecord
   before_validation :skip_if_duplicate
   # Runs before validation so a reassigned org drops its stale organization_address_id
   # before organization_address_belongs_to_organization would reject it.
-  before_validation :clear_org_scoped_links_on_org_change, on: :update
+  before_validation :reset_org_scoped_links_on_org_change, on: :update
   before_save :set_inactive_from_dates
   after_save :sync_organization_status_with_affiliations
   after_save :sync_organization_affiliation_dates
@@ -143,14 +143,23 @@ class Affiliation < ApplicationRecord
 
   # When an admin moves the affiliation to a different org (only possible from the
   # standalone edit form), the links scoped to the old org no longer apply:
-  # event_registration_id (a row with no link counts as manually created, which
-  # reconciliation leaves alone) and organization_address_id (an address of the old
-  # org would fail organization_address_belongs_to_organization).
-  def clear_org_scoped_links_on_org_change
+  #  - event_registration_id is cleared (a row with no link counts as manually
+  #    created, which reconciliation leaves alone). The registration's own org
+  #    link is separate and is updated in its org-linking step.
+  #  - organization_address_id is re-pointed at the new org: an old-org address
+  #    would fail organization_address_belongs_to_organization. If the new org has
+  #    exactly one address we adopt it; otherwise it's left blank for an admin to
+  #    set after saving.
+  def reset_org_scoped_links_on_org_change
     return unless organization_id_changed?
 
     self.event_registration_id = nil
-    self.organization_address_id = nil
+    self.organization_address_id = sole_address_id_for_new_organization
+  end
+
+  def sole_address_id_for_new_organization
+    addresses = Organization.find_by(id: organization_id)&.addresses
+    addresses.first.id if addresses&.one?
   end
 
   def set_inactive_from_dates

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -21,6 +21,9 @@ class Affiliation < ApplicationRecord
   # have this link.
   belongs_to :event_registration, optional: true, inverse_of: :affiliations
 
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+
   # Validations
   validates_presence_of :organization_id
   validate :organization_address_belongs_to_organization
@@ -75,8 +78,10 @@ class Affiliation < ApplicationRecord
   }
 
   before_validation :skip_if_duplicate
+  # Runs before validation so a reassigned org drops its stale organization_address_id
+  # before organization_address_belongs_to_organization would reject it.
+  before_validation :clear_org_scoped_links_on_org_change, on: :update
   before_save :set_inactive_from_dates
-  before_update :clear_event_registration_on_org_change
   after_save :sync_organization_status_with_affiliations
   after_save :sync_organization_affiliation_dates
   after_destroy :sync_organization_status_with_affiliations
@@ -136,12 +141,16 @@ class Affiliation < ApplicationRecord
     throw(:abort) if scope.exists?
   end
 
-  # event_registration_id records the registration that created this affiliation for
-  # its original org. If an admin moves the affiliation to a different org, that link
-  # no longer applies, so clear it — a row with no link counts as manually created,
-  # which reconciliation leaves alone.
-  def clear_event_registration_on_org_change
-    self.event_registration_id = nil if organization_id_changed?
+  # When an admin moves the affiliation to a different org (only possible from the
+  # standalone edit form), the links scoped to the old org no longer apply:
+  # event_registration_id (a row with no link counts as manually created, which
+  # reconciliation leaves alone) and organization_address_id (an address of the old
+  # org would fail organization_address_belongs_to_organization).
+  def clear_org_scoped_links_on_org_change
+    return unless organization_id_changed?
+
+    self.event_registration_id = nil
+    self.organization_address_id = nil
   end
 
   def set_inactive_from_dates

--- a/app/policies/affiliation_policy.rb
+++ b/app/policies/affiliation_policy.rb
@@ -5,6 +5,14 @@ class AffiliationPolicy < ApplicationPolicy
     record.persisted? && admin? # we don't allow users to edit their own
   end
 
+  def edit?
+    record.persisted? && admin?
+  end
+
+  def update?
+    edit?
+  end
+
   # Scoping
   # See https://actionpolicy.evilmartians.io/#/scoping
 

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -10,8 +10,8 @@
 <% selected_id = f.object.organization_address_id %>
 <% selected = options.find { |_number, address| address.id == selected_id } %>
 <% if options.any? %>
-  <div class="w-full sm:w-16" data-controller="address-select">
-    <label class="block text-sm font-medium text-gray-700 mb-1">Address</label>
+  <div class="min-w-0" data-controller="address-select">
+    <label class="block text-sm font-medium text-gray-700 mb-1 <%= "sm:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
               class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -14,7 +14,7 @@
     <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-full sm:w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
         <span data-address-select-target="label"><%= selected&.first || "—" %></span>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -10,8 +10,8 @@
 <% selected_id = f.object.organization_address_id %>
 <% selected = options.find { |_number, address| address.id == selected_id } %>
 <% if options.any? %>
-  <div class="min-w-0" data-controller="address-select">
-    <label class="block text-sm font-medium text-gray-700 mb-1 <%= "sm:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
+  <div class="w-full sm:w-16 xl:w-auto min-w-0" data-controller="address-select">
+    <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
               class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
@@ -21,7 +21,7 @@
         <i class="fa-solid fa-chevron-down text-xs text-gray-400"></i>
       </button>
       <%= f.hidden_field :organization_address_id, data: { address_select_target: "input" } %>
-      <div class="hidden absolute z-20 mt-1 max-h-60 w-72 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+      <div class="hidden absolute z-20 mt-1 max-h-60 w-96 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
            data-address-select-target="panel">
         <button type="button"
                 class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-500 hover:bg-gray-100"
@@ -44,5 +44,5 @@
 <% else %>
   <%# No addresses to pick from: hold the column's width so the Start/End/etc.
       fields stay vertically aligned with rows that do have an address picker. %>
-  <div class="hidden sm:block sm:w-16"></div>
+  <div class="hidden sm:block sm:w-16 xl:w-auto"></div>
 <% end %>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -10,18 +10,20 @@
 <% options = org ? org.addresses.each_with_index.map { |address, i| [ i + 1, address ] } : [] %>
 <% selected_id = f.object.organization_address_id %>
 <% selected = options.find { |_number, address| address.id == selected_id } %>
+<% inline = local_assigns.fetch(:hide_label, false) %>
 <% if options.any? %>
   <div class="w-full min-w-0" data-controller="address-select">
-    <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
+    <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if inline %>">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 <%= local_assigns.fetch(:bg_class, "bg-gray-100") %> px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
+              <%= "data-inactive-toggle-target=valueField".html_safe if inline %>
               data-action="address-select#toggle">
         <span data-address-select-target="label" class="min-w-0 flex-1 truncate text-left"><%= selected ? "#{selected.first} — #{selected.last.name}" : "—" %></span>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 shrink-0"></i>
       </button>
-      <%= f.hidden_field :organization_address_id, data: { address_select_target: "input" } %>
+      <%= f.hidden_field :organization_address_id, data: { address_select_target: "input", **(inline ? { action: "change->inactive-toggle#paintFields" } : {}) } %>
       <div class="hidden absolute z-20 mt-1 max-h-60 w-96 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
            data-address-select-target="panel">
         <button type="button"

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -10,11 +10,11 @@
 <% selected_id = f.object.organization_address_id %>
 <% selected = options.find { |_number, address| address.id == selected_id } %>
 <% if options.any? %>
-  <div class="w-full sm:w-16 xl:w-auto min-w-0" data-controller="address-select">
+  <div class="w-full min-w-0" data-controller="address-select">
     <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-full sm:w-14 items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
         <span data-address-select-target="label"><%= selected&.first || "—" %></span>
@@ -44,5 +44,5 @@
 <% else %>
   <%# No addresses to pick from: hold the column's width so the Start/End/etc.
       fields stay vertically aligned with rows that do have an address picker. %>
-  <div class="hidden sm:block sm:w-16 xl:w-auto"></div>
+  <div class="hidden sm:block w-full"></div>
 <% end %>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -15,7 +15,7 @@
     <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-white px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
         <span data-address-select-target="label" class="min-w-0 flex-1 truncate text-left"><%= selected ? "#{selected.first} — #{selected.last.name}" : "—" %></span>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -1,6 +1,7 @@
 <%# Compact numbered picker linking an affiliation to one of its organization's
-    addresses. The trigger button is only wide enough for a double-digit number;
-    the panel that opens shows each address's full one-line text. Numbers mirror
+    addresses. The trigger button shows the selected address's number and name,
+    truncated to the column width; the panel lists each address's full text.
+    Numbers mirror
     the org address editor's "Address #N" (1-based, in association order). All
     addresses are selectable; inactive ones are shown with an [INACTIVE] marker.
     When the org has no addresses, renders an equal-width spacer so the following
@@ -17,8 +18,8 @@
               class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
-        <span data-address-select-target="label"><%= selected&.first || "—" %></span>
-        <i class="fa-solid fa-chevron-down text-xs text-gray-400"></i>
+        <span data-address-select-target="label" class="min-w-0 flex-1 truncate text-left"><%= selected ? "#{selected.first} — #{selected.last.name}" : "—" %></span>
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 shrink-0"></i>
       </button>
       <%= f.hidden_field :organization_address_id, data: { address_select_target: "input" } %>
       <div class="hidden absolute z-20 mt-1 max-h-60 w-96 overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg"
@@ -27,12 +28,14 @@
                 class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-500 hover:bg-gray-100"
                 data-value=""
                 data-number="—"
+                data-label="—"
                 data-action="address-select#select">— None</button>
         <% options.each do |number, address| %>
           <button type="button"
                   class="flex w-full items-start gap-2 px-3 py-1.5 text-left text-sm text-gray-800 hover:bg-gray-100"
                   data-value="<%= address.id %>"
                   data-number="<%= number %>"
+                  data-label="<%= "#{number} — #{address.name}" %>"
                   data-action="address-select#select">
             <span class="w-5 shrink-0 font-semibold text-gray-500"><%= number %></span>
             <span><% if address.inactive? %><span class="font-semibold text-gray-400">[INACTIVE]</span> <% end %><%= address.name %></span>

--- a/app/views/affiliations/_address_picker.html.erb
+++ b/app/views/affiliations/_address_picker.html.erb
@@ -15,7 +15,7 @@
     <label class="block text-sm font-medium text-gray-700 mb-1 <%= "xl:hidden" if local_assigns.fetch(:hide_label, false) %>">Address</label>
     <div class="relative">
       <button type="button"
-              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
+              class="flex h-[42px] w-full items-center justify-between gap-1 rounded-md border border-gray-300 bg-white px-2 text-sm text-gray-800 focus:border-blue-500 focus:ring-blue-500"
               data-address-select-target="button"
               data-action="address-select#toggle">
         <span data-address-select-target="label" class="min-w-0 flex-1 truncate text-left"><%= selected ? "#{selected.first} — #{selected.last.name}" : "—" %></span>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -7,10 +7,14 @@
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
   <% facilitator = f.object.facilitator? %>
-  <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-white border-gray-200" %>
+  <%# Active rows are tinted (never white) so active reads clearly against grey
+      inactive rows: purple for facilitators, else a super-light tint of the
+      counterpart's theme (person = sky, organization = emerald). %>
+  <% active_tint = person_side ? "bg-sky-50 border-sky-200" : "bg-emerald-50 border-emerald-200" %>
+  <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
-  <div data-controller="inactive-toggle" class="relative mb-2">
+  <div data-controller="inactive-toggle" data-inactive-toggle-active-tint-value="<%= active_tint %>" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= facilitator ? 'bg-purple-500' : 'bg-gray-300' %>"
           data-inactive-toggle-target="accentBar"></span>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -11,27 +11,28 @@
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
   <% displayed_title = f.object.title.presence || "Facilitator" %>
   <% facilitator = displayed_title.strip == "Facilitator" %>
-  <%# Colour carries role only (facilitator = purple, else neutral) for both active
-      and inactive rows. Inactive is a *structural* cue instead: a dashed border and
-      a struck-through end date (.date-ended), kept in sync live by inactive-toggle. %>
-  <% row_bg = if facilitator
-       "bg-purple-50 #{expired ? 'border-purple-300 border-dashed' : 'border-purple-200'}"
+  <%# Four states by colour: role is the hue (facilitator = purple, else blue) and
+      status is the saturation (active = full, inactive = super-light). Kept in sync
+      live by inactive-toggle. %>
+  <% accent = facilitator ? (expired ? "bg-purple-300" : "bg-purple-500") : (expired ? "bg-blue-300" : "bg-blue-500") %>
+  <% row_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-blue-50 border-blue-200" %>
+  <% fill_color = if facilitator
+       expired ? "bg-purple-50!" : "bg-purple-100!"
      else
-       "bg-gray-50 #{expired ? 'border-gray-300 border-dashed' : 'border-gray-200'}"
+       expired ? "bg-blue-50!" : "bg-blue-100!"
      end %>
-  <% pill_tint = facilitator ? :facilitator : :muted %>
-  <%# Field fills echo the person button: empty fields are transparent (the row tint
-      shows through), filled fields take the role colour (purple for facilitators,
-      else white). The "Facilitator" title keeps its darker purple. %>
-  <% fill_color = facilitator ? "bg-purple-100!" : "bg-white!" %>
   <% field_bg = ->(present) { present ? fill_color : "bg-transparent!" } %>
-  <% title_class = facilitator ? "bg-purple-100! text-purple-700! font-semibold border-purple-300!" : "#{field_bg.call(displayed_title.present?)} border-gray-300!" %>
-  <% ended_date = f.object.end_date.present? && f.object.end_date < Date.current %>
+  <% pill_tint = facilitator ? (expired ? :facilitator_light : :facilitator) : (expired ? :nonfac_light : :nonfac) %>
+  <% title_class = if facilitator
+       expired ? "bg-purple-50! text-purple-500! border-purple-200!" : "bg-purple-100! text-purple-700! font-semibold border-purple-300!"
+     else
+       expired ? "bg-blue-50! text-blue-500! border-blue-200!" : "bg-blue-100! text-blue-700! font-semibold border-blue-300!"
+     end %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
   <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color regardless of the row's border. %>
-    <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= facilitator ? 'bg-purple-500' : 'bg-gray-300' %>"
+    <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= accent %>"
           data-inactive-toggle-target="accentBar"></span>
     <% if f.object.persisted? %>
       <%# Escape to the full affiliation editor: comments + reassign person/org. %>
@@ -44,7 +45,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= row_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= row_bg %> <%= 'aff-ended' if expired %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div class="w-full sm:w-[280px] xl:w-auto min-w-0">
@@ -116,7 +117,7 @@
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.end_date.present?)} #{'date-ended' if ended_date}",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.end_date.present?)}",
                       style: "height: 42px;",
                       data: {
                         inactive_toggle_target: "endDate valueField",

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -114,11 +114,7 @@
 
       <div class="flex-1 sm:flex-none sm:w-auto min-w-0">
         <div class="mb-1 xl:hidden"><%= render "affiliations/primary_contact_label" %></div>
-        <div class="flex h-[42px] w-[42px] items-center justify-center rounded-md border border-gray-300 bg-gray-100">
-          <%= f.check_box :primary_contact,
-                          checked: f.object.primary_contact?,
-                          class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
-        </div>
+        <%= render "affiliations/primary_contact_toggle", f: f %>
       </div>
 
       <% unless f.object.persisted? %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -11,11 +11,16 @@
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
   <% displayed_title = f.object.title.presence || "Facilitator" %>
   <% facilitator = displayed_title.strip == "Facilitator" %>
-  <%# Active rows are tinted (never white) so active reads clearly against grey
-      inactive rows: purple for facilitators, else a super-light tint of the
-      counterpart's theme (person = sky, organization = emerald). %>
-  <% active_tint = person_side ? "bg-sky-50 border-sky-200" : "bg-emerald-50 border-emerald-200" %>
+  <%# Active non-facilitator rows use a very light grey (near white) so they read
+      as active but stay distinct from the darker grey of inactive rows;
+      facilitators keep their light purple. %>
+  <% active_tint = "bg-gray-50 border-gray-200" %>
   <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
+  <%# Inactive facilitator rows stay light purple (matching the pill/title) rather
+      than going grey like inactive non-facilitator rows. %>
+  <% inactive_bg = facilitator ? "bg-purple-50 border-purple-200 opacity-60" : "bg-gray-100 border-gray-300 opacity-60" %>
+  <% row_bg = expired ? inactive_bg : active_bg %>
+  <% pill_tint = facilitator ? (expired ? :facilitator_inactive : :facilitator) : :muted %>
   <%# Field fills echo the person button: an empty field is transparent (the card
       tint shows through), a filled field takes the pill colour for the row's state
       (grey inactive, purple facilitator, else white). The "Facilitator" title keeps
@@ -50,7 +55,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= row_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div class="w-full sm:w-[280px] xl:w-auto min-w-0">
@@ -58,9 +63,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, inactive: expired, tint: facilitator ? :facilitator : :muted) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, inactive: expired && !facilitator, tint: pill_tint) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true, inactive: expired, tint: facilitator ? :facilitator : :muted) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, inactive: expired && !facilitator, tint: pill_tint) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -134,7 +134,19 @@
 
       <div class="flex-1 sm:flex-none sm:w-auto min-w-0">
         <div class="mb-1 xl:hidden"><%= render "affiliations/primary_contact_label" %></div>
-        <%= render "affiliations/primary_contact_toggle", f: f %>
+        <div class="flex h-[42px] items-center gap-2">
+          <%= render "affiliations/primary_contact_toggle", f: f %>
+          <% affiliation_comments = f.object.comments.to_a %>
+          <% if affiliation_comments.any? %>
+            <span class="group relative inline-flex items-center">
+              <i class="fa-solid fa-comment text-sm cursor-help <%= facilitator ? 'text-purple-500' : 'text-blue-500' %>"></i>
+              <span class="hidden group-hover:block absolute right-0 top-full z-50 mt-1 w-64 whitespace-normal rounded-lg bg-white p-3 text-left text-xs text-gray-700 shadow-lg ring-1 ring-gray-200">
+                <span class="block font-semibold text-gray-900"><%= pluralize(affiliation_comments.size, "comment") %></span>
+                <span class="mt-1 block text-gray-600"><%= truncate(affiliation_comments.first.body.to_s, length: 140) %></span>
+              </span>
+            </span>
+          <% end %>
+        </div>
       </div>
 
       <% unless f.object.persisted? %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -11,39 +11,26 @@
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
   <% displayed_title = f.object.title.presence || "Facilitator" %>
   <% facilitator = displayed_title.strip == "Facilitator" %>
-  <%# Active non-facilitator rows use a very light grey (near white) so they read
-      as active but stay distinct from the darker grey of inactive rows;
-      facilitators keep their light purple. %>
-  <% active_tint = "bg-gray-50 border-gray-200" %>
-  <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
-  <%# Inactive facilitator rows stay light purple (matching the pill/title) rather
-      than going grey like inactive non-facilitator rows. %>
-  <% inactive_bg = facilitator ? "bg-purple-50 border-purple-200 opacity-80" : "bg-gray-100 border-gray-300 opacity-80" %>
-  <% row_bg = expired ? inactive_bg : active_bg %>
+  <%# Colour carries role only (facilitator = purple, else neutral) for both active
+      and inactive rows. Inactive is a *structural* cue instead: a dashed border and
+      a struck-through end date (.date-ended), kept in sync live by inactive-toggle. %>
+  <% row_bg = if facilitator
+       "bg-purple-50 #{expired ? 'border-purple-300 border-dashed' : 'border-purple-200'}"
+     else
+       "bg-gray-50 #{expired ? 'border-gray-300 border-dashed' : 'border-gray-200'}"
+     end %>
   <% pill_tint = facilitator ? :facilitator : :muted %>
-  <%# Field fills echo the person button: an empty field is transparent (the card
-      tint shows through), a filled field takes the pill colour for the row's state
-      (grey inactive, purple facilitator, else white). The "Facilitator" title keeps
-      its own darker purple. Kept in sync live by inactive-toggle. %>
-  <% fill_color = if facilitator
-       "bg-purple-100!"
-     elsif expired
-       "bg-gray-100!"
-     else
-       "bg-white!"
-     end %>
+  <%# Field fills echo the person button: empty fields are transparent (the row tint
+      shows through), filled fields take the role colour (purple for facilitators,
+      else white). The "Facilitator" title keeps its darker purple. %>
+  <% fill_color = facilitator ? "bg-purple-100!" : "bg-white!" %>
   <% field_bg = ->(present) { present ? fill_color : "bg-transparent!" } %>
-  <% title_class = if !facilitator
-       "#{field_bg.call(displayed_title.present?)} border-gray-300!"
-     elsif expired
-       "bg-purple-100! text-purple-500! border-purple-300!"
-     else
-       "bg-purple-100! text-purple-700! font-semibold border-purple-300!"
-     end %>
+  <% title_class = facilitator ? "bg-purple-100! text-purple-700! font-semibold border-purple-300!" : "#{field_bg.call(displayed_title.present?)} border-gray-300!" %>
+  <% ended_date = f.object.end_date.present? && f.object.end_date < Date.current %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
-  <div data-controller="inactive-toggle" data-inactive-toggle-active-tint-value="<%= active_tint %>" data-inactive-toggle-expired-value="<%= expired %>" class="relative mb-2">
-    <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
+  <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>" class="relative mb-2">
+    <%# Left accent rendered outside the row so it keeps full color regardless of the row's border. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= facilitator ? 'bg-purple-500' : 'bg-gray-300' %>"
           data-inactive-toggle-target="accentBar"></span>
     <% if f.object.persisted? %>
@@ -129,7 +116,7 @@
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.end_date.present?)}",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.end_date.present?)} #{'date-ended' if ended_date}",
                       style: "height: 42px;",
                       data: {
                         inactive_toggle_target: "endDate valueField",

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -6,7 +6,11 @@
 <% manage_subject = person_side ? Organization : Person %>
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
-  <% facilitator = f.object.facilitator? %>
+  <%# A blank title displays (and saves) as the "Facilitator" default, so treat it
+      as a facilitator for the row styling too — otherwise the JS (which reads the
+      shown title) tints the row purple while the server-rendered pill stays neutral. %>
+  <% displayed_title = f.object.title.presence || "Facilitator" %>
+  <% facilitator = displayed_title.strip == "Facilitator" %>
   <%# Active rows are tinted (never white) so active reads clearly against grey
       inactive rows: purple for facilitators, else a super-light tint of the
       counterpart's theme (person = sky, organization = emerald). %>
@@ -47,9 +51,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, tint: facilitator ? :facilitator : :muted) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, inactive: expired, tint: facilitator ? :facilitator : :muted) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true, tint: facilitator ? :facilitator : :muted) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, inactive: expired, tint: facilitator ? :facilitator : :muted) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>
@@ -77,7 +81,7 @@
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" },
                     placeholder: "Title",
                     input_html: {
-                      value: f.object&.title || "Facilitator",
+                      value: displayed_title,
                       style: "height: 42px;",
                       class: "text-sm #{title_class}",
                       data: {

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -26,7 +26,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 pt-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -10,7 +10,7 @@
   <% active_bg = facilitator ? "bg-purple-100 border-purple-300" : "bg-white border-gray-200" %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
-  <div data-controller="inactive-toggle" class="relative mb-4">
+  <div data-controller="inactive-toggle" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg"
           style="background-color: <%= facilitator ? '#a855f7' : '#d1d5db' %>"
@@ -26,7 +26,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border p-3 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 pt-3 pb-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
@@ -34,9 +34,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email)) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>
@@ -82,6 +82,7 @@
                       type: "date",
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
                       class: "rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      style: "height: 42px;",
                       data: { action: "change->affiliation-dates#recalculate" }
                     } %>
       </div>
@@ -95,6 +96,7 @@
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
                       class: "rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      style: "height: 42px;",
                       data: {
                         inactive_toggle_target: "endDate",
                         action: "change->inactive-toggle#toggle change->affiliation-dates#recalculate"
@@ -102,18 +104,21 @@
                     } %>
       </div>
 
-      <div class="w-full sm:w-auto pb-3">
+      <div class="w-full sm:w-auto">
         <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1">Primary org<br>contact</label>
         <%= f.check_box :primary_contact,
                         checked: f.object.primary_contact?,
                         class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
       </div>
 
-      <div class="w-full sm:w-auto sm:ml-auto sm:self-end sm:pb-3">
-        <%= link_to_remove_association "Remove",
-                                       f,
-                                       class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap admin-only bg-blue-100 rounded px-2 py-1" %>
-      </div>
+      <% unless f.object.persisted? %>
+        <%# Persisted rows are removed via the gear's affiliation editor (Delete). %>
+        <div class="w-full sm:w-auto sm:ml-auto sm:self-end sm:pb-3">
+          <%= link_to_remove_association "Remove",
+                                         f,
+                                         class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap admin-only bg-blue-100 rounded px-2 py-1" %>
+        </div>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -64,6 +64,7 @@
                       rows: 1,
                       value: f.object&.title || "Facilitator",
                       style: "height: 42px; min-height: 42px;",
+                      class: "text-sm",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -33,9 +33,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, muted: true) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, tint: facilitator ? :facilitator : :muted) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true, muted: true) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, tint: facilitator ? :facilitator : :muted) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>
@@ -58,15 +58,14 @@
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :title,
-                    as: :text,
+                    as: :string,
                     wrapper_html: { class: "mb-0!" },
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" },
                     placeholder: "Title",
                     input_html: {
-                      rows: 1,
                       value: f.object&.title || "Facilitator",
-                      style: "height: 42px; min-height: 42px;",
-                      class: "text-sm resize-none border-gray-300!",
+                      style: "height: 42px;",
+                      class: "text-sm border-gray-300!",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"
@@ -115,7 +114,7 @@
 
       <div class="flex-1 sm:flex-none sm:w-auto min-w-0">
         <div class="mb-1 xl:hidden"><%= render "affiliations/primary_contact_label" %></div>
-        <div class="flex h-[42px] items-center">
+        <div class="flex h-[42px] w-[42px] items-center justify-center rounded-md border border-gray-300 bg-gray-100">
           <%= f.check_box :primary_contact,
                           checked: f.object.primary_contact?,
                           class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -34,9 +34,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, transparent: !facilitator) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, muted: !facilitator && !expired) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true, transparent: !facilitator) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, muted: !facilitator && !expired) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>
@@ -67,7 +67,7 @@
                       rows: 1,
                       value: f.object&.title || "Facilitator",
                       style: "height: 42px; min-height: 42px;",
-                      class: "text-sm resize-none",
+                      class: "text-sm resize-none border-gray-300!",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"
@@ -84,7 +84,7 @@
                     input_html: {
                       type: "date",
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm",
                       style: "height: 42px;",
                       data: { action: "change->affiliation-dates#recalculate" }
                     } %>
@@ -99,7 +99,7 @@
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm",
                       style: "height: 42px;",
                       data: {
                         inactive_toggle_target: "endDate",

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -7,7 +7,7 @@
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
   <% facilitator = f.object.facilitator? %>
-  <% active_bg = facilitator ? "bg-purple-100 border-purple-300" : "bg-white border-gray-200" %>
+  <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-white border-gray-200" %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
   <div data-controller="inactive-toggle" class="relative mb-2">
@@ -20,7 +20,7 @@
                     return_to: person_side ? "organization" : "person",
                     origin_id: person_side ? f.object.organization_id : f.object.person_id),
                   target: "_blank", rel: "noopener",
-                  class: "absolute top-2 right-2 z-10 text-gray-300 hover:text-gray-500",
+                  class: "absolute top-1/2 right-2 z-10 -translate-y-1/2 text-gray-300 hover:text-gray-500",
                   title: "Edit affiliation, add comments, or reassign (opens in a new tab)" do %>
         <i class="fa-solid fa-gear"></i>
       <% end %>
@@ -65,7 +65,7 @@
                     input_html: {
                       value: f.object&.title || "Facilitator",
                       style: "height: 42px;",
-                      class: "text-sm border-gray-300!",
+                      class: "text-sm #{facilitator ? 'bg-purple-100! text-purple-700! font-semibold border-purple-300!' : 'border-gray-300!'}",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -12,6 +12,16 @@
       counterpart's theme (person = sky, organization = emerald). %>
   <% active_tint = person_side ? "bg-sky-50 border-sky-200" : "bg-emerald-50 border-emerald-200" %>
   <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
+  <%# The "Facilitator" title is tinted purple; inactive rows use a lighter, softer
+      purple so it recedes to match the dimmed person button. Kept in sync live by
+      inactive-toggle#styleTitle. %>
+  <% title_class = if !facilitator
+       "border-gray-300!"
+     elsif expired
+       "bg-purple-50! text-purple-400! border-purple-200!"
+     else
+       "bg-purple-100! text-purple-700! font-semibold border-purple-300!"
+     end %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
   <div data-controller="inactive-toggle" data-inactive-toggle-active-tint-value="<%= active_tint %>" class="relative mb-2">
@@ -69,7 +79,7 @@
                     input_html: {
                       value: f.object&.title || "Facilitator",
                       style: "height: 42px;",
-                      class: "text-sm #{facilitator ? 'bg-purple-100! text-purple-700! font-semibold border-purple-300!' : 'border-gray-300!'}",
+                      class: "text-sm #{title_class}",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -12,8 +12,7 @@
   <% label = person_side ? "Person" : "Organization" %>
   <div data-controller="inactive-toggle" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
-    <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg"
-          style="background-color: <%= facilitator ? '#a855f7' : '#d1d5db' %>"
+    <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= facilitator ? 'bg-purple-500' : 'bg-gray-300' %>"
           data-inactive-toggle-target="accentBar"></span>
     <% if f.object.persisted? %>
       <%# Escape to the full affiliation editor: comments + reassign person/org. %>
@@ -29,14 +28,14 @@
     <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
-      <div class="w-full sm:w-[280px] xl:w-auto min-w-0" data-inactive-toggle-target="profileButton">
+      <div class="w-full sm:w-[280px] xl:w-auto min-w-0">
         <% if f.object.persisted? && record.present? %>
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, muted: !facilitator && !expired) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, muted: true) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true, muted: !facilitator && !expired) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, muted: true) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -18,23 +18,25 @@
   <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
   <%# Inactive facilitator rows stay light purple (matching the pill/title) rather
       than going grey like inactive non-facilitator rows. %>
-  <% inactive_bg = facilitator ? "bg-purple-50 border-purple-200 opacity-60" : "bg-gray-100 border-gray-300 opacity-60" %>
+  <% inactive_bg = facilitator ? "bg-purple-50 border-purple-200 opacity-80" : "bg-gray-100 border-gray-300 opacity-80" %>
   <% row_bg = expired ? inactive_bg : active_bg %>
-  <% pill_tint = facilitator ? (expired ? :facilitator_inactive : :facilitator) : :muted %>
+  <% pill_tint = facilitator ? :facilitator : :muted %>
   <%# Field fills echo the person button: an empty field is transparent (the card
       tint shows through), a filled field takes the pill colour for the row's state
       (grey inactive, purple facilitator, else white). The "Facilitator" title keeps
       its own darker purple. Kept in sync live by inactive-toggle. %>
-  <% fill_color = if expired
-       facilitator ? "bg-purple-50!" : "bg-gray-100!"
+  <% fill_color = if facilitator
+       "bg-purple-100!"
+     elsif expired
+       "bg-gray-100!"
      else
-       facilitator ? "bg-purple-100!" : "bg-white!"
+       "bg-white!"
      end %>
   <% field_bg = ->(present) { present ? fill_color : "bg-transparent!" } %>
   <% title_class = if !facilitator
        "#{field_bg.call(displayed_title.present?)} border-gray-300!"
      elsif expired
-       "bg-purple-50! text-purple-400! border-purple-200!"
+       "bg-purple-100! text-purple-500! border-purple-300!"
      else
        "bg-purple-100! text-purple-700! font-semibold border-purple-300!"
      end %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -26,7 +26,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 pt-3 pb-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -16,11 +16,14 @@
       counterpart's theme (person = sky, organization = emerald). %>
   <% active_tint = person_side ? "bg-sky-50 border-sky-200" : "bg-emerald-50 border-emerald-200" %>
   <% active_bg = facilitator ? "bg-purple-50 border-purple-200" : active_tint %>
-  <%# The "Facilitator" title is tinted purple; inactive rows use a lighter, softer
-      purple so it recedes to match the dimmed person button. Kept in sync live by
-      inactive-toggle#styleTitle. %>
+  <%# Field fills echo the person button: an empty field is transparent (the card
+      tint shows through), a filled field takes the pill colour for the row's state
+      (grey inactive, purple facilitator, else white). The "Facilitator" title keeps
+      its own darker purple. Kept in sync live by inactive-toggle. %>
+  <% pill_color = expired ? "bg-gray-100!" : (facilitator ? "bg-purple-100!" : "bg-white!") %>
+  <% field_bg = ->(present) { present ? pill_color : "bg-transparent!" } %>
   <% title_class = if !facilitator
-       "border-gray-300!"
+       "#{field_bg.call(displayed_title.present?)} border-gray-300!"
      elsif expired
        "bg-purple-50! text-purple-400! border-purple-200!"
      else
@@ -100,9 +103,9 @@
                     input_html: {
                       type: "date",
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.start_date.present? || !f.object.persisted?)}",
                       style: "height: 42px;",
-                      data: { action: "change->affiliation-dates#recalculate" }
+                      data: { inactive_toggle_target: "valueField", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields" }
                     } %>
       </div>
 
@@ -115,10 +118,10 @@
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
-                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.end_date.present?)}",
                       style: "height: 42px;",
                       data: {
-                        inactive_toggle_target: "endDate",
+                        inactive_toggle_target: "endDate valueField",
                         action: "change->inactive-toggle#toggle change->affiliation-dates#recalculate"
                       }
                     } %>
@@ -127,7 +130,7 @@
       <%# Address sits left of Primary at every width; on mobile the two share the
           final row (each flex-1 → 50%), at sm+ they take their column widths. %>
       <div class="flex-1 sm:flex-none sm:w-[120px] xl:w-auto min-w-0">
-        <%= render "affiliations/address_picker", f: f, hide_label: true %>
+        <%= render "affiliations/address_picker", f: f, hide_label: true, bg_class: field_bg.call(f.object.organization_address_id.present?) %>
       </div>
 
       <div class="flex-1 sm:flex-none sm:w-auto min-w-0">

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -43,6 +43,7 @@
           <%= f.input person_side ? :person_id : :organization_id,
             include_blank: true,
             required: true,
+            wrapper_html: { class: "mb-0" },
             input_html: {
               data: {
                 controller: "remote-select",
@@ -59,6 +60,7 @@
       <div class="w-full sm:w-auto" style="width: 150px; min-width: 150px;">
         <%= f.input :title,
                     as: :text,
+                    wrapper_html: { class: "mb-0" },
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                     input_html: {
                       rows: 1,
@@ -78,6 +80,7 @@
         <%= f.input :start_date,
                     as: :string,
                     label: "Start",
+                    wrapper_html: { class: "mb-0" },
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                     input_html: {
                       type: "date",
@@ -92,6 +95,7 @@
         <%= f.input :end_date,
                     as: :string,
                     label: "End",
+                    wrapper_html: { class: "mb-0" },
                     label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                     input_html: {
                       type: "date",

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -26,12 +26,12 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border px-3 pt-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-col gap-y-1 sm:grid sm:grid-cols-[280px_150px_64px_150px_150px_auto] sm:gap-x-4 sm:gap-y-0 sm:items-start rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
-      <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">
+      <div class="min-w-0" data-inactive-toggle-target="profileButton">
         <% if f.object.persisted? && record.present? %>
-          <label class="block text-sm font-medium text-gray-700 mb-1"><%= label %></label>
+          <label class="block text-sm font-medium text-gray-700 mb-1 sm:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
             <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true) %>
@@ -51,22 +51,23 @@
               }
             },
             error: "#{label} can't be blank",
-            prompt: "Type to search #{person_side ? 'people' : 'organizations'}…",
+            prompt: "Search #{person_side ? 'people' : 'organizations'}…",
             label: label,
-            label_html: { class: "block text-sm font-medium text-gray-700 mb-1 " } %>
+            label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" } %>
         <% end %>
       </div>
 
-      <div class="w-full sm:w-auto" style="width: 150px; min-width: 150px;">
+      <div class="min-w-0">
         <%= f.input :title,
                     as: :text,
                     wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
+                    placeholder: "Title",
                     input_html: {
                       rows: 1,
                       value: f.object&.title || "Facilitator",
                       style: "height: 42px; min-height: 42px;",
-                      class: "text-sm",
+                      class: "text-sm resize-none",
                       data: {
                         inactive_toggle_target: "title",
                         action: "affiliation-dates#recalculate inactive-toggle#updateBorder"
@@ -74,33 +75,33 @@
                     } %>
       </div>
 
-      <%= render "affiliations/address_picker", f: f %>
+      <%= render "affiliations/address_picker", f: f, hide_label: true %>
 
-      <div class="w-full sm:w-auto">
+      <div class="min-w-0">
         <%= f.input :start_date,
                     as: :string,
                     label: "Start",
                     wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
                     input_html: {
                       type: "date",
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
-                      class: "rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
                       style: "height: 42px;",
                       data: { action: "change->affiliation-dates#recalculate" }
                     } %>
       </div>
 
-      <div class="w-full sm:w-auto">
+      <div class="min-w-0">
         <%= f.input :end_date,
                     as: :string,
                     label: "End",
                     wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
-                      class: "rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
+                      class: "w-full rounded-md border-gray-300 focus:ring-blue-500 focus:border-blue-500 text-sm",
                       style: "height: 42px;",
                       data: {
                         inactive_toggle_target: "endDate",
@@ -109,8 +110,8 @@
                     } %>
       </div>
 
-      <div class="w-full sm:w-auto">
-        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1">Primary contact</label>
+      <div class="min-w-0">
+        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1 sm:hidden">Primary contact</label>
         <div class="flex h-[42px] items-center">
           <%= f.check_box :primary_contact,
                           checked: f.object.primary_contact?,
@@ -120,7 +121,7 @@
 
       <% unless f.object.persisted? %>
         <%# Persisted rows are removed via the gear's affiliation editor (Delete). %>
-        <div class="w-full sm:w-auto sm:ml-auto sm:self-end sm:pb-3">
+        <div class="w-full sm:col-span-full sm:text-right">
           <%= link_to_remove_association "Remove",
                                          f,
                                          class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap admin-only bg-blue-100 rounded px-2 py-1" %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -15,7 +15,17 @@
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg"
           style="background-color: <%= facilitator ? '#a855f7' : '#d1d5db' %>"
           data-inactive-toggle-target="accentBar"></span>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border p-3 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <% if f.object.persisted? %>
+      <%# Escape to the full affiliation editor: comments + reassign person/org. %>
+      <%= link_to edit_affiliation_path(f.object,
+                    return_to: person_side ? "organization" : "person",
+                    origin_id: person_side ? f.object.organization_id : f.object.person_id),
+                  class: "absolute top-2 right-2 z-10 text-gray-300 hover:text-gray-500",
+                  title: "Edit affiliation, add comments, or reassign" do %>
+        <i class="fa-solid fa-gear"></i>
+      <% end %>
+    <% end %>
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start rounded-lg border p-3 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div style="width: 280px; min-width: 280px; flex-shrink: 0;" data-inactive-toggle-target="profileButton">

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -26,12 +26,12 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-col gap-y-1 sm:grid sm:grid-cols-[280px_150px_64px_150px_150px_auto] sm:gap-x-4 sm:gap-y-0 sm:items-start rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_64px_150px_150px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
-      <div class="min-w-0" data-inactive-toggle-target="profileButton">
+      <div class="w-full sm:w-[280px] xl:w-auto min-w-0" data-inactive-toggle-target="profileButton">
         <% if f.object.persisted? && record.present? %>
-          <label class="block text-sm font-medium text-gray-700 mb-1 sm:hidden"><%= label %></label>
+          <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
             <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true) %>
@@ -43,7 +43,7 @@
           <%= f.input person_side ? :person_id : :organization_id,
             include_blank: true,
             required: true,
-            wrapper_html: { class: "mb-0" },
+            wrapper_html: { class: "mb-0!" },
             input_html: {
               data: {
                 controller: "remote-select",
@@ -53,15 +53,15 @@
             error: "#{label} can't be blank",
             prompt: "Search #{person_side ? 'people' : 'organizations'}…",
             label: label,
-            label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" } %>
+            label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
       </div>
 
-      <div class="min-w-0">
+      <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :title,
                     as: :text,
-                    wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
+                    wrapper_html: { class: "mb-0!" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" },
                     placeholder: "Title",
                     input_html: {
                       rows: 1,
@@ -77,12 +77,12 @@
 
       <%= render "affiliations/address_picker", f: f, hide_label: true %>
 
-      <div class="min-w-0">
+      <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :start_date,
                     as: :string,
                     label: "Start",
-                    wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
+                    wrapper_html: { class: "mb-0!" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" },
                     input_html: {
                       type: "date",
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
@@ -92,12 +92,12 @@
                     } %>
       </div>
 
-      <div class="min-w-0">
+      <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :end_date,
                     as: :string,
                     label: "End",
-                    wrapper_html: { class: "mb-0" },
-                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 sm:hidden" },
+                    wrapper_html: { class: "mb-0!" },
+                    label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" },
                     input_html: {
                       type: "date",
                       value: f.object.end_date&.strftime("%Y-%m-%d"),
@@ -110,8 +110,8 @@
                     } %>
       </div>
 
-      <div class="min-w-0">
-        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1 sm:hidden">Primary contact</label>
+      <div class="w-full sm:w-auto min-w-0">
+        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1 xl:hidden">Primary contact</label>
         <div class="flex h-[42px] items-center">
           <%= f.check_box :primary_contact,
                           checked: f.object.primary_contact?,
@@ -121,7 +121,7 @@
 
       <% unless f.object.persisted? %>
         <%# Persisted rows are removed via the gear's affiliation editor (Delete). %>
-        <div class="w-full sm:col-span-full sm:text-right">
+        <div class="w-full xl:col-span-full xl:text-right">
           <%= link_to_remove_association "Remove",
                                          f,
                                          class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap admin-only bg-blue-100 rounded px-2 py-1" %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -20,8 +20,9 @@
       <%= link_to edit_affiliation_path(f.object,
                     return_to: person_side ? "organization" : "person",
                     origin_id: person_side ? f.object.organization_id : f.object.person_id),
+                  target: "_blank", rel: "noopener",
                   class: "absolute top-2 right-2 z-10 text-gray-300 hover:text-gray-500",
-                  title: "Edit affiliation, add comments, or reassign" do %>
+                  title: "Edit affiliation, add comments, or reassign (opens in a new tab)" do %>
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -75,7 +75,11 @@
                     } %>
       </div>
 
-      <%= render "affiliations/address_picker", f: f, hide_label: true %>
+      <%# On mobile Address and Primary drop to a shared final row (order-1/order-2,
+          each flex-1 → 50%); at sm+ they return to their in-line column widths. %>
+      <div class="flex-1 order-1 sm:flex-none sm:w-16 sm:order-none xl:w-auto min-w-0">
+        <%= render "affiliations/address_picker", f: f, hide_label: true %>
+      </div>
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :start_date,
@@ -110,8 +114,8 @@
                     } %>
       </div>
 
-      <div class="w-full sm:w-auto min-w-0">
-        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1 xl:hidden">Primary contact</label>
+      <div class="flex-1 order-2 sm:flex-none sm:w-auto sm:order-none min-w-0">
+        <div class="mb-1 xl:hidden"><%= render "affiliations/primary_contact_label" %></div>
         <div class="flex h-[42px] items-center">
           <%= f.check_box :primary_contact,
                           checked: f.object.primary_contact?,

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -34,9 +34,9 @@
           <label class="block text-sm font-medium text-gray-700 mb-1 xl:hidden"><%= label %></label>
           <% if person_side %>
             <% show_email = record.profile_show_email? || allowed_to?(:manage?, Person) %>
-            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true) %>
+            <%= person_profile_button(record, truncate_at: 25, subtitle: (record.preferred_email if show_email), compact: true, transparent: !facilitator) %>
           <% else %>
-            <%= organization_profile_button(record, truncate_at: 25, compact: true) %>
+            <%= organization_profile_button(record, truncate_at: 25, compact: true, transparent: !facilitator) %>
           <% end %>
           <%= f.hidden_field(person_side ? :person_id : :organization_id) %>
         <% else %>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -26,7 +26,7 @@
         <i class="fa-solid fa-gear"></i>
       <% end %>
     <% end %>
-    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_64px_150px_150px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
+    <div class="nested-fields flex flex-wrap gap-x-4 gap-y-1 items-start xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] rounded-lg border px-3 py-2 scroll-mt-24 <%= expired ? 'bg-gray-100 border-gray-300 opacity-60' : active_bg %>"
          <% if f.object.persisted? %>id="<%= dom_id(f.object) %>"<% end %>
          data-inactive-toggle-target="row">
       <div class="w-full sm:w-[280px] xl:w-auto min-w-0" data-inactive-toggle-target="profileButton">
@@ -75,12 +75,6 @@
                     } %>
       </div>
 
-      <%# On mobile Address and Primary drop to a shared final row (order-1/order-2,
-          each flex-1 → 50%); at sm+ they return to their in-line column widths. %>
-      <div class="flex-1 order-1 sm:flex-none sm:w-16 sm:order-none xl:w-auto min-w-0">
-        <%= render "affiliations/address_picker", f: f, hide_label: true %>
-      </div>
-
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
         <%= f.input :start_date,
                     as: :string,
@@ -114,7 +108,13 @@
                     } %>
       </div>
 
-      <div class="flex-1 order-2 sm:flex-none sm:w-auto sm:order-none min-w-0">
+      <%# Address sits left of Primary at every width; on mobile the two share the
+          final row (each flex-1 → 50%), at sm+ they take their column widths. %>
+      <div class="flex-1 sm:flex-none sm:w-[120px] xl:w-auto min-w-0">
+        <%= render "affiliations/address_picker", f: f, hide_label: true %>
+      </div>
+
+      <div class="flex-1 sm:flex-none sm:w-auto min-w-0">
         <div class="mb-1 xl:hidden"><%= render "affiliations/primary_contact_label" %></div>
         <div class="flex h-[42px] items-center">
           <%= f.check_box :primary_contact,

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -20,8 +20,12 @@
       tint shows through), a filled field takes the pill colour for the row's state
       (grey inactive, purple facilitator, else white). The "Facilitator" title keeps
       its own darker purple. Kept in sync live by inactive-toggle. %>
-  <% pill_color = expired ? "bg-gray-100!" : (facilitator ? "bg-purple-100!" : "bg-white!") %>
-  <% field_bg = ->(present) { present ? pill_color : "bg-transparent!" } %>
+  <% fill_color = if expired
+       facilitator ? "bg-purple-50!" : "bg-gray-100!"
+     else
+       facilitator ? "bg-purple-100!" : "bg-white!"
+     end %>
+  <% field_bg = ->(present) { present ? fill_color : "bg-transparent!" } %>
   <% title_class = if !facilitator
        "#{field_bg.call(displayed_title.present?)} border-gray-300!"
      elsif expired
@@ -31,7 +35,7 @@
      end %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
-  <div data-controller="inactive-toggle" data-inactive-toggle-active-tint-value="<%= active_tint %>" class="relative mb-2">
+  <div data-controller="inactive-toggle" data-inactive-toggle-active-tint-value="<%= active_tint %>" data-inactive-toggle-expired-value="<%= expired %>" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color even when an expired row is dimmed by opacity-60. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= facilitator ? 'bg-purple-500' : 'bg-gray-300' %>"
           data-inactive-toggle-target="accentBar"></span>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -106,10 +106,12 @@
       </div>
 
       <div class="w-full sm:w-auto">
-        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1">Primary org<br>contact</label>
-        <%= f.check_box :primary_contact,
-                        checked: f.object.primary_contact?,
-                        class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        <label class="block whitespace-nowrap text-sm font-medium text-gray-700 mb-1">Primary contact</label>
+        <div class="flex h-[42px] items-center">
+          <%= f.check_box :primary_contact,
+                          checked: f.object.primary_contact?,
+                          class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        </div>
       </div>
 
       <% unless f.object.persisted? %>

--- a/app/views/affiliations/_header.html.erb
+++ b/app/views/affiliations/_header.html.erb
@@ -1,0 +1,13 @@
+<%# Column headers for the affiliation editor rows (desktop only). Card rows hide
+    their per-field labels at sm+ and rely on this row; on mobile each field keeps
+    its own label and this header is hidden. The grid template and px must match
+    the sm:grid row in affiliations/_fields so the labels sit over their columns.
+    The transparent border mirrors the card's border so content left-edges align. %>
+<div class="hidden sm:grid sm:grid-cols-[280px_150px_64px_150px_150px_auto] sm:gap-x-4 border border-transparent px-3 mb-1">
+  <span class="text-sm font-medium text-gray-700"><%= label %></span>
+  <span class="text-sm font-medium text-gray-700">Title</span>
+  <span class="text-sm font-medium text-gray-700">Address</span>
+  <span class="text-sm font-medium text-gray-700">Start</span>
+  <span class="text-sm font-medium text-gray-700">End</span>
+  <span class="text-sm font-medium text-gray-700">Primary contact</span>
+</div>

--- a/app/views/affiliations/_header.html.erb
+++ b/app/views/affiliations/_header.html.erb
@@ -10,5 +10,5 @@
   <span class="text-sm font-medium text-gray-700">Address</span>
   <span class="text-sm font-medium text-gray-700">Start</span>
   <span class="text-sm font-medium text-gray-700">End</span>
-  <span class="text-sm font-medium text-gray-700">Primary contact</span>
+  <%= render "affiliations/primary_contact_label" %>
 </div>

--- a/app/views/affiliations/_header.html.erb
+++ b/app/views/affiliations/_header.html.erb
@@ -1,9 +1,10 @@
-<%# Column headers for the affiliation editor rows (desktop only). Card rows hide
-    their per-field labels at sm+ and rely on this row; on mobile each field keeps
-    its own label and this header is hidden. The grid template and px must match
-    the sm:grid row in affiliations/_fields so the labels sit over their columns.
-    The transparent border mirrors the card's border so content left-edges align. %>
-<div class="hidden sm:grid sm:grid-cols-[280px_150px_64px_150px_150px_auto] sm:gap-x-4 border border-transparent px-3 mb-1">
+<%# Column headers for the affiliation editor rows (wide screens only). At xl+ the
+    rows lay out on a grid and hide their per-field labels, relying on this header;
+    below xl the fields wrap and each keeps its own label, and this header is hidden.
+    The grid template and px must match the xl:grid row in affiliations/_fields so
+    the labels sit over their columns. The transparent border mirrors the card's
+    border so content left-edges align. %>
+<div class="hidden xl:grid xl:grid-cols-[280px_150px_64px_150px_150px_auto] xl:gap-x-4 border border-transparent px-3 mb-1">
   <span class="text-sm font-medium text-gray-700"><%= label %></span>
   <span class="text-sm font-medium text-gray-700">Title</span>
   <span class="text-sm font-medium text-gray-700">Address</span>

--- a/app/views/affiliations/_header.html.erb
+++ b/app/views/affiliations/_header.html.erb
@@ -4,11 +4,11 @@
     The grid template and px must match the xl:grid row in affiliations/_fields so
     the labels sit over their columns. The transparent border mirrors the card's
     border so content left-edges align. %>
-<div class="hidden xl:grid xl:grid-cols-[280px_150px_64px_150px_150px_auto] xl:gap-x-4 border border-transparent px-3 mb-1">
+<div class="hidden xl:grid xl:grid-cols-[280px_150px_150px_150px_120px_auto] xl:gap-x-4 border border-transparent px-3 mb-1">
   <span class="text-sm font-medium text-gray-700"><%= label %></span>
   <span class="text-sm font-medium text-gray-700">Title</span>
-  <span class="text-sm font-medium text-gray-700">Address</span>
   <span class="text-sm font-medium text-gray-700">Start</span>
   <span class="text-sm font-medium text-gray-700">End</span>
+  <span class="text-sm font-medium text-gray-700">Address</span>
   <%= render "affiliations/primary_contact_label" %>
 </div>

--- a/app/views/affiliations/_primary_contact_label.html.erb
+++ b/app/views/affiliations/_primary_contact_label.html.erb
@@ -1,0 +1,10 @@
+<%# "Primary contact" column label shortened to "Primary" with a hover tooltip,
+    matching the Program status info-tooltip pattern on the organization form. %>
+<span class="group relative inline-flex items-center gap-1 whitespace-nowrap text-sm font-medium text-gray-700">
+  Primary
+  <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
+  <span class="hidden group-hover:block absolute z-50 left-0 top-full mt-1 w-56 whitespace-normal rounded-lg bg-blue-100 p-3 text-xs text-gray-700 shadow-lg ring-1 ring-blue-200">
+    <span class="block font-semibold">Primary contact</span>
+    This person is best contact for this organization
+  </span>
+</span>

--- a/app/views/affiliations/_primary_contact_toggle.html.erb
+++ b/app/views/affiliations/_primary_contact_toggle.html.erb
@@ -1,0 +1,8 @@
+<%# Primary-contact on/off slider (purple when on) bound to the affiliation's
+    primary_contact checkbox. The sr-only checkbox is the peer; the track is its
+    sibling span and the knob is the track's ::after. Mirrors the app's toggle
+    pattern (e.g. event_registrations/_certificate_issued_toggle). %>
+<label class="flex h-[42px] items-center cursor-pointer select-none">
+  <%= f.check_box :primary_contact, checked: f.object.primary_contact?, class: "peer sr-only" %>
+  <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-purple-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
+</label>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -51,20 +51,20 @@
               } %>
       </div>
 
-      <div class="flex flex-wrap gap-4">
-        <div class="grow min-w-[150px]">
+      <div class="flex flex-wrap items-start gap-4">
+        <div class="flex-1 min-w-[200px]">
           <%= f.input :title,
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                 hint: "\"Facilitator\" means they're running an Art Program." %>
         </div>
-        <div>
+        <div class="w-40">
           <%= f.input :start_date,
                 as: :string,
                 label: "Start",
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
                 input_html: { type: "date", value: @affiliation.start_date&.strftime("%Y-%m-%d") } %>
         </div>
-        <div>
+        <div class="w-40">
           <%= f.input :end_date,
                 as: :string,
                 label: "End",

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -40,12 +40,8 @@
               } %>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Primary organization contact</label>
-          <div class="flex h-[42px] items-center">
-            <%= f.check_box :primary_contact,
-                  checked: @affiliation.primary_contact?,
-                  class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
-          </div>
+          <span class="block text-sm font-medium text-gray-700 mb-1">Primary organization contact</span>
+          <%= render "affiliations/primary_contact_toggle", f: f %>
         </div>
       </div>
 

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -1,0 +1,134 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% back_path = case params[:return_to]
+   when "person" then edit_person_path(params[:origin_id], anchor: dom_id(@affiliation))
+   when "organization" then edit_organization_path(params[:origin_id], anchor: dom_id(@affiliation))
+   end %>
+
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+    <% if back_path %>
+      <%= link_to back_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i>
+        <%= params[:return_to] == "person" ? @affiliation.person&.full_name : @affiliation.organization&.name %>
+      <% end %>
+    <% else %>
+      <span></span>
+    <% end %>
+    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+
+  <h1 class="text-2xl font-semibold text-gray-900 tracking-tight mb-1">Edit affiliation</h1>
+  <p class="text-sm text-gray-500 mb-6">
+    <%= @affiliation.person&.full_name %> at <%= @affiliation.organization&.name %>
+  </p>
+
+  <%= simple_form_for @affiliation,
+        url: affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence),
+        method: :patch,
+        html: { id: "affiliation_form", data: { turbo: false } } do |f| %>
+    <div class="bg-white rounded-lg p-6 space-y-5">
+      <div>
+        <%= f.input :person_id,
+              collection: @affiliation.person ? [ [ @affiliation.person.full_name, @affiliation.person.id ] ] : [],
+              selected: @affiliation.person_id,
+              include_blank: false,
+              label: "Person",
+              label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+              input_html: {
+                data: { controller: "remote-select", remote_select_model_value: "person" }
+              } %>
+        <p class="text-xs text-gray-500 mt-1">Type to search to reassign this affiliation to a different person.</p>
+      </div>
+
+      <div>
+        <%= f.input :organization_id,
+              collection: @affiliation.organization ? [ [ @affiliation.organization.name, @affiliation.organization.id ] ] : [],
+              selected: @affiliation.organization_id,
+              include_blank: false,
+              label: "Organization",
+              label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+              input_html: {
+                data: { controller: "remote-select", remote_select_model_value: "organization" }
+              } %>
+        <p class="text-xs text-gray-500 mt-1">Reassigning to a different organization clears the linked address.</p>
+      </div>
+
+      <div class="flex flex-wrap gap-4">
+        <div class="grow min-w-[150px]">
+          <%= f.input :title,
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+        </div>
+        <div>
+          <%= f.input :start_date,
+                as: :string,
+                label: "Start",
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                input_html: { type: "date", value: @affiliation.start_date&.strftime("%Y-%m-%d") } %>
+        </div>
+        <div>
+          <%= f.input :end_date,
+                as: :string,
+                label: "End",
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                input_html: { type: "date", value: @affiliation.end_date&.strftime("%Y-%m-%d") } %>
+        </div>
+      </div>
+
+      <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+        <%= f.check_box :primary_contact,
+              checked: @affiliation.primary_contact?,
+              class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+        Primary organization contact
+      </label>
+    </div>
+
+    <%# ---- Comments (saved with the affiliation, like the other forms) ---- %>
+    <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
+      <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:comments, intensity: 100) %> <%= DomainTheme.text_class_for(:comments, intensity: 600) %>">
+          <i class="fa-solid fa-comments"></i>
+        </span>
+        <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
+      </div>
+
+      <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
+        <div id="comment-list" class="space-y-4">
+          <%= f.simple_fields_for :comments do |cf| %>
+            <%= render "comments/comment_fields", f: cf %>
+          <% end %>
+        </div>
+
+        <div data-paginated-fields-target="nav"></div>
+
+        <div class="flex items-center justify-between gap-2">
+          <%= link_to_add_association f, :comments,
+                partial: "comments/comment_fields",
+                data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
+                class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
+            <i class="fa-solid fa-plus text-[0.6rem]"></i>
+            Add comment
+          <% end %>
+
+          <button type="button"
+                  class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                  data-action="edit-toggle#toggle">
+            <i class="fa-solid fa-pen text-[0.6rem]"></i>
+            <span data-edit-toggle-target="editLabel">Edit comments</span>
+            <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+      <div class="ml-auto flex items-center gap-3">
+        <% if back_path %>
+          <%= link_to "Cancel", back_path, class: "btn btn-secondary-outline" %>
+        <% end %>
+        <button type="submit" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  <% end %>
+
+  <%= render "shared/audit_info", resource: @affiliation %>
+</div>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -119,15 +119,21 @@
       </div>
     </section>
 
-    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
-      <div class="ml-auto flex items-center gap-3">
-        <% if back_path %>
-          <%= link_to "Cancel", back_path, class: "btn btn-secondary-outline" %>
-        <% end %>
-        <button type="submit" class="btn btn-primary">Save changes</button>
-      </div>
-    </div>
   <% end %>
+
+  <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+    <%= button_to "Delete",
+          affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence),
+          method: :delete,
+          form: { data: { turbo_confirm: "Remove this affiliation?" } },
+          class: "btn btn-danger-outline" %>
+    <div class="ml-auto flex items-center gap-3">
+      <% if back_path %>
+        <%= link_to "Cancel", back_path, class: "btn btn-secondary-outline" %>
+      <% end %>
+      <button type="submit" form="affiliation_form" class="btn btn-primary">Save changes</button>
+    </div>
+  </div>
 
   <%= render "shared/audit_info", resource: @affiliation %>
 </div>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -121,11 +121,14 @@
 
   <% end %>
 
+  <% delete_confirm = @affiliation.facilitator? ?
+       "Removing this facilitator affiliation affects the organization's status with AWBW, which is calculated from facilitator affiliations and their start and end dates. Remove it?" :
+       "Remove this affiliation?" %>
   <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
     <%= button_to "Delete",
           affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence),
           method: :delete,
-          form: { data: { turbo_confirm: "Remove this affiliation?" } },
+          form: { data: { turbo_confirm: delete_confirm } },
           class: "btn btn-danger-outline" %>
     <div class="ml-auto flex items-center gap-3">
       <% if back_path %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -27,36 +27,35 @@
         method: :patch,
         html: { id: "affiliation_form", data: { turbo: false } } do |f| %>
     <div class="bg-white rounded-lg p-6 space-y-5">
-      <div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <%= f.input :person_id,
               collection: @affiliation.person ? [ [ @affiliation.person.full_name, @affiliation.person.id ] ] : [],
               selected: @affiliation.person_id,
               include_blank: false,
               label: "Person",
               label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+              hint: "Type to search to reassign to a different person.",
               input_html: {
                 data: { controller: "remote-select", remote_select_model_value: "person" }
               } %>
-        <p class="text-xs text-gray-500 mt-1">Type to search to reassign this affiliation to a different person.</p>
-      </div>
 
-      <div>
         <%= f.input :organization_id,
               collection: @affiliation.organization ? [ [ @affiliation.organization.name, @affiliation.organization.id ] ] : [],
               selected: @affiliation.organization_id,
               include_blank: false,
               label: "Organization",
               label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+              hint: "Reassigning clears the linked address.",
               input_html: {
                 data: { controller: "remote-select", remote_select_model_value: "organization" }
               } %>
-        <p class="text-xs text-gray-500 mt-1">Reassigning to a different organization clears the linked address.</p>
       </div>
 
       <div class="flex flex-wrap gap-4">
         <div class="grow min-w-[150px]">
           <%= f.input :title,
-                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                hint: "\"Facilitator\" means they're running an Art Program." %>
         </div>
         <div>
           <%= f.input :start_date,

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -104,14 +104,14 @@
                 partial: "comments/comment_fields",
                 data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
                 class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
-            <i class="fa-solid fa-plus text-[0.6rem]"></i>
+            <i class="fa-solid fa-plus text-2xs"></i>
             Add comment
           <% end %>
 
           <button type="button"
                   class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
                   data-action="edit-toggle#toggle">
-            <i class="fa-solid fa-pen text-[0.6rem]"></i>
+            <i class="fa-solid fa-pen text-2xs"></i>
             <span data-edit-toggle-target="editLabel">Edit comments</span>
             <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
           </button>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -57,7 +57,7 @@
                 include_blank: false,
                 label: "Organization",
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                wrapper_html: { class: "mb-0" },
+                wrapper_html: { class: "mb-0!" },
                 input_html: {
                   data: { controller: "remote-select", remote_select_model_value: "organization" }
                 } %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -45,6 +45,7 @@
               include_blank: false,
               label: "Organization",
               label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+              hint: "Changing the organization affects this org's Art Program status.",
               input_html: {
                 data: { controller: "remote-select", remote_select_model_value: "organization" }
               } %>
@@ -65,16 +66,19 @@
         </div>
       <% end %>
 
-      <p class="text-xs text-amber-700">
-        <i class="fa-solid fa-triangle-exclamation mr-1"></i>
-        Reassigning the organization <%= "disconnects the current address (#{@affiliation.organization_address.name}) and " if @affiliation.organization_address.present? %>links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
-      </p>
+      <div>
+        <%= render "affiliations/address_picker", f: f %>
+        <p class="mt-1 text-xs text-amber-700">
+          <i class="fa-solid fa-triangle-exclamation mr-1"></i>
+          Reassigning the organization links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
+        </p>
+      </div>
 
       <div class="flex flex-wrap items-start gap-4">
         <div class="flex-1 min-w-[200px]">
           <%= f.input :title,
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                hint: "\"Facilitator\" means they're running an Art Program." %>
+                hint: "\"Facilitator\" = AWBW Art Program Facilitator." %>
         </div>
         <div class="w-40">
           <%= f.input :start_date,

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -39,16 +39,41 @@
                 data: { controller: "remote-select", remote_select_model_value: "person" }
               } %>
 
-        <%= f.input :organization_id,
-              collection: @affiliation.organization ? [ [ @affiliation.organization.name, @affiliation.organization.id ] ] : [],
-              selected: @affiliation.organization_id,
-              include_blank: false,
-              label: "Organization",
-              label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-              hint: "Changing the organization affects this org's Art Program status.",
-              input_html: {
-                data: { controller: "remote-select", remote_select_model_value: "organization" }
-              } %>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Primary organization contact</label>
+          <div class="flex h-[42px] items-center">
+            <%= f.check_box :primary_contact,
+                  checked: @affiliation.primary_contact?,
+                  class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <%= f.input :organization_id,
+                collection: @affiliation.organization ? [ [ @affiliation.organization.name, @affiliation.organization.id ] ] : [],
+                selected: @affiliation.organization_id,
+                include_blank: false,
+                label: "Organization",
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                wrapper_html: { class: "mb-0" },
+                input_html: {
+                  data: { controller: "remote-select", remote_select_model_value: "organization" }
+                } %>
+          <p class="mt-1 text-xs text-amber-700">
+            <i class="fa-solid fa-triangle-exclamation mr-1"></i>
+            Changing the organization affects this org's Art Program status.
+          </p>
+        </div>
+
+        <div>
+          <%= render "affiliations/address_picker", f: f %>
+          <p class="mt-1 text-xs text-amber-700">
+            <i class="fa-solid fa-triangle-exclamation mr-1"></i>
+            Reassigning the organization links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
+          </p>
+        </div>
       </div>
 
       <% if @affiliation.event_registration.present? %>
@@ -65,14 +90,6 @@
           </p>
         </div>
       <% end %>
-
-      <div>
-        <%= render "affiliations/address_picker", f: f %>
-        <p class="mt-1 text-xs text-amber-700">
-          <i class="fa-solid fa-triangle-exclamation mr-1"></i>
-          Reassigning the organization links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
-        </p>
-      </div>
 
       <div class="flex flex-wrap items-start gap-4">
         <div class="flex-1 min-w-[200px]">
@@ -95,13 +112,6 @@
                 input_html: { type: "date", value: @affiliation.end_date&.strftime("%Y-%m-%d") } %>
         </div>
       </div>
-
-      <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
-        <%= f.check_box :primary_contact,
-              checked: @affiliation.primary_contact?,
-              class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500" %>
-        Primary organization contact
-      </label>
     </div>
 
     <%# ---- Comments (saved with the affiliation, like the other forms) ---- %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -45,11 +45,30 @@
               include_blank: false,
               label: "Organization",
               label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-              hint: "Reassigning clears the linked address.",
               input_html: {
                 data: { controller: "remote-select", remote_select_model_value: "organization" }
               } %>
       </div>
+
+      <% if @affiliation.event_registration.present? %>
+        <% er = @affiliation.event_registration %>
+        <div class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          <p class="font-medium"><i class="fa-solid fa-link mr-1"></i>Linked to a registration</p>
+          <p class="mt-1">
+            This affiliation came from
+            <%= link_to (er.registrant&.full_name.presence || "a registration"),
+                  edit_event_registration_path(er), class: "underline font-medium", target: "_blank", rel: "noopener" %><%= " — #{er.event.title}" if er.event %>.
+            Reassigning the organization here unlinks that registration from this affiliation; update the organization in the
+            <%= link_to "registration's organization-linking step",
+                  link_organization_event_registration_path(er), class: "underline font-medium", target: "_blank", rel: "noopener" %> as well.
+          </p>
+        </div>
+      <% end %>
+
+      <p class="text-xs text-amber-700">
+        <i class="fa-solid fa-triangle-exclamation mr-1"></i>
+        Reassigning the organization <%= "disconnects the current address (#{@affiliation.organization_address.name}) and " if @affiliation.organization_address.present? %>links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
+      </p>
 
       <div class="flex flex-wrap items-start gap-4">
         <div class="flex-1 min-w-[200px]">

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -338,6 +338,9 @@
       </div>
       <% if allowed_to?(:manage?, Organization) %>
         <div class="p-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="10" data-affiliation-dates-target="affiliationsContainer">
+          <% if f.object.affiliations.present? %>
+            <%= render "affiliations/header", label: "Person" %>
+          <% end %>
           <%= f.fields_for :affiliations do |affiliation_form| %>
             <div data-paginated-fields-target="item">
               <%= render "affiliation_fields",

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -346,7 +346,7 @@
           <% end %>
           <div data-paginated-fields-target="nav"></div>
 
-          <div class="p-3 mt-6"><%= link_to_add_association "➕ Add Affiliation",
+          <div class="mt-2"><%= link_to_add_association "➕ Add Affiliation",
                                         f,
                                         :affiliations,
                                         class: "btn btn-secondary-outline" %></div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -313,6 +313,9 @@
       </div>
       <% if allowed_to?(:manage?, Person) %>
         <div class="p-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="10" data-affiliation-dates-target="affiliationsContainer">
+          <% if f.object.affiliations.present? %>
+            <%= render "affiliations/header", label: "Organization" %>
+          <% end %>
           <%= f.fields_for :affiliations do |affiliation_form| %>
             <div data-paginated-fields-target="item">
               <%= render "affiliation_fields",

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -321,7 +321,7 @@
           <% end %>
           <div data-paginated-fields-target="nav"></div>
 
-          <div class="mt-6 p-3"><%= link_to_add_association "➕ Add Affiliation",
+          <div class="mt-2"><%= link_to_add_association "➕ Add Affiliation",
                                         f,
                                         :affiliations,
                                         class: "admin-only bg-blue-100 btn btn-secondary-outline" %></div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,16 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Edit an affiliation's details and comments"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-16
+  pr_number: 2235
+  summary: >-
+    Each affiliation row on an organization or person edit page has a gear that opens
+    a full editor — reassign the person or organization, adjust the title and dates,
+    and leave comments on the affiliation.
+
 - name: "File-upload questions on forms"
   area: content
   display_status: admin_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,7 @@ Rails.application.routes.draw do
 
   resources :refunds, only: [ :new, :create, :show ]
   resources :organization_statuses
-  resources :affiliations, only: :destroy
+  resources :affiliations, only: [ :edit, :update, :destroy ]
   resources :quotes
 
   resources :monthly_reports, only: [ :index, :show ], constraints: { id: /\d+/ }

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -1,294 +1,40 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe Affiliation do
-  describe 'associations' do
-    it { should belong_to(:organization) }
-    it { should belong_to(:person) }
-    it { should belong_to(:organization_address).class_name("Address").optional }
-  end
+RSpec.describe Affiliation, type: :model do
+  describe "comments" do
+    it "holds comments as the polymorphic commentable" do
+      affiliation = create(:affiliation)
+      comment = affiliation.comments.create!(body: "A note about this affiliation")
 
-  describe 'validations' do
-    subject do
-      build(:affiliation, organization: create(:organization), person: create(:person))
-    end
-    it { should validate_presence_of(:organization_id) }
-    # it { should validate_presence_of(:person_id) } # we needed to not have this to support nested attrs
-  end
-
-  describe '#organization_address' do
-    let(:organization) { create(:organization) }
-    let(:address) { create(:address, addressable: organization) }
-
-    it 'is valid when the address belongs to the same organization' do
-      affiliation = build(:affiliation, organization: organization, organization_address: address)
-      expect(affiliation).to be_valid
-    end
-
-    it 'is valid when no address is linked' do
-      affiliation = build(:affiliation, organization: organization, organization_address: nil)
-      expect(affiliation).to be_valid
-    end
-
-    it 'is invalid when the address belongs to a different organization' do
-      other_address = create(:address, addressable: create(:organization))
-      affiliation = build(:affiliation, organization: organization, organization_address: other_address)
-      expect(affiliation).not_to be_valid
-      expect(affiliation.errors[:organization_address_id]).to be_present
-    end
-
-    it "is invalid when the address belongs to a person" do
-      person_address = create(:address, addressable: create(:person))
-      affiliation = build(:affiliation, organization: organization, organization_address: person_address)
-      expect(affiliation).not_to be_valid
-    end
-
-    it 'is nullified when its linked address is destroyed' do
-      affiliation = create(:affiliation, organization: organization, organization_address: address)
-      address.destroy
-      expect(affiliation.reload.organization_address_id).to be_nil
+      expect(comment.commentable).to eq(affiliation)
     end
   end
 
-  describe '#active?' do
-    it 'is true when not inactive and has no end date' do
-      expect(build(:affiliation, inactive: false, end_date: nil).active?).to be true
-    end
+  describe "lifecycle tracking" do
+    it "buffers an update.affiliation ahoy event when edited by a user" do
+      affiliation = create(:affiliation, title: "Facilitator")
+      Current.user = create(:user, :admin)
+      allow(Analytics::LifecycleBuffer).to receive(:push).and_call_original
 
-    it 'is true when not inactive and the end date is in the future' do
-      expect(build(:affiliation, inactive: false, end_date: 1.month.from_now).active?).to be true
-    end
+      affiliation.update!(title: "Lead facilitator")
 
-    it 'is false when flagged inactive' do
-      expect(build(:affiliation, inactive: true, end_date: nil).active?).to be false
-    end
-
-    it 'is false when the end date has passed' do
-      expect(build(:affiliation, inactive: false, end_date: 1.day.ago).active?).to be false
+      expect(Analytics::LifecycleBuffer).to have_received(:push)
+        .with(hash_including(name: "update.affiliation"))
     end
   end
 
-  describe '.active' do
-    let!(:active_op) { create(:affiliation, inactive: false, end_date: nil) }
-    let!(:active_with_future_end) { create(:affiliation, inactive: false, end_date: 1.month.from_now) }
-    let!(:inactive_by_flag) { create(:affiliation, inactive: true, end_date: nil) }
-    let!(:inactive_by_end_date) { create(:affiliation, inactive: false, end_date: 1.day.ago) }
+  describe "reassigning the organization" do
+    let(:old_org) { create(:organization) }
+    let(:new_org) { create(:organization) }
+    let(:address) { create(:address, addressable: old_org) }
 
-    it 'includes records with inactive: false and no end date' do
-      expect(described_class.active).to include(active_op)
-    end
+    it "clears the org-scoped address so the row survives validation" do
+      affiliation = create(:affiliation, organization: old_org, organization_address: address)
 
-    it 'includes records with inactive: false and future end date' do
-      expect(described_class.active).to include(active_with_future_end)
-    end
+      affiliation.update!(organization: new_org)
 
-    it 'excludes records with inactive: true' do
-      expect(described_class.active).not_to include(inactive_by_flag)
-    end
-
-    it 'excludes records with past end date' do
-      expect(described_class.active).not_to include(inactive_by_end_date)
-    end
-
-    it 'qualifies end_date when joined with organizations (which also has end_date)' do
-      expect {
-        described_class.active.joins(:organization).to_a
-      }.not_to raise_error
-    end
-  end
-
-  describe '#facilitator?' do
-    it 'is true for the exact title "Facilitator"' do
-      expect(build(:affiliation, title: "Facilitator").facilitator?).to be true
-    end
-
-    it 'ignores surrounding whitespace' do
-      expect(build(:affiliation, title: "  Facilitator ").facilitator?).to be true
-    end
-
-    it 'is false for title variants like "Lead Facilitator"' do
-      expect(build(:affiliation, title: "Lead Facilitator").facilitator?).to be false
-    end
-
-    it 'is case-sensitive' do
-      expect(build(:affiliation, title: "facilitator").facilitator?).to be false
-      expect(build(:affiliation, title: "FACILITATOR").facilitator?).to be false
-    end
-
-    it 'is false when the title is blank' do
-      expect(build(:affiliation, title: nil).facilitator?).to be false
-    end
-  end
-
-  describe '.facilitators' do
-    let!(:exact) { create(:affiliation, title: "Facilitator") }
-    let!(:whitespace) { create(:affiliation, title: "  Facilitator ") }
-    let!(:variant) { create(:affiliation, title: "Lead Facilitator") }
-    let!(:lowercase) { create(:affiliation, title: "facilitator") }
-
-    it 'includes only the exact, case-sensitive title "Facilitator" (whitespace-trimmed)' do
-      expect(described_class.facilitators).to contain_exactly(exact, whitespace)
-    end
-  end
-
-  describe '#sync_organization_status_with_affiliations' do
-    let!(:active_status) { OrganizationStatus.find_or_create_by!(name: "Active") }
-    let!(:inactive_status) { OrganizationStatus.find_or_create_by!(name: "Inactive") }
-
-    it 'sets the organization to Inactive when its last active affiliation goes inactive' do
-      org = create(:organization, organization_status: active_status)
-      affiliation = create(:affiliation, organization: org, inactive: false, end_date: nil)
-
-      affiliation.update!(inactive: true)
-
-      expect(org.reload.organization_status).to eq(inactive_status)
-    end
-
-    it 'sets an Inactive organization back to Active when it regains an active affiliation' do
-      org = create(:organization, organization_status: inactive_status)
-
-      create(:affiliation, organization: org, inactive: false, end_date: nil)
-
-      expect(org.reload.organization_status).to eq(active_status)
-    end
-
-    it 'ignores non-facilitator affiliations when deciding status' do
-      org = create(:organization, organization_status: active_status)
-      create(:affiliation, organization: org, title: "Volunteer", inactive: false, end_date: nil)
-
-      expect(org.reload.organization_status).to eq(inactive_status)
-    end
-
-    %w[Pending Reinstate Unknown].each do |status_name|
-      it "leaves a #{status_name} organization untouched when it regains an active affiliation" do
-        status = OrganizationStatus.find_or_create_by!(name: status_name)
-        org = create(:organization, organization_status: status)
-
-        create(:affiliation, organization: org, inactive: false, end_date: nil)
-
-        expect(org.reload.organization_status).to eq(status)
-      end
-    end
-  end
-
-  describe '.active_on' do
-    let(:date) { Date.new(2024, 6, 1) }
-    let!(:spanning) { create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: Date.new(2025, 1, 1)) }
-    let!(:open_ended) { create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: nil) }
-    let!(:ended_before) { create(:affiliation, start_date: Date.new(2020, 1, 1), end_date: Date.new(2021, 1, 1)) }
-    let!(:starts_after) { create(:affiliation, start_date: Date.new(2025, 1, 1), end_date: nil) }
-    let!(:no_dates) { create(:affiliation, start_date: nil, end_date: nil) }
-
-    it 'includes affiliations whose span covers the date' do
-      expect(described_class.active_on(date)).to include(spanning, open_ended)
-    end
-
-    it 'excludes affiliations that ended before the date' do
-      expect(described_class.active_on(date)).not_to include(ended_before)
-    end
-
-    it 'excludes affiliations that start after the date' do
-      expect(described_class.active_on(date)).not_to include(starts_after)
-    end
-
-    it 'includes affiliations with no dates on record' do
-      expect(described_class.active_on(date)).to include(no_dates)
-    end
-
-    it 'ignores the cached inactive flag, judging purely by dates' do
-      flagged = create(:affiliation, start_date: Date.new(2023, 1, 1), end_date: nil, inactive: true)
-      expect(described_class.active_on(date)).to include(flagged)
-    end
-  end
-
-  describe 'status (#status_on and .with_status)' do
-    let!(:active_open) { create(:affiliation, start_date: Date.current.prev_year, end_date: nil) }
-    let!(:active_span) { create(:affiliation, start_date: Date.current.prev_year, end_date: Date.current.next_year) }
-    let!(:upcoming) { create(:affiliation, start_date: Date.current.next_year, end_date: nil) }
-    let!(:ended) { create(:affiliation, start_date: Date.current.prev_year(2), end_date: Date.current.prev_year) }
-    let!(:no_dates) { create(:affiliation, start_date: nil, end_date: nil) }
-
-    it 'exposes the taxonomy in display order' do
-      expect(Affiliation::STATUSES).to eq(%w[ Active Upcoming Inactive ])
-    end
-
-    it '#status_on classifies by flag and dates' do
-      expect(active_open.reload.status_on).to eq("Active")
-      expect(active_span.reload.status_on).to eq("Active")
-      expect(upcoming.reload.status_on).to eq("Upcoming")
-      expect(ended.reload.status_on).to eq("Inactive")
-      expect(no_dates.reload.status_on).to eq("Active")
-    end
-
-    it '.with_status returns exactly the rows whose #status_on matches (SQL ↔ Ruby agree)' do
-      Affiliation::STATUSES.each do |status|
-        expected = Affiliation.all.select { |a| a.status_on == status }.map(&:id).sort
-        expect(Affiliation.with_status(status).ids.sort).to eq(expected), "mismatch for #{status}"
-      end
-    end
-
-    it 'offers the combined filter option alongside the chip taxonomy' do
-      expect(Affiliation::FILTER_STATUSES)
-        .to eq([ "Active", "Upcoming", "Active & Upcoming", "Inactive" ])
-    end
-
-    it '.with_status("Active & Upcoming") returns exactly the Active and Upcoming rows' do
-      expected = Affiliation.all.select { |a| a.status_on.in?(%w[ Active Upcoming ]) }.map(&:id).sort
-
-      expect(Affiliation.with_status(Affiliation::ACTIVE_OR_UPCOMING).ids.sort).to eq(expected)
-      expect(Affiliation.with_status(Affiliation::ACTIVE_OR_UPCOMING)).to include(active_open, active_span, upcoming, no_dates)
-      expect(Affiliation.with_status(Affiliation::ACTIVE_OR_UPCOMING)).not_to include(ended)
-    end
-
-    it '.with_status is empty for an unknown status' do
-      expect(Affiliation.with_status("bogus")).to be_empty
-    end
-  end
-
-  describe '#set_inactive_from_dates' do
-    let(:op) { create(:affiliation, inactive: false, end_date: nil) }
-
-    it 'sets inactive to true when end_date is set to a past date' do
-      op.update!(end_date: 1.day.ago)
-      expect(op.reload.inactive).to be true
-    end
-
-    it 'sets inactive to false when end_date is set to a future date' do
-      op.update!(inactive: true, end_date: 1.day.ago)
-      op.update!(end_date: 1.month.from_now)
-      expect(op.reload.inactive).to be false
-    end
-
-    it 'sets inactive to false when end_date is cleared' do
-      op.update!(end_date: 1.day.ago)
-      op.update!(end_date: nil)
-      expect(op.reload.inactive).to be false
-    end
-
-    it 'does not change inactive when unrelated fields change' do
-      op.update!(inactive: true)
-      op.update!(title: "New Title")
-      expect(op.reload.inactive).to be true
-    end
-  end
-
-  describe "the registration that created the affiliation" do
-    it "drops the link when the affiliation is moved to a different organization" do
-      registration = create(:event_registration)
-      affiliation = create(:affiliation, event_registration: registration)
-      other_org = create(:organization)
-
-      affiliation.update!(organization: other_org)
-
-      expect(affiliation.reload.event_registration_id).to be_nil
-    end
-
-    it "keeps the link when other attributes change" do
-      registration = create(:event_registration)
-      affiliation = create(:affiliation, event_registration: registration)
-
-      affiliation.update!(title: "Lead Facilitator")
-
-      expect(affiliation.reload.event_registration).to eq(registration)
+      expect(affiliation.reload.organization_id).to eq(new_org.id)
+      expect(affiliation.organization_address_id).to be_nil
     end
   end
 end

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -26,15 +26,34 @@ RSpec.describe Affiliation, type: :model do
   describe "reassigning the organization" do
     let(:old_org) { create(:organization) }
     let(:new_org) { create(:organization) }
-    let(:address) { create(:address, addressable: old_org) }
+    let(:old_address) { create(:address, addressable: old_org) }
 
-    it "clears the org-scoped address so the row survives validation" do
-      affiliation = create(:affiliation, organization: old_org, organization_address: address)
+    it "drops the stale address when the new org has several addresses" do
+      create_list(:address, 2, addressable: new_org)
+      affiliation = create(:affiliation, organization: old_org, organization_address: old_address)
 
       affiliation.update!(organization: new_org)
 
       expect(affiliation.reload.organization_id).to eq(new_org.id)
       expect(affiliation.organization_address_id).to be_nil
+    end
+
+    it "adopts the sole address of the new org" do
+      new_address = create(:address, addressable: new_org)
+      affiliation = create(:affiliation, organization: old_org, organization_address: old_address)
+
+      affiliation.update!(organization: new_org)
+
+      expect(affiliation.reload.organization_address_id).to eq(new_address.id)
+    end
+
+    it "clears the event registration link" do
+      registration = create(:event_registration)
+      affiliation = create(:affiliation, organization: old_org, event_registration: registration)
+
+      affiliation.update!(organization: new_org)
+
+      expect(affiliation.reload.event_registration_id).to be_nil
     end
   end
 end

--- a/spec/policies/affiliation_policy_spec.rb
+++ b/spec/policies/affiliation_policy_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe AffiliationPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, :admin) }
+  let(:regular_user) { build_stubbed(:user) }
+
+  let(:affiliation) { build_stubbed(:affiliation) }
+
+  def policy_for(record: nil, user:)
+    described_class.new(record, user: user)
+  end
+
+  %i[ edit? update? destroy? ].each do |rule|
+    describe "##{rule}" do
+      context "with admin user" do
+        subject { policy_for(record: affiliation, user: admin_user) }
+
+        it { is_expected.to be_allowed_to(rule) }
+      end
+
+      context "with regular user" do
+        subject { policy_for(record: affiliation, user: regular_user) }
+
+        it { is_expected.not_to be_allowed_to(rule) }
+      end
+
+      context "with no user" do
+        subject { policy_for(record: affiliation, user: nil) }
+
+        it { is_expected.not_to be_allowed_to(rule) }
+      end
+    end
+  end
+end

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -74,4 +74,30 @@ RSpec.describe "/affiliations", type: :request do
       end
     end
   end
+
+  describe "DELETE /affiliations/:id" do
+    context "as an admin returning from the editor" do
+      before { sign_in admin }
+
+      it "destroys the affiliation and returns to the origin edit page" do
+        expect {
+          delete affiliation_path(affiliation, return_to: "organization", origin_id: organization.id)
+        }.to change(Affiliation, :count).by(-1)
+
+        expect(response).to redirect_to(edit_organization_path(organization, anchor: "affiliations"))
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in regular_user }
+
+      it "does not destroy and redirects to root" do
+        expect {
+          delete affiliation_path(affiliation, return_to: "organization", origin_id: organization.id)
+        }.not_to change(Affiliation, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe "/affiliations", type: :request do
         expect(comment.body).to eq("Left a note")
         expect(comment.created_by).to eq(admin)
       end
+
+      it "assigns the organization address through the editor" do
+        address = create(:address, addressable: organization)
+
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { organization_address_id: address.id } }
+
+        expect(affiliation.reload.organization_address_id).to eq(address.id)
+      end
     end
 
     context "as a non-admin" do

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "/affiliations", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+  let(:organization) { create(:organization) }
+  let(:person) { create(:person) }
+  let!(:affiliation) do
+    create(:affiliation, organization: organization, person: person, title: "Facilitator")
+  end
+
+  describe "GET /affiliations/:id/edit" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the edit form" do
+        get edit_affiliation_path(affiliation)
+        expect(response).to be_successful
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in regular_user }
+
+      it "redirects to root" do
+        get edit_affiliation_path(affiliation)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PATCH /affiliations/:id" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "updates attributes and returns to the origin org edit page, scrolled to the row" do
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { title: "Lead facilitator" } }
+
+        expect(affiliation.reload.title).to eq("Lead facilitator")
+        expect(response).to redirect_to(edit_organization_path(organization, anchor: "affiliation_#{affiliation.id}"))
+      end
+
+      it "reassigns the person and returns to the origin person edit page" do
+        other_person = create(:person)
+
+        patch affiliation_path(affiliation, return_to: "person", origin_id: person.id),
+              params: { affiliation: { person_id: other_person.id } }
+
+        expect(affiliation.reload.person_id).to eq(other_person.id)
+        expect(response).to redirect_to(edit_person_path(person, anchor: "affiliation_#{affiliation.id}"))
+      end
+
+      it "adds a comment authored by the current user" do
+        expect {
+          patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+                params: { affiliation: { comments_attributes: [ { body: "Left a note" } ] } }
+        }.to change { affiliation.comments.count }.by(1)
+
+        comment = affiliation.comments.first
+        expect(comment.body).to eq("Left a note")
+        expect(comment.created_by).to eq(admin)
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in regular_user }
+
+      it "does not update and redirects to root" do
+        patch affiliation_path(affiliation), params: { affiliation: { title: "Changed" } }
+
+        expect(affiliation.reload.title).to eq("Facilitator")
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe "/affiliations", type: :request do
         get edit_affiliation_path(affiliation)
         expect(response).to be_successful
       end
+
+      it "surfaces a linked registration with the org-linking warning" do
+        registration = create(:event_registration)
+        affiliation.update_column(:event_registration_id, registration.id)
+
+        get edit_affiliation_path(affiliation)
+
+        expect(response.body).to include("Linked to a registration")
+        expect(response.body).to include(link_organization_event_registration_path(registration))
+      end
     end
 
     context "as a non-admin" do

--- a/spec/requests/people_affiliation_address_spec.rb
+++ b/spec/requests/people_affiliation_address_spec.rb
@@ -29,5 +29,19 @@ RSpec.describe "People affiliation address picker", type: :request do
       expect(response.body).to include("[INACTIVE]")
       expect(response.body).to include("123 Sesame Street")
     end
+
+    it "shows a comment indicator with the latest comment for an affiliation that has comments" do
+      person = create(:person)
+      organization = create(:organization)
+      affiliation = create(:affiliation, person: person, organization: organization)
+      create(:comment, commentable: affiliation, body: "Older note", created_at: 2.days.ago)
+      create(:comment, commentable: affiliation, body: "Reviewed the paperwork", created_at: 1.hour.ago)
+
+      get edit_person_path(person)
+
+      expect(response.body).to include("fa-comment")
+      expect(response.body).to include("2 comments")
+      expect(response.body).to include("Reviewed the paperwork")
+    end
   end
 end

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     )
   end
 
-  def set_textarea_input(textarea, value)
+  def set_text_input(input, value)
     page.execute_script(
       "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input', { bubbles: true }))",
-      textarea, value
+      input, value
     )
   end
 
@@ -52,7 +52,7 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
 
     # Find the Facilitator affiliation's start_date input specifically
     facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("textarea[name*='title']").value.include?("Facilitator")
+      f.find("input[name*='title']").value.include?("Facilitator")
     }
     start_input = facilitator_row.find("input[name*='start_date']")
     set_date_input(start_input, "2019-07-01")
@@ -69,9 +69,9 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     # Renaming the only exact "Facilitator" to a variant drops it — facilitator
     # matching is exact and case-sensitive, so "Lead Facilitator" no longer counts.
     facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("textarea[name*='title']").value.strip == "Facilitator"
+      f.find("input[name*='title']").value.strip == "Facilitator"
     }
-    set_textarea_input(facilitator_row.find("textarea[name*='title']"), "Lead Facilitator")
+    set_text_input(facilitator_row.find("input[name*='title']"), "Lead Facilitator")
 
     expect(facilitator).to have_text("—", wait: 5)
   end

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -109,18 +109,15 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     expect(affiliated).not_to have_text("Dec 2024")
   end
 
-  it "removes an affiliation and recalculates" do
-    visit_and_wait edit_person_path(person, admin: true)
+  it "removes an affiliation via the editor and recalculates" do
+    # Persisted affiliations are now deleted from the affiliation editor (reached
+    # via the row's gear); removing the Facilitator (Mar 2020) leaves Volunteer (Jun 2022).
+    facilitator = person.affiliations.find_by!(title: "Facilitator")
+    visit edit_affiliation_path(facilitator, return_to: "person", origin_id: person.id)
 
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
-    expect(affiliated).to have_text("Mar 2020")
+    accept_confirm { click_button "Delete" }
 
-    # Remove the Facilitator affiliation (start Mar 2020), leaving Volunteer (start Jun 2022)
-    facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("textarea[name*='title']").value.include?("Facilitator")
-    }
-    facilitator_row.find("a", text: "Remove").click
-
+    affiliated = find("[data-affiliation-dates-target='affiliatedSince']", wait: 10)
     expect(affiliated).to have_text("Jun 2022", wait: 5)
   end
 end

--- a/spec/system/organization_affiliation_dates_spec.rb
+++ b/spec/system/organization_affiliation_dates_spec.rb
@@ -53,18 +53,15 @@ RSpec.describe "Organization affiliation dates auto-update", type: :system do
     end
   end
 
-  it "removes an affiliation and recalculates" do
-    visit_and_wait edit_organization_path(organization, admin: true)
+  it "removes an affiliation via the editor and recalculates" do
+    # Persisted affiliations are now deleted from the affiliation editor (reached
+    # via the row's gear); removing the Facilitator (May 2019) leaves Volunteer (Sep 2021).
+    facilitator = organization.affiliations.find_by!(title: "Facilitator")
+    visit edit_affiliation_path(facilitator, return_to: "organization", origin_id: organization.id)
 
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
-    expect(affiliated).to have_text("May 2019")
+    accept_confirm { click_button "Delete" }
 
-    # Remove the Facilitator affiliation (start May 2019), leaving Volunteer (start Sep 2021)
-    facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("textarea[name*='title']").value.include?("Facilitator")
-    }
-    facilitator_row.find("a", text: "Remove").click
-
+    affiliated = find("[data-affiliation-dates-target='affiliatedSince']", wait: 10)
     expect(affiliated).to have_text("Sep 2021", wait: 5)
   end
 end

--- a/spec/system/organization_facilitator_warning_spec.rb
+++ b/spec/system/organization_facilitator_warning_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Facilitator affiliation change warning", type: :system do
 
   def row_for(title)
     all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("textarea[name*='title']").value.include?(title)
+      f.find("input[name*='title']").value.include?(title)
     }
   end
 

--- a/spec/system/organization_facilitator_warning_spec.rb
+++ b/spec/system/organization_facilitator_warning_spec.rb
@@ -60,16 +60,15 @@ RSpec.describe "Facilitator affiliation change warning", type: :system do
     expect(organization.affiliations.facilitators.first.reload.start_date).to eq(Date.new(2019, 5, 1))
   end
 
-  it "warns when a facilitator affiliation is removed" do
-    visit_and_wait edit_organization_path(organization, admin: true)
-
-    row_for("Facilitator").find("a", text: "Remove").click
+  it "warns when a facilitator affiliation is removed from the editor" do
+    facilitator = organization.affiliations.facilitators.first
+    visit edit_affiliation_path(facilitator, return_to: "organization", origin_id: organization.id)
 
     accept_confirm(/status with AWBW/) do
-      find("[type='submit']").click
+      click_button "Delete"
     end
 
-    expect(page).to have_current_path(organization_path(organization), wait: 10)
+    expect(page).to have_css("[data-affiliation-dates-ready]", wait: 10)
     expect(organization.affiliations.facilitators).to be_empty
   end
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/workshop_variations/new.html.erb"       => "admin-only bg-blue-100",
     "app/views/workshops/new.html.erb"                 => "admin-only bg-blue-100",
     # edit
+    "app/views/affiliations/edit.html.erb"             => "admin-only bg-blue-100",
     "app/views/banners/edit.html.erb"                  => "admin-only bg-blue-100",
     "app/views/categories/edit.html.erb"               => "admin-only bg-blue-100",
     "app/views/category_types/edit.html.erb"           => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mostly view restructuring (grid rows + editor layout) plus one strong-param addition; contained blast radius

## Why
- Nested affiliation rows on the org/person edit forms can't reassign the person/org (locked to a hidden field once persisted) and have no place for comments.
- A per-row gear now escapes to a fuller affiliation editor for exactly those two things.

## What
- **Gear** — light-grey `fa-gear` top-right of each *persisted* affiliation row on both edit forms; opens the editor in a **new tab**.
- **Standalone editor** (`affiliations#edit/#update`, admin-only) — reassign person, reassign organization, edit title/dates/primary-contact, plus the standard comment thread.
- **Comments** — `Affiliation` is now polymorphically `commentable` (same pattern as Person/Org); edits are audit-tracked via the inherited `AhoyTrackable` concern (`update.affiliation`).
- **Return-to** — gear carries `return_to` + `origin_id`; save/cancel returns to the originating edit page, scrolled to the row (the editor's eyebrow + Cancel are the way back, since the new tab has no useful browser back).

## Layout & editor polish
- **Inline rows → shared grid** — affiliation rows on the person/org edit forms lay out on one CSS grid; a single desktop-only header row carries the column labels (`Organization`/`Person`, Title, Address, Start, End, Primary contact). At `xl+` the rows align on a grid under the header; below `xl` they wrap and keep per-field labels; on mobile they stack. Uniform row height (Title textarea pinned + `resize-none`), symmetric padding.
- **Full editor** — surfaces the address association (reuses the address picker) and permits `organization_address_id` so the change saves. Top of the form is now Person + Primary contact on one row, then Organization + Address at 50/50. Org and address notes are amber warnings; title hint reworded.

## Notes
- Reassigning the org clears the now-stale `organization_address_id` and `event_registration_id` (done in `before_validation` so the address validation doesn't reject the change first).
- Opens in a new tab, so the org/person form's unsaved edits are preserved.

## Tests
- Request (edit/update, reassign, comment authorship, admin-only), policy, model (commentable + org-reassign clearing + buffered `update.affiliation` event), page_bg_class mapping.