### PR TITLE
Track "responded" on incoming communications

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -407,7 +407,7 @@ class EventRegistrationsController < ApplicationController
       organization_ids: [],
       registrant_attributes: [ :id, :shoutout_text ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :noticeable_type, :noticeable_id, :_destroy ]
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -620,7 +620,7 @@ class PeopleController < ApplicationController
         :_destroy
       ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :noticeable_type, :noticeable_id, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ],
       professional_licenses_attributes: [ :id, :number, :kind, :issuing_state, :expires_on, :_destroy ]
     )
   end

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -263,7 +263,7 @@ class ScholarshipsController < ApplicationController
     params.require(:scholarship).permit(
       :amount_dollars, :amount_cents, :tasks_completed, :agreement_signed, :grant_id, :recipient_id,
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :noticeable_type, :noticeable_id, :_destroy ]
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -234,7 +234,7 @@ class StoriesController < ApplicationController
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :noticeable_type, :noticeable_id, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ],
     )
   end
 

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -154,7 +154,7 @@ class StoryIdeasController < ApplicationController
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :noticeable_type, :noticeable_id, :_destroy ]
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 end

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -85,6 +85,18 @@ class NotificationDecorator < ApplicationDecorator
     contact_person if incoming?
   end
 
+  # The Person to render as a profile button on each side of the detail page:
+  # the contact on their side, the staff sender (resolved to their person) on the
+  # other. nil for the AWBW Portal — or a sender with no linked person — which
+  # fall back to plain text.
+  def from_button_person
+    incoming? ? contact_person : sender&.person
+  end
+
+  def to_button_person
+    incoming? ? sender&.person : contact_person
+  end
+
   # The contact's email for each side, mirroring to_person/from_person — always
   # recipient_email, on whichever side the contact sits. nil on the staff/portal
   # side, which is a person's name (or "AWBW Portal"), not an address.

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -15,11 +15,11 @@ class NotificationDecorator < ApplicationDecorator
 
   # At-a-glance audience pill for the compact row/index and detail page — only
   # the two exceptions are flagged: sky for an incoming message (the person wrote
-  # to us) and a neutral grey "FYI" for an admin copy (recipient_role "admin").
-  # A regular message to the person is the norm and shows no pill.
+  # to us) and teal for an admin "FYI" copy (recipient_role "admin"). A regular
+  # message to the person is the norm and shows no pill.
   AUDIENCE_META = {
     "incoming" => { label: "Incoming", classes: "bg-sky-100 text-sky-800" },
-    "fyi" => { label: "FYI", classes: "bg-gray-100 text-gray-700" }
+    "fyi" => { label: "FYI", classes: "bg-teal-100 text-teal-800" }
   }.freeze
 
   # Additional "Bulk" pill for a communication sent as part of a bulk operation

--- a/app/frontend/javascript/controllers/conditional_fields_controller.js
+++ b/app/frontend/javascript/controllers/conditional_fields_controller.js
@@ -1,7 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Shows/hides fields based on a source <select>. A field appears when its
-// data-show-when matches the select's value, or — for option-driven conditions —
+// Shows/hides fields based on a source control (a <select>, or a checkbox that
+// reports its value when on and "" when off). A field appears when its
+// data-show-when matches the source's value, or — for option-driven conditions —
 // when its data-show-when-attr names a data-* flag that is "true" on the selected
 // option (e.g. data-show-when-attr="eventSelector" reads the option's
 // data-event-selector).
