### PR TITLE
Capture what a save actually changed

### DIFF
--- a/app/controllers/concerns/tag_assignable.rb
+++ b/app/controllers/concerns/tag_assignable.rb
@@ -9,6 +9,8 @@ module TagAssignable
     selected_category_ids = Array(params[key][:category_ids]).reject(&:blank?).map(&:to_i)
     selected = Category.where(id: selected_category_ids).to_a
 
+    categories_before = record.categories.to_a
+
     if params[key].key?(:managed_category_type_ids)
       # The form only edits certain category types (e.g. age ranges + workshop
       # settings). Preserve taggings of every other type the form never shows so
@@ -20,10 +22,14 @@ module TagAssignable
     else
       record.categories = selected
     end
+    categories_after = record.categories.to_a
 
-    if params[key].key?(:sector_ids)
+    sectors_changed = params[key].key?(:sector_ids)
+    if sectors_changed
+      sectors_before = record.sectors.to_a
       selected_sector_ids = Array(params[key][:sector_ids]).reject(&:blank?).map(&:to_i)
       record.sectors = Sector.where(id: selected_sector_ids)
+      sectors_after = record.sectors.to_a
     end
 
     record.save!
@@ -34,5 +40,20 @@ module TagAssignable
     if params[key].key?(:primary_age_category_ids) && record.respond_to?(:apply_primary_age_groups!)
       record.apply_primary_age_groups!(Array(params[key][:primary_age_category_ids]))
     end
+
+    # These memberships change outside the record's dirty tracking, so hand the
+    # diff to the change log directly (a no-op when nothing actually moved).
+    return unless record.respond_to?(:track_membership_changes)
+
+    record.track_membership_changes(
+      categories: membership_delta(categories_before, categories_after),
+      sectors: (membership_delta(sectors_before, sectors_after) if sectors_changed)
+    )
+  end
+
+  def membership_delta(before, after)
+    before = Array(before)
+    after = Array(after)
+    { added: after - before, removed: before - after }
   end
 end

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -64,7 +64,7 @@ module Ahoy
     end
 
     def hash_rows(hash, label, depth)
-      return [ reference_row(label, hash, depth) ] if reference?(hash)
+      return reference_rows(label, hash, depth) if reference?(hash)
       return [ { label: label, value: "(empty)", depth: depth } ] if hash.empty?
 
       rows = label ? [ { label: label, value: nil, depth: depth } ] : []
@@ -81,7 +81,7 @@ module Ahoy
       elsif array.all? { |item| reference?(item) }
         header = label ? [ { label: label, value: nil, depth: depth } ] : []
         child_depth = label ? depth + 1 : depth
-        header + array.map { |item| reference_row(nil, item, child_depth) }
+        header + array.flat_map { |item| reference_rows(nil, item, child_depth) }
       else
         [ { label: label, value: array.map { |item| display_value(item) }.join(", "), depth: depth } ]
       end
@@ -99,6 +99,16 @@ module Ahoy
       name = item["name"] || item["title"]
       type = item["type"]
       type.present? ? "#{name} (#{type.to_s.underscore.humanize})" : name
+    end
+
+    # The link, then what the record actually said — a comment's body reads better
+    # than "a comment was added".
+    def reference_rows(label, item, depth)
+      detail = item["changes"].presence || item["attributes"].presence
+      rows = [ reference_row(label, item, depth) ]
+      return rows if detail.blank?
+
+      rows + flatten_rows(detail, nil, depth + 1)
     end
 
     def reference_row(label, item, depth)

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -115,9 +115,18 @@ module Ahoy
       type = item["type"] || item["record_type"]
       id = item["id"] || item["record_id"]
       record = find_referenced_record(type, id)
-      text = record.try(:title).presence || record.try(:name).presence || "#{type} ##{id}"
+      text = safe_label(record) || "#{type} ##{id}"
       { label: label, depth: depth, action: item["action"],
         link: { text: text, path: show_path_for(record) } }
+    end
+
+    # A model's own title/name can raise on records it wasn't written for, and a
+    # change log is not the place to find out.
+    def safe_label(record)
+      label = record.try(:title).presence || record.try(:name).presence
+      label.is_a?(String) ? label : label&.to_s
+    rescue StandardError
+      nil
     end
 
     # Prefer the page-level cache (one query per type, built by

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -97,6 +97,8 @@ module Ahoy
         header = label ? [ { label: label, value: nil, depth: depth } ] : []
         child_depth = label ? depth + 1 : depth
         header + array.flat_map { |item| reference_rows(nil, item, child_depth) }
+      elsif array.all? { |item| attachment_change?(item) }
+        array.map { |item| attachment_row(label, item, depth) }
       else
         [ { label: label, value: array.map { |item| display_value(item) }.join(", "), depth: depth } ]
       end
@@ -104,6 +106,19 @@ module Ahoy
 
     def reference?(item)
       Analytics::EventReferenceLoader.reference?(item)
+    end
+
+    # An attachment is staged on the record and has no id until the save lands,
+    # so it travels as a filename rather than as a reference to look up.
+    def attachment_change?(item)
+      item.is_a?(Hash) && item["type"] == "ActiveStorage::Attachment" &&
+        item["action"].present? && item["id"].blank? && item["record_id"].blank?
+    end
+
+    # A file has no page to link to, so it reads as its name. A removal keeps only
+    # the action — the blob is gone by the time anyone reads this.
+    def attachment_row(label, item, depth)
+      { label: label, depth: depth, action: item["action"], value: item["filename"].presence }
     end
 
     def named_entity?(item)

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -115,8 +115,8 @@ module Ahoy
         item["action"].present? && item["id"].blank? && item["record_id"].blank?
     end
 
-    # A file has no page to link to, so it reads as its name. A removal keeps only
-    # the action — the blob is gone by the time anyone reads this.
+    # A file has no page to link to, so it reads as its name — kept on a removal
+    # too, since the blob it named is gone by the time anyone reads this.
     def attachment_row(label, item, depth)
       { label: label, depth: depth, action: item["action"], value: item["filename"].presence }
     end

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -3,6 +3,9 @@ module Ahoy
     # Already surfaced in their own table columns, so redundant inside the details cell.
     REDUNDANT_KEYS = %w[resource_type resource_id resource_title].freeze
 
+    # Fields that title the record they belong to, in the order they should lead.
+    HEADING_KEYS = %w[topic title name subject].freeze
+
     # Everything the dedicated columns don't already show.
     def extra_properties
       properties_hash.except(*REDUNDANT_KEYS)
@@ -21,8 +24,10 @@ module Ahoy
     def changes_summary
       return [] unless changes?
 
-      change_diffs.map do |field, diff|
+      change_diffs.filter_map do |field, diff|
         diff = {} unless diff.is_a?(Hash)
