### PR TITLE
Add author to idea models and credit profiles by authorship

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -85,16 +85,18 @@ class PeopleController < ApplicationController
         @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/events", locals: { person: @person, event_registrations: @event_registrations }
       when "workshop_ideas"
-        @workshop_ideas = @person.user&.workshop_ideas_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
+        # Credit the person for ideas they authored — not ones their user merely
+        # entered (created_by is a pure audit trail).
+        @workshop_ideas = @person.workshop_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_ideas", locals: { person: @person, workshop_ideas: @workshop_ideas }
       when "story_ideas"
-        @story_ideas = @person.user&.story_ideas_as_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
+        @story_ideas = @person.story_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/story_ideas", locals: { person: @person, story_ideas: @story_ideas }
       when "workshop_logs"
         @workshop_logs = @person.user&.workshop_logs&.includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets)&.order(workshop_held_on: :desc, created_at: :desc) || WorkshopLog.none
         render partial: "people/sections/workshop_logs", locals: { person: @person, workshop_logs: @workshop_logs }
       when "workshop_variation_ideas"
-        @workshop_variation_ideas = @person.user&.workshop_variation_ideas_creator&.order(created_at: :desc)&.paginate(page: params[:page], per_page: per_page) || []
+        @workshop_variation_ideas = @person.workshop_variation_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variation_ideas", locals: { person: @person, workshop_variation_ideas: @workshop_variation_ideas }
       when "affiliations"
         @affiliations = @person.affiliations.active.includes(organization: :logo_attachment).paginate(page: params[:page], per_page: per_page)

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -39,6 +39,9 @@ class StoryIdeasController < ApplicationController
     @story_idea = StoryIdea.new(story_idea_params.except(:category_ids, :sector_ids))
     @story_idea.created_by = current_user
     @story_idea.updated_by = current_user
+    # Credit the submitter as the author, so the idea lists on their profile by
+    # authorship like every other content type. An admin can reassign it later.
+    @story_idea.author ||= current_user.person
     authorize! @story_idea
 
     success = false

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -24,6 +24,9 @@ class WorkshopIdeasController < ApplicationController
 
   def create
     @workshop_idea = WorkshopIdea.new(workshop_idea_params)
+    # Credit the submitting account's person as the author, so the idea lists on
+    # their profile by authorship like every other content type.
+    @workshop_idea.author ||= @workshop_idea.created_by&.person
     authorize! @workshop_idea
 
     if @workshop_idea.save

--- a/app/controllers/workshop_variation_ideas_controller.rb
+++ b/app/controllers/workshop_variation_ideas_controller.rb
@@ -42,6 +42,9 @@ class WorkshopVariationIdeasController < ApplicationController
 
   def create
     @workshop_variation_idea = WorkshopVariationIdea.new(workshop_variation_idea_params)
+    # Credit the submitting account's person as the author, so the idea lists on
+    # their profile by authorship like every other content type.
+    @workshop_variation_idea.author ||= @workshop_variation_idea.created_by&.person
     authorize! @workshop_variation_idea
 
     if @workshop_variation_idea.save

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,6 +35,12 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   has_many :resources_as_author, inverse_of: :author, class_name: "Resource", foreign_key: :author_id,
            dependent: :restrict_with_error
+  has_many :story_ideas_as_author, inverse_of: :author, class_name: "StoryIdea", foreign_key: :author_id,
+           dependent: :restrict_with_error
+  has_many :workshop_ideas_as_author, inverse_of: :author, class_name: "WorkshopIdea", foreign_key: :author_id,
+           dependent: :restrict_with_error
+  has_many :workshop_variation_ideas_as_author, inverse_of: :author, class_name: "WorkshopVariationIdea",
+           foreign_key: :author_id, dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :topic_subscriptions, dependent: :destroy

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -15,6 +15,7 @@ class StoryIdea < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :author, class_name: "Person", inverse_of: :story_ideas_as_author, optional: true
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"
   belongs_to :organization

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -1,6 +1,7 @@
 class WorkshopIdea < ApplicationRecord
   include AuthorCreditable
 
+  belongs_to :author, class_name: "Person", inverse_of: :workshop_ideas_as_author, optional: true
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"
   belongs_to :windows_type

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -14,6 +14,7 @@ class WorkshopVariationIdea < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :author, class_name: "Person", inverse_of: :workshop_variation_ideas_as_author, optional: true
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"
   belongs_to :workshop

