### PR TITLE
Add hover: support to DomainTheme.text_class_for

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,6 +138,35 @@ picker), use `MoneyFormatter.compact_from_cents(cents)` (`$12.5k`, `$1.2m`) — 
   `scholarship_preview_controller.js`). Keep the server-rendered initial value and the JS-updated value
   formatted identically.
 
+## Domain colors (DomainTheme)
+
+Each domain (workshops, organizations, events, forms, sectors, scholarships, …) has one
+canonical Tailwind color, mapped in **`DomainTheme::COLORS`** (`lib/domain_theme.rb`). The
+point is single-source theming: re-coloring a whole domain is a one-line change in `COLORS`.
+
+- **Never hard-code a domain's own identity color.** When a panel, badge, chip, button, link,
+  or icon is themed to a domain, resolve the class through `DomainTheme`, not a literal like
+  `bg-emerald-50` / `text-indigo-700` / `hover:text-purple-800`.
+- **Helpers** (all take a domain key symbol, e.g. `:organizations`):
+  - `DomainTheme.bg_class_for(key, intensity: 50, hover: false)` → `"bg-emerald-50"` (`hover: true`
+    prefixes `hover:bg-` and bumps one step).
+  - `DomainTheme.text_class_for(key, intensity: 800, hover: false)` → `"text-emerald-800"`
+    (**`hover: true` prefixes `hover:text-`** at the intensity you pass — use it for link hover
+    states instead of a literal `hover:text-*`).
+  - `DomainTheme.border_class_for(key, intensity: 300)` → `"border-emerald-300"`.
+  - `DomainTheme.color_for(key)` → the raw color symbol (e.g. `:emerald`); unknown keys fall back
+    to `:gray`.
+- **In views** interpolate the helper into the class list (`<%= DomainTheme.bg_class_for(:forms) %>`);
+  **in decorators/POROs** (no helper access) call `DomainTheme.…` directly — it's a plain module.
+- **New color?** Add the key → color to `DomainTheme::COLORS` **and** add the color to the
+  `@source inline(...)` safelist in `app/frontend/stylesheets/application.tailwind.css`, or Tailwind
+  won't generate the dynamically-built class and it renders unstyled.
+- **Leave genuinely non-domain colors literal** — don't force these through `DomainTheme`: the
+  `bg-blue-100` `page_bg_class` marker, the global `focus:border-blue-500 focus:ring-blue-200`
+  form-focus convention, status colors (green = success, amber/yellow = warning, red = error),
+  multi-color pickers/swatches, and classes a Stimulus controller also toggles (keep ERB and JS in
+  sync as literals). Convert only a domain's *own identity* color.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,35 @@ picker), use `MoneyFormatter.compact_from_cents(cents)` (`$12.5k`, `$1.2m`) — 
   `scholarship_preview_controller.js`). Keep the server-rendered initial value and the JS-updated value
   formatted identically.
 
