### PR TITLE
Validate length of editable varchar(255) columns to surface friendly errors

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -17,9 +17,15 @@ class Address < ApplicationRecord
   has_many :affiliations, foreign_key: :organization_address_id, dependent: :nullify, inverse_of: :organization_address
 
   validates :locality, presence: true
-  validates :city, presence: true
+  validates :city, presence: true, length: { maximum: 255 }
   validates :state, presence: true
   validates :address_type, inclusion: { in: CONTACT_TYPES }
+  validates :street_address, length: { maximum: 255 }
+  validates :zip_code, length: { maximum: 255 }
+  validates :district, length: { maximum: 255 }
+  validates :county, length: { maximum: 255 }
+  validates :country, length: { maximum: 255 }
+  validates :phone, length: { maximum: 255 }
 
   scope :active, -> { where(inactive: false) }
 

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -26,6 +26,7 @@ class Affiliation < ApplicationRecord
 
   # Validations
   validates_presence_of :organization_id
+  validates :title, length: { maximum: 255 }
   validate :organization_address_belongs_to_organization
 
   # Not flagged inactive and not past its end date. Includes affiliations whose

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,7 +17,7 @@ class Category < ApplicationRecord
   scope :story_share_featured, -> { where.not(story_share_position: nil).order(:story_share_position) }
 
   # Validations
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
   validates :position, numericality: {
     only_integer: true,
     greater_than: 0,

--- a/app/models/category_type.rb
+++ b/app/models/category_type.rb
@@ -5,7 +5,8 @@ class CategoryType < ApplicationRecord
   has_many :categorizable_items, through: :categories, dependent: :destroy
 
   # Validations
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
+  validates :display_text, length: { maximum: 255 }
 
   # Scopes
   # See Publishable

--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -29,6 +29,8 @@ class CommunityNews < ApplicationRecord
   # (created before author became a person) remain valid.
   validates :title, presence: true, length: { maximum: 150 }
   validates :rhino_body, presence: true
+  validates :reference_url, length: { maximum: 255 }
+  validates :youtube_url, length: { maximum: 255 }
 
   # Unattributed community news is credited to the organization's staff.
   def missing_author_label

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -10,6 +10,6 @@ class ContactMethod < ApplicationRecord
     whatsapp: "whatsapp"
   }
 
-  validates :value, presence: true
+  validates :value, presence: true, length: { maximum: 255 }
   validates :kind, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -60,6 +60,16 @@ class Event < ApplicationRecord
   validates_presence_of :title, :start_date, :end_date
   validates_inclusion_of :published, in: [ true, false ]
   validates_numericality_of :cost_cents, greater_than_or_equal_to: 0, allow_nil: true
+  validates :title, length: { maximum: 255 }
+  validates :abbreviation, length: { maximum: 255 }
+  validates :pre_title, length: { maximum: 255 }
+  validates :pre_date_text, length: { maximum: 255 }
+  validates :videoconference_url, length: { maximum: 255 }
+  validates :videoconference_label, length: { maximum: 255 }
+  validates :videoconference_passcode, length: { maximum: 255 }
+  validates :hint_dates, length: { maximum: 255 }
+  validates :hint_times, length: { maximum: 255 }
+  validates :hint_registration_cost, length: { maximum: 255 }
   validate :registration_form_required_when_publicly_registerable, on: :update
   validate :staff_members_are_unique, on: :update
 

--- a/app/models/event_staff.rb
+++ b/app/models/event_staff.rb
@@ -3,6 +3,7 @@ class EventStaff < ApplicationRecord
   belongs_to :person
 
   validates :person_id, uniqueness: { scope: :event_id }
+  validates :title, length: { maximum: 255 }
 
   normalizes :bio, with: ->(value) { value&.strip.presence }
 

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -6,6 +6,7 @@ class Faq < ApplicationRecord
 
   # Validations
   validates_presence_of :question, :answer