@@ -13,12 +14,14 @@ export default class extends Controller {
   }
 
   toggle() {
-    const selected = this.sourceTarget.selectedOptions[0]
+    const source = this.sourceTarget
+    const value = source.type === "checkbox" ? (source.checked ? source.value : "") : source.value
+    const selected = source.selectedOptions?.[0]
     this.fieldTargets.forEach(el => {
       const attr = el.dataset.showWhenAttr
       el.hidden = attr
         ? selected?.dataset[attr] !== "true"
-        : el.dataset.showWhen !== this.sourceTarget.value
+        : el.dataset.showWhen !== value
     })
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -420,6 +420,31 @@ module ApplicationHelper
     label.presence || "##{record.id}"
   end
 
+  # A pill button for any noticeable record — same shape as the person/event
+  # profile buttons (bordered, rounded, themed by the record's domain) but with
+  # no avatar or icon: a small type label plus the record's name, linking to it.
+  # Falls back to a non-clickable span when the record has no routable path.
+  def record_button(record, compact: true)
+    key = record.model_name.plural.to_sym
+    padding = compact ? "px-2 py-1" : "px-4 py-2"
+    name_size = compact ? "text-xs" : "text-sm"
+
+    inner = content_tag(:span, noticeable_type_label(record), class: "shrink-0 text-2xs text-gray-400 uppercase") +
+            content_tag(:span, noticeable_label(record), class: "truncate font-semibold #{name_size} #{DomainTheme.text_class_for(key)}")
+    body = content_tag(:div, inner, class: "flex min-w-0 items-center gap-1.5 leading-none text-left")
+
+    classes = "group relative flex w-fit max-w-md items-center gap-2 #{padding} " \
+              "rounded-lg border #{DomainTheme.border_class_for(key)} #{DomainTheme.bg_class_for(key, intensity: 50)} " \
+              "#{DomainTheme.bg_class_for(key, intensity: 50, hover: true)} font-medium shadow-sm leading-none transition-colors duration-200"
+
+    path = routable_path(record)
+    return content_tag(:span, body, class: classes, title: noticeable_label(record)) unless path
+
+    link_to path, class: classes, title: noticeable_label(record) do
+      body
+    end
+  end
+
   # Event title with its month and year appended (e.g. "AWBW Facilitator
   # Training (August 2026)") so a registration reads as which occurrence it's for.
   def event_title_with_month_year(event)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -146,6 +146,8 @@ class Notification < ApplicationRecord
   # communication. Fall back to a manual channel so one is never autoemail (the
   # channel column defaults to "autoemail", so this also covers a blank choice).
   before_validation :force_manual_log_channel, if: :manual_log?
+  # A contact_us_fyi is always something a person sent us — stamp it incoming.
+  before_validation :mark_incoming, on: :create, if: -> { kind == "contact_us_fyi" }
 
   def manual_log?
     kind == "manual_log"
@@ -163,12 +165,14 @@ class Notification < ApplicationRecord
   scope :record_type, ->(record_type) { where(noticeable_type: record_type.to_s.camelize.titleize.gsub(" ", "")) }
   scope :subject_line, ->(subject) { where("notifications.email_subject LIKE ?", "%#{subject}%") }
   scope :email_topic, ->(topic) { where("notifications.email_subject LIKE ?", "%#{topic}%") }
+  # contact_us_fyi is included explicitly for historical rows predating #mark_incoming.
+  scope :requires_response, -> { where(direction: "incoming").or(where(kind: "contact_us_fyi")) }
+  scope :no_response_needed, -> { where.not(direction: "incoming").where.not(kind: "contact_us_fyi") }
   scope :responded_status, ->(status) {
-    needs_response = where(kind: "contact_us_fyi").or(where(direction: "incoming"))
     case status.to_s
-    when "yes" then needs_response.where(responded: true)
-    when "no"  then needs_response.where(responded: false)
-    when "na"  then where.not(kind: "contact_us_fyi").where.not(direction: "incoming")
+    when "yes" then requires_response.where(responded: true)
+    when "no"  then requires_response.where(responded: false)
+    when "na"  then no_response_needed
     else all
     end
   }
@@ -194,7 +198,7 @@ class Notification < ApplicationRecord
   end
 
   def requires_response?
-    kind == "contact_us_fyi" || incoming?
+    incoming? || kind == "contact_us_fyi"
   end
 
   def delivered?
@@ -287,5 +291,9 @@ class Notification < ApplicationRecord
 
   def classify_manual_channel_as_manual_log
     self.kind = "manual_log"
+  end
+
+  def mark_incoming
+    self.direction = "incoming"
   end
 end

--- a/app/views/notifications/_direction_toggle.html.erb
+++ b/app/views/notifications/_direction_toggle.html.erb
@@ -8,10 +8,10 @@
 <% compact = local_assigns.fetch(:compact, false) %>
 <% source_data = local_assigns.fetch(:source_data, {}) %>
 <div class="flex items-center gap-2">
-  <label class="relative inline-flex items-center cursor-pointer select-none"
+  <label class="relative inline-flex cursor-pointer items-center select-none"
          title="On = incoming: the person sent this to us, rather than us sending it to them">
     <%= f.check_box :direction, { class: "peer sr-only", "aria-label": "Incoming — sent by the person", data: source_data }, "incoming", "outgoing" %>
-    <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-sky-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
+    <span class="relative inline-block h-5 w-9 rounded-full bg-gray-300 transition-colors peer-checked:bg-sky-600 after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform after:content-[''] peer-checked:after:translate-x-4"></span>
     <span class="ml-2 text-sm text-gray-600 peer-checked:text-sky-700">Incoming</span>
   </label>
   <% unless compact %>

--- a/app/views/notifications/_direction_toggle.html.erb
+++ b/app/views/notifications/_direction_toggle.html.erb
@@ -6,10 +6,11 @@
     ::after. Caller passes the form builder `f`; pass compact: true to drop the
     helper text where space is tight (the inline edit fields). ---- %>
 <% compact = local_assigns.fetch(:compact, false) %>
+<% source_data = local_assigns.fetch(:source_data, {}) %>
 <div class="flex items-center gap-2">
   <label class="relative inline-flex items-center cursor-pointer select-none"
          title="On = incoming: the person sent this to us, rather than us sending it to them">
-    <%= f.check_box :direction, { class: "peer sr-only", "aria-label": "Incoming — sent by the person" }, "incoming", "outgoing" %>
+    <%= f.check_box :direction, { class: "peer sr-only", "aria-label": "Incoming — sent by the person", data: source_data }, "incoming", "outgoing" %>
     <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-sky-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
     <span class="ml-2 text-sm text-gray-600 peer-checked:text-sky-700">Incoming</span>
   </label>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -64,9 +64,9 @@
             <%= link_to noticeable_label(notification.noticeable),
                         record_path,
                         data: { turbo_frame: "_top" },
-                        class: "font-medium text-blue-600 hover:underline" %>
+                        class: "font-medium text-gray-800 underline decoration-gray-300 underline-offset-2 hover:text-gray-900 hover:decoration-gray-500" %>
           <% else %>
-            <span class="font-medium text-gray-700"><%= noticeable_label(notification.noticeable) %></span>
+            <span class="font-medium text-gray-800"><%= noticeable_label(notification.noticeable) %></span>
           <% end %>
         <% else %>
           <span class="text-gray-400">—</span>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -64,7 +64,7 @@
             <%= link_to noticeable_label(notification.noticeable),
                         record_path,
                         data: { turbo_frame: "_top" },
-                        class: "font-medium text-gray-800 underline decoration-gray-200 underline-offset-2 hover:text-gray-900 hover:decoration-gray-500" %>
+                        class: "font-medium text-gray-800 hover:text-gray-900 hover:underline" %>
           <% else %>
             <span class="font-medium text-gray-800"><%= noticeable_label(notification.noticeable) %></span>
           <% end %>

--- a/app/views/notifications/_index.html.erb
+++ b/app/views/notifications/_index.html.erb
@@ -64,7 +64,7 @@
             <%= link_to noticeable_label(notification.noticeable),
                         record_path,
                         data: { turbo_frame: "_top" },
-                        class: "font-medium text-gray-800 underline decoration-gray-300 underline-offset-2 hover:text-gray-900 hover:decoration-gray-500" %>
+                        class: "font-medium text-gray-800 underline decoration-gray-200 underline-offset-2 hover:text-gray-900 hover:decoration-gray-500" %>
           <% else %>
             <span class="font-medium text-gray-800"><%= noticeable_label(notification.noticeable) %></span>
           <% end %>

--- a/app/views/notifications/_notification_form.html.erb
+++ b/app/views/notifications/_notification_form.html.erb
@@ -22,7 +22,7 @@
 <% sender_color = label_colors[(sender_user&.id || 0) % label_colors.length] %>
 <% sender_first = sender_user&.person&.first_name || sender_user&.name.to_s.split.first %>
 <% select_class = "min-w-0 flex-1 truncate bg-white rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
-<div data-controller="field-required" data-action="input->field-required#update">
+<div data-controller="field-required conditional-fields" data-action="input->field-required#update">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
     <div class="space-y-2 sm:w-56 sm:shrink-0">
       <label class="flex items-center gap-2">
@@ -38,8 +38,13 @@
       <%= f.hidden_field :sender_id, value: sender_user&.id %>
       <div class="flex items-center gap-2">
         <span class="w-20 shrink-0 text-sm font-medium text-gray-700">Direction</span>
-        <%= render "notifications/direction_toggle", f: f, compact: true %>
+        <%= render "notifications/direction_toggle", f: f, compact: true,
+                   source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
       </div>
+      <label class="flex items-center gap-2" data-conditional-fields-target="field" data-show-when="incoming" hidden>
+        <%= f.check_box :responded, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500" %>
+        <span class="text-sm text-gray-700">Already responded</span>
+      </label>
     </div>
     <%# Subject marked required (shows the asterisk) — a blank subject is dropped
         on save. field-required only enforces it once the row is in use, so an

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -15,7 +15,7 @@
     <%= simple_form_for @notification, url: notifications_path do |f| %>
       <%= render "shared/errors", resource: @notification if @notification.errors.any? %>
 
-      <div class="space-y-5">
+      <div class="space-y-5" data-controller="conditional-fields">
         <div>
           <% person_label = @person&.remote_search_label %>
           <label for="person_id" class="block text-sm font-medium text-gray-700 mb-1">Person</label>
@@ -46,7 +46,16 @@
 
         <div>
           <span class="block text-sm font-medium text-gray-700 mb-1">Direction</span>
-          <%= render "notifications/direction_toggle", f: f %>
+          <%= render "notifications/direction_toggle", f: f,
+                     source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
+        </div>
+
+        <div data-conditional-fields-target="field" data-show-when="incoming" hidden>
+          <label class="inline-flex items-center gap-2 text-sm font-medium text-gray-700">
+            <%= f.check_box :responded, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500" %>
+            Already responded
+          </label>
+          <p class="mt-1 text-xs text-gray-500">Check if you've already replied to this incoming message.</p>
         </div>
 
         <div>

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -1,53 +1,57 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-3xl mx-auto">
+<div class="mx-auto max-w-3xl">
   <div class="mb-3">
     <%= link_to notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
     <% end %>
   </div>
-  <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
   <h1 class="mt-3 mb-1 text-2xl font-semibold text-gray-900"><%= t("communications.new") %></h1>
   <p class="mb-5 text-sm text-gray-500">
     Log a communication you had with a person by hand (a call, text, or email sent outside the portal).
   </p>
 
-  <div class="bg-white rounded-lg p-6">
+  <div class="rounded-lg bg-white p-6">
     <%= simple_form_for @notification, url: notifications_path do |f| %>
       <%= render "shared/errors", resource: @notification if @notification.errors.any? %>
 
       <div class="space-y-5" data-controller="conditional-fields">
-        <div>
-          <% person_label = @person&.remote_search_label %>
-          <label for="person_id" class="block text-sm font-medium text-gray-700 mb-1">Person</label>
-          <%= select_tag "person_id",
-                options_for_select(person_label ? [ [ person_label[:label], @person.id ] ] : [], @person&.id),
-                include_blank: "Search people by name or email",
-                data: { controller: "remote-select", remote_select_model_value: "person" },
-                class: "w-full bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
-          <p class="mt-1 text-xs text-gray-500">The communication is logged against this person and their email.</p>
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <div>
+            <% person_label = @person&.remote_search_label %>
+            <label for="person_id" class="mb-1 block text-sm font-medium text-gray-700">Person</label>
+            <%= select_tag "person_id",
+                  options_for_select(person_label ? [ [ person_label[:label], @person.id ] ] : [], @person&.id),
+                  include_blank: "Search people by name or email",
+                  data: { controller: "remote-select", remote_select_model_value: "person" },
+                  class: "w-full bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
+            <p class="mt-1 text-xs text-gray-500">The communication is logged against this person and their email.</p>
+          </div>
+
+          <div>
+            <span class="mb-1 block text-sm font-medium text-gray-700">From</span>
+            <span class="inline-flex items-center gap-2 rounded bg-sky-100 px-2 py-1 text-sm text-sky-800">
+              <i class="fa-solid fa-user text-xs"></i><%= current_user.full_name %>
+            </span>
+            <p class="mt-1 text-xs text-gray-500">You are recorded as the sender.</p>
+          </div>
         </div>
 
-        <div>
-          <span class="block text-sm font-medium text-gray-700 mb-1">From</span>
-          <span class="inline-flex items-center gap-2 rounded bg-sky-100 px-2 py-1 text-sm text-sky-800">
-            <i class="fa-solid fa-user text-xs"></i><%= current_user.full_name %>
-          </span>
-          <p class="mt-1 text-xs text-gray-500">You are recorded as the sender.</p>
-        </div>
+        <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <div>
+            <span class="mb-1 block text-sm font-medium text-gray-700">Direction</span>
+            <%= render "notifications/direction_toggle", f: f,
+                       source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
+          </div>
 
-        <div>
-          <%= f.input :channel,
-                      collection: Notification::MANUAL_CHANNELS.map { |c| [ c.titleize, c ] },
-                      selected: @notification.channel.presence || "email",
-                      include_blank: false,
-                      label: "Channel",
-                      input_html: { class: "w-full sm:w-1/3 bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
-        </div>
-
-        <div>
-          <span class="block text-sm font-medium text-gray-700 mb-1">Direction</span>
-          <%= render "notifications/direction_toggle", f: f,
-                     source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
+          <div>
+            <%= f.input :channel,
+                        collection: Notification::MANUAL_CHANNELS.map { |c| [ c.titleize, c ] },
+                        selected: @notification.channel.presence || "email",
+                        include_blank: false,
+                        label: "Channel",
+                        input_html: { class: "w-full bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+          </div>
         </div>
 
         <div data-conditional-fields-target="field" data-show-when="incoming" hidden>
@@ -61,7 +65,7 @@
         <div>
           <%= f.input :email_subject, as: :text, required: true,
                       label: "Subject (visible to user)",
-                      input_html: { rows: 2, placeholder: "Topic or subject line",
+                      input_html: { rows: 1, placeholder: "Topic or subject line",
                                     class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
         </div>
 

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -39,18 +39,18 @@
 
         <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
           <div>
-            <span class="mb-1 block text-sm font-medium text-gray-700">Direction</span>
-            <%= render "notifications/direction_toggle", f: f,
-                       source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
-          </div>
-
-          <div>
             <%= f.input :channel,
                         collection: Notification::MANUAL_CHANNELS.map { |c| [ c.titleize, c ] },
                         selected: @notification.channel.presence || "email",
                         include_blank: false,
                         label: "Channel",
                         input_html: { class: "w-full bg-white rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" } %>
+          </div>
+
+          <div>
+            <span class="mb-1 block text-sm font-medium text-gray-700">Direction</span>
+            <%= render "notifications/direction_toggle", f: f,
+                       source_data: { conditional_fields_target: "source", action: "change->conditional-fields#toggle" } %>
           </div>
         </div>
 

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 </div>
 
-<div class="<%= @notification.decorate.card_bg_class %> border rounded-xl shadow p-6" data-turbo="false">
+<div class="<%= @notification.decorate.card_bg_class %> rounded-xl border p-6 shadow" data-turbo="false">
   <div class="space-y-6">
 
   <!-- Header -->
@@ -27,25 +27,25 @@
       </p>
     </div>
 
-    <div class="text-right text-sm space-y-2">
+    <div class="space-y-2 text-right text-sm">
       <% if @notification.delivered_at.present? %>
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-green-100 text-green-700">
+        <span class="inline-flex items-center gap-1 rounded bg-green-100 px-2 py-1 text-green-700">
           <i class="fas fa-check-circle"></i>
           Delivered
         </span>
       <% elsif @notification.failed? %>
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-red-100 text-red-700">
+        <span class="inline-flex items-center gap-1 rounded bg-red-100 px-2 py-1 text-red-700">
           <i class="fas fa-exclamation-circle"></i>
           Failed
         </span>
       <% elsif @notification.archived? %>
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-gray-100 text-gray-600"
+        <span class="inline-flex items-center gap-1 rounded bg-gray-100 px-2 py-1 text-gray-600"
               title="Retired — old undelivered email, no longer tracked as pending">
           <i class="fas fa-box-archive"></i>
           Archived
         </span>
       <% else %>
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-yellow-100 text-yellow-700">
+        <span class="inline-flex items-center gap-1 rounded bg-yellow-100 px-2 py-1 text-yellow-700">
           <i class="fas fa-clock"></i>
           Pending
         </span>
@@ -63,7 +63,7 @@
       <% elsif @notification.resend_count > 0 %>
         <%# This is a root notification with resends - show count %>
         <div>
-          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-blue-100 text-blue-700">
+          <span class="inline-flex items-center gap-1 rounded bg-blue-100 px-2 py-1 text-blue-700">
             <i class="fas fa-redo"></i>
             Resent <%= pluralize(@notification.resend_count, 'time') %>
           </span>
@@ -76,13 +76,13 @@
              data-autosave-url-value="<%= notification_path(@notification) %>"
              data-autosave-id-value="<%= @notification.id %>"
              data-action="change->autosave#save">
-          <label class="inline-flex items-center gap-2 px-2 py-1 rounded bg-gray-50 hover:bg-gray-100 cursor-pointer">
+          <label class="inline-flex cursor-pointer items-center gap-2 rounded bg-gray-50 px-2 py-1 hover:bg-gray-100">
             <input type="hidden" name="notification[responded]" value="0">
             <input type="checkbox"
                    name="notification[responded]"
                    value="1"
                    <%= "checked" if @notification.responded? %>
-                   class="w-4 h-4 rounded border-gray-300 text-green-600 accent-green-600 focus:ring-green-500">
+                   class="h-4 w-4 rounded border-gray-300 text-green-600 accent-green-600 focus:ring-green-500">
             <span class="text-gray-700">Responded</span>
           </label>
         </div>
@@ -96,7 +96,7 @@
                       class: "admin-only bg-blue-100 btn btn-primary" %>
       <% elsif !@notification.resendable? && allowed_to?(:index?) %>
         <div>
-          <span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-gray-100 text-gray-500 text-xs cursor-help"
+          <span class="inline-flex cursor-help items-center gap-1 rounded bg-gray-100 px-2 py-1 text-xs text-gray-500"
                 title="This email was sent by Devise with a unique security token. To resend, use the user's confirmation or password reset actions instead.">
             <i class="fas fa-ban"></i>
             Not resendable
@@ -107,27 +107,35 @@
   </div>
 
   <!-- Metadata -->
-  <div class="bg-white rounded-lg shadow-sm p-4">
+  <div class="rounded-lg bg-white p-4 shadow-sm">
     <% nd = @notification.decorate %>
     <dl class="space-y-3 text-sm">
 
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">From</dt>
-        <dd class="text-gray-900 font-medium break-all" title="<%= nd.from_title %>">
-          <%= nd.from_name.presence || "—" %>
+        <dd class="min-w-0 flex-1">
+          <% if nd.from_button_person %>
+            <%= person_profile_button(nd.from_button_person, compact: true, width_class: "w-fit max-w-md", subtitle: nd.from_email) %>
+          <% else %>
+            <span class="font-medium break-all text-gray-900" title="<%= nd.from_title %>"><%= nd.from_name.presence || "—" %></span>
+          <% end %>
         </dd>
       </div>
 
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">To</dt>
-        <dd class="text-gray-900 font-medium break-all" title="<%= nd.to_title %>">
-          <%= nd.to_name.presence || "—" %>
+        <dd class="min-w-0 flex-1">
+          <% if nd.to_button_person %>
+            <%= person_profile_button(nd.to_button_person, compact: true, width_class: "w-fit max-w-md", subtitle: nd.to_email) %>
+          <% else %>
+            <span class="font-medium break-all text-gray-900" title="<%= nd.to_title %>"><%= nd.to_name.presence || "—" %></span>
+          <% end %>
         </dd>
       </div>
 
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">Subject</dt>
-        <dd class="text-gray-900 font-medium">
+        <dd class="font-medium text-gray-900">
           <%= @notification.email_subject.presence || "—" %>
         </dd>
       </div>
@@ -163,17 +171,9 @@
 
       <div class="flex items-start gap-4">
         <dt class="w-28 text-gray-500">Noticeable</dt>
-        <dd class="text-gray-900">
+        <dd class="min-w-0 flex-1 text-gray-900">
           <% if @notification.noticeable.present? %>
-            <% record_path = routable_path(@notification.noticeable) %>
-            <span class="text-xs uppercase text-gray-400 mr-2"><%= noticeable_type_label(@notification.noticeable) %></span>
-            <% if record_path %>
-              <%= link_to noticeable_label(@notification.noticeable),
-                          record_path,
-                          class: "font-medium text-blue-600 hover:underline" %>
-            <% else %>
-              <span class="font-medium"><%= noticeable_label(@notification.noticeable) %></span>
-            <% end %>
+            <%= record_button(@notification.noticeable) %>
           <% else %>
             —
           <% end %>
@@ -186,9 +186,9 @@
 
 
   <!-- Email Preview -->
-  <div class="bg-white rounded-lg shadow-sm p-4">
+  <div class="rounded-lg bg-white p-4 shadow-sm">
 
-    <div class="px-4 py-2 bg-gray-50 flex items-center justify-between">
+    <div class="flex items-center justify-between bg-gray-50 px-4 py-2">
       <h2 class="text-sm font-semibold text-gray-700">
         Email Preview
       </h2>
@@ -218,7 +218,7 @@
         </div>
       </div>
     <% elsif @notification.email_body_text.present? %>
-      <pre class="whitespace-pre-wrap text-sm text-gray-800 p-4">
+      <pre class="p-4 text-sm whitespace-pre-wrap text-gray-800">
         <%= @notification.email_body_text %>
       </pre>
     <% else %>

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -212,9 +212,9 @@ RSpec.describe NotificationDecorator, type: :decorator do
       expect(html).to include("Incoming")
     end
 
-    it "shows a grey FYI pill for an admin-directed communication" do
+    it "shows a teal FYI pill for an admin-directed communication" do
       html = build_stubbed(:notification, recipient_role: "admin").decorate.flag_badges
-      expect(html).to include("bg-gray-100")
+      expect(html).to include("bg-teal-100")
       expect(html).to include("FYI")
     end
 

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -149,6 +149,35 @@ RSpec.describe NotificationDecorator, type: :decorator do
     end
   end
 
+  describe "#from_button_person / #to_button_person" do
+    it "resolves the staff sender's person on the opposite side of an outgoing communication" do
+      person = create(:person)
+      sender = create(:user, person: person)
+      contact = create(:person, email: "kim@example.com")
+      decorated = create(:notification, sender: sender, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.from_button_person).to eq(person)
+      expect(decorated.to_button_person).to eq(contact)
+    end
+
+    it "flips the sides for an incoming communication" do
+      person = create(:person)
+      sender = create(:user, person: person)
+      contact = create(:person, email: "kim@example.com")
+      decorated = create(:notification, :incoming, sender: sender, recipient_email: "kim@example.com").decorate
+
+      expect(decorated.from_button_person).to eq(contact)
+      expect(decorated.to_button_person).to eq(person)
+    end
+
+    it "has no person for the AWBW Portal side (no sender)" do
+      decorated = build_stubbed(:notification, sender: nil, recipient_email: "stranger@example.com").decorate
+
+      expect(decorated.from_button_person).to be_nil
+      expect(decorated.to_button_person).to be_nil
+    end
+  end
+
   describe "#to_value / #from_value" do
     it "links the resolved contact to their profile" do
       person = create(:person, email: "kim@example.com")

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -203,6 +203,10 @@ RSpec.describe Notification do
       expect(build(:notification, kind: "contact_us_fyi").requires_response?).to be true
     end
 
+    it "returns false for an outgoing manual log" do
+      expect(build(:notification, kind: "manual_log").requires_response?).to be false
+    end
+
     it "returns false for contact_us kind (auto-confirmation to submitter)" do
       expect(build(:notification, kind: "contact_us").requires_response?).to be false
     end
@@ -213,6 +217,16 @@ RSpec.describe Notification do
 
     it "returns true for an incoming communication regardless of kind" do
       expect(build(:notification, :incoming, kind: "reset_password_fyi").requires_response?).to be true
+    end
+  end
+
+  describe "contact_us_fyi direction" do
+    it "is marked incoming when created" do
+      expect(create(:notification, kind: "contact_us_fyi").direction).to eq("incoming")
+    end
+
+    it "forces incoming even when built as outgoing" do
+      expect(create(:notification, kind: "contact_us_fyi", direction: "outgoing").direction).to eq("incoming")
     end
   end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -225,6 +225,11 @@ RSpec.describe "Notifications", type: :request do
         expect(Notification.last).to be_incoming
       end
 
+      it "records the responded flag on an incoming communication" do
+        post notifications_path, params: valid_params.deep_merge(notification: { direction: "incoming", responded: "1" })
+        expect(Notification.last).to be_responded
+      end
+
       it "re-renders with an error when no person is selected" do
         expect {
           post notifications_path, params: valid_params.except(:person_id)

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -344,6 +344,25 @@ RSpec.describe "Notifications", type: :request do
         expect(from_row(response.body)).to have_text("kim@example.com")
         expect(to_row(response.body)).to have_text("Dana Sender")
       end
+
+      it "renders a profile-button link to a known contact on the To side" do
+        contact = create(:person, email: "kim@example.com")
+        sent = create(:notification, kind: "event_registration_reminder", recipient_email: "kim@example.com")
+
+        get notification_path(sent)
+
+        expect(to_row(response.body)).to have_link(href: person_path(contact))
+      end
+
+      it "renders the noticeable as a record button linking to the record" do
+        person = create(:person)
+        about = create(:notification, noticeable: person)
+
+        get notification_path(about)
+
+        noticeable_row = Capybara.string(response.body).find(:xpath, "//dt[normalize-space()='Noticeable']/following-sibling::dd[1]")
+        expect(noticeable_row).to have_link(href: person_path(person))
+      end
     end
 
     context "as a non-admin owner" do

--- a/spec/requests/people_notifications_spec.rb
+++ b/spec/requests/people_notifications_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe "Person notifications", type: :request do
       expect(person.notifications.order(:created_at).last).to be_incoming
     end
 
+    it "records the responded flag on an incoming communication" do
+      patch person_path(person), params: {
+        person: {
+          notifications_attributes: { "0" => { channel: "phone", email_subject: "They called, we replied", direction: "incoming", responded: "1" } }
+        }
+      }
+
+      expect(person.notifications.order(:created_at).last).to be_responded
+    end
+
     it "ignores a blank notification with no note" do
       expect {
         patch person_path(person), params: {

--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -300,6 +300,28 @@ RSpec.describe "Event registration edit page", type: :system do
       expect(notification).to be_present
       expect(notification.channel).to eq("email")
     end
+
+    it "reveals and saves the responded flag once a logged communication is incoming" do
+      sign_in(admin)
+      visit edit_event_registration_path(registration)
+
+      within("section", text: "Registration communications") do
+        click_on "Add communication"
+        expect(page).to have_field("Subject")
+        fill_in "Subject", with: "They emailed us"
+
+        expect(page).not_to have_field("Already responded")
+        find("label", text: "Incoming").click
+        check "Already responded"
+      end
+
+      click_on "Save changes"
+      expect(page).to have_text("successfully updated")
+
+      notification = registration.notifications.find_by(email_subject: "They emailed us")
+      expect(notification).to be_incoming
+      expect(notification).to be_responded
+    end
   end
 
   describe "comments box" do

--- a/spec/system/notification_incoming_responded_spec.rb
+++ b/spec/system/notification_incoming_responded_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Logging an incoming communication", type: :system, js: true do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  it "reveals the responded checkbox only when the direction is incoming" do
+    visit new_notification_path
+
+    expect(page).not_to have_field("notification[responded]")
+
+    check "notification[direction]", allow_label_click: true
+
+    expect(page).to have_field("notification[responded]")
+
+    uncheck "notification[direction]", allow_label_click: true
+
+    expect(page).not_to have_field("notification[responded]")
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view + small controller/decorator/helper changes across the communication forms and detail page; logic layered on #2239

### What is the goal of this PR and why is this important?
- Let staff track whether an **incoming** communication has been responded to, from the moment it's logged.
- Tidy up the communications surfaces (index + detail page) so identity and status read clearly.
- #2239 (on main) already broadened `requires_response?` / `responded_status`; this PR adds the create-time behavior and the UI.

### How did you approach the change?
#### Model
- Stamp new `contact_us_fyi` records `incoming` on create (`mark_incoming`); extract `requires_response` / `no_response_needed` scopes.

#### "Already responded" checkbox — revealed only when Direction = Incoming
- On the standalone new form and the inline nested-logging panel (scoped **per row** so one row's toggle only reveals its own checkbox). Reuses `conditional-fields` (no new controller), generalized once for a checkbox source.
- Permit `:responded` on the five nested `notifications_attributes` paths.

#### Communications index
- Standalone new form: Person beside From; Channel beside Direction; one-row Subject textarea.
- **Record** column: neutral text (hover underline) instead of a blue link.
- **FYI** audience pill: teal instead of grey (amber is reserved for the stuck-pending warning; indigo is Bulk).

#### Communication detail page
- **From / To**: a compact person profile button when the party resolves to a known person (contact via email, staff sender via their linked person); plain text for the AWBW Portal or an unresolved person.
- **Noticeable**: a generic `record_button` — an icon-less pill the same height as the profile buttons, colored by the record's `DomainTheme` — replacing the blue link.

### Anything else to add?
- `record_button` is a new `ApplicationHelper` for any noticeable record; profile-button styling is reused, not duplicated.