### PR TITLE
Consolidate age group field identifiers to primary_age_group + additional_age_groups

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -165,7 +165,7 @@ module EventHelper
     case field&.field_identifier
     when *FormField::SECTOR_FIELD_IDENTIFIERS
       resolve.call(Sector)
-    when "primary_age_group", "additional_age_group"
+    when *FormField::AGE_GROUP_FIELD_IDENTIFIERS
       resolve.call(Category)
     else
       submitted_answer

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -30,22 +30,27 @@ class FormField < ApplicationRecord
   # submitted value for these is a Sector id (as a string).
   SECTOR_FIELD_IDENTIFIERS = (ADDITIONAL_SECTOR_FIELD_IDENTIFIERS + PRIMARY_SECTOR_FIELD_IDENTIFIERS).freeze
 
+  # Single-select "primary age group" field identifier.
+  PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS = %w[primary_age_group].freeze
+
+  # Multi-select "additional age groups" field identifiers. "additional_age_groups"
+  # is the canonical name new forms are built with; the legacy singular
+  # "additional_age_group" is still accepted so existing forms keep resolving.
+  ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIERS = %w[additional_age_groups additional_age_group].freeze
+
+  # Both age group fields (the single-select "primary" and the multi-select
+  # "additional"), backing the "All age groups" breakdown. The primary field
+  # alone backs the "Primary age group" chart.
+  AGE_GROUP_FIELD_IDENTIFIERS = (PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS + ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIERS).freeze
+
   # Field identifiers whose selectable options are sourced dynamically from a
   # CategoryType's published categories. The submitted value is a Category id
   # (as a string). Maps the field identifier to its backing CategoryType name.
-  # Both the "primary" and "additional" age group fields are backed by the
-  # published AgeRange categories. Unlike the sector fields, age groups have no
-  # catch-all option — the additional sector field keeps "Other", but neither age
+  # Every age group field (primary + additional, canonical and legacy) is backed
+  # by the published AgeRange categories. Unlike the sector fields, age groups have
+  # no catch-all option — the additional sector field keeps "Other", but no age
   # field offers one.
-  DYNAMIC_FIELD_CATEGORY_TYPES = {
-    "primary_age_group" => "AgeRange",
-    "additional_age_group" => "AgeRange"
-  }.freeze
-
-  # Both age group fields (the single-select "primary" and the multi-select
-  # "additional"), backing the "All age groups" breakdown. The "primary_age_group"
-  # field alone backs the "Primary age group" chart.
-  AGE_GROUP_FIELD_IDENTIFIERS = %w[primary_age_group additional_age_group].freeze
+  DYNAMIC_FIELD_CATEGORY_TYPES = AGE_GROUP_FIELD_IDENTIFIERS.index_with { "AgeRange" }.freeze
 
   # The payment-method field. Its answer options ("Credit card (now)", etc.) are
   # wired to Stripe charge logic in the controllers, so they must not be edited

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -358,7 +358,7 @@ class Person < ApplicationRecord
 
   # Field identifiers whose "Other" free text maps onto the category-backed
   # profile fields shown on the edit page.
-  OTHER_WORKSHOP_SETTING_IDENTIFIERS = %w[primary_age_group additional_age_group].freeze
+  OTHER_WORKSHOP_SETTING_IDENTIFIERS = FormField::AGE_GROUP_FIELD_IDENTIFIERS
 
   # Free-text "Other" sectors the person typed on registration forms, captured
   # as OtherResponse records (see EventRegistrationServices::PublicRegistration).

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -169,7 +169,7 @@ class EventDashboard
   # file as form answers. Sector answers are normalized under the "sector" key
   # (see #header_answers_by_applicant) so the view reads one key regardless of
   # which sector field identifier the answer was stored under.
-  HEADER_ANSWER_IDENTIFIERS = (FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS + %w[primary_age_group]).freeze
+  HEADER_ANSWER_IDENTIFIERS = (FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS + FormField::PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS).freeze
 
   # The key sector answers are filed under in the per-applicant header hash.
   HEADER_SECTOR_KEY = "sector".freeze
@@ -805,8 +805,8 @@ class EventDashboard
   end
 
   # Every age group (primary + additional) served, read from registrants'
