### PR TITLE
Use brand cream (#FCFAEB) as the site background instead of white

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -17,6 +17,10 @@
   --color-info: var(--color-blue-500);
   --color-success: var(--color-green-500);
   --color-transparent: transparent;
+  /* AWBW brand page background — "BACKGROUND COLOR: #FCFAEB" in
+     app/assets/images/brand/awbw-brand-guide.pdf. The site canvas; change it here
+     and every `bg-canvas` (the <body> in the app layout) updates. */
+  --color-canvas: #fcfaeb;
   --font-telefon: "Telefon Bold", sans-serif;
 
   /* Social network brand colors, used for the hover fill on share/follow

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   </head>
 
   <body class="<%= controller.controller_name %> <%= controller.action_name %>
-      flex flex-col min-h-screen bg-white">
+      flex flex-col min-h-screen bg-canvas">
     <%= yield :body_start %>
     <%= render "shared/svg_symbols" %>
     <div class="flex-grow flex flex-col" id="main">


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 two-line theming change (one canvas token + <body> class); no logic, but it recolors every page's canvas

> ⚠️ Needs AWBW staff branding sign-off before merge — see #2289.

### What is the goal of this PR and why is this important?
- The AWBW brand guide names **#FCFAEB** ("BACKGROUND COLOR") as the page background, but the site rendered on plain white.
- Moves the site canvas to the brand cream, controlled from **one** place.

### How did you approach the change?
- Added a single `--color-canvas: #fcfaeb` token to the `@theme` block in `application.tailwind.css` (same mechanism `--color-primary` uses for the navbar) — Tailwind generates `bg-canvas` from it.
- Pointed the app layout `<body>` at `bg-canvas` instead of `bg-white`. Change the hex once and the whole site updates.
- Not routed through `DomainTheme` — that's for per-domain identity colors, not global site chrome.
- Verified the built CSS emits `.bg-canvas{background-color:var(--color-canvas)}` with `--color-canvas:#fcfaeb`.

### Scope
- Only the site canvas changes. All ~748 card/input/modal `bg-white` usages are intentional surfaces — they stay white and now pop against the cream.
- The 4 admin pages that painted their content column white are handled separately in #2288 (align to the standard `bg-blue-100` admin tint).

### UI Testing Checklist
- [ ] Public index/show pages show the cream background
- [ ] Admin pages still show their blue content wrapper over the cream canvas/margins
- [ ] Navbar, banner, footer, and white cards render correctly against cream

### Anything else to add?
- Branding coordination / staff sign-off tracked in #2289. Screenshot to follow.