+        next if blank_change?(diff)
+
         {
           field: field.to_s.humanize,
           before: display_value(diff["before"]),
@@ -69,8 +74,18 @@ module Ahoy
 
       rows = label ? [ { label: label, value: nil, depth: depth } ] : []
       child_depth = label ? depth + 1 : depth
-      hash.each { |key, val| rows.concat(flatten_rows(val, humanize_key(key), child_depth)) }
+      heading_first(hash).each do |key, val|
+        child_rows = flatten_rows(val, humanize_key(key), child_depth)
+        child_rows.first[:emphasis] = true if HEADING_KEYS.include?(key.to_s) && child_rows.one?
+        rows.concat(child_rows)
+      end
       rows
+    end
+
+    # A comment's topic titles its body rather than sitting beside it, so it leads.
+    def heading_first(hash)
+      headings, rest = hash.partition { |key, _| HEADING_KEYS.include?(key.to_s) }
+      headings.sort_by { |key, _| HEADING_KEYS.index(key.to_s) } + rest
     end
 
     def array_rows(array, label, depth)
@@ -104,11 +119,29 @@ module Ahoy
     # The link, then what the record actually said — a comment's body reads better
     # than "a comment was added".
     def reference_rows(label, item, depth)
-      detail = item["changes"].presence || item["attributes"].presence
       rows = [ reference_row(label, item, depth) ]
-      return rows if detail.blank?
+      rows += change_rows(item["changes"], depth + 1)
+      rows += flatten_rows(item["attributes"], nil, depth + 1) if item["attributes"].present?
+      rows
+    end
 
-      rows + flatten_rows(detail, nil, depth + 1)
+    # A nested record's diffs read like the record's own: field, then before, then
+    # after. The order comes from here rather than the payload — MySQL reorders
+    # the keys of a JSON object.
+    def change_rows(diffs, depth)
+      return [] unless diffs.is_a?(Hash)
+
+      diffs.filter_map do |field, diff|
+        diff = {} unless diff.is_a?(Hash)
+        next if blank_change?(diff)
+
+        { label: humanize_key(field), depth: depth,
+          change: { before: display_value(diff["before"]), after: display_value(diff["after"]) } }
+      end
+    end
+
+    def blank_change?(diff)
+      diff["before"].blank? && diff["after"].blank?
     end
 
     def reference_row(label, item, depth)

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -5,4 +5,13 @@ class Ahoy::Event < ApplicationRecord
 
   belongs_to :visit
   belongs_to :user, optional: true
+
+  # Reading a record isn't a change to it. A record's change log asks what
+  # happened to it, so these stay on the admin activities index, which is where
+  # browsing belongs.
+  NON_MUTATION_PREFIXES = %w[view search filter download].freeze
+
+  scope :mutations, -> {
+    NON_MUTATION_PREFIXES.reduce(all) { |scope, prefix| scope.where.not(arel_table[:name].matches("#{prefix}.%")) }
+  }
 end

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -9,7 +9,7 @@ class Ahoy::Event < ApplicationRecord
   # Reading a record isn't a change to it. A record's change log asks what
   # happened to it, so these stay on the admin activities index, which is where
   # browsing belongs.
-  NON_MUTATION_PREFIXES = %w[view search filter download].freeze
+  NON_MUTATION_PREFIXES = %w[view print search filter download].freeze
 
   scope :mutations, -> {
     NON_MUTATION_PREFIXES.reduce(all) { |scope, prefix| scope.where.not(arel_table[:name].matches("#{prefix}.%")) }

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -202,13 +202,24 @@ module AhoyTrackable
         assoc: :"#{name}_attachment",
         type: "ActiveStorage::Attachment",
         action: removal ? "removed" : "added",
-        filename: (attachment_filenames(change) unless removal)
+        filename: removal ? removed_attachment_filenames(name) : attachment_filenames(change)
       }.compact
     end
   end
 
   def attachment_filenames(change)
-    blobs = change.try(:blobs) || Array(change.try(:blob))
+    blob_names(change.try(:blobs) || Array(change.try(:blob)))
+  end
+
+  # A staged delete carries no blob of its own, so read what is still attached:
+  # the outgoing file stays on the record until the save applies the change, and
+  # its name is all the log can keep once the blob is gone.
+  def removed_attachment_filenames(name)
+    attached = try(:"#{name}_attachments") || try(:"#{name}_attachment")
+    blob_names(Array(attached).filter_map(&:blob))
+  end
+
+  def blob_names(blobs)
     blobs.filter_map { |blob| blob.filename.to_s.presence }.join(", ").presence
   end
 

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -318,6 +318,10 @@ module AhoyTrackable
   def format_tracked_changes(changes)
     safe_changes = changes.reject { |attr, _| attr.match?(/password|token|secret|key|digest|salt|otp/i) }
     safe_changes.each_with_object({}) do |(attr, (before, after)), h|
+      # A form posts every field, so untouched blanks arrive as nil -> "". Dirty
+      # tracking counts that; a reader shouldn't have to.
+      next if before.blank? && after.blank?
+
       h[attr] = { before: before, after: after }
     end
   end

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -1,11 +1,16 @@
 module AhoyTrackable
   extend ActiveSupport::Concern
 
+  # Long-form bodies are stored as a readable preview, not in full: an event is a
+  # summary, and whole articles would bloat every row of ahoy_events.
+  RICH_TEXT_PREVIEW_LIMIT = 300
+
   included do
     after_create  -> { track_create_event }
     after_update  -> { track_update_event }
     after_destroy -> { track_lifecycle_event("destroy", @_destroy_snapshot || {}) }
     before_save :capture_pending_association_removals
+    before_save :capture_pending_rich_text_changes
     before_destroy :capture_destroy_snapshot
   end
 
@@ -40,7 +45,7 @@ module AhoyTrackable
   def track_update_event
     return if previously_new_record? # Skip the fake "update" that happens right after create
 
-    changes = previous_changes.except("updated_at", "created_at")
+    changes = previous_changes.except("updated_at", "created_at").merge(@_pending_rich_text_changes.to_h)
     assoc_changes = collect_association_changes
 
     return if changes.empty? && assoc_changes.empty?
@@ -100,30 +105,44 @@ module AhoyTrackable
       end
     end
 
-    # Track rich text changes
-    collect_rich_text_changes(changes)
-
     # Track attachment changes
     collect_attachment_changes(changes)
 
     changes
   end
 
-  def collect_rich_text_changes(changes)
+  # Rich text saves through the parent's autosave chain, so by the time the update
+  # event is built the body is no longer reliably readable as a change — capture it
+  # here, while it's still dirty. Keyed on the attribute (`rhino_body`), not the
+  # association, because a reader thinks of it as a field of the record; the plain
+  # text is stored rather than the markup, truncated, so an event stays readable
+  # and small.
+  def capture_pending_rich_text_changes
+    @_pending_rich_text_changes = {}
+
     self.class.reflect_on_all_associations(:has_one).each do |assoc|
       next if assoc.polymorphic?
       next unless safe_assoc_class_name(assoc) == "ActionText::RichText"
 
-      record = public_send(assoc.name)
-      next unless record&.persisted?
+      # Reading the association would build an empty record for an untouched field.
+      # The name has to stay a symbol: the association cache is symbol-keyed, and a
+      # string lookup hands back a fresh, unloaded association whose target is nil.
+      record = association(assoc.name).target
+      # plain_text_body is derived when the rich text itself saves, which happens
+      # after this, so the body is the only diff available on a first edit.
+      diff = record&.changes&.values_at("plain_text_body", "body")&.compact&.first
+      next if diff.blank?
 
-      rt_changes = record.previous_changes.slice("body", "plain_text_body")
-      next if rt_changes.empty?
+      before, after = diff.map { |value| rich_text_preview(value) }
+      next if before == after
 
-      changes[assoc.name] ||= []
-      changes[assoc.name] << { action: "updated", id: record.id, type: "ActionText::RichText",
-                                changes: format_tracked_changes(rt_changes) }
+      @_pending_rich_text_changes[assoc.name.to_s.delete_prefix("rich_text_")] = [ before, after ]
     end
+  end
+
+  def rich_text_preview(value)
+    text = value.respond_to?(:to_plain_text) ? value.to_plain_text : value.to_s
+    text.squish.truncate(RICH_TEXT_PREVIEW_LIMIT)
   end
 
   def collect_attachment_changes(changes)

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -10,6 +10,7 @@ module AhoyTrackable
     after_update  -> { track_update_event }
     after_destroy -> { track_lifecycle_event("destroy", @_destroy_snapshot || {}) }
     before_save :capture_pending_changes
+    after_save :resolve_pending_association_ids
     before_destroy :capture_destroy_snapshot
   end
 
@@ -80,8 +81,10 @@ module AhoyTrackable
   end
 
   def pending_association_change(assoc_name, record)
-    return { assoc: assoc_name, record: record, action: "removed" } if record.marked_for_destruction?
-    return { assoc: assoc_name, record: record, action: "added" } if record.new_record?
+    if record.marked_for_destruction? || record.new_record?
+      action = record.marked_for_destruction? ? "removed" : "added"
+      return { assoc: assoc_name, record: record, action: action, attributes: content_attributes(record) }
+    end
 
     record_changes = record.changes.except("updated_at", "created_at")
     return if record_changes.empty?
@@ -89,17 +92,39 @@ module AhoyTrackable
     { assoc: assoc_name, record: record, action: "updated", changes: format_tracked_changes(record_changes) }
   end
 
+  # What the record says, minus the plumbing: an added comment should read as its
+  # body, not as a row of foreign keys. Keys, timestamps, and anything
+  # secret-shaped are left out; the child's own event keeps the full snapshot.
+  def content_attributes(record)
+    record.attributes
+      .except("id", "created_at", "updated_at")
+      .reject { |key, value| value.blank? || key.end_with?("_id", "_type") }
+      .reject { |key, _| key.match?(/password|token|secret|key|digest|salt|otp/i) }
+  end
+
   # Ids are read now rather than at capture time: a record added through nested
   # attributes has none until the save goes through.
   def collect_association_changes
+    @_unresolved_association_ids = []
+
     (@_pending_association_changes.to_a + @_pending_attachment_changes.to_a).each_with_object({}) do |pending, changes|
       entry = { action: pending[:action], type: pending[:type] || pending[:record].class.name }
       entry[:id] = pending[:record].id if pending[:record]
       entry[:filename] = pending[:filename] if pending[:filename]
       entry[:changes] = pending[:changes] if pending[:changes]
+      entry[:attributes] = pending[:attributes] if pending[:attributes].present?
+      @_unresolved_association_ids << [ entry, pending[:record] ] if pending[:record] && entry[:id].nil?
 
       (changes[pending[:assoc]] ||= []) << entry
     end
+  end
+
+  # A record added through nested attributes has no id until the collection
+  # autosave runs, which is after the update event is assembled. The buffered
+  # event holds the same hash, so filling it in here fills it in there.
+  def resolve_pending_association_ids
+    @_unresolved_association_ids.to_a.each { |entry, record| entry[:id] ||= record.id }
+    @_unresolved_association_ids = nil
   end
 
   # Rich text saves through the parent's autosave chain, so by the time the update

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -9,8 +9,7 @@ module AhoyTrackable
     after_create  -> { track_create_event }
     after_update  -> { track_update_event }
     after_destroy -> { track_lifecycle_event("destroy", @_destroy_snapshot || {}) }
-    before_save :capture_pending_association_removals
-    before_save :capture_pending_rich_text_changes
+    before_save :capture_pending_changes
     before_destroy :capture_destroy_snapshot
   end
 
@@ -58,57 +57,49 @@ module AhoyTrackable
     track_lifecycle_event("update", extra)
   end
 
-  # Capture records marked for destruction before autosave removes them from the target
-  def capture_pending_association_removals
-    @_pending_association_removals = {}
+  # Autosave writes children, rich text, and attachments *after* this record's own
+  # callbacks have run, clearing their dirty state on the way — so everything the
+  # update event says about them has to be read here, while it's still pending.
+  def capture_pending_changes
+    capture_pending_association_changes
+    capture_pending_rich_text_changes
+    capture_pending_attachment_changes
+  end
+
+  def capture_pending_association_changes
+    @_pending_association_changes = []
 
     self.class.nested_attributes_options.each_key do |assoc_name|
-      assoc = association(assoc_name.to_s)
-      next unless assoc.loaded?
-
-      marked = Array(assoc.target).compact.select(&:marked_for_destruction?)
-      next if marked.empty?
-
-      @_pending_association_removals[assoc_name] = marked.map do |record|
-        { action: "removed", id: record.id, type: record.class.name }
+      # A symbol: the association cache is symbol-keyed, and a string lookup hands
+      # back a fresh, unloaded association whose target is empty.
+      Array(association(assoc_name).target).compact.each do |record|
+        pending = pending_association_change(assoc_name, record)
+        @_pending_association_changes << pending if pending
       end
     end
   end
 
+  def pending_association_change(assoc_name, record)
+    return { assoc: assoc_name, record: record, action: "removed" } if record.marked_for_destruction?
+    return { assoc: assoc_name, record: record, action: "added" } if record.new_record?
+
+    record_changes = record.changes.except("updated_at", "created_at")
+    return if record_changes.empty?
+
+    { assoc: assoc_name, record: record, action: "updated", changes: format_tracked_changes(record_changes) }
+  end
+
+  # Ids are read now rather than at capture time: a record added through nested
+  # attributes has none until the save goes through.
   def collect_association_changes
-    changes = {}
+    (@_pending_association_changes.to_a + @_pending_attachment_changes.to_a).each_with_object({}) do |pending, changes|
+      entry = { action: pending[:action], type: pending[:type] || pending[:record].class.name }
+      entry[:id] = pending[:record].id if pending[:record]
+      entry[:filename] = pending[:filename] if pending[:filename]
+      entry[:changes] = pending[:changes] if pending[:changes]
 
-    self.class.nested_attributes_options.each_key do |assoc_name|
-      assoc = association(assoc_name.to_s)
-      next unless assoc.loaded?
-
-      Array(assoc.target).compact.each do |record|
-        if record.previously_new_record?
-          changes[assoc_name] ||= []
-          changes[assoc_name] << { action: "added", id: record.id, type: record.class.name }
-        else
-          record_changes = record.previous_changes.except("updated_at", "created_at")
-          next if record_changes.empty?
-
-          changes[assoc_name] ||= []
-          changes[assoc_name] << { action: "updated", id: record.id, type: record.class.name,
-                                   changes: format_tracked_changes(record_changes) }
-        end
-      end
+      (changes[pending[:assoc]] ||= []) << entry
     end
-
-    # Merge in removals captured before save
-    if @_pending_association_removals.present?
-      @_pending_association_removals.each do |assoc_name, removals|
-        changes[assoc_name] ||= []
-        changes[assoc_name].concat(removals)
-      end
-    end
-
-    # Track attachment changes
-    collect_attachment_changes(changes)
-
-    changes
   end
 
   # Rich text saves through the parent's autosave chain, so by the time the update
@@ -145,39 +136,28 @@ module AhoyTrackable
     text.squish.truncate(RICH_TEXT_PREVIEW_LIMIT)
   end
 
-  def collect_attachment_changes(changes)
-    self.class.reflect_on_all_associations.each do |assoc|
-      next if assoc.polymorphic?
-      next unless safe_assoc_class_name(assoc) == "ActiveStorage::Attachment"
+  # ActiveStorage stages attach/purge on the record and applies it during save, so
+  # the staged change is the only reliable description of what happened.
+  def capture_pending_attachment_changes
+    @_pending_attachment_changes = []
+    return unless respond_to?(:attachment_changes, true)
 
-      if assoc.macro == :has_many
-        Array(association(assoc.name.to_s).target).compact.each do |record|
-          next unless record.previously_new_record?
+    attachment_changes.each do |name, change|
+      removal = change.is_a?(ActiveStorage::Attached::Changes::DeleteOne) ||
+        change.is_a?(ActiveStorage::Attached::Changes::DeleteMany)
 
-          changes[assoc.name] ||= []
-          changes[assoc.name] << { action: "added", type: "ActiveStorage::Attachment", record_id: record.id, blob_id: record.blob_id }
-        end
-      elsif assoc.macro == :has_one
-        record = public_send(assoc.name)
-        next unless record&.previously_new_record?
-
-        changes[assoc.name] ||= []
-        changes[assoc.name] << { action: "added", type: "ActiveStorage::Attachment", record_id: record.id, blob_id: record.blob_id }
-      end
+      @_pending_attachment_changes << {
+        assoc: :"#{name}_attachment",
+        type: "ActiveStorage::Attachment",
+        action: removal ? "removed" : "added",
+        filename: (attachment_filenames(change) unless removal)
+      }.compact
     end
+  end
 
-    if @_pending_association_removals.blank?
-      # Check for attachment removals via attachment_changes (Rails built-in tracking)
-      return unless respond_to?(:attachment_changes, true) && attachment_changes.present?
-
-      attachment_changes.each do |name, change|
-        assoc_name = "#{name}_attachment".to_sym
-        if change.is_a?(ActiveStorage::Attached::Changes::DeleteOne) || change.is_a?(ActiveStorage::Attached::Changes::DeleteMany)
-          changes[assoc_name] ||= []
-          changes[assoc_name] << { action: "removed", type: "ActiveStorage::Attachment" }
-        end
-      end
-    end
+  def attachment_filenames(change)
+    blobs = change.try(:blobs) || Array(change.try(:blob))
+    blobs.filter_map { |blob| blob.filename.to_s.presence }.join(", ").presence
   end
 
   def capture_destroy_snapshot
@@ -194,7 +174,7 @@ module AhoyTrackable
     records = {}
 
     self.class.nested_attributes_options.each_key do |assoc_name|
-      assoc = association(assoc_name.to_s)
+      assoc = association(assoc_name)
       next unless assoc.loaded?
 
       created = Array(assoc.target).compact.select(&:persisted?)
@@ -222,7 +202,7 @@ module AhoyTrackable
       next if assoc.polymorphic?
       next unless safe_assoc_class_name(assoc) == "ActiveStorage::Attachment"
 
-      target = association(assoc.name.to_s).target
+      target = association(assoc.name).target
       attached = Array(target).compact.select(&:persisted?)
       next if attached.empty?
 

--- a/app/models/concerns/ahoy_trackable.rb
+++ b/app/models/concerns/ahoy_trackable.rb
@@ -14,7 +14,34 @@ module AhoyTrackable
     before_destroy :capture_destroy_snapshot
   end
 
+  # Category and sector memberships are reassigned through has_many :through
+  # collection setters (categories=/sectors=) that persist immediately, outside
+  # this record's dirty tracking — so the update callbacks never see them. The
+  # code that reassigns them (TagAssignable) hands the before/after records here
+  # to fold the diff onto the change log as the record's own update event.
+  def track_membership_changes(memberships)
+    association_changes = memberships.each_with_object({}) do |(assoc_name, delta), changes|
+      entries = membership_change_entries(delta)
+      changes[assoc_name] = entries if entries.present?
+    end
+    return if association_changes.blank?
+
+    track_lifecycle_event("update", association_changes: association_changes)
+  end
+
   private
+
+  def membership_change_entries(delta)
+    return [] if delta.blank?
+
+    added = Array(delta[:added]).map { |record| membership_entry("added", record) }
+    removed = Array(delta[:removed]).map { |record| membership_entry("removed", record) }
+    added + removed
+  end
+
+  def membership_entry(action, record)
+    { action: action, type: record.class.name, id: record.id }
+  end
 
   def devise_only_changes?(changes)
     auth_fields = %w[

--- a/app/models/sectorable_item.rb
+++ b/app/models/sectorable_item.rb
@@ -9,10 +9,13 @@ class SectorableItem < ApplicationRecord
 
   before_create :skip_if_duplicate
 
-  # Methods
+  # A tagging reads as the sector it applied. Only a workshop log carries a title
+  # and a windows type to compose with it — an organization or a person doesn't,
+  # and asking for one raised.
   def title
-    return id unless sectorable && sectorable.class != WorkshopLog
-    "#{sectorable.title} - #{sectorable.windows_type.name if sectorable.windows_type}"
+    return sector&.name.to_s unless sectorable.is_a?(WorkshopLog)
+
+    "#{sectorable.title} - #{sectorable.windows_type&.name}"
   end
 
   private

--- a/app/services/analytics/event_builder.rb
+++ b/app/services/analytics/event_builder.rb
@@ -20,7 +20,13 @@ module Analytics
 
       resource.decorate.title
     rescue
-      resource.try(:title) || resource.try(:name) || resource.id
+      fallback_title(resource)
+    end
+
+    def self.fallback_title(resource)
+      resource.try(:title).presence || resource.try(:name).presence || resource.id
+    rescue StandardError
+      resource.id
     end
   end
 end

--- a/app/services/analytics/event_reference_loader.rb
+++ b/app/services/analytics/event_reference_loader.rb
@@ -7,7 +7,7 @@ module Analytics
     # A referenced record inside event properties: a type + id and nothing but
     # reference bookkeeping — no name/title (those render as a plain label) and
     # no snapshot columns.
-    REFERENCE_KEYS = %w[type id record_type record_id action blob_id changes].freeze
+    REFERENCE_KEYS = %w[type id record_type record_id action blob_id changes attributes].freeze
 
     def self.reference?(item)
       return false unless item.is_a?(Hash)

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -27,47 +27,6 @@
 
   <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
   <td data-label="Details" class="px-4 py-3 align-top text-gray-500">
-    <% if activity.extra_details? %>
-      <div class="space-y-1.5">
-        <% if activity.changes? %>
-          <ul class="space-y-1.5">
-            <% activity.changes_summary.each do |change| %>
-              <li>
-                <span class="font-medium text-gray-700"><%= change[:field] %></span>
-                <div class="mt-0.5 space-y-0.5 text-xs">
-                  <div class="flex flex-wrap items-baseline gap-1">
-                    <span class="text-gray-400">Before:</span>
-                    <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= change[:before] %></span>
-                  </div>
-                  <div class="flex flex-wrap items-baseline gap-1">
-                    <span class="text-gray-400">After:</span>
-                    <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
-                  </div>
-                </div>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-        <% activity.detail_rows.each do |row| %>
-          <div class="text-xs" style="padding-left: <%= row[:depth] * 12 %>px;">
-            <% if row[:label] %>
-              <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] %></span>
-            <% end %>
-            <% if row[:link] %>
-              <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
-              <% if row[:link][:path] %>
-                <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline" %>
-              <% else %>
-                <span class="text-gray-600"><%= row[:link][:text] %></span>
-              <% end %>
-            <% elsif row[:value] %>
-              <span class="text-gray-600"><%= row[:value] %></span>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <span class="text-gray-300">—</span>
-    <% end %>
+    <%= render "admin/ahoy_activities/event_details", activity: activity %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -1,0 +1,45 @@
+<%# Inline before/after + property rows for one Ahoy event. Shared by the admin
+    activities table's Details column and any record's inline change log, so both
+    read the same way. %>
+<% if activity.extra_details? %>
+  <div class="space-y-1.5">
+    <% if activity.changes? %>
+      <ul class="space-y-1.5">
+        <% activity.changes_summary.each do |change| %>
+          <li>
+            <span class="font-medium text-gray-700"><%= change[:field] %></span>
+            <div class="mt-0.5 space-y-0.5 text-xs">
+              <div class="flex flex-wrap items-baseline gap-1">
+                <span class="text-gray-400">Before:</span>
+                <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= change[:before] %></span>
+              </div>
+              <div class="flex flex-wrap items-baseline gap-1">
+                <span class="text-gray-400">After:</span>
+                <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
+              </div>
+            </div>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+    <% activity.detail_rows.each do |row| %>
+      <div class="text-xs" style="padding-left: <%= row[:depth] * 12 %>px;">
+        <% if row[:label] %>
+          <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] %></span>
+        <% end %>
+        <% if row[:link] %>
+          <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
+          <% if row[:link][:path] %>
+            <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline" %>
+          <% else %>
+            <span class="text-gray-600"><%= row[:link][:text] %></span>
+          <% end %>
+        <% elsif row[:value] %>
+          <span class="text-gray-600"><%= row[:value] %></span>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <span class="text-gray-300">—</span>
+<% end %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -27,8 +27,8 @@
         <% if row[:label] %>
           <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] %></span>
         <% end %>