--- a/app/services/author_credit_divergence_query.rb
+++ b/app/services/author_credit_divergence_query.rb
@@ -75,8 +75,8 @@ class AuthorCreditDivergenceQuery
     @models ||= type ? [ self.class.model_for(type) ].compact : MODEL_NAMES.map(&:constantize)
   end
 
-  # The idea models have no author_id, so they credit generically — there's no
-  # author to reconcile, so they're left out of every section.
+  # Every content model now names an author, so all of them can be reconciled —
+  # kept as a guard in case a future model joins without an author_id column.
   def authorable_models
     models.select { |model| model.column_names.include?("author_id") }
   end

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -92,7 +92,7 @@
       <p class="text-sm text-gray-600 mb-4">
         No <code>author_id</code>, so they credit a generic AWBW label &mdash; entering
         a record isn't claiming it. Grouped under whoever created them, the likeliest author to assign
-        (but confirm it). Idea records are excluded: they never name an author.
+        (but confirm it). Idea submissions land here too, credited to whoever entered them.
       </p>
 
       <% if @result.creator.empty? %>

--- a/db/migrate/20260820155015_add_author_to_idea_models.rb
+++ b/db/migrate/20260820155015_add_author_to_idea_models.rb
@@ -1,0 +1,25 @@
+class AddAuthorToIdeaModels < ActiveRecord::Migration[8.1]
+  TABLES = %i[story_ideas workshop_ideas workshop_variation_ideas].freeze
+
+  def up
+    TABLES.each do |table|
+      add_reference table, :author, foreign_key: { to_table: :people }, index: true, null: true unless column_exists?(table, :author_id)
+      # Backfill authorship from the submitting account's person so the profile can
+      # credit ideas by author (matching every other content type) without dropping
+      # anything already shown. An admin can reassign the author afterward.
+      execute <<~SQL.squish
+        UPDATE #{table}
+        JOIN users ON users.id = #{table}.created_by_id
+        SET #{table}.author_id = users.person_id
+        WHERE #{table}.author_id IS NULL
+          AND users.person_id IS NOT NULL
+      SQL
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      remove_reference table, :author, foreign_key: { to_table: :people }, if_exists: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_155015) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1369,6 +1369,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
 
   create_table "story_ideas", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "body"
     t.datetime "created_at", null: false
     t.integer "created_by_id", null: false
@@ -1381,6 +1382,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
     t.integer "windows_type_id", null: false
     t.integer "workshop_id"
     t.string "youtube_url"
+    t.index ["author_id"], name: "index_story_ideas_on_author_id"
     t.index ["created_by_id"], name: "index_story_ideas_on_created_by_id"
     t.index ["organization_id"], name: "index_story_ideas_on_organization_id"
     t.index ["updated_by_id"], name: "index_story_ideas_on_updated_by_id"
@@ -1573,6 +1575,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
     t.text "age_range"
     t.text "age_range_spanish"
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "closing"
     t.text "closing_spanish"
     t.datetime "created_at", null: false
@@ -1622,6 +1625,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
     t.text "warm_up"
     t.text "warm_up_spanish"
     t.integer "windows_type_id", null: false
+    t.index ["author_id"], name: "index_workshop_ideas_on_author_id"
     t.index ["created_by_id"], name: "index_workshop_ideas_on_created_by_id"
     t.index ["updated_by_id"], name: "index_workshop_ideas_on_updated_by_id"
     t.index ["windows_type_id"], name: "index_workshop_ideas_on_windows_type_id"
@@ -1678,6 +1682,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
 
   create_table "workshop_variation_ideas", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "author_credit_preference"
+    t.bigint "author_id"
     t.text "body", size: :long
     t.datetime "created_at", null: false
     t.integer "created_by_id", null: false
@@ -1689,6 +1694,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
     t.integer "windows_type_id", null: false
     t.integer "workshop_id", null: false
     t.string "youtube_url"
+    t.index ["author_id"], name: "index_workshop_variation_ideas_on_author_id"
     t.index ["body"], name: "index_workshop_variation_ideas_on_body", type: :fulltext
     t.index ["created_by_id"], name: "index_workshop_variation_ideas_on_created_by_id"
     t.index ["name"], name: "index_workshop_variation_ideas_on_name"
@@ -1934,6 +1940,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
   add_foreign_key "stories", "windows_types"
   add_foreign_key "stories", "workshops"
   add_foreign_key "story_ideas", "organizations"