+  validates :question, length: { maximum: 255 }
 
   # Scopes
   # See Publishable

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,9 +53,12 @@ class Organization < ApplicationRecord
   validates :logo,
             content_type: %w[image/png image/jpeg image/webp],
             size: { less_than: 5.megabytes }
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 255 }
   validates :organization_status_id, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true, length: { maximum: 255 }
+  validates :agency_type_other, length: { maximum: 255 }
+  validates :website_url, length: { maximum: 255 }
+  validates :mission_vision_values, length: { maximum: 255 }
   validate :affiliation_dates_locked, if: -> { affiliations.any? && !Current.user&.super_user? }
 
   # Nested attributes

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -62,10 +62,19 @@ class Person < ApplicationRecord
             content_type: %w[image/png image/jpeg image/webp],
             size: { less_than: 5.megabytes },
             unless: -> { Rails.env.test? }
-  validates :first_name, presence: true
-  validates :last_name, presence: true
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true
-  validates :email_2, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true
+  validates :first_name, presence: true, length: { maximum: 255 }
+  validates :last_name, presence: true, length: { maximum: 255 }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true, length: { maximum: 255 }
+  validates :email_2, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true, length: { maximum: 255 }
+  validates :legal_first_name, length: { maximum: 255 }
+  validates :pronouns, length: { maximum: 255 }
+  validates :best_time_to_call, length: { maximum: 255 }
+  validates :racial_ethnic_identity, length: { maximum: 255 }
+  validates :linked_in_url, length: { maximum: 255 }
+  validates :facebook_url, length: { maximum: 255 }
+  validates :instagram_url, length: { maximum: 255 }
+  validates :youtube_url, length: { maximum: 255 }
+  validates :twitter_url, length: { maximum: 255 }
   validate :unique_name_and_email_combination
 
   CONTACT_TYPES = [ "work", "personal" ].freeze

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -17,6 +17,8 @@ class Quote < ApplicationRecord
   has_many :sectors, through: :sectorable_items
 
   validates :quote, presence: true, unless: -> { quote.blank? }
+  validates :age, length: { maximum: 255 }
+  validates :speaker_name, length: { maximum: 255 }
 
   # Search Cop
   include SearchCop

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -65,7 +65,8 @@ class RegistrationTicketCallout < ApplicationRecord
   # after validations, so position must allow nil here.
   positioned on: :event_id
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :subtitle, length: { maximum: 255 }
   validates :callout_type, inclusion: { in: CALLOUT_TYPES }
   validates :color_class, inclusion: { in: DomainTheme::SWATCH_COLORS.map(&:to_s) }, allow_blank: true
   validates :position, numericality: { only_integer: true, greater_than: 0, allow_nil: true }

--- a/app/models/registration_ticket_callout_resource.rb
+++ b/app/models/registration_ticket_callout_resource.rb
@@ -13,6 +13,7 @@ class RegistrationTicketCalloutResource < ApplicationRecord
   positioned on: :registration_ticket_callout_id
 
   validates :resource_id, uniqueness: { scope: :registration_ticket_callout_id }
+  validates :subtitle, length: { maximum: 255 }
   validates :position, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 
   scope :ordered, -> { order(:position, :id) }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -47,6 +47,8 @@ class Report < ApplicationRecord
     application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel
     application/vnd.openxmlformats-officedocument.spreadsheetml.sheet]
   validates :form_file, content_type: FORM_FILE_CONTENT_TYPES
+  validates :other_description, length: { maximum: 255 }
+  validates :workshop_name, length: { maximum: 255 }
 
   before_save :set_has_attachment # TODO verify set_has_attachment works as expected once this feature is enabled in the UI
   after_create :set_windows_type

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -54,7 +54,7 @@ class Resource < ApplicationRecord
   attribute :hidden_from_search, :boolean, default: false
 
   # Validations
