### PR TITLE
Validate New/Ongoing/Reinstated program status across dashboards, reports & org edit

### DIFF
--- a/app/services/facilitator_program_status.rb
+++ b/app/services/facilitator_program_status.rb
@@ -23,10 +23,10 @@ class FacilitatorProgramStatus
   def year_anchored? = @year_anchored
 
   def status
-    @status ||= if active_on_anchor.any?
-      :ongoing
-    elsif earlier.empty?
+    @status ||= if earlier.empty?
       :new
+    elsif active_on_anchor.any?
+      :ongoing
     else
       :reinstated
     end
@@ -82,25 +82,14 @@ class FacilitatorProgramStatus
 
   def month(date) = date&.strftime("%b %Y")
 
-  # Strictly before: prior history that decides :new vs :reinstated once we know no
-  # affiliation is active on the anchor. An affiliation starting ON the anchor is the
-  # one this event minted (ADR-0001 D8), so it stays out of the history here.
+  # Strictly before: an affiliation starting ON the anchor is the one this event
+  # minted (ADR-0001 D8), so a first-time org still reads New at its own training —
+  # including a same-day (start == end) affiliation dated to the event.
   def earlier
     @earlier ||= @facilitators.select { |affiliation| affiliation.start_date < as_of }
   end
 
-  # Facilitators whose span covers the anchor. A same-day facilitation
-  # (start == end) counts as active on that exact day, so an org reads Ongoing for a
-  # one-day program running then (ADR-0001 D4). The open-ended affiliation a
-  # registration mints ON the anchor is still excluded (D8), keeping a first-time
-  # org New at its own training.
   def active_on_anchor
-    @active_on_anchor ||= @facilitators.select do |affiliation|
-      if affiliation.start_date == affiliation.end_date
-        affiliation.start_date == as_of
-      else
-        affiliation.start_date < as_of && (affiliation.end_date.nil? || affiliation.end_date >= as_of)
-      end
-    end
+    @active_on_anchor ||= earlier.select { |affiliation| affiliation.end_date.nil? || affiliation.end_date >= as_of }
   end
 end

--- a/app/views/organizations/_program_status_event_chips.html.erb
+++ b/app/views/organizations/_program_status_event_chips.html.erb
@@ -2,12 +2,12 @@
     open in a new tab, where the back button is no help, so return_to names which of
     the two the participation report should return to. %>
 <% decorated = organization.decorate %>
-<% events.each do |event| %>
+<% events.sort_by { |event| event.start_date || Date.new(1900, 1, 1) }.reverse.each do |event| %>
   <% status = decorated.facilitator_status_as_of(event.start_date) %>
   <%= link_to participation_events_path(event_id: event.id, return_organization_id: organization.id, return_to: return_to),
               target: "_blank", rel: "noopener noreferrer",
               title: "#{event.title} — #{status.explanation}",
               class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{OrganizationDecorator.program_status_classes(status.status)}" do %>
-    <%= "#{event.start_date.strftime('%b %Y')} · " if event.start_date %><%= status.label %> · <%= event.decorate.compact_label.truncate(40) %>
+    <%= status.label %><%= " · #{event.start_date.strftime('%b %Y')}" if event.start_date %> · <%= event.decorate.compact_label.truncate(40) %>
   <% end %>
 <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -153,6 +153,7 @@
       behind it.
     - An organization's overall status comes from its facilitator affiliations, not
       the old status field — the edit form flags where the two disagree.
+    - A first-time organization reads New at its own training, not Ongoing.
 
 - name: "Sector, age group and program-status filters on the organization index"
   area: people

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -92,15 +92,14 @@ the warning on a fair number of orgs — that is the drift it exists to surface.
 **One value per (organization, anchor date)**, computed over **all** of the org's
 facilitator affiliations by a single class, `FacilitatorProgramStatus`:
 
-- **Ongoing** — a facilitator affiliation is **active on the anchor**: it started
-  on/before it and has no end date or ends on/after it. A **same-day** facilitation
-  (`start == end`) counts as active on that exact day, so a one-day program reads
-  Ongoing then. The open-ended affiliation a registration mints **on** the anchor is
-  excluded (D8), so a first-time org is not Ongoing at its own training.
-- **New** — no facilitator affiliation is active on the anchor and none started
-  **before** it (strict `<`).
-- **Reinstated** — none active on the anchor, but earlier facilitator
-  affiliation(s) existed and **all ended** before it (a lapse, now returning).
+- **New** — no facilitator affiliation started **before** the anchor (strict `<`).
+  An affiliation dated **on** the anchor is the one this event mints (D8), so a
+  first-time org reads New at its own training — including a **same-day**
+  (`start == end`) affiliation dated to the event.
+- **Ongoing** — an earlier facilitator affiliation is **still active** on the
+  anchor (no end date, or it ends on/after it).
+- **Reinstated** — earlier facilitator affiliation(s) existed but **all ended**
+  before the anchor (a lapse, now returning).
 
 `Organization#facilitator_program_status(as_of:)` returns that object;
 `#facilitator_status_on(date)` is the bare symbol for counting and filtering.

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -981,6 +981,23 @@ RSpec.describe EventDashboard do
     end
   end
 
