### PR TITLE
Match people by legal first name in funder & registration searches

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -124,7 +124,7 @@ class GrantsController < ApplicationController
   def filter_by_funder_name(scope, query)
     like = "%#{Grant.sanitize_sql_like(query)}%"
     org_ids = Organization.where("name LIKE ?", like).pluck(:id)
-    person_ids = Person.where("first_name LIKE :q OR last_name LIKE :q OR CONCAT(first_name, ' ', last_name) LIKE :q", q: like).pluck(:id)
+    person_ids = Person.where("first_name LIKE :q OR legal_first_name LIKE :q OR last_name LIKE :q OR CONCAT(first_name, ' ', last_name) LIKE :q OR CONCAT(legal_first_name, ' ', last_name) LIKE :q", q: like).pluck(:id)
     scope.where(funder_type: "Organization", funder_id: org_ids)
          .or(scope.where(funder_type: "Person", funder_id: person_ids))
   end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -151,7 +151,10 @@ class EventRegistration < ApplicationRecord
   scope :registrant_name, ->(registrant_name) { joins(:registrant).where(
     "LOWER(REPLACE(CONCAT(people.first_name, people.last_name), ' ', '')) LIKE :name
     OR LOWER(REPLACE(CONCAT(people.last_name, people.first_name), ' ', '')) LIKE :name
+    OR LOWER(REPLACE(CONCAT(people.legal_first_name, people.last_name), ' ', '')) LIKE :name
+    OR LOWER(REPLACE(CONCAT(people.last_name, people.legal_first_name), ' ', '')) LIKE :name
     OR LOWER(REPLACE(people.first_name, ' ', '')) LIKE :name
+    OR LOWER(REPLACE(people.legal_first_name, ' ', '')) LIKE :name
     OR LOWER(REPLACE(people.last_name, ' ', '')) LIKE :name", name: "%#{registrant_name}%") }
   scope :event_title, ->(event_title) { joins(:event).where("LOWER(events.title LIKE ?)", "%#{event_title}%") }
   scope :active, -> { where(status: ACTIVE_STATUSES) }
@@ -466,8 +469,10 @@ class EventRegistration < ApplicationRecord
       .left_joins(registrant: { affiliations: { organization: :addresses } })
       .where(
         "LOWER(people.first_name) LIKE :term
+        OR LOWER(people.legal_first_name) LIKE :term
         OR LOWER(people.last_name) LIKE :term
         OR LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :term
+        OR LOWER(CONCAT(people.legal_first_name, ' ', people.last_name)) LIKE :term
         OR LOWER(users.email) LIKE :term
         OR LOWER(people.email) LIKE :term
         OR LOWER(contact_methods.value) LIKE :term

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -112,7 +112,7 @@ class Person < ApplicationRecord
   # Search Cop
   include SearchCop
   search_scope :search do
-    attributes :first_name, :last_name, :email, :email_2
+    attributes :first_name, :legal_first_name, :last_name, :email, :email_2
 
     scope { left_joins(:user, :contact_methods, :addresses) }
     attributes user_first_name: "user.first_name"
@@ -126,7 +126,7 @@ class Person < ApplicationRecord
     attributes address_zip:    "addresses.zip_code"
     attributes address_phone:  "addresses.phone"
 
-    attributes all: [ :first_name, :last_name, :email, :email_2,
+    attributes all: [ :first_name, :legal_first_name, :last_name, :email, :email_2,
                       "user.first_name", "user.last_name", "user.email", "user.phone",
                       "contact_methods.value",
                       "addresses.street_address", "addresses.city", "addresses.state",

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -62,6 +62,32 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe ".registrant_name" do
+    it "matches a registrant by their legal first name and last name" do
+      match = create(:event_registration,
+        registrant: create(:person, first_name: "Bob", legal_first_name: "Robert", last_name: "Smith"))
+      other = create(:event_registration,
+        registrant: create(:person, first_name: "Jane", last_name: "Doe"))
+
+      results = EventRegistration.registrant_name("robertsmith")
+      expect(results).to include(match)
+      expect(results).not_to include(other)
+    end
+  end
+
+  describe ".keyword" do
+    it "matches a registrant by their legal first name and last name" do
+      match = create(:event_registration,
+        registrant: create(:person, first_name: "Bob", legal_first_name: "Robert", last_name: "Smith"))
+      other = create(:event_registration,
+        registrant: create(:person, first_name: "Jane", last_name: "Doe"))
+
+      results = EventRegistration.keyword("robert smith")
+      expect(results).to include(match)
+      expect(results).not_to include(other)
+    end
+  end
+
   describe "#sync_attendance_status_to_days!" do
     # A two-day event: start and end one day apart → day_count == 2.
     let(:event) { create(:event, start_date: 12.days.from_now, end_date: 13.days.from_now) }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -430,6 +430,14 @@ RSpec.describe Person, type: :model do
       expect(results).not_to include(person_bob)
     end
 
+    it 'filters by contact_info matching legal first name' do
+      person_carol = create(:person, first_name: 'Carol', legal_first_name: 'Caroline', last_name: 'White')
+
+      results = Person.search_by_params(contact_info: 'Caroline')
+      expect(results).to include(person_carol)
+      expect(results).not_to include(person_alice, person_bob)
+    end
+
     it 'filters by contact_info matching email' do
       results = Person.search_by_params(contact_info: 'bob@example')
       expect(results).to include(person_bob)

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe "/grants", type: :request do
         expect(response.body).not_to include("Other grant")
       end
 
+      it "filters by a funder's legal first name" do
+        create(:grant, name: "Legal-funded",
+          funder: create(:person, first_name: "Bob", legal_first_name: "Robert", last_name: "Funder"))
+        create(:grant, name: "Other grant", funder: create(:organization, name: "Unrelated Inc"))
+
+        get grants_url(funder_name: "robert funder"), headers: frame_headers
+        expect(response.body).to include("Legal-funded")
+        expect(response.body).not_to include("Other grant")
+      end
+
       it "filters by task completion" do
         all_done = create(:grant, name: "All done")
         create(:scholarship, grant: all_done, tasks_completed: true)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained changes to four person-name search paths, covered by new specs

### What is the goal of this PR and why is this important?
People whose legal first name differs from their display first name were invisible when searched by their legal name. This closes that gap across every person-search path that missed it — the same fix already applied to the activities index.

### How did you approach the change?
Added `legal_first_name` matching to four person searches: `GrantsController#filter_by_funder_name`, the `EventRegistration` `registrant_name` and `keyword` scopes (a field match plus a `CONCAT(legal_first_name, ' ', last_name)` clause each), and the free-text `Person.search` SearchCop scope (added the column to its attribute list). On MySQL a NULL `legal_first_name` yields NULL from `CONCAT`, so those rows simply don't match — no COALESCE needed. The remote/autocomplete searches already covered legal first name.

### UI Testing Checklist
- [ ] Search grants by a funder's legal first name + last name
- [ ] Search event registrants by legal first name
- [ ] Search the people directory by legal first name

### Anything else to add?
New specs cover all four sites. `registrant_name` strips spaces DB-side (spaceless search), so its spec queries `"robertsmith"`.