-  # answers to BOTH the "primary_age_group" and "additional_age_group"
-  # registration questions, backing the "All age groups" chart. The
+  # answers to BOTH the primary and additional age group registration
+  # questions, backing the "All age groups" chart. The
   # "Primary age group" chart instead uses #age_groups / #age_group_counts,
   # which read only the primary question.
   def all_age_groups
@@ -1433,7 +1433,7 @@ class EventDashboard
   # registrants' "primary_age_group" registration answers. Deduped per
   # [ person, category ].
   def age_group_answer_rows
-    @age_group_answer_rows ||= age_group_rows_for(%w[primary_age_group])
+    @age_group_answer_rows ||= age_group_rows_for(FormField::PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS)
   end
 
   # Same, but across BOTH the primary and additional age group questions —

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -377,10 +377,10 @@ module EventRegistrationServices
     end
 
     def assign_tags(person, organization)
-      primary_sector_ids = collect_sector_ids(FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS)
-      additional_sector_ids = collect_sector_ids(FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS)
-      primary_age_ids = collect_ids_from_checkboxes("primary_age_group")
-      additional_age_ids = collect_ids_from_checkboxes("additional_age_group")
+      primary_sector_ids = collect_ids_across(FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS)
+      additional_sector_ids = collect_ids_across(FormField::ADDITIONAL_SECTOR_FIELD_IDENTIFIERS)
+      primary_age_ids = collect_ids_across(FormField::PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS)
+      additional_age_ids = collect_ids_across(FormField::ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIERS)
 
       if primary_sector_ids.any? || additional_sector_ids.any?
         SectorTagging.apply(person: person, organizations: [ organization ],
@@ -393,7 +393,7 @@ module EventRegistrationServices
       end
     end
 
-    def collect_sector_ids(identifiers)
+    def collect_ids_across(identifiers)
       identifiers.flat_map { |id| collect_ids_from_checkboxes(id) }
     end
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -50,7 +50,7 @@ class FormBuilderService
       agency_street agency_city agency_state agency_zip agency_country
     ],
     person_background: %w[racial_ethnic_identity],
-    professional_info: %w[primary_sector additional_sectors primary_age_group additional_age_group],
+    professional_info: %w[primary_sector additional_sectors primary_age_group additional_age_groups],
     marketing: %w[referral_source training_motivation interested_in_more],
     continuing_education: %w[ce_credit_interest ce_license_number],
     scholarship: %w[scholarship_eligibility scholarship_contribution impact_description implementation_plan additional_comments],
@@ -464,7 +464,7 @@ class FormBuilderService
                          key: "primary_age_group", group: "professional", required: false,
                          subtitle: "Select the age group you primarily intend to serve through the art workshops")
     position = add_field(form, position, "Additional Age Group(s) Served", :multi_select_checkbox,
-                         key: "additional_age_group", group: "professional", required: false,
+                         key: "additional_age_groups", group: "professional", required: false,
                          subtitle: "Select all additional age groups you may serve through the art workshops (check all that apply)")
     position
   end

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -111,8 +111,9 @@ class SmartFormFields
         [ "primary_sector", "Primary sector", "Tags the person and organization with one primary sector. Offers no \"Other\" — a primary sector must be a real sector." ],
         [ "additional_sectors", "Additional sectors", "Tags the person and organization with any number of additional sectors. An \"Other\" answer goes to the Other responses review queue, where it can be promoted into a real sector." ],
         [ "primary_age_group", "Primary age group(s) served", "Tags the person and organization with the primary age range served." ],
