### PR TITLE
Show the smart field name on every form field, with a linked reference

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -17,6 +17,7 @@ class FormsController < ApplicationController
     @answer_only_identifiers = SmartFormFields::ANSWER_ONLY_IDENTIFIERS
     @return_form = Form.find_by(id: params[:form_id])
     @dashboard_event = Event.find_by(id: params[:event_id])
+    @return_field_id = params[:field_id]
   end
 
   def show

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -17,4 +17,17 @@ module FormsHelper
   def form_role_label(form)
     form.role.presence&.titleize || "General"
   end
+
+  OTHER_RESPONSES_PHRASE = "Other responses review queue"
+
+  # Renders a smart field's plain-text effect with the "Other responses review
+  # queue" phrase turned into a link to that page. The effect strings stay plain
+  # prose (testable, no markup); the link is woven in here at render time.
+  def smart_field_effect(effect)
+    return effect unless effect.include?(OTHER_RESPONSES_PHRASE)
+
+    link = link_to OTHER_RESPONSES_PHRASE, other_responses_path,
+      class: "text-purple-600 hover:text-purple-800 underline", target: "_blank", rel: "noopener"
+    safe_join(effect.split(OTHER_RESPONSES_PHRASE, -1), link)
+  end
 end

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -84,8 +84,10 @@ class SmartFormFields
       title: "The registrant's organization",
       summary: "The organization name is looked up by exact name — the registration never creates an " \
                "organization by itself. When it matches, the organization is linked to the registration, " \
