### PR TITLE
Show affiliated-since as a grey note only when it differs from facilitators-since

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -47,14 +47,6 @@ class OrganizationsController < ApplicationController
 
     track_view(@organization)
 
-    # The admin-only "Program status" block. Trainings only — program status is
-    # meaningless for other events (ADR-0001 D6).
-    @organization_events = authorized_scope(
-      Event.where(id: @organization.event_registrations.active.select(:event_id))
-           .where(facilitator_training: true)
-           .order(start_date: :desc)
-    )
-
     workshop_logs = WorkshopLog.where(organization_id: @organization.id)
     @month_year_options = workshop_logs.group("DATE_FORMAT(COALESCE(workshop_held_on, created_at, NOW()), '%Y-%m')")
                                        .select("DATE_FORMAT(COALESCE(workshop_held_on, created_at, NOW()), '%Y-%m') AS ym,

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -102,6 +102,20 @@ class OrganizationDecorator < ApplicationDecorator
     AffiliationPeriods.label(affiliations.select(&:facilitator?), precision: :month) || ""
   end
 
+  def program_since_date
+    @program_since_date ||= object.affiliations.select(&:facilitator?).filter_map(&:start_date).min
+  end
+
+  # A grey secondary line under "Facilitators since", shown only when the earliest
+  # affiliation start differs (by month/year) from the facilitator start — so the
+  # two aren't redundant. Nil when they match or there's no affiliation date.
+  def affiliated_since_note
+    date = affiliated_since_date
+    return nil if date.nil?
+    return nil if program_since_date && date.beginning_of_month == program_since_date.beginning_of_month
+    "Affiliated since #{date.strftime('%b %Y')}"
+  end
+
   ORG_STATUS_BUCKET_LABELS = {
     active: "Active", formerly_active: "Formerly active", never_active: "Never active"
   }.freeze

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -100,6 +100,16 @@ class PersonDecorator < ApplicationDecorator
     date_range_display(facilitator_since_date, facilitation_end_date, ended_title: "No active facilitator affiliations")
   end
 
+  # A grey secondary line under "Facilitator since", shown only when the earliest
+  # affiliation start differs (by month/year) from the facilitator start — so the
+  # two aren't redundant. Nil when they match or there's no affiliation date.
+  def affiliated_since_note
+    date = affiliated_since_date
+    return nil if date.nil?
+    return nil if facilitator_since_date && date.beginning_of_month == facilitator_since_date.beginning_of_month
+    "Affiliated since #{date.strftime('%b %Y')}"
+  end
+
   private
 
   def compute_badges

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -25,11 +25,6 @@ class PersonDecorator < ApplicationDecorator
     "missing.png"
   end
 
-  def affiliation_end_date
-    return nil if affiliations.active.exists?
-    affiliations.maximum(:end_date)
-  end
-
   # Org names where this person is currently an active facilitator. Filters the
   # affiliations in Ruby (rather than re-querying via the .facilitators.active
   # scopes) so list pages that preload `affiliations: :organization` pay no
@@ -88,12 +83,6 @@ class PersonDecorator < ApplicationDecorator
     # preload affiliations don't fire a MIN(start_date) query per row.
     # `.minimum` would ignore the loaded records and hit the DB every time.
     @affiliated_since_date ||= affiliations.filter_map(&:start_date).min
-  end
-
-  # The server-rendered twin of affiliation_dates_controller#updateDisplay, which
-  # replaces this content as the person form's affiliation rows are edited.
-  def affiliated_since_range
-    date_range_display(affiliated_since_date, affiliation_end_date, ended_title: "No active affiliations")
   end
 
   def facilitator_since_range

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -52,19 +52,9 @@ class PersonDecorator < ApplicationDecorator
     member_since.present? && earliest_facilitator.present? && member_since.beginning_of_month < earliest_facilitator.beginning_of_month
   end
 
-  def member_since_earlier_than_all_affiliations?
-    earliest = affiliations.minimum(:start_date)
-    member_since.present? && earliest.present? && member_since.beginning_of_month < earliest.beginning_of_month
-  end
-
   def member_since_differs_from_facilitator_affiliations?
     earliest_facilitator = affiliations.facilitators.minimum(:start_date)
     member_since.present? && earliest_facilitator.present? && member_since.beginning_of_month != earliest_facilitator.beginning_of_month
-  end
-
-  def member_since_differs_from_all_affiliations?
-    earliest = affiliations.minimum(:start_date)
-    member_since.present? && earliest.present? && member_since.beginning_of_month != earliest.beginning_of_month
   end
 
   def badges

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["facilitatorSince", "affiliationsContainer", "programStatus"]
+  static targets = ["facilitatorSince", "affiliatedNote", "affiliatedNoteText", "affiliationsContainer", "programStatus"]
   // The person form shows a single Mon YYYY – Mon YYYY range; the org form
   // (mergedPeriods) mirrors the AffiliationPeriods service so the live value
   // matches the server render. statusBuckets carries each bucket's label + pill
@@ -73,6 +73,15 @@ export default class extends Controller {
       }
     }
 
+    // Mirrors PersonDecorator/OrganizationDecorator#affiliated_since_note: the
+    // earliest start across all roles, surfaced only when it predates (differs by
+    // month/year from) the facilitator start, so it isn't redundant.
+    if (this.hasAffiliatedNoteTarget) {
+      const allStartDates = affiliations.map(a => a.startDate).filter(Boolean).map(d => new Date(d))
+      const affiliatedSince = allStartDates.length ? new Date(Math.min(...allStartDates)) : null
+      this.updateAffiliatedNote(affiliatedSince, facilitatorSince)
+    }
+
     // Mirrors OrganizationDecorator#organization_status_bucket.
     if (this.hasProgramStatusTarget) {
       let bucket
@@ -82,6 +91,17 @@ export default class extends Controller {
         bucket = allFacInactive ? "formerly_active" : "active"
       }
       this.updateProgramStatus(bucket)
+    }
+  }
+
+  updateAffiliatedNote(affiliatedSince, facilitatorSince) {
+    const sameMonth = affiliatedSince && facilitatorSince &&
+      affiliatedSince.getUTCFullYear() === facilitatorSince.getUTCFullYear() &&
+      affiliatedSince.getUTCMonth() === facilitatorSince.getUTCMonth()
+    const show = Boolean(affiliatedSince) && !sameMonth
+    this.affiliatedNoteTarget.classList.toggle("hidden", !show)
+    if (show && this.hasAffiliatedNoteTextTarget) {
+      this.affiliatedNoteTextTarget.textContent = `Affiliated since ${this.formatDate(affiliatedSince)}`
     }
   }
 

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -1,13 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["facilitatorSince", "affiliatedNote", "affiliatedNoteText", "affiliationsContainer", "programStatus"]
+  static targets = ["facilitatorSince", "affiliatedNote", "affiliatedNoteText", "memberSinceFlag", "affiliationsContainer", "programStatus"]
   // The person form shows a single Mon YYYY – Mon YYYY range; the org form
   // (mergedPeriods) mirrors the AffiliationPeriods service so the live value