+## Domain colors (DomainTheme)
+
+Each domain (workshops, organizations, events, forms, sectors, scholarships, …) has one
+canonical Tailwind color, mapped in **`DomainTheme::COLORS`** (`lib/domain_theme.rb`). The
+point is single-source theming: re-coloring a whole domain is a one-line change in `COLORS`.
+
+- **Never hard-code a domain's own identity color.** When a panel, badge, chip, button, link,
+  or icon is themed to a domain, resolve the class through `DomainTheme`, not a literal like
+  `bg-emerald-50` / `text-indigo-700` / `hover:text-purple-800`.
+- **Helpers** (all take a domain key symbol, e.g. `:organizations`):
+  - `DomainTheme.bg_class_for(key, intensity: 50, hover: false)` → `"bg-emerald-50"` (`hover: true`
+    prefixes `hover:bg-` and bumps one step).
+  - `DomainTheme.text_class_for(key, intensity: 800, hover: false)` → `"text-emerald-800"`
+    (**`hover: true` prefixes `hover:text-`** at the intensity you pass — use it for link hover
+    states instead of a literal `hover:text-*`).
+  - `DomainTheme.border_class_for(key, intensity: 300)` → `"border-emerald-300"`.
+  - `DomainTheme.color_for(key)` → the raw color symbol (e.g. `:emerald`); unknown keys fall back
+    to `:gray`.
+- **In views** interpolate the helper into the class list (`<%= DomainTheme.bg_class_for(:forms) %>`);
+  **in decorators/POROs** (no helper access) call `DomainTheme.…` directly — it's a plain module.
+- **New color?** Add the key → color to `DomainTheme::COLORS` **and** add the color to the
+  `@source inline(...)` safelist in `app/frontend/stylesheets/application.tailwind.css`, or Tailwind
+  won't generate the dynamically-built class and it renders unstyled.
+- **Leave genuinely non-domain colors literal** — don't force these through `DomainTheme`: the
+  `bg-blue-100` `page_bg_class` marker, the global `focus:border-blue-500 focus:ring-blue-200`
+  form-focus convention, status colors (green = success, amber/yellow = warning, red = error),
+  multi-color pickers/swatches, and classes a Stimulus controller also toggles (keep ERB and JS in
+  sync as literals). Convert only a domain's *own identity* color.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/app/views/events/_attendance_totals.html.erb
+++ b/app/views/events/_attendance_totals.html.erb
@@ -41,10 +41,10 @@
           <div class="relative z-10 min-w-0 justify-self-start">
             <% if ce_reg %>
               <%= link_to row.name, registration_ce_path(row.registration.slug, return_to: return_to),
-                    class: "font-medium text-gray-900 hover:text-teal-700 hover:underline" %>
+                    class: "font-medium text-gray-900 #{DomainTheme.text_class_for(:events, intensity: 700, hover: true)} hover:underline" %>
             <% else %>
               <%= link_to row.name, edit_event_registration_path(row.registration, return_to: return_to),
-                    class: "font-medium text-gray-900 hover:text-teal-700 hover:underline" %>
+                    class: "font-medium text-gray-900 #{DomainTheme.text_class_for(:events, intensity: 700, hover: true)} hover:underline" %>
             <% end %>
           </div>
           <% if report.ce_only? %>

--- a/app/views/events/attendance.html.erb
+++ b/app/views/events/attendance.html.erb
@@ -160,10 +160,10 @@
                   <div class="relative z-10 min-w-0 justify-self-start">
                     <% if ce_reg %>
                       <%= link_to row.name, registration_ce_path(row.registration.slug, return_to: "attendance"),
-                            class: "font-medium text-gray-900 hover:text-teal-700 hover:underline" %>
+                            class: "font-medium text-gray-900 #{DomainTheme.text_class_for(:events, intensity: 700, hover: true)} hover:underline" %>
                     <% else %>
                       <%= link_to row.name, edit_event_registration_path(row.registration, return_to: "attendance"),
-                            class: "font-medium text-gray-900 hover:text-teal-700 hover:underline" %>
+                            class: "font-medium text-gray-900 #{DomainTheme.text_class_for(:events, intensity: 700, hover: true)} hover:underline" %>
                     <% end %>
                     <%# Day-scoped: this row is one day, so the flag has to be about
                         this day's entries, not any open entry on any day. %>

--- a/app/views/events/callouts/certificate.html.erb
+++ b/app/views/events/callouts/certificate.html.erb
@@ -56,7 +56,7 @@
           Your continuing education (CE) credit<%= " (#{ce_hours_label} hours)" if ce_hours.positive? %>
           isn't shown on this certificate yet — it's added once <%= ce_pending_reason %>.
           <%= link_to "View your CE status", registration_ce_path(@event_registration.slug),
-                class: "font-medium text-teal-700 underline hover:text-teal-900" %>.
+                class: "font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} underline #{DomainTheme.text_class_for(:events, intensity: 900, hover: true)}" %>.
         </span>
       </div>
     </div>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -19,7 +19,7 @@
      <% if field.section.present? %>data-section="<%= field.section %>"<% end %>
      <% if field.group_header? %>data-group-header<% end %>>
   <% if field.group_header? %>
