### PR TITLE
Widen mission_vision_values to text to fit long mission statements

### DIFF
--- a/db/migrate/20260820010750_change_mission_vision_values_to_text.rb
+++ b/db/migrate/20260820010750_change_mission_vision_values_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeMissionVisionValuesToText < ActiveRecord::Migration[8.1]
+  def up
+    change_column :organizations, :mission_vision_values, :text
+  end
+
+  def down
+    change_column :organizations, :mission_vision_values, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_115845) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_010750) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -883,7 +883,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_115845) do
     t.boolean "legacy", default: false
     t.integer "legacy_id"
     t.integer "location_id"
-    t.string "mission_vision_values"
+    t.text "mission_vision_values"
     t.string "name"
     t.text "notes", size: :long
     t.integer "organization_status_id"


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 single reversible column-type migration, no logic change

### What is the goal of this PR and why is this important?
Fix a production `ActiveRecord::ValueTooLong` error on organization create: `organizations.mission_vision_values` was `varchar(255)` while the form renders it as a multi-line textarea, so realistic mission statements overflowed the column.

### How did you approach the change?
Added a reversible migration changing `mission_vision_values` to `text` (matching the neighboring `description` column).

### UI Testing Checklist
- [ ] Create an organization with a mission statement longer than 255 characters and confirm it saves.

### Anything else to add?
Nothing — display-only change to storage capacity; no logic or view changes.
