### PR TITLE
Pad unpadded back-nav eyebrows to match the standard eyebrow

### DIFF
--- a/app/views/admin/ahoy_activities/charts.html.erb
+++ b/app/views/admin/ahoy_activities/charts.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
       <div class="mb-2 flex flex-wrap items-center gap-y-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -5,12 +5,12 @@
         <%# Scoped to a person (from their edit page's History card, or the filter) —
             return to that person, not the generic Admin default. %>
         <% if @person %>
-          <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+          <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fas fa-arrow-left"></i>
             <span><%= truncate(@person.name, length: 30) %></span>
           <% end %>
         <% elsif allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -3,7 +3,7 @@
 
       <div class="flex flex-wrap items-center gap-y-2 mb-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+          <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fas fa-arrow-left"></i>
             <span>Admin</span>
           <% end %>

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
   <div class="mb-2 flex flex-wrap items-center gap-y-2">
     <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
-      <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+      <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fas fa-arrow-left"></i>
         <span>Admin</span>
       <% end %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -7,14 +7,14 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if back_path %>
-      <%= link_to back_path, class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i>
         <%= params[:return_to] == "person" ? @affiliation.person&.full_name : @affiliation.organization&.name %>
       <% end %>
     <% else %>
       <span></span>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <h1 class="text-2xl font-semibold text-gray-900 tracking-tight mb-1">Edit affiliation</h1>

--- a/app/views/allocations/index.html.erb
+++ b/app/views/allocations/index.html.erb
@@ -7,35 +7,35 @@
     <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
       <% if @allocatable.is_a?(EventRegistration) && params[:return_to] == "bulk_payments" %>
         <%# Re-expand the originating submission's row and scroll to it on return. %>
-        <%= link_to bulk_payments_return_path(@allocatable.event), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to bulk_payments_return_path(@allocatable.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "registrants" %>
-        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) && params[:return_to] == "onboarding" %>
-        <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
         <% end %>
       <% elsif @allocatable.is_a?(EventRegistration) %>
-        <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registration
         <% end %>
       <% elsif @allocatable.is_a?(ContinuingEducationRegistration) %>
-        <%= link_to edit_continuing_education_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to edit_continuing_education_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> CE registration
         <% end %>
       <% elsif @allocatable.respond_to?(:event) %>
-        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+        <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
         <% end %>
       <% else %>
         <span></span>
       <% end %>
       <div class="flex items-center gap-3">
-        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
-        <%= link_to "All allocations", allocations_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "All allocations", allocations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
     </div>
 
@@ -124,7 +124,7 @@
       registrants index (left-aligned title, filter form, results table). ---- %>
   <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:payments) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-      <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
 
     <div class="flex flex-wrap items-center justify-between gap-4 mb-6">

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-white") %>
 <div class="mb-3">
-  <%= link_to admin_path, class: "text-sm #{eyebrow_link_class}" do %>
+  <%= link_to admin_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
   <% end %>
 </div>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back link + secondary links, matching the scholarship edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
-    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label %>
     <% end %>
     <div class="flex items-center gap-3">
@@ -18,7 +18,7 @@
             icon: "fa-solid fa-id-card text-2xs",
             href: registration_ce_path(registration.slug, return_to: "ce_registration"),
             target: "_blank", rel: "noopener" %>
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/continuing_education_registrations/index.html.erb
+++ b/app/views/continuing_education_registrations/index.html.erb
@@ -3,10 +3,10 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top-left menu: jump to the cross-event CE sign-ins. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to signins_events_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to signins_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-clipboard-check text-xs"></i> CE sign-ins
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="flex items-center gap-3 mb-6">

--- a/app/views/continuing_education_registrations/new.html.erb
+++ b/app/views/continuing_education_registrations/new.html.erb
@@ -5,10 +5,10 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: back link + Home, matching the CE edit page. %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
-    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= ce_registration_return_label %>
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <%= render "shared/event_page_header",