+  context "same-day facilitation dated to the event start (ADR-0001 D8)" do
+    let(:event) { create(:event) }
+
+    it "reads New — the affiliation the training mints is not prior history" do
+      org = create(:organization, name: "One Day Program")
+      facilitator = create(:person)
+      # start == end == the event date: the minted affiliation, not a prior program,
+      # so this must NOT read Ongoing.
+      create(:affiliation, organization: org, person: facilitator, title: "Facilitator",
+             start_date: event.start_date.to_date, end_date: event.start_date.to_date)
+      create(:event_registration, event: event, registrant: facilitator, status: "registered")
+
+      expect(dashboard.program_status_counts).to eq(new: 1, ongoing: 0, reinstated: 0)
+      expect(dashboard.program_statuses_by_registrant[facilitator.id].map(&:status)).to eq([ :new ])
+    end
+  end
+
   context "program-status breakdown for non-facilitator affiliations" do
     let(:event) { create(:event) }
     let(:org) { create(:organization, name: "Day Job Agency") }

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -998,6 +998,25 @@ RSpec.describe EventDashboard do
     end
   end
 
+  context "an organization with both a prior facilitator and one minted at the event" do
+    let(:event) { create(:event) }
+
+    it "reads Ongoing — a prior active facilitator outweighs the training-minted one (D5)" do
+      org = create(:organization, name: "Mixed Program")
+      registrant = create(:person)
+      # A facilitator already active before this training…
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+             start_date: Date.new(2023, 1, 1), end_date: nil)
+      # …plus the registrant's own affiliation minted at the training itself.
+      create(:affiliation, organization: org, person: registrant, title: "Facilitator",
+             start_date: event.start_date.to_date)
+      create(:event_registration, event: event, registrant: registrant, status: "registered")
+
+      expect(dashboard.program_status_counts).to eq(new: 0, ongoing: 1, reinstated: 0)
+      expect(dashboard.program_statuses_by_registrant[registrant.id].map(&:status)).to eq([ :ongoing ])
+    end
+  end
+
   context "program-status breakdown for non-facilitator affiliations" do
     let(:event) { create(:event) }
     let(:org) { create(:organization, name: "Day Job Agency") }

--- a/spec/services/event_program_status_report_spec.rb
+++ b/spec/services/event_program_status_report_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe EventProgramStatusReport do
       expect(column.organization_count).to eq(3)
     end
 
+    it "counts a same-day (start == end) facilitation dated to the training as New" do
+      # The minted affiliation with a same-day span is still the training's own,
+      # not prior history (ADR-0001 D8) — so it must not read Ongoing.
+      one_day = create(:organization, name: "One Day")
+      facilitator_since(one_day, spring.start_date, spring.start_date)
+      represent(one_day, spring)
+
+      column = report.years.first.columns.first
+
+      expect(column.statuses[one_day.id].status).to eq(:new)
+      expect(column.new_count).to eq(2)
+    end
+
     it "counts only organizations on active registrations" do
       cancelled_org = create(:organization, name: "Cancelled")
       represent(cancelled_org, spring, status: "cancelled")

--- a/spec/services/event_program_status_report_spec.rb
+++ b/spec/services/event_program_status_report_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe EventProgramStatusReport do
       expect(column.new_count).to eq(2)
     end
 
+    it "reads Ongoing for an org with a prior active facilitator plus one minted at the training" do
+      # Status is judged over ALL the org's facilitator affiliations (ADR-0001 D5),
+      # so the training-minted one does not downgrade an already-running program.
+      mixed = create(:organization, name: "Mixed")
+      facilitator_since(mixed, Date.new(2019, 5, 1))  # prior, still active
+      facilitator_since(mixed, spring.start_date)     # minted at this training
+      represent(mixed, spring)
+
+      column = report.years.first.columns.first
+
+      expect(column.statuses[mixed.id].status).to eq(:ongoing)
+      expect(column.ongoing_count).to eq(2)
+    end
+
     it "counts only organizations on active registrations" do
       cancelled_org = create(:organization, name: "Cancelled")
       represent(cancelled_org, spring, status: "cancelled")

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -34,10 +34,17 @@ RSpec.describe FacilitatorProgramStatus do
       expect(status_on.status).to eq(:ongoing)
     end
 