-  // matches the server render. statusBuckets carries each bucket's label + pill
-  // classes from DomainTheme.
+  // matches the server render. memberSince is the person's legacy facilitator-since
+  // date (person form only), flagged when it disagrees with the facilitator start.
+  // statusBuckets carries each bucket's label + pill classes from DomainTheme.
   static values = {
     mergedPeriods: Boolean,
+    memberSince: String,
     statusBuckets: Object
   }
 
@@ -82,6 +84,11 @@ export default class extends Controller {
       this.updateAffiliatedNote(affiliatedSince, facilitatorSince)
     }
 
+    // Mirrors PersonDecorator#member_since_{earlier_than,differs_from}_facilitator_affiliations?.
+    if (this.hasMemberSinceFlagTarget) {
+      this.updateMemberSinceFlag(facilitatorSince)
+    }
+
     // Mirrors OrganizationDecorator#organization_status_bucket.
     if (this.hasProgramStatusTarget) {
       let bucket
@@ -102,6 +109,27 @@ export default class extends Controller {
     this.affiliatedNoteTarget.classList.toggle("hidden", !show)
     if (show && this.hasAffiliatedNoteTextTarget) {
       this.affiliatedNoteTextTarget.textContent = `Affiliated since ${this.formatDate(affiliatedSince)}`
+    }
+  }
+
+  // Compares member_since (fixed) with the live facilitator start; only meaningful
+  // when a facilitator affiliation has a start date, matching the decorator guards.
+  updateMemberSinceFlag(facilitatorSince) {
+    const target = this.memberSinceFlagTarget
+    const ms = this.memberSinceValue ? new Date(this.memberSinceValue) : null
+    const msMonth = ms ? Date.UTC(ms.getUTCFullYear(), ms.getUTCMonth()) : null
+    const facMonth = facilitatorSince ? Date.UTC(facilitatorSince.getUTCFullYear(), facilitatorSince.getUTCMonth()) : null
+    if (msMonth === null || facMonth === null || msMonth === facMonth) {
+      target.className = "mt-1 text-xs hidden"
+      return
+    }
+    const label = this.formatDate(ms)
+    if (msMonth < facMonth) {
+      target.className = "mt-1 text-xs text-amber-700"
+      target.textContent = `⚠ Earlier date on file: ${label}`
+    } else {
+      target.className = "mt-1 text-xs text-gray-500"
+      target.innerHTML = `<i class="fa-solid fa-circle-info mr-1"></i>Different date on file: ${label}`
     }
   }
 

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -1,14 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["affiliatedSince", "facilitatorSince", "affiliationsContainer", "programStatus"]
+  static targets = ["facilitatorSince", "affiliationsContainer", "programStatus"]
   // The person form shows a single Mon YYYY – Mon YYYY range; the org form
   // (mergedPeriods) mirrors the AffiliationPeriods service so the live value
-  // matches the server render. affiliatedSinceFallback is the org's own start_date,
-  // and statusBuckets each bucket's label + pill classes from DomainTheme.
+  // matches the server render. statusBuckets carries each bucket's label + pill
+  // classes from DomainTheme.
   static values = {
     mergedPeriods: Boolean,
-    affiliatedSinceFallback: String,
     statusBuckets: Object
   }
 
@@ -49,24 +48,6 @@ export default class extends Controller {
     const affiliations = this.getVisibleAffiliations()
     const now = new Date()
     const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()))
-
-    if (this.hasAffiliatedSinceTarget) {
-      if (this.mergedPeriodsValue) {
-        const label = this.periodsLabel(affiliations, today, "year") || this.affiliatedSinceFallbackValue
-        this.affiliatedSinceTarget.textContent = label || "—"
-      } else {
-        const startDates = affiliations.map(a => a.startDate).filter(Boolean)
-        const affiliatedSince = startDates.length
-          ? new Date(Math.min(...startDates.map(d => new Date(d))))
-          : null
-        const allInactive = affiliations.length > 0 &&
-          affiliations.every(a => a.endDate && new Date(a.endDate) < today)
-        const affiliatedEnd = allInactive
-          ? new Date(Math.max(...affiliations.map(a => new Date(a.endDate))))
-          : null
-        this.updateDisplay(this.affiliatedSinceTarget, affiliatedSince, affiliatedEnd)
-      }
-    }
 
     // Mirrors Affiliation#facilitator?: exact, case-sensitive, trimmed — so the
     // live figure matches the server render.

--- a/app/services/facilitator_program_status.rb
+++ b/app/services/facilitator_program_status.rb
@@ -23,10 +23,10 @@ class FacilitatorProgramStatus
   def year_anchored? = @year_anchored
 
   def status
-    @status ||= if earlier.empty?
-      :new
-    elsif active_on_anchor.any?
+    @status ||= if active_on_anchor.any?
       :ongoing
+    elsif earlier.empty?
+      :new
     else
       :reinstated
     end
@@ -82,13 +82,25 @@ class FacilitatorProgramStatus
 
   def month(date) = date&.strftime("%b %Y")
 
-  # Strictly before: an affiliation starting ON the anchor is the one this event
-  # minted (ADR-0001 D8), so a first-time org still reads New at its own training.
+  # Strictly before: prior history that decides :new vs :reinstated once we know no
+  # affiliation is active on the anchor. An affiliation starting ON the anchor is the
+  # one this event minted (ADR-0001 D8), so it stays out of the history here.
   def earlier
     @earlier ||= @facilitators.select { |affiliation| affiliation.start_date < as_of }
   end
 
+  # Facilitators whose span covers the anchor. A same-day facilitation
+  # (start == end) counts as active on that exact day, so an org reads Ongoing for a
+  # one-day program running then (ADR-0001 D4). The open-ended affiliation a
+  # registration mints ON the anchor is still excluded (D8), keeping a first-time
+  # org New at its own training.
   def active_on_anchor
-    @active_on_anchor ||= earlier.select { |affiliation| affiliation.end_date.nil? || affiliation.end_date >= as_of }
+    @active_on_anchor ||= @facilitators.select do |affiliation|
+      if affiliation.start_date == affiliation.end_date
+        affiliation.start_date == as_of
+      else
+        affiliation.start_date < as_of && (affiliation.end_date.nil? || affiliation.end_date >= as_of)
+      end
+    end
   end
 end

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -301,19 +301,20 @@
           </div>
           <div class="pt-1">
             <span class="text-gray-900 font-medium" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>