+        <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
         <% if row[:link] %>
-          <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
           <% if row[:link][:path] %>
             <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline" %>
           <% else %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -34,8 +34,19 @@
           <% else %>
             <span class="text-gray-600"><%= row[:link][:text] %></span>
           <% end %>
+        <% elsif row[:change] %>
+          <div class="mt-0.5 space-y-0.5">
+            <div class="flex flex-wrap items-baseline gap-1">
+              <span class="text-gray-400">Before:</span>
+              <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= row[:change][:before] %></span>
+            </div>
+            <div class="flex flex-wrap items-baseline gap-1">
+              <span class="text-gray-400">After:</span>
+              <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= row[:change][:after] %></span>
+            </div>
+          </div>
         <% elsif row[:value] %>
-          <span class="text-gray-600"><%= row[:value] %></span>
+          <span class="<%= row[:emphasis] ? "font-semibold text-gray-900" : "text-gray-600" %>"><%= row[:value] %></span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -24,8 +24,8 @@
      expired ? "bg-blue-50! text-blue-500! border-blue-200!" : "bg-blue-100! text-blue-700! font-semibold border-blue-300!"
    end %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if back_path %>
       <%= link_to back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i>
@@ -37,8 +37,8 @@
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="text-2xl font-semibold text-gray-900 tracking-tight mb-1">Edit affiliation</h1>
-  <p class="text-sm text-gray-500 mb-6">
+  <h1 class="mb-1 text-2xl font-semibold tracking-tight text-gray-900">Edit affiliation</h1>
+  <p class="mb-6 text-sm text-gray-500">
     <%= @affiliation.person&.full_name %> at <%= @affiliation.organization&.name %>
   </p>
 
@@ -46,8 +46,8 @@
         url: affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
         method: :patch,
         html: { id: "affiliation_form", data: { turbo: false } } do |f| %>
-    <div class="bg-white rounded-lg p-6 space-y-5">
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="space-y-5 rounded-lg bg-white p-6">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <%= f.input :person_id,
               collection: @affiliation.person ? [ [ @affiliation.person.full_name, @affiliation.person.id ] ] : [],
               selected: @affiliation.person_id,
@@ -61,7 +61,7 @@
 
         <div class="flex items-start gap-4">
           <div>
-            <span class="block text-sm font-medium text-gray-700 mb-1">Primary contact</span>
+            <span class="mb-1 block text-sm font-medium text-gray-700">Primary contact</span>
             <%= render "affiliations/primary_contact_toggle", f: f %>
             <p class="mt-1 text-xs text-gray-500">Main contact for this org</p>
           </div>
@@ -76,7 +76,7 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
           <%= f.input :organization_id,
                 collection: @affiliation.organization ? [ [ @affiliation.organization.name, @affiliation.organization.id ] ] : [],
@@ -143,7 +143,7 @@
       <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>">
         <div class="flex flex-wrap items-start gap-4 rounded-lg border p-3 <%= row_bg %> <%= 'aff-ended' if expired %>"
              data-inactive-toggle-target="row">
-          <div class="flex-1 min-w-[200px]">
+          <div class="min-w-[200px] flex-1">
             <%= f.input :title,
                   as: :string,
                   label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
@@ -210,7 +210,7 @@
           <% end %>
 
           <button type="button"
-                  class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
+                  class="inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
                   data-action="edit-toggle#toggle">
             <i class="fa-solid fa-pen text-2xs"></i>
             <span data-edit-toggle-target="editLabel">Edit comments</span>
@@ -225,7 +225,7 @@
   <% delete_confirm = @affiliation.facilitator? ?
        "Removing this facilitator affiliation affects the organization's status with AWBW, which is calculated from facilitator affiliations and their start and end dates. Remove it?" :
        "Remove this affiliation?" %>
-  <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+  <div class="mt-6 flex items-center gap-3 border-t border-gray-200 pt-6">
     <%= button_to "Delete",
           affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
           method: :delete,
@@ -240,4 +240,9 @@
   </div>
 
   <%= render "shared/audit_info", resource: @affiliation %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @affiliation %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -6,7 +6,7 @@
 <%# Pages hand over decorated records as readily as models — resolve to the model
     the events were recorded against, the same way shared/_audit_info does. %>
 <% model = record.respond_to?(:object) ? record.object : record %>