--- a/app/views/continuing_education_registrations/show.html.erb
+++ b/app/views/continuing_education_registrations/show.html.erb
@@ -8,12 +8,12 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back to the CE registrations index + Edit / Home. %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> CE registrations
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "Edit", edit_continuing_education_registration_path(@ce_registration, return_to: "ce_index"), class: "text-sm #{eyebrow_link_class}" %>
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Edit", edit_continuing_education_registration_path(@ce_registration, return_to: "ce_index"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -7,51 +7,51 @@
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if params[:return_to] == "bulk_payments" %>
       <%# Re-expand the originating submission's row and scroll to it on return. %>
-      <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to bulk_payments_return_path(@event_registration.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Bulk payments
       <% end %>
     <% elsif params[:return_to] == "preview_reminder" %>
-      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to preview_reminder_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Send reminders
       <% end %>
     <% elsif params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif params[:return_to] == "attendees" %>
-      <%= link_to attendees_events_path, class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to attendees_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Attendees
       <% end %>
     <% elsif params[:return_to] == "roster" %>
-      <%= link_to roster_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to roster_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Roster
       <% end %>
     <%# Two ways in from the recipients page: a recipient's name (back to their own
         card) and the feature-a-shout-out flow (back to the shout-outs section). %>
     <% elsif params[:return_to] == "recipient_card" %>
-      <%= link_to recipients_event_card_path(@event_registration.event, @event_registration.slug), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to recipients_event_card_path(@event_registration.event, @event_registration.slug), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarship recipients
       <% end %>
     <% elsif params[:return_to] == "recipients" %>
-      <%= link_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to recipients_event_path(@event_registration.event, anchor: "shout-outs"), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
       <% end %>
     <% elsif params[:return_to] == "index" %>
-      <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
       <% end %>
     <% elsif params[:return_to] == "attendance" %>
-      <%= link_to attendance_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to attendance_event_path(@event_registration.event), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Sign-ins
       <% end %>
     <% else %>
-      <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "View", event_registration_path(@event_registration), class: "text-sm #{eyebrow_link_class}" %>
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "View", event_registration_path(@event_registration), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -6,9 +6,9 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="mb-4">
     <% if params[:return_to] == "onboarding" %>
-      <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% else %>
-      <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
   <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">

--- a/app/views/event_registrations/new.html.erb
+++ b/app/views/event_registrations/new.html.erb
@@ -3,10 +3,10 @@
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link, matching the event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <%# Title block %>

--- a/app/views/event_registrations/transfer.html.erb
+++ b/app/views/event_registrations/transfer.html.erb
@@ -10,7 +10,7 @@
   roster_path = registrants_event_path(source.event)
 %>
 <div class="mb-4">
-  <%= link_to roster_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+  <%= link_to roster_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i>
     <%= source.event.title %> registrants
   <% end %>

--- a/app/views/events/attendance.html.erb
+++ b/app/views/events/attendance.html.erb
@@ -10,13 +10,13 @@
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% case params[:return_to] %>
       <% when "dashboard" %>
-        <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% when "registrants" %>
-        <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% when "signins" %>
-        <%= link_to "← All sign-ins", signins_events_path(report_to_hub_params.except(:period)), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← All sign-ins", signins_events_path(report_to_hub_params.except(:period)), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
-        <%= link_to "← Events participation", participation_events_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Events participation", participation_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <%= render "events/subnav", event: @event, current: :attendance %>
     </div>

--- a/app/views/events/attendees.html.erb
+++ b/app/views/events/attendees.html.erb
@@ -11,16 +11,16 @@
       <div>
       <% case params[:return_to] %>
       <% when "participation" %>
-        <%= link_to "← Event participation", participation_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Event participation", participation_events_path(report_return), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% when "revenue" %>
-        <%= link_to "← Event revenue", revenue_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Event revenue", revenue_events_path(report_return), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% when "reports" %>
-        <%= link_to "← Event reports", reports_events_path(report_return), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Event reports", reports_events_path(report_return), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
         <% if @filter_event %>
-          <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class}" %>
+          <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% else %>
-          <%= link_to "← Event reports", reports_events_path, class: "text-sm #{eyebrow_link_class}" %>
+          <%= link_to "← Event reports", reports_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       <% end %>
       </div>

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -3,7 +3,7 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,7 +3,7 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -6,7 +6,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
   <%# Title block with the action buttons pinned top-right so they share the

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-4">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :edit %>
   </div>
   <div class="flex items-center justify-between mb-3">

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-5xl mx-auto px-4 pt-4">
-  <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class}" do %>
+  <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     &larr; Back to registrants
   <% end %>
 

