### PR TITLE
Theme hardcoded-blue buttons with the primary token

### DIFF
--- a/app/frontend/stylesheets/components/buttons.css
+++ b/app/frontend/stylesheets/components/buttons.css
@@ -6,6 +6,11 @@
            disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
+  /* Compact size modifier — pair with .btn (e.g. `btn btn-sm btn-primary`). */
+  .btn-sm {
+    @apply px-3 py-1 text-xs;
+  }
+
   /* solid */
   .btn-primary {
     @apply border border-primary bg-primary text-white

--- a/app/helpers/rhino_editor_helper.rb
+++ b/app/helpers/rhino_editor_helper.rb
@@ -50,13 +50,13 @@ module RhinoEditorHelper
                 :button,
                 "Cancel",
                 data: { action: "click->rhino-source#hide" },
-                class: "mr-2 px-4 py-2 bg-gray-200 rounded"
+                class: "btn btn-utility mr-2"
               ),
               content_tag(
                 :button,
                 "Save",
                 data: { action: "click->rhino-source#save" },
-                class: "px-4 py-2 bg-primary text-white rounded"
+                class: "btn btn-primary"
               )
             ])
           end

--- a/app/helpers/rhino_editor_helper.rb
+++ b/app/helpers/rhino_editor_helper.rb
@@ -56,7 +56,7 @@ module RhinoEditorHelper
                 :button,
                 "Save",
                 data: { action: "click->rhino-source#save" },
-                class: "px-4 py-2 bg-blue-600 text-white rounded"
+                class: "px-4 py-2 bg-primary text-white rounded"
               )
             ])
           end