-               "the registrant gets a job affiliation and a facilitator affiliation, and the answers " \
-               "below fill in the organization's profile. When it doesn't match, nothing is written and " \
+               "the registrant gets a Job Affiliation and a Facilitator Affiliation, and the answers " \
+               "below fill in the organization's profile. Both affiliations are connected to the " \
+               "organization's address when it has exactly one; with several addresses the address is " \
+               "left blank for an admin to set. When it doesn't match, nothing is written and " \
                "an admin resolves it on the event registration's Link organization page.",
       fields: [
         [ "agency_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -89,7 +89,7 @@ class SmartFormFields
                "an admin resolves it on the event registration's Link organization page.",
       fields: [
         [ "agency_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],
-        [ "agency_position", "Position / title", "Becomes the job title on the registrant's affiliation with that organization." ],
+        [ "agency_position", "Position / title", "Becomes the job title on the registrant's Job Affiliation with that organization." ],
         [ "agency_website", "Organization website", "Sets the organization's website. Replaces what is on file when the registrant submits it; when an admin links the organization by hand it only fills a blank, and a conflicting answer is flagged instead." ],
         [ "agency_type", "Organization type", "Sets the organization's type. An \"Other\" choice stores the typed text separately and adds it to the Other responses review queue." ],
         [ "agency_street", "Organization street address", "Sets the street of the organization's work address." ],

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -90,7 +90,7 @@ class SmartFormFields
       fields: [
         [ "agency_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],
         [ "agency_position", "Position / title", "Becomes the job title on the registrant's Job Affiliation with that organization." ],
-        [ "agency_website", "Organization website", "Sets the organization's website. Replaces what is on file when the registrant submits it; when an admin links the organization by hand it only fills a blank, and a conflicting answer is flagged instead." ],
+        [ "agency_website", "Organization website", "Sets the organization's website. Replaces what is on file when the registrant submits it; when an admin links it by hand (Link or Create and link) it only fills a blank, and a conflicting answer is flagged instead. Note: a raw URL is saved exactly as entered, so it may not be clickable if it isn't a properly formed URL." ],
         [ "agency_type", "Organization type", "Sets the organization's type. An \"Other\" choice stores the typed text separately and adds it to the Other responses review queue." ],
         [ "agency_street", "Organization street address", "Sets the street of the organization's work address." ],
         [ "agency_city", "Organization city", "Sets the city, and decides whether an organization address is saved at all — no city answered means no address." ],

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -86,7 +86,7 @@ class SmartFormFields
                "organization by itself. When it matches, the organization is linked to the registration, " \
                "the registrant gets a job affiliation and a facilitator affiliation, and the answers " \
                "below fill in the organization's profile. When it doesn't match, nothing is written and " \
-               "an admin resolves it on the registration's Link organization page.",
+               "an admin resolves it on the event registration's Link organization page.",
       fields: [
         [ "agency_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],
         [ "agency_position", "Position / title", "Becomes the job title on the registrant's affiliation with that organization." ],

--- a/app/views/forms/_form_field_answer_option_fields.html.erb
+++ b/app/views/forms/_form_field_answer_option_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="nested-fields flex items-center gap-2">
   <i class="fa-solid fa-circle text-4xs shrink-0 text-gray-300"></i>
   <%= f.text_field :option_name, placeholder: "Option text",
-        class: "flex-1 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
+        class: "flex-1 min-w-0 max-w-md rounded border-gray-300 shadow-sm px-2 py-1 text-sm" %>
   <%= link_to_remove_association f,
         class: "shrink-0 text-gray-400 hover:text-red-600 px-1 cursor-pointer",
         title: "Remove option" do %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -101,8 +101,9 @@
       <% option_source = form_field_option_source(field) %>
       <div class="hidden mt-2 pb-2 flex flex-col gap-3" data-field-options-target="panel">
         <div class="flex flex-wrap items-center gap-2">
-          <%# Fixed-width first column so the Subtitle box lines up under the answer-type dropdown above. %>
-          <div class="min-w-0 flex-[3_1_10rem]">
+          <%# Fixed-width first column (no grow) so it doesn't balloon and push the rest of
+              the row rightward, keeping room for the smart field name and Remove. %>
+          <div class="min-w-0 flex-[0_1_10rem]">
             <% if option_source %>
               <%# These options are managed centrally, not per-field — link admins to that list. %>
               <span class="inline-flex items-center gap-1.5 text-sm text-gray-500">
@@ -132,10 +133,10 @@
             ]
           %>
           <%= f.text_area :subtitle, rows: 1, placeholder: "Subtitle",
-                class: "min-w-0 flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional subtitle shown under the field label" %>
           <%= f.text_area :hint_text, rows: 1, placeholder: "Hint",
-                class: "min-w-0 flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional hint shown below the field input" %>
           <%= f.select :width, width_options,
                 {},

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -132,17 +132,17 @@
               [ "Quarter width", "quarter" ]
             ]
           %>
+          <%# ml-auto here pushes Subtitle and everything after it to the right, so
+              Subtitle/Hint sit next to the width control as one right-aligned cluster. %>
           <%= f.text_area :subtitle, rows: 1, placeholder: "Subtitle",
-                class: "min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "ml-auto min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional subtitle shown under the field label" %>
           <%= f.text_area :hint_text, rows: 1, placeholder: "Hint",
                 class: "min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional hint shown below the field input" %>
-          <%# Right-align the trailing controls to the row's edge so Remove keeps its
-              original right margin — the shrunk Subtitle/Hint keep it all on one line. %>
           <%= f.select :width, width_options,
                 {},
-                class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "How wide this field appears on the form" %>
           <%= f.number_field :min_words, min: 0, placeholder: "Min words",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -139,7 +139,7 @@
                 title: "Optional hint shown below the field input" %>
           <%= f.select :width, width_options,
                 {},
-                class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "How wide this field appears on the form" %>
           <%= f.number_field :min_words, min: 0, placeholder: "Min words",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
@@ -147,19 +147,21 @@
           <%= f.number_field :max_characters, min: 1, placeholder: "Max chars",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Maximum number of characters allowed (free-form text fields only)" %>
-          <%# The smart field name wires this field to backend logic (Stripe, service
-              areas, email checks, etc.); most fields need none. The linked hint opens
-              the reference page listing what each name does. %>
-          <div class="flex flex-col shrink-0">
-            <%= f.text_field :field_identifier, placeholder: "Smart field name",
-                  class: "w-32 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
-                  title: "Internal name that wires this field to backend logic — leave blank for an ordinary field" %>
-            <%= link_to "What's this?", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id, field_id: field.id),
-                  class: "mt-0.5 text-3xs text-purple-600 hover:text-purple-800 underline",
-                  target: "_blank", rel: "noopener" %>
+          <%# Smart field name + Remove stay pinned together so Remove never lands on its own
+              line. The name wires this field to backend logic (Stripe, service areas, email
+              checks, etc.); most fields need none, and the linked hint explains each one. %>
+          <div class="flex shrink-0 items-center gap-2">
+            <div class="flex flex-col shrink-0">
+              <%= f.text_field :field_identifier, placeholder: "Smart field name",
+                    class: "w-32 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
+                    title: "Internal name that wires this field to backend logic — leave blank for an ordinary field" %>
+              <%= link_to "What's this?", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id, field_id: field.id),
+                    class: "mt-0.5 text-3xs text-purple-600 hover:text-purple-800 underline",
+                    target: "_blank", rel: "noopener" %>
+            </div>
+            <%= link_to_remove_association "Remove", f,
+                  class: "shrink-0 text-sm text-gray-400 hover:text-red-600 underline" %>
           </div>
-          <%= link_to_remove_association "Remove", f,
-                class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0" %>
         </div>
 
         <% unless option_source %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -13,7 +13,8 @@
     answers_on_file: "bg-white text-amber-600 border-amber-300"
   }
 %>
-<div class="nested-fields flex items-center gap-3 <%= field.group_header? ? 'pl-3 pr-6' : 'px-6' %> py-3 border-b border-gray-100 hover:bg-gray-50"
+<div class="nested-fields flex items-center gap-3 <%= field.group_header? ? 'pl-3 pr-6' : 'px-6' %> py-3 border-b border-gray-100 hover:bg-gray-50 scroll-mt-24"
+     <% if field.persisted? %>id="form_field_<%= field.id %>"<% end %>
      data-sortable-id="<%= field.id %>"
      <% if field.section.present? %>data-section="<%= field.section %>"<% end %>
      <% if field.group_header? %>data-group-header<% end %>>
@@ -146,20 +147,20 @@
           <%= f.number_field :max_characters, min: 1, placeholder: "Max chars",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Maximum number of characters allowed (free-form text fields only)" %>
+          <%# The smart field name wires this field to backend logic (Stripe, service
+              areas, email checks, etc.); most fields need none. The linked hint opens
+              the reference page listing what each name does. %>
+          <div class="flex flex-col shrink-0">
+            <%= f.text_field :field_identifier, placeholder: "Smart field name",
+                  class: "w-32 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
+                  title: "Internal name that wires this field to backend logic — leave blank for an ordinary field" %>
+            <%= link_to "What's this?", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id, field_id: field.id),
+                  class: "mt-0.5 text-3xs text-purple-600 hover:text-purple-800 underline",
+                  target: "_blank", rel: "noopener" %>
+          </div>
           <%= link_to_remove_association "Remove", f,
                 class: "text-sm text-gray-400 hover:text-red-600 underline shrink-0" %>
         </div>
