### PR TITLE
Widen features.summary to text to fit long summaries

### DIFF
--- a/db/migrate/20260820144446_change_features_summary_to_text.rb
+++ b/db/migrate/20260820144446_change_features_summary_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeFeaturesSummaryToText < ActiveRecord::Migration[8.1]
+  def up
+    change_column :features, :summary, :text, null: false
+  end
+
+  def down
+    change_column :features, :summary, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_010750) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -621,7 +621,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_010750) do
     t.text "pro_tips"
     t.boolean "published", default: true, null: false
     t.date "released_on", null: false
-    t.string "summary", null: false
+    t.text "summary", null: false
     t.datetime "updated_at", null: false
     t.index ["area"], name: "index_features_on_area"
     t.index ["display_status"], name: "index_features_on_display_status"


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-column type change + regenerated schema

### What is the goal of this PR and why is this important?
The Features & tips summary form is a textarea capped at 300 chars and the model validates `maximum: 300`, but `features.summary` was `varchar(255)`. A 256–300 char summary passed both checks then raised `ActiveRecord::ValueTooLong` on insert under `STRICT_ALL_TABLES` — a bare 500. This took down `POST /features/import` (the "Sync latest updates" seed import) and the catalog spec.

### How did you approach the change?
Widened `features.summary` to `text` via a reversible migration, matching the `mission_vision_values` precedent (#2265). No model or form change needed — the existing `maximum: 300` validation and `maxlength: 300` textarea now agree with a column that can hold them.

### UI Testing Checklist
- [ ] No UI change; verify a super-admin can save a ~300-char feature summary and run **Sync latest updates** on `/features` without a 500.

### Anything else to add?
Migration is reversible (`down` narrows back to `string`).