### PR TITLE
Align green action buttons with brand green (#4E8324)

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -314,17 +314,6 @@ textarea.comment-truncated:focus {
   text-align: left;
 }
 
-/* Event register/deregister buttons (!important needed to override inline styles) */
-.event-register-btn:hover {
-  color: rgb(170, 46, 0) !important;
-  background-color: white !important;
-}
-
-.event-deregister-btn:hover {
-  background-color: rgb(170, 46, 0) !important;
-  color: white !important;
-}
-
 /* Responsive table: Kevin Powell card-based approach for small screens */
 @media (max-width: 767px) {
   .responsive-table thead {

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -15,7 +15,7 @@
   --color-danger: var(--color-red-500);
   --color-warning: var(--color-yellow-500);
   --color-info: var(--color-blue-500);
-  --color-success: var(--color-green-500);
+  --color-success: #4e8324;
   --color-transparent: transparent;
   --font-telefon: "Telefon Bold", sans-serif;
 
@@ -317,11 +317,6 @@ textarea.comment-truncated:focus {
 /* Event register/deregister buttons (!important needed to override inline styles) */
 .event-register-btn:hover {
   color: rgb(170, 46, 0) !important;
-  background-color: white !important;
-}
-
-.event-view-registration-btn:hover {
-  color: rgb(22, 101, 52) !important;
   background-color: white !important;
 }
 

--- a/app/frontend/stylesheets/components/buttons.css
+++ b/app/frontend/stylesheets/components/buttons.css
@@ -24,6 +24,13 @@
            hover:bg-white hover:text-accent;
   }
 
+  /* The brand-green "registered / view ticket" action button — the confirmed-
+     state counterpart to btn-accent's register CTA, so it shares its border-2. */
+  .btn-success {
+    @apply border-2 border-success bg-success text-white
+           hover:bg-white hover:text-success;
+  }
+
   .btn-secondary {
     @apply border border-secondary bg-secondary text-white
            hover:bg-white hover:text-secondary;
@@ -58,6 +65,11 @@
   .btn-accent-outline {
     @apply border-2 border-accent text-accent
            hover:bg-accent hover:text-white;
+  }
+
+  .btn-success-outline {
+    @apply border-2 border-success text-success
+           hover:bg-success hover:text-white;
   }
 
   .btn-secondary-outline {

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -55,8 +55,7 @@
       <% if registration&.slug.present? %>
       <%= link_to "View ticket", registration_ticket_path(registration.slug),
                   data: { turbo_frame: "_top" },
-                  class: "btn px-3 py-2 text-xs uppercase leading-tight text-white hover:bg-white event-view-registration-btn",
-                  style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 2px solid rgb(22, 101, 52);" %>
+                  class: "btn btn-success px-3 py-2 text-xs uppercase leading-tight font-telefon" %>
       <% end %>
     <% elsif event.ended? %>
       <span class="text-sm text-gray-500 italic">Event ended</span>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -47,12 +47,12 @@
     <% if registered %>
       <% registration = event.active_registration_for(current_user&.person) %>
       <%= link_to "View ticket", registration_ticket_path(registration.slug),
-                  class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-view-registration-btn",
-                  style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 3px solid rgb(22, 101, 52);" %>
+                  class: "btn btn-success px-10 py-2 text-2xl uppercase",
+                  style: "font-family: 'Telefon Bold', sans-serif;" %>
     <% elsif slug_registered %>
       <%= link_to "View ticket", registration_ticket_path(slug_registration.slug),
-                  class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white event-view-registration-btn",
-                  style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 3px solid rgb(22, 101, 52);" %>
+                  class: "btn btn-success px-10 py-2 text-2xl uppercase",
+                  style: "font-family: 'Telefon Bold', sans-serif;" %>
     <% end %>
   </div>
 

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -89,7 +89,7 @@
             <% end %>
 
             <details class="group/details">
-              <summary class="inline-flex cursor-pointer list-none items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 [&::-webkit-details-marker]:hidden">
+              <summary class="btn btn-secondary-outline cursor-pointer list-none [&::-webkit-details-marker]:hidden">
                 <i class="fa-solid fa-xmark"></i> Decline
               </summary>
               <%= form_with url: registration_scholarship_decline_path(@event_registration.slug), method: :post, class: "mt-3 w-full max-w-md" do %>

--- a/app/views/events/callouts/scholarship.html.erb
+++ b/app/views/events/callouts/scholarship.html.erb
@@ -83,7 +83,7 @@
           <%# Native <details>; while it's open :has() hides Agree so the decline form stands alone. %>
           <div class="group mt-3 flex flex-wrap items-center gap-3">
             <%= form_with url: registration_scholarship_agreement_path(@event_registration.slug), method: :post, class: "group-has-[[open]]:hidden" do %>
-              <button type="submit" name="agreement" value="yes" class="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-700">
+              <button type="submit" name="agreement" value="yes" class="btn btn-success">
                 <i class="fa-solid fa-check"></i> Agree
               </button>
             <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -110,8 +110,8 @@
     <div class="mt-4">
       <%= link_to Form::BULK_PAYMENT_PUBLIC_NAME,
                   new_event_bulk_payment_path(@event),
-                  class: "btn px-10 py-2 text-2xl uppercase text-white hover:bg-white",
-                  style: "font-family: 'Telefon Bold', sans-serif; background-color: rgb(22, 101, 52); border: 3px solid rgb(22, 101, 52);" %>
+                  class: "btn btn-success px-10 py-2 text-2xl uppercase",
+                  style: "font-family: 'Telefon Bold', sans-serif;" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 token swap + button-class replacements across the event register flow and scholarship callout

## Why
- Green action buttons hardcoded `rgb(22,101,52)` / `bg-green-600`, colors not in the brand guide.
- Mirrors the accent-orange alignment (#2290): brand color → token → `.btn-*` class → replace hardcoded usages.

## What
- `--color-success` now points at brand green **#4E8324** (was the unused `green-500`).
- New `.btn-success` / `.btn-success-outline` — `border-2`, the confirmed-state counterpart to `btn-accent`'s register CTA.
- Routed the hardcoded green buttons through `.btn-success`:
  - 2× "View ticket" in the registration section
  - bulk-payment button on event show
  - "View ticket" on the event card
  - scholarship "Agree" confirm button
- Scholarship "Decline" toggle → `.btn-secondary-outline`.
- Fixes the bulk-payment button's white-on-white hover (`hover:bg-white` with no hover text color).
- Removed dead CSS: `.event-view-registration-btn`, and the `.event-register-btn` / `.event-deregister-btn` rules that referenced the old rust accent `rgb(170,46,0)` and were used nowhere.

## Notes
- Navbar + primary buttons stay brand blue — unchanged.