### PR TITLE
Unify eyebrow / back-nav link color via an eyebrow_link_class helper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -167,6 +167,24 @@ point is single-source theming: re-coloring a whole domain is a one-line change 
   multi-color pickers/swatches, and classes a Stimulus controller also toggles (keep ERB and JS in
   sync as literals). Convert only a domain's *own identity* color.
 
+## Sharing repeated Tailwind (avoid `@apply`)
+
+When the same utility string is repeated across many views, **unify it with a Rails view
+helper or a shared partial — not `@apply`.** `@apply` hides the utilities inside a CSS rule
+and creates the indirection the tailwind-best-practices guidance warns against; a helper
+keeps the utilities scannable (Tailwind already scans `app/helpers`) and reads as a real
+template abstraction.
+
+- **Helper returning a class string** — the same shape as the `DomainTheme.*_class_for`
+  helpers. Return only the *shared* fragment (e.g. a color pair) and let each caller keep its
+  own context-specific layout classes. Example: `eyebrow_link_class` returns the muted gray for
+  page eyebrows / back-nav links; views interpolate it
+  (`class: "text-sm #{eyebrow_link_class} px-2 py-1"`).
+- **Shared partial** — when the repeated thing is markup (icon + text + structure), not just a
+  class list.
+- **`@apply` is reserved** for genuine element/base styles (e.g. `.btn` in
+  `components/buttons.css`), not for extracting repeated utility clusters.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,24 @@ point is single-source theming: re-coloring a whole domain is a one-line change 
   multi-color pickers/swatches, and classes a Stimulus controller also toggles (keep ERB and JS in
   sync as literals). Convert only a domain's *own identity* color.
 
+## Sharing repeated Tailwind (avoid `@apply`)
+
+When the same utility string is repeated across many views, **unify it with a Rails view
+helper or a shared partial — not `@apply`.** `@apply` hides the utilities inside a CSS rule
+and creates the indirection the tailwind-best-practices guidance warns against; a helper
+keeps the utilities scannable (Tailwind already scans `app/helpers`) and reads as a real
+template abstraction.
+
+- **Helper returning a class string** — the same shape as the `DomainTheme.*_class_for`
+  helpers. Return only the *shared* fragment (e.g. a color pair) and let each caller keep its
+  own context-specific layout classes. Example: `eyebrow_link_class` returns the muted gray for
+  page eyebrows / back-nav links; views interpolate it
+  (`class: "text-sm #{eyebrow_link_class} px-2 py-1"`).
+- **Shared partial** — when the repeated thing is markup (icon + text + structure), not just a
+  class list.
+- **`@apply` is reserved** for genuine element/base styles (e.g. `.btn` in
+  `components/buttons.css`), not for extracting repeated utility clusters.
+
 ## HTML/ERB Formatting
 
 ### Tag Attributes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  # Single source of truth for the muted gray on page eyebrows / back-nav links.
+  # Callers keep their own size/padding; interpolate this for the color.
+  def eyebrow_link_class
+    "text-gray-500 hover:text-gray-700"
+  end
+
   # Byline for an AuthorCreditable record. Links to the credited author's person
   # profile when the credit resolves to a searchable person; otherwise renders
   # plain text. The text always honors the credit preference (author_credit), so

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -4,7 +4,7 @@ module FormsHelper
   # "View form" link to the real public-facing registration page — the preview
   # can't fill header tokens or run conditional logic without an event.
   def form_editor_view_links(form, event)
-    link_class = "text-sm text-gray-500 hover:text-gray-700 px-2 py-1"
+    link_class = "text-sm #{eyebrow_link_class} px-2 py-1"
     preview = link_to "Preview", form_path(form), class: link_class
     return preview unless event
 

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -45,7 +45,7 @@
     <div class="mb-3 flex items-center justify-end text-sm">
       <%= link_to "View all communications",
                   notifications_path(email: @person.communications_email, return_to_type: "Person", return_to_id: @person.id),
-                  class: "inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                  class: "inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                   target: "_blank", rel: "noopener" %>
     </div>
   <% end %>

--- a/app/views/admin/ahoy_activities/charts.html.erb
+++ b/app/views/admin/ahoy_activities/charts.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
       <div class="mb-2 flex flex-wrap items-center gap-y-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -5,12 +5,12 @@
         <%# Scoped to a person (from their edit page's History card, or the filter) —
             return to that person, not the generic Admin default. %>
         <% if @person %>
-          <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
             <i class="fas fa-arrow-left"></i>
             <span><%= truncate(@person.name, length: 30) %></span>
           <% end %>
         <% elsif allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>
@@ -131,7 +131,7 @@
                         class: "text-indigo-600 hover:underline" %>
 
             <%= link_to "Clear filters", request.path,
-                        class: "ml-auto text-gray-500 hover:text-gray-700",
+                        class: "ml-auto #{eyebrow_link_class}",
                         data: { action: "collection#clearAndSubmit" } %>
           </div>
 

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -3,7 +3,7 @@
 
       <div class="flex flex-wrap items-center gap-y-2 mb-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
   <div class="mb-2 flex flex-wrap items-center gap-y-2">
     <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-      <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
         <i class="fas fa-arrow-left"></i>
         <span>Admin</span>
       <% end %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -7,14 +7,14 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if back_path %>
-      <%= link_to back_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to back_path, class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i>
         <%= params[:return_to] == "person" ? @affiliation.person&.full_name : @affiliation.organization&.name %>
       <% end %>
     <% else %>
       <span></span>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <h1 class="text-2xl font-semibold text-gray-900 tracking-tight mb-1">Edit affiliation</h1>

--- a/app/views/allocations/index.html.erb
+++ b/app/views/allocations/index.html.erb
@@ -7,35 +7,35 @@
     <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
       <% if @allocatable.is_a?(EventRegistration) && params[:return_to] == "bulk_payments" %>
         <%# Re-expand the originating submission's row and scroll to it on return. %>
-        <%= link_to bulk_payments_return_path(@allocatable.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to bulk_payments_return_path(@allocatable.event), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "registrants" %>
-        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "onboarding" %>
-        <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) %>
-        <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registration
         <% end %>
       <% elsif @allocatable.is_a?(ContinuingEducationRegistration) %>
-        <%= link_to edit_continuing_education_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to edit_continuing_education_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> CE registration
         <% end %>
       <% elsif @allocatable.respond_to?(:event) %>
-        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% else %>
         <span></span>
       <% end %>
       <div class="flex items-center gap-3">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
-        <%= link_to "All allocations", allocations_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "All allocations", allocations_path, class: "text-sm #{eyebrow_link_class}" %>
       </div>
     </div>
 
@@ -124,7 +124,7 @@
       registrants index (left-aligned title, filter form, results table). ---- %>
   <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:payments) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-      <%= link_to "← Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
 
     <div class="flex flex-wrap items-center justify-between gap-4 mb-6">

--- a/app/views/application/_papertrail_versions.html.erb
+++ b/app/views/application/_papertrail_versions.html.erb
@@ -3,7 +3,7 @@
     <button type="button"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"<%= dom_id(record, :versions) %>":"hidden"}]'
-            class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 cursor-pointer">
+            class="inline-flex items-center gap-1.5 text-sm font-medium <%= eyebrow_link_class %> cursor-pointer">
       Change Log
       <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
     </button>

--- a/app/views/banners/edit.html.erb
+++ b/app/views/banners/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
           <div class="flex flex-wrap justify-end gap-2 mb-4">
-            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "Banners", banners_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "View", banner_path(@banner), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "Banners", banners_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "View", banner_path(@banner), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
           <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @banner.class.model_name.human.downcase %></h1>
 

--- a/app/views/banners/show.html.erb
+++ b/app/views/banners/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Banners", banners_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Banners", banners_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @banner) %>
-          <%= link_to "Edit", edit_banner_path(@banner), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_banner_path(@banner), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Categories", categories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Taggings", taggings_path(category_names_all: @category.name), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View", category_path(@category), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Categories", categories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Taggings", taggings_path(category_names_all: @category.name), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "View", category_path(@category), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category.class.model_name.human.downcase %></h1>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,7 +10,7 @@
       <div class="flex gap-2">
         <%= link_to "Dedupe",
                     dedupe_index_categories_path,
-                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                    class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "New #{Category.model_name.human.downcase}",
                     new_category_path,
                     class: "admin-only bg-blue-100 btn btn-primary-outline" %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Categories", categories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Categories", categories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @category) %>
-          <%= link_to "Edit", edit_category_path(@category), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_category_path(@category), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -3,9 +3,9 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Category Types", category_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", category_type_path(@category_type), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Category Types", category_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", category_type_path(@category_type), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category_type.class.model_name.human.downcase %></h1>
 

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -3,10 +3,10 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Category types", category_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Categories", categories_path(category_type_id: @category_type.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Edit", edit_category_type_path(@category_type), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Category types", category_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Categories", categories_path(category_type_id: @category_type.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Edit", edit_category_type_path(@category_type), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">
         Category type details: <%= @category_type.name %>

--- a/app/views/comments/_aggregated_comment.html.erb
+++ b/app/views/comments/_aggregated_comment.html.erb
@@ -19,7 +19,7 @@
       <div class="flex shrink-0 items-center gap-3">
         <%= render "comments/flag_toggle", commentable: comment.commentable, comment: comment.object %>
         <button type="button" data-action="edit-toggle#toggle"
-                class="text-xs text-gray-500 hover:text-gray-700">
+                class="text-xs <%= eyebrow_link_class %>">
           <i class="fa-solid fa-pen text-2xs"></i> Edit
         </button>
       </div>
@@ -45,7 +45,7 @@
       </div>
       <div class="mt-3 flex items-center gap-x-3">
         <%= f.submit "Save", class: "btn btn-secondary-outline" %>
-        <button type="button" data-action="edit-toggle#toggle" class="text-sm text-gray-500 hover:text-gray-700">Cancel</button>
+        <button type="button" data-action="edit-toggle#toggle" class="text-sm <%= eyebrow_link_class %>">Cancel</button>
         <label class="inline-flex items-center cursor-pointer select-none" title="Flag this note for follow-up">
           <%= f.check_box :flagged, class: "peer sr-only" %>
           <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-white") %>
 <div class="mb-3">
-  <%= link_to admin_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+  <%= link_to admin_path, class: "text-sm #{eyebrow_link_class}" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
   <% end %>
 </div>

--- a/app/views/community_news/edit.html.erb
+++ b/app/views/community_news/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
           <div class="flex flex-wrap justify-end gap-2 mb-4">
-            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "Community News", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "Community News", community_news_index_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <% if @community_news.reference_url.present? %>
               <%= link_to "External URL", safe_url(@community_news.reference_url), target: "_blank", rel: "noopener noreferrer",
-                          class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                          class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <% end %>
             <%= link_to "View", community_news_path(@community_news, no_redirect: true),
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
           <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @community_news.class.model_name.human.downcase %></h1>
 

--- a/app/views/community_news/show.html.erb
+++ b/app/views/community_news/show.html.erb
@@ -4,11 +4,11 @@
 <div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Links -->
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Community news", community_news_index_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Community news", community_news_index_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @community_news) %>
           <%= link_to "Edit", edit_community_news_path(@community_news),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @community_news %>

