### PR TITLE
Track communications in Ahoy + preserve them as a durable audit log

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -58,8 +58,10 @@ class NotificationsController < ApplicationController
   def update
     authorize! @notification
     responded_was = @notification.responded?
+    body_was = @notification.email_body_text
     @notification.update!(notification_params)
     track_responded_change(responded_was)
+    track_incoming_body_change(body_was)
     head :ok
   end
 
@@ -106,6 +108,19 @@ class NotificationsController < ApplicationController
       resource_type: "Notification",
       resource_id: @notification.id,
       responded: @notification.responded?
+    })
+  end
+
+  # An incoming communication is logged by hand, so an edit to its body is a real
+  # content change worth surfacing — unlike outgoing/system messages, whose body
+  # is generated, not authored.
+  def track_incoming_body_change(previous)
+    return unless @notification.incoming?
+    return if @notification.email_body_text == previous
+
+    track_event("update.notification.body", {
+      resource_type: "Notification",
+      resource_id: @notification.id
     })
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,4 +1,6 @@
 class NotificationsController < ApplicationController
+  include AhoyTracking
+
   before_action :set_notification, only: [ :show, :update, :resend ]
 
   def index
@@ -13,6 +15,7 @@ class NotificationsController < ApplicationController
 
       render :notifications_results
     else
+      track_view("notifications", { page: "index" })
       render :index
     end
   end
@@ -49,11 +52,14 @@ class NotificationsController < ApplicationController
 
   def show
     authorize! @notification
+    track_view @notification
   end
 
   def update
     authorize! @notification
+    responded_was = @notification.responded?
     @notification.update!(notification_params)
+    track_responded_change(responded_was)
     head :ok
   end
 
@@ -92,6 +98,16 @@ class NotificationsController < ApplicationController
   end
 
   private
+
+  def track_responded_change(previous)
+    return if @notification.responded? == previous
+
+    track_event("update.notification.responded", {
+      resource_type: "Notification",
+      resource_id: @notification.id,
+      responded: @notification.responded?
+    })
+  end
 
   def set_notification
     @notification = Notification.find(params[:id])

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -139,7 +139,11 @@ class NotificationDecorator < ApplicationDecorator
   end
 
   def title
-    "Re #{noticeable_type} ##{noticeable_id}"
+    return "Re #{noticeable_type} ##{noticeable_id}" if noticeable_type.present?
+
+    # The subject record was deleted (nullified) — fall back to the recipient so
+    # an orphaned communication still reads as a real message, not "Re  #".
+    "Re #{object.recipient_email}"
   end
 
   def detail(length: nil)

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -265,7 +265,11 @@ module AhoyTrackable
   def track_lifecycle_event(action, extra_properties = {})
     return unless Current.user || Current.source
     return if self.class.name.start_with?("Ahoy::")
-    return if self.class.name.in?(%w[Notification ActiveStorage::Attachment ActiveStorage::Blob])
+    return if self.class.name.in?(%w[ActiveStorage::Attachment ActiveStorage::Blob])
+    # A Notification is already a durable, timestamped log, so a create/update event
+    # per email sent would be redundant noise. A destroy is the exception — we do want
+    # destroy.notification so a removed communication isn't silently lost.
+    return if self.class.name == "Notification" && action != "destroy"
 
     # prevent nested tracking loops
     return if Thread.current[:_ahoy_tracking]

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -12,7 +12,7 @@ class EventRegistration < ApplicationRecord
   belongs_to :event
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :event_registration_organizations, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :organizations, through: :event_registration_organizations
   has_many :allocations, as: :allocatable
   has_many :continuing_education_registrations, dependent: :destroy

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -12,7 +12,7 @@ class MonthlyReport < Report
   belongs_to :organization
   belongs_to :windows_type
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy, autosave: false
+  has_many :notifications, as: :noticeable, dependent: :nullify, autosave: false
   has_many :quotable_item_quotes, as: :quotable, dependent: :nullify, inverse_of: :quotable
   has_many :report_form_field_answers,
            foreign_key: :report_id, inverse_of: :report,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -164,10 +164,11 @@ class Notification < ApplicationRecord
   scope :subject_line, ->(subject) { where("notifications.email_subject LIKE ?", "%#{subject}%") }
   scope :email_topic, ->(topic) { where("notifications.email_subject LIKE ?", "%#{topic}%") }
   scope :responded_status, ->(status) {
+    needs_response = where(kind: "contact_us_fyi").or(where(direction: "incoming"))
     case status.to_s
-    when "yes" then where(kind: "contact_us_fyi", responded: true)
-    when "no"  then where(kind: "contact_us_fyi", responded: false)
-    when "na"  then where.not(kind: "contact_us_fyi")
+    when "yes" then needs_response.where(responded: true)
+    when "no"  then needs_response.where(responded: false)
+    when "na"  then where.not(kind: "contact_us_fyi").where.not(direction: "incoming")
     else all
     end
   }
