### PR TITLE
Block event-connected forms from being used as public standalone forms

### DIFF
--- a/app/controllers/public_forms_controller.rb
+++ b/app/controllers/public_forms_controller.rb
@@ -46,9 +46,9 @@ class PublicFormsController < ApplicationController
 
   private
 
-  # Scoped so a draft, an event form, or an unknown slug 404s.
+  # Scoped so a draft, an event-connected form, or an unknown slug 404s.
   def set_form
-    @form = Form.standalone.published.find_by!(slug: params[:slug])
+    @form = Form.standalone.published.not_event_connected.find_by!(slug: params[:slug])
   end
 
   def ordered_fields

--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -11,4 +11,14 @@ class EventForm < ApplicationRecord
   scope :scholarship, -> { where(role: "scholarship") }
   scope :bulk_payment, -> { where(role: "bulk_payment") }
   scope :continuing_education, -> { where(role: "continuing_education") }
+
+  after_create :unpublish_public_form
+
+  private
+
+  # An event-connected form is never offered at a public link, so linking a
+  # published standalone form to an event retires its public form.
+  def unpublish_public_form
+    form.update_column(:published, false) if form.published?
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -19,6 +19,7 @@ class Form < ApplicationRecord
 
   scope :standalone, -> { where(owner_id: nil, owner_type: nil) }
   scope :published, -> { where(published: true) }
+  scope :not_event_connected, -> { where.missing(:event_forms) }
 
   before_validation :normalize_slug
 
@@ -26,6 +27,7 @@ class Form < ApplicationRecord
   validates :slug, format: { with: /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/,
     message: "may only contain lowercase letters, numbers, and hyphens" }, allow_blank: true
   validate :published_form_has_slug
+  validate :event_form_not_published
 
   def display_name
     name.presence || (owner ? "#{owner.try(:name)} Form" : "New Form")
@@ -35,9 +37,14 @@ class Form < ApplicationRecord
     owner_id.nil? && owner_type.nil?
   end
 
-  # Gates the public /f/:slug endpoint (controller + FormPolicy#public_show?).
+  def event_connected?
+    event_forms.exists?
+  end
+
+  # Gates the public /f/:slug endpoint (controller + FormPolicy#public_show?). An
+  # event-connected form stays tied to its event and is never offered publicly.
   def publicly_fillable?
-    standalone? && published? && slug.present?
+    standalone? && !event_connected? && published? && slug.present?
   end
 
   private
@@ -55,5 +62,11 @@ class Form < ApplicationRecord
     return unless published? && slug.blank?
 
     errors.add(:slug, "is required to publish a form")
+  end
+
+  def event_form_not_published
+    return unless published? && event_connected?
+
+    errors.add(:published, "can't be enabled for a form connected to an event")
   end
 end

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -101,7 +101,17 @@
     </div>
 
     <% if @form.standalone? %>
-      <%# Only a standalone form can be published publicly; event forms use their event. %>
+      <%# Only a standalone form with no event connection can be published publicly;
+          an event-connected form stays tied to its event. %>
+      <% if @form.event_connected? %>
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
+            <i class="fa-solid fa-link text-purple-700"></i>
+            <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Public form</h2>
+          </div>
+          <p class="p-6 text-sm text-gray-600">This form is connected to an event, so it can't be published at a public link — event-connected forms are filled out through their event.</p>
+        </div>
+      <% else %>
       <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
           <i class="fa-solid fa-link text-purple-700"></i>
@@ -112,7 +122,7 @@
             <%= f.check_box :published, class: "rounded border-gray-300 text-purple-600" %>
             <span class="text-sm text-gray-800">Publish this form at a public link (anyone can fill it out, no account needed)</span>
           </label>
-          <p class="text-xs text-gray-500">Only affects the public link below — this form keeps working in event registration whether or not it's published.</p>
+          <p class="text-xs text-gray-500">Publishes the form at the public link below. A form connected to an event can't be published — event forms are filled out through their event.</p>
 
           <div>
             <label class="mb-1 block text-sm font-medium text-gray-700">Public link address</label>
@@ -134,6 +144,7 @@
           <% end %>
         </div>
       </div>