-    <div class="cursor-grab rounded bg-purple-50 text-purple-500 hover:bg-purple-100 hover:text-purple-700 px-1.5 py-1"
+    <div class="cursor-grab rounded <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 500) %> <%= DomainTheme.bg_class_for(:forms, hover: true) %> <%= DomainTheme.text_class_for(:forms, intensity: 700, hover: true) %> px-1.5 py-1"
          data-sortable-handle
          title="Drag to move this entire section">
       <i class="fa-solid fa-up-down-left-right"></i>
@@ -110,7 +110,7 @@
                 <i class="fa-solid fa-database text-xs text-gray-400"></i>
                 Options from
                 <%= link_to option_source[:label], option_source[:path],
-                      class: "font-medium text-purple-600 hover:text-purple-800 underline",
+                      class: "font-medium #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline",
                       target: "_blank", rel: "noopener" %>
               </span>
             <% else %>
@@ -159,7 +159,7 @@
                     class: "w-32 min-w-0 rounded border-gray-300 shadow-sm px-2 py-1 font-mono text-xs",
                     title: "Internal name that wires this field to backend logic — leave blank for an ordinary field" %>
               <%= link_to "What's this?", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id, field_id: field.id),
-                    class: "mt-0.5 text-3xs text-purple-600 hover:text-purple-800 underline",
+                    class: "mt-0.5 text-3xs #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline",
                     target: "_blank", rel: "noopener" %>
             </div>
             <%= link_to_remove_association "Remove", f,
@@ -187,7 +187,7 @@
                 <%= render "form_field_answer_option_fields", f: opt %>
               <% end %>
               <%= link_to_add_association "+ Add option", f, :form_field_answer_options,
-                    class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
+                    class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} font-medium" %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -188,7 +188,7 @@
         <div class="flex items-center gap-3">
           <span class="text-sm text-gray-500"><%= pluralize(@form_fields.size, "question") %></span>
           <button type="button"
-                  class="text-sm text-purple-600 hover:text-purple-800 font-medium cursor-pointer"
+                  class="text-sm <%= DomainTheme.text_class_for(:forms, intensity: 600) %> <%= DomainTheme.text_class_for(:forms, intensity: 800, hover: true) %> font-medium cursor-pointer"
                   data-action="expand-all#toggleAll"
                   data-expand-all-target="btn">Expand all</button>
         </div>
@@ -251,7 +251,7 @@
         <%= link_to_add_association "+ Add field", f, :form_fields,
               data: { association_insertion_node: "[data-controller='form-fields-sortable']",
                       association_insertion_method: "append" },
-              class: "text-sm text-purple-600 hover:text-purple-800 font-medium" %>
+              class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} font-medium" %>
       </div>
     </div>
 

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -71,10 +71,10 @@
               <% end %>
             </td>
             <td class="space-x-3 px-4 py-2 text-right text-sm">
-              <%= link_to "View", form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
-              <%= link_to "Edit", edit_form_path(form), class: "text-purple-600 hover:text-purple-800 underline" %>
+              <%= link_to "View", form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
+              <%= link_to "Edit", edit_form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
               <% if allowed_to?(:copy?, form) %>
-                <%= link_to "Copy", copy_form_path(form), class: "text-purple-600 hover:text-purple-800 underline",
+                <%= link_to "Copy", copy_form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline",
                             data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
               <% end %>
             </td>

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -25,7 +25,7 @@
             <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">
               Promoted to:
               <% visible_variations.each do |variation| %>
-                <%= link_to variation.title, workshop_variation_path(variation), class: "underline hover:text-purple-600" %>
+                <%= link_to variation.title, workshop_variation_path(variation), class: "underline #{DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600, hover: true)}" %>
               <% end %>
             </span>
           </div>

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -74,7 +74,7 @@
                   <% if promoted_variation %>
                     <%= link_to "Variation ##{promoted_variation.id}",
                                 workshop_variation_path(promoted_variation),
-                                class: "text-purple-600 hover:text-purple-800 hover:underline" %>
+                                class: "#{DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600)} #{DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 800, hover: true)} hover:underline" %>
                   <% else %>
                     <span class="text-gray-300">--</span>
                   <% end %>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -30,7 +30,7 @@
           <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">
             Promoted to:
             <% visible_variations.each do |variation| %>