@@ -193,7 +194,7 @@ class Notification < ApplicationRecord
   end
 
   def requires_response?
-    kind == "contact_us_fyi"
+    kind == "contact_us_fyi" || incoming?
   end
 
   def delivered?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -20,7 +20,7 @@ class Person < ApplicationRecord
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :contact_methods, as: :contactable, dependent: :destroy
   has_many :categorizable_items, inverse_of: :categorizable, as: :categorizable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :sectorable_items, as: :sectorable, dependent: :destroy
   has_many :other_responses, as: :owner, dependent: :destroy
   has_many :stories_as_spotlighted_facilitator, inverse_of: :spotlighted_facilitator, class_name: "Story",

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,7 +6,7 @@ class Report < ApplicationRecord
   belongs_to :workshop, optional: true
   has_one :form, as: :owner
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy, autosave: false
+  has_many :notifications, as: :noticeable, dependent: :nullify, autosave: false
   has_many :quotable_item_quotes, as: :quotable, dependent: :nullify, inverse_of: :quotable
   has_many :report_form_field_answers,
            foreign_key: :report_id, inverse_of: :report,

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -3,7 +3,7 @@ class Scholarship < ApplicationRecord
   belongs_to :grant, optional: true
   has_one :allocation, as: :source, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
   accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -17,7 +17,7 @@ class Story < ApplicationRecord
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
 
   # Asset associations
   has_one :primary_asset, -> { where(type: "PrimaryAsset") },

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -25,7 +25,7 @@ class StoryIdea < ApplicationRecord
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :stories
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :event_registrations, through: :person
-  has_many :notifications, as: :noticeable
+  has_many :notifications, as: :noticeable, dependent: :nullify
 
   has_many :reports, foreign_key: :created_by_id, inverse_of: :created_by
   has_many :resources, foreign_key: :created_by_id, inverse_of: :created_by

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -8,7 +8,7 @@ class WorkshopIdea < ApplicationRecord
   belongs_to :windows_type
 
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :workshops
   has_many :workshop_series_children, # When this workshop is the parent in a series
            -> { order(:position) },

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -4,7 +4,7 @@ class WorkshopLog < ApplicationRecord
   belongs_to :windows_type, optional: true
   belongs_to :workshop, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy, autosave: false
+  has_many :notifications, as: :noticeable, dependent: :nullify, autosave: false
   has_many :quotable_item_quotes, as: :quotable, dependent: :nullify, inverse_of: :quotable
   has_many :report_form_field_answers,
            foreign_key: :workshop_log_id, inverse_of: :workshop_log,

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -31,7 +31,7 @@ class WorkshopVariation < ApplicationRecord
   belongs_to :author, class_name: "Person", optional: true
   belongs_to :workshop_variation_idea, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
 
   # Asset associations
   has_one :primary_asset, -> { where(type: "PrimaryAsset") },

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -22,7 +22,7 @@ class WorkshopVariationIdea < ApplicationRecord
   belongs_to :organization, optional: true
   belongs_to :windows_type, optional: true
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :destroy
+  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :workshop_variations, dependent: :nullify
 
   # Asset associations

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
   end
 
+  describe "#title" do
+    it "references the subject record when one is linked" do
+      notification = build_stubbed(:notification, noticeable_type: "Person", noticeable_id: 42)
+
+      expect(notification.decorate.title).to eq("Re Person #42")
+    end
+
+    it "falls back to the recipient when the subject record was deleted (nullified)" do
+      notification = build_stubbed(:notification, noticeable: nil, recipient_email: "kim@example.com")
+
+      expect(notification.decorate.title).to eq("Re kim@example.com")
+    end
+  end
+
   describe "#row_class" do
     it "tints the row amber for an email stuck pending past the grace period" do
       notification = build_stubbed(:notification, delivered_at: nil, error_at: nil, created_at: 2.hours.ago)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Notification do
   describe "Ahoy lifecycle tracking" do
     after { Current.reset }
 