+      <% end %>
     <% end %>
 
     <%# Optional HTML intro rendered under the title on the form's public pages %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -40,8 +40,9 @@
                 0
               <% end %>
             </td>
-            <%# A form can be both a public link and an event form — the two are
-                independent, so show a chip for each that applies. %>
+            <%# A public link and an event form are mutually exclusive — an
+                event-connected form is never offered publicly — so at most one
+                chip applies. %>
             <td class="px-4 py-2 text-sm text-gray-600">
               <div class="flex flex-wrap items-center gap-1.5">
                 <% if form.publicly_fillable? %>

--- a/spec/models/event_form_spec.rb
+++ b/spec/models/event_form_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe EventForm, type: :model do
     end
   end
 
+  describe "linking a published form to an event" do
+    it "retires the form's public link" do
+      form = create(:form, slug: "apply", published: true)
+      create(:event_form, form: form)
+      expect(form.reload.published?).to be(false)
+      expect(form).not_to be_publicly_fillable
+    end
+  end
+
   describe "scopes" do
     let!(:registration) { create(:event_form, role: "registration") }
     let!(:scholarship) { create(:event_form, role: "scholarship") }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -119,6 +119,21 @@ RSpec.describe Form do
         form.update_column(:published, true)
         expect(form).not_to be_publicly_fillable
       end
+
+      it 'is false when connected to an event' do
+        form = create(:form, slug: 'apply', published: true)
+        create(:event_form, form: form)
+        expect(form.reload).not_to be_publicly_fillable
+      end
+    end
+
+    it 'rejects publishing a form connected to an event' do
+      form = create(:form, slug: 'apply')
+      create(:event_form, form: form)
+      form.published = true
+
+      expect(form).not_to be_valid
+      expect(form.errors[:published]).to include("can't be enabled for a form connected to an event")
     end
 
     describe '.published scope' do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include("Event form")
       end
 
-      it "shows both the public link and event-form chips when a form is both" do
+      it "shows only the event-form chip, not a public link, when a published form is connected to an event" do
         form = create(:form, :standalone, name: "Dual Form", slug: "dual", published: true)
         EventForm.create!(form: form, event: create(:event), role: "registration")
         get forms_path
-        expect(response.body).to include("/f/dual")
+        expect(response.body).not_to include("/f/dual")
         expect(response.body).to include("Event form")
       end
 
@@ -296,6 +296,20 @@ RSpec.describe "Forms", type: :request do
 
       expect(response.body).to include('data-controller="expand-all"')
       expect(response.body).to include("Expand all")
+    end
+
+    it "offers the public-link section for a standalone form with no events" do
+      form = create(:form, :standalone)
+      get edit_form_path(form)
+      expect(response.body).to include("Publish this form at a public link")
+    end
+
+    it "hides the public-link section for a form connected to an event" do
+      form = create(:form, :standalone, slug: "reg")
+      create(:event_form, form: form, event: create(:event))
+      get edit_form_path(form)
+      expect(response.body).not_to include("Publish this form at a public link")
+      expect(response.body).to include("filled out through their event")
     end
 
     it "renders the form header section with a textarea for HTML" do

--- a/spec/requests/public_forms_spec.rb
+++ b/spec/requests/public_forms_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe "PublicForms", type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "404s a form connected to an event even if published" do
+      EventForm.create!(form: form, event: create(:event), role: "registration")
+      get public_form_path(form.slug)
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "404s an unknown slug" do
       get public_form_path("nope")
       expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small model/controller guard plus view/copy changes, low blast radius

### Goal
- An event form must stay filled out through its event — it should never be reachable at the account-free public `/f/:slug` endpoint.
- Before this, a form could be both event-connected and publicly published at the same time.

### Approach
- `Form#publicly_fillable?` now excludes event-connected forms; a validation blocks publishing one.
- `PublicFormsController` 404s an event-connected form (new `not_event_connected` scope).
- Linking a published form to an event retires its public link (`EventForm` after_create), so no admin gets stuck with a hidden publish toggle on an invalid record.
- Form editor hides the publish controls for event forms and shows a short explanation instead.

### Anything else
- Reverses the prior "a form can be both" behavior (old index comment + spec updated).