--- a/app/views/continuing_education_registrations/_payment_history.html.erb
+++ b/app/views/continuing_education_registrations/_payment_history.html.erb
@@ -10,7 +10,7 @@
     </span>
     <h2 class="text-sm font-semibold text-gray-700">CE payments and allocations</h2>
     <%= link_to allocations_path(allocatable_sgid: ce_registration.to_sgid.to_s, return_to: "ce_registration"),
-                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                 target: "_blank", rel: "noopener" do %>
       View all
       <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back link + secondary links, matching the scholarship edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
-    <%= link_to ce_registration_return_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label %>
     <% end %>
     <div class="flex items-center gap-3">
@@ -18,7 +18,7 @@
             icon: "fa-solid fa-id-card text-2xs",
             href: registration_ce_path(registration.slug, return_to: "ce_registration"),
             target: "_blank", rel: "noopener" %>
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/continuing_education_registrations/index.html.erb
+++ b/app/views/continuing_education_registrations/index.html.erb
@@ -3,10 +3,10 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top-left menu: jump to the cross-event CE sign-ins. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to signins_events_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to signins_events_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-clipboard-check text-xs"></i> CE sign-ins
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="flex items-center gap-3 mb-6">

--- a/app/views/continuing_education_registrations/new.html.erb
+++ b/app/views/continuing_education_registrations/new.html.erb
@@ -5,10 +5,10 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back link + Home, matching the CE edit page. %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
-    <%= link_to ce_registration_return_path(registration), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label %>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <%= render "shared/event_page_header",

--- a/app/views/continuing_education_registrations/show.html.erb
+++ b/app/views/continuing_education_registrations/show.html.erb
@@ -8,12 +8,12 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back to the CE registrations index + Edit / Home. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to continuing_education_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> CE registrations
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "Edit", edit_continuing_education_registration_path(@ce_registration, return_to: "ce_index"), class: "text-sm text-gray-500 hover:text-gray-700" %>
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "Edit", edit_continuing_education_registration_path(@ce_registration, return_to: "ce_index"), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Allocations", allocations_path, class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
+    <%= link_to "← Allocations", allocations_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
 
     <h1 class="text-2xl font-semibold text-gray-900">Discount</h1>
 

--- a/app/views/event_registrations/_continuing_education.html.erb
+++ b/app/views/event_registrations/_continuing_education.html.erb
@@ -34,7 +34,7 @@
           <span class="text-xs text-gray-400">·</span>
           <span class="text-sm text-gray-600"><%= plain_number(ce_registration.hours) || "0" %> hrs</span>
           <%= link_to edit_continuing_education_registration_path(ce_registration, return_to: "registration"),
-                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                       target: "_blank", rel: "noopener" do %>
             Edit
             <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/event_registrations/_payment_history.html.erb
+++ b/app/views/event_registrations/_payment_history.html.erb
@@ -13,7 +13,7 @@
     </span>
     <h2 class="text-sm font-semibold text-gray-700">Registration payments and allocations</h2>
     <%= link_to allocations_path(allocatable_sgid: event_registration.to_sgid.to_s, return_to: "registration"),
-                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline after:absolute after:inset-0 after:content-['']",
+                class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline after:absolute after:inset-0 after:content-['']",
                 target: "_blank", rel: "noopener" do %>
       View all
       <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/event_registrations/_scholarship.html.erb
+++ b/app/views/event_registrations/_scholarship.html.erb
@@ -28,7 +28,7 @@
         <div class="flex items-center gap-2">
           <span class="text-sm font-semibold text-gray-900 tabular-nums"><%= dollars_from_cents(scholarship.amount_cents) %></span>
           <%= link_to edit_scholarship_path(scholarship, return_to: "registration"),
-                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                       target: "_blank", rel: "noopener" do %>
             Edit
             <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -7,51 +7,51 @@
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if params[:return_to] == "bulk_payments" %>
       <%# Re-expand the originating submission's row and scroll to it on return. %>
-      <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
       <% end %>
     <% elsif params[:return_to] == "preview_reminder" %>
-      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Send reminders
       <% end %>
     <% elsif params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif params[:return_to] == "attendees" %>
-      <%= link_to attendees_events_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to attendees_events_path, class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Attendees
       <% end %>
     <% elsif params[:return_to] == "roster" %>
-      <%= link_to roster_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to roster_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Roster
       <% end %>
     <%# Two ways in from the recipients page: a recipient's name (back to their own
         card) and the feature-a-shout-out flow (back to the shout-outs section). %>
     <% elsif params[:return_to] == "recipient_card" %>
-      <%= link_to recipients_event_card_path(@event_registration.event, @event_registration.slug), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to recipients_event_card_path(@event_registration.event, @event_registration.slug), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarship recipients
       <% end %>
     <% elsif params[:return_to] == "recipients" %>
-      <%= link_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
       <% end %>
     <% elsif params[:return_to] == "index" %>
-      <%= link_to event_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
       <% end %>
     <% elsif params[:return_to] == "attendance" %>
-      <%= link_to attendance_event_path(@event_registration.event), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to attendance_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Sign-ins
       <% end %>
     <% else %>
-      <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "View", event_registration_path(@event_registration), class: "text-sm text-gray-500 hover:text-gray-700" %>
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "View", event_registration_path(@event_registration), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -9,14 +9,14 @@
             <div class="flex gap-2">
               <% if @filtered_event %>
                 <%= link_to "#{@filtered_event.decorate.compact_label} event dashboard", dashboard_event_path(@filtered_event),
-                            class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                            class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
               <% end %>
               <%= link_to "Events", events_path,
-                          class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                          class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
               <% if params[:admin] == "true" %>
                 <%= link_to "Export CSV",
                             event_registrations_path(request.query_parameters.merge(format: :csv)),
-                            class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                            class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
               <% end %>
               <% if allowed_to?(:new?, EventRegistration) %>
                 <%= link_to "New #{EventRegistration.model_name.human.downcase}",

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -6,9 +6,9 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="mb-4">
     <% if params[:return_to] == "onboarding" %>
-      <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" %>
     <% else %>
-      <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" %>
     <% end %>
   </div>
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">

--- a/app/views/event_registrations/new.html.erb
+++ b/app/views/event_registrations/new.html.erb
@@ -3,10 +3,10 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link, matching the event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to event_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <%# Title block %>

--- a/app/views/event_registrations/transfer.html.erb
+++ b/app/views/event_registrations/transfer.html.erb
@@ -10,7 +10,7 @@
   roster_path = registrants_event_path(source.event)
 %>
 <div class="mb-4">
-  <%= link_to roster_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700" do %>
+  <%= link_to roster_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i>
     <%= source.event.title %> registrants
   <% end %>

--- a/app/views/events/_attendance_day_form.html.erb
+++ b/app/views/events/_attendance_day_form.html.erb
@@ -35,7 +35,7 @@
 
   <div class="flex items-center gap-3 pt-1">
     <button type="submit" class="rounded-lg bg-teal-600 px-3 py-1 text-xs font-medium text-white shadow-sm hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-300 cursor-pointer">Save</button>
-    <%= link_to "Cancel", cancel_path, class: "text-xs text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Cancel", cancel_path, class: "text-xs #{eyebrow_link_class}" %>
     <span class="text-2xs text-gray-400">Leave the sign-out blank to leave a session open.</span>
   </div>
 <% end %>

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -90,7 +90,7 @@
       <%= link_to "Dashboard",
                 dashboard_event_path(event),
                 data: { turbo_frame: "_top" },
-                class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1 ml-auto" %>
+                class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1 ml-auto" %>
     <% end %>
     </div>
   </div>

--- a/app/views/events/_charts_toggle_bar.html.erb
+++ b/app/views/events/_charts_toggle_bar.html.erb
@@ -20,7 +20,7 @@
             data-panel-toggle-hidden-label="<%= button[:hidden_label] %>"
             data-action="panel-toggle#toggle"
             aria-expanded="<%= button[:expanded] %>"
-            class="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700">
+            class="inline-flex items-center gap-1.5 text-xs font-medium <%= eyebrow_link_class %>">
       <i class="fa-solid <%= button[:icon] %>"></i>
       <span data-panel-toggle-target="label"><%= button[:expanded] ? button[:shown_label] : button[:hidden_label] %></span>
       <i class="fa-solid fa-chevron-down text-xs transition-transform in-aria-expanded:rotate-180"></i>

--- a/app/views/events/_filter_bar.html.erb
+++ b/app/views/events/_filter_bar.html.erb
@@ -56,7 +56,7 @@
       <div class="w-full md:w-auto md:ml-auto flex items-end gap-4">
         <% if has_more %>
           <label for="more-filters-toggle"