-<% events = Ahoy::Event.where(resource_type: model.class.name, resource_id: model.id)
+<% events = Ahoy::Event.mutations.where(resource_type: model.class.name, resource_id: model.id)
                        .includes(:user).order(time: :desc) %>
 <div data-controller="dropdown" class="relative">
     <button type="button"

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -8,8 +8,7 @@
 <% model = record.respond_to?(:object) ? record.object : record %>
 <% events = Ahoy::Event.where(resource_type: model.class.name, resource_id: model.id)
                        .includes(:user).order(time: :desc) %>
-<% if events.any? %>
-  <div data-controller="dropdown" class="relative">
+<div data-controller="dropdown" class="relative">
     <button type="button"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"<%= dom_id(model, :activity) %>":"hidden"}]'
@@ -20,6 +19,11 @@
     <div id="<%= dom_id(model, :activity) %>"
          data-dropdown-target="content"
          class="mt-2 hidden space-y-2">
+      <% if events.empty? %>
+        <p class="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
+          No changes recorded yet.
+        </p>
+      <% end %>
       <% events.each do |event| %>
         <% action = event.name.split(".").first %>
         <div class="rounded-lg border border-gray-200 p-3 <%= { "create" => "bg-green-50", "destroy" => "bg-red-50" }.fetch(action, "bg-gray-50") %>">
@@ -37,4 +41,3 @@
       <% end %>
     </div>
   </div>
-<% end %>

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -3,18 +3,21 @@
     same details partial as the admin activities table, so a change reads
     identically wherever it's shown; that page remains the filterable full
     history, linked from shared/_audit_info. %>
-<% events = Ahoy::Event.where(resource_type: record.class.name, resource_id: record.id)
+<%# Pages hand over decorated records as readily as models — resolve to the model
+    the events were recorded against, the same way shared/_audit_info does. %>
+<% model = record.respond_to?(:object) ? record.object : record %>
+<% events = Ahoy::Event.where(resource_type: model.class.name, resource_id: model.id)
                        .includes(:user).order(time: :desc) %>
 <% if events.any? %>
   <div data-controller="dropdown" class="relative">
     <button type="button"
             data-action="dropdown#toggle"
-            data-dropdown-payload-param='[{"<%= dom_id(record, :activity) %>":"hidden"}]'
+            data-dropdown-payload-param='[{"<%= dom_id(model, :activity) %>":"hidden"}]'
             class="inline-flex cursor-pointer items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-700">
       Change log
       <i class="fa-solid fa-chevron-down h-3 w-3 text-gray-400"></i>
     </button>
-    <div id="<%= dom_id(record, :activity) %>"
+    <div id="<%= dom_id(model, :activity) %>"
          data-dropdown-target="content"
          class="mt-2 hidden space-y-2">
       <% events.each do |event| %>

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -1,0 +1,37 @@
+<%# Inline change log for one record, read from its Ahoy lifecycle events
+    (create/update/destroy tracked for every model by AhoyTrackable). Renders the
+    same details partial as the admin activities table, so a change reads
+    identically wherever it's shown; that page remains the filterable full
+    history, linked from shared/_audit_info. %>
+<% events = Ahoy::Event.where(resource_type: record.class.name, resource_id: record.id)
+                       .includes(:user).order(time: :desc) %>
+<% if events.any? %>
+  <div data-controller="dropdown" class="relative">
+    <button type="button"
+            data-action="dropdown#toggle"
+            data-dropdown-payload-param='[{"<%= dom_id(record, :activity) %>":"hidden"}]'
+            class="inline-flex cursor-pointer items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-700">
+      Change log
+      <i class="fa-solid fa-chevron-down h-3 w-3 text-gray-400"></i>
+    </button>
+    <div id="<%= dom_id(record, :activity) %>"
+         data-dropdown-target="content"
+         class="mt-2 hidden space-y-2">
+      <% events.each do |event| %>
+        <% action = event.name.split(".").first %>
+        <div class="rounded-lg border border-gray-200 p-3 <%= { "create" => "bg-green-50", "destroy" => "bg-red-50" }.fetch(action, "bg-gray-50") %>">
+          <div class="mb-1 flex items-center gap-2">
+            <span class="rounded-full px-2 py-0.5 text-xs font-medium <%= { "create" => "bg-green-100 text-green-700", "destroy" => "bg-red-100 text-red-700" }.fetch(action, "bg-blue-100 text-blue-700") %>">
+              <%= action.humanize %>
+            </span>
+            <span class="text-xs text-gray-500"><%= event.time&.in_time_zone&.strftime("%B %d, %Y at %I:%M %p") %></span>
+            <span class="text-xs text-gray-400">
+              by <%= event.user&.full_name.presence || event.properties["source"] || "Unknown" %>
+            </span>
+          </div>
+          <%= render "admin/ahoy_activities/event_details", activity: event.decorate %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -8,7 +8,12 @@
 <% model = record.respond_to?(:object) ? record.object : record %>
 <% events = Ahoy::Event.mutations.where(resource_type: model.class.name, resource_id: model.id)
                        .includes(:user).order(time: :desc) %>
-<div data-controller="dropdown" class="relative">
+<% if events.empty? %>
+  <%# Said plainly rather than left out: an absent log reads as "this page hasn't
+      got one", which is a different thing from "nothing has happened yet". %>
+  <span class="text-sm font-medium text-gray-400">Change log empty</span>
+<% else %>
+  <div data-controller="dropdown" class="relative">
     <button type="button"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"<%= dom_id(model, :activity) %>":"hidden"}]'
@@ -19,11 +24,6 @@
     <div id="<%= dom_id(model, :activity) %>"
          data-dropdown-target="content"
          class="mt-2 hidden space-y-2">
-      <% if events.empty? %>
-        <p class="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
-          No changes recorded yet.
-        </p>
-      <% end %>
       <% events.each do |event| %>
         <% action = event.name.split(".").first %>
         <div class="rounded-lg border border-gray-200 p-3 <%= { "create" => "bg-green-50", "destroy" => "bg-red-50" }.fetch(action, "bg-gray-50") %>">
@@ -41,3 +41,4 @@
       <% end %>
     </div>
   </div>
+<% end %>

--- a/app/views/application/_activity_log.html.erb
+++ b/app/views/application/_activity_log.html.erb
@@ -7,7 +7,11 @@
     the events were recorded against, the same way shared/_audit_info does. %>
 <% model = record.respond_to?(:object) ? record.object : record %>
 <% events = Ahoy::Event.mutations.where(resource_type: model.class.name, resource_id: model.id)
-                       .includes(:user).order(time: :desc) %>
+                       .includes(:user).order(time: :desc).to_a %>
+<%# Resolve every record the events reference up front, one query per type, the
+    same way the admin activities table does — otherwise each reference on each
+    event costs its own lookup. %>
+<% record_cache = Analytics::EventReferenceLoader.new(events).records %>
 <% if events.empty? %>
   <%# Said plainly rather than left out: an absent log reads as "this page hasn't
       got one", which is a different thing from "nothing has happened yet". %>
@@ -36,7 +40,8 @@
               by <%= event.user&.full_name.presence || event.properties["source"] || "Unknown" %>
             </span>
           </div>
-          <%= render "admin/ahoy_activities/event_details", activity: event.decorate %>
+          <%= render "admin/ahoy_activities/event_details",
+                     activity: event.decorate(context: { record_cache: record_cache }) %>
         </div>
       <% end %>
     </div>

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -14,12 +14,13 @@
           <%= render "form" %>
         </div>
       </div>
+
+      <%= render "shared/audit_info", resource: @category_type %>
+      <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+        <div class="mt-4 flex justify-end">
+          <%= render "application/activity_log", record: @category_type %>
+        </div>
+      <% end %>
     </div>
   </div>
-  <%= render "shared/audit_info", resource: @category_type %>
-  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
-    <div class="mt-4 flex justify-end">
-      <%= render "application/activity_log", record: @category_type %>
-    </div>
-  <% end %>
 </div>

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-5xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Category Types", category_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", category_type_path(@category_type), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category_type.class.model_name.human.downcase %></h1>
+      <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit <%= @category_type.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">
@@ -16,4 +16,10 @@
       </div>
     </div>
   </div>
+  <%= render "shared/audit_info", resource: @category_type %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @category_type %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -145,4 +145,9 @@
   </div>
 
   <%= render "shared/audit_info", resource: @ce_registration %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @ce_registration %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/continuing_education_registrations/show.html.erb
+++ b/app/views/continuing_education_registrations/show.html.erb
@@ -5,9 +5,9 @@
 <% payment = ce.payment_status_badge %>
 <% certificate = ce.certificate_badge %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back to the CE registrations index + Edit / Home. %>
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> CE registrations
     <% end %>
@@ -35,27 +35,27 @@
 
       <dl class="grid grid-cols-1 gap-px bg-gray-100 sm:grid-cols-2">
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">License</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">License</dt>
           <dd class="mt-1 text-sm font-medium text-gray-900"><%= ce.license_label %></dd>
         </div>
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Issuing state</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">Issuing state</dt>
           <dd class="mt-1 text-sm text-gray-900"><%= license&.issuing_state.presence || "—" %></dd>
         </div>
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">License expires</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">License expires</dt>
           <dd class="mt-1 text-sm text-gray-900"><%= license&.expires_on&.to_fs(:long) || "—" %></dd>
         </div>
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Hours</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">Hours</dt>
           <dd class="mt-1 text-sm text-gray-900 tabular-nums"><%= number_with_precision(@ce_registration.hours, precision: 1, strip_insignificant_zeros: true) %></dd>
         </div>
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Payment</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">Payment</dt>
           <dd class="mt-1"><%= render "shared/badge", label: payment.label, classes: payment.classes, icon: payment.icon %></dd>
         </div>
         <div class="bg-white px-4 py-3">
-          <dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Certificate</dt>
+          <dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">Certificate</dt>
           <dd class="mt-1"><%= render "shared/badge", label: certificate.label, classes: certificate.classes, icon: certificate.icon %></dd>
         </div>
       </dl>
@@ -75,9 +75,9 @@
           <% @ce_registration.comments.each do |comment| %>
             <li class="px-4 py-3">
               <% if comment.topic.present? %>
-                <p class="text-xs font-semibold uppercase tracking-wide text-gray-400"><%= comment.topic %></p>
+                <p class="text-xs font-semibold tracking-wide text-gray-400 uppercase"><%= comment.topic %></p>
               <% end %>
-              <p class="text-sm text-gray-700 whitespace-pre-line"><%= comment.body %></p>
+              <p class="text-sm whitespace-pre-line text-gray-700"><%= comment.body %></p>
             </li>
           <% end %>
         </ul>
@@ -86,4 +86,9 @@
   </div>
 
   <%= render "shared/audit_info", resource: @ce_registration %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @ce_registration %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -64,4 +64,9 @@
 
   <%= render "form", event_registration: @event_registration %>
   <%= render "shared/audit_info", resource: @event_registration %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "activity_log", record: @event_registration %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back link + secondary links, matching the event pages. When the
       admin arrived from the bulk payments page, the back link returns there with
       the originating submission re-expanded instead of the registrants roster. %>
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if params[:return_to] == "bulk_payments" %>
       <%# Re-expand the originating submission's row and scroll to it on return. %>
       <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -66,7 +66,7 @@
   <%= render "shared/audit_info", resource: @event_registration %>
   <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
     <div class="mt-4 flex justify-end">
-      <%= render "activity_log", record: @event_registration %>
+      <%= render "application/activity_log", record: @event_registration %>
     </div>
   <% end %>
 </div>