--- a/app/views/events/onboarding.html.erb
+++ b/app/views/events/onboarding.html.erb
@@ -3,7 +3,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow m-2 p-4">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -6,7 +6,7 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% label, return_path = participation_return_link %>
-      <%= link_to label, return_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to label, return_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= render "events/report_subnav", current: :details %>
     </div>
 

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -2,7 +2,7 @@
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 

--- a/app/views/events/program_statuses.html.erb
+++ b/app/views/events/program_statuses.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <%= render "events/report_subnav", current: :program_statuses %>
     </div>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -16,7 +16,7 @@
 <div class="bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :scholarships %>
   </div>
   <%# Reports / Grants are cross-page navigation, so they read as text links; only

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -7,9 +7,9 @@
   <%# Top bar: eyebrow + sub-nav, matching the other event pages. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <% if params[:return_to] == "scholarships" %>
-      <%= link_to "← Events scholarships", scholarships_report_return_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Events scholarships", scholarships_report_return_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% else %>
-      <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>

--- a/app/views/events/reports.html.erb
+++ b/app/views/events/reports.html.erb
@@ -6,13 +6,13 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if @filter_event %>
-        <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% elsif params[:return_to] == "events" || !current_user&.super_user? %>
         <%# Event owners reach the unfiltered hub too, and can't follow the admin
             home link — send them back to the events index instead. %>
-        <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
-        <%= link_to "← Admin home", admin_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Admin home", admin_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
     </div>
 

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
     </div>
 

--- a/app/views/events/roster.html.erb
+++ b/app/views/events/roster.html.erb
@@ -12,7 +12,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :roster %>
   </div>
   <% print_button = capture do %>

--- a/app/views/events/scholarships.html.erb
+++ b/app/views/events/scholarships.html.erb
@@ -6,9 +6,9 @@
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
-        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% else %>
-        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <%= render "events/report_subnav", current: :scholarships %>
     </div>

--- a/app/views/events/signins.html.erb
+++ b/app/views/events/signins.html.erb
@@ -7,7 +7,7 @@
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
-      <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= render "events/report_subnav", current: :signins %>
     </div>
 

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -7,7 +7,7 @@
 <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
-    <%= link_to "← Event", event_path(@event), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Event", event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:manage?, @event) %>
       <%= render "events/subnav", event: @event, current: nil %>
     <% end %>

--- a/app/views/features/show.html.erb
+++ b/app/views/features/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="w-full max-w-3xl mx-auto">
   <div class="mb-3">
-    <%= link_to features_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left"></i> Features &amp; tips
     <% end %>
   </div>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -4,13 +4,13 @@
   <div class="w-full">
     <% if params[:return_to] == "forms" && @form %>
       <div class="mb-4">
-        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Forms
         <% end %>
       </div>
     <% elsif @person %>
       <div class="mb-4">
-        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
           <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
         <% end %>
       </div>

--- a/app/views/membership_invoices/edit.html.erb
+++ b/app/views/membership_invoices/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/membership_invoices/new.html.erb
+++ b/app/views/membership_invoices/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -4,10 +4,10 @@
 
 <div class="mx-auto max-w-3xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= @person.full_name %>
     <% end %>
-    <%= link_to "All memberships", membership_invoices_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "All memberships", membership_invoices_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="flex flex-wrap items-end justify-between gap-2 mb-6">

--- a/app/views/memberships/new.html.erb
+++ b/app/views/memberships/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -5,11 +5,11 @@
     or to admin home when reached directly. %>
 <div class="mb-3">
   <% if return_record %>
-    <%= link_to notification_return_path(return_record), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to notification_return_path(return_record), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= noticeable_label(return_record) %>
     <% end %>
   <% else %>
-    <%= link_to admin_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to admin_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
     <% end %>
   <% end %>

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="mx-auto max-w-3xl">
   <div class="mb-3">