-  validates :title, presence: true, uniqueness: { case_sensitive: false }
+  validates :title, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
   validates :kind, presence: true
 
   # Nested attributes

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -56,7 +56,7 @@ class Sector < ApplicationRecord
   has_many :quotes, through: :workshops
 
   # Validations
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
 
   # Cache expiration
   after_save :expire_sectors_cache

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -36,8 +36,11 @@ class Story < ApplicationRecord
   validates :windows_type_id, presence: true
   validates :created_by_id, presence: true
   validates :updated_by_id, presence: true
-  validates :title, presence: true, uniqueness: true
+  validates :title, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :rhino_body, presence: true
+  validates :external_workshop_title, length: { maximum: 255 }
+  validates :website_url, length: { maximum: 255 }
+  validates :youtube_url, length: { maximum: 255 }
 
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -46,6 +46,8 @@ class StoryIdea < ApplicationRecord
   validates :windows_type_id, presence: true
   validates :permission_given, presence: true
   validates :rhino_body, presence: true
+  validates :external_workshop_title, length: { maximum: 255 }
+  validates :youtube_url, length: { maximum: 255 }
 
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank

--- a/app/models/video_recording.rb
+++ b/app/models/video_recording.rb
@@ -15,8 +15,8 @@ class VideoRecording < ApplicationRecord
            as: :owner, class_name: "GalleryAsset", dependent: :destroy
   has_many :assets, as: :owner, dependent: :destroy
 
-  validates :title, presence: true, uniqueness: { case_sensitive: false }
-  validates :youtube_url, presence: true
+  validates :title, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
+  validates :youtube_url, presence: true, length: { maximum: 255 }
 
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, reject_if: :all_blank, allow_destroy: true

--- a/app/models/windows_type.rb
+++ b/app/models/windows_type.rb
@@ -14,6 +14,6 @@ class WindowsType < ApplicationRecord
   has_many :categories, through: :categorizable_items
   has_many :category_types, through: :categories
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 255 }
   validates :short_name, presence: true
 end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -123,6 +123,8 @@ class Workshop < ApplicationRecord
 
   # Validations
   validates_presence_of :title
+  validates :title, length: { maximum: 255 }
+  validates :full_name, length: { maximum: 255 }
   # validates_presence_of :month, :year, if: Proc.new { |workshop| workshop.legacy }
   validates :rating, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 5 }
 

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -30,7 +30,7 @@ class WorkshopIdea < ApplicationRecord
 
   before_save :set_time_frame
 
-  validates :title, presence: true, uniqueness: { case_sensitive: false }
+  validates :title, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
 
   # Nested attributes
   accepts_nested_attributes_for :primary_asset, reject_if: :all_blank, allow_destroy: true

--- a/app/models/workshop_series_membership.rb
+++ b/app/models/workshop_series_membership.rb
@@ -4,6 +4,9 @@ class WorkshopSeriesMembership < ApplicationRecord
 
   # Validations
   validates :position, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :series_description, length: { maximum: 255 }
+  validates :series_description_spanish, length: { maximum: 255 }
+  validates :theme_name, length: { maximum: 255 }
 
   def series_description_for(spanish: false, length: nil, parent_workshop: false)
     description =

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -42,9 +42,10 @@ class WorkshopVariation < ApplicationRecord
          as: :owner, class_name: "RichTextAsset", dependent: :destroy
   has_many :assets, as: :owner, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { scope: :workshop_id, case_sensitive: false }
+  validates :name, presence: true, uniqueness: { scope: :workshop_id, case_sensitive: false }, length: { maximum: 255 }
   validates :windows_type_id, presence: true
   validates :rhino_body, presence: true
+  validates :youtube_url, length: { maximum: 255 }
 
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -33,7 +33,8 @@ class WorkshopVariationIdea < ApplicationRecord
   has_many :assets, as: :owner, dependent: :destroy
 
   # Validations
