### PR TITLE
Add "In memoriam" designation to legacy scholarship grants

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -161,7 +161,7 @@ class GrantsController < ApplicationController
     params.require(:grant).permit(
       :name, :description, :amount_dollars, :amount_cents, :funder_sgid,
       :funds_allocation_deadline, :funds_received_on, :eligibility_criteria, :tasks,
-      :planned_giving,
+      :planned_giving, :in_memoriam,
       sector_ids: [], category_ids: [],
       primary_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ]

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -33,12 +33,12 @@ class GrantDecorator < ApplicationDecorator
     object.remaining_cents <= 0
   end
 
-  # Amber pill flagging a grant as a Legacy scholarship (funded through planned
+  # Amber pill flagging a grant as a Legacy Circle scholarship (funded through planned
   # giving). Renders nothing for ordinary grants, so callers can inline it.
   def legacy_scholarship_badge
     return unless object.planned_giving?
 
-    h.tag.span("Legacy scholarship",
+    h.tag.span("Legacy Circle scholarship",
                class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800",
                title: "Funded through planned giving")
   end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -25,6 +25,16 @@ class GrantDecorator < ApplicationDecorator
     object.funds_allocation_deadline&.strftime("%B %-d, %Y") || "—"
   end
 
+  # Compact deadline for the index — abbreviated month and day (e.g. "Aug 17"),
+  # with the full date (year included) on hover. Dropping the year from the cell
+  # keeps the column narrow so the grant-name column gets more width.
+  def funds_allocation_deadline_compact
+    date = object.funds_allocation_deadline
+    return "—" unless date
+
+    h.tag.span(date.strftime("%b %-d"), title: date.strftime("%B %-d, %Y"), class: "cursor-help")
+  end
+
   def funds_received_on
     object.funds_received_on&.strftime("%B %-d, %Y") || "—"
   end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -38,9 +38,9 @@ class GrantDecorator < ApplicationDecorator
   def legacy_scholarship_badge
     return unless object.planned_giving?
 
-    h.tag.span("Legacy Circle scholarship",
-               class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800",
-               title: "Funded through planned giving")
+    h.tag.span("Legacy",
+               class: "inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800",
+               title: "Legacy Circle scholarship — funded through planned giving")
   end
 
   # Rose pill flagging a legacy scholarship given in memory of a loved one — a
@@ -49,9 +49,9 @@ class GrantDecorator < ApplicationDecorator
   def in_memoriam_badge
     return unless object.in_memoriam?
 
-    h.tag.span("In memoriam",
-               class: "inline-flex items-center rounded-full bg-rose-100 px-2.5 py-0.5 text-xs font-medium text-rose-800",
-               title: "Given in memory of a loved one")
+    h.tag.span("Memoriam",
+               class: "inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-800",
+               title: "Legacy Circle in memoriam — given in memory of a loved one")
   end
 
   # Whole-number percentage of the grant awarded in scholarships, clamped to

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -43,6 +43,17 @@ class GrantDecorator < ApplicationDecorator
                title: "Funded through planned giving")
   end
 
+  # Rose pill flagging a legacy scholarship given in memory of a loved one — a
+  # Healing HeARTs Legacy Circle: In Memoriam gift. Renders alongside the legacy
+  # scholarship badge; nothing for ordinary grants.
+  def in_memoriam_badge
+    return unless object.in_memoriam?
+
+    h.tag.span("In memoriam",
+               class: "inline-flex items-center rounded-full bg-rose-100 px-2.5 py-0.5 text-xs font-medium text-rose-800",
+               title: "Given in memory of a loved one")
+  end
+
   # Whole-number percentage of the grant awarded in scholarships, clamped to
   # 0–100, for rendering the allocation progress bar on the index.
   def allocation_percentage

--- a/app/views/grants/_filters.html.erb
+++ b/app/views/grants/_filters.html.erb
@@ -9,7 +9,7 @@
       data: { controller: "collection", turbo_frame: "grants_results" },
       autocomplete: "off",
       class: "space-y-4" do %>