--- a/app/views/features/edit.html.erb
+++ b/app/views/features/edit.html.erb
@@ -1,9 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="w-full max-w-3xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="mx-auto w-full max-w-3xl rounded-xl border border-gray-200 bg-white p-6 shadow">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Features & tips", features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "View", feature_path(@feature), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit feature</h1>
+  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit feature</h1>
   <%= render "form", feature: @feature %>
+  <%= render "shared/audit_info", resource: @feature %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @feature %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -290,4 +290,10 @@
   <% end %>
     </div>
   </div>
+  <%= render "shared/audit_info", resource: @form %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @form %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/membership_invoices/edit.html.erb
+++ b/app/views/membership_invoices/edit.html.erb
@@ -1,24 +1,30 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% person = @membership_invoice.person %>
 
-<div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-4 shadow sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="text-2xl font-bold mb-1">Edit membership invoice</h1>
-  <p class="text-sm text-gray-500 mb-6"><%= person.full_name %> &middot; <%= @membership_invoice.decorate.period_range %></p>
+  <h1 class="mb-1 text-2xl font-bold">Edit membership invoice</h1>
+  <p class="mb-6 text-sm text-gray-500"><%= person.full_name %> &middot; <%= @membership_invoice.decorate.period_range %></p>
 
   <%= simple_form_for @membership_invoice do |f| %>
     <%= render "fields", f: f, include_end_date: true %>
 
-    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+    <div class="mt-6 flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", person_memberships_path(person), class: "btn btn-secondary-outline" %>
         <%= f.button :submit, "Save invoice", class: "btn btn-primary" %>
       </div>
+    </div>
+  <% end %>
+  <%= render "shared/audit_info", resource: @membership_invoice %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @membership_invoice %>
     </div>
   <% end %>
 </div>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-4 shadow sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="text-2xl font-bold mb-1">Membership cost</h1>
-  <p class="text-sm text-gray-500 mb-6"><%= @person.full_name %></p>
+  <h1 class="mb-1 text-2xl font-bold">Membership cost</h1>
+  <p class="mb-6 text-sm text-gray-500"><%= @person.full_name %></p>
 
   <%= simple_form_for @membership do |f| %>
     <%= render "shared/errors", resource: f.object %>
@@ -19,11 +19,17 @@
           hint: "Leave blank for the standard cost (#{dollars_from_cents(Membership::ANNUAL_COST_CENTS)}). Applies to future membership invoices only - those already created keep the price they were billed at.",
           input_html: { min: 0, step: 0.01, placeholder: "Standard", class: "bg-white" } %>
 
-    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+    <div class="mt-6 flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", person_memberships_path(@person), class: "btn btn-secondary-outline" %>
         <%= f.button :submit, "Save cost", class: "btn btn-primary" %>
       </div>
+    </div>
+  <% end %>
+  <%= render "shared/audit_info", resource: @membership %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @membership %>
     </div>
   <% end %>
 </div>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> rounded-xl border border-gray-200 p-6 shadow">
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
           <div class="mb-2">
             <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -7,18 +7,23 @@
             <% end %>
           </div>
         <% end %>
-        <div class="flex flex-wrap justify-end gap-2 mb-4">
+        <div class="mb-4 flex flex-wrap justify-end gap-2">
           <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "Profile", organization_path(@organization), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
-        <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
+        <h1 class="mb-3 text-3xl font-semibold tracking-tight text-gray-900">
           Edit Organization: <%= truncate(@organization.name, length: 40) %>
         </h1>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @organization %>
+            <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+              <div class="mt-4 flex justify-end">
+                <%= render "application/activity_log", record: @organization %>
+              </div>
+            <% end %>
           </div>
         </div>
 </div>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -52,6 +52,11 @@
             </div>
             <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
               <%= render "associated_records", person: @person %>
+              <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+                <div class="mt-4 flex justify-end">
+                  <%= render "application/activity_log", record: @person %>
+                </div>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -45,6 +45,11 @@
           <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @person %>
+            <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+              <div class="mt-4 flex justify-end">
+                <%= render "application/activity_log", record: @person %>
+              </div>
+            <% end %>
           </div>
           <div class="rounded bg-white p-6">
             <div class="mb-2 font-semibold text-gray-700">
@@ -52,11 +57,6 @@
             </div>
             <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
               <%= render "associated_records", person: @person %>
-              <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
-                <div class="mt-4 flex justify-end">
-                  <%= render "application/activity_log", record: @person %>
-                </div>
-              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -1,23 +1,29 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-6 shadow">
   <div class="mb-6">
     <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>
 
-  <div class="flex items-center gap-3 mb-6">
+  <div class="mb-6 flex items-center gap-3">
     <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
       <i class="fa-solid fa-id-card"></i>
     </span>
     <div>
       <h1 class="text-2xl font-semibold text-gray-900">Edit license</h1>
-      <p class="text-gray-600 mt-1">Update this registrant's professional license</p>
+      <p class="mt-1 text-gray-600">Update this registrant's professional license</p>
     </div>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+  <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
     <%= render "form", professional_license: @professional_license %>
   </div>
+  <%= render "shared/audit_info", resource: @professional_license %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @professional_license %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -100,4 +100,9 @@
   <%= render "agreement_history", scholarship: @scholarship %>
 
   <%= render "shared/audit_info", resource: @scholarship %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @scholarship %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/staff_tags/show.html.erb
+++ b/app/views/staff_tags/show.html.erb
@@ -51,6 +51,11 @@
       </div>
 
       <%= render "shared/audit_info", resource: @staff_tag %>
+      <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+        <div class="mt-4 flex justify-end">
+          <%= render "application/activity_log", record: @staff_tag %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/topic_subscription_types/edit.html.erb
+++ b/app/views/topic_subscription_types/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow">
   <div class="mb-6">
     <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit topic</h1>
+  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit topic</h1>
   <%= render "form", submit_label: "Save changes" %>
 
   <%# Archive/restore and delete moved off the index — the topic's actions live on
@@ -39,4 +39,10 @@
       <p class="mt-2 text-xs text-gray-500">Topics with subscriptions can't be deleted — archive to retire without losing them.</p>
     <% end %>
   </div>
+  <%= render "shared/audit_info", resource: @topic_subscription_type %>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @topic_subscription_type %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/topic_subscriptions/edit.html.erb
+++ b/app/views/topic_subscriptions/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow">
   <div class="mb-6">
     <%= render "eyebrow" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit subscription</h1>
+  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit subscription</h1>
   <%= render "form", submit_label: "Save changes" %>
 
   <%# These actions redirect too, so they carry the same origin params as the form. %>
@@ -30,4 +30,9 @@
       Remove
     <% end %>
   </div>
+  <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
+    <div class="mt-4 flex justify-end">
+      <%= render "application/activity_log", record: @topic_subscription %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/topic_subscriptions/edit.html.erb
+++ b/app/views/topic_subscriptions/edit.html.erb
@@ -30,6 +30,7 @@
       Remove
     <% end %>
   </div>
+  <%= render "shared/audit_info", resource: @topic_subscription %>
   <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
     <div class="mt-4 flex justify-end">
       <%= render "application/activity_log", record: @topic_subscription %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2194,3 +2194,26 @@
     subscription form, filter the subscriptions list by organization, and see it
     in the new Organization column. It's optional — leave it blank for a topic
     that isn't tied to any organization.
+
+- name: "Change log on every record's edit page"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-22
+  pr_number: 2245
+  summary: >-
+    Every edit page now shows a change log under its edit history: a plain-language
+    record of what changed, who changed it, and when — including nested records,
+    attached files, and rich text. When nothing has happened yet, it says so rather
+    than showing nothing.
+  description: >-
+    The change log answers "what happened to this record?" It captures real edits
+    only — plain browsing (views, prints, searches, filters, downloads) is kept out —
+    and reads each entry in plain language: what a save did to the record itself, to
+    its nested child records, to attached files (shown by name), and to rich text
+    that previously passed through unrecorded. A nested record reports what it
+    contained, not just that it changed. It sits in the same spot on every page,
+    under the edit history, and is available on the organization, continuing
+    education, staff tag, and category type pages, among others. Admin-only.
+  pro_tips:
+    - "Only mutations show: opening or printing a record never clutters its log."
+    - "Deleting a child or attachment is recorded too — the entry keeps the name even after the file is gone."

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -47,10 +47,15 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.changes_summary).to match_array(
         [
           { field: "Display name", before: "Old", after: "New" },
-          { field: "Active", before: "No", after: "Yes" },
-          { field: "Note", before: "(empty)", after: "(empty)" }
+          { field: "Active", before: "No", after: "Yes" }
         ]
       )
+    end
+
+    it "leaves out a field that was blank before and after" do
+      event = decorate("changes" => { "note" => { "before" => nil, "after" => "" } })
+
+      expect(event.changes_summary).to eq([])
     end
 
     it "is empty when the event has no changes" do
@@ -180,6 +185,56 @@ RSpec.describe Ahoy::EventDecorator do
       rows = event.decorate.detail_rows
 
       expect(rows.map { |row| row[:link] }.compact.first[:text]).to eq("SectorableItem ##{tagging.id}")
+    end
+  end
+
+  describe "detail rows for a nested record" do
+    let(:organization) { create(:organization) }
+
+    def event_with(association_changes)
+      create(
+        :ahoy_event,
+        name: "update.organization",
+        resource_type: "Organization",
+        resource_id: organization.id,
+        properties: {
+          resource_type: "Organization", resource_id: organization.id,
+          association_changes: association_changes
+        }
+      ).decorate
+    end
+
+    it "reads the topic first and marks it as the heading" do
+      rows = event_with(comments: [ {
+        action: "added", type: "Comment", id: 1,
+        attributes: { "body" => "Left a voicemail", "topic" => "Payment" }
+      } ]).detail_rows
+
+      labelled = rows.select { |row| row[:value].present? }
+      expect(labelled.map { |row| row[:label] }).to eq([ "Topic", "Body" ])
+      expect(labelled.first[:emphasis]).to be(true)
+      expect(labelled.last[:emphasis]).to be_nil
+    end
+
+    it "renders a diff as before then after, whatever order it was stored in" do
+      rows = event_with(addresses: [ {
+        action: "updated", type: "Address", id: 1,
+        changes: { "city" => { "after" => "Long Beach", "before" => "Lake Lamar" } }
+      } ]).detail_rows
+
+      change = rows.find { |row| row[:change] }
+      expect(change[:label]).to eq("City")
+      expect(change[:change]).to eq({ before: "Lake Lamar", after: "Long Beach" })
+    end
+
+    it "leaves out a field that was blank before and after" do
+      rows = event_with(addresses: [ {
+        action: "updated", type: "Address", id: 1,
+        changes: { "phone" => { "before" => nil, "after" => "" },
+                   "city" => { "before" => "Lake Lamar", "after" => "Long Beach" } }
+      } ]).detail_rows
+
+      expect(rows.filter_map { |row| row[:label] if row[:change] }).to eq([ "City" ])
     end
   end
 end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -236,5 +236,26 @@ RSpec.describe Ahoy::EventDecorator do
 
       expect(rows.filter_map { |row| row[:label] if row[:change] }).to eq([ "City" ])
     end
+
+    it "reads an added attachment as its filename" do
+      rows = event_with(avatar_attachment: [ {
+        action: "added", type: "ActiveStorage::Attachment", filename: "headshot.png"
+      } ]).detail_rows
+
+      attachment = rows.last
+      expect(attachment[:action]).to eq("added")
+      expect(attachment[:value]).to eq("headshot.png")
+      expect(rows.map { |row| row[:value] }).not_to include(a_string_including("ActiveStorage"))
+    end
+
+    it "reads a removed attachment as the removal, the file being gone" do
+      rows = event_with(avatar_attachment: [ {
+        action: "removed", type: "ActiveStorage::Attachment"
+      } ]).detail_rows
+
+      attachment = rows.last
+      expect(attachment[:action]).to eq("removed")
+      expect(attachment[:value]).to be_nil
+    end
   end
 end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -160,4 +160,26 @@ RSpec.describe Ahoy::EventDecorator do
       expect(queries).to eq(0)
     end
   end