-
-        <% if params[:admin] == "true" %>
-          <%# Field identifiers tie a field to backend logic (Stripe, service areas, email, etc.),
-              so they're only editable with ?admin=true on the URL. %>
-          <label class="flex items-center justify-end gap-2 text-xs text-gray-500">
-            <span class="shrink-0 font-medium">Field identifier</span>
-            <%= f.text_field :field_identifier, placeholder: "e.g. payment_method",
-                  class: "w-1/4 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
-                  title: "Internal identifier linking this field to system logic — leave blank for an ordinary field" %>
-          </label>
-        <% end %>
 
         <% unless option_source %>
           <% options_locked = field.fixed_options? && params[:admin] != "true" %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -155,7 +155,7 @@
               checks, etc.); most fields need none, and the linked hint explains each one. %>
           <div class="flex shrink-0 items-center gap-2">
             <div class="flex flex-col shrink-0">
-              <%= f.text_field :field_identifier, placeholder: "Smart field name",
+              <%= f.text_field :field_identifier, placeholder: "Smart field",
                     class: "w-32 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
                     title: "Internal name that wires this field to backend logic — leave blank for an ordinary field" %>
               <%= link_to "What's this?", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id, field_id: field.id),

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -138,9 +138,11 @@
           <%= f.text_area :hint_text, rows: 1, placeholder: "Hint",
                 class: "min-w-0 flex-[0_1_7rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "Optional hint shown below the field input" %>
+          <%# Right-align the trailing controls to the row's edge so Remove keeps its
+              original right margin — the shrunk Subtitle/Hint keep it all on one line. %>
           <%= f.select :width, width_options,
                 {},
-                class: "shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
+                class: "ml-auto shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
                 title: "How wide this field appears on the form" %>
           <%= f.number_field :min_words, min: 0, placeholder: "Min words",
                 class: "w-24 shrink-0 rounded border-gray-300 shadow-sm px-2 py-1 text-sm",

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <% end %>
     <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Smart form settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
+    <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
                 class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -6,7 +6,7 @@
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Smart form settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
+    <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
                 class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
     <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -30,16 +30,23 @@
 
     <div class="bg-white px-4 sm:px-6 py-6 space-y-6">
       <div class="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-        <p class="flex items-start gap-2">
+        <div class="flex items-start gap-2">
           <i class="fa-solid fa-circle-info mt-0.5 shrink-0"></i>