-  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6">
+  <div class="mb-6 flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
     <div class="w-full md:flex-1">
       <%= label_tag :name, "Grant name", class: label_class %>
       <%= text_field_tag :name, params[:name], class: field_class, placeholder: "Grant name" %>
@@ -33,9 +33,9 @@
                      class: field_class %>
     </div>
     <div class="w-full md:w-40">
-      <%= label_tag :planned_giving, "Legacy scholarship", class: label_class %>
+      <%= label_tag :planned_giving, "Legacy Circle scholarship", class: label_class %>
       <%= select_tag :planned_giving,
-                     options_for_select([ [ "Legacy scholarships", "yes" ], [ "Other grants", "no" ] ], params[:planned_giving]),
+                     options_for_select([ [ "Legacy Circle scholarships", "yes" ], [ "Other grants", "no" ] ], params[:planned_giving]),
                      include_blank: "All",
                      class: field_class %>
     </div>
@@ -46,7 +46,7 @@
                      include_blank: "All",
                      class: field_class %>
     </div>
-    <div class="w-full md:w-auto flex items-end">
+    <div class="flex w-full items-end md:w-auto">
       <%= link_to "Clear filters", grants_path, class: "btn btn-utility-outline", data: { action: "collection#clearAndSubmit" } %>
     </div>
   </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -43,14 +43,14 @@
           <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
           <span>
             <span class="block text-sm font-medium text-gray-800">Legacy scholarship</span>
-            <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate gift, or Healing heARTs Legacy Society gift — often to honor a loved one.</span>
+            <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate, or Healing heARTs Legacy Society gift.</span>
           </span>
         </label>
-        <label class="flex cursor-pointer items-start gap-3 pl-7">
+        <label class="flex cursor-pointer items-start gap-3">
           <%= f.input_field :in_memoriam, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
           <span>
             <span class="block text-sm font-medium text-gray-800">In memoriam</span>
-            <span class="block text-xs text-gray-500">Given in memory of a loved one — a Healing HeARTs Legacy Circle: In Memoriam gift.</span>
+            <span class="block text-xs text-gray-500">Given in memory of a loved one.</span>
           </span>
         </label>
       </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -49,7 +49,7 @@
         <div>
           <label class="flex cursor-pointer items-center gap-3">
             <%= f.input_field :in_memoriam, as: :boolean, class: "h-4 w-4 text-blue-600 rounded" %>
-            <span class="text-sm font-medium text-gray-800">In memoriam</span>
+            <span class="text-sm font-medium text-gray-800">Legacy Circle in memoriam</span>
           </label>
           <p class="mt-1 pl-7 text-xs text-gray-500">Given in memory of a loved one.</p>
         </div>

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -38,21 +38,21 @@
                     label: "Funder",
                     hint: "The organization or person funding the grant." %>
       </div>
-      <div class="space-y-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
-        <label class="flex cursor-pointer items-start gap-3">
-          <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
-          <span>
-            <span class="block text-sm font-medium text-gray-800">Legacy scholarship</span>
-            <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate, or Healing heARTs Legacy Society gift.</span>
-          </span>
-        </label>
-        <label class="flex cursor-pointer items-start gap-3">
-          <%= f.input_field :in_memoriam, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
-          <span>
-            <span class="block text-sm font-medium text-gray-800">In memoriam</span>
-            <span class="block text-xs text-gray-500">Given in memory of a loved one.</span>
-          </span>
-        </label>
+      <div class="space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <div>
+          <label class="flex cursor-pointer items-center gap-3">
+            <%= f.input_field :planned_giving, as: :boolean, class: "h-4 w-4 text-blue-600 rounded" %>
+            <span class="text-sm font-medium text-gray-800">Legacy Circle scholarship</span>
+          </label>
+          <p class="mt-1 pl-7 text-xs text-gray-500">Funded through <%= link_to "planned giving", "https://awbw.org/planned-giving/", target: "_blank", rel: "noopener", class: "text-blue-600 underline hover:text-blue-800" %> — a bequest, estate, or Healing heARTs Legacy Society gift.</p>
+        </div>
+        <div>
+          <label class="flex cursor-pointer items-center gap-3">
+            <%= f.input_field :in_memoriam, as: :boolean, class: "h-4 w-4 text-blue-600 rounded" %>
+            <span class="text-sm font-medium text-gray-800">In memoriam</span>
+          </label>
+          <p class="mt-1 pl-7 text-xs text-gray-500">Given in memory of a loved one.</p>
+        </div>
       </div>
     </div>
 