-                 class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition">
+                 class="inline-flex items-center gap-1.5 text-sm <%= eyebrow_link_class %> cursor-pointer transition">
             <span class="group-has-[#more-filters-toggle:checked]:hidden">More filters</span>
             <span class="hidden group-has-[#more-filters-toggle:checked]:inline">Fewer filters</span>
             <i class="fa-solid fa-chevron-down text-xs transition-transform group-has-[#more-filters-toggle:checked]:rotate-180"></i>

--- a/app/views/events/_panel_cta.html.erb
+++ b/app/views/events/_panel_cta.html.erb
@@ -22,7 +22,7 @@
         data-action="panel-toggle#toggle"
         aria-expanded="<%= open %>"
         aria-label="Toggle <%= section %>"
-        class="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 print:hidden">
+        class="shrink-0 inline-flex items-center gap-1 text-xs font-medium <%= eyebrow_link_class %> print:hidden">
   <span data-panel-toggle-target="label"><%= open ? "Hide" : "Show" %></span>
   <i class="fa-solid fa-chevron-down text-xs transition-transform in-aria-expanded:rotate-180"></i>
 </button>

--- a/app/views/events/_recipient_card.html.erb
+++ b/app/views/events/_recipient_card.html.erb
@@ -165,7 +165,7 @@
         <%= render "scholarships/tasks_status", scholarship: scholarship %>
         <% if allowed_to?(:edit?, scholarship) %>
           <%= link_to edit_scholarship_path(scholarship, return_to: "recipients", participant: participant_slug),
-                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                       target: "_blank", rel: "noopener" do %>
             Edit
             <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -7,12 +7,12 @@
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Attendance filter">
         <%= link_to registrants_event_path(@event, status_filter: "active", keyword: params[:keyword].presence),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Active <span class="text-gray-400">(<%= @active_count %>)</span>
         <% end %>
         <%= link_to registrants_event_path(@event, status_filter: "inactive", keyword: params[:keyword].presence),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "inactive" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "inactive" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Inactive <span class="text-gray-400">(<%= @inactive_count %>)</span>
         <% end %>
       </nav>
@@ -518,7 +518,7 @@
                 <td class="hidden px-4 py-2 text-center text-sm" data-column-toggle-col="certificate">
                   <%= render "event_registrations/certificate_issued_toggle", registration: registration %>
                 </td>
-                <td class="px-4 py-2 text-right text-sm"><%= link_to "Edit", edit_event_registration_path(registration, return_to: "registrants"), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
+                <td class="px-4 py-2 text-right text-sm"><%= link_to "Edit", edit_event_registration_path(registration, return_to: "registrants"), class: "#{eyebrow_link_class} underline", data: { turbo_frame: "_top" } %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/events/_report_subnav.html.erb
+++ b/app/views/events/_report_subnav.html.erb
@@ -37,7 +37,7 @@
     <% if tab[:key] == current %>
       <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
     <% else %>
-      <%= link_to tab[:label], tab[:path], class: "text-sm text-gray-500 hover:text-gray-700 border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
+      <%= link_to tab[:label], tab[:path], class: "text-sm #{eyebrow_link_class} border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
     <% end %>
   <% end %>
 </nav>

--- a/app/views/events/_subnav.html.erb
+++ b/app/views/events/_subnav.html.erb
@@ -19,7 +19,7 @@
     <% if tab[:key] == current %>
       <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
     <% else %>
-      <%= link_to tab[:label], tab[:path], class: "text-sm text-gray-500 hover:text-gray-700 border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
+      <%= link_to tab[:label], tab[:path], class: "text-sm #{eyebrow_link_class} border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
     <% end %>
   <% end %>
 </nav>

--- a/app/views/events/attendance.html.erb
+++ b/app/views/events/attendance.html.erb
@@ -10,13 +10,13 @@
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% case params[:return_to] %>
       <% when "dashboard" %>
-        <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
       <% when "registrants" %>
-        <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
       <% when "signins" %>
-        <%= link_to "← All sign-ins", signins_events_path(report_to_hub_params.except(:period)), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← All sign-ins", signins_events_path(report_to_hub_params.except(:period)), class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
-        <%= link_to "← Events participation", participation_events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Events participation", participation_events_path, class: "text-sm #{eyebrow_link_class}" %>
       <% end %>
       <%= render "events/subnav", event: @event, current: :attendance %>
     </div>
@@ -63,9 +63,9 @@
         <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500"><%= group_by_day ? "Sessions by day" : "Sessions by person" %></h2>
         <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-xs font-medium" aria-label="Session grouping">
           <%= link_to "By person", attendance_event_path(@event, **toggle_params),
-                class: "px-3 py-1 rounded-md transition-colors #{group_by_day ? "text-gray-500 hover:text-gray-700" : "bg-white text-gray-800 shadow-sm"}" %>
+                class: "px-3 py-1 rounded-md transition-colors #{group_by_day ? "#{eyebrow_link_class}" : "bg-white text-gray-800 shadow-sm"}" %>
           <%= link_to "By day", attendance_event_path(@event, group: "day", **toggle_params),
-                class: "px-3 py-1 rounded-md transition-colors #{group_by_day ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" %>
+                class: "px-3 py-1 rounded-md transition-colors #{group_by_day ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" %>
         </nav>
       </div>
 

--- a/app/views/events/attendees.html.erb
+++ b/app/views/events/attendees.html.erb
@@ -11,16 +11,16 @@
       <div>
       <% case params[:return_to] %>
       <% when "participation" %>
-        <%= link_to "← Event participation", participation_events_path(report_return), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Event participation", participation_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
       <% when "revenue" %>
-        <%= link_to "← Event revenue", revenue_events_path(report_return), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Event revenue", revenue_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
       <% when "reports" %>
-        <%= link_to "← Event reports", reports_events_path(report_return), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Event reports", reports_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
         <% if @filter_event %>
-          <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+          <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class}" %>
         <% else %>
-          <%= link_to "← Event reports", reports_events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+          <%= link_to "← Event reports", reports_events_path, class: "text-sm #{eyebrow_link_class}" %>
         <% end %>
       <% end %>
       </div>

--- a/app/views/events/attendees_results.html.erb
+++ b/app/views/events/attendees_results.html.erb
@@ -54,7 +54,7 @@
 
       <%# Charts panel — hidden by default; the lazy frame loads on first reveal. %>
       <% back_to_top = capture do %>
-        <%= link_to "#main", class: "inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700" do %>
+        <%= link_to "#main", class: "inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-up"></i> Go to top
         <% end %>
       <% end %>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -2,15 +2,15 @@
 
 <div class="max-w-2xl mx-auto px-4">
   <div class="flex flex-wrap items-center gap-2 pt-4">