-          <span>
-            Most questions need no smart field — their answers are saved on the submission and read there.
-            A <strong>smart field</strong> is what wires a question to a record, so the answer also updates
-            a person, an organization, or a payment. This page lists every smart field that does something, and
-            what it does. Smart fields are set per question in the form editor, and only one question per form
-            may carry a given smart field.
-          </span>
-        </p>
+          <div class="space-y-2">
+            <p>
+              A <strong>smart field</strong> is what wires a question to a record, so the answer also updates
+              a person, an organization, or a payment.
+            </p>
+            <p>
+              This page lists every smart field and related actions. Smart fields are set per question in the
+              form editor, and only one question per form may carry a given smart field.
+            </p>
+            <p>
+              <strong>Note:</strong> most questions need no smart field — their answers are saved on the
+              submission and read there.
+            </p>
+          </div>
+        </div>
       </div>
 
       <%# Jump list — the page is long and admins arrive looking for one identifier. %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div>
           <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Reference</p>
-          <h1 class="text-2xl font-bold tracking-tight leading-tight">Smart form settings</h1>
+          <h1 class="text-2xl font-bold tracking-tight leading-tight">Smart field settings</h1>
         </div>
       </div>
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
@@ -33,11 +33,11 @@
         <p class="flex items-start gap-2">
           <i class="fa-solid fa-circle-info mt-0.5 shrink-0"></i>
           <span>
-            Most questions need no field identifier — their answers are saved on the submission and read there.
-            A <strong>field identifier</strong> is what wires a question to a record, so the answer also updates
-            a person, an organization, or a payment. This page lists every identifier that does something, and
-            what it does. Identifiers are set per question in the form editor, and only one question per form
-            may carry a given identifier.
+            Most questions need no smart field — their answers are saved on the submission and read there.
+            A <strong>smart field</strong> is what wires a question to a record, so the answer also updates
+            a person, an organization, or a payment. This page lists every smart field that does something, and
+            what it does. Smart fields are set per question in the form editor, and only one question per form
+            may carry a given smart field.
           </span>
         </p>
       </div>
@@ -80,12 +80,12 @@
 
       <section class="rounded-xl border border-gray-200 shadow-sm overflow-hidden">
         <div class="px-5 py-3 bg-gray-100 border-b border-gray-300">
-          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Identifiers that do nothing extra</h2>
+          <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">Smart fields that do nothing extra</h2>
         </div>
         <div class="px-5 py-4">
           <p class="text-sm text-gray-600 mb-3">
             These come with the question library and are stored on the submission like any ordinary question.
-            They carry an identifier only so reports and exports can find them by name — no record is updated.
+            They carry a smart field only so reports and exports can find them by name — no record is updated.
           </p>
           <div class="flex flex-wrap gap-2">
             <% @answer_only_identifiers.each do |identifier| %>
@@ -96,8 +96,8 @@
       </section>
 
       <p class="text-xs text-gray-500">
-        An identifier not listed here does nothing — the answer is stored on the submission and no record is updated.
-        Changing an identifier on a live form changes where future answers go; answers already submitted stay as they are.
+        A smart field not listed here does nothing — the answer is stored on the submission and no record is updated.
+        Changing a smart field on a live form changes where future answers go; answers already submitted stay as they are.
       </p>
     </div>
   </div>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -34,8 +34,8 @@
           <i class="fa-solid fa-circle-info mt-0.5 shrink-0"></i>
           <div class="space-y-2">
             <p>
-              A <strong>smart field</strong> is what wires a question to a record, so the answer also updates
-              a person, an organization, or a payment.
+              A <strong>smart field</strong> connects a question to a person, an organization, or a payment,
+              so answering it updates them directly — not just this form.
             </p>
             <p>
               This page lists every smart field and related actions. Smart fields are set per question in the

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -39,11 +39,8 @@
             </p>
             <p>
               This page lists every smart field and related actions. Smart fields are set per question in the