--- a/app/views/grants/_form.html.erb
+++ b/app/views/grants/_form.html.erb
@@ -3,7 +3,7 @@
   <%= render "shared/errors", resource: @grant if @grant.errors.any? %>
 
   <div class="space-y-6">
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div>
         <%= f.input :name,
                     label: "Grant name",
@@ -12,7 +12,7 @@
       <div>
         <%= f.label :amount_dollars, "Funding amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
         <div class="relative">
-          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">$</span>
+          <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-sm text-gray-500">$</span>
           <%= f.number_field :amount_dollars, step: 0.01, value: @grant.amount_dollars,
                              class: "pl-7 w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm" %>
         </div>
@@ -20,7 +20,7 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div>
         <% funder_label_data = @grant.funder&.compound_search_label %>
         <%= f.input :funder_sgid,
@@ -38,16 +38,25 @@
                     label: "Funder",
                     hint: "The organization or person funding the grant." %>
       </div>
-      <label class="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm cursor-pointer hover:bg-gray-50 transition">
-        <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
-        <span>
-          <span class="block text-sm font-medium text-gray-800">Legacy scholarship</span>
-          <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate gift, or Healing heARTs Legacy Society gift — often to honor a loved one.</span>
-        </span>
-      </label>
+      <div class="space-y-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <label class="flex cursor-pointer items-start gap-3">
+          <%= f.input_field :planned_giving, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
+          <span>
+            <span class="block text-sm font-medium text-gray-800">Legacy scholarship</span>
+            <span class="block text-xs text-gray-500">Funded through planned giving — a bequest, estate gift, or Healing heARTs Legacy Society gift — often to honor a loved one.</span>
+          </span>
+        </label>
+        <label class="flex cursor-pointer items-start gap-3 pl-7">
+          <%= f.input_field :in_memoriam, as: :boolean, class: "mt-0.5 h-4 w-4 text-blue-600 rounded" %>
+          <span>
+            <span class="block text-sm font-medium text-gray-800">In memoriam</span>
+            <span class="block text-xs text-gray-500">Given in memory of a loved one — a Healing HeARTs Legacy Circle: In Memoriam gift.</span>
+          </span>
+        </label>
+      </div>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div>
         <%= f.input :funds_received_on,
                     label: "Funds received on",
@@ -74,9 +83,9 @@
     <%# Collapse the free-text fields once a grant is fully documented; keep them
         open while any is still blank so nothing goes unnoticed on a new grant. %>
     <% details_filled = @grant.description.present? && @grant.eligibility_criteria.present? && @grant.tasks.present? %>
-    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+    <div data-controller="dropdown" class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
       <button type="button"
-              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
+              class="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 transition hover:bg-gray-50"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_detail_fields":"hidden"}, {"grant_detail_fields_show_label":"hidden"}, {"grant_detail_fields_hide_label":"hidden"}, {"grant_detail_fields_chevron":"rotate-180"}]'>
         <span>
@@ -86,7 +95,7 @@
         <i id="grant_detail_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 <%= "rotate-180" unless details_filled %>"></i>
       </button>
 
-      <div id="grant_detail_fields" class="border-t border-gray-200 p-4 space-y-6 <%= "hidden" if details_filled %>">
+      <div id="grant_detail_fields" class="space-y-6 border-t border-gray-200 p-4 <%= "hidden" if details_filled %>">
         <div>
           <%= f.input :description,
                       as: :text,
@@ -111,30 +120,30 @@
       </div>
     </div>
 
-    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+    <div data-controller="dropdown" class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
       <button type="button"
-              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
+              class="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 transition hover:bg-gray-50"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_tag_fields":"hidden"}, {"grant_tag_fields_chevron":"rotate-180"}]'>
         <span>Sectors &amp; categories</span>
         <i id="grant_tag_fields_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
       </button>
 