+
+  describe "a reference whose record has a broken label" do
+    it "falls back to the type and id instead of raising" do
+      organization = create(:organization)
+      tagging = create(:sectorable_item, sectorable: organization, sector: create(:sector))
+      allow_any_instance_of(SectorableItem).to receive(:title).and_raise(NoMethodError)
+      event = create(
+        :ahoy_event,
+        name: "update.organization",
+        resource_type: "Organization",
+        resource_id: organization.id,
+        properties: {
+          resource_type: "Organization", resource_id: organization.id,
+          association_changes: { sectorable_items: [ { action: "added", type: "SectorableItem", id: tagging.id } ] }
+        }
+      )
+
+      rows = event.decorate.detail_rows
+
+      expect(rows.map { |row| row[:link] }.compact.first[:text]).to eq("SectorableItem ##{tagging.id}")
+    end
+  end
 end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -248,7 +248,17 @@ RSpec.describe Ahoy::EventDecorator do
       expect(rows.map { |row| row[:value] }).not_to include(a_string_including("ActiveStorage"))
     end
 
-    it "reads a removed attachment as the removal, the file being gone" do
+    it "reads a removed attachment as its name" do
+      rows = event_with(avatar_attachment: [ {
+        action: "removed", type: "ActiveStorage::Attachment", filename: "headshot.png"
+      } ]).detail_rows
+
+      attachment = rows.last
+      expect(attachment[:action]).to eq("removed")
+      expect(attachment[:value]).to eq("headshot.png")
+    end
+
+    it "falls back to the action alone for an older entry with no filename" do
       rows = event_with(avatar_attachment: [ {
         action: "removed", type: "ActiveStorage::Attachment"
       } ]).detail_rows

--- a/spec/models/ahoy/event_spec.rb
+++ b/spec/models/ahoy/event_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Ahoy::Event do
+  describe ".mutations" do
+    it "keeps the events that changed the record" do
+      %w[create.workshop update.workshop destroy.workshop].each do |name|
+        create(:ahoy_event, name: name)
+      end
+
+      expect(described_class.mutations.pluck(:name))
+        .to contain_exactly("create.workshop", "update.workshop", "destroy.workshop")
+    end
+
+    it "leaves out reads of the record" do
+      %w[view.workshop print.workshop download.workshop search.workshops filter.workshops].each do |name|
+        create(:ahoy_event, name: name)
+      end
+
+      expect(described_class.mutations).to be_empty
+    end
+  end
+end

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe AhoyTrackable do
+  # Events are buffered here and written by ApplicationController's after_action,
+  # so a model-level spec reads the buffer rather than the table.
+  def buffered
+    Analytics::LifecycleBuffer.store
+  end
+
+  def event_named(name)
+    buffered.find { |event| event[:name] == name }
+  end
+
+  before do
+    Current.user = create(:user)
+    Analytics::LifecycleBuffer.store.clear
+  end
+
+  after { Current.user = nil }
+
+  describe "rich text" do
+    let(:event) { create(:event) }
+
+    it "records a rich text edit as a change on the record's own event" do
+      Analytics::LifecycleBuffer.store.clear
+
+      event.update!(rhino_description: "<p>Bring a friend</p>", title: "Renamed")
+
+      changes = event_named("update.event")[:properties][:changes]
+      expect(changes["rhino_description"]).to eq({ before: "", after: "Bring a friend" })
+      expect(changes["title"]).to be_present
+    end
+
+    it "stores the plain text rather than the markup" do
+      Analytics::LifecycleBuffer.store.clear
+
+      event.update!(rhino_description: "<p>Bring <strong>a friend</strong></p>")
+
+      after_text = event_named("update.event")[:properties][:changes]["rhino_description"][:after]
+      expect(after_text).to eq("Bring a friend")
+      expect(after_text).not_to include("<")
+    end
+
+    it "records an edit that touches nothing but the rich text" do
+      event.update!(rhino_description: "<p>First</p>")
+      Analytics::LifecycleBuffer.store.clear
+
+      event.update!(rhino_description: "<p>Second</p>")
+
+      expect(event_named("update.event")[:properties][:changes]["rhino_description"])
+        .to eq({ before: "First", after: "Second" })
+    end
+
+    it "truncates a long body to a preview" do
+      Analytics::LifecycleBuffer.store.clear
+
+      event.update!(rhino_description: "<p>#{"word " * 200}</p>")
+
+      after_text = event_named("update.event")[:properties][:changes]["rhino_description"][:after]
+      expect(after_text.length).to eq(AhoyTrackable::RICH_TEXT_PREVIEW_LIMIT)
+      expect(after_text).to end_with("...")
+    end
+
+    it "records nothing when the rich text is saved unchanged" do
+      event.update!(rhino_description: "<p>Same</p>")
+      Analytics::LifecycleBuffer.store.clear
+
+      event.update!(rhino_description: "<p>Same</p>")
+
+      expect(event_named("update.event")).to be_nil
+    end
+  end
+end

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -106,6 +106,17 @@ RSpec.describe AhoyTrackable do
       removed = event_named("update.person")[:properties][:association_changes][:professional_licenses].first
       expect(removed).to include(action: "removed", id: license.id, type: "ProfessionalLicense")
     end
+
+    it "records a staff tag given to a person on the person's own event" do
+      person = create(:person)
+      tag = create(:staff_tag)
+      Analytics::LifecycleBuffer.store.clear
+
+      person.update!(staff_taggings_attributes: [ { staff_tag_id: tag.id } ])
+
+      tagged = event_named("update.person")[:properties][:association_changes][:staff_taggings].first
+      expect(tagged).to include(action: "added", type: "StaffTagging")
+    end
   end
 
   describe "attachments" do

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -194,7 +194,18 @@ RSpec.describe AhoyTrackable do
       person.update!(avatar: Rack::Test::UploadedFile.new(Rails.root.join("app/assets/images/missing.png"), "image/png"))
 
       attached = event_named("update.person")[:properties][:association_changes][:avatar_attachment].first
-      expect(attached).to include(action: "added", type: "ActiveStorage::Attachment")
+      expect(attached).to include(action: "added", type: "ActiveStorage::Attachment", filename: "missing.png")
+    end
+
+    it "keeps the name of a removed attachment, the blob being gone afterwards" do
+      person = create(:person)
+      person.update!(avatar: Rack::Test::UploadedFile.new(Rails.root.join("app/assets/images/missing.png"), "image/png"))
+      Analytics::LifecycleBuffer.store.clear
+
+      person.update!(avatar: nil)
+
+      removed = event_named("update.person")[:properties][:association_changes][:avatar_attachment].first
+      expect(removed).to include(action: "removed", filename: "missing.png")
     end
   end
 end

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -153,6 +153,39 @@ RSpec.describe AhoyTrackable do
     end
   end
 
+  describe "membership changes" do
+    it "records an added record as the parent's own update event" do
+      person = create(:person)
+      category = create(:category)
+      Analytics::LifecycleBuffer.store.clear
+
+      person.track_membership_changes(categories: { added: [ category ], removed: [] })
+
+      added = event_named("update.person")[:properties][:association_changes][:categories].first
+      expect(added).to eq({ action: "added", type: "Category", id: category.id })
+    end
+
+    it "records a removed record" do
+      person = create(:person)
+      category = create(:category)
+      Analytics::LifecycleBuffer.store.clear
+
+      person.track_membership_changes(categories: { added: [], removed: [ category ] })
+
+      removed = event_named("update.person")[:properties][:association_changes][:categories].first
+      expect(removed).to include(action: "removed", type: "Category", id: category.id)
+    end
+
+    it "records nothing when nothing moved" do
+      person = create(:person)
+      Analytics::LifecycleBuffer.store.clear
+
+      person.track_membership_changes(categories: { added: [], removed: [] }, sectors: nil)
+
+      expect(event_named("update.person")).to be_nil
+    end
+  end
+
   describe "attachments" do
     it "records an added attachment on the record's event" do
       person = create(:person)

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe AhoyTrackable do
     end
   end
 
+  describe "blank-to-blank changes" do
+    it "records nothing for a field that was blank before and after" do
+      organization = create(:organization, email: nil)
+      Analytics::LifecycleBuffer.store.clear
+
+      organization.update!(email: "", name: "Renamed")
+
+      changes = event_named("update.organization")[:properties][:changes]
+      expect(changes.keys).to contain_exactly("name")
+    end
+  end
+
   describe "nested records" do
     it "records an added nested record on the parent's event" do
       registration = create(:event_registration)

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe AhoyTrackable do
       expect(added).to include(action: "added", type: "Comment")
     end
 
+    it "records what an added nested record said, once it has an id" do
+      registration = create(:event_registration)
+      Analytics::LifecycleBuffer.store.clear
+
+      registration.update!(comments_attributes: [ { body: "Left a voicemail", topic: "Payment" } ])
+
+      added = event_named("update.event_registration")[:properties][:association_changes][:comments].first
+      expect(added[:attributes]).to eq({ "body" => "Left a voicemail", "topic" => "Payment" })
+      expect(added[:id]).to eq(registration.comments.reload.first.id)
+    end
+
+    it "leaves keys and timestamps out of what an added record said" do
+      registration = create(:event_registration)
+      Analytics::LifecycleBuffer.store.clear
+
+      registration.update!(comments_attributes: [ { body: "Left a voicemail" } ])
+
+      added = event_named("update.event_registration")[:properties][:association_changes][:comments].first
+      expect(added[:attributes].keys).to contain_exactly("body")
+    end
+
     it "records an edited nested record with its field changes" do
       person = create(:person)
       license = create(:professional_license, person: person, number: "LIC-1")
@@ -105,6 +126,7 @@ RSpec.describe AhoyTrackable do
 
       removed = event_named("update.person")[:properties][:association_changes][:professional_licenses].first
       expect(removed).to include(action: "removed", id: license.id, type: "ProfessionalLicense")
+      expect(removed[:attributes]).to include("number" => license.number)
     end
 
     it "records a staff tag given to a person on the person's own event" do

--- a/spec/models/concerns/ahoy_trackable_spec.rb
+++ b/spec/models/concerns/ahoy_trackable_spec.rb
@@ -70,4 +70,53 @@ RSpec.describe AhoyTrackable do
       expect(event_named("update.event")).to be_nil
     end
   end
+
+  describe "nested records" do
+    it "records an added nested record on the parent's event" do
+      registration = create(:event_registration)
+      Analytics::LifecycleBuffer.store.clear
+
+      registration.update!(comments_attributes: [ { body: "Called the registrant" } ])
+
+      added = event_named("update.event_registration")[:properties][:association_changes][:comments].first
+      expect(added).to include(action: "added", type: "Comment")
+    end
+
+    it "records an edited nested record with its field changes" do
+      person = create(:person)
+      license = create(:professional_license, person: person, number: "LIC-1")
+      person.professional_licenses.load
+      Analytics::LifecycleBuffer.store.clear
+
+      person.update!(professional_licenses_attributes: [ { id: license.id, number: "LIC-2" } ])
+
+      edited = event_named("update.person")[:properties][:association_changes][:professional_licenses].first
+      expect(edited).to include(action: "updated")
+      expect(edited[:changes]["number"]).to eq({ before: "LIC-1", after: "LIC-2" })
+    end
+
+    it "records a removed nested record" do
+      person = create(:person)
+      license = create(:professional_license, person: person)
+      person.professional_licenses.load
+      Analytics::LifecycleBuffer.store.clear
+
+      person.update!(professional_licenses_attributes: [ { id: license.id, _destroy: "1" } ])
+
+      removed = event_named("update.person")[:properties][:association_changes][:professional_licenses].first
+      expect(removed).to include(action: "removed", id: license.id, type: "ProfessionalLicense")
+    end
+  end
+
+  describe "attachments" do
+    it "records an added attachment on the record's event" do
+      person = create(:person)
+      Analytics::LifecycleBuffer.store.clear
+
+      person.update!(avatar: Rack::Test::UploadedFile.new(Rails.root.join("app/assets/images/missing.png"), "image/png"))
+
+      attached = event_named("update.person")[:properties][:association_changes][:avatar_attachment].first
+      expect(attached).to include(action: "added", type: "ActiveStorage::Attachment")
+    end
+  end
 end