-            <div class="group/aff relative mt-1 inline-flex items-center gap-1 cursor-help <%= "hidden" unless org_decorated.affiliated_since_note %>"
-                 data-affiliation-dates-target="affiliatedNote">
-              <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= org_decorated.affiliated_since_note %></span>
-              <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
-              <div class="hidden group-hover/aff:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
-                <p>The earliest date this organization was affiliated with anyone, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
-              </div>
+            <div class="mt-1 <%= "hidden" unless org_decorated.affiliated_since_note %>" data-affiliation-dates-target="affiliatedNote">
+              <span class="group/aff relative inline-flex items-center gap-1 cursor-help">
+                <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= org_decorated.affiliated_since_note %></span>
+                <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+                <div class="hidden group-hover/aff:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+                  <p>The earliest date this organization was affiliated with anyone, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
+                </div>
+              </span>
             </div>
           </div>
         </div>
         <% if allowed_to?(:manage?, Organization) %>
           <% org_events = @organization_events || [] %>
-          <div id="program-status" class="shrink-0 relative group cursor-help scroll-mt-20">
+          <div id="program-status" class="flex-1 min-w-0 relative group cursor-help scroll-mt-20">
             <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
               Program status <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
             </label>
@@ -323,7 +324,7 @@
                 • <span class="font-medium">Ongoing</span> — has an active facilitator<br>
                 • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).</p>
             </div>
-            <div class="pt-1 flex flex-wrap items-center gap-2 max-w-md">
+            <div class="pt-1 flex flex-wrap items-center gap-2">
               <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }) %>
               <%= render "organizations/program_status_event_chips",
                          organization: f.object, events: org_events, return_to: "organization_edit" %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,7 +1,6 @@
 <%= simple_form_for(@organization, html: { data: {
       controller: "affiliation-dates affiliation-facilitator-warning",
       affiliation_dates_merged_periods_value: true,
-      affiliation_dates_affiliated_since_fallback_value: @organization.start_date&.strftime("%b %Y") || "",
       affiliation_dates_status_buckets_value: OrganizationDecorator.status_bucket_styles.to_json
     } }) do |f| %>
   <%= render 'shared/errors', resource: @organization if @organization.errors.any? %>
@@ -276,40 +275,11 @@
           </div>
         </div>
       <% end %>
-      <% org_earliest_aff = f.object.persisted? ? f.object.affiliations.minimum(:start_date) : nil %>
-      <% org_aff_ended = f.object.persisted? && f.object.affiliations.any? && !f.object.affiliations.active.exists? %>
       <% org_decorated = f.object.decorate %>
       <div class="flex flex-col md:flex-row gap-6 mb-4">
-        <div class="shrink-0 relative group cursor-help">
-          <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
-            Affiliated since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
-          </label>
-          <div class="hidden group-hover:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
-            <% if has_affiliations && org_earliest_aff.present? %>
-              <p>Auto-managed from affiliation records — shown as merged year-based periods (e.g. "2010-2012, 2026").</p>
-              <% if f.object.start_date.present? && f.object.start_date.beginning_of_month != org_earliest_aff.beginning_of_month %>
-                <p class="mt-2 text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Organization start_date (<%= f.object.start_date.strftime('%b %Y') %>) differs from earliest affiliation.</p>
-              <% end %>
-            <% elsif has_affiliations %>
-              <p>Auto-managed from affiliation records.<br><br><span class="text-amber-700 font-medium">⚠ No affiliations have a start date. Add a start date to an affiliation record.</span></p>
-            <% else %>
-              <p>No affiliations yet. Set this date directly, or add affiliation records to auto-manage it.</p>
-            <% end %>
-            <% if org_aff_ended %>
-              <p class="mt-2 text-amber-700 font-medium">⚠ All affiliations have ended.</p>
-            <% elsif f.object.end_date.present? && !has_affiliations %>
-              <p class="mt-2 text-amber-700 font-medium">⚠ Organization end_date: <%= f.object.end_date.strftime('%b %Y') %>.</p>
-            <% end %>
-          </div>
-          <div class="pt-1">
-            <span class="text-gray-900 font-medium" data-affiliation-dates-target="affiliatedSince"><%= org_decorated.affiliated_since_display.presence || "—" %></span>
-            <% if has_affiliations && org_earliest_aff.nil? %>
-              <i class="fa-solid fa-triangle-exclamation text-amber-500 ml-1"></i>
-            <% elsif f.object.start_date.present? && org_earliest_aff.present? && f.object.start_date.beginning_of_month != org_earliest_aff.beginning_of_month %>
-              <p class="text-xs text-gray-500 mt-1"><i class="fa-solid fa-circle-info mr-1"></i>Organization start_date: <%= f.object.start_date.strftime("%b %Y") %></p>
-            <% end %>
-          </div>
-          <% unless has_affiliations %>
+        <% unless has_affiliations %>
+          <div class="shrink-0">
+            <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">Affiliated since</label>
             <%= f.input :start_date,
                         label: false,
                         as: :string,
@@ -318,8 +288,8 @@
                           value: f.object.start_date&.strftime('%Y-%m-%d'),
                           class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 mt-2"
                         } %>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
         <div class="shrink-0 relative group cursor-help">
           <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
             Facilitators since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
@@ -329,6 +299,9 @@
           </div>
           <div class="pt-1">
             <span class="text-gray-900 font-medium" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>
+            <% if (affiliated_note = org_decorated.affiliated_since_note) %>
+              <p class="text-xs text-gray-500 mt-1"><%= affiliated_note %></p>
+            <% end %>
           </div>
         </div>
         <% if allowed_to?(:manage?, Organization) %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -290,18 +290,25 @@
                         } %>
           </div>
         <% end %>
-        <div class="shrink-0 relative group cursor-help">
-          <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
-            Facilitators since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
-          </label>
-          <div class="hidden group-hover:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
-            <p>When this organization started having AWBW facilitators, from its 'Facilitator' affiliations — one period per stretch of facilitating, so a lapse and a return read as separate periods (e.g. "Aug 2015 – Jun 2018, Feb 2024"). Updates live as you edit the affiliation rows below.</p>
+        <div class="shrink-0 relative">
+          <div class="group/fac relative inline-block cursor-help">
+            <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
+              Facilitators since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+            </label>
+            <div class="hidden group-hover/fac:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+              <p>When this organization started having AWBW facilitators, from its 'Facilitator' affiliations — one period per stretch of facilitating, so a lapse and a return read as separate periods (e.g. "Aug 2015 – Jun 2018, Feb 2024"). Updates live as you edit the affiliation rows below.</p>
+            </div>
           </div>
           <div class="pt-1">
             <span class="text-gray-900 font-medium" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>
