### PR TITLE
Show license credentials on staff cards

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -260,7 +260,7 @@ module Events
 
       @event = @event.decorate
       @event_staffs = @event.event_staffs
-        .includes(person: [ :sectors, { categorizable_items: { category: :category_type } }, { avatar_attachment: :blob }, { affiliations: :organization } ])
+        .includes(person: [ :sectors, :professional_licenses, { categorizable_items: { category: :category_type } }, { avatar_attachment: :blob }, { affiliations: :organization } ])
         .ordered_by_name
     end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -315,7 +315,7 @@ class EventsController < ApplicationController
     authorize! @event, to: :staff?
     @event = @event.decorate
     @event_staffs = @event.event_staffs
-      .includes(person: [ :sectors, { categorizable_items: { category: :category_type } }, { avatar_attachment: :blob }, { affiliations: :organization } ])
+      .includes(person: [ :sectors, :professional_licenses, { categorizable_items: { category: :category_type } }, { avatar_attachment: :blob }, { affiliations: :organization } ])
       .ordered_by_name
   end
 

--- a/app/views/events/_staff_cards.html.erb
+++ b/app/views/events/_staff_cards.html.erb
@@ -10,6 +10,7 @@
       <% active_affiliation = person.affiliations.find { |a| !a.inactive? } %>
       <% org = active_affiliation&.organization %>
       <% bio = event_staff.public_bio %>
+      <% credentials = person.profile_show_credentials? ? person.license_credentials : nil %>
       <%# Sectors and age ranges, each gated by its own profile toggle. The card
           leads with the primary sector and primary age range (primary sorts first);
           any remaining sectors/age ranges collapse into a "+N" chip that lists them
@@ -67,6 +68,10 @@
               <p class="text-sm font-medium text-gray-600 leading-tight"><%= person.last_name %></p>
             <% else %>
               <p class="text-lg font-bold text-gray-900 leading-tight"><%= person.name %></p>
+            <% end %>
+
+            <% if credentials.present? %>
+              <p class="text-xs font-medium text-gray-500 leading-tight mt-0.5"><%= credentials %></p>
             <% end %>
 
             <% if person.pronouns_display.present? %>

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -183,6 +183,20 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).not_to include("Youth")
     end
 
+    it "shows a staff member's license credentials, gated by their profile toggle" do
+      staffer = create(:person)
+      create(:professional_license, person: staffer, kind: "LMFT", number: "44556")
+      create(:registration_ticket_callout, event:, builtin_key: "staff", hidden: false)
+      create(:event_staff, event:, person: staffer)
+
+      get registration_staff_path(registration.slug)
+      expect(response.body).to include("LMFT")
+
+      staffer.update!(profile_show_credentials: false)
+      get registration_staff_path(registration.slug)
+      expect(response.body).not_to include("LMFT")
+    end
+
     it "shows an admin-only Edit staff button to admins" do
       create(:registration_ticket_callout, event:, builtin_key: "staff", hidden: false)
       sign_in create(:user, super_user: true)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3751,6 +3751,18 @@ RSpec.describe "Events", type: :request do
         get staff_event_path(published_event)
         expect(response.body).not_to include("LMFT")
       end
+
+      it "joins a staff member's multiple license credentials comma-separated" do
+        staffer.update!(profile_show_credentials: true)
+        create(:professional_license, person: staffer, kind: "LMFT", number: "44556")
+        create(:professional_license, person: staffer, kind: "LCSW", number: "77889")
+        create(:event_staff, event: published_event, person: staffer)
+        credentials = staffer.reload.license_credentials
+        expect(credentials).to include(", ").and(include("LMFT")).and(include("LCSW"))
+        sign_in admin
+        get staff_event_path(published_event)
+        expect(response.body).to include(credentials)
+      end
     end
 
     describe "GET /staff/edit" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3733,6 +3733,24 @@ RSpec.describe "Events", type: :request do
         get staff_event_path(published_event)
         expect(response.body).to include(edit_staff_event_path(published_event))
       end
+
+      it "shows a staff member's license credentials when their profile allows it" do
+        staffer.update!(profile_show_credentials: true)
+        create(:professional_license, person: staffer, kind: "LMFT", number: "44556")
+        create(:event_staff, event: published_event, person: staffer)
+        sign_in admin
+        get staff_event_path(published_event)
+        expect(response.body).to include("LMFT")
+      end
+
+      it "hides a staff member's license credentials when their profile disallows it" do
+        staffer.update!(profile_show_credentials: false)
+        create(:professional_license, person: staffer, kind: "LMFT", number: "44556")
+        create(:event_staff, event: published_event, person: staffer)
+        sign_in admin
+        get staff_event_path(published_event)
+        expect(response.body).not_to include("LMFT")
+      end
     end
 
     describe "GET /staff/edit" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view addition mirroring the existing profile credential gate, plus eager-loading and specs

## What

- Surface a person's license-derived credentials on the shared staff flip-cards (`events/_staff_cards`), used by both the event admin **Meet the staff** page and the registrant **staff callout** page.
- Gated by `profile_show_credentials?` — the same toggle already governing the suffix on the profile show page.

## Why

- Credentials were only visible on the profile page; staff cards should surface them too when the person opted in.

## Notes

- Eager-load `professional_licenses` in both staff actions to avoid an N+1.
- Specs cover both card locations, on and off.