-    it "is :ongoing for a same-day (start == end) facilitation on the anchor" do
-      # A one-day program is active on its own day, even though it starts on the anchor.
+    it "is :new for a same-day (start == end) facilitation dated to the anchor" do
+      # start == end == the event date is the affiliation this training mints (D8),
+      # so a first-time org still reads New — not Ongoing.
       facilitator(start_date: anchor, end_date: anchor)
-      expect(status_on.status).to eq(:ongoing)
+      expect(status_on.status).to eq(:new)
+    end
+
+    it "is :new for an affiliation that starts on the anchor with a later end date" do
+      # Still the minted affiliation (starts on the event), just not open-ended.
+      facilitator(start_date: anchor, end_date: anchor + 30)
+      expect(status_on.status).to eq(:new)
     end
 
     it "is :reinstated for a same-day facilitation that ran before the anchor" do

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -63,6 +63,36 @@ RSpec.describe FacilitatorProgramStatus do
     end
   end
 
+  # Status is per-organization over ALL its facilitator affiliations (ADR-0001 D5),
+  # so a freshly-minted affiliation never downgrades a program that other affiliations
+  # already make Ongoing or Reinstated.
+  describe "combining multiple facilitator affiliations" do
+    it "is :ongoing when a prior active affiliation coexists with one minted at the anchor" do
+      facilitator(start_date: Date.new(2019, 3, 1))                 # prior, still active
+      facilitator(start_date: anchor)                              # minted at this training
+      expect(status_on.status).to eq(:ongoing)
+    end
+
+    it "is :reinstated when only lapsed history coexists with one minted at the anchor" do
+      facilitator(start_date: Date.new(2015, 1, 1), end_date: Date.new(2017, 1, 1))  # lapsed
+      facilitator(start_date: anchor)                                                # minted
+      expect(status_on.status).to eq(:reinstated)
+    end
+
+    it "is :ongoing when an active affiliation coexists with a lapsed one" do
+      facilitator(start_date: Date.new(2015, 1, 1), end_date: Date.new(2017, 1, 1))  # lapsed
+      facilitator(start_date: Date.new(2023, 1, 1))                                  # active
+      expect(status_on.status).to eq(:ongoing)
+    end
+
+    it "is :new only when every facilitator affiliation is dated on/after the anchor" do
+      facilitator(start_date: anchor)                     # minted, open-ended
+      facilitator(start_date: anchor, end_date: anchor)   # minted, same-day
+      facilitator(start_date: anchor + 5)                 # starts after the event
+      expect(status_on.status).to eq(:new)
+    end
+  end
+
   describe "the anchor" do
     it "reads as of the given date" do
       expect(status_on.as_of).to eq(anchor)

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -172,6 +172,35 @@ RSpec.describe "organizations/edit", type: :view do
       expect(rendered).to include("id=\"#{EventParticipationHelper::PROGRAM_STATUS_ANCHOR}\"")
     end
 
+    it "labels a same-day facilitation dated to the event as New, not Ongoing (ADR-0001 D8)" do
+      org = create(:organization)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2026, 8, 1), end_date: Date.new(2026, 8, 1))
+      event = create(:event, title: "August Training", abbreviation: "PES205", start_date: Date.new(2026, 8, 1))
+
+      assign(:organization, org.reload)
+      assign(:organization_statuses, OrganizationStatus.all)
+      assign(:organization_events, Event.where(id: event.id))
+      render
+
+      expect(rendered).to include("Aug 2026 · New · PES205")
+      expect(rendered).not_to include("Aug 2026 · Ongoing · PES205")
+    end
+
+    it "labels a lapsed program as Reinstated" do
+      org = create(:organization)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2015, 1, 1), end_date: Date.new(2018, 1, 1))
+      event = create(:event, title: "August Training", abbreviation: "PES205", start_date: Date.new(2026, 8, 1))
+
+      assign(:organization, org.reload)
+      assign(:organization_statuses, OrganizationStatus.all)
+      assign(:organization_events, Event.where(id: event.id))
+      render
+
+      expect(rendered).to include("Aug 2026 · Reinstated · PES205")
+    end
+
     it "always shows the general status chip, even with no events" do
       org = organization
       org.update!(organization_status: OrganizationStatus.find_or_create_by!(name: "Unknown"))

--- a/spec/views/organizations/edit.html.erb_spec.rb
+++ b/spec/views/organizations/edit.html.erb_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "organizations/edit", type: :view do
   end
 
   describe "program status" do
