### PR TITLE
Add "Copy form" button to duplicate a form with its fields and options

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,5 +1,5 @@
 class FormsController < ApplicationController
-  before_action :set_form, only: %i[show edit update destroy reorder_field reorder_fields edit_sections update_sections]
+  before_action :set_form, only: %i[show edit update destroy copy reorder_field reorder_fields edit_sections update_sections]
   before_action :set_dashboard_event, only: %i[show edit edit_sections update update_sections]
 
   def index
@@ -76,6 +76,13 @@ class FormsController < ApplicationController
 
     @form.destroy!
     redirect_to forms_path, notice: "Form deleted."
+  end
+
+  def copy
+    authorize! @form
+
+    copy = FormCopyService.new(@form).call
+    redirect_to edit_form_path(copy), notice: "Form copied. Now editing \"#{copy.display_name}\"."
   end
 
   def edit_sections

--- a/app/services/form_copy_service.rb
+++ b/app/services/form_copy_service.rb
@@ -1,0 +1,55 @@
+class FormCopyService
+  COPY_NAME_PREFIX = "COPY of ".freeze
+
+  def initialize(form)
+    @form = form
+  end
+
+  def call
+    Form.transaction do
+      copy = build_form_copy
+      copy.save!
+      copy_fields_into(copy)
+      copy
+    end
+  end
+
+  private
+
+  # A published form requires a slug, and slug is globally unique — so a copy
+  # starts unpublished with no slug for the admin to set before publishing.
+  def build_form_copy
+    @form.dup.tap do |copy|
+      copy.name = "#{COPY_NAME_PREFIX}#{@form.display_name}"
+      copy.slug = nil
+      copy.published = false
+    end
+  end
+
+  def copy_fields_into(copy)
+    field_map = {}
+
+    @form.form_fields.order(:position, :id).each do |field|
+      new_field = field.dup
+      new_field.form = copy
+      new_field.save!
+      field_map[field.id] = new_field
+
+      # AnswerOptions are shared globally — re-point the join rows at the existing
+      # records rather than duplicating them.
+      field.form_field_answer_options.each do |ffao|
+        new_field.form_field_answer_options.create!(answer_option_id: ffao.answer_option_id)
+      end
+    end
+
+    remap_field_parents(field_map)
+  end
+
+  def remap_field_parents(field_map)
+    field_map.each_value do |new_field|
+      next if new_field.parent_id.nil?
+
+      new_field.update!(parent_id: field_map[new_field.parent_id]&.id)
+    end
+  end
+end

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -72,6 +72,10 @@
             <td class="space-x-3 px-4 py-2 text-right text-sm">
               <%= link_to "View", form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
               <%= link_to "Edit", edit_form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
+              <% if allowed_to?(:copy?, form) %>
+                <%= link_to "Copy", copy_form_path(form), class: "text-purple-600 hover:text-purple-800 underline",
+                            data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -7,6 +7,10 @@
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <% if allowed_to?(:copy?, @form) %>
+      <%= link_to "Copy", copy_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1",
+                  data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{@form.display_name}\"?" } %>
+    <% end %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>
       <%= link_to "Delete", form_path(@form), class: "text-sm text-red-600 hover:text-red-800 px-2 py-1",
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1462,3 +1462,19 @@
     Publish a standalone form (one not tied to an event) at a shareable public
     link that anyone can fill out without an account. Responses appear in the
     form submissions index, filterable by form.
+
+- name: "Copy a form"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-18
+  action_path: "/forms"
+  pr_number: 2258
+  summary: >-
+    Duplicate any form with one click. The copy ("COPY of ...") carries over
+    every field and answer option so you can tweak a near-identical form instead
+    of rebuilding it from scratch.
+  pro_tips:
+    - The copy starts unpublished with no public link — set those on the new form
+      when you're ready.
+    - Event links and past submissions stay with the original; the copy is a fresh
+      form.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
       get :smart_form_settings
     end
     member do
+      post :copy
       patch :reorder_field
       put :reorder_fields
       get :edit_sections

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -670,6 +670,34 @@ RSpec.describe "Forms", type: :request do
     end
   end
 
