### PR TITLE
Cache recipient_name on notifications to preserve contact names

### DIFF
--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -42,9 +42,10 @@ class NotificationDecorator < ApplicationDecorator
     end
   end
 
-  # Name of the person when we know them, otherwise the raw email.
+  # Name of the person when we know them, then the cached snapshot taken at send
+  # time (survives a deleted/nullified Person), otherwise the raw email.
   def contact_name
-    contact_person&.name.presence || recipient_email
+    contact_person&.name.presence || recipient_name.presence || recipient_email
   end
 
   # Email to reveal on hover — only when we're showing a resolved name (nil when

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -148,6 +148,10 @@ class Notification < ApplicationRecord
   before_validation :force_manual_log_channel, if: :manual_log?
   # A contact_us_fyi is always something a person sent us — stamp it incoming.
   before_validation :mark_incoming, on: :create, if: -> { kind == "contact_us_fyi" }
+  # Snapshot the contact person's name from recipient_email so it survives even
+  # if the Person record is later nullified or deleted. Only fills a blank value,
+  # so a caller-supplied name (and resends carrying the stored value) is kept.
+  before_create :cache_recipient_name
 
   def manual_log?
     kind == "manual_log"
@@ -295,5 +299,12 @@ class Notification < ApplicationRecord
 
   def mark_incoming
     self.direction = "incoming"
+  end
+
+  def cache_recipient_name
+    return if recipient_name.present? || recipient_email.blank?
+
+    person = Person.where(email: recipient_email).or(Person.where(email_2: recipient_email)).first
+    self.recipient_name = person&.name
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -148,9 +148,7 @@ class Notification < ApplicationRecord
   before_validation :force_manual_log_channel, if: :manual_log?
   # A contact_us_fyi is always something a person sent us — stamp it incoming.
   before_validation :mark_incoming, on: :create, if: -> { kind == "contact_us_fyi" }
-  # Snapshot the contact person's name from recipient_email so it survives even
-  # if the Person record is later nullified or deleted. Only fills a blank value,
-  # so a caller-supplied name (and resends carrying the stored value) is kept.
+  # Snapshot the contact's name so it survives a deleted Person; only fills blanks.
   before_create :cache_recipient_name
 
   def manual_log?

--- a/db/migrate/20260817070050_add_recipient_name_to_notifications.rb
+++ b/db/migrate/20260817070050_add_recipient_name_to_notifications.rb
@@ -1,0 +1,14 @@
+class AddRecipientNameToNotifications < ActiveRecord::Migration[8.0]
+  def up
+    return if column_exists?(:notifications, :recipient_name)
+
+    # Snapshot of the contact person's name at send time, resolved from
+    # recipient_email. Cached so the name survives even if the Person record is
+    # later nullified or deleted. Populated going forward only (no backfill).
+    add_column :notifications, :recipient_name, :string
+  end
+
+  def down
+    remove_column :notifications, :recipient_name, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_070050) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -838,6 +838,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
     t.integer "notification_type"
     t.integer "parent_notification_id"
     t.string "recipient_email", null: false
+    t.string "recipient_name"
     t.string "recipient_role", null: false
     t.boolean "responded", default: false, null: false
     t.integer "root_notification_id"

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
 
     it "falls back to the cached recipient_name when the person is gone" do
-      decorated = build_stubbed(:notification, recipient_email: "gone@example.com", recipient_name: "Departed Person").decorate
+      decorated = build_stubbed(:notification, recipient_email: "gone@example.com", recipient_name: "Deleted Person").decorate
 
-      expect(decorated.to_name).to eq("Departed Person")
+      expect(decorated.to_name).to eq("Deleted Person")
     end
   end
 

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -122,6 +122,12 @@ RSpec.describe NotificationDecorator, type: :decorator do
       expect(decorated.to_name).to eq("stranger@example.com")
       expect(decorated.to_title).to be_nil
     end
+
+    it "falls back to the cached recipient_name when the person is gone" do
+      decorated = build_stubbed(:notification, recipient_email: "gone@example.com", recipient_name: "Departed Person").decorate
+
+      expect(decorated.to_name).to eq("Departed Person")
+    end
   end
 
   describe "#to_person / #from_person" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -135,6 +135,31 @@ RSpec.describe Notification do
     end
   end
 
+  describe "recipient_name caching" do
+    it "snapshots the contact person's name from recipient_email on create" do
+      person = create(:person, first_name: "Casey", last_name: "Contact", email: "casey@example.com")
+      notification = create(:notification, recipient_email: person.email)
+      expect(notification.recipient_name).to eq(person.name)
+    end
+
+    it "resolves a person by their secondary email" do
+      person = create(:person, first_name: "Casey", last_name: "Contact", email_2: "casey2@example.com")
+      notification = create(:notification, recipient_email: "casey2@example.com")
+      expect(notification.recipient_name).to eq(person.name)
+    end
+
+    it "leaves recipient_name blank when no person matches" do
+      notification = create(:notification, recipient_email: "unknown@example.com")
+      expect(notification.recipient_name).to be_nil
+    end
+
+    it "does not overwrite a caller-supplied recipient_name" do
+      create(:person, first_name: "Casey", last_name: "Contact", email: "casey@example.com")
+      notification = create(:notification, recipient_email: "casey@example.com", recipient_name: "Custom Name")
+      expect(notification.recipient_name).to eq("Custom Name")
+    end
+  end
+
   describe "KINDS" do
     it "includes account_email_change_requested" do
       expect(Notification::KINDS).to include("account_email_change_requested")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small denormalization + a before_create hook and decorator fallback

### What is the goal of this PR and why is this important?

Cache the contact person's name onto each notification so the communications index and detail views keep showing a real name even after the linked `Person` is nullified or deleted — today they degrade to a raw email once the person is gone.

### How did you approach the change?

Added a nullable `recipient_name` column, a `before_create` hook that snapshots the person's name from `recipient_email` (primary or `email_2`, reusing the decorator's lookup) filling only blanks, and a `contact_name` fallback to the cached value before the raw email. Populated going forward only — no backfill.

### UI Testing Checklist

- [ ] Communications index/detail still show the person's live name and email hover when the person is on file.
- [ ] A communication whose person has been deleted shows the cached name instead of a bare email.

### Anything else to add?

Scope is intentionally just `recipient_name` — `sender_name` and the separate `User` `dependent: :nullify` gap were discussed but left out.