-  validates :name, presence: true, uniqueness: { scope: :workshop_id, case_sensitive: false }
+  validates :name, presence: true, uniqueness: { scope: :workshop_id, case_sensitive: false }, length: { maximum: 255 }
+  validates :youtube_url, length: { maximum: 255 }
   validates :created_by_id, presence: true
   validates :updated_by_id, presence: true
   validates :organization_id, presence: true

--- a/spec/models/string_column_length_validations_spec.rb
+++ b/spec/models/string_column_length_validations_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Every editable varchar(255) column a human types free text into needs a length
+# validation. Without one, an over-255 submission raises ActiveRecord::ValueTooLong
+# deep in the adapter (STRICT_ALL_TABLES) — a 500 with no reason — instead of a
+# friendly inline form error. This locks in `length: { maximum: 255 }` across those
+# columns (public, admin, and staff forms). Grant is intentionally excluded (handled
+# separately); columns already validated stricter (e.g. CommunityNews#title) are omitted.
+RSpec.describe "varchar(255) length validations" do
+  LENGTH_LIMITED_COLUMNS = {
+    Address => %i[city street_address zip_code district county country phone],
+    ContactMethod => %i[value],
+    Person => %i[first_name last_name email email_2 legal_first_name pronouns
+                 best_time_to_call racial_ethnic_identity linked_in_url facebook_url
+                 instagram_url youtube_url twitter_url],
+    Event => %i[title abbreviation pre_title pre_date_text videoconference_url
+                videoconference_label videoconference_passcode hint_dates hint_times
+                hint_registration_cost],
+    Organization => %i[name email agency_type_other website_url mission_vision_values],
+    Affiliation => %i[title],
+    Workshop => %i[title full_name],
+    WorkshopVariation => %i[name youtube_url],
+    WorkshopVariationIdea => %i[name youtube_url],
+    WorkshopIdea => %i[title],
+    WorkshopSeriesMembership => %i[series_description series_description_spanish theme_name],
+    Resource => %i[title],
+    VideoRecording => %i[title youtube_url],
+    Story => %i[title external_workshop_title website_url youtube_url],
+    StoryIdea => %i[external_workshop_title youtube_url],
+    CommunityNews => %i[reference_url youtube_url],
+    Faq => %i[question],
+    Quote => %i[age speaker_name],
+    Category => %i[name],
+    CategoryType => %i[name display_text],
+    Sector => %i[name],
+    RegistrationTicketCallout => %i[title subtitle],
+    RegistrationTicketCalloutResource => %i[subtitle],
+    Report => %i[other_description workshop_name],
+    WindowsType => %i[name],
+    EventStaff => %i[title]
+  }.freeze
+
+  LENGTH_LIMITED_COLUMNS.each do |model, columns|
+    columns.each do |column|
+      it "#{model} rejects an over-255 #{column} with a readable error" do
+        record = model.new(column => "a" * 256)
+        record.valid?
+
+        expect(record.errors[column].join).to match(/too long/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mechanical declarative length validations across 26 models; no data or behavior change beyond surfacing errors — the main check is that the column list is right

### What is the goal of this PR and why is this important?
Editable `varchar(255)` columns had no length validation, so an over-255 submission raised `ActiveRecord::ValueTooLong` deep in the adapter (`STRICT_ALL_TABLES`) — a 500 with no reason — on many public, admin, and staff forms.

### How did you approach the change?
Added `length: { maximum: 255 }` (each column's real DB limit) to every editable free-text 255 column across 26 models, so an over-long entry now fails validation and renders a readable inline error with the input preserved. `Grant` is intentionally excluded (handled separately) and `CommunityNews#title` already validates stricter.

### Anything else to add?
A new data-driven spec locks in the length validation for all 72 columns. Follow-up option: a few genuine prose fields (e.g. `Organization#mission_vision_values`, `WorkshopSeriesMembership#series_description`) are capped at 255 by their column — if admins need more room, those specific columns could migrate to `text`.