### PR TITLE
Rename organization "Art program since" surfaces to "Facilitators since"

### DIFF
--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -96,7 +96,7 @@ class OrganizationDecorator < ApplicationDecorator
     AffiliationPeriods.label(affiliations) || object.start_date&.strftime("%b %Y") || ""
   end
 
-  # "Art program since" — facilitators only, at month precision, since the exact
+  # "Facilitators since" — facilitators only, at month precision, since the exact
   # start/lapse month is the point. Blank when the org has never facilitated.
   def program_since_display(affiliations = object.affiliations)
     AffiliationPeriods.label(affiliations.select(&:facilitator?), precision: :month) || ""

--- a/app/services/affiliation_periods.rb
+++ b/app/services/affiliation_periods.rb
@@ -3,8 +3,8 @@
 #
 #   * :year (default) — "Affiliated since", e.g. "2010-2012, 2026". A lone ongoing
 #     period keeps its month when it began this year ("Jul 2026").
-#   * :month — "Art program since", e.g. "Aug 2015 – Jun 2018, Feb 2024", where the
-#     month a program started or lapsed is the point.
+#   * :month — "Facilitators since", e.g. "Aug 2015 – Jun 2018, Feb 2024", where the
+#     month facilitating started or lapsed is the point.
 #
 # Nil when no affiliation carries a start date, so callers can fall back to the
 # organization's own start_date.

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -59,7 +59,7 @@
                 } %>
           <p class="mt-1 text-xs text-amber-700">
             <i class="fa-solid fa-triangle-exclamation mr-1"></i>
-            Changing the organization affects this org's Art Program status.
+            Changing the organization affects this org's Program status.
           </p>
         </div>
 
@@ -91,7 +91,7 @@
         <div class="flex-1 min-w-[200px]">
           <%= f.input :title,
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                hint: "\"Facilitator\" = AWBW Art Program Facilitator." %>
+                hint: "\"Facilitator\" = AWBW Facilitator." %>
         </div>
         <div class="w-40">
           <%= f.input :start_date,

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -322,10 +322,10 @@
         </div>
         <div class="shrink-0 relative group cursor-help">
           <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
-            Art program since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+            Facilitators since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
           </label>
           <div class="hidden group-hover:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
-            <p>When this organization's art program ran, from its 'Facilitator' affiliations — one period per stretch of facilitating, so a lapse and a return read as separate periods (e.g. "Aug 2015 – Jun 2018, Feb 2024"). Updates live as you edit the affiliation rows below.</p>
+            <p>When this organization started having AWBW facilitators, from its 'Facilitator' affiliations — one period per stretch of facilitating, so a lapse and a return read as separate periods (e.g. "Aug 2015 – Jun 2018, Feb 2024"). Updates live as you edit the affiliation rows below.</p>
           </div>
           <div class="pt-1">
             <span class="text-gray-900 font-medium" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>

--- a/app/views/organizations/_search_boxes.html.erb
+++ b/app/views/organizations/_search_boxes.html.erb
@@ -36,9 +36,9 @@
         <%= select_tag :program_status,
                        options_for_select([
                          [ "Active", "active" ],
+                         [ "Inactive", "formerly_or_never" ],
                          [ "Formerly active", "formerly_active" ],
-                         [ "Never active", "never_active" ],
-                         [ "Formerly + Never active", "formerly_or_never" ]
+                         [ "Never active", "never_active" ]
                        ], params[:program_status]),
                        include_blank: "All statuses",
                        class: "w-44 rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm

--- a/app/views/organizations/organizations_results.html.erb
+++ b/app/views/organizations/organizations_results.html.erb
@@ -10,7 +10,7 @@
             <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
             <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Sectors</th>
             <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Age group(s)</th>
-            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Program since</th>
+            <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Facilitators since</th>
             <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">People (<%= number_with_delimiter(@active_people_count) %>)</th>
             <% if allowed_to?(:manage?, Organization) %>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -58,7 +58,7 @@
         <% program_since = org_decorated.program_since_display %>
         <% if program_since.present? %>
           <p class="text-gray-500 text-sm mt-1">
-            Art program since
+            Facilitators since
             <span class="font-medium"><%= program_since %></span>
           </p>
         <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -161,12 +161,12 @@
   action_path: "/organizations"
   pr_number: 1993
   summary: >-
-    The organization list gains Sectors and Age group columns and an "Art program
+    The organization list gains Sectors and Age group columns and a "Facilitators
     since" chip, filterable by sector, age group and program status.
   pro_tips:
     - Sector and age group match the organization's own tags plus its affiliated
       people's primary tags.