-    <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
     <% end %>
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @form) %>
-          <%= link_to "Edit form", edit_form_path(@form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_form_path(@form, event_id: @event.id), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
-        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/bulk_payment_form_submissions/show.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/show.html.erb
@@ -7,12 +7,12 @@
       slugless submissions, which have no public ticket. %>
   <div class="flex flex-col items-start gap-1">
     <% if @submission.slug.present? %>
-      <%= link_to bulk_payment_ticket_path(@submission.slug, return_to: params[:return_to], expand: params[:expand]), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to bulk_payment_ticket_path(@submission.slug, return_to: params[:return_to], expand: params[:expand]), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
       <% end %>
     <% end %>
     <% if params[:return_to] == "bulk_payments" %>
-      <%= link_to bulk_payments_return_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to bulk_payments_return_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to bulk payments
       <% end %>
     <% end %>

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -14,19 +14,19 @@
         dashboard (return_to=bulk_payments) get a second link back there, with
         their originating row re-expanded. %>
     <div class="flex flex-col items-start gap-1">
-      <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
       <% end %>
       <% if params[:return_to] == "bulk_payments" %>
-        <%= link_to bulk_payments_return_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+        <%= link_to bulk_payments_return_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Back to bulk payments
         <% end %>
       <% end %>
     </div>
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
-        <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
-        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <%= link_to "Bulk payments", bulk_payments_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
+        <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -3,7 +3,7 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 

--- a/app/views/events/callouts/_callout_page.html.erb
+++ b/app/views/events/callouts/_callout_page.html.erb
@@ -13,7 +13,7 @@
 <% if back_path %>
   <div class="<%= container_width %> mx-auto px-4 pt-4">
     <%= link_to back_path,
-                class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+                class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
     <% end %>
   </div>

--- a/app/views/events/callouts/ce.html.erb
+++ b/app/views/events/callouts/ce.html.erb
@@ -232,7 +232,7 @@
 
               <% if license_on_file %>
                 <%= link_to "Cancel", registration_ce_path(@event_registration.slug, return_to: params[:return_to].presence),
-                      class: "shrink-0 px-2 py-2 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+                      class: "shrink-0 px-2 py-2 text-sm font-medium #{eyebrow_link_class}" %>
               <% end %>
             </div>
 

--- a/app/views/events/callouts/certificate.html.erb
+++ b/app/views/events/callouts/certificate.html.erb
@@ -29,7 +29,7 @@
 
   <%# Screen-only controls: return link + print. Hidden from the printed page. %>
   <div class="max-w-4xl mx-auto flex flex-wrap items-center gap-2 px-4 sm:px-8 pt-4 print:hidden">
-    <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to ticket
     <% end %>
     <button onclick="window.print();"

--- a/app/views/events/callouts/payment.html.erb
+++ b/app/views/events/callouts/payment.html.erb
@@ -44,7 +44,7 @@
     </div>
 
     <details class="mt-6">
-      <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-700">Prefer to pay by check?</summary>
+      <summary class="cursor-pointer text-sm <%= eyebrow_link_class %>">Prefer to pay by check?</summary>
 
       <div class="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 leading-relaxed space-y-2">
         <p>Write the check out to <strong>A Window Between Worlds</strong> and mail it to:</p>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,7 +3,7 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -6,7 +6,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
   <%# Title block with the action buttons pinned top-right so they share the

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-4">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :edit %>
   </div>
   <div class="flex items-center justify-between mb-3">

--- a/app/views/events/edit_staff.html.erb
+++ b/app/views/events/edit_staff.html.erb
@@ -10,7 +10,7 @@
      else [ staff_event_path(@event), "← Back to staff" ]
      end %>
   <div class="flex flex-wrap items-center gap-2 mb-6">
-    <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="mb-8">

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-5xl mx-auto px-4 pt-4">
-  <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700" do %>
+  <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
     &larr; Back to registrants
   <% end %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,7 +17,7 @@
           <div class="admin-only bg-blue-100 flex flex-wrap items-center justify-end gap-4">
             <%= link_to "Reports",
                         reports_events_path(return_to: "events"),
-                        class: "whitespace-nowrap text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "whitespace-nowrap text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "New event",
                         new_event_path,
                         class: "whitespace-nowrap btn btn-secondary-outline" %>

--- a/app/views/events/invoices/_actions.html.erb
+++ b/app/views/events/invoices/_actions.html.erb
@@ -2,7 +2,7 @@
     only the invoice document lands in the PDF. `back_path` / `back_label` set
     the return link to wherever the invoice was opened from. %>
 <div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 sm:px-8 pt-4 print:hidden">
-  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+  <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
   <% end %>
   <button onclick="window.print();"

--- a/app/views/events/onboarding.html.erb
+++ b/app/views/events/onboarding.html.erb
@@ -3,7 +3,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow m-2 p-4">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 

--- a/app/views/events/onboarding/_results.html.erb
+++ b/app/views/events/onboarding/_results.html.erb
@@ -10,12 +10,12 @@
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Attendance filter">
         <%= link_to onboarding_event_path(@event, status_filter: "active", **filter_params),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Active <span class="text-gray-400">(<%= @active_count %>)</span>
         <% end %>
         <%= link_to onboarding_event_path(@event, status_filter: "inactive", **filter_params),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "inactive" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{current_filter == "inactive" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Inactive <span class="text-gray-400">(<%= @inactive_count %>)</span>
         <% end %>
       </nav>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -6,7 +6,7 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% label, return_path = participation_return_link %>
-      <%= link_to label, return_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to label, return_path, class: "text-sm #{eyebrow_link_class}" %>
       <%= render "events/report_subnav", current: :details %>
     </div>
 

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -2,7 +2,7 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 

--- a/app/views/events/program_statuses.html.erb
+++ b/app/views/events/program_statuses.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
       <% end %>
       <%= render "events/report_subnav", current: :program_statuses %>
     </div>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -5,15 +5,15 @@
 
 <div class="max-w-3xl mx-auto px-4">
   <div class="flex flex-wrap items-center gap-2 pt-4">
-    <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
     <% end %>
     <% if allowed_to?(:dashboard?, @event) %>
       <div class="ml-auto flex flex-wrap items-center gap-1">
         <% if allowed_to?(:edit?, @registration_form) %>
-          <%= link_to "Edit form", edit_form_path(@registration_form, event_id: @event.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+          <%= link_to "Edit form", edit_form_path(@registration_form, event_id: @event.id), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
         <% end %>
-        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+        <%= link_to "Edit event", edit_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -15,19 +15,19 @@
 <% end %>
 <div class="max-w-3xl mx-auto px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
-    <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+    <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
     <% end %>
     <%# Came here from the admin org-linking popup (opens in a new tab, so the
         browser back button is useless); carry its own return_to so its
         "Back to registrants" eyebrow still resolves. %>
     <% if reg && params[:return_to] == "link_organization" && allowed_to?(:index?, EventRegistration) %>
-      <%= link_to link_organization_event_registration_path(reg, return_to: params[:link_org_return_to].presence), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to link_organization_event_registration_path(reg, return_to: params[:link_org_return_to].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to linked organizations
       <% end %>
     <% end %>
     <% if reg && allowed_to?(:index?, EventRegistration) %>
-      <%= link_to "Edit registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 </div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -16,7 +16,7 @@
 <div class="bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :scholarships %>
   </div>
   <%# Reports / Grants are cross-page navigation, so they read as text links; only
@@ -24,13 +24,13 @@
   <% recipient_actions = capture do %>
     <% if allowed_to?(:cross_event_reports?, @event) %>
       <%= link_to scholarships_events_path, target: "_blank", rel: "noopener",
-            class: "text-sm text-gray-500 hover:text-gray-700 whitespace-nowrap" do %>
+            class: "text-sm #{eyebrow_link_class} whitespace-nowrap" do %>
         <i class="fa-solid fa-chart-line"></i> Reports
       <% end %>
     <% end %>
     <% if allowed_to?(:index?, Grant) %>
       <%= link_to grants_path, target: "_blank", rel: "noopener",
-            class: "text-sm text-gray-500 hover:text-gray-700 whitespace-nowrap" do %>
+            class: "text-sm #{eyebrow_link_class} whitespace-nowrap" do %>
         <i class="fa-solid fa-hand-holding-dollar"></i> Grants
       <% end %>
     <% end %>
@@ -255,7 +255,7 @@
             <% reg_id = @dashboard.registration_id_by_registrant[shoutout.recipient.id] %>
             <% if reg_id %>
               <%= link_to edit_event_registration_path(reg_id, return_to: "recipients", anchor: "shout-out"),
-                          class: "shrink-0 inline-flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline print:hidden" do %>
+                          class: "shrink-0 inline-flex items-center gap-1 text-xs font-medium #{eyebrow_link_class} hover:underline print:hidden" do %>
                 <i class="fa-solid fa-pen"></i> Edit
               <% end %>
             <% end %>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -7,9 +7,9 @@
   <%# Top bar: eyebrow + sub-nav, matching the other event pages. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <% if params[:return_to] == "scholarships" %>
-      <%= link_to "← Events scholarships", scholarships_report_return_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Events scholarships", scholarships_report_return_path, class: "text-sm #{eyebrow_link_class}" %>
     <% else %>
-      <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <% end %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -1,16 +1,16 @@
 <% content_for(:page_bg_class, "public") %>
 <div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
-  <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+  <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
   <% end %>
   <div class="ml-auto flex gap-2">
     <% if allowed_to?(:edit?, @event_registration.event) %>
-      <%= link_to "Edit event", edit_event_path(@event_registration.event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit event", edit_event_path(@event_registration.event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:index?, EventRegistration) %>
-      <%= link_to "Edit registration", edit_event_registration_path(@event_registration), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit registration", edit_event_registration_path(@event_registration), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 </div>
 <%= render "event_registrations/ticket", event_registration: @event_registration %>

--- a/app/views/events/reports.html.erb
+++ b/app/views/events/reports.html.erb
@@ -6,13 +6,13 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if @filter_event %>
-        <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class}" %>
       <% elsif params[:return_to] == "events" || !current_user&.super_user? %>
         <%# Event owners reach the unfiltered hub too, and can't follow the admin
             home link — send them back to the events index instead. %>
-        <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
-        <%= link_to "← Admin home", admin_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Admin home", admin_path, class: "text-sm #{eyebrow_link_class}" %>
       <% end %>
     </div>
 

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
       <% end %>
     </div>
 

--- a/app/views/events/roster.html.erb
+++ b/app/views/events/roster.html.erb
@@ -12,7 +12,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <%= render "events/subnav", event: @event, current: :roster %>
   </div>
   <% print_button = capture do %>

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -14,10 +14,10 @@
   <% back_path = dashboard_event_path(@event) %>
 <% end %>
 <div class="max-w-2xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
-  <%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <div class="ml-auto flex gap-2">
-    <%= link_to "Edit event", edit_event_path(@event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit event", edit_event_path(@event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 </div>
 <div class="max-w-2xl mx-auto px-4">

--- a/app/views/events/scholarships.html.erb
+++ b/app/views/events/scholarships.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
       <% end %>
       <%= render "events/report_subnav", current: :scholarships %>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,17 +17,17 @@
 <% else %>
 <!-- Top Right Actions -->
 <div class="flex flex-wrap items-center gap-2 mb-4">
-  <%= link_to "← Events", events_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <div class="ml-auto flex flex-wrap gap-1">
-  <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+  <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <% if @event.event_registrations.active.exists? %>
-    <%= link_to "Meet the staff", staff_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Meet the staff", staff_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <% end %>
   <% if allowed_to?(:dashboard?, @event) %>
-    <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <% if allowed_to?(:manage?, @event) %>
-    <%= link_to "Registrations", registrants_event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+    <%= link_to "Registrations", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
   <% end %>
   <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
   </div>

--- a/app/views/events/signins.html.erb
+++ b/app/views/events/signins.html.erb
@@ -7,7 +7,7 @@
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
-      <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
       <%= render "events/report_subnav", current: :signins %>
     </div>
 

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -7,7 +7,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Event", event_path(@event), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Event", event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
     <% if allowed_to?(:manage?, @event) %>
       <%= render "events/subnav", event: @event, current: nil %>
     <% end %>

--- a/app/views/faqs/edit.html.erb
+++ b/app/views/faqs/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
         <div class="flex flex-wrap justify-end gap-2 mb-4">
-          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "FAQs", faqs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "View", faq_path(@faq), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "FAQs", faqs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "View", faq_path(@faq), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
         <h1 class="text-2xl font-semibold text-gray-900 mb-3">
           Edit <%= @faq.class.model_name.human.downcase %>

--- a/app/views/faqs/show.html.erb
+++ b/app/views/faqs/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "FAQs", faqs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "FAQs", faqs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @faq) %>
-          <%= link_to "Edit", edit_faq_path(@faq), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_faq_path(@faq), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/features/_feature.html.erb
+++ b/app/views/features/_feature.html.erb
@@ -46,7 +46,7 @@
             <% end %>
             <% if feature.external_url.present? %>
               <%= link_to safe_url(feature.external_url), target: "_blank", rel: "noopener noreferrer",
-                          class: "text-gray-500 hover:text-gray-700" do %>
+                          class: "#{eyebrow_link_class}" do %>
                 <i class="fa-solid fa-up-right-from-square"></i> Full guide
               <% end %>
             <% end %>

--- a/app/views/features/edit.html.erb
+++ b/app/views/features/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="w-full max-w-3xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Features & tips", features_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View", feature_path(@feature), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Features & tips", features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "View", feature_path(@feature), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit feature</h1>
   <%= render "form", feature: @feature %>

--- a/app/views/features/new.html.erb
+++ b/app/views/features/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="w-full max-w-3xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Features & tips", features_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Features & tips", features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">New feature</h1>
   <%= render "form", feature: @feature %>

--- a/app/views/features/show.html.erb
+++ b/app/views/features/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="w-full max-w-3xl mx-auto">
   <div class="mb-3">
-    <%= link_to features_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to features_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left"></i> Features &amp; tips
     <% end %>
   </div>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -4,13 +4,13 @@
   <div class="w-full">
     <% if params[:return_to] == "forms" && @form %>
       <div class="mb-4">
-        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Forms
         <% end %>
       </div>
     <% elsif @person %>
       <div class="mb-4">
-        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700" do %>
+        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
         <% end %>
       </div>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -2,15 +2,15 @@
 <div class="max-w-2xl mx-auto px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>
-      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>
-      <%= link_to bulk_payments_return_path(event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to bulk_payments_return_path(event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to bulk payments
       <% end %>
     <% elsif event %>
-      <%= link_to event_path(event), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+      <%= link_to event_path(event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
       <% end %>
     <% end %>

--- a/app/views/forms/_field_list_toggle.html.erb
+++ b/app/views/forms/_field_list_toggle.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (count:) %>
 <button type="button"
-        class="flex shrink-0 items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
+        class="flex shrink-0 items-center gap-1.5 text-xs <%= eyebrow_link_class %> cursor-pointer"
         data-action="expandable-card#toggle">
   <%= pluralize(count, "field") %>
   <i class="fa-solid fa-chevron-down transition-transform" data-expandable-card-target="icon"></i>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -2,15 +2,15 @@
 <div class="px-4 py-8">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <% if @dashboard_event %>
-      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if @dashboard_event %>
-      <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
-                class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>
 

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -2,12 +2,12 @@
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <% if @dashboard_event %>
-      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
-                class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_editor_view_links(@form, @dashboard_event) %>
   </div>
 

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
-    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -2,13 +2,13 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <% if @dashboard_event %>
-      <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Edit", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Edit", edit_form_path(@form), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:copy?, @form) %>
-      <%= link_to "Copy", copy_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1",
+      <%= link_to "Copy", copy_form_path(@form), class: "text-sm #{eyebrow_link_class} px-2 py-1",
                   data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{@form.display_name}\"?" } %>
     <% end %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -9,9 +9,9 @@
       <%= link_to "← Back to #{@return_form.display_name}",
                   edit_form_path(@return_form, event_id: @dashboard_event&.id,
                                  anchor: @return_field_id.present? ? "form_field_#{@return_field_id}" : nil),
-                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 mr-auto" %>
+                  class: "text-sm #{eyebrow_link_class} px-2 py-1 mr-auto" %>
     <% end %>
-    <%= link_to "Forms", forms_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">

--- a/app/views/grants/_grant.html.erb
+++ b/app/views/grants/_grant.html.erb
@@ -39,5 +39,5 @@
     <% end %>
   </td>
   <td class="px-4 py-3.5 align-middle text-sm text-gray-700 whitespace-nowrap" data-sort-value="<%= grant.object.funds_allocation_deadline&.iso8601 %>"><%= grant.funds_allocation_deadline_compact %></td>
-  <td class="px-4 py-3.5 align-middle text-right text-sm"><%= link_to "Edit", edit_grant_path(grant), class: "text-gray-500 hover:text-gray-700 underline", data: { turbo_frame: "_top" } %></td>
+  <td class="px-4 py-3.5 align-middle text-right text-sm"><%= link_to "Edit", edit_grant_path(grant), class: "#{eyebrow_link_class} underline", data: { turbo_frame: "_top" } %></td>
 </tr>

--- a/app/views/grants/_results.html.erb
+++ b/app/views/grants/_results.html.erb
@@ -21,7 +21,7 @@
           <% columns.each do |col| %>
             <th class="px-4 py-3 <%= col[:align] %>" aria-sort="none">
               <%= render "shared/sortable_header", label: col[:label], index: col[:index],
-                    class: "text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-700" %>
+                    class: "text-xs font-semibold uppercase tracking-wider #{eyebrow_link_class}" %>
             </th>
           <% end %>
           <%# Non-sortable action column for the per-row Edit link. %>

--- a/app/views/grants/_scholarships.html.erb
+++ b/app/views/grants/_scholarships.html.erb
@@ -4,7 +4,7 @@
       Scholarships (<%= scholarships.total_entries %>)
     </h2>
     <%= link_to new_scholarship_path(grant_id: grant.id, return_to: return_to),
-                class: "inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+                class: "inline-flex items-center gap-1.5 text-sm font-medium #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-plus text-xs"></i>
       Add scholarship
       <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400"></i>
@@ -45,7 +45,7 @@
               </td>
               <td class="px-4 py-2 whitespace-nowrap text-sm text-right">
                 <%= link_to "Edit", edit_scholarship_path(scholarship, return_to: return_to),
-                            class: "text-gray-500 hover:text-gray-700 underline" %>
+                            class: "#{eyebrow_link_class} underline" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/grants/edit.html.erb
+++ b/app/views/grants/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Grants", grants_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View", grant_path(@grant), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Grants", grants_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "View", grant_path(@grant), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-3">
     Edit <%= Grant.model_name.human.downcase %>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -4,7 +4,7 @@
   <div class="w-full">
     <%# Back link to the scholarship that opened this page via its grant "View all". %>
     <% if params[:from_scholarship].present? %>
-      <%= link_to edit_scholarship_path(params[:from_scholarship]), class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-4" do %>
+      <%= link_to edit_scholarship_path(params[:from_scholarship]), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} mb-4" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarship
       <% end %>
     <% end %>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -6,11 +6,11 @@
     <%# Eyebrow returns to wherever the grant was opened from: the scholarships
         index (when linked from a grant group there) or the grants index. %>
     <% if params[:from_scholarships].present? %>
-      <%= link_to scholarships_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-3" do %>
+      <%= link_to scholarships_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} mb-3" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
       <% end %>
     <% else %>
-      <%= link_to grants_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-3" do %>
+      <%= link_to grants_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} mb-3" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grants
       <% end %>
     <% end %>

--- a/app/views/membership_invoices/edit.html.erb
+++ b/app/views/membership_invoices/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/membership_invoices/new.html.erb
+++ b/app/views/membership_invoices/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(@person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -4,10 +4,10 @@
 
 <div class="mx-auto max-w-3xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_path(@person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= @person.full_name %>
     <% end %>
-    <%= link_to "All memberships", membership_invoices_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "All memberships", membership_invoices_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="flex flex-wrap items-end justify-between gap-2 mb-6">

--- a/app/views/memberships/new.html.erb
+++ b/app/views/memberships/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(@person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/monthly_reports/index.html.erb
+++ b/app/views/monthly_reports/index.html.erb
@@ -15,7 +15,7 @@
 
       <div class="flex gap-2 items-center text-right">
         <% if @organization %>
-          <%= link_to "Back to organization", edit_organization_path(@organization), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Back to organization", edit_organization_path(@organization), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
     </div>

--- a/app/views/monthly_reports/show.html.erb
+++ b/app/views/monthly_reports/show.html.erb
@@ -5,9 +5,9 @@
 
 <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end items-center gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, MonthlyReport) %>
-      <%= link_to "My Monthly Reports", monthly_reports_path(created_by_id: current_user.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "My Monthly Reports", monthly_reports_path(created_by_id: current_user.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "All monthly reports", monthly_reports_path, class: "text-sm bg-blue-100 text-blue-700 hover:bg-blue-200 rounded px-2 py-1" %>
     <% end %>
     <%= render "bookmarks/editable_bookmark_button", resource: @monthly_report %>

--- a/app/views/notifications/_communications.html.erb
+++ b/app/views/notifications/_communications.html.erb
@@ -42,7 +42,7 @@
       <% view_all_marker = mark_admin_only ? "admin-only bg-blue-100 rounded px-1.5 py-0.5" : "" %>
       <%# Carry the origin so the index can show a back eyebrow to this record. %>
       <%= link_to notifications_path(email: email, return_to_type: record_type, return_to_id: record.id),
-                  class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline #{view_all_marker}",
+                  class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline #{view_all_marker}",
                   target: "_blank", rel: "noopener" do %>
         View all
         <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -5,11 +5,11 @@
     or to admin home when reached directly. %>
 <div class="mb-3">
   <% if return_record %>
-    <%= link_to notification_return_path(return_record), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to notification_return_path(return_record), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= noticeable_label(return_record) %>
     <% end %>
   <% else %>
-    <%= link_to admin_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to admin_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
     <% end %>
   <% end %>

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="mx-auto max-w-3xl">
   <div class="mb-3">
-    <%= link_to notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
     <% end %>
   </div>
@@ -78,7 +78,7 @@
       </div>
 
       <div class="mt-6 flex items-center justify-end gap-3">
-        <%= link_to "Cancel", notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+        <%= link_to "Cancel", notifications_path, class: "text-sm #{eyebrow_link_class}" %>
         <%= f.button :submit, t("communications.new"),
                      class: "btn btn-primary" %>
       </div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -5,7 +5,7 @@
    ========================================= %>
 
 <div class="mb-3">
-  <%= link_to notifications_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+  <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class}" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
   <% end %>
 </div>

--- a/app/views/organization_statuses/edit.html.erb
+++ b/app/views/organization_statuses/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", organization_status_path(@organization_status), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", organization_status_path(@organization_status), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @organization_status.class.model_name.human.downcase %></h1>
 

--- a/app/views/organization_statuses/show.html.erb
+++ b/app/views/organization_statuses/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @organization_status) %>
-          <%= link_to "Edit", edit_organization_status_path(@organization_status), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_organization_status_path(@organization_status), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -2,15 +2,15 @@
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
           <div class="mb-2">
-            <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+            <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
               <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
             <% end %>
           </div>
         <% end %>
         <div class="flex flex-wrap justify-end gap-2 mb-4">
-          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "Organizations", organizations_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "Profile", organization_path(@organization), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "Profile", organization_path(@organization), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
         <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
           Edit Organization: <%= truncate(@organization.name, length: 40) %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -12,11 +12,11 @@
     <div class="p-8">
     <!-- Header actions -->
     <div class="flex flex-wrap justify-end gap-2 mb-4">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Organizations", organizations_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% if allowed_to?(:edit?, @organization) %>
         <%= link_to "Edit", edit_organization_path(@organization),
-                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                    class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <span class="inline-block text-sm">
         <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
@@ -175,7 +175,7 @@
                   <div class="mt-4">
                     <%= link_to "Explore sector data",
                                 populations_served_organization_path(@organization),
-                                class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
                   </div>
                 </div>
               <% end %>

--- a/app/views/other_responses/index.html.erb
+++ b/app/views/other_responses/index.html.erb
@@ -8,7 +8,7 @@
    else
      [ sectors_path, "Sectors" ]
    end %>
-<%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1 mb-2" do %>
+<%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1 mb-2" do %>
   <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
 <% end %>
 <div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
@@ -107,7 +107,7 @@
                     <div class="flex items-center gap-3 text-sm">
                       <%= button_to "Keep all",
                                     curate_other_responses_path(kind: group[:kind], field_identifier: group[:field_identifier], normalized_text: group[:normalized_text], status: "kept", return_status: @status_filter),
-                                    class: "text-gray-500 hover:text-gray-700 whitespace-nowrap" %>
+                                    class: "#{eyebrow_link_class} whitespace-nowrap" %>
                       <%= button_to "Dismiss all",
                                     curate_other_responses_path(kind: group[:kind], field_identifier: group[:field_identifier], normalized_text: group[:normalized_text], status: "dismissed", return_status: @status_filter),
                                     class: "text-gray-500 hover:text-red-600 whitespace-nowrap",

--- a/app/views/payments/edit.html.erb
+++ b/app/views/payments/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-xl mx-auto">
-  <%= link_to "← Payment", payment_path(@payment), class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
+  <%= link_to "← Payment", payment_path(@payment), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
   <h1 class="text-2xl font-bold mb-6">Edit Payment</h1>
   <div class="bg-white rounded border border-gray-200 p-6">
     <%= simple_form_for @payment, as: :payment, url: payment_path(@payment), method: :patch do |f| %>

--- a/app/views/payments/new_checkout_link.html.erb
+++ b/app/views/payments/new_checkout_link.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-lg mx-auto">
   <div class="flex items-center gap-2 mb-6">
-    <%= link_to payments_path, class: "text-sm text-gray-500 hover:text-gray-700 inline-flex items-center gap-1" do %>
+    <%= link_to payments_path, class: "text-sm #{eyebrow_link_class} inline-flex items-center gap-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Payments
     <% end %>
   </div>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-2xl mx-auto">
-  <%= link_to "← Payments", payments_path, class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
+  <%= link_to "← Payments", payments_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">Payment</h1>
     <div class="flex gap-2">
@@ -74,7 +74,7 @@
           <button type="button"
                   data-action="dropdown#toggle"
                   data-dropdown-payload-param='[{"payment-metadata-<%= @payment.id %>":"hidden"}]'
-                  class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 cursor-pointer">
+                  class="inline-flex items-center gap-1.5 text-sm font-medium <%= eyebrow_link_class %> cursor-pointer">
             Metadata
             <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
           </button>

--- a/app/views/people/_membership.html.erb
+++ b/app/views/people/_membership.html.erb
@@ -1,7 +1,7 @@
 <div class="admin-only bg-blue-100 border border-blue-200 rounded-lg shadow-sm">
   <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3 border-b border-blue-200">
     <h2 class="text-xl font-semibold text-gray-800">Membership</h2>
-    <%= link_to "Manage membership", person_memberships_path(person), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Manage membership", person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="section-content px-3 sm:px-4 py-4">

--- a/app/views/people/all_comments.html.erb
+++ b/app/views/people/all_comments.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-white") %>
 <div class="mb-3">
-  <%= link_to person_path(@person), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+  <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to <%= @person.full_name %>
   <% end %>
 </div>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -3,13 +3,13 @@
         <div class="sticky top-0 z-10 <%= DomainTheme.bg_class_for(:people) %> pb-3">
           <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
             <div class="mb-2">
-              <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+              <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
                 <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
               <% end %>
             </div>
           <% elsif params[:return_to] == "registration_link" && params[:event_registration_id].present? %>
             <div class="mb-2">
-              <%= link_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+              <%= link_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence), class: "text-sm #{eyebrow_link_class}" do %>
                 <i class="fa-solid fa-arrow-left text-xs"></i> Organization linking
               <% end %>
             </div>
@@ -24,12 +24,12 @@
               </div>
             <% end %>
             <% if @person.user %>
-              <%= link_to "User account", edit_user_path(@person.user), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+              <%= link_to "User account", edit_user_path(@person.user), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
             <% end %>
-            <%= link_to "Change password", change_password_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "People", people_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-            <%= link_to "Profile", person_path(@person), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Change password", change_password_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "People", people_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+            <%= link_to "Profile", person_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
           <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
             Edit Person: <%= truncate(@person.name, length: 30) %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -95,7 +95,7 @@
                           <% if allowed_to?(:show?, person) %>
                             <%= link_to "+#{affiliations.size - 3} more", person_path(person),
                                 data: { turbo_frame: "_top" },
-                                class: "text-xs text-gray-500 hover:text-gray-700" %>
+                                class: "text-xs #{eyebrow_link_class}" %>
                           <% else %>
                             <span class="text-xs text-gray-500">+<%= affiliations.size - 3 %> more</span>
                           <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -4,7 +4,7 @@
 <% if params[:return_to] == "registrants" && params[:event_id].present? %>
   <% back_registration = @person.event_registrations.find_by(event_id: params[:event_id]) %>
   <div class="mb-3">
-    <%= link_to(back_registration ? registrants_event_row_path(params[:event_id], back_registration.id) : registrants_event_path(params[:event_id]), class: "text-sm text-gray-500 hover:text-gray-700") do %>
+    <%= link_to(back_registration ? registrants_event_row_path(params[:event_id], back_registration.id) : registrants_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}") do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to registrants
     <% end %>
   </div>
@@ -24,7 +24,7 @@
     <div class="flex flex-wrap justify-end gap-2 mb-4">
       <% if params[:return_to] == "bulk_payments" && params[:event_id].present? %>
         <%# Returned from a bulk payment tray: mr-auto pins this back link left while the rest stay right. %>
-        <%= link_to bulk_payments_return_path(params[:event_id]), class: "mr-auto text-sm text-gray-500 hover:text-gray-700 px-2 py-1" do %>
+        <%= link_to bulk_payments_return_path(params[:event_id]), class: "mr-auto text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
         <% end %>
       <% end %>
@@ -36,13 +36,13 @@
                         class: "btn btn-warning px-2 py-1" %>
         </div>
       <% end %>
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% if allowed_to?(:index?, Person) %>
-        <%= link_to "People", people_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "People", people_path, class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <% if allowed_to?(:edit?, @person) %>
         <%= link_to "Edit", edit_person_path(@person),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
 
       <span class="inline-block text-sm">

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to professional_licenses_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>

--- a/app/views/professional_licenses/index.html.erb
+++ b/app/views/professional_licenses/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to continuing_education_registrations_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-certificate text-xs"></i> CE registrations
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="flex justify-end mb-6">

--- a/app/views/professional_licenses/new.html.erb
+++ b/app/views/professional_licenses/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to professional_licenses_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -3,7 +3,7 @@
 <div class="mx-auto max-w-3xl px-4 pt-6 pb-12">
   <% if allowed_to?(:edit?, @form) %>
     <div class="flex flex-wrap items-center justify-end gap-1 pb-2">
-      <%= link_to "Edit form", edit_form_path(@form), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1 admin-only bg-blue-100" %>
+      <%= link_to "Edit form", edit_form_path(@form), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
     </div>
   <% end %>
 

--- a/app/views/quotes/edit.html.erb
+++ b/app/views/quotes/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Quotes", quotes_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", quote_path(@quote), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Quotes", quotes_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", quote_path(@quote), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @quote.class.model_name.human.downcase %></h1>
 

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -5,10 +5,10 @@
 <div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Links -->
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @quote) %>
           <%= link_to "Edit", edit_quote_path(@quote),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
 