-            <% if (affiliated_note = org_decorated.affiliated_since_note) %>
-              <p class="text-xs text-gray-500 mt-1"><%= affiliated_note %></p>
-            <% end %>
+            <div class="group/aff relative mt-1 inline-flex items-center gap-1 cursor-help <%= "hidden" unless org_decorated.affiliated_since_note %>"
+                 data-affiliation-dates-target="affiliatedNote">
+              <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= org_decorated.affiliated_since_note %></span>
+              <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+              <div class="hidden group-hover/aff:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+                <p>The earliest date this organization was affiliated with anyone, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
+              </div>
+            </div>
           </div>
         </div>
         <% if allowed_to?(:manage?, Organization) %>

--- a/app/views/organizations/_program_status_event_chips.html.erb
+++ b/app/views/organizations/_program_status_event_chips.html.erb
@@ -8,6 +8,6 @@
               target: "_blank", rel: "noopener noreferrer",
               title: "#{event.title} — #{status.explanation}",
               class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{OrganizationDecorator.program_status_classes(status.status)}" do %>
-    <%= "#{event.start_date.strftime('%b %Y')} · " if event.start_date %><%= status.label %> · <%= event.decorate.compact_label.truncate(24) %>
+    <%= "#{event.start_date.strftime('%b %Y')} · " if event.start_date %><%= status.label %> · <%= event.decorate.compact_label.truncate(40) %>
   <% end %>
 <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -34,9 +34,17 @@
         <% end %>
       </div>
       <div class="flex-1 text-center md:text-left">
-        <h1 class="text-3xl font-bold text-gray-900">
-          <%= @organization.name %>
-        </h1>
+        <% org_decorated = @organization.decorate %>
+        <div class="flex flex-wrap items-center justify-center md:justify-start gap-3">
+          <h1 class="text-3xl font-bold text-gray-900">
+            <%= @organization.name %>
+          </h1>
+          <% if allowed_to?(:manage?, @organization) %>
+            <span id="program-status" class="admin-only bg-blue-100 rounded-lg px-2 py-1 scroll-mt-20">
+              <%= org_decorated.organization_status_chip %>
+            </span>
+          <% end %>
+        </div>
         <% address = if @organization.addresses.loaded?
                        @organization.addresses.find { |a| !a.inactive? }
                      else
@@ -47,7 +55,6 @@
             <%= [address.locality, [address.city, address.state].compact_blank.join(", "), address.district].compact_blank.join(" · ") %>
           </p>
         <% end %>
-        <% org_decorated = @organization.decorate %>
         <% affiliated_since = org_decorated.affiliated_since_display %>
         <% if affiliated_since.present? %>
           <p class="text-gray-500 text-sm mt-1">
@@ -109,16 +116,6 @@
         <% end %>
       </div>
     </div>
-    <% if allowed_to?(:manage?, @organization) %>
-      <div id="program-status" class="admin-only bg-blue-100 rounded-lg p-3 mb-6 scroll-mt-20">
-        <p class="text-xs font-semibold text-gray-600 mb-2">Program status</p>
-        <div class="flex flex-wrap items-center gap-2">
-          <%= org_decorated.organization_status_chip %>
-          <%= render "organizations/program_status_event_chips",
-                     organization: @organization, events: @organization_events, return_to: "organization" %>
-        </div>
-      </div>
-    <% end %>
     <hr class="my-8 border-gray-200">
     <!-- Info grid -->
     <div class="grid grid-cols-1 md:grid-cols-5 gap-8">

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -256,36 +256,6 @@
       <div class="mb-4 flex flex-col gap-6 md:flex-row">
         <div class="group relative shrink-0 cursor-help">
           <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
-            Affiliated since <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
-          </label>
-          <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
-            <% affiliated_start = person.affiliations.minimum(:start_date) %>
-            <% if affiliated_start.nil? && person.affiliations.exists? && person.member_since.present? %>
-              <p>Earliest start date from any affiliation, regardless of title.<br><br><span class="font-medium text-amber-700">⚠ No affiliations have a start date. Legacy member_since value is <%= person.member_since.strftime('%b %Y') %>. Add a start date to an affiliation to use it here.</span></p>
-            <% elsif affiliated_start.nil? && person.affiliations.exists? %>
-              <p>Earliest start date from any affiliation, regardless of title.<br><br><span class="font-medium text-amber-700">⚠ No affiliations have a start date. Edit the affiliation records to add one.</span></p>
-            <% else %>
-              <p>Earliest start date from any affiliation, regardless of title. Edit affiliation records to change this date.</p>
-              <% if decorated.member_since_earlier_than_all_affiliations? %>
-                <p class="mt-2 font-medium text-amber-700">⚠ Member since (<%= person.member_since.strftime('%b %Y') %>) is earlier than any affiliation. Create an affiliation with that start date to reflect it on the profile.</p>
-              <% elsif decorated.member_since_differs_from_all_affiliations? %>
-                <p class="mt-2 text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Member since (<%= person.member_since.strftime('%b %Y') %>) differs from the earliest affiliation start date.</p>
-              <% end %>
-            <% end %>
-          </div>
-          <div class="pt-1">
-            <span class="font-medium text-gray-900" data-affiliation-dates-target="affiliatedSince"><%= decorated.affiliated_since_range %></span>
-            <% if decorated.affiliated_since_date.nil? && person.affiliations.exists? %>
-              <i class="fa-solid fa-triangle-exclamation ml-1 text-amber-500"></i>
-            <% elsif decorated.member_since_earlier_than_all_affiliations? %>
-              <p class="mt-1 text-xs text-amber-700">⚠ Earlier date on file: <%= person.member_since.strftime("%b %Y") %></p>
-            <% elsif decorated.member_since_differs_from_all_affiliations? %>
-              <p class="mt-1 text-xs text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %></p>
-            <% end %>
-          </div>
-        </div>
-        <div class="group relative shrink-0 cursor-help">
-          <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
             Facilitator since <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
           </label>
           <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
@@ -307,6 +277,9 @@
               <p class="mt-1 text-xs text-amber-700">⚠ Earlier date on file: <%= person.member_since.strftime("%b %Y") %></p>
             <% elsif decorated.member_since_differs_from_facilitator_affiliations? %>
               <p class="mt-1 text-xs text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %></p>
+            <% end %>
+            <% if (affiliated_note = decorated.affiliated_since_note) %>
+              <p class="mt-1 text-xs text-gray-500"><%= affiliated_note %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @person, html: { multipart: true, class: "space-y-8",
-                                          data: { controller: "dirty-form affiliation-dates affiliation-facilitator-warning" } } do |f| %>
+                                          data: { controller: "dirty-form affiliation-dates affiliation-facilitator-warning",
+                                                  affiliation_dates_member_since_value: @person.member_since&.strftime("%Y-%m-%d") || "" } } do |f| %>
   <%= render 'shared/errors', resource: @person if @person.errors.any? %>
   <%= render "duplicate_people_warning" %>
 