+  add_foreign_key "story_ideas", "people", column: "author_id"
   add_foreign_key "story_ideas", "users", column: "created_by_id"
   add_foreign_key "story_ideas", "users", column: "updated_by_id"
   add_foreign_key "story_ideas", "windows_types"
@@ -1954,6 +1961,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
   add_foreign_key "users", "users", column: "updated_by_id"
   add_foreign_key "workshop_age_ranges", "age_ranges"
   add_foreign_key "workshop_age_ranges", "workshops"
+  add_foreign_key "workshop_ideas", "people", column: "author_id"
   add_foreign_key "workshop_ideas", "users", column: "created_by_id"
   add_foreign_key "workshop_ideas", "users", column: "updated_by_id"
   add_foreign_key "workshop_ideas", "windows_types"
@@ -1966,6 +1974,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_144446) do
   add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_child_id"
   add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_parent_id"
   add_foreign_key "workshop_variation_ideas", "organizations"
+  add_foreign_key "workshop_variation_ideas", "people", column: "author_id"
   add_foreign_key "workshop_variation_ideas", "users", column: "created_by_id"
   add_foreign_key "workshop_variation_ideas", "users", column: "updated_by_id"
   add_foreign_key "workshop_variation_ideas", "windows_types"

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe WorkshopIdea, type: :model do
   it_behaves_like "author_creditable", factory: :workshop_idea, org_credited: false
 
-  # No author_id column, and the creator never claims authorship, so an idea always
-  # falls to the generic label rather than crediting whoever entered it.
+  # With no author set the creator never claims authorship, so the idea falls to the
+  # generic label rather than crediting whoever entered it.
   describe "#author_credit" do
     it "credits the generic label, not the creating user's person" do
       creator = create(:user, :with_person)
@@ -15,8 +15,8 @@ RSpec.describe WorkshopIdea, type: :model do
     end
   end
 
-  # Crediting nobody leaves `by_credited_person_name` empty for this model, so the
-  # admin filter has to reach the submitter directly or it matches nothing at all.
+  # An idea usually names no author, so `by_credited_person_name` can't reach the
+  # submitter — the admin filter matches the submitting account directly instead.
   describe ".author_name" do
     let(:creator) { create(:user, :with_person) }
 

--- a/spec/requests/people_private_sections_spec.rb
+++ b/spec/requests/people_private_sections_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe "Person profile private (submitted) sections", type: :request do
   end
 
   before do
-    # The story-idea card titles by workshop_title, so put the marker there.
-    create(:story_idea, created_by: owner_user, updated_by: owner_user,
+    # The section lists ideas by authorship; the story-idea card titles by
+    # workshop_title, so put the marker there.
+    create(:story_idea, created_by: owner_user, updated_by: owner_user, author: person,
                         external_workshop_title: "My Private Submission")
   end
 

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -164,9 +164,9 @@ RSpec.describe AuthorCreditDivergenceQuery do
       expect(described_class.new.call.creator.flat_map(&:records)).not_to include(story)
     end
 
-    it "excludes idea models, whose only credit path is the creator" do
+    it "includes an idea with a creator but no author, now that ideas name an author" do
       idea = create(:story_idea, created_by: author_user)
-      expect(described_class.new.call.creator.flat_map(&:records)).not_to include(idea)
+      expect(described_class.new.call.creator.flat_map(&:records)).to include(idea)
     end
 
     it "excludes records covered by the legacy section instead" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 schema change with a data backfill, new authorship on idea submissions, and a person-profile query switch

## Why

The person profile credits content by **authorship** everywhere (`*_as_author`) — except the three idea sections, which listed by **creatorship** (`user.*_as_creator`), because the idea models had no `author_id`. They were the only content models missing it.

## What

- **Migration** — `author_id` on `story_ideas`, `workshop_ideas`, `workshop_variation_ideas` (FK → `people`, indexed), **backfilled** from each row's submitting account's person so nothing already shown on a profile drops.
- **Models** — `belongs_to :author` on each idea model; `*_ideas_as_author` inverses on `Person`.
- **Creation** — the idea controllers credit the submitter as the author on create.
- **Profile** — the three idea sections now list by authorship (`person.*_ideas_as_author`), matching every other section.
- **Divergences** — ideas are now authorable, so they appear on the reconciliation page like other content; an admin can reassign an idea's author.

## Notes

- Backfill and new-idea authorship both default to the submitting account's person, so this is behavior-preserving for existing profiles (same ideas, now joined via `author_id`) while making an idea's author reassignable.
- Full suite green (7468 examples, 0 failures); migration verified reversible.