-    # Notifications are intentionally excluded from AhoyTrackable — they're
-    # already a durable, timestamped log, so ahoy events would be redundant.
+    # Notifications are excluded from create/update tracking — they're already a
+    # durable, timestamped log, so an event per email sent would be redundant.
     # The activities page surfaces them from the notifications table instead.
-    it "does not emit ahoy lifecycle events, even in a user context" do
+    it "does not emit create lifecycle events, even in a user context" do
       allow(Analytics::LifecycleBuffer).to receive(:push)
       noticeable = create(:user)
       Current.user = create(:user)
@@ -16,6 +16,18 @@ RSpec.describe Notification do
 
       expect(Analytics::LifecycleBuffer).not_to have_received(:push)
         .with(hash_including(name: "create.notification"))
+    end
+
+    # Deletes are the exception — a removed communication should not vanish silently.
+    it "emits a destroy lifecycle event when a communication is deleted" do
+      allow(Analytics::LifecycleBuffer).to receive(:push)
+      Current.user = create(:user)
+      notification = create(:notification)
+
+      notification.destroy
+
+      expect(Analytics::LifecycleBuffer).to have_received(:push)
+        .with(hash_including(name: "destroy.notification"))
     end
   end
 
@@ -131,26 +143,29 @@ RSpec.describe Notification do
   end
 
   describe ".responded_status" do
-    let!(:fyi_responded)     { create(:notification, kind: "contact_us_fyi", responded: true) }
-    let!(:fyi_not_responded) { create(:notification, kind: "contact_us_fyi", responded: false) }
-    let!(:contact_us)        { create(:notification, kind: "contact_us") }
-    let!(:other)             { create(:notification, kind: "reset_password_fyi") }
+    let!(:fyi_responded)          { create(:notification, kind: "contact_us_fyi", responded: true) }
+    let!(:fyi_not_responded)      { create(:notification, kind: "contact_us_fyi", responded: false) }
+    let!(:incoming_responded)     { create(:notification, :incoming, responded: true) }
+    let!(:incoming_not_responded) { create(:notification, :incoming, responded: false) }
+    let!(:contact_us)             { create(:notification, kind: "contact_us") }
+    let!(:other)                  { create(:notification, kind: "reset_password_fyi") }
 
-    it "returns only responded contact_us_fyi notifications for 'yes'" do
-      expect(Notification.responded_status("yes")).to contain_exactly(fyi_responded)
+    it "returns responded contact_us_fyi and incoming notifications for 'yes'" do
+      expect(Notification.responded_status("yes")).to contain_exactly(fyi_responded, incoming_responded)
     end
 
-    it "returns only unresponded contact_us_fyi notifications for 'no'" do
-      expect(Notification.responded_status("no")).to contain_exactly(fyi_not_responded)
+    it "returns unresponded contact_us_fyi and incoming notifications for 'no'" do
+      expect(Notification.responded_status("no")).to contain_exactly(fyi_not_responded, incoming_not_responded)
     end
 
-    it "returns notifications other than contact_us_fyi for 'na'" do
+    it "returns notifications that are neither contact_us_fyi nor incoming for 'na'" do
       expect(Notification.responded_status("na")).to contain_exactly(contact_us, other)
     end
 
     it "returns all notifications for blank/unknown values" do
-      expect(Notification.responded_status("")).to contain_exactly(fyi_responded, fyi_not_responded, contact_us, other)
-      expect(Notification.responded_status("bogus")).to contain_exactly(fyi_responded, fyi_not_responded, contact_us, other)
+      all = [ fyi_responded, fyi_not_responded, incoming_responded, incoming_not_responded, contact_us, other ]
+      expect(Notification.responded_status("")).to contain_exactly(*all)
+      expect(Notification.responded_status("bogus")).to contain_exactly(*all)
     end
   end
 
@@ -165,6 +180,10 @@ RSpec.describe Notification do
 
     it "returns false for other kinds" do
       expect(build(:notification, kind: "reset_password_fyi").requires_response?).to be false
+    end
+
+    it "returns true for an incoming communication regardless of kind" do
+      expect(build(:notification, :incoming, kind: "reset_password_fyi").requires_response?).to be true
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Notification do
       expect { registration.destroy }.not_to change(Notification, :count)
       expect(notification.reload.noticeable).to be_nil
     end