--- a/app/views/allocations/_search_boxes.html.erb
+++ b/app/views/allocations/_search_boxes.html.erb
@@ -1,6 +1,4 @@
-<%# Filters — field, label, and button styling modeled on the registrants search. %>
-<% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
+<%# Filters — field and label styling modeled on the registrants search. %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>
@@ -9,9 +7,7 @@
     data: {
       controller: "collection",
       collection_search_type_select_outlet: "[data-type-picker]",
-      turbo_frame: "allocations_results",
-      collection_unselected_class: default_btn,
-      collection_selected_class: selected_btn
+      turbo_frame: "allocations_results"
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div class="space-y-4">

--- a/app/views/allocations/_search_boxes.html.erb
+++ b/app/views/allocations/_search_boxes.html.erb
@@ -1,6 +1,6 @@
 <%# Filters — field, label, and button styling modeled on the registrants search. %>
 <% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
+<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -91,7 +91,7 @@
       </div>
 
       <%= submit_tag "Apply to profile",
-                     class: "rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 cursor-pointer" %>
+                     class: "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90 cursor-pointer" %>
     <% end %>
   </div>
 </div>

--- a/app/views/author_credit_divergences/_preference_group.html.erb
+++ b/app/views/author_credit_divergences/_preference_group.html.erb
@@ -91,7 +91,7 @@
       </div>
 
       <%= submit_tag "Apply to profile",
-                     class: "rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:bg-primary/90 cursor-pointer" %>
+                     class: "btn btn-primary cursor-pointer" %>
     <% end %>
   </div>
 </div>

--- a/app/views/continuing_education_registrations/_search_boxes.html.erb
+++ b/app/views/continuing_education_registrations/_search_boxes.html.erb
@@ -1,6 +1,6 @@
 <%# Filters — field/label/button styling modeled on the allocations search. %>
 <% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
+<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>

--- a/app/views/continuing_education_registrations/_search_boxes.html.erb
+++ b/app/views/continuing_education_registrations/_search_boxes.html.erb
@@ -1,6 +1,4 @@
-<%# Filters — field/label/button styling modeled on the allocations search. %>
-<% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
+<%# Filters — field/label styling modeled on the allocations search. %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>
@@ -14,9 +12,7 @@
   <%= form_tag continuing_education_registrations_path, method: :get, class: "space-y-4",
     data: {
       controller: "collection",
-      turbo_frame: "continuing_education_registrations_results",
-      collection_unselected_class: default_btn,
-      collection_selected_class: selected_btn
+      turbo_frame: "continuing_education_registrations_results"
     }, autocomplete: "off" do %>
     <%= hidden_field_tag "professional_license_id", params[:professional_license_id] if params[:professional_license_id].present? %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -37,8 +37,8 @@
         expected next step — so those take the solid (primary) style and "Link
         organization" is demoted to the outline style. %>
     <% create_is_primary = @creatable_org_names.any? %>
-    <% btn_solid = "bg-primary text-white hover:bg-primary/90" %>
-    <% btn_outline = "border border-primary text-primary hover:bg-primary/10" %>
+    <% btn_solid = "btn btn-primary" %>
+    <% btn_outline = "btn btn-primary-outline" %>
     <details class="mb-8" open>
       <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
@@ -174,7 +174,7 @@
                             method: :post,
                             params: { organization_name: creatable_name },
                             form: { class: "shrink-0", data: { turbo_frame: "_top" } },
-                            class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{btn_solid} focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition cursor-pointer" do %>
+                            class: "btn #{btn_solid} shrink-0 w-48 justify-center focus:ring-primary cursor-pointer" do %>
                 Create and link
               <% end %>
             </div>
@@ -195,7 +195,7 @@
                 <div class="min-w-0">
                   <p class="font-medium text-gray-800"><%= org.name %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 </div>
-                <%= submit_tag "Link organization", class: "rounded-md bg-primary px-4 py-1.5 text-white text-sm font-medium hover:bg-primary/90 transition cursor-pointer" %>
+                <%= submit_tag "Link organization", class: "btn btn-primary cursor-pointer" %>
               <% end %>
             <% end %>
           </div>
@@ -215,7 +215,7 @@
                            prompt: "Type to search organizations…" %>
           </div>
           <%= submit_tag "Link organization",
-                         class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{create_is_primary ? btn_outline : btn_solid} focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition cursor-pointer" %>
+                         class: "btn #{create_is_primary ? btn_outline : btn_solid} shrink-0 w-48 justify-center focus:ring-primary cursor-pointer" %>
         <% end %>
       </div>
     </div>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -37,8 +37,8 @@
         expected next step — so those take the solid (primary) style and "Link
         organization" is demoted to the outline style. %>
     <% create_is_primary = @creatable_org_names.any? %>
-    <% btn_solid = "bg-blue-900 text-white hover:bg-blue-800" %>
-    <% btn_outline = "border border-blue-900 text-blue-900 hover:bg-blue-50" %>
+    <% btn_solid = "bg-primary text-white hover:bg-primary/90" %>
+    <% btn_outline = "border border-primary text-primary hover:bg-primary/10" %>
     <details class="mb-8" open>
       <summary class="flex items-center justify-between gap-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden mb-3">
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
@@ -174,7 +174,7 @@
                             method: :post,
                             params: { organization_name: creatable_name },
                             form: { class: "shrink-0", data: { turbo_frame: "_top" } },
-                            class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{btn_solid} focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" do %>
+                            class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{btn_solid} focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition cursor-pointer" do %>
                 Create and link
               <% end %>
             </div>
@@ -195,7 +195,7 @@
                 <div class="min-w-0">
                   <p class="font-medium text-gray-800"><%= org.name %><% if org.city_state.present? %> <span class="text-xs text-gray-500">· <%= org.city_state %></span><% end %></p>
                 </div>
-                <%= submit_tag "Link organization", class: "rounded-md bg-blue-900 px-4 py-1.5 text-white text-sm font-medium hover:bg-blue-800 transition cursor-pointer" %>
+                <%= submit_tag "Link organization", class: "rounded-md bg-primary px-4 py-1.5 text-white text-sm font-medium hover:bg-primary/90 transition cursor-pointer" %>
               <% end %>
             <% end %>
           </div>
@@ -215,7 +215,7 @@
                            prompt: "Type to search organizations…" %>
           </div>
           <%= submit_tag "Link organization",
-                         class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{create_is_primary ? btn_outline : btn_solid} focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition cursor-pointer" %>
+                         class: "shrink-0 w-48 text-center rounded-md px-6 py-2 font-semibold #{create_is_primary ? btn_outline : btn_solid} focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition cursor-pointer" %>
         <% end %>
       </div>
     </div>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -226,7 +226,7 @@
 
         <div class="pt-7">
           <%= button_tag type: "submit",
-                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-blue-900 px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-blue-900/20 transition hover:bg-blue-800 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer" do %>
+                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-primary px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-primary/20 transition hover:bg-primary/90 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 cursor-pointer" do %>
             <i class="fa-regular fa-circle-check"></i>Submit
           <% end %>
           <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">

--- a/app/views/events/callouts/videoconference.html.erb
+++ b/app/views/events/callouts/videoconference.html.erb
@@ -7,7 +7,7 @@
         <div>
           <p class="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">Join link</p>
           <%= link_to @event.videoconference_url, target: "_blank", rel: "noopener",
-                      class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700" do %>
+                      class: "btn btn-primary font-semibold" do %>
             <i class="fa-solid fa-video"></i> Join on <%= @event.videoconference_domain %>
           <% end %>
           <p class="mt-2 text-xs text-gray-500 break-all"><%= @event.videoconference_url %></p>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -196,7 +196,7 @@
 
         <div class="pt-7">
           <%= button_tag type: "submit",
-                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-blue-900 px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-blue-900/20 transition hover:bg-blue-800 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer" do %>
+                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-primary px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-primary/20 transition hover:bg-primary/90 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 cursor-pointer" do %>
             <i class="fa-regular fa-circle-check"></i>Register
           <% end %>
           <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -80,7 +80,7 @@
       <div class="mt-6 flex items-center justify-end gap-3">
         <%= link_to "Cancel", notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
         <%= f.button :submit, t("communications.new"),
-                     class: "inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700" %>
+                     class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -1,6 +1,4 @@
-<!-- Filters — field, label, and button styling modeled on the allocations search. -->
-<% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
+<!-- Filters — field and label styling modeled on the allocations search. -->
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>
@@ -9,9 +7,7 @@
   <%= form_tag payments_path, method: :get, class: "space-y-4",
     data: {
       controller: "collection",
-      turbo_frame: "payments_results",
-      collection_unselected_class: default_btn,
-      collection_selected_class: selected_btn
+      turbo_frame: "payments_results"
     }, autocomplete: "off" do %>
     <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
       <div class="md:col-span-2">

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -1,6 +1,6 @@
 <!-- Filters — field, label, and button styling modeled on the allocations search. -->
 <% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
+<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>

--- a/app/views/professional_licenses/_search_boxes.html.erb
+++ b/app/views/professional_licenses/_search_boxes.html.erb
@@ -1,6 +1,6 @@
 <%# Filters — field/label/button styling modeled on the CE registrations search. %>
 <% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-blue-600 border-blue-600 hover:bg-blue-700 hover:text-white shadow-md ring-2 ring-blue-300" %>
+<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>

--- a/app/views/professional_licenses/_search_boxes.html.erb
+++ b/app/views/professional_licenses/_search_boxes.html.erb
@@ -1,6 +1,4 @@
-<%# Filters — field/label/button styling modeled on the CE registrations search. %>
-<% default_btn = "text-gray-600 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-800 shadow-sm" %>
-<% selected_btn = "text-white bg-primary border-primary hover:bg-primary/90 hover:text-white shadow-md ring-2 ring-primary/40" %>
+<%# Filters — field/label styling modeled on the CE registrations search. %>
 <% field_class = search_field_class %>
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>
@@ -10,9 +8,7 @@
   <%= form_tag professional_licenses_path, method: :get, class: "space-y-4",
     data: {
       controller: "collection",
-      turbo_frame: "professional_licenses_results",
-      collection_unselected_class: default_btn,
-      collection_selected_class: selected_btn
+      turbo_frame: "professional_licenses_results"
     }, autocomplete: "off" do %>
     <div class="flex flex-wrap md:flex-nowrap items-end gap-4">
       <div class="flex-1 min-w-[200px]">

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -48,7 +48,7 @@
 
         <div class="pt-7">
           <%= button_tag type: "submit",
-                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-blue-900 px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-blue-900/20 transition hover:bg-blue-800 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer" do %>
+                class: "w-full inline-flex items-center justify-center gap-2.5 rounded-xl bg-primary px-6 py-3.5 text-white font-semibold text-lg shadow-lg shadow-primary/20 transition hover:bg-primary/90 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 cursor-pointer" do %>
             <i class="fa-regular fa-circle-check"></i>Submit
           <% end %>
           <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">

--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -34,7 +34,7 @@
   <button id="fab-button"
           type="button"
           class="bg-primary text-white w-10 h-10 rounded-full shadow-lg flex items-center
-                 justify-center text-lg font-bold hover:bg-blue-700 transition">
+                 justify-center text-lg font-bold hover:bg-primary/90 transition">
     ?
   </button>
 </div>

--- a/app/views/topic_subscriptions/_form.html.erb
+++ b/app/views/topic_subscriptions/_form.html.erb
@@ -55,9 +55,9 @@
 
       <div class="mb-2 flex w-fit text-sm">
         <label for="person-source-existing"
-               class="cursor-pointer rounded-l-lg border border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/existing:border-blue-600 peer-checked/existing:bg-blue-600 peer-checked/existing:text-white">Existing person</label>
+               class="cursor-pointer rounded-l-lg border border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/existing:border-primary peer-checked/existing:bg-primary peer-checked/existing:text-white">Existing person</label>
         <label for="person-source-new"
-               class="cursor-pointer rounded-r-lg border border-l-0 border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/new:border-blue-600 peer-checked/new:bg-blue-600 peer-checked/new:text-white">New person</label>
+               class="cursor-pointer rounded-r-lg border border-l-0 border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/new:border-primary peer-checked/new:bg-primary peer-checked/new:text-white">New person</label>
       </div>
 
       <div class="hidden peer-checked/existing:block"><%= person_select %></div>

--- a/app/views/users/confirm_email.turbo_stream.erb
+++ b/app/views/users/confirm_email.turbo_stream.erb
@@ -9,7 +9,7 @@
               data-controller="confirm-email"
               data-confirm-email-user-id-value="<%= @user.id %>"
               data-action="click->confirm-email#confirm"
-              class="btn btn-sm bg-blue-600 hover:bg-blue-700 text-white border-blue-600">
+              class="btn btn-sm btn-primary">
         Manually confirm email
       </button>
     </div>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 CSS-class swaps + one new size class + dead-code removal; no logic changes

## Why

- Several action buttons and selected-state controls used literal Tailwind blue (`bg-blue-600/700/900`), so they ignored the brand primary token and did not follow the corrected brand blue (`#24479e`).
- Point them at the standard `.btn` components / the `primary` token so they theme with the brand color.

## What

### Standard button components (`.btn btn-primary` / `-outline` / `-utility`)
- Manually-confirm-email button, notification submit, videoconference "Join" link.
- Link-organization solid + outline paired buttons and both submits (shape already matched `.btn`; kept `w-48` equal-width).
- Author-credit "Apply to profile".
- Rhino editor Save → `.btn btn-primary`, Cancel → `.btn btn-utility`.

### New `.btn-sm` size modifier
- `btn-sm` was used in ~8 views but **defined nowhere** (silently did nothing). Added it to `buttons.css` (`px-3 py-1 text-xs`).

### `primary` token swap (bespoke shape kept — no matching component)
- Footer FAB (circular; was `bg-primary` but `hover:bg-blue-700` — now hovers on-token).
- Large public-form CTAs (public form, public registration, bulk payment): oversized hero CTAs with hover-lift + colored shadow — kept their size/motion, swapped the blue literals to the token.
- Existing/new-person segmented radios (`peer-checked` labels).

### Dead-code removal
- The payments / allocations / continuing-ed / professional-license search forms defined `default_btn`/`selected_btn` pill classes + `collection_*_class` data attrs, but render **no toggle buttons** — removed as dead. The live filter pills (resources) keep their per-domain color (indigo), which is intentional and untouched.

### Left as-is (semantic, not brand-primary)
- Links (`text-blue-600`), info chips, input focus rings, checkbox/toggle "on" states, upload progress bars, data-table stat cells, and categorical color maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)