### PR TITLE
Route home + discrete domain-color hardcodings through DomainTheme

### DIFF
--- a/app/decorators/scholarship_decorator.rb
+++ b/app/decorators/scholarship_decorator.rb
@@ -35,9 +35,9 @@ class ScholarshipDecorator < ApplicationDecorator
   # Tailwind pill classes for the program-status badge.
   def program_status_classes
     case program&.program_status(object.recipient)
-    when "Ongoing"   then "bg-blue-50 text-blue-700 border-blue-200"
-    when "New"       then "bg-indigo-50 text-indigo-700 border-indigo-200"
-    when "Reinstate" then "bg-purple-50 text-purple-700 border-purple-200"
+    when "Ongoing"   then program_pill(:program_ongoing)
+    when "New"       then program_pill(:program_new)
+    when "Reinstate" then program_pill(:program_reinstated)
     else "bg-gray-50 text-gray-500 border-gray-200"
     end
   end
@@ -94,5 +94,12 @@ class ScholarshipDecorator < ApplicationDecorator
     label = prefix ? "Agreement #{agreement_status_label.downcase}" : agreement_status_label
     h.render "shared/badge", label: label, classes: agreement_status_classes,
              icon: [ agreement_status_icon, icon_size ].compact_blank.join(" ")
+  end
+
+  private
+
+  # Program-status pill classes for a DomainTheme program key (bg-50/text-700/border-200).
+  def program_pill(key)
+    "#{DomainTheme.bg_class_for(key)} #{DomainTheme.text_class_for(key, intensity: 700)} #{DomainTheme.border_class_for(key, intensity: 200)}"
   end
 end

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -62,8 +62,8 @@ module OrganizationHelper
       else
         content_tag(:span, organization.name.first.upcase,
                     class: "#{avatar_size} rounded-full flex items-center justify-center
-                            bg-emerald-200 text-emerald-700 font-bold #{initial_text_size}
-                            border border-emerald-300 shadow-sm flex-shrink-0")
+                            #{DomainTheme.bg_class_for(:organizations, intensity: 200)} #{DomainTheme.text_class_for(:organizations, intensity: 700)} font-bold #{initial_text_size}
+                            border #{DomainTheme.border_class_for(:organizations, intensity: 300)} shadow-sm flex-shrink-0")
       end
 
       display_name = truncate_at ? truncate(organization.name.to_s, length: truncate_at) : organization.name.to_s

--- a/app/views/grants/_count.html.erb
+++ b/app/views/grants/_count.html.erb
@@ -1,4 +1,4 @@
 <%# Rendered in the page header and replaced via turbo_stream from _results when
     the frame reloads, so the badge reflects the active filters. @grants is nil on
     the initial full-page render (the frame fills it in moments later). %>
-<span id="grants_count" class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-sm font-semibold text-green-700"><%= @grants&.total_entries %></span>
+<span id="grants_count" class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:grants, intensity: 100) %> px-2.5 py-0.5 text-sm font-semibold <%= DomainTheme.text_class_for(:grants, intensity: 700) %>"><%= @grants&.total_entries %></span>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     <div class="flex items-start justify-between gap-6 mb-6">
       <div class="flex items-start gap-4">
-        <span class="hidden sm:flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-100 text-green-700 shadow-sm">
+        <span class="hidden sm:flex h-12 w-12 shrink-0 items-center justify-center rounded-xl <%= DomainTheme.bg_class_for(:grants, intensity: 100) %> <%= DomainTheme.text_class_for(:grants, intensity: 700) %> shadow-sm">
           <i class="fa-solid fa-hand-holding-dollar text-xl" aria-hidden="true"></i>
         </span>
         <div>

--- a/app/views/home/_community_news.html.erb
+++ b/app/views/home/_community_news.html.erb
@@ -1,6 +1,6 @@
 <% title ||= "Community News" %>
 
-<section class="<%# mt-6 %> py-10 bg-orange-50">
+<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:community_news) %>">
   <div class="max-w-6xl mx-auto px-4">
     <%= render "home/home_section_header",
                title: title,