-        [ "additional_age_group", "Additional age group(s) served", "Tags the person and organization with additional age ranges served." ],
-        [ "primary_sector_single", "Primary sector (legacy)", "Older name for the primary sector question. Still honored; use primary_sector on new forms." ]
+        [ "additional_age_groups", "Additional age group(s) served", "Tags the person and organization with additional age ranges served." ],
+        [ "primary_sector_single", "Primary sector (legacy)", "Older name for the primary sector question. Still honored; use primary_sector on new forms." ],
+        [ "additional_age_group", "Additional age group(s) served (legacy)", "Older singular name for the additional age groups question. Still honored; use additional_age_groups on new forms." ]
       ]
     },
     {

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1172,7 +1172,7 @@ record_professional_answers = ->(submission, i) do
   # Additional age groups are multi-select checkboxes, so store a couple of
   # ", "-joined AgeRange ids the way public registration does.
   additional_ages = age_range_categories.rotate(i + 1).reject { |category| category == age }.first(2)
-  additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_group")
+  additional_age_field = form.form_fields.find_by(field_identifier: "additional_age_groups")
   if additional_age_field && additional_ages.present? && submission.form_answers.where(form_field: additional_age_field).none?
     submission.form_answers.create!(form_field: additional_age_field,
                                     submitted_answer: additional_ages.map(&:id).join(", "),

--- a/db/seeds/dev/legacy_form_identifiers.rb
+++ b/db/seeds/dev/legacy_form_identifiers.rb
@@ -1,15 +1,17 @@
 # Legacy field-identifier registration form (dev-only).
 #
-# The professional sector questions still accept one *legacy* field_identifier —
-# "primary_sector_single" for the single-select primary sector — so older forms
-# keep working (see FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS). The canonical
-# combination already ships as "Training Registration Form"; this extra standalone
-# form carries the legacy primary identifier, with a demo registrant + submission
-# + tags, so every surface (form rendering, the form submission show, and the
-# registrant's profile/edit pages) can be eyeballed on real data.
+# Two professional questions still accept a *legacy* field_identifier —
+# "primary_sector_single" for the single-select primary sector (see
+# FormField::PRIMARY_SECTOR_FIELD_IDENTIFIERS) and "additional_age_group" for the
+# multi-select additional age groups (see
+# FormField::ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIERS) — so older forms keep working.
+# The canonical combination already ships as "Training Registration Form"; this
+# extra standalone form carries the legacy identifiers, with a demo registrant +
+# submission + tags, so every surface (form rendering, the form submission show,
+# and the registrant's profile/edit pages) can be eyeballed on real data.
 #
-# The additional sector field and both age-group fields have never been renamed,
-# so they stay canonical.
+# The additional sector field and the primary age-group field have never been
+# renamed, so they stay canonical.
 #
 # Loaded last in the dev seed order so its extra role: "registration" form can't
 # shadow the canonical one that events_management.rb / scholarships.rb look up via
@@ -24,7 +26,7 @@ concrete_sectors = Sector.published.excluding_other.order(:name).to_a
 other_sector = Sector.published.find_by(name: Sector::OTHER_SECTOR_NAME)
 age_categories = Category.age_ranges.published.order(:position, :name).to_a
 
-form_name = "Training Registration Form (legacy primary sector name)"
+form_name = "Training Registration Form (legacy field names)"
 
 form = Form.standalone.find_by(name: form_name)
 unless form
@@ -33,8 +35,9 @@ unless form
     sections: %i[person_identifier professional_info],
     role: "registration"
   ).call
-  # Rename the canonical primary sector field onto its still-accepted legacy name.
+  # Rename the canonical fields onto their still-accepted legacy names.
   form.form_fields.find_by(field_identifier: "primary_sector")&.update!(field_identifier: "primary_sector_single")
+  form.form_fields.find_by(field_identifier: "additional_age_groups")&.update!(field_identifier: "additional_age_group")
 end
 
 # A demo registrant whose submission + tags back the form, so the profile and

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -476,13 +476,22 @@ RSpec.describe FormField do
         adults = create(:category, :published, category_type: type, name: "Adults (18+)")
         unpublished = create(:category, :unpublished, category_type: type, name: "Retired range")
         primary = create(:form_field, form: form, answer_type: :single_select_dropdown, field_identifier: "primary_age_group")
-        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
+        additional = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_groups")
 
         # Age groups have no catch-all to drop (unlike the additional sector field's
         # "Other"), so both fields offer exactly the published categories.
         expect(primary.dynamic_categories).to contain_exactly(children, adults)
         expect(additional.dynamic_categories).to contain_exactly(children, adults)
         expect(additional.answer_inclusion_error([ unpublished.id.to_s ])).to eq("has an invalid selection")
+      end
+
+      it "backs the additional age group field under its legacy singular identifier too" do
+        type = create(:category_type, name: "AgeRange")
+        offered = create(:category, :published, category_type: type, name: "Teens (13-17)")
+        legacy = create(:form_field, form: form, answer_type: :multi_select_checkbox, field_identifier: "additional_age_group")
+
+        expect(legacy.dynamic_categories).to contain_exactly(offered)
+        expect(legacy.answer_inclusion_error([ offered.id.to_s ])).to be_nil
       end
 
       it "accepts a folded \"Other: <text>\" value for the additional sectors field" do

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
       let(:primary_sector_field)    { form.form_fields.find_by!(field_identifier: ids[:primary_sector]) }
       let(:additional_sector_field) { form.form_fields.find_by!(field_identifier: ids[:additional_sector]) }
       let(:primary_age_field)       { form.form_fields.find_by!(field_identifier: "primary_age_group") }
-      let(:additional_age_field)    { form.form_fields.find_by!(field_identifier: "additional_age_group") }
+      let(:additional_age_field)    { form.form_fields.find_by!(field_identifier: "additional_age_groups") }
 
       before { EventForm.create!(event: event, form: form, role: "registration") }
 
@@ -93,7 +93,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
             ids[:primary_sector] => sector_education.id.to_s,
             ids[:additional_sector] => "#{sector_mh.id}, Other: Equine therapy",
             "primary_age_group" => age_adults.id.to_s,
-            "additional_age_group" => "#{age_teens.id}, #{age_children.id}"
+            "additional_age_groups" => "#{age_teens.id}, #{age_children.id}"
           )
         end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         registration_form: form,
         form_params: base_form_params(first_name: "Al", last_name: "Ng", email: "al@example.com").merge(
           field_id("primary_age_group") => [ young.id.to_s ],
-          field_id("additional_age_group") => [ teen.id.to_s ]
+          field_id("additional_age_groups") => [ teen.id.to_s ]
         )
       )
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe FormBuilderService do
 
       it "asks for a single primary age group via a dropdown alongside additional-age checkboxes" do
         primary = form.form_fields.find_by(field_identifier: "primary_age_group")