+
+    it "is nullified, not destroyed, when the subject user account is deleted" do
+      user = create(:user)
+      notification = create(:notification, noticeable: user)
+
+      expect { user.destroy }.not_to change(Notification, :count)
+      expect(notification.reload.noticeable).to be_nil
+    end
   end
 
   describe "manual log channel" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -38,6 +38,27 @@ RSpec.describe Notification do
     it { should have_many(:child_notifications).class_name('Notification').with_foreign_key(:parent_notification_id) }
   end
 
+  describe "when its subject record is deleted" do
+    # notifications are the durable record of what we sent — deleting the person
+    # or registration a message was about must not destroy that history, so the
+    # link is nullified and the communication survives as an orphaned record.
+    it "is nullified, not destroyed, when the person is deleted" do
+      person = create(:person)
+      notification = create(:notification, noticeable: person)
+
+      expect { person.destroy }.not_to change(Notification, :count)
+      expect(notification.reload.noticeable).to be_nil
+    end
+
+    it "is nullified, not destroyed, when the event registration is deleted" do
+      registration = create(:event_registration)
+      notification = create(:notification, noticeable: registration)
+
+      expect { registration.destroy }.not_to change(Notification, :count)
+      expect(notification.reload.noticeable).to be_nil
+    end
+  end
+
   describe "manual log channel" do
     def build_notification(**attrs)
       build(:notification, recipient_role: "person", recipient_email: "x@example.com", notification_type: 0, **attrs)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Report do
     it { should have_many(:report_form_field_answers).dependent(:destroy) }
     it { should have_many(:quotable_item_quotes).dependent(:nullify) }
     it { should have_many(:quotes).through(:all_quotable_item_quotes).dependent(:nullify) }