--- a/app/views/refunds/show.html.erb
+++ b/app/views/refunds/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Payment", payment_path(@refund.refundable), class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
+    <%= link_to "← Payment", payment_path(@refund.refundable), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
 
     <h1 class="text-2xl font-semibold text-gray-900">Refund</h1>
   </div>

--- a/app/views/resources/edit.html.erb
+++ b/app/views/resources/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Resources", resources_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", resource_path(@resource, no_redirect: true), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Resources", resources_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", resource_path(@resource, no_redirect: true), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-3">Edit <%= @resource.class.model_name.human.downcase %></h1>
 

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -2,11 +2,11 @@
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Links -->
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Resources", resources_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Resources", resources_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @resource) %>
           <%= link_to "Edit", edit_resource_path(@resource),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @resource.object %>

--- a/app/views/scholarships/_form.html.erb
+++ b/app/views/scholarships/_form.html.erb
@@ -126,7 +126,7 @@
     <h2 class="text-sm font-semibold text-gray-700">Grant</h2>
     <%# from_scholarship lets the grants index show a "← Scholarship" back link
         returning here (omitted for an unsaved scholarship, which has no id yet). %>
-    <%= link_to grants_path(from_scholarship: f.object.id), class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline", target: "_blank", rel: "noopener" do %>
+    <%= link_to grants_path(from_scholarship: f.object.id), class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline", target: "_blank", rel: "noopener" do %>
       View all
       <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
     <% end %>