--- a/spec/models/sectorable_item_spec.rb
+++ b/spec/models/sectorable_item_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe SectorableItem do
     it { should validate_uniqueness_of(:sector_id).scoped_to([ :sectorable_type, :sectorable_id ]).with_message("has already been added") }
   end
 
+  describe "#title" do
+    it "reads as the sector for a sectorable with no title of its own" do
+      tagging = create(:sectorable_item, sectorable: create(:organization), sector: create(:sector, name: "Housing"))
+
+      expect(tagging.title).to eq("Housing")
+    end
+
+    it "composes the log's title and windows type for a workshop log" do
+      log = create(:workshop_log)
+      tagging = create(:sectorable_item, sectorable: log)
+
+      expect(tagging.title).to start_with(log.title.to_s)
+    end
+  end
+
   # it 'is valid with valid attributes' do
   #   # Note: Factory needs associations uncommented for create
   #   # expect(build(:sectorable_item)).to be_valid

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "/affiliations", type: :request do
     context "as an admin" do
       before { sign_in admin }
 
+      it_behaves_like "a page with a change log" do
+        let(:record) { affiliation }
+        let(:page_path) { edit_affiliation_path(affiliation) }
+      end
+
       it "renders the edit form" do
         get edit_affiliation_path(affiliation)
         expect(response).to be_successful

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
       let(:page_path) { edit_continuing_education_registration_path(ce_registration) }
     end
 
+    it_behaves_like "a page with a change log" do
+      let(:record) { ce_registration }
+      let(:page_path) { continuing_education_registration_path(ce_registration) }
+    end
+
     describe "a transferred-in registration (two-record CE model, #1944)" do
       let(:source) { create(:event_registration, event: event) }
       let(:transferred_in) do

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
   describe "as an admin" do
     before { sign_in admin }
 
+    it_behaves_like "a page with a change log" do
+      let(:record) { ce_registration }
+      let(:page_path) { edit_continuing_education_registration_path(ce_registration) }
+    end
+
     describe "a transferred-in registration (two-record CE model, #1944)" do
       let(:source) { create(:event_registration, event: event) }
       let(:transferred_in) do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -483,10 +483,11 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include("attended")
       end
 
-      it "omits the change log when the record has no tracked activity" do
+      it "says so rather than disappearing when the record has no tracked activity" do
         get edit_event_registration_path(existing_registration)
 
-        expect(response.body).not_to include("Change log")
+        expect(response.body).to include("Change log")
+        expect(response.body).to include("No changes recorded yet")
       end
 
       it "shows a Delete button for a deletable registration" do

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -462,6 +462,33 @@ RSpec.describe "EventRegistrations", type: :request do
         )
       end
 
+      it "shows the record's tracked changes in a change log" do
+        create(
+          :ahoy_event,
+          name: "update.event_registration",
+          resource_type: "EventRegistration",
+          resource_id: existing_registration.id,
+          properties: {
+            resource_type: "EventRegistration", resource_id: existing_registration.id,
+            changes: { "status" => { "before" => "registered", "after" => "attended" } }
+          }
+        )
+
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include("Change log")
+        # Rendered by the shared details partial: humanized field, before → after.
+        expect(response.body).to include("Status")
+        expect(response.body).to include("registered")
+        expect(response.body).to include("attended")
+      end
+
+      it "omits the change log when the record has no tracked activity" do
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).not_to include("Change log")
+      end
+
       it "shows a Delete button for a deletable registration" do
         get edit_event_registration_path(existing_registration)
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -483,6 +483,25 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include("attended")
       end
 
+      it "shows what a nested record said, not just that one changed" do
+        create(
+          :ahoy_event,
+          name: "update.event_registration",
+          resource_type: "EventRegistration",
+          resource_id: existing_registration.id,
+          properties: {
+            resource_type: "EventRegistration", resource_id: existing_registration.id,
+            association_changes: {
+              comments: [ { action: "added", type: "Comment", id: 1, attributes: { "body" => "Left a voicemail" } } ]
+            }
+          }
+        )
+
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include("Left a voicemail")
+      end
+
       it "says the log is empty rather than disappearing when the record has no tracked activity" do
         get edit_event_registration_path(existing_registration)
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -483,11 +483,10 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include("attended")
       end
 
-      it "says so rather than disappearing when the record has no tracked activity" do
+      it "says the log is empty rather than disappearing when the record has no tracked activity" do
         get edit_event_registration_path(existing_registration)
 
-        expect(response.body).to include("Change log")
-        expect(response.body).to include("No changes recorded yet")
+        expect(response.body).to include("Change log empty")
       end
 
       it "shows a Delete button for a deletable registration" do

--- a/spec/requests/membership_invoices_spec.rb
+++ b/spec/requests/membership_invoices_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "MembershipInvoices", type: :request do
       end_date: start_date + 1.year - 1.day)
   end
 
+  describe "GET /membership_invoices/:id/edit" do
+    before { sign_in admin }
+
+    it_behaves_like "a page with a change log" do
+      let(:record) { term_for("Renewal") }
+      let(:page_path) { edit_membership_invoice_path(record) }
+    end
+  end
+
   describe "GET /membership_invoices" do
     it "is not available to a signed-out visitor" do
       get membership_invoices_path

--- a/spec/requests/organizations_change_log_spec.rb
+++ b/spec/requests/organizations_change_log_spec.rb
@@ -7,4 +7,26 @@ RSpec.describe "Organizations change log", type: :request do
     let(:record) { create(:organization) }
     let(:page_path) { edit_organization_path(record) }
   end
+
+  # Sector taggings are nested attributes on the org, so its change log
+  # references them — and reaching for their label used to raise.
+  it "renders a change log that references the org's sector taggings" do
+    organization = create(:organization)
+    tagging = create(:sectorable_item, sectorable: organization, sector: create(:sector, name: "Housing"))
+    create(
+      :ahoy_event,
+      name: "update.organization",
+      resource_type: "Organization",
+      resource_id: organization.id,
+      properties: {
+        resource_type: "Organization", resource_id: organization.id,
+        association_changes: { sectorable_items: [ { action: "added", type: "SectorableItem", id: tagging.id } ] }
+      }
+    )
+
+    get edit_organization_path(organization)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Housing")
+  end
 end

--- a/spec/requests/organizations_change_log_spec.rb
+++ b/spec/requests/organizations_change_log_spec.rb
@@ -13,6 +13,30 @@ RSpec.describe "Organizations change log", type: :request do
   it "renders a change log that references the org's sector taggings" do
     organization = create(:organization)
     tagging = create(:sectorable_item, sectorable: organization, sector: create(:sector, name: "Housing"))
+    create_tagging_event(organization, tagging)
+
+    get edit_organization_path(organization)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Housing")
+  end
+
+  # The referenced records load in one batch per type, so a longer log costs no
+  # more queries than a short one.
+  it "does not query per reference as the change log grows" do
+    organization = create(:organization)
+
+    create_tagging_event(organization, create(:sectorable_item, sectorable: organization))
+    one_event = tagging_queries_for(edit_organization_path(organization))
+
+    2.times { create_tagging_event(organization, create(:sectorable_item, sectorable: organization)) }
+    three_events = tagging_queries_for(edit_organization_path(organization))
+
+    expect(response).to have_http_status(:ok)
+    expect(three_events).to eq(one_event)
+  end
+
+  def create_tagging_event(organization, tagging)
     create(
       :ahoy_event,
       name: "update.organization",
@@ -23,10 +47,12 @@ RSpec.describe "Organizations change log", type: :request do
         association_changes: { sectorable_items: [ { action: "added", type: "SectorableItem", id: tagging.id } ] }
       }
     )
+  end
 
-    get edit_organization_path(organization)
-
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to include("Housing")
+  def tagging_queries_for(path)
+    count = 0
+    counter = ->(_n, _s, _f, _i, payload) { count += 1 if payload[:sql]&.match?(/SELECT.+FROM `sectorable_items`/) }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { get path }
+    count
   end
 end

--- a/spec/requests/organizations_change_log_spec.rb
+++ b/spec/requests/organizations_change_log_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Organizations change log", type: :request do
+  before { sign_in create(:user, :admin) }
+
+  it_behaves_like "a page with a change log" do
+    let(:record) { create(:organization) }
+    let(:page_path) { edit_organization_path(record) }
+  end
+end

--- a/spec/requests/people_category_change_log_spec.rb
+++ b/spec/requests/people_category_change_log_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# Categories are assigned through the has_many :through collection setter in
+# TagAssignable#assign_associations, which persists immediately and outside the
+# record's dirty tracking — so without help they never reach the change log.
+# These specs drive the real edit-form flow and read the lifecycle buffer the
+# controller flushes to Ahoy, pinning that a category change is now recorded on
+# the person's own event.
+RSpec.describe "People change log — category assignments", type: :request do
+  let(:person) { create(:person) }
+  let(:category) { create(:category) }
+
+  before do
+    Analytics::LifecycleBuffer.store.clear
+    sign_in create(:user, :admin)
+  end
+
+  after { Current.user = nil }
+
+  # The controller flushes the buffer (and clears it) in an after_action, so grab
+  # a copy as it flushes rather than reading the emptied buffer afterwards.
+  def buffered_during_request
+    events = []
+    allow(Analytics::LifecycleBuffer).to receive(:flush) do
+      events.concat(Analytics::LifecycleBuffer.store)
+      Analytics::LifecycleBuffer.store.clear
+    end
+    yield
+    events
+  end
+
+  def person_association_changes(events)
+    event = events.find { |e| e[:name] == "update.person" }
+    event&.dig(:properties, :association_changes)
+  end
+
+  it "records a category added through the edit form on the person's change log" do
+    events = buffered_during_request do
+      patch person_path(person), params: {
+        person: { category_ids: [ category.id ], managed_category_type_ids: [ category.category_type_id ] }
+      }
+    end
+
+    added = person_association_changes(events)&.dig(:categories)
+    expect(added).to be_present
+    expect(added.first).to include(action: "added", type: "Category", id: category.id)
+  end
+
+  it "records a category removed through the edit form on the person's change log" do
+    create(:categorizable_item, categorizable: person, category: category)
+
+    events = buffered_during_request do
+      patch person_path(person), params: {
+        person: { category_ids: [], managed_category_type_ids: [ category.category_type_id ] }
+      }
+    end
+
+    removed = person_association_changes(events)&.dig(:categories)
+    expect(removed).to be_present
+    expect(removed.first).to include(action: "removed", type: "Category", id: category.id)
+  end
+
+  it "records nothing when the category set is unchanged" do
+    create(:categorizable_item, categorizable: person, category: category)
+
+    events = buffered_during_request do
+      patch person_path(person), params: {
+        person: { category_ids: [ category.id ], managed_category_type_ids: [ category.category_type_id ] }
+      }
+    end
+
+    expect(person_association_changes(events)).to be_nil
+  end
+end