@@ -275,11 +276,16 @@
           </div>
           <div class="pt-1">
             <span class="font-medium text-gray-900" data-affiliation-dates-target="facilitatorSince"><%= decorated.facilitator_since_range %></span>
-            <% if decorated.member_since_earlier_than_facilitator_affiliations? %>
-              <p class="mt-1 text-xs text-amber-700">⚠ Earlier date on file: <%= person.member_since.strftime("%b %Y") %></p>
-            <% elsif decorated.member_since_differs_from_facilitator_affiliations? %>
-              <p class="mt-1 text-xs text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %></p>
-            <% end %>
+            <% member_since_earlier = decorated.member_since_earlier_than_facilitator_affiliations? %>
+            <% member_since_differs = !member_since_earlier && decorated.member_since_differs_from_facilitator_affiliations? %>
+            <p class="mt-1 text-xs <%= member_since_earlier ? "text-amber-700" : member_since_differs ? "text-gray-500" : "hidden" %>"
+               data-affiliation-dates-target="memberSinceFlag">
+              <% if member_since_earlier %>
+                ⚠ Earlier date on file: <%= person.member_since.strftime("%b %Y") %>
+              <% elsif member_since_differs %>
+                <i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %>
+              <% end %>
+            </p>
             <div class="group/aff relative mt-1 inline-flex items-center gap-1 cursor-help <%= "hidden" unless decorated.affiliated_since_note %>"
                  data-affiliation-dates-target="affiliatedNote">
               <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= decorated.affiliated_since_note %></span>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -286,13 +286,14 @@
                 <i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %>
               <% end %>
             </p>
-            <div class="group/aff relative mt-1 inline-flex items-center gap-1 cursor-help <%= "hidden" unless decorated.affiliated_since_note %>"
-                 data-affiliation-dates-target="affiliatedNote">
-              <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= decorated.affiliated_since_note %></span>
-              <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
-              <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/aff:block">
-                <p>The earliest date this person was affiliated with any organization, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
-              </div>
+            <div class="mt-1 <%= "hidden" unless decorated.affiliated_since_note %>" data-affiliation-dates-target="affiliatedNote">
+              <span class="group/aff relative inline-flex items-center gap-1 cursor-help">
+                <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= decorated.affiliated_since_note %></span>
+                <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
+                <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/aff:block">
+                  <p>The earliest date this person was affiliated with any organization, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
+                </div>
+              </span>
             </div>
           </div>
         </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -254,22 +254,24 @@
         </div>
       <% end %>
       <div class="mb-4 flex flex-col gap-6 md:flex-row">
-        <div class="group relative shrink-0 cursor-help">
-          <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
-            Facilitator since <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
-          </label>
-          <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
-            <% facilitator_start = person.affiliations.facilitators.minimum(:start_date) %>
-            <% if facilitator_start.nil? && person.member_since.present? %>
-              <p>Earliest start date from affiliations with 'facilitator' somewhere in the title.<br><br><span class="font-medium text-amber-700">⚠ Currently showing the legacy member_since value (<%= person.member_since.strftime('%b %Y') %>) because no Facilitator affiliation has a start date. Add a start date to a Facilitator affiliation to stop using the legacy value.</span></p>
-            <% else %>
-              <p>Earliest start date from affiliations with 'facilitator' somewhere in the title. Edit affiliation records to change this date.</p>
-              <% if decorated.member_since_earlier_than_facilitator_affiliations? %>
-                <p class="mt-2 font-medium text-amber-700">⚠ Member since (<%= person.member_since.strftime('%b %Y') %>) is earlier than any Facilitator affiliation. Create an affiliation with that start date to reflect it on the profile.</p>
-              <% elsif decorated.member_since_differs_from_facilitator_affiliations? %>
-                <p class="mt-2 text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Member since (<%= person.member_since.strftime('%b %Y') %>) differs from the earliest Facilitator affiliation start date.</p>
+        <div class="relative shrink-0">
+          <div class="group/fac relative inline-block cursor-help">
+            <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
+              Facilitator since <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
+            </label>
+            <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/fac:block">
+              <% facilitator_start = person.affiliations.facilitators.minimum(:start_date) %>
+              <% if facilitator_start.nil? && person.member_since.present? %>
+                <p>Earliest start date from affiliations with 'facilitator' somewhere in the title.<br><br><span class="font-medium text-amber-700">⚠ Currently showing the legacy member_since value (<%= person.member_since.strftime('%b %Y') %>) because no Facilitator affiliation has a start date. Add a start date to a Facilitator affiliation to stop using the legacy value.</span></p>
+              <% else %>
+                <p>Earliest start date from affiliations with 'facilitator' somewhere in the title. Edit affiliation records to change this date.</p>
+                <% if decorated.member_since_earlier_than_facilitator_affiliations? %>
+                  <p class="mt-2 font-medium text-amber-700">⚠ Member since (<%= person.member_since.strftime('%b %Y') %>) is earlier than any Facilitator affiliation. Create an affiliation with that start date to reflect it on the profile.</p>
+                <% elsif decorated.member_since_differs_from_facilitator_affiliations? %>
+                  <p class="mt-2 text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Member since (<%= person.member_since.strftime('%b %Y') %>) differs from the earliest Facilitator affiliation start date.</p>
+                <% end %>
               <% end %>
-            <% end %>
+            </div>
           </div>
           <div class="pt-1">
             <span class="font-medium text-gray-900" data-affiliation-dates-target="facilitatorSince"><%= decorated.facilitator_since_range %></span>
@@ -278,9 +280,14 @@
             <% elsif decorated.member_since_differs_from_facilitator_affiliations? %>
               <p class="mt-1 text-xs text-gray-500"><i class="fa-solid fa-circle-info mr-1"></i>Different date on file: <%= person.member_since.strftime("%b %Y") %></p>
             <% end %>