--- a/app/views/scholarships/_form_submission.html.erb
+++ b/app/views/scholarships/_form_submission.html.erb
@@ -11,7 +11,7 @@
     <h2 class="text-sm font-semibold text-gray-700">Form submission</h2>
     <% if @form_submission %>
       <%= link_to event_public_registration_path(@event, **submission_params),
-                  class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:underline",
+                  class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                   target: "_blank", rel: "noopener" do %>
         View full submission
         <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -7,31 +7,31 @@
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if grant_nav %>
-      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
-      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "recipients" %>
-      <%= link_to recipients_event_card_path(@allocatable.event, params[:participant]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to recipients_event_card_path(@allocatable.event, params[:participant]), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% elsif grant.present? %>
-      <%= link_to grant_path(grant), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to grant_path(grant), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% else %>
-      <%= link_to scholarships_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
       <% end %>
     <% end %>
@@ -47,8 +47,8 @@
                    href: registration_scholarship_path(@allocatable.slug, return_to: "scholarship"),
                    target: "_blank", rel: "noopener" %>
       <% end %>
-      <%= link_to "View", scholarship_path(@scholarship), class: "text-sm text-gray-500 hover:text-gray-700" %>
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "View", scholarship_path(@scholarship), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -5,28 +5,28 @@
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if @grant %>
-      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
-      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% else %>
-      <%= link_to scholarships_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
       <% end %>
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-6 shadow">
   <div class="mb-6">
-    <%= link_to "← Edit scholarship", edit_scholarship_path(@scholarship), class: "text-sm text-gray-500 hover:text-gray-700 mb-2 inline-block" %>
+    <%= link_to "← Edit scholarship", edit_scholarship_path(@scholarship), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
     <h1 class="text-2xl font-semibold text-gray-900">Scholarship</h1>
     <% if @scholarship.recipient.present? %>
       <p class="mt-1 text-gray-600"><%= @scholarship.recipient.full_name %></p>

--- a/app/views/sectors/edit.html.erb
+++ b/app/views/sectors/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Sectors", sectors_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Taggings", taggings_path(sector_names_all: @sector.name), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", sector_path(@sector), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Sectors", sectors_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Taggings", taggings_path(sector_names_all: @sector.name), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", sector_path(@sector), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit sector</h1>
 

--- a/app/views/sectors/index.html.erb
+++ b/app/views/sectors/index.html.erb
@@ -10,10 +10,10 @@
           <div class="flex gap-2">
             <%= link_to "Review “Other”",
                         other_responses_path,
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "Dedupe",
                         dedupe_index_sectors_path,
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "New #{Sector.model_name.human.downcase}",
                         new_sector_path,
                         class: "admin-only bg-blue-100 btn btn-primary-outline" %>

--- a/app/views/sectors/show.html.erb
+++ b/app/views/sectors/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Sectors", sectors_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Sectors", sectors_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @sector) %>
-          <%= link_to "Edit", edit_sector_path(@sector), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_sector_path(@sector), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -420,7 +420,7 @@
                 placeholder="Search keywords to find more stories..."
                 class="portal-search w-80 pl-4 pr-10 py-2 rounded-md border border-gray-300 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-purple-700"
                 value="<%= params[:query] %>"/>
