### PR TITLE
Align accent color with brand orange

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -10,7 +10,7 @@
 
 @theme {
   --color-primary: #24479e;
-  --color-accent: #aa2e00;
+  --color-accent: #d56027;
   --color-secondary: var(--color-gray-500);
   --color-danger: var(--color-red-500);
   --color-warning: var(--color-yellow-500);

--- a/app/frontend/stylesheets/components/buttons.css
+++ b/app/frontend/stylesheets/components/buttons.css
@@ -55,6 +55,11 @@
            hover:bg-primary hover:text-white;
   }
 
+  .btn-accent-outline {
+    @apply border-2 border-accent text-accent
+           hover:bg-accent hover:text-white;
+  }
+
   .btn-secondary-outline {
     @apply border border-secondary text-secondary
            hover:bg-secondary hover:text-white;

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -68,12 +68,12 @@
           <%= button_to "Register",
                       event_registrant_registration_path(event_id: event),
                       data: { turbo: !event.object.cost_cents.to_i.positive? },
-                      class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
+                      class: "btn btn-accent-outline px-3 py-2 text-xs uppercase leading-tight font-telefon" %>
         <% else %>
           <%= link_to "Register",
                       new_event_public_registration_path(event),
                       data: { turbo_frame: "_top" },
-                      class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
+                      class: "btn btn-accent-outline px-3 py-2 text-xs uppercase leading-tight font-telefon" %>
         <% end %>
       <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
         <%= link_to "Register",

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -79,7 +79,7 @@
         <%= link_to "Register",
                     new_event_public_registration_path(event),
                     data: { turbo_frame: "_top" },
-                    class: "btn px-3 py-2 text-xs uppercase leading-tight font-telefon text-accent border-2 border-accent hover:text-white hover:bg-orange-700" %>
+                    class: "btn btn-accent-outline px-3 py-2 text-xs uppercase leading-tight font-telefon" %>
       <% end %>
     <% else %>
       <span class="text-sm text-gray-500 italic">Registration closed</span>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 accent token change + new outline variant; recolors btn-accent / text-accent / accent gradients across event, payment, ticket, and form surfaces

## Why

- `--color-accent` was `#aa2e00` (a dark rust) — not in the brand guide. Set it to the brand primary orange `#D56027`.
- Themes every `accent` usage in one place: the "pay / register" buttons, accent labels, and the decorative gradient bars.

## What

### Accent token
- `application.tailwind.css`: `--color-accent` → `#d56027`.

### New `.btn-accent-outline` variant
- Accent was the only color without an outline variant, so the event-card **Register** buttons hand-rolled it and **hardcoded the hover fill** (`hover:bg-orange-700`) instead of the token.
- Added `.btn-accent-outline` (mirrors the other outline variants + accent’s `border-2`) and pointed all three buttons at it, so the hover fill now follows `--color-accent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)