+  describe "POST /forms/:id/copy" do
+    context "as admin" do
+      before { sign_in admin }
+
+      it "creates a full copy named \"COPY of [name]\" and redirects to its editor" do
+        form = create(:form, :standalone, name: "Volunteer")
+        create(:form_field, form: form, name: "First name")
+
+        expect { post copy_form_path(form) }.to change(Form, :count).by(1)
+
+        copy = Form.find_by(name: "COPY of Volunteer")
+        expect(copy.name).to eq("COPY of Volunteer")
+        expect(copy.form_fields.map(&:name)).to eq([ "First name" ])
+        expect(response).to redirect_to(edit_form_path(copy))
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in user }
+
+      it "denies access and copies nothing" do
+        form = create(:form, :standalone)
+        expect { post copy_form_path(form) }.not_to change(Form, :count)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
   describe "GET /forms/:id" do
     before { sign_in admin }
 

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe FormCopyService do
+  describe "#call" do
+    it "names the copy \"COPY of [name]\"" do
+      form = create(:form, name: "Volunteer Intake")
+
+      copy = described_class.new(form).call
+
+      expect(copy.name).to eq("COPY of Volunteer Intake")
+    end
+
+    it "returns a persisted, distinct record" do
+      form = create(:form)
+
+      copy = described_class.new(form).call
+
+      expect(copy).to be_persisted
+      expect(copy.id).not_to eq(form.id)
+    end
+
+    it "copies every form field with its attributes and order" do
+      form = create(:form)
+      create(:form_field, form: form, name: "First name", position: 1, required: true, section: "person")
+      create(:form_field, form: form, name: "Notes", position: 2, required: false, section: "extra")
+
+      copy = described_class.new(form).call
+
+      fields = copy.form_fields.order(:position)
+      expect(fields.map(&:name)).to eq([ "First name", "Notes" ])
+      expect(fields.map(&:section)).to eq([ "person", "extra" ])
+      expect(fields.map(&:required)).to eq([ true, false ])
+    end
+
+    it "copies answer options by re-pointing at the shared AnswerOption records" do
+      form = create(:form)
+      field = create(:form_field, form: form)
+      option = create(:answer_option, name: "Yes")
+      create(:form_field_answer_option, form_field: field, answer_option: option)
+
+      copy = nil
+      expect { copy = described_class.new(form).call }.not_to change(AnswerOption, :count)
+
+      copied_option = copy.form_fields.first.form_field_answer_options.first
+      expect(copied_option.answer_option).to eq(option)
+    end
+
+    it "does not copy the slug or published state" do
+      form = create(:form, slug: "volunteer", published: true, name: "Volunteer")
+
+      copy = described_class.new(form).call
+
+      expect(copy.slug).to be_nil
+      expect(copy.published).to be(false)
+    end
+
+    it "does not copy submissions or event links" do
+      form = create(:form)
+      EventForm.create!(form: form, event: create(:event), role: "registration")
+
+      copy = described_class.new(form).call
+
+      expect(copy.event_forms).to be_empty
+      expect(copy.form_submissions).to be_empty
+    end
+
+    it "leaves the original form untouched" do
+      form = create(:form, name: "Original")
+      create(:form_field, form: form)
+
+      expect { described_class.new(form).call }.to change(Form, :count).by(1)
+      expect(form.reload.name).to eq("Original")
+      expect(form.form_fields.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small additive feature — one service, one action, two view links; core risk is what the deep-copy includes/omits

## Why
Admins rebuild near-identical forms by hand. A one-click **Copy** seeds a new editable form (`COPY of [Name]`) from an existing one so they can tweak rather than start from scratch.

## What
- **`FormCopyService`** — transactional deep-copy of a `Form`.
  - Copies every `form_field` (order preserved) and each field's `form_field_answer_options`, **re-pointed at the shared `AnswerOption` records** (not duplicated).
  - Leaves `slug` nil and `published` false — a published form requires a unique slug.
  - Does **not** copy submissions, event links, `user_forms`, or reports.
  - Keeps `role` — nothing selects a standalone form by role expecting uniqueness (event-level lookups go through `event_forms`), and role stays editable in the form editor.
- **`POST /forms/:id/copy`** → `FormsController#copy` (admin-gated), redirects to the new form's editor.
- **Copy** link on the forms index row and the show-page action bar, each with a confirm.
- **Features & tips seed** — new `Copy a form` entry in `config/features.yml`.

## Tests
- `FormCopyService` spec — naming, field/option copy, shared AnswerOption reuse, slug/published reset, submissions/event links excluded, original untouched.
- `POST /forms/:id/copy` request spec — admin success + redirect, non-admin denied.