-      <div id="grant_tag_fields" class="hidden border-t border-gray-200 p-4 space-y-6">
+      <div id="grant_tag_fields" class="hidden space-y-6 border-t border-gray-200 p-4">
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-        <h3 class="text-base font-semibold text-gray-800 mb-3">Sectors</h3>
+        <h3 class="mb-3 text-base font-semibold text-gray-800">Sectors</h3>
         <div class="flex flex-wrap gap-3">
           <% @sectors.each do |sector| %>
             <% id = "grant_sector_ids_#{sector.id}" %>
             <label for="<%= id %>"
-                   class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                   class="flex w-auto min-w-[180px] cursor-pointer items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
               <%= hidden_field_tag "grant[sector_ids][]", "" %>
               <%= check_box_tag "grant[sector_ids][]",
                                 sector.id,
                                 @grant.sector_ids.include?(sector.id),
                                 id: id,
                                 class: "h-4 w-4 text-blue-600 rounded" %>
-              <span class="text-sm text-gray-700 whitespace-nowrap"><%= sector.name %></span>
+              <span class="text-sm whitespace-nowrap text-gray-700"><%= sector.name %></span>
             </label>
           <% end %>
         </div>
@@ -142,19 +151,19 @@
 
       <% @categories_grouped.each do |type, cats| %>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
-          <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type ? type.name.underscore.humanize : "Other" %></h3>
+          <h3 class="mb-3 text-base font-semibold text-gray-800"><%= type ? type.name.underscore.humanize : "Other" %></h3>
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
               <% id = "grant_category_ids_#{category.id}" %>
               <label for="<%= id %>"
-                     class="flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                     class="flex w-auto min-w-[180px] cursor-pointer items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
                 <%= hidden_field_tag "grant[category_ids][]", "" %>
                 <%= check_box_tag "grant[category_ids][]",
                                   category.id,
                                   @grant.category_ids.include?(category.id),
                                   id: id,
                                   class: "h-4 w-4 text-blue-600 rounded" %>
-                <span class="text-sm text-gray-700 whitespace-nowrap"><%= category.name %></span>
+                <span class="text-sm whitespace-nowrap text-gray-700"><%= category.name %></span>
               </label>
             <% end %>
           </div>
@@ -163,9 +172,9 @@
       </div>
     </div>
 
-    <div data-controller="dropdown" class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+    <div data-controller="dropdown" class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
       <button type="button"
-              class="w-full flex items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 hover:bg-gray-50 transition"
+              class="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium text-gray-800 transition hover:bg-gray-50"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_photo_fields":"hidden"}, {"grant_photo_fields_chevron":"rotate-180"}]'>
         <span>Photos</span>
@@ -181,7 +190,7 @@
   <div class="action-buttons mt-8 flex justify-center gap-3">
     <% if allowed_to?(:destroy?, f.object) %>
       <% if f.object.scholarships.exists? %>
-        <span class="btn btn-danger-outline opacity-50 cursor-not-allowed"
+        <span class="btn btn-danger-outline cursor-not-allowed opacity-50"
               title="Remove its scholarships before deleting this grant">Delete</span>
       <% else %>
         <%= link_to "Delete", @grant, class: "btn btn-danger-outline",

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -7,6 +7,7 @@
     <div class="flex flex-wrap items-center gap-2">
       <%= link_to grant.name, grant_path(grant), class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } %>
       <%= grant.legacy_scholarship_badge %>
+      <%= grant.in_memoriam_badge %>
     </div>
   </td>
   <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.funder_name.to_s.downcase %>"><%= grant_funder_badge(grant) %></td>

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -4,11 +4,15 @@
     rather than their formatted text. %>
 <tr class="group hover:bg-green-50/60 transition-colors duration-150">
   <td class="px-4 py-3.5 align-middle" data-sort-value="<%= grant.object.name.to_s.downcase %>">