-            <% if (affiliated_note = decorated.affiliated_since_note) %>
-              <p class="mt-1 text-xs text-gray-500"><%= affiliated_note %></p>
-            <% end %>
+            <div class="group/aff relative mt-1 inline-flex items-center gap-1 cursor-help <%= "hidden" unless decorated.affiliated_since_note %>"
+                 data-affiliation-dates-target="affiliatedNote">
+              <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= decorated.affiliated_since_note %></span>
+              <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
+              <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/aff:block">
+                <p>The earliest date this person was affiliated with any organization, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -180,6 +180,23 @@ Person.where(
   end
 end
 
+# A deterministic person whose legacy member_since AND earlier non-facilitator
+# affiliation both diverge from the facilitator start — so the person edit form
+# shows BOTH the grey "Affiliated since" note and the member_since flag at once.
+puts "Creating the member-since discrepancy demo person…"
+unless Person.exists?(first_name: "Grace", last_name: "Legacy")
+  demo = Person.create!(
+    first_name: "Grace",
+    last_name: "Legacy",
+    profile_is_searchable: true,
+    member_since: Date.new(2016, 1, 1),
+    created_by: admin_user,
+    updated_by: admin_user
+  )
+  Affiliation.create!(person: demo, organization: orgs.first, title: "Board Member", start_date: Date.new(2015, 3, 1))
+  Affiliation.create!(person: demo, organization: orgs.second || orgs.first, title: "Facilitator", start_date: Date.new(2018, 6, 1))
+end
+
 puts "Assigning addresses and sectors to people…"
 # Curated state/county pairs so the event overview's States and Counties cards
 # show a recognizable spread rather than scattered random values.

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -35,6 +35,15 @@ puts "Creating Persons and Affiliations for seed users…"
   )
 end
 
+# Give Amy and Aisha a legacy member_since that predates their facilitator
+# affiliations, so their person edit pages show the member_since-vs-facilitator
+# discrepancy flag (alongside the grey "Affiliated since" note).
+{ "amy.user@example.com" => 8.years.ago.to_date,
+  "aisha.user@example.com" => 5.years.ago.to_date }.each do |email, date|
+  person = User.find_by(email: email)&.person
+  person.update!(member_since: date) if person && person.member_since.nil?
+end
+
 puts "Creating People…"
 admin_user = User.find_by(email: "umberto.user@example.com")
 orgs = Organization.all.to_a

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -92,11 +92,15 @@ the warning on a fair number of orgs — that is the drift it exists to surface.
 **One value per (organization, anchor date)**, computed over **all** of the org's
 facilitator affiliations by a single class, `FacilitatorProgramStatus`:
 
-- **New** — no facilitator affiliation started **before** the anchor (strict `<`).
-- **Ongoing** — an earlier facilitator affiliation is **still active** on the
-  anchor (no end date, or it ends on/after it).
-- **Reinstated** — earlier facilitator affiliation(s) existed but **all ended**
-  before the anchor (a lapse, now returning).
+- **Ongoing** — a facilitator affiliation is **active on the anchor**: it started
+  on/before it and has no end date or ends on/after it. A **same-day** facilitation
+  (`start == end`) counts as active on that exact day, so a one-day program reads
+  Ongoing then. The open-ended affiliation a registration mints **on** the anchor is
+  excluded (D8), so a first-time org is not Ongoing at its own training.
+- **New** — no facilitator affiliation is active on the anchor and none started
+  **before** it (strict `<`).
+- **Reinstated** — none active on the anchor, but earlier facilitator
+  affiliation(s) existed and **all ended** before it (a lapse, now returning).
 
 `Organization#facilitator_program_status(as_of:)` returns that object;
 `#facilitator_status_on(date)` is the bare symbol for counting and filtering.

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe OrganizationDecorator do
     end
   end
 
+  describe "#affiliated_since_note" do
+    let(:organization) { create(:organization) }
+
+    it "surfaces the affiliation start when it differs from the facilitator start" do
+      create(:affiliation, organization: organization, person: create(:person), title: "Volunteer", start_date: Date.new(2010, 3, 1))
+      create(:affiliation, organization: organization, person: create(:person), title: "Facilitator", start_date: Date.new(2015, 8, 1))
+
+      expect(organization.reload.decorate.affiliated_since_note).to eq("Affiliated since Mar 2010")
+    end
+
+    it "is nil when the affiliation and facilitator starts share a month and year" do
+      create(:affiliation, organization: organization, person: create(:person), title: "Facilitator", start_date: Date.new(2015, 8, 1))
+
+      expect(organization.reload.decorate.affiliated_since_note).to be_nil
+    end
+
+    it "is nil when there is no affiliation start date" do
+      create(:affiliation, organization: organization, person: create(:person), title: "Facilitator", start_date: nil)
+
+      expect(organization.reload.decorate.affiliated_since_note).to be_nil
+    end
+  end
+
   describe "#organization_status_label" do
     # Every stored status reads "Never active" here: with no facilitator affiliation
     # there is no program, whatever the legacy column says.

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -52,4 +52,27 @@ RSpec.describe PersonDecorator do
       expect(person.decorate.affiliated_since_date).to be_nil
     end
   end
+
+  describe "#affiliated_since_note" do
+    let(:person) { create(:person) }
+
+    it "surfaces the affiliation start when it differs from the facilitator start" do
+      create(:affiliation, person: person, title: "Board Member", start_date: Date.new(2015, 3, 1))
+      create(:affiliation, person: person, title: "Facilitator", start_date: Date.new(2018, 8, 1))
+
+      expect(person.decorate.affiliated_since_note).to eq("Affiliated since Mar 2015")
+    end
+
+    it "is nil when the affiliation and facilitator starts share a month and year" do
+      create(:affiliation, person: person, title: "Facilitator", start_date: Date.new(2018, 8, 1))
+
+      expect(person.decorate.affiliated_since_note).to be_nil
+    end
+
+    it "is nil when there is no affiliation start date" do
+      create(:affiliation, person: person, start_date: nil)
+
+      expect(person.decorate.affiliated_since_note).to be_nil
+    end
+  end
 end

--- a/spec/requests/organizations_events_section_spec.rb
+++ b/spec/requests/organizations_events_section_spec.rb
@@ -57,24 +57,14 @@ RSpec.describe "Organization profile events-attended section", type: :request do
     expect(response.body.scan(/>\s*Shared Event/).size).to eq(1)
   end
 
-  it "shows an admin program-status chip per event in the profile's Program status block" do
-    event = create(:event, title: "Trauma-Informed Onsite", abbreviation: "TOS205", start_date: 2.days.from_now, facilitator_training: true)
-    person = create(:person)
-    create(:affiliation, organization: organization, person: person, title: "Facilitator", start_date: 1.year.ago, end_date: nil)
-    registration = create(:event_registration, registrant: person, event: event, status: "registered")
-    registration.event_registration_organizations.create!(organization: organization)
+  it "shows the org program-status chip beside the name in an admin-only wrapper" do
+    create(:affiliation, organization: organization, person: create(:person), title: "Facilitator", start_date: 1.year.ago, end_date: nil)
 
     get organization_path(organization)
 