--- a/spec/requests/people_change_log_spec.rb
+++ b/spec/requests/people_change_log_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "People change log", type: :request do
+  let(:person) { create(:person) }
+
+  context "as an admin" do
+    before { sign_in create(:user, :admin) }
+
+    it_behaves_like "a page with a change log" do
+      let(:record) { person }
+      let(:page_path) { edit_person_path(person) }
+    end
+  end
+
+  # The profile is admin-or-owner, but the change log is admin data — the owner
+  # sees their own page without it.
+  context "as the person themselves" do
+    it "hides the change log" do
+      user = create(:user, person: person)
+      create(:ahoy_event, name: "update.person", resource_type: "Person", resource_id: person.id,
+             properties: { resource_type: "Person", resource_id: person.id })
+      sign_in user
+
+      get edit_person_path(person)
+
+      expect(response.body).not_to include("Change log")
+    end
+  end
+end

--- a/spec/requests/people_change_log_spec.rb
+++ b/spec/requests/people_change_log_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "People change log", type: :request do
   context "as the person themselves" do
     it "hides the change log" do
       user = create(:user, person: person)
-      create(:ahoy_event, name: "update.person", resource_type: "Person", resource_id: person.id,
-             properties: { resource_type: "Person", resource_id: person.id })
       sign_in user
 
       get edit_person_path(person)

--- a/spec/requests/scholarships_spec.rb
+++ b/spec/requests/scholarships_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe "Scholarships", type: :request do
   before { sign_in admin }
 
   describe "GET /scholarships/:id/edit" do
+    it_behaves_like "a page with a change log" do
+      let(:record) { scholarship }
+      let(:page_path) { edit_scholarship_path(scholarship) }
+    end
+
     it "renders the cost summary with event cost, scholarship amount, and still owed" do
       get edit_scholarship_path(scholarship)
 

--- a/spec/requests/staff_tags_spec.rb
+++ b/spec/requests/staff_tags_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe "/staff_tags", type: :request do
   describe "as an admin" do
     before { sign_in admin }
 
+    it_behaves_like "a page with a change log" do
+      let(:record) { create(:staff_tag) }
+      let(:page_path) { staff_tag_path(record) }
+    end
+
     it "lists staff tags" do
       tag = create(:staff_tag, name: "Highlight roster")
       get staff_tags_path

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe "TopicSubscriptions", type: :request do
 
   before { sign_in admin }
 
+  describe "GET /topic_subscriptions/:id/edit" do
+    it_behaves_like "a page with a change log" do
+      let(:record) { create(:topic_subscription, topic_subscription_type: trainings) }
+      let(:page_path) { edit_topic_subscription_path(record) }
+    end
+  end
+
   describe "GET /topic_subscriptions" do
     it "renders the index shell for a full-page request" do
       get topic_subscriptions_path

--- a/spec/support/shared_examples/change_log_page.rb
+++ b/spec/support/shared_examples/change_log_page.rb
@@ -19,9 +19,10 @@ RSpec.shared_examples "a page with a change log" do
     expect(response.body).to include("after value")
   end
 
-  it "omits the change log when the record has no tracked activity" do
+  it "says so rather than disappearing when the record has no tracked activity" do
     get page_path
 
-    expect(response.body).not_to include("Change log")
+    expect(response.body).to include("Change log")
+    expect(response.body).to include("No changes recorded yet")
   end
 end

--- a/spec/support/shared_examples/change_log_page.rb
+++ b/spec/support/shared_examples/change_log_page.rb
@@ -1,0 +1,27 @@
+# A record's page shows its own Ahoy lifecycle events. Include with `record` and
+# `page_path` defined, signed in as whoever should see it.
+RSpec.shared_examples "a page with a change log" do
+  it "shows the record's change log" do
+    create(
+      :ahoy_event,
+      name: "update.#{record.class.name.underscore}",
+      resource_type: record.class.name,
+      resource_id: record.id,
+      properties: {
+        resource_type: record.class.name, resource_id: record.id,
+        changes: { "status" => { "before" => "before value", "after" => "after value" } }
+      }
+    )
+
+    get page_path
+
+    expect(response.body).to include("Change log")
+    expect(response.body).to include("after value")
+  end
+
+  it "omits the change log when the record has no tracked activity" do
+    get page_path
+
+    expect(response.body).not_to include("Change log")
+  end
+end

--- a/spec/support/shared_examples/change_log_page.rb
+++ b/spec/support/shared_examples/change_log_page.rb
@@ -16,6 +16,7 @@ RSpec.shared_examples "a page with a change log" do
     get page_path
 
     expect(response.body).to include("Change log")
+    expect(response.body).not_to include("Change log empty")
     expect(response.body).to include("after value")
   end
 
@@ -30,13 +31,12 @@ RSpec.shared_examples "a page with a change log" do
 
     get page_path
 
-    expect(response.body).to include("No changes recorded yet")
+    expect(response.body).to include("Change log empty")
   end
 
-  it "says so rather than disappearing when the record has no tracked activity" do
+  it "says the log is empty rather than disappearing when the record has no tracked activity" do
     get page_path
 
-    expect(response.body).to include("Change log")
-    expect(response.body).to include("No changes recorded yet")
+    expect(response.body).to include("Change log empty")
   end
 end

--- a/spec/support/shared_examples/change_log_page.rb
+++ b/spec/support/shared_examples/change_log_page.rb
@@ -19,6 +19,20 @@ RSpec.shared_examples "a page with a change log" do
     expect(response.body).to include("after value")
   end
 
+  it "leaves out views and other reads of the record" do
+    create(
+      :ahoy_event,
+      name: "view.#{record.class.name.underscore}",
+      resource_type: record.class.name,
+      resource_id: record.id,
+      properties: { resource_type: record.class.name, resource_id: record.id }
+    )
+
+    get page_path
+
+    expect(response.body).to include("No changes recorded yet")
+  end
+
   it "says so rather than disappearing when the record has no tracked activity" do
     get page_path
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 `AhoyTrackable` is included in `ApplicationRecord`, so this changes what every save in the app records, and how much it writes

## What a save did to a record's children went unrecorded

Rich text, nested records, and attachments were all invisible to activity tracking. Every `rhino_*` field passed through unrecorded — event descriptions, stories, resources, community news — and no event ever said a nested record was added, edited, or removed, or that a file was attached.

`AhoyTrackable` has collectors for exactly this. None of them ever produced anything, for the same two reasons:

- They looked associations up with a **string**, but the association cache is symbol-keyed — a string returns a fresh, unloaded association whose target is empty, so there was never anything to inspect.
- They read the result **after** the save, by which point autosave has cleared the dirty state they were looking for.

**This is the half that can't wait.** An event that isn't captured today can't be reconstructed later; every admin edit to a description, a phone number, or a license is lost until this lands.

## What's captured now

Everything is read in `before_save`, while it's still pending, and the update event assembles what was captured.

- **Rich text** lands on the record's own event keyed by the attribute (`rhino_description`), as plain text truncated to a 300-character preview — readable in a change log, and no whole articles in `ahoy_events`.
- **Nested records** report added / updated / removed **with their content** — an added comment reads as its body, an edited one as before/after. Keys, timestamps, and secret-shaped columns are left out; the child's own event keeps the full snapshot. The id is filled in after the save, since a record added through nested attributes has none while the parent's event is being assembled.
- **Attachments** come from ActiveStorage's staged changes — the only reliable account of an attach or purge — and carry the filename, which is the part a reader of a change log wants. A staged attachment has no id yet, so the details cell renders it by name and action instead of a dead reference lookup.

Children's own events are unaffected; this is the parent's account of what a save did.

## Category and sector changes, assigned outside dirty tracking

`categories=` / `sectors=` — the `has_many :through` collection setters behind the category / workshop-settings and sector checkboxes — persist immediately, outside the record's own save, so the collectors above never saw them and a category changed on the edit form was invisible in the log. `TagAssignable#assign_associations` now diffs the memberships around the reassignment and folds added / removed entries onto the record's own update event, reading like the nested edits do. Covers every `assign_associations` consumer (people, organizations, workshops, resources, stories, events, …), not just people.

## Seeing it on the record

`application/_activity_log` puts a record's own events on its page as a **Change log** dropdown, under the audit line already there. Rendered on the pages admins correct records from:

`people` · `organizations` · `affiliations` · `scholarships` · `continuing_education_registrations` · `topic_subscriptions` · `topic_subscription_types` · `event_registrations` · `memberships` · `membership_invoices` · `professional_licenses` · `forms` · `features` · `category_types` (all `#edit`)

Same position on every one: directly under the created/updated line, so it reads as the rest of that record's edit history. Eight of those pages had no created/updated line at all — they have one now.

CE registrations and staff tags get it on their **show** page — that's the page an admin lands on for those, not the form.

A record with no tracked activity reads "Change log empty" as plain text; the control with its chevron appears only when there's something to expand. Leaving it out entirely gave no way to tell *nothing has changed* from *this page hasn't got one*, which matters while tracking is new and most records predate it.

Browsing stays out of it: `Ahoy::Event.mutations` drops `view.`, `print.`, `search.`, `filter.`, and `download.` events, which remain on the admin activities index where browsing is the point.

`payments#show` deliberately keeps its existing PaperTrail change log (#1737) rather than switching — not an oversight.

A shared example (`spec/support/shared_examples/change_log_page.rb`) keeps each honest about both halves: the log appears when the record has activity, and stays out of the way when it doesn't.

The before/after rendering isn't rebuilt — #2316's details cell is extracted from `_activity_row` into `admin/ahoy_activities/_event_details`, rendered by both, so a change reads the same inline as it does in the admin table. That cell also gained the detail an association entry carries: it linked the record and dropped its `changes`/`attributes`, so both pages showed "added Comment" and nothing else. Admin-gated by `Admin::AhoyActivityPolicy`, matching the activity links in `shared/_audit_info`.

Each log resolves its referenced records in one batch per type (`Analytics::EventReferenceLoader`, already used by the admin table) rather than one query per reference.

## A model fix this uncovered

`SectorableItem#title` had its guard inverted — everything that *wasn't* a `WorkshopLog` fell into the branch that calls `sectorable.title`, and an organization hasn't got one. Nothing reached it while association changes were never recorded; once they were, the org's change log referenced its sector taggings and `/organizations/:id/edit` raised `NoMethodError`.

The guard is fixed (a tagging reads as the sector it applied), and two callers are hardened, because a model's label shouldn't be able to take down a page that merely mentions the record:

- `Ahoy::EventDecorator#reference_row` falls back to `SectorableItem #12` instead of raising.
- `Analytics::EventBuilder.safe_title`'s rescue was calling the same raising method again, so `create.sectorable_item` events were **being dropped and logged** rather than recorded. That was already happening on `main`.

## Comments and communications read as their own domain

- Person edit was the only comments card in the app hard-coded blue. It is now the standard card with the comments (purple) icon chip, matching the communications card directly above it.
- A comment in edit mode had no box at all, so opening the editor looked like reading it. It now gets the comments-theme card, like a new comment and an open communication already did.
- The `admin-only` blue wash moves off the card and onto the heading, so the section still reads as privileged.

Listed on **Features & tips** (`config/features.yml`) so facilitators find it.

## How to test

Ahoy events are written during a **signed-in request**, so console and rake edits produce nothing to look at.

1. `ai/server`, sign in as an admin.
2. Edit an event's description (`/events/:id/edit`) — previously recorded nothing at all; now `update.event` carries a `Rhino description` before/after. Check `/admin/activities/events`.
3. Edit a person's nested records (`/people/:id/edit` — add a phone, change a license, remove one) or replace their avatar. The person's own event now reports each child change, with the filename for the avatar.
4. On any of the pages above, change a field, save, reload, and open **Change log** under the created/updated line. On `/people/:id/edit`, give the person a staff tag — the log reports the tagging, since staff tags are assigned through nested attributes on that form.
5. On `/people/:id/edit`, tick or untick a category or workshop-settings box (or a sector on `/organizations/:id/edit`) and save — the **Change log** now reports the category/sector added or removed.