-    it { should have_many(:notifications).dependent(:destroy) }
+    it { should have_many(:notifications).dependent(:nullify) }
     it { should have_many(:sectorable_items).dependent(:destroy) }
     it { should have_many(:sectors).through(:sectorable_items).dependent(:destroy) }
     it { should have_many(:media_files).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe User do
     it { should have_many(:user_form_form_fields).through(:user_forms).dependent(:destroy) }
     # Custom scope/select for colleagues might interfere
     # it { should have_many(:colleagues).through(:organizations).source(:organization_users) }
-    it { should have_many(:notifications) } # As :noticeable
+    it { should have_many(:notifications).dependent(:nullify) } # As :noticeable
 
     # Nested Attributes
     it { should accept_nested_attributes_for(:user_forms) }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe "Notifications", type: :request do
       expect(response.body).to include('id="notifications_results"')
     end
 
+    it "tracks a page view of the communications list (staff usage)" do
+      expect(Analytics::AhoyTracker).to receive(:track_event).with(anything, "view.notifications", { page: "index" })
+      get notifications_path
+    end
+
+    it "does not track a page view on the lazy turbo-frame request" do
+      expect(Analytics::AhoyTracker).not_to receive(:track_event).with(anything, "view.notifications", anything)
+      get notifications_path, headers: turbo_headers
+    end
+
     it "links a form submission noticeable to its show page" do
       submission = create(:form_submission)
       create(:notification, noticeable: submission, recipient_email: "bulk-payer@example.com")
@@ -268,6 +278,18 @@ RSpec.describe "Notifications", type: :request do
         expect(response.body).to match(/<input[^>]*name="notification\[responded\]"[^>]*value="1"/)
       end
 
+      it "renders the responded checkbox for an incoming communication" do
+        incoming = create(:notification, :incoming, kind: "reset_password_fyi")
+        get notification_path(incoming)
+
+        expect(response.body).to match(/<input[^>]*name="notification\[responded\]"[^>]*value="1"/)
+      end
+
+      it "tracks the view so staff usage of communications is measurable" do
+        expect(Analytics::AhoyTracker).to receive(:track).with(anything, :view, fyi)
+        get notification_path(fyi)
+      end
+
       it "does not render the responded checkbox for contact_us (auto-confirmation)" do
         get notification_path(user_confirm)
 
@@ -352,6 +374,19 @@ RSpec.describe "Notifications", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(contact_notification.reload.responded).to be(false)
+      end
+
+      it "tracks a responded change as an ahoy event" do
+        expect(Analytics::AhoyTracker).to receive(:track_event)
+          .with(anything, "update.notification.responded", hash_including(resource_id: contact_notification.id, responded: true))
+
+        patch notification_path(contact_notification), params: { notification: { responded: "1" } }
+      end
+
+      it "does not track when the update leaves responded unchanged" do
+        expect(Analytics::AhoyTracker).not_to receive(:track_event)
+
+        patch notification_path(contact_notification), params: { notification: { channel: "email" } }
       end
     end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -388,6 +388,33 @@ RSpec.describe "Notifications", type: :request do
 
         patch notification_path(contact_notification), params: { notification: { channel: "email" } }
       end
+
+      context "editing the body of an incoming communication" do
+        let(:incoming) { create(:notification, :incoming, kind: "manual_log", channel: "phone", email_subject: "They called", email_body_text: "Original note") }
+
+        it "tracks a body change as an ahoy event" do
+          expect(Analytics::AhoyTracker).to receive(:track_event)
+            .with(anything, "update.notification.body", hash_including(resource_id: incoming.id))
+
+          patch notification_path(incoming), params: { notification: { email_body_text: "Updated note" } }
+        end
+
+        it "does not track when the body is unchanged" do
+          expect(Analytics::AhoyTracker).not_to receive(:track_event)
+            .with(anything, "update.notification.body", anything)
+
+          patch notification_path(incoming), params: { notification: { email_body_text: "Original note" } }
+        end
+      end
+
+      it "does not track a body change on an outgoing communication" do
+        outgoing = create(:notification, email_body_text: "Original")
+
+        expect(Analytics::AhoyTracker).not_to receive(:track_event)
+          .with(anything, "update.notification.body", anything)
+
+        patch notification_path(outgoing), params: { notification: { email_body_text: "Changed" } }
+      end
     end
 
     context "as a regular user" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained tracking + a data-lifecycle change (12 associations destroy/none→nullify); no migration

### What is the goal of this PR and why is this important?

Two related things for communications (`Notification`):
1. **Add the Ahoy analytics we were missing** — comms had no tracking at all, unlike the ~15 other models that emit `view.*`.
2. **Stop deleting the comms record when its subject is deleted** — `notifications` is our durable log of what we sent someone; it shouldn't vanish because a person/registration was cleaned up.

### How did you approach the change?

**Preserve the record: nullify, not destroy**
- All 12 `has_many :notifications, as: :noticeable` parents now use `dependent: :nullify` (EventRegistration, MonthlyReport, Person, Report, Scholarship, Story, StoryIdea, User, WorkshopLog, WorkshopIdea, WorkshopVariation, WorkshopVariationIdea). 11 were `:destroy`; `User` had no `dependent:` at all (its notifications used to dangle at a deleted account).
- Orphaned rows keep everything that matters — `recipient_email`, subject/body, kind, direction, timestamps, sender. Views already guard on `noticeable.present?`, so they render fine.
- Decorator `#title` now falls back to `Re <recipient_email>` instead of `Re  #` when the subject is gone.
- No migration — `noticeable_id/type` are already nullable.

**Deletes → Ahoy**
- `AhoyTrackable` still skips `Notification` create/update (avoids one event per email sent) but now emits `destroy.notification`. With nullify, parent deletion no longer cascades, so this fires only on a **direct** deletion of a communication — no cascade noise.

**Responded → Ahoy**
- `update.notification.responded` when `responded` actually flips.

**Incoming body edits → Ahoy**
- `update.notification.body` when an incoming (hand-logged) communication's body actually changes. Outgoing/system messages skipped — their body is generated, not authored.

**Staff view tracking**
- `view.notification` (detail) and `view.notifications` (list, full render only — not the lazy turbo frame), to measure section usage.

**Responded checkbox on incoming communications**
- `requires_response?` now covers incoming comms; `responded_status` Yes/No includes them and N/A means "neither contact-us-fyi nor incoming".

### Anything else to add?

- **GDPR:** nullify intentionally *retains* comms content past a person's deletion (correct for an audit log). There's no erasure flow in the app today; if one is ever needed it should be a dedicated scrub by `recipient_email`, not association cascade.
- Considered and dropped for now: denormalizing `recipient_name`/`sender_name` onto notifications. The person is always identified by `recipient_email` (both directions), so it's not needed to keep the record legible.
- Day 1–5 onboarding checkboxes were already logged via `update.event_registration`, so they're untouched.