### PR TITLE
Align portal primary color with brand blue

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -9,7 +9,7 @@
 @source "../../decorators/**/*.rb";
 
 @theme {
-  --color-primary: #063b8d;
+  --color-primary: #24479e;
   --color-accent: #aa2e00;
   --color-secondary: var(--color-gray-500);
   --color-danger: var(--color-red-500);
@@ -391,4 +391,4 @@ textarea.comment-truncated:focus {
 .rich-label h6 { font-size: 0.875rem; line-height: 1.25rem; font-weight: 600; }
 .rich-label ul { list-style: disc; padding-left: 1.5rem; }
 .rich-label ol { list-style: decimal; padding-left: 1.5rem; }
-.rich-label a { color: #063b8d; text-decoration: underline; }
+.rich-label a { color: var(--color-primary); text-decoration: underline; }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line token change, but recolors every text-primary/bg-primary/button across the app

## Why

- `--color-primary` was `#063b8d` (a darker navy) — not the official AWBW brand blue `#24479E` from the brand guide.
- Corrects the brand color everywhere the token is used: `text-primary`, `bg-primary`, buttons, and the logged-out welcome banner.

## What

- `application.tailwind.css`: `--color-primary` → `#24479e`.
- `.rich-label a` now references `var(--color-primary)` instead of duplicating the old hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)