-        additional = form.form_fields.find_by(field_identifier: "additional_age_group")
+        additional = form.form_fields.find_by(field_identifier: "additional_age_groups")
 
         expect(primary.answer_type).to eq("single_select_dropdown")
         expect(additional.answer_type).to eq("multi_select_checkbox")

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Public form submissions", type: :system do
         "primary_sector" => sector_education.id.to_s,
         "additional_sectors" => sector_mental_health.id.to_s,
         "primary_age_group" => age_adults.id.to_s,
-        "additional_age_group" => age_teens.id.to_s,
+        "additional_age_groups" => age_teens.id.to_s,
         "racial_ethnic_identity" => "Multi-racial",
         "referral_source" => "Online Search",
         "training_motivation" => "Address staff burnout through art",
@@ -412,7 +412,7 @@ RSpec.describe "Public form submissions", type: :system do
     select_pr reg_field("primary_sector"), "Education"
     check_pr_box reg_field("additional_sectors"), sector_mental_health.id.to_s
     select_pr reg_field("primary_age_group"), "Adults (18+)"
-    check_pr_box reg_field("additional_age_group"), age_teens.id.to_s
+    check_pr_box reg_field("additional_age_groups"), age_teens.id.to_s
 
     choose_pr_radio reg_field("racial_ethnic_identity"), "Multi-racial"
     choose_pr_radio reg_field("referral_source"), "Online Search"


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mechanical identifier consolidation mirroring #2275, plus one new accepted alias

Follows #2275 (sectors) for age groups.

## What
- Split the combined `AGE_GROUP_FIELD_IDENTIFIERS` into parallel `PRIMARY_AGE_GROUP_FIELD_IDENTIFIERS` + `ADDITIONAL_AGE_GROUP_FIELD_IDENTIFIERS`; the union stays `AGE_GROUP_FIELD_IDENTIFIERS`.
- New default: forms build the multi-select additional field as `additional_age_groups` (plural).
- Legacy singular `additional_age_group` stays in the additional array, so existing forms keep resolving.
- Consumers (person, event helper, dashboard, public registration) now read the constants instead of string literals.
- `DYNAMIC_FIELD_CATEGORY_TYPES` derived from the union — no drift.

## Why
- The multi-select field is plural; its identifier should be too (matches `additional_sectors`).

## Coverage
- Canonical end-to-end path now asserts `additional_age_groups`.
- Added a `FormField` test that the legacy singular still resolves as a dynamic AgeRange field.
- Legacy-identifier dev seed extended to carry `additional_age_group` (was primary-sector-only).