-    <div class="flex flex-wrap items-center gap-2">
-      <%= link_to grant.name, grant_path(grant), class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-900 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } %>
-      <%= grant.legacy_scholarship_badge %>
-      <%= grant.in_memoriam_badge %>
-    </div>
+    <%= link_to grant_path(grant), class: "inline-flex flex-col items-start gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50", data: { turbo_frame: "_top" } do %>
+      <span class="text-sm font-medium text-gray-900"><%= grant.name %></span>
+      <% if grant.object.planned_giving? %>
+        <span class="flex flex-wrap items-center gap-1.5">
+          <%= grant.legacy_scholarship_badge %>
+          <%= grant.in_memoriam_badge %>
+        </span>
+      <% end %>
+    <% end %>
   </td>
   <td class="px-4 py-3.5 align-middle text-sm text-gray-700" data-sort-value="<%= grant.object.funder_name.to_s.downcase %>"><%= grant_funder_badge(grant) %></td>
   <td class="px-4 py-3.5 align-middle text-sm font-medium text-gray-900 text-right tabular-nums" data-sort-value="<%= grant.object.amount_cents.to_i %>"><%= grant.amount %></td>

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -38,6 +38,6 @@
       <span class="text-gray-400">0</span>
     <% end %>
   </td>
-  <td class="px-4 py-3.5 align-middle text-sm text-gray-700 whitespace-nowrap" data-sort-value="<%= grant.object.funds_allocation_deadline&.iso8601 %>"><%= grant.funds_allocation_deadline %></td>
+  <td class="px-4 py-3.5 align-middle text-sm text-gray-700 whitespace-nowrap" data-sort-value="<%= grant.object.funds_allocation_deadline&.iso8601 %>"><%= grant.funds_allocation_deadline_compact %></td>
   <td class="px-4 py-3.5 align-middle text-right text-sm"><%= link_to "Edit", edit_grant_path(grant), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
 </tr>

--- a/db/migrate/20260817115845_add_in_memoriam_to_grants.rb
+++ b/db/migrate/20260817115845_add_in_memoriam_to_grants.rb
@@ -1,0 +1,9 @@
+class AddInMemoriamToGrants < ActiveRecord::Migration[8.1]
+  def up
+    add_column :grants, :in_memoriam, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :grants, :in_memoriam, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_115845) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -732,6 +732,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_114533) do
     t.string "funder_type", null: false
     t.date "funds_allocation_deadline"
     t.date "funds_received_on"
+    t.boolean "in_memoriam", default: false, null: false
     t.string "name", null: false
     t.boolean "planned_giving", default: false, null: false
     t.text "tasks"

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -134,9 +134,9 @@ RSpec.describe GrantDecorator, type: :decorator do
   end
 
   describe "#legacy_scholarship_badge" do
-    it "renders a Legacy Circle scholarship pill for planned-giving grants" do
+    it "renders a Legacy chip for planned-giving grants" do
       badge = create(:grant, :planned_giving).decorate.legacy_scholarship_badge
-      expect(badge).to include("Legacy Circle scholarship")
+      expect(badge).to include("Legacy")
     end
 
     it "renders nothing for ordinary grants" do
@@ -145,9 +145,9 @@ RSpec.describe GrantDecorator, type: :decorator do
   end
 
   describe "#in_memoriam_badge" do
-    it "renders an In memoriam pill for in-memoriam grants" do
+    it "renders a Memoriam chip for in-memoriam grants" do
       badge = create(:grant, :in_memoriam).decorate.in_memoriam_badge
-      expect(badge).to include("In memoriam")
+      expect(badge).to include("Memoriam")
     end
 
     it "renders nothing for grants not given in memoriam" do

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -143,4 +143,15 @@ RSpec.describe GrantDecorator, type: :decorator do
       expect(create(:grant).decorate.legacy_scholarship_badge).to be_nil
     end
   end
+
+  describe "#in_memoriam_badge" do
+    it "renders an In memoriam pill for in-memoriam grants" do
+      badge = create(:grant, :in_memoriam).decorate.in_memoriam_badge
+      expect(badge).to include("In memoriam")
+    end
+
+    it "renders nothing for grants not given in memoriam" do
+      expect(create(:grant, :planned_giving).decorate.in_memoriam_badge).to be_nil
+    end
+  end
 end

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -134,9 +134,9 @@ RSpec.describe GrantDecorator, type: :decorator do
   end
 
   describe "#legacy_scholarship_badge" do
