### PR TITLE
Stabilize recipients program-status anchor spec against clock time

### DIFF
--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3258,6 +3258,9 @@ RSpec.describe "Events", type: :request do
                              title: "Facilitator", start_date: 2.weeks.from_now.to_date)
         registration = EventRegistration.find_by!(registrant: applicant, event: event)
         create(:event_registration_organization, event_registration: registration, organization: org)
+        # Anchor the start time at noon so the event's calendar date is the same in
+        # the request's viewer time zone and the assertion below, whatever the clock.
+        event.update!(start_date: event.start_date.change(hour: 12))
 
         get recipients_event_path(event), headers: { "Turbo-Frame" => "recipients_charts" }
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 test-only fix to a time-zone-fragile assertion

Closes [link an issue or remove this line]

### What is the goal of this PR and why is this important?
- The recipients program-status anchor spec failed intermittently — it asserted the event's start date but only compared cleanly outside the request's viewer time zone.

### How did you approach the change?
- The event's `start_date` inherited the run's time-of-day from `1.month.from_now`; a run in the early-UTC window rendered the note a day earlier in the request's Pacific viewer zone than the UTC assertion expected.
- Pinned the event start to noon so its calendar date matches across all US/UTC zones regardless of the clock. Test-only; no app code changed.

### Anything else to add?
- Root cause is `set_time_zone_from_user` displaying event datetimes in the viewer zone (Pacific default) while the spec formatted the date in UTC.