-              <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700" aria-label="Search">
+              <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 <%= eyebrow_link_class %>" aria-label="Search">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
         <div class="flex flex-wrap justify-end gap-2 mb-4">
-          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "Stories", stories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% if @story.external_url.present? %>
             <%= link_to "External URL", safe_url(@story.external_url), target: "_blank", rel: "noopener noreferrer",
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% end %>
           <%= link_to "View", story_path(@story, no_redirect: true),
-                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
         <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
           Edit <%= @story.class.model_name.human.downcase %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -5,11 +5,11 @@
 <div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Links -->
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Stories", stories_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Stories", stories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @story) %>
           <%= link_to "Edit", edit_story_path(@story.id),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @story %>

--- a/app/views/story_ideas/edit.html.erb
+++ b/app/views/story_ideas/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Story Ideas", story_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if @story_idea.stories.any? %>
           <% @story_idea.stories.each do |story| %>
-            <%= link_to "View Story", story_path(story), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "View Story", story_path(story), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% end %>
         <% end %>
-        <%= link_to "View", story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "View", story_idea_path(@story_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
 

--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, StoryIdea) %>
-      <%= link_to "Story Ideas", story_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Story Ideas", story_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:edit?, @story_idea) %>
-      <%= link_to "Edit", edit_story_idea_path(@story_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit", edit_story_idea_path(@story_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 

--- a/app/views/story_imports/create.html.erb
+++ b/app/views/story_imports/create.html.erb
@@ -2,7 +2,7 @@
 <div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
     <%= link_to "← Choose a different file", new_story_import_path,
-                class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-1">

--- a/app/views/story_imports/new.html.erb
+++ b/app/views/story_imports/new.html.erb
@@ -2,7 +2,7 @@
 <div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
     <%= link_to "← Stories", stories_path,
-                class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">

--- a/app/views/topic_subscription_types/edit.html.erb
+++ b/app/views/topic_subscription_types/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit topic</h1>
   <%= render "form", submit_label: "Save changes" %>

--- a/app/views/topic_subscription_types/index.html.erb
+++ b/app/views/topic_subscription_types/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscription_types) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Subscriptions", topic_subscriptions_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Subscriptions", topic_subscriptions_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
@@ -20,11 +20,11 @@
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Status filter">
         <%= link_to topic_subscription_types_path(status: "active"),
-              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Active <span class="text-gray-400">(<%= @active_count %>)</span>
         <% end %>
         <%= link_to topic_subscription_types_path(status: "archived"),
-              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "archived" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "archived" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Archived <span class="text-gray-400">(<%= @archived_count %>)</span>
         <% end %>
       </nav>

--- a/app/views/topic_subscription_types/new.html.erb
+++ b/app/views/topic_subscription_types/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">New topic</h1>
   <%= render "form", submit_label: "Add topic" %>

--- a/app/views/topic_subscriptions/_eyebrow.html.erb
+++ b/app/views/topic_subscriptions/_eyebrow.html.erb
@@ -1,4 +1,4 @@
 <%# Back link adapts to where the form was opened from (an event's Forms menu, a
     person's associated records, or the subscriptions index). %>
 <% back_label, back_path = topic_subscription_return_link %>
-<%= link_to back_label, back_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+<%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class}" %>

--- a/app/views/topic_subscriptions/email_addresses.html.erb
+++ b/app/views/topic_subscriptions/email_addresses.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class}" %>
   </div>
 
   <div class="mb-6">

--- a/app/views/topic_subscriptions/index.html.erb
+++ b/app/views/topic_subscriptions/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
     <div class="flex items-center gap-4">
-      <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm text-gray-500 hover:text-gray-700" %>
-      <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+      <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
     </div>
   </div>
 

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -10,12 +10,12 @@
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Status filter">
         <%= link_to topic_subscriptions_path(toggle_params.merge(status: "active")),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "active" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Active <span class="text-gray-400">(<%= @active_count %>)</span>
         <% end %>
         <%= link_to topic_subscriptions_path(toggle_params.merge(status: "unsubscribed")),
               data: { turbo_frame: "_top" },
-              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "unsubscribed" ? "bg-white text-gray-800 shadow-sm" : "text-gray-500 hover:text-gray-700"}" do %>
+              class: "px-3 py-1 rounded-md transition-colors #{@status_filter == "unsubscribed" ? "bg-white text-gray-800 shadow-sm" : "#{eyebrow_link_class}"}" do %>
           Unsubscribed <span class="text-gray-400">(<%= @unsubscribed_count %>)</span>
         <% end %>
       </nav>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,7 +12,7 @@
       <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8 space-y-6">
 
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
-          <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
             <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
           <% end %>
         <% end %>
@@ -26,13 +26,13 @@
                           class: "btn btn-warning px-2 py-1" %>
             </div>
           <% end %>
-          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% if @user.person %>
             <%= link_to "Person profile", person_path(@user.person),
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% end %>
-          <%= link_to "View", user_path(@user), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "View", user_path(@user), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
 
         <!-- Identity header -->

--- a/app/views/users/flow_diagram.html.erb
+++ b/app/views/users/flow_diagram.html.erb
@@ -4,8 +4,8 @@
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-semibold text-gray-900">Account management flows</h1>
     <div class="flex items-center gap-1">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Users", users_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Users", users_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
   <p class="text-sm text-gray-500 mb-6">How invitation, password reset, email change, lockout, and unlock work from an admin's perspective</p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <div class="flex gap-2 items-center">
-          <%= link_to flow_diagram_users_path, class: "text-sm text-gray-500 hover:text-gray-700" do %>
+          <%= link_to flow_diagram_users_path, class: "text-sm #{eyebrow_link_class}" do %>
             <i class="fa-solid fa-diagram-project"></i> Account flow diagram
           <% end %>
           <% if allowed_to?(:new?, User) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
   <div class="mb-2">
-    <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm text-gray-500 hover:text-gray-700" do %>
+    <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,16 +28,16 @@
                         form_class: "inline",
                         class: "btn btn-secondary-outline" %>
         <% end %>
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:index?, User) %>
-          <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Users", users_path, class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if @user.person %>
           <%= link_to "Person profile", person_path(@user.person),
-                      class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:edit?, @user) %>
-          <%= link_to "Edit", edit_user_path(@user), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_user_path(@user), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
 

--- a/app/views/video_recordings/edit.html.erb
+++ b/app/views/video_recordings/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
         <div class="flex flex-wrap justify-end gap-2 mb-4">
-          <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-          <%= link_to "View", video_recording_path(@video_recording), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+          <%= link_to "View", video_recording_path(@video_recording), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
         <h1 class="text-2xl font-semibold text-gray-900 mb-3">
           Edit <%= @video_recording.class.model_name.human.downcase %>

--- a/app/views/video_recordings/index.html.erb
+++ b/app/views/video_recordings/index.html.erb
@@ -32,7 +32,7 @@
 
       <div class="text-right space-y-2">
         <% if @video_type == "instructional" %>
-          <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm text-gray-500 hover:text-gray-700" %>
+          <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm #{eyebrow_link_class}" %>
         <% end %>
         <% if allowed_to?(:new?, VideoRecording) %>
           <%= link_to "New #{VideoRecording.model_name.human.downcase}",