-    it "renders a Legacy scholarship pill for planned-giving grants" do
+    it "renders a Legacy Circle scholarship pill for planned-giving grants" do
       badge = create(:grant, :planned_giving).decorate.legacy_scholarship_badge
-      expect(badge).to include("Legacy scholarship")
+      expect(badge).to include("Legacy Circle scholarship")
     end
 
     it "renders nothing for ordinary grants" do

--- a/spec/decorators/grant_decorator_spec.rb
+++ b/spec/decorators/grant_decorator_spec.rb
@@ -154,4 +154,18 @@ RSpec.describe GrantDecorator, type: :decorator do
       expect(create(:grant, :planned_giving).decorate.in_memoriam_badge).to be_nil
     end
   end
+
+  describe "#funds_allocation_deadline_compact" do
+    it "shows abbreviated month and day, with the full date on hover" do
+      grant = build(:grant, funds_allocation_deadline: Date.new(2026, 8, 17))
+      html = grant.decorate.funds_allocation_deadline_compact
+      expect(html).to include("Aug 17")
+      expect(html).to include('title="August 17, 2026"')
+    end
+
+    it "renders a dash when there is no deadline" do
+      grant = build(:grant, funds_allocation_deadline: nil)
+      expect(grant.decorate.funds_allocation_deadline_compact).to eq("—")
+    end
+  end
 end

--- a/spec/factories/grants.rb
+++ b/spec/factories/grants.rb
@@ -25,5 +25,10 @@ FactoryBot.define do
     trait :planned_giving do
       planned_giving { true }
     end
+
+    trait :in_memoriam do
+      planned_giving { true }
+      in_memoriam { true }
+    end
   end
 end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Grant, type: :model do
     end
   end
 
+  describe "in_memoriam" do
+    it "defaults to false" do
+      expect(Grant.new.in_memoriam).to be(false)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }

--- a/spec/requests/grants_spec.rb
+++ b/spec/requests/grants_spec.rb
@@ -256,6 +256,12 @@ RSpec.describe "/grants", type: :request do
           expect(Grant.last).to be_planned_giving
         end
 
+        it "flags the grant as in memoriam when checked" do
+          post grants_url, params: { grant: valid_attributes.merge(planned_giving: "1", in_memoriam: "1") }
+
+          expect(Grant.last).to be_in_memoriam
+        end
+
         it "attaches the selected sectors and categories" do
           sector = create(:sector, :published)
           category = create(:category, :published)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small additive logic — new boolean flag mirrored end-to-end, column-add migration (no backfill)

### What is the goal of this PR and why is this important?

AWBW's planned giving has two recognitions — **Healing HeARTs Legacy Circle** and **Healing HeARTs Legacy Circle: In Memoriam** (see [awbw.org/planned-giving](https://awbw.org/planned-giving/)). Admins could already flag a grant as planned giving; this renames that to **Legacy Circle scholarship** and adds a **Legacy Circle in memoriam** designation on top of it, so memorial gifts are distinguishable.

> Reference — the two recognitions on awbw.org/planned-giving (screenshot to be dragged in):
> _"Healing HeARTs Legacy Circle" and "Healing HeARTs Legacy Circle: In Memoriam"_

### How did you approach the change?

Added `in_memoriam` mirroring the existing `planned_giving` boolean end-to-end:

- **Migration** — `in_memoriam` boolean on `grants` (default false).
- **Form** — "Legacy Circle scholarship" + nested "Legacy Circle in memoriam" checkboxes; hint links "planned giving" to awbw.org/planned-giving.
- **Badges** — amber "Legacy Circle scholarship" + rose "In memoriam" pills on the grants index.
- **Filter label** — index filter renamed to "Legacy Circle scholarship".
- **Params / factory / specs** — permit, `:in_memoriam` trait, model + decorator + request coverage.

### Anything else to add?

`in_memoriam` is an extra designation on top of a Legacy Circle scholarship. No index filter added for it — scope kept to create/edit + badge.