### PR TITLE
Surface an org-scope chip on the people index

### DIFF
--- a/app/views/people/_search_boxes.html.erb
+++ b/app/views/people/_search_boxes.html.erb
@@ -1,7 +1,11 @@
+<% scoped_organization = Organization.find_by(id: params[:organization_id]) if params[:organization_id].present? %>
+<%= render "shared/filtered_to", record: scoped_organization,
+      clear_path: people_path(request.query_parameters.except("organization_id")) %>
 <%= form_tag(people_path, method: :get,
   data: { controller: "collection", turbo_frame: "people_results" },
   autocomplete: "off",
   class: "space-y-4") do |f| %>
+  <%= hidden_field_tag "organization_id", params[:organization_id] if params[:organization_id].present? %>
   <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6">
     <!-- Contact info -->
     <div class="w-full md:flex-1">

--- a/app/views/shared/_filtered_to.html.erb
+++ b/app/views/shared/_filtered_to.html.erb
@@ -3,7 +3,12 @@
     to and the path that clears the filter. %>
 <% if record %>
   <div class="mb-4 flex items-center gap-2 text-sm text-gray-600">
-    <span>Filtered to <span class="font-medium text-gray-900"><%= record.try(:name) || record.try(:full_name) %></span></span>
-    <%= link_to "Clear", clear_path, class: "text-blue-600 hover:underline" %>
+    <span>Filtered to</span>
+    <span class="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
+      <%= record.try(:name) || record.try(:full_name) %>
+      <%= link_to clear_path, class: "text-blue-400 hover:text-blue-700", aria: { label: "Clear filter" } do %>
+        <i class="fa-solid fa-xmark"></i>
+      <% end %>
+    </span>
   </div>
 <% end %>

--- a/spec/requests/people_search_spec.rb
+++ b/spec/requests/people_search_spec.rb
@@ -39,4 +39,21 @@ RSpec.describe "People search", type: :request do
       expect(response.body).not_to include("Bob")
     end
   end
+
+  describe "GET /people?organization_id=X (full page)" do
+    let!(:org) { create(:organization, name: "Scoped Org") }
+
+    it "surfaces a chip naming the scoped organization" do
+      get people_path, params: { organization_id: org.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Filtered to")
+      expect(response.body).to include("Scoped Org")
+    end
+
+    it "preserves the organization_id filter when the search form is submitted" do
+      get people_path, params: { organization_id: org.id }
+      page = Capybara.string(response.body)
+      expect(page).to have_css("input[type=hidden][name=organization_id][value='#{org.id}']", visible: :all)
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view change on the people index + a shared filter-chip restyle across scoped index pages

### What is the goal of this PR and why is this important?
Landing on `/people?organization_id=X` applied the affiliation filter silently — the Organization box searches by *name*, so an id-based scope left no visible trace and was silently dropped the moment you ran any other search. This makes the scope visible, clearable, and durable, and gives every scoped index a proper removable chip.

### How did you approach the change?
On the people index, reused the existing non-search-box-param pattern (same one the CE index uses): render the `shared/filtered_to` chip above the form plus a `hidden_field_tag` so `organization_id` survives a search. Then restyled the shared `shared/filtered_to` banner itself into a removable chip — the record name in a rounded blue pill with an inline × — matching the attendees filter-chip pattern; this lifts every index that scopes to one record (people, grants, scholarships, stories, workshops, resources, CE registrations, …).

### UI Testing Checklist
- [ ] Visit `/people?organization_id=<id>` → chip reads "Filtered to <org name>" as a blue pill with an ×, list is scoped.
- [ ] Run a name/sector/org search from that page → the org scope is preserved.
- [ ] Click the chip's × → only `organization_id` is dropped, other filters remain.
- [ ] Spot-check another scoped index (e.g. `/grants?funder_id=…`, an author-filtered `/stories`) → same chip styling, clear still works.

### Anything else to add?
Chose a chip over pre-filling the name box because that box is free-text name search, not an id dropdown. Request-spec coverage added for the people chip and the preserved hidden field; existing "Filtered to" specs across grants/scholarships/authored-content still pass.