--- a/app/views/video_recordings/show.html.erb
+++ b/app/views/video_recordings/show.html.erb
@@ -2,15 +2,15 @@
 <div class="<%= DomainTheme.bg_class_for(:video_recordings, intensity: @video_recording.is_instructional? ? 100 : 50) %> border border-gray-200 rounded-xl shadow p-6">
       <!-- Top Right Utility Links -->
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if @video_recording.is_instructional? %>
-          <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% else %>
-          <%= link_to "Videos", video_recordings_path(video_type: "all"), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Videos", video_recordings_path(video_type: "all"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:edit?, @video_recording) %>
           <%= link_to "Edit", edit_video_recording_path(@video_recording),
-                      class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <span class="inline-block text-sm">
           <%= render "bookmarks/editable_bookmark_button", resource: @video_recording.object %>
@@ -49,9 +49,9 @@
         <!-- Back Button -->
         <div class="mt-8">
           <% if @video_recording.is_instructional? %>
-            <%= link_to "← Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm text-gray-500 hover:text-gray-700" %>
+            <%= link_to "← Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class}" %>
           <% else %>
-            <%= link_to "← Videos", video_recordings_path(video_type: "all"), class: "text-sm text-gray-500 hover:text-gray-700" %>
+            <%= link_to "← Videos", video_recordings_path(video_type: "all"), class: "text-sm #{eyebrow_link_class}" %>
           <% end %>
         </div>
 

--- a/app/views/windows_types/edit.html.erb
+++ b/app/views/windows_types/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Windows Types", windows_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", windows_type_path(@windows_type), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Windows Types", windows_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", windows_type_path(@windows_type), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @windows_type.class.model_name.human.downcase %></h1>
 

--- a/app/views/windows_types/show.html.erb
+++ b/app/views/windows_types/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Windows Types", windows_types_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Windows Types", windows_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @windows_type) %>
-          <%= link_to "Edit", edit_windows_type_path(@windows_type), class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+          <%= link_to "Edit", edit_windows_type_path(@windows_type), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">

--- a/app/views/workshop_ideas/edit.html.erb
+++ b/app/views/workshop_ideas/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", workshop_idea_path(@workshop_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
 

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, WorkshopIdea) %>
-      <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:edit?, @workshop_idea) %>
-      <%= link_to "Edit", edit_workshop_idea_path(@workshop_idea), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit", edit_workshop_idea_path(@workshop_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 

--- a/app/views/workshop_logs/_index.html.erb
+++ b/app/views/workshop_logs/_index.html.erb
@@ -17,12 +17,12 @@
             <%= WorkshopLog.model_name.human.pluralize %> (<%= number_with_delimiter(workshop_logs_count) %>)
           </h1>
           <div class="flex gap-2 items-center">
-            <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+            <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <% if allowed_to?(:manage?, WorkshopLog) %>
               <% if params[:created_by_id].present? %>
-                <%= link_to "All workshop logs", workshop_logs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                <%= link_to "All workshop logs", workshop_logs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
               <% else %>
-                <%= link_to "My workshop logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                <%= link_to "My workshop logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
               <% end %>
             <% end %>
             <%= link_to "New #{WorkshopLog.model_name.human.downcase}",

--- a/app/views/workshop_logs/edit.html.erb
+++ b/app/views/workshop_logs/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
       <div class="flex flex-wrap justify-end gap-2 mb-4">
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-        <%= link_to "View", workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "View", workshop_log_path(@workshop_log), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
 

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-member") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end items-center gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, WorkshopLog) %>
-      <%= link_to "My Workshop Logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "My Workshop Logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:manage?, WorkshopLog) %>
       <%= link_to "All workshop logs", workshop_logs_path, class: "text-sm bg-blue-100 text-blue-700 hover:bg-blue-200 rounded px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:edit?, @workshop_log) %>
-      <%= link_to "Edit", edit_workshop_log_path(@workshop_log), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Edit", edit_workshop_log_path(@workshop_log), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <%= render "bookmarks/editable_bookmark_button", resource: @workshop_log %>
   </div>

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -4,12 +4,12 @@
         <% if @workshop_variation_idea.workshop_variations.any? %>
           <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
             <%= link_to "View Variation", workshop_variation_path(workshop_variation),
-                        class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                        class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% end %>
         <% end %>
-        <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", workshop_variation_idea_path(@workshop_variation_idea),
-                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                    class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
       <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop variation idea: <%= @workshop_variation_idea.name %></h1>
       <% if @workshop_variation_idea.workshop.present? %>

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -67,7 +67,7 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-2 text-sm text-center">
-                  <%= credited_author_link(workshop_variation_idea, class: "text-gray-500 hover:text-gray-700") %>
+                  <%= credited_author_link(workshop_variation_idea, class: "#{eyebrow_link_class}") %>
                 </td>
                 <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
                   <% promoted_variation = workshop_variation_idea.workshop_variations.first %>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -4,16 +4,16 @@
     <% if @workshop_variation_idea.workshop_variations.any? %>
       <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
         <%= link_to "View Variation", workshop_variation_path(workshop_variation),
-                    class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                    class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, WorkshopVariationIdea) %>
-      <%= link_to "Workshop Variation Ideas", workshop_variation_ideas_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Workshop Variation Ideas", workshop_variation_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <% if allowed_to?(:edit?, @workshop_variation_idea) %>
       <%= link_to "Edit", edit_workshop_variation_idea_path(@workshop_variation_idea),
-                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                  class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 

--- a/app/views/workshop_variations/_workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_results.html.erb
@@ -62,7 +62,7 @@
               <% end %>
             </td>
             <td class="px-4 py-2 text-sm text-gray-800 text-center">
-              <%= credited_author_link(workshop_variation, class: "text-gray-500 hover:text-gray-700") %>
+              <%= credited_author_link(workshop_variation, class: "#{eyebrow_link_class}") %>
             </td>
             <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
               <% if workshop_variation.workshop_variation_idea %>

--- a/app/views/workshop_variations/edit.html.erb
+++ b/app/views/workshop_variations/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap justify-end gap-2 mb-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "View", workshop_variation_path(@workshop_variation), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "View", workshop_variation_path(@workshop_variation), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop variation: <%= @workshop_variation.name %></h1>
   <% if @workshop_variation.workshop.present? %>

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -2,12 +2,12 @@
 <div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
 
     <div class="flex flex-wrap justify-end gap-2 mb-4">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "Workshop", workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
-                  class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                  class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% if allowed_to?(:edit?, @workshop_variation) %>
         <%= link_to "Edit", edit_workshop_variation_path(@workshop_variation),
-                    class: "#{ "admin-only bg-blue-100 " if allowed_to?(:manage?, WorkshopVariation) }text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                    class: "#{ "admin-only bg-blue-100 " if allowed_to?(:manage?, WorkshopVariation) }text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
     </div>
 

--- a/app/views/workshops/_show_actions_row.html.erb
+++ b/app/views/workshops/_show_actions_row.html.erb
@@ -18,12 +18,12 @@
 
   <!-- Right: Utilities -->
   <div class="flex items-center gap-4">
-    <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-    <%= link_to "Workshops", workshops_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Workshops", workshops_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:edit?, workshop) %>
       <%= link_to "Edit",
                   edit_workshop_path(workshop),
-                  class: "admin-only bg-blue-100 text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+                  class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <%= print_button(workshop, printable_type: "Workshop", button_text: "Print", image_toggle: true) %>
   </div>

--- a/app/views/workshops/_show_tags.html.erb
+++ b/app/views/workshops/_show_tags.html.erb
@@ -2,7 +2,7 @@
 <div class="tags-section print:hidden p-2 mb-4" data-controller="dropdown">
   <button
     type="button"
-    class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 cursor-pointer transition"
+    class="inline-flex items-center gap-1 text-sm <%= eyebrow_link_class %> cursor-pointer transition"
     data-action="dropdown#toggle"
     data-dropdown-payload-param='[{"workshop_tags_content":"hidden"}, {"workshop_tags_show_label":"hidden"}, {"workshop_tags_hide_label":"hidden"}, {"workshop_tags_chevron":"rotate-180"}]'>
     <i id="workshop_tags_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 rotate-180"></i>

--- a/app/views/workshops/edit.html.erb
+++ b/app/views/workshops/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="flex flex-wrap justify-end gap-2 mb-4">
-      <%= link_to "Home", root_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "Workshops", workshops_path, class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
-      <%= link_to "View", workshop_path(@workshop), class: "text-sm text-gray-500 hover:text-gray-700 px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Workshops", workshops_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "View", workshop_path(@workshop), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
     <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop: <%= @workshop.remote_search_label[:label] %></h1>
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 wide but mechanical: ~400 eyebrow links across 178 views now interpolate one helper for their color; verified by build + full view/helper specs

### Goal
- The muted-gray page eyebrows / back-nav links ("Home | View | Edit") hard-coded `text-gray-500 hover:text-gray-700` in ~400 places across 178 views.
- Route that color through one `eyebrow_link_class` helper so it's a single-source change.

### Approach
- Added `eyebrow_link_class` (ApplicationHelper) returning the muted-gray color pair — a class-string helper like the `DomainTheme.*_class_for` helpers, **not `@apply`**.
- Views interpolate it (`class: "text-sm #{eyebrow_link_class} px-2 py-1"`) and keep their own size/padding/layout, which varies by context.
- Documented in `CLAUDE.md` + `.github/copilot-instructions.md`: unify repeated Tailwind with a helper/partial, not `@apply` (reserved for base styles like `.btn`).

### Verification
- Tailwind still generates `text-gray-500` / `hover:text-gray-700` (from the helper's literal, which it scans in `app/helpers`).
- Full view + helper specs green (620 examples, 0 failures); RuboCop clean.

### Follow-up under discussion
- Folding font-size/padding into the helper so eyebrows are fully single-controlled — but the ~400 links are 3 sub-styles sharing only the color (217 padded nav eyebrows, 171 unpadded inline links, 18 `text-xs`), so this needs a split (see PR thread).