-    <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
     <% end %>
   </div>
@@ -78,7 +78,7 @@
       </div>
 
       <div class="mt-6 flex items-center justify-end gap-3">
-        <%= link_to "Cancel", notifications_path, class: "text-sm #{eyebrow_link_class}" %>
+        <%= link_to "Cancel", notifications_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= f.button :submit, t("communications.new"),
                      class: "btn btn-primary" %>
       </div>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -5,7 +5,7 @@
    ========================================= %>
 
 <div class="mb-3">
-  <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class}" do %>
+  <%= link_to notifications_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
   <% end %>
 </div>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
           <div class="mb-2">
-            <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
+            <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
               <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
             <% end %>
           </div>

--- a/app/views/people/_membership.html.erb
+++ b/app/views/people/_membership.html.erb
@@ -1,7 +1,7 @@
 <div class="admin-only bg-blue-100 border border-blue-200 rounded-lg shadow-sm">
   <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3 border-b border-blue-200">
     <h2 class="text-xl font-semibold text-gray-800">Membership</h2>
-    <%= link_to "Manage membership", person_memberships_path(person), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Manage membership", person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="section-content px-3 sm:px-4 py-4">

--- a/app/views/people/all_comments.html.erb
+++ b/app/views/people/all_comments.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-white") %>
 <div class="mb-3">
-  <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class}" do %>
+  <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to <%= @person.full_name %>
   <% end %>
 </div>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -3,13 +3,13 @@
         <div class="sticky top-0 z-10 <%= DomainTheme.bg_class_for(:people) %> pb-3">
           <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
             <div class="mb-2">
-              <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
+              <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
                 <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
               <% end %>
             </div>
           <% elsif params[:return_to] == "registration_link" && params[:event_registration_id].present? %>
             <div class="mb-2">
-              <%= link_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence), class: "text-sm #{eyebrow_link_class}" do %>
+              <%= link_to link_organization_event_registration_path(params[:event_registration_id], return_to: params[:link_org_return_to].presence), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
                 <i class="fa-solid fa-arrow-left text-xs"></i> Organization linking
               <% end %>
             </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -4,7 +4,7 @@
 <% if params[:return_to] == "registrants" && params[:event_id].present? %>
   <% back_registration = @person.event_registrations.find_by(event_id: params[:event_id]) %>
   <div class="mb-3">
-    <%= link_to(back_registration ? registrants_event_row_path(params[:event_id], back_registration.id) : registrants_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class}") do %>
+    <%= link_to(back_registration ? registrants_event_row_path(params[:event_id], back_registration.id) : registrants_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1") do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to registrants
     <% end %>
   </div>

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>

--- a/app/views/professional_licenses/index.html.erb
+++ b/app/views/professional_licenses/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
-    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-certificate text-xs"></i> CE registrations
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="flex justify-end mb-6">

--- a/app/views/professional_licenses/new.html.erb
+++ b/app/views/professional_licenses/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -7,31 +7,31 @@
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if grant_nav %>
-      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(grant) : grant_path(grant)), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
-      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "recipients" %>
-      <%= link_to recipients_event_card_path(@allocatable.event, params[:participant]), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to recipients_event_card_path(@allocatable.event, params[:participant]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Recipients
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% elsif grant.present? %>
-      <%= link_to grant_path(grant), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to grant_path(grant), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% else %>
-      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
       <% end %>
     <% end %>
@@ -47,8 +47,8 @@
                    href: registration_scholarship_path(@allocatable.slug, return_to: "scholarship"),
                    target: "_blank", rel: "noopener" %>
       <% end %>
-      <%= link_to "View", scholarship_path(@scholarship), class: "text-sm #{eyebrow_link_class}" %>
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "View", scholarship_path(@scholarship), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -5,28 +5,28 @@
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if @grant %>
-      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "registration" %>
-      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to edit_event_registration_path(@allocatable), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registration
       <% end %>
     <% elsif @allocatable.respond_to?(:event) && params[:return_to] == "onboarding" %>
-      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to onboarding_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
       <% end %>
     <% elsif @allocatable.respond_to?(:event) %>
-      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to registrants_event_row_path(@allocatable.event, @allocatable.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Registrants
       <% end %>
     <% else %>
-      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class}" do %>
+      <%= link_to scholarships_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarships
       <% end %>
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/topic_subscription_types/edit.html.erb
+++ b/app/views/topic_subscription_types/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit topic</h1>
   <%= render "form", submit_label: "Save changes" %>

--- a/app/views/topic_subscription_types/index.html.erb
+++ b/app/views/topic_subscription_types/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscription_types) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Subscriptions", topic_subscriptions_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Subscriptions", topic_subscriptions_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">