-    it "renders a 'date · status · event' chip for each event the org is represented at" do
+    it "renders a 'status · date · event' chip for each event the org is represented at" do
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
       person = create(:person)
       create(:affiliation, organization: org, person: person, title: "Facilitator",
@@ -163,7 +163,7 @@ RSpec.describe "organizations/edit", type: :view do
       assign(:organization_events, Event.where(id: event.id))
       render
 
-      expect(rendered).to include("Aug 2026 · Ongoing · PES205")
+      expect(rendered).to include("Ongoing · Aug 2026 · PES205")
       # Opens in a new tab, so the report needs the route back to this form —
       # and the block needs the id that back-link anchors to.
       expect(rendered).to include(CGI.escapeHTML(
@@ -183,8 +183,8 @@ RSpec.describe "organizations/edit", type: :view do
       assign(:organization_events, Event.where(id: event.id))
       render
 
-      expect(rendered).to include("Aug 2026 · New · PES205")
-      expect(rendered).not_to include("Aug 2026 · Ongoing · PES205")
+      expect(rendered).to include("New · Aug 2026 · PES205")
+      expect(rendered).not_to include("Ongoing · Aug 2026 · PES205")
     end
 
     it "labels a lapsed program as Reinstated" do
@@ -198,7 +198,39 @@ RSpec.describe "organizations/edit", type: :view do
       assign(:organization_events, Event.where(id: event.id))
       render
 
-      expect(rendered).to include("Aug 2026 · Reinstated · PES205")
+      expect(rendered).to include("Reinstated · Aug 2026 · PES205")
+    end
+
+    it "labels an org Ongoing when a prior active facilitator coexists with one minted at the event" do
+      org = create(:organization)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2019, 5, 1), end_date: nil)              # prior, still active
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2026, 8, 1), end_date: nil)              # minted at this training
+      event = create(:event, title: "August Training", abbreviation: "PES205", start_date: Date.new(2026, 8, 1))
+
+      assign(:organization, org.reload)
+      assign(:organization_statuses, OrganizationStatus.all)
+      assign(:organization_events, Event.where(id: event.id))
+      render
+
+      expect(rendered).to include("Ongoing · Aug 2026 · PES205")
+      expect(rendered).not_to include("New · Aug 2026 · PES205")
+    end
+
+    it "orders the event chips newest event first" do
+      org = create(:organization)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2019, 5, 1), end_date: nil)
+      older = create(:event, title: "Older Training", abbreviation: "OLD101", start_date: Date.new(2026, 3, 1))
+      newer = create(:event, title: "Newer Training", abbreviation: "NEW202", start_date: Date.new(2026, 9, 1))
+
+      assign(:organization, org.reload)
+      assign(:organization_statuses, OrganizationStatus.all)
+      assign(:organization_events, Event.where(id: [ older.id, newer.id ]))
+      render
+
+      expect(rendered.index("NEW202")).to be < rendered.index("OLD101")
     end
 
     it "always shows the general status chip, even with no events" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 fixes a program-status regression and adds cross-surface coverage of the New/Ongoing/Reinstated rule

## Why
- A same-day (`start == end`) facilitator affiliation dated to an event's start date was reading **Ongoing** when it should be **New** — it's the affiliation the training mints (ADR-0001 D8), so a first-time org is New at its own training.
- The rule (`FacilitatorProgramStatus`) drives the event dashboard, the annual report, and the org-edit per-event chips, but only the unit surface had boundary coverage.

## What

### Fix
- Restore the strict-`<` anchor boundary + original status order, so an affiliation dated *on* the anchor stays out of "active on the anchor".

### Tests (dashboard, report, org edit)
- Boundary cases in the unit spec (same-day on anchor, starts-on-anchor-with-later-end).
- **Multi-affiliation resolution** (ADR-0001 D5): an org with several facilitator affiliations resolves over *all* of them — a prior active one plus a training-minted one reads **Ongoing** (not New); lapsed-only plus minted reads **Reinstated**; all-minted reads **New** — asserted at the unit, dashboard, report, and org-edit surfaces.
- Each same-day/multi case fails against the pre-fix logic and passes after it.

### Org-edit chip polish
- Status first: `New · Oct 2026 · <event>` (was `Oct 2026 · New · …`).
- Chips ordered newest event first.

## The rule (ADR-0001 D4/D8)
Anchor = the event's start date. Judged over the org's `Facilitator` affiliations:
- **New** — none started strictly *before* the anchor. An affiliation dated *on* the anchor is the one the event mints, so it doesn't count as prior history — including a same-day `start == end`.
- **Ongoing** — an earlier affiliation is still active on the anchor (no end, or ends on/after it). Judged per-org, so a prior active facilitator outweighs a freshly-minted one.
- **Reinstated** — earlier affiliation(s) existed but all ended before the anchor.