### PR TITLE
Route remaining hard-coded domain colors through DomainTheme

### DIFF
--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -104,7 +104,7 @@
           <% end %>
         </p>
         <%= button_to toggle_certificate_continuing_education_registration_path(@ce_registration, return_to: params[:return_to].presence),
-              method: :patch, class: "rounded-lg border px-3 py-1.5 text-sm font-medium #{@ce_registration.certificate_sent_at.present? ? "border-gray-300 text-gray-600 hover:bg-gray-50" : "border-teal-300 bg-teal-50 text-teal-700 hover:bg-teal-100"} cursor-pointer" do %>
+              method: :patch, class: "rounded-lg border px-3 py-1.5 text-sm font-medium #{@ce_registration.certificate_sent_at.present? ? "border-gray-300 text-gray-600 hover:bg-gray-50" : "#{DomainTheme.border_class_for(:continuing_education_registrations)} #{DomainTheme.bg_class_for(:continuing_education_registrations)} #{DomainTheme.text_class_for(:continuing_education_registrations, intensity: 700)} #{DomainTheme.bg_class_for(:continuing_education_registrations, hover: true)}"} cursor-pointer" do %>
           <%= @ce_registration.certificate_sent_at.present? ? "Mark not issued" : "Mark certificate issued" %>
         <% end %>
       </div>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -35,7 +35,7 @@
             <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_fields.size %></td>
             <td class="px-4 py-2 text-sm text-gray-600">
               <% if form.events.size.positive? %>
-                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md bg-purple-50 px-2 py-0.5 text-purple-700 font-medium hover:bg-purple-100" %>
+                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
               <% else %>
                 0
               <% end %>
@@ -52,7 +52,7 @@
                   <% end %>
                 <% end %>
                 <% if form.events.size.positive? %>
-                  <span class="inline-flex items-center gap-1.5 rounded-md bg-purple-50 px-2 py-0.5 text-xs text-purple-700">
+                  <span class="inline-flex items-center gap-1.5 rounded-md <%= DomainTheme.bg_class_for(:forms) %> px-2 py-0.5 text-xs <%= DomainTheme.text_class_for(:forms, intensity: 700) %>">
                     <i class="fa-solid fa-calendar-day"></i>Event form
                   </span>
                 <% end %>
@@ -65,7 +65,7 @@
               <% submissions_count = form.form_submissions.size %>
               <% if submissions_count.positive? %>
                 <%= link_to submissions_count, form_submissions_path(form_id: form.id, return_to: "forms"),
-                            class: "inline-flex items-center rounded-md bg-purple-50 px-2 py-0.5 text-purple-700 font-medium hover:bg-purple-100" %>
+                            class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
               <% else %>
                 0
               <% end %>

--- a/app/views/home/workshops/_workshops_carousel.html.erb
+++ b/app/views/home/workshops/_workshops_carousel.html.erb
@@ -11,8 +11,8 @@
       swiper-button-next-custom
       absolute top-36 sm:top-36 right-2
       w-12 h-12 rounded-full
-      bg-white border border-indigo-200
-      text-indigo-700
+      bg-white border <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
+      <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>
       shadow-md hover:shadow-lg
       flex items-center justify-center
       transition hover:<%= DomainTheme.bg_class_for(:workshops) %>
@@ -36,8 +36,8 @@
       swiper-button-prev-custom
       absolute top-36 sm:top-36 left-2
       w-12 h-12 rounded-full
-      bg-white border border-indigo-200
-      text-indigo-700
+      bg-white border <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
+      <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>
       shadow-md hover:shadow-lg
       flex items-center justify-center
       transition hover:<%= DomainTheme.bg_class_for(:workshops) %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -18,7 +18,7 @@
 
     <div class="space-y-6">
       <!-- SECTORS -->
-      <section class="bg-lime-100 border border-lime-200 rounded-xl p-6">
+      <section class="<%= DomainTheme.bg_class_for(:sectors, intensity: 100) %> border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> rounded-xl p-6">
         <div class="flex items-start justify-between gap-6 mb-5">
           <div>
             <h2 class="text-lg font-semibold text-slate-900">
@@ -42,7 +42,7 @@
       </section>
 
       <!-- CATEGORIES -->
-      <section class="bg-lime-100 border border-lime-200 rounded-xl p-6">
+      <section class="<%= DomainTheme.bg_class_for(:categories, intensity: 100) %> border <%= DomainTheme.border_class_for(:categories, intensity: 200) %> rounded-xl p-6">
         <div class="flex items-start justify-between gap-6 mb-5">
           <div>
             <h2 class="text-lg font-semibold text-stone-900">

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -19,10 +19,10 @@
 
       <% visible_variations = allowed_to?(:manage?, WorkshopVariation) ? @workshop_variation_idea.workshop_variations : @workshop_variation_idea.workshop_variations.where(published: true) %>
       <% if visible_variations.any? %>