-    expect(response.body).to include("Program status")
-    expect(response.body).to include("TOS205")
-    expect(response.body).to include("Ongoing")
-    # The chip opens in a new tab, so it must tell the report how to get back here —
-    # and the block needs the id the report's eyebrow anchors to.
-    expect(response.body).to include(
-      CGI.escapeHTML(participation_events_path(event_id: event.id, return_organization_id: organization.id, return_to: "organization"))
-    )
-    expect(response.body).to include("id=\"#{EventParticipationHelper::PROGRAM_STATUS_ANCHOR}\"")
+    chip_wrapper = Capybara.string(response.body).find("##{EventParticipationHelper::PROGRAM_STATUS_ANCHOR}")
+    expect(chip_wrapper[:class]).to include("admin-only")
+    expect(chip_wrapper).to have_text("Active")
   end
 
   it "renders the section heading and lazy frame on the profile page" do

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -175,16 +175,16 @@ RSpec.describe "/organizations", type: :request do
       expect(response.body).to include("Monthly reports")
     end
 
-    it "renders affiliated-since as merged year-based periods (server-side)" do
+    it "surfaces the affiliated-since note when it predates the facilitator start" do
       organization = Organization.create!(valid_attributes)
       create(:affiliation, organization: organization, person: create(:person),
-                           start_date: Date.new(2010, 1, 1), end_date: Date.new(2012, 6, 1))
+                           title: "Volunteer", start_date: Date.new(2010, 1, 1))
       create(:affiliation, organization: organization, person: create(:person),
-                           start_date: Date.new(2013, 1, 1), end_date: Date.new(2015, 6, 1))
+                           title: "Facilitator", start_date: Date.new(2015, 3, 1))
 
       get edit_organization_url(organization)
 
-      expect(response.body).to include("2010-2012, 2013-2015")
+      expect(response.body).to include("Affiliated since Jan 2010")
     end
 
     it "renders per-event program-status chips only for facilitator-training events" do

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe FacilitatorProgramStatus do
       expect(status_on.status).to eq(:ongoing)
     end
 
+    it "is :ongoing for a same-day (start == end) facilitation on the anchor" do
+      # A one-day program is active on its own day, even though it starts on the anchor.
+      facilitator(start_date: anchor, end_date: anchor)
+      expect(status_on.status).to eq(:ongoing)
+    end
+
+    it "is :reinstated for a same-day facilitation that ran before the anchor" do
+      facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))
+      expect(status_on.status).to eq(:reinstated)
+    end
+
     it "is :reinstated when every earlier facilitator affiliation has ended" do
       facilitator(start_date: Date.new(2015, 8, 1), end_date: Date.new(2018, 6, 1))
       expect(status_on.status).to eq(:reinstated)

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     expect(page).to have_css("#{note}.hidden", visible: :all, wait: 5)
   end
 
+  it "toggles the member-since flag live as the facilitator start crosses member_since" do
+    flagged = create(:person, member_since: Date.new(2015, 6, 1))
+    create(:affiliation, person: flagged, organization: org1, title: "Facilitator", start_date: "2020-03-01")
+
+    visit_and_wait edit_person_path(flagged, admin: true)
+    flag = "[data-affiliation-dates-target='memberSinceFlag']"
+    fac_start = -> {
+      all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
+        f.find("input[name*='title']").value.strip == "Facilitator"
+      }.find("input[name*='start_date']")
+    }
+
+    # member_since (Jun 2015) is earlier than the facilitator start (Mar 2020).
+    expect(page).to have_css("#{flag}.text-amber-700", text: "Earlier date on file: Jun 2015")
+
+    # Facilitator start now precedes member_since — it merely differs.
+    set_date_input(fac_start.call, "2014-01-01")
+    expect(page).to have_css("#{flag}.text-gray-500", text: "Different date on file: Jun 2015", wait: 5)
+
+    # Facilitator start lands in member_since's month — no flag.
+    set_date_input(fac_start.call, "2015-06-10")
+    expect(page).to have_css("#{flag}.hidden", visible: :all, wait: 5)
+  end
+
   it "shows end date and icon when the facilitator affiliation is inactive" do
     visit_and_wait edit_person_path(person, admin: true)
 

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -32,16 +32,10 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     )
   end
 
-  it "updates Affiliated since when a start date changes" do
-    visit_and_wait edit_person_path(person, admin: true)
-
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
-    expect(affiliated).to have_text("Mar 2020")
-
-    start_inputs = all("input[name*='affiliations_attributes'][name*='start_date']")
-    set_date_input(start_inputs.first, "2018-01-15")
-
-    expect(affiliated).to have_text("Jan 2018", wait: 5)
+  def facilitator_row
+    all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
+      f.find("input[name*='title']").value.strip == "Facilitator"
+    }
   end
 
   it "updates Facilitator since when a start date changes" do
@@ -50,12 +44,7 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     facilitator = find("[data-affiliation-dates-target='facilitatorSince']")
     expect(facilitator).to have_text("Mar 2020")
 
-    # Find the Facilitator affiliation's start_date input specifically
-    facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("input[name*='title']").value.include?("Facilitator")
-    }
-    start_input = facilitator_row.find("input[name*='start_date']")
-    set_date_input(start_input, "2019-07-01")
+    set_date_input(facilitator_row.find("input[name*='start_date']"), "2019-07-01")
 
     expect(facilitator).to have_text("Jul 2019", wait: 5)
   end
@@ -68,25 +57,20 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
 
     # Renaming the only exact "Facilitator" to a variant drops it — facilitator
     # matching is exact and case-sensitive, so "Lead Facilitator" no longer counts.
-    facilitator_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-      f.find("input[name*='title']").value.strip == "Facilitator"
-    }
     set_text_input(facilitator_row.find("input[name*='title']"), "Lead Facilitator")
 
     expect(facilitator).to have_text("—", wait: 5)
   end
 
-  it "shows end date and icon when all affiliations are inactive" do
+  it "shows end date and icon when the facilitator affiliation is inactive" do
     visit_and_wait edit_person_path(person, admin: true)
 
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
+    facilitator = find("[data-affiliation-dates-target='facilitatorSince']")
 
-    end_inputs = all("input[name*='affiliations_attributes'][name*='end_date']")
-    set_date_input(end_inputs[0], "2023-01-01")
-    set_date_input(end_inputs[1], "2024-06-01")
+    set_date_input(facilitator_row.find("input[name*='end_date']"), "2023-01-01")
 
-    expect(affiliated).to have_text("Jun 2024", wait: 5)
-    within(affiliated) do
+    expect(facilitator).to have_text("Jan 2023", wait: 5)
+    within(facilitator) do
       expect(page).to have_css("i.fa-circle-xmark")
     end
   end
@@ -94,36 +78,30 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
   it "displays correct month for first-of-month dates in US timezones" do
     visit_and_wait edit_person_path(person, admin: true)
 
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
+    facilitator = find("[data-affiliation-dates-target='facilitatorSince']")
 