--- a/app/views/topic_subscription_types/new.html.erb
+++ b/app/views/topic_subscription_types/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
   <div class="mb-6">
-    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
   <h1 class="text-2xl font-semibold text-gray-900 mb-6">New topic</h1>
   <%= render "form", submit_label: "Add topic" %>

--- a/app/views/topic_subscriptions/_eyebrow.html.erb
+++ b/app/views/topic_subscriptions/_eyebrow.html.erb
@@ -1,4 +1,4 @@
 <%# Back link adapts to where the form was opened from (an event's Forms menu, a
     person's associated records, or the subscriptions index). %>
 <% back_label, back_path = topic_subscription_return_link %>
-<%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class}" %>
+<%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/topic_subscriptions/email_addresses.html.erb
+++ b/app/views/topic_subscriptions/email_addresses.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="mb-6">

--- a/app/views/topic_subscriptions/index.html.erb
+++ b/app/views/topic_subscriptions/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class}" %>
+    <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <div class="flex items-center gap-4">
-      <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class}" %>
-      <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,7 +12,7 @@
       <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8 space-y-6">
 
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
-          <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
+          <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
           <% end %>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div>
         <div class="flex gap-2 items-center">
-          <%= link_to flow_diagram_users_path, class: "text-sm #{eyebrow_link_class}" do %>
+          <%= link_to flow_diagram_users_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fa-solid fa-diagram-project"></i> Account flow diagram
           <% end %>
           <% if allowed_to?(:new?, User) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
   <div class="mb-2">
-    <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class}" do %>
+    <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Onboarding
     <% end %>
   </div>

--- a/app/views/video_recordings/index.html.erb
+++ b/app/views/video_recordings/index.html.erb
@@ -32,7 +32,7 @@
 
       <div class="text-right space-y-2">
         <% if @video_type == "instructional" %>
-          <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm #{eyebrow_link_class}" %>
+          <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:new?, VideoRecording) %>
           <%= link_to "New #{VideoRecording.model_name.human.downcase}",

--- a/app/views/video_recordings/show.html.erb
+++ b/app/views/video_recordings/show.html.erb
@@ -49,9 +49,9 @@
         <!-- Back Button -->
         <div class="mt-8">
           <% if @video_recording.is_instructional? %>
-            <%= link_to "← Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class}" %>
+            <%= link_to "← Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% else %>
-            <%= link_to "← Videos", video_recordings_path(video_type: "all"), class: "text-sm #{eyebrow_link_class}" %>
+            <%= link_to "← Videos", video_recordings_path(video_type: "all"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% end %>
         </div>
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 adds `px-2 py-1` to 128 back-nav eyebrow links so they match the standard; verified by view specs

Follow-up to #2292 (merged, added `eyebrow_link_class`).

### Goal
- 128 back-nav / eyebrow links used the shared `eyebrow_link_class` color but omitted the `px-2 py-1` the standard eyebrows carry, so they sat slightly out of line.
- Pad them so every back-nav eyebrow is visually identical — same helper, same class string.

### Scope
- Only the plain unpadded back-nav eyebrows (`text-sm #{eyebrow_link_class}` at the end of the class list) — confirmed nav links ("← Subscriptions", "Home", back links).
- **Left distinct components alone**: `text-xs` "View all" links, edit/close toggle buttons (`<summary>`, search close-X, edit toggles), and a few eyebrows with special margins.

### Verification
- Full view-spec suite green (494 examples, 0 failures). No new Tailwind classes, so no build change.

### Note
- Visual consistency, not new single-control — fully single-controlling eyebrow size/padding would be the two-helper split discussed on #2292.