-        <div class="rounded-lg border border-purple-200 bg-purple-50 p-4 mb-4">
+        <div class="rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 mb-4">
           <div class="flex items-center gap-2">
-            <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-            <span class="text-sm font-medium text-purple-800">
+            <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
+            <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">
               Promoted to:
               <% visible_variations.each do |variation| %>
                 <%= link_to variation.title, workshop_variation_path(variation), class: "underline hover:text-purple-600" %>
@@ -31,10 +31,10 @@
           </div>
         </div>
       <% elsif @workshop_variation_idea.persisted? && allowed_to?(:manage?, WorkshopVariation) %>
-        <div class="admin-only rounded-lg border border-purple-200 bg-purple-50 p-4 mb-4">
+        <div class="admin-only rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 mb-4">
           <div class="flex items-center gap-2">
-            <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-            <span class="text-sm font-medium text-purple-800">This idea has not been promoted yet.</span>
+            <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
+            <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">This idea has not been promoted yet.</span>
             <%= link_to "Promote to Workshop Variation",
                         new_workshop_variation_path(workshop_variation_idea_id: @workshop_variation_idea.id),
                         class: "btn btn-secondary-outline text-sm" %>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -24,10 +24,10 @@
 
     <% visible_variations = allowed_to?(:manage?, WorkshopVariation) ? @workshop_variation_idea.workshop_variations : @workshop_variation_idea.workshop_variations.where(published: true) %>
     <% if visible_variations.any? %>
-      <div class="rounded-lg border border-purple-200 bg-purple-50 p-4">
+      <div class="rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4">
         <div class="flex items-center gap-2">
-          <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-          <span class="text-sm font-medium text-purple-800">
+          <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
+          <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">
             Promoted to:
             <% visible_variations.each do |variation| %>
               <%= link_to variation.title, workshop_variation_path(variation), class: "underline hover:text-purple-600" %>
@@ -36,10 +36,10 @@
         </div>
       </div>
     <% elsif @workshop_variation_idea.persisted? && allowed_to?(:manage?, WorkshopVariation) %>
-      <div class="admin-only rounded-lg border border-purple-200 bg-purple-50 p-4">
+      <div class="admin-only rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4">
         <div class="flex items-center gap-2">
-          <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-          <span class="text-sm font-medium text-purple-800">This idea has not been promoted yet.</span>
+          <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
+          <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">This idea has not been promoted yet.</span>
           <%= link_to "Promote to Workshop Variation",
                       new_workshop_variation_path(workshop_variation_idea_id: @workshop_variation_idea.id),
                       class: "btn btn-secondary-outline text-sm" %>

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -20,10 +20,10 @@
       </div>
 
       <% if @workshop_variation.workshop_variation_idea.present? && allowed_to?(:edit?, @workshop_variation) %>
-        <div class="admin-only rounded-lg border border-purple-200 bg-purple-50 p-4">
+        <div class="admin-only rounded-lg border <%= DomainTheme.border_class_for(:workshop_variations, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variations) %> p-4">
           <div class="flex items-center gap-2">
-            <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-            <span class="text-sm font-medium text-purple-800">Promoted from:</span>
+            <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variations, intensity: 600) %>"></i>
+            <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variations) %>">Promoted from:</span>
             <%= link_to @workshop_variation.workshop_variation_idea.name,
                         workshop_variation_idea_path(@workshop_variation.workshop_variation_idea),
                         class: "btn btn-secondary-outline text-sm" %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only class swaps across 7 templates, emitted classes are byte-identical

### What is the goal of this PR and why is this important?
- A few views still hard-coded their own domain's identity color (indigo, purple, teal, lime) for panels, chips, and buttons.
- Neighboring elements in the same files already resolved that color via `DomainTheme`, so these were half-migrated leftovers.
- Centralizing them means a future re-theme is a one-line change in `DomainTheme::COLORS`.

### How did you approach the change?
- Audited every view referencing `DomainTheme` and cross-checked each hard-coded palette literal against the domain's `COLORS` entry.
- Converted only genuine domain-identity styling; left focus rings, status colors, the comment color-picker, JS-coupled scholarship state classes, and the deliberately-tinted sector "primary" chip alone.
- Verified each `DomainTheme` call emits the exact class string it replaced, so rendered HTML is byte-identical (no visual change).

### UI Testing Checklist
- [ ] Workshops carousel nav buttons unchanged
- [ ] Workshop variation / variation-idea "Promoted to/from" panels unchanged
- [ ] Forms index event/submission chips unchanged
- [ ] CE registration "Mark certificate issued" button unchanged
- [ ] Tags index sector/category section panels unchanged

### Anything else to add?
- Some domain-colored links use `hover:text-*`, which `DomainTheme` has no helper for; left fully literal rather than half-converting.