-              form editor, and only one question per form may carry a given smart field.
-            </p>
-            <p>
-              <strong>Note:</strong> most questions need no smart field — their answers are saved on the
-              submission and read there.
+              form editor, and only one question per form may carry a given smart field. Note: most questions
+              need no smart field — their answers are saved on the submission and read there.
             </p>
           </div>
         </div>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -4,7 +4,11 @@
       carrying the event so the editor reopens in its dashboard context. %>
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <% if @return_form %>
-      <%= link_to "← Back to #{@return_form.display_name}", edit_form_path(@return_form, event_id: @dashboard_event&.id),
+      <%# Anchor straight back to the field the hint was opened from — this page opens in
+          a new tab, so the browser back button can't return the admin to that row. %>
+      <%= link_to "← Back to #{@return_form.display_name}",
+                  edit_form_path(@return_form, event_id: @dashboard_event&.id,
+                                 anchor: @return_field_id.present? ? "form_field_#{@return_field_id}" : nil),
                   class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 mr-auto" %>
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -74,7 +74,7 @@
                     <code class="inline-block rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-800 break-all"><%= field.identifier %></code>
                     <p class="mt-1 text-xs text-gray-500"><%= field.question %></p>
                   </dt>
-                  <dd class="mt-1 sm:mt-0 text-sm text-gray-700"><%= field.effect %></dd>
+                  <dd class="mt-1 sm:mt-0 text-sm text-gray-700"><%= smart_field_effect(field.effect) %></dd>
                 </div>
               <% end %>
             </dl>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Forms", type: :request do
         get smart_form_settings_forms_path
 
         expect(response.body).to include("referral_source")
-        expect(response.body).to include("Identifiers that do nothing extra")
+        expect(response.body).to include("Smart fields that do nothing extra")
       end
 
       # Reached from a form editor, so it has to offer a way back to that editor

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "Forms", type: :request do
 
       get edit_form_path(form)
 
-      expect(response.body).to include("Smart field name")
+      expect(response.body).to include("Smart field")
       expect(response.body).to include("[field_identifier]")
       expect(response.body).to include(smart_form_settings_forms_path(form_id: form.id))
     end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include("Looked up against existing organizations by exact name")
       end
 
+      it "links the Other responses review queue phrase to that page" do
+        get smart_form_settings_forms_path
+
+        expect(response.body).to include(other_responses_path)
+        expect(response.body).to match(/href="#{Regexp.escape(other_responses_path)}"[^>]*>Other responses review queue</)
+      end
+
       it "lists the identifiers that only store an answer" do
         get smart_form_settings_forms_path
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Forms", type: :request do
         get smart_form_settings_forms_path
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include("Smart form settings")
+        expect(response.body).to include("Smart field settings")
         expect(response.body).to include("agency_name")
         expect(response.body).to include("Looked up against existing organizations by exact name")
       end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe "Forms", type: :request do
 
         expect(response.body).not_to include("Back to")
       end
+
+      # Opened in a new tab from a field's "What's this?" hint, so the back link
+      # must anchor to that exact field's row, not just the editor.
+      it "anchors the back link to the field it was opened from" do
+        form = create(:form, :standalone, name: "Reg form")
+        field = create(:form_field, form: form)
+
+        get smart_form_settings_forms_path(form_id: form.id, field_id: field.id)
+
+        expect(response.body).to include("#{edit_form_path(form)}#form_field_#{field.id}")
+      end
     end
 
     context "as regular user" do
@@ -264,6 +275,16 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).not_to match(/payment_method.{0,600}\+ Add option/m)
       # A note explains why they're locked.
       expect(response.body).to include("tied to system logic")
+    end
+
+    it "shows the smart field name input without the admin override, with a link to the reference page" do
+      form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
+
+      get edit_form_path(form)
+
+      expect(response.body).to include("Smart field name")
+      expect(response.body).to include("[field_identifier]")
+      expect(response.body).to include(smart_form_settings_forms_path(form_id: form.id))
     end
 
     it "renders payment-method options as editable inputs with ?admin=true" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 form-editor view logic + one controller line, no data changes

## What
- Show the **smart field** (was "Field identifier", editable only with `?admin=true`) on every form field in the editor — the whole editor is already admin-only, so the extra URL toggle just hid it.
- Move it into the field's options row (right of **Max chars**); placeholder "Smart field", no label.
- Add a small linked **"What's this?"** hint under it, opening the **Smart field settings** reference page (lists every smart field + what it does).

## Naming
- Renamed the reference page "Smart form settings" → **Smart field settings**, and replaced the public-facing "field identifier" / "identifier" wording with **smart field**. The `field_identifier` column is unchanged.

## Back link
- The hint opens in a new tab, so the reference page eyebrow anchors straight back to the field it came from (`#form_field_<id>`); the field row gets a matching `id` + `scroll-mt`.

## Layout
- Smart field + Remove pinned together; Subtitle/Hint shrunk and clustered with the width control so the whole row fits on one line with Remove at its original right margin.
- Answer-option inputs capped at a readable width instead of stretching edge-to-edge.