-    # Set both affiliations to first-of-month dates and verify the JS controller
-    # formats them correctly. This catches UTC-to-local timezone bugs where midnight
-    # UTC rolls back to the previous month in behind-UTC timezones
-    # (e.g., 2025-01-01T00:00Z → Dec 31 in EST).
-    start_inputs = all("input[name*='affiliations_attributes'][name*='start_date']")
-    set_date_input(start_inputs[0], "2025-03-01")
-    set_date_input(start_inputs[1], "2025-01-01")
+    # A first-of-month date must format to that month, not roll back a day. This
+    # catches UTC-to-local timezone bugs where midnight UTC lands on the previous
+    # month in behind-UTC timezones (e.g., 2025-01-01T00:00Z → Dec 31 in EST).
+    set_date_input(facilitator_row.find("input[name*='start_date']"), "2025-01-01")
 
-    # Should show Jan 2025, not Dec 2024
-    expect(affiliated).to have_text("Jan 2025", wait: 5)
-    expect(affiliated).not_to have_text("Dec 2024")
+    expect(facilitator).to have_text("Jan 2025", wait: 5)
+    expect(facilitator).not_to have_text("Dec 2024")
   end
 
-  it "removes an affiliation via the editor and recalculates" do
-    # Persisted affiliations are now deleted from the affiliation editor (reached
-    # via the row's gear); removing the Facilitator (Mar 2020) leaves Volunteer (Jun 2022).
+  it "surfaces the affiliation start as a grey note when it differs from the facilitator start" do
+    # Facilitator (Mar 2020) gone; the remaining Volunteer (Jun 2022) now surfaces
+    # as the grey "Affiliated since" note beside an empty Facilitator since.
     facilitator = person.affiliations.find_by!(title: "Facilitator")
     visit edit_affiliation_path(facilitator, return_to: "person", origin_id: person.id)
 
     accept_confirm { click_button "Delete" }
 
-    affiliated = find("[data-affiliation-dates-target='affiliatedSince']", wait: 10)
-    expect(affiliated).to have_text("Jun 2022", wait: 5)
+    expect(page).to have_text("Affiliated since Jun 2022", wait: 10)
   end
 
-  # The org form renders "Affiliated since" as merged, year-based periods
-  # (AffiliationPeriods) rather than a single range; it must live-update in that
-  # same format so the value doesn't jump on save.
+  # "Facilitators since" on the org form is a merged-period value at month
+  # precision, so it must live-update in that format — not an earliest→latest range.
   context "on the organization form" do
     let!(:org_person) { create(:person) }
     let!(:merged_org) { create(:organization) }
@@ -135,22 +113,6 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
              title: "Facilitator", start_date: "2022-01-01", end_date: nil)
     end
 
-    it "live-updates the merged 'Affiliated since' periods" do
-      visit_and_wait edit_organization_path(merged_org)
-
-      affiliated = find("[data-affiliation-dates-target='affiliatedSince']")
-      expect(affiliated).to have_text("2018-2019, 2022")
-
-      ongoing_row = all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
-        f.find("input[name*='start_date']").value == "2022-01-01"
-      }
-      set_date_input(ongoing_row.find("input[name*='start_date']"), "2021-05-01")
-
-      expect(affiliated).to have_text("2018-2019, 2021", wait: 5)
-    end
-
-    # "Facilitators since" is the same merged-period value at month precision, so it
-    # has to live-update in that format too — not the old earliest→latest range.
     it "live-updates 'Facilitators since' as month-precision periods" do
       visit_and_wait edit_organization_path(merged_org)
 

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     expect(facilitator).to have_text("—", wait: 5)
   end
 
+  it "toggles the affiliated-since note live as the earliest start crosses the facilitator start" do
+    visit_and_wait edit_person_path(person, admin: true)
+    note = "[data-affiliation-dates-target='affiliatedNote']"
+
+    volunteer_start = -> {
+      all("[data-affiliation-dates-target='affiliationsContainer'] .nested-fields").find { |f|
+        f.find("input[name*='title']").value.strip == "Volunteer"
+      }.find("input[name*='start_date']")
+    }
+
+    # Facilitator (Mar 2020) is the earliest affiliation, so affiliated == facilitator.
+    expect(page).to have_css("#{note}.hidden", visible: :all)
+
+    # Move it before the facilitator start — now affiliated differs, note appears.
+    set_date_input(volunteer_start.call, "2018-01-15")
+    expect(page).to have_css(note, text: "Affiliated since Jan 2018", wait: 5)
+
+    # Move it back into the facilitator's month — note disappears again.
+    set_date_input(volunteer_start.call, "2020-03-20")
+    expect(page).to have_css("#{note}.hidden", visible: :all, wait: 5)
+  end
+
   it "shows end date and icon when the facilitator affiliation is inactive" do
     visit_and_wait edit_person_path(person, admin: true)
 

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
     }
 
     # Facilitator (Mar 2020) is the earliest affiliation, so affiliated == facilitator.
-    expect(page).to have_css("#{note}.hidden", visible: :all)
+    expect(page).to have_no_css(note)
 
     # Move it before the facilitator start — now affiliated differs, note appears.
     set_date_input(volunteer_start.call, "2018-01-15")
@@ -81,7 +81,7 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
 
     # Move it back into the facilitator's month — note disappears again.
     set_date_input(volunteer_start.call, "2020-03-20")
-    expect(page).to have_css("#{note}.hidden", visible: :all, wait: 5)
+    expect(page).to have_no_css(note, wait: 5)
   end
 
   it "toggles the member-since flag live as the facilitator start crosses member_since" do
@@ -105,7 +105,7 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
 
     # Facilitator start lands in member_since's month — no flag.
     set_date_input(fac_start.call, "2015-06-10")
-    expect(page).to have_css("#{flag}.hidden", visible: :all, wait: 5)
+    expect(page).to have_no_css(flag, wait: 5)
   end
 
   it "shows end date and icon when the facilitator affiliation is inactive" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small display change on two edit forms + a decorator method and its tests

## Why
- On person/org edit, "Affiliated since" sat beside "Facilitator(s) since" and duplicated it whenever the record is only ever a facilitator.

## What
- Removed the standalone "Affiliated since" column on both edit forms.
- Added `affiliated_since_note` on `PersonDecorator` / `OrganizationDecorator`: returns `"Affiliated since <Mon YYYY>"` only when the earliest affiliation start differs (by month/year) from the facilitator start, else nil.
- Renders as a grey secondary line under "Facilitator(s) since".
- Org form: kept the `start_date` editor for the no-affiliations setup case.
- Dropped the now-dead `affiliatedSince` target / `affiliatedSinceFallback` value from the Stimulus controller and retargeted the system specs to `facilitatorSince` / the new note.