-    - The "Art program since" chip shows each stretch of facilitating separately,
+    - The "Facilitators since" chip shows each stretch of facilitating separately,
       so a lapse and a return read as two periods.
 
 - name: "Edit an affiliation's details and comments"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -132,7 +132,7 @@ rename_registration_header.call("Mailing Address", "Primary Mailing Address",
                                 subtitle: "For mailing raffle prizes, incentives, and important announcements")
 rename_registration_header.call("Organization Information", "Your Organization",
                                 subtitle: "If your organization has a website, please put your organization name as it appears on the website. " \
-                                          "If you're not associated with an organization, please provide a name for your art program.")
+                                          "If you're not associated with an organization, please provide a name for your program.")
 rename_registration_header.call("Professional Information", "Participant Information")
 rename_registration_header.call("Background Information", "About You")
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -46,6 +46,10 @@ with a registrant**. Rendered as merged year-based periods
 
 ### D2 — "Facilitators since": facilitator affiliations only, month precision
 
+*Formerly labeled "Art program since" in the UI; the decorator method is still
+`program_since_display`, so code, old references, and the current label all name
+the same figure.*
+
 Same merged-period rendering as D1 but over **facilitator** affiliations only,
 and at **month** precision (`AffiliationPeriods.label(…, precision: :month)`) —
 when facilitating started or lapsed is the point of the figure. Ongoing reads

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -9,7 +9,7 @@ The organization profile/edit page surfaces several affiliation-derived figures
 that are easy to confuse with one another:
 
 - **Affiliated since**
-- **Facilitations/program since**
+- **Facilitators since**
 - an org-wide **status chip** (Active / Formerly active / Never active)
 - per-event **program-status chips** (New / Ongoing / Reinstate)
 
@@ -44,11 +44,11 @@ with a registrant**. Rendered as merged year-based periods
 (`AffiliationPeriods.label`), e.g. `2010-2012, 2026`; falls back to the org's own
 `start_date`, then blank. See `OrganizationDecorator#affiliated_since_display`.
 
-### D2 — "Art program since": facilitator affiliations only, month precision
+### D2 — "Facilitators since": facilitator affiliations only, month precision
 
 Same merged-period rendering as D1 but over **facilitator** affiliations only,
 and at **month** precision (`AffiliationPeriods.label(…, precision: :month)`) —
-when a program started or lapsed is the point of the figure. Ongoing reads
+when facilitating started or lapsed is the point of the figure. Ongoing reads
 `Feb 2024`, closed reads `Aug 2015 – Jun 2018`, e.g.
 `Aug 2015 – Jun 2018, Feb 2024`. Blank when the org has never facilitated. See
 `OrganizationDecorator#program_since_display`.

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
       expect(affiliated).to have_text("2018-2019, 2021", wait: 5)
     end
 
-    # "Art program since" is the same merged-period value at month precision, so it
+    # "Facilitators since" is the same merged-period value at month precision, so it
     # has to live-update in that format too — not the old earliest→latest range.
-    it "live-updates 'Art program since' as month-precision periods" do
+    it "live-updates 'Facilitators since' as month-precision periods" do
       visit_and_wait edit_organization_path(merged_org)
 
       program = find("[data-affiliation-dates-target='facilitatorSince']")

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "organizations/edit", type: :view do
     end
   end
 
-  describe "art program since" do
+  describe "facilitators since" do
     before(:each) { assign(:organization_statuses, OrganizationStatus.all) }
 
     around { |ex| travel_to(Date.new(2026, 8, 3)) { ex.run } }
@@ -132,7 +132,7 @@ RSpec.describe "organizations/edit", type: :view do
       assert_select "[data-affiliation-dates-target='facilitatorSince']", text: /Sep 2026/, count: 0
     end
 
-    # This form and the profile used to render "Art program since" two different
+    # This form and the profile used to render "Facilitators since" two different
     # ways — the profile as merged periods, this form as one earliest→latest span,
     # which silently swallowed the gap. Both now render the one decorator value.
     it "renders a lapse and a return as separate periods, matching the profile" do


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only copy/label changes, no logic or data changes

### What is the goal of this PR and why is this important?
"Art program" is confusing wording for a figure that derives purely from an org's **Facilitator** affiliations. This renames it to "Facilitators since" so it reads consistently everywhere and matches what the code already computes.

### How did you approach the change?
- **Org "Facilitators since"** (was "Art program since" / "Program since"): unified the label across the profile chip, index column, and edit form + tooltip.
- **Status filter:** renamed the "Formerly + Never active" option to **"Inactive"** (same `formerly_or_never` bucket) and moved it above its two sub-buckets. No filter logic or value tokens changed.
- Person-scoped "Facilitator since" labels stay singular (a person *is* a facilitator); only org surfaces went plural.
- Swept the phrase from the affiliation-edit hint, `config/features.yml`, code comments, ADR-0001, and spec descriptions.

### UI Testing Checklist
- [ ] Org index: column header reads "Facilitators since"; "Program status" filter lists Active / Inactive / Formerly active / Never active and each still filters correctly.
- [ ] Org profile + edit form: "Facilitators since" label and tooltip render.
- [ ] Affiliation edit: hint reads "Facilitator = AWBW Facilitator".

### Anything else to add?
Labels/copy only — no model, query, or value-token changes, so existing specs (which assert on the `facilitatorSince` data-target, not label text) are unaffected.