--- a/app/views/home/_resources.html.erb
+++ b/app/views/home/_resources.html.erb
@@ -1,6 +1,6 @@
 <% title ||= "Popular Resources" %>
 
-<section class="<%# mt-6 %> py-10 bg-violet-50">
+<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:resources) %>">
   <div class="max-w-6xl mx-auto px-4">
     <%= render "home/home_section_header",
                title: title,

--- a/app/views/home/_stories.html.erb
+++ b/app/views/home/_stories.html.erb
@@ -1,6 +1,6 @@
 <% title ||= "Highlighted Stories" %>
 
-<section class="<%# mt-6 %> py-10 bg-rose-50">
+<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:stories) %>">
   <div class="max-w-6xl mx-auto px-4">
     <%= render "home/home_section_header",
                title: title,

--- a/app/views/workshop_variations/_form.html.erb
+++ b/app/views/workshop_variations/_form.html.erb
@@ -33,10 +33,10 @@
         </div>
 
         <% if linked_idea %>
-          <div class="admin-only bg-purple-100 rounded-lg border border-purple-200 p-4">
+          <div class="admin-only <%= DomainTheme.bg_class_for(:workshop_variations, intensity: 100) %> rounded-lg border <%= DomainTheme.border_class_for(:workshop_variations, intensity: 200) %> p-4">
             <div class="flex items-center gap-2">
-              <i class="fas fa-arrow-up-from-bracket text-purple-600"></i>
-              <span class="text-sm font-medium text-purple-800"><%= f.object.persisted? ? "Promoted from:" : "Promoting from:" %></span>
+              <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variations, intensity: 600) %>"></i>
+              <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variations, intensity: 800) %>"><%= f.object.persisted? ? "Promoted from:" : "Promoting from:" %></span>
               <%= link_to linked_idea.name,
                           workshop_variation_idea_path(linked_idea),
                           class: "btn btn-secondary-outline text-sm" %>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 tokenizes domain colors across home + a few badges/helpers; stories also changes color (rose → its theme fuchsia)

## Why
The home page mixed tokenized and hardcoded section tints, and a sweep found the same pattern in a handful of other discrete spots. Centralize each domain’s color in `DomainTheme` so it lives in one place.

## What

### Home section tints
- `_community_news.html.erb`: `bg-orange-50` → `DomainTheme.bg_class_for(:community_news)` (same color).
- `_resources.html.erb`: `bg-violet-50` → `:resources` (same color).
- `_stories.html.erb`: `bg-rose-50` → `:stories` (**rose → fuchsia** — was the wrong color).

### Discrete conversions found by the sweep
- **Scholarship program-status badge** (`scholarship_decorator.rb`) → the dedicated `program_ongoing/new/reinstated` keys (via a small `program_pill` helper), instead of literal blue/indigo/purple.
- **Grants** index header badge + count pill → `:grants`.
- **Organization** avatar-initials fallback (`organization_helper.rb`) → `:organizations`, matching the method’s other branches.
- **Workshop-variation** “promoted from” box → `:workshop_variations`.

## Deliberately left alone
- Neutral grays (skeletons, headers, empty states), semantic status colors, focus rings.
- Facilitator (purple) / non-facilitator (blue) tints in `organization_helper` — a status distinction, not the org color.

## Deferred to follow-ups (not in this PR)
- **`forms/*` (purple)** — blocked: its header **gradients** (`from-purple-950 …`) can’t route through `DomainTheme` (no gradient helper; `from-/via-/to-` aren’t safelisted). Needs a gradient helper first.
- **Scholarship report tables** (`events/_scholarships_report_table` etc., fuchsia) — clean but pervasive; inlining `DomainTheme` per class hurts readability. Better as a locals-based refactor in its own PR.
- **`event_registrations` transferred-in teal** — a teal-in / purple-out **status** pairing, not the domain color.
- **`person_helper` avatar (sky)** — people’s domain color is **cyan**; converting would *change* the color, so flagging rather than silently altering (possible bug).
- **Lime chips** (`tags`/`categories`/`sectors` hovers) — partial-default indirection; one already has a reverted `DomainTheme` attempt commented out.

Tracked alongside #2291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)