### PR TITLE
Add name pronunciation field to person edit

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -545,6 +545,7 @@ class PeopleController < ApplicationController
       :bio, :shoutout_text, :notes,
       :display_name_preference,
       :anonymous_contributions,
+      :pronunciation,
       :pronouns,
       :profile_is_searchable,
       :profile_show_pronouns,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,6 +74,7 @@ class Person < ApplicationRecord
   validates :email_2, format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email address" }, allow_blank: true, length: { maximum: 255 }
   validates :legal_first_name, length: { maximum: 255 }
   validates :pronouns, length: { maximum: 255 }
+  validates :pronunciation, length: { maximum: 255 }
   validates :best_time_to_call, length: { maximum: 255 }
   validates :racial_ethnic_identity, length: { maximum: 255 }
   validates :linked_in_url, length: { maximum: 255 }

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -17,9 +17,9 @@
   <% end %>
 
   <div class="flex flex-col items-start gap-8 md:flex-row">
-    <div class="w-full md:w-3/4">
+    <div class="w-full md:w-5/6">
       <div class="space-y-6">
-        <div class="flex flex-col gap-4 md:flex-row"><%= f.input :first_name, input_html: { value: f.object.first_name || @user&.first_name } %><%= f.input :legal_first_name, label: "Legal First Name", hint: "If different from first name" %><%= f.input :last_name, input_html: { value: f.object.last_name || @user&.last_name } %><%= f.input :pronouns %></div>
+        <div class="flex flex-col gap-4 md:flex-row md:flex-wrap"><%= f.input :first_name, wrapper_html: { class: "w-full md:w-40" }, input_html: { value: f.object.first_name || @user&.first_name, class: "w-full" } %><%= f.input :legal_first_name, label: "Legal First Name", hint: "If different from first name", wrapper_html: { class: "w-full md:w-40" }, input_html: { class: "w-full" } %><%= f.input :last_name, wrapper_html: { class: "w-full md:w-40" }, input_html: { value: f.object.last_name || @user&.last_name, class: "w-full" } %><%= f.input :pronunciation, hint: "How to say the name", wrapper_html: { class: "w-full md:w-44" }, input_html: { class: "w-full" } %><%= f.input :pronouns, wrapper_html: { class: "w-full md:w-32" }, input_html: { class: "w-full" } %></div>
 
         <div class="emails">
           <h3 class="mb-2 font-semibold text-gray-700">Emails</h3>
@@ -76,7 +76,7 @@
     </div>
 
     <!-- Avatar -->
-    <div class="flex w-full flex-col items-center gap-4 md:w-1/4"><%= render "shared/form_image_field", f: f, field_name: :avatar %></div>
+    <div class="flex w-full flex-col items-center gap-4 md:w-1/6"><%= render "shared/form_image_field", f: f, field_name: :avatar %></div>
   </div>
 
   <div class="phones">

--- a/db/migrate/20260820200730_add_pronunciation_to_people.rb
+++ b/db/migrate/20260820200730_add_pronunciation_to_people.rb
@@ -1,0 +1,9 @@
+class AddPronunciationToPeople < ActiveRecord::Migration[8.1]
+  def up
+    add_column :people, :pronunciation, :string unless column_exists?(:people, :pronunciation)
+  end
+
+  def down
+    remove_column :people, :pronunciation, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_155015) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_200730) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1099,6 +1099,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_155015) do
     t.boolean "profile_show_workshop_variations", default: true, null: false
     t.boolean "profile_show_workshops", default: true, null: false
     t.string "pronouns"
+    t.string "pronunciation"
     t.string "racial_ethnic_identity"
     t.text "shoutout_text"
     t.string "twitter_url"

--- a/spec/models/string_column_length_validations_spec.rb
+++ b/spec/models/string_column_length_validations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "varchar(255) length validations" do
   LENGTH_LIMITED_COLUMNS = {
     Address => %i[city street_address zip_code district county country phone],
     ContactMethod => %i[value],
-    Person => %i[first_name last_name email email_2 legal_first_name pronouns
+    Person => %i[first_name last_name email email_2 legal_first_name pronouns pronunciation
                  best_time_to_call racial_ethnic_identity linked_in_url facebook_url
                  instagram_url youtube_url twitter_url],
     Event => %i[title abbreviation pre_title pre_date_text videoconference_url


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small form field + migration, contained to the person edit form

## What
- New `pronunciation` string column on `Person`, added to the edit form before Pronouns.
- Narrowed the first name / legal first name / last name / pronouns fields to fixed widths and slimmed the avatar column (`md:w-1/6`) so all name fields — including the new one — fit on the top row on desktop.

## Why
- Facilitators want to record how a name is pronounced; the wide name/avatar layout left no room, so the fields were tightened to make space.