-              <%= link_to variation.title, workshop_variation_path(variation), class: "underline hover:text-purple-600" %>
+              <%= link_to variation.title, workshop_variation_path(variation), class: "underline #{DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600, hover: true)}" %>
             <% end %>
           </span>
         </div>

--- a/app/views/workshop_variations/_workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_results.html.erb
@@ -69,7 +69,7 @@
                 <%= link_to "Idea ##{workshop_variation.workshop_variation_idea.id}",
                             workshop_variation_idea_path(workshop_variation.workshop_variation_idea),
                             data: { turbo_frame: "_top" },
-                            class: "text-purple-600 hover:text-purple-800 hover:underline" %>
+                            class: "#{DomainTheme.text_class_for(:workshop_variations, intensity: 600)} #{DomainTheme.text_class_for(:workshop_variations, intensity: 800, hover: true)} hover:underline" %>
               <% else %>
                 <span class="text-gray-300">--</span>
               <% end %>

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -118,8 +118,9 @@ module DomainTheme
     "#{prefix}-#{color}-#{intensity}"
   end
 
-  def self.text_class_for(key, intensity: 800)
-    "text-#{color_for(key)}-#{intensity}"
+  def self.text_class_for(key, intensity: 800, hover: false)
+    prefix = hover ? "hover:text" : "text"
+    "#{prefix}-#{color_for(key)}-#{intensity}"
   end
 
   def self.border_class_for(key, intensity: 300)

--- a/spec/lib/domain_theme_spec.rb
+++ b/spec/lib/domain_theme_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe DomainTheme do
     end
   end
 
+  describe ".text_class_for" do
+    it "returns the correct Tailwind text class for a domain" do
+      expect(DomainTheme.text_class_for(:workshops)).to eq("text-indigo-800")
+    end
+
+    it "supports intensity overrides" do
+      expect(DomainTheme.text_class_for(:forms, intensity: 600))
+        .to eq("text-purple-600")
+    end
+
+    it "supports hover classes" do
+      expect(DomainTheme.text_class_for(:forms, intensity: 800, hover: true))
+        .to eq("hover:text-purple-800")
+    end
+
+    it "falls back safely for unknown keys" do
+      expect(DomainTheme.text_class_for(:unknown)).to eq("text-gray-800")
+    end
+  end
+
   describe ".color_for" do
     it "returns configured color symbols" do
       expect(DomainTheme.color_for(:workshops)).to eq(:indigo)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small helper addition to DomainTheme plus byte-identical view class swaps and an AI-instruction doc, covered by a new unit test

Follow-up to #2283 (merged): finishes routing the last hard-coded domain colors through `DomainTheme`, and documents the convention.

### What is the goal of this PR and why is this important?
- The remaining hard-coded domain colors were `hover:text-*` utilities on links, which `DomainTheme` couldn't express (it did bg/text/border + `hover:bg` only).
- Adds a `hover:` flag to `DomainTheme.text_class_for` so these links resolve their own domain color centrally — a re-theme stays a one-line `COLORS` change.

### How did you approach the change?
- Extended `text_class_for(key, intensity:, hover:)` to prefix `hover:text-` when `hover: true`; added spec coverage.
- Routed the remaining domain-colored `hover:text-*` links (forms, workshop variations / variation ideas, event attendance + certificate callout) through the helper.
- Verified each call emits the exact class it replaced (byte-identical HTML); the `hover:text-*` safelist already existed, so no CSS change.
- Left `certificate.html.erb`'s purple link alone — purple isn't the events theme color, so it's a deliberate accent, not a domain leftover.

### Docs
- Added a **Domain colors (DomainTheme)** section to `CLAUDE.md` and the mirrored `.github/copilot-instructions.md`: use `DomainTheme` for a domain's own identity color (incl. `hover:`), and which colors to leave literal (page-bg markers, focus rings, status, pickers, JS-toggled classes).

### UI Testing Checklist
- [ ] Forms index/edit/field links hover unchanged
- [ ] Workshop variation / variation-idea "Promoted" links hover unchanged
- [ ] Event attendance name links + CE certificate callout link hover unchanged

### Anything else to add?
- `domain_theme_spec` + affected view/request specs pass (198 examples, 0 failures); RuboCop clean.