### PR TITLE
Add registration date-range filter to the shared registrant filter bar

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ When changing a model or controller, check whether these related files need upda
 | Decorator | Decorator spec |
 | Mailer (add/remove) | Mailer spec, mailer preview (follow existing patterns) |
 | Add/remove model, concern, service, or gem | AGENTS.md |
-| Ship a user-facing feature | `config/features.yml` (the Features & tips seed — see below) |
+| Ship a user-facing feature **or improvement/change** | `config/features.yml` (the Features & tips seed — see below) |
 
 ## Code Style
 
@@ -280,9 +280,21 @@ The login-gated **Features & tips** page lists shipped, user-facing features
 (`Feature` model) and edited in-app by super-admins — the rich `description` uses
 the Rhino WYSIWYG (for screenshots), plus an optional external process-doc link.
 
-**Keep it current as you ship.** When you add a user-facing feature, append an
-entry to `config/features.yml` (the checked-in **seed**):
+**Keep it current as you ship.** When you ship anything a facilitator or admin
+would want to know about, append an entry to `config/features.yml` (the checked-in
+**seed**). This is **not just brand-new features** — a user-facing *improvement,
+change, or enhancement* to something that already exists (a new filter, an extra
+column, a reworked flow) belongs here too. If in doubt whether a change is "big
+enough," add it: a short entry is cheap and the page is where non-devs discover
+what changed.
 
+- **There is no separate "feature vs. update" flag** — every entry is just a
+  `Feature` row, and audience is the only axis (`display_status`). Signal that an
+  entry is a smaller update through its `summary`/`name` wording (e.g. "Filter
+  registrants by registration date"), not a schema field. (If we ever want the UI
+  to visually separate launches from tweaks, that's a `kind:` column on `Feature` +
+  `CATALOG_FIELDS` + a decorator badge — a deliberate change, not something to
+  fake with `area`/`display_status`.)
 - Fields: `name`, `area` (a `Feature::AREA_KEYS` value), `display_status`
   (`public_facing` / `user_facing` / `admin_facing`), `summary` (1–2 plain
   sentences), `released_on` (ship date), plus optional `pro_tips` (list),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ When changing a model or controller, check whether these related files need upda
 | Decorator | Decorator spec |
 | Mailer (add/remove) | Mailer spec, mailer preview (follow existing patterns) |
 | Add/remove model, concern, service, or gem | AGENTS.md |
-| Ship a user-facing feature | `config/features.yml` (the Features & tips seed — see below) |
+| Ship a user-facing feature **or improvement/change** | `config/features.yml` (the Features & tips seed — see below) |
 
 ## Code Style
 
@@ -291,9 +291,21 @@ see what the portal does. It is **database-backed** (`Feature` model) and edited
 in-app by super-admins — the rich `description` uses the Rhino WYSIWYG (so pages
 can carry screenshots), and each feature can link an external process doc.
 
-**Keep it current as you ship.** When you add a user-facing feature, append an
-entry to `config/features.yml` (the checked-in **seed**):
+**Keep it current as you ship.** When you ship anything a facilitator or admin
+would want to know about, append an entry to `config/features.yml` (the checked-in
+**seed**). This is **not just brand-new features** — a user-facing *improvement,
+change, or enhancement* to something that already exists (a new filter, an extra
+column, a reworked flow) belongs here too. If in doubt whether a change is "big
+enough," add it: a short entry is cheap and the page is where non-devs discover
+what changed.
 
+- **There is no separate "feature vs. update" flag** — every entry is just a
+  `Feature` row, and audience is the only axis (`display_status`). Signal that an
+  entry is a smaller update through its `summary`/`name` wording (e.g. "Filter
+  registrants by registration date"), not a schema field. (If we ever want the UI
+  to visually separate launches from tweaks, that's a `kind:` column on `Feature` +
+  `CATALOG_FIELDS` + a decorator badge — a deliberate change, not something to
+  fake with `area`/`display_status`.)
 - Fields: `name`, `area` (a `Feature::AREA_KEYS` value), `display_status`
   (`public_facing` / `user_facing` / `admin_facing`), `summary` (1–2 plain
   sentences), `released_on` (ship date), plus optional `pro_tips` (list),

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -228,6 +228,7 @@ class EventsController < ApplicationController
     scope = scope.registrant_state(params[:state]) if params[:state].present?
     scope = scope.registrant_county(params[:county]) if params[:county].present?
     scope = scope.registrant_sector(params[:sector]) if params[:sector].present?
+    scope = scope.registered_between(params[:registered_from], params[:registered_to])
 
     @active_count = scope.active.count
     @inactive_count = scope.inactive.count

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -136,6 +136,15 @@
   text-decoration: line-through;
 }
 
+/* An empty date filter renders its mm/dd/yyyy hint in the field's text color,
+   not a ::placeholder, so it can't be greyed with placeholder:* utilities. Match
+   it to the neighboring placeholders (placeholder:text-gray-400). The empty class
+   is only present while the field has no value (see events/_filter_date), so a
+   real date still renders in the normal text color. */
+input.date-filter-empty::-webkit-datetime-edit {
+  color: var(--color-gray-400);
+}
+
 /* Tom Select "flat" variant: the wrapper inherits the field's bordered box,
    so the inner control is transparent and borderless — no box-within-a-box.
    Used for optional searchable-selects (e.g. the event location) so the field

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -203,6 +203,19 @@ class EventRegistration < ApplicationRecord
   # Registrations whose event falls in the given calendar year. Uses a subquery
   # (via Event.in_year) so it composes with the other filters without extra joins.
   scope :in_event_year, ->(year) { where(event_id: Event.in_year(year.to_i)) }
+  # Registration date range, matched on when the registration was created. Accepts
+  # raw "YYYY-MM-DD" filter strings and no-ops on either end when blank/unparseable,
+  # so callers can pass params straight through.
+  scope :registered_between, ->(start_date, end_date) {
+    scope = all
+    if (from = parse_filter_date(start_date))
+      scope = scope.where(created_at: from.beginning_of_day..)
+    end
+    if (to = parse_filter_date(end_date))
+      scope = scope.where(created_at: ..to.end_of_day)
+    end
+    scope
+  }
   scope :registrant_state, ->(state) {
     joins(registrant: :addresses)
       .where(addresses: { inactive: false, state: state })
@@ -300,6 +313,13 @@ class EventRegistration < ApplicationRecord
     Allocation
       .where(allocatable_type: "EventRegistration", source_type: "Scholarship", source_id: scholarships.select(:id))
       .select(:allocatable_id)
+  end
+
+  def self.parse_filter_date(value)
+    return if value.blank?
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
   end
   # Funding source of a registrant's scholarship. "awbw" = org-subsidized (no
   # grant, or a grant AWBW funded itself); "external" = grant-funded (drawn from an

--- a/app/services/reminder_recipient_filter.rb
+++ b/app/services/reminder_recipient_filter.rb
@@ -22,12 +22,16 @@ class ReminderRecipientFilter
   # keeps registrants whose person holds an active subscription to the chosen topic
   # subscription list; matched in memory against the registrant's topic_subscriptions.
   PICKER_KEYS = %i[ topic_subscription ].freeze
-  FILTER_KEYS = (TEXT_KEYS + DROPDOWN_KEYS + PICKER_KEYS).freeze
+  # Registration date-range filters shared with the roster. Backed by the
+  # EventRegistration.registered_between scope (run once as a query), so the same
+  # range narrows both pages identically.
+  DATE_KEYS = %i[ registered_from registered_to ].freeze
+  FILTER_KEYS = (TEXT_KEYS + DROPDOWN_KEYS + PICKER_KEYS + DATE_KEYS).freeze
   # Every key above that is also a registrants-roster param, so the roster's
   # "Send bulk emails" link can carry the active filters straight into the picker
   # (see EventHelper#reminder_recipient_filters). The remaining text keys (name,
   # reg_org, email) exist only here.
-  SHARED_ROSTER_KEYS = (DROPDOWN_KEYS + %i[ funder_name comment city ]).freeze
+  SHARED_ROSTER_KEYS = (DROPDOWN_KEYS + DATE_KEYS + %i[ funder_name comment city ]).freeze
 
   def initialize(event_registrations, params, event: nil)
     @event_registrations = event_registrations
@@ -58,13 +62,14 @@ class ReminderRecipientFilter
       matches_city?(reg)
   end
 
-  # Apply the registrants-roster scopes for whichever dropdowns are set, then
-  # return the matching ids. With no dropdown filter this is every registration,
-  # so the text-match set passes through unchanged.
+  # Apply the registrants-roster scopes for whichever dropdowns / date-range
+  # filters are set, then return the matching ids. With none set this is every
+  # registration, so the text-match set passes through unchanged.
   def dropdown_matched_ids
     return @event_registrations.map(&:id).to_set if @event.nil?
 
     scope = @event.event_registrations
+    scope = scope.registered_between(@params[:registered_from], @params[:registered_to])
     scope = scope.attendance_status(@params[:attendance_status]) if @params[:attendance_status].present?
     scope = scope.payment_status(@params[:payment_status]) if @params[:payment_status].present?
     scope = scope.payment_method(@params[:payment_method]) if @params[:payment_method].present?

--- a/app/views/events/_filter_date.html.erb
+++ b/app/views/events/_filter_date.html.erb
@@ -1,0 +1,11 @@
+<%# Shared labeled date filter for the registrant filter bar — the date-input
+    sibling of events/_filter_text, so date-range boxes match the dropdowns and
+    text inputs. Locals:
+      param        – input name/id (Symbol)
+      label        – field label
+      field_class  – Tailwind classes for the <input>
+      wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
+<div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
+  <%= label_tag param, label, class: search_label_class %>
+  <%= date_field_tag param, params[param], class: field_class %>
+</div>

--- a/app/views/events/_filter_date.html.erb
+++ b/app/views/events/_filter_date.html.erb
@@ -5,7 +5,13 @@
       label        – field label
       field_class  – Tailwind classes for the <input>
       wrapper_class – optional wrapper width (defaults to the roster's w-48) %>
+<%# A native date input has no ::placeholder, so the browser renders its
+    mm/dd/yyyy format hint in the field's own text color (dark). Tag it empty so
+    the stylesheet can grey that hint to match the text/select placeholders next
+    to it; the class drops once a date is set (server-rendered), so a real value
+    stays dark. %>
+<% input_class = params[param].present? ? field_class : "#{field_class} date-filter-empty" %>
 <div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
   <%= label_tag param, label, class: search_label_class %>
-  <%= date_field_tag param, params[param], class: field_class %>
+  <%= date_field_tag param, params[param], class: input_class %>
 </div>

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -25,7 +25,7 @@
 <% primary_text, more_text = Array(text_fields).partition { |f| f[:primary] } %>
 <%# Open the collapsed section on load when any control inside it already carries
     a value, so an active filter is never hidden behind the toggle. %>
-<% collapsed_keys = %i[submission_status payment_method org_status scholarship funder_name ce_status city state county account_status comment_status comment topic_subscription] %>
+<% collapsed_keys = %i[submission_status payment_method org_status scholarship funder_name ce_status city state county account_status comment_status comment topic_subscription registered_from registered_to] %>
 <% more_active = more_text.any? { |f| params[f[:param]].present? } || collapsed_keys.any? { |k| params[k].present? } %>
 
 <% hidden = capture do %>
@@ -146,6 +146,11 @@
 
   <%= render "events/filter_text", param: :comment, label: "Comment text",
         placeholder: "Topic or content", field_class: field_class %>
+
+  <%# Registration date range — filters on when the registration was created
+      (event_registrations.created_at). Shared across both pages. %>
+  <%= render "events/filter_date", param: :registered_from, label: "Registered from", field_class: field_class %>
+  <%= render "events/filter_date", param: :registered_to, label: "Registered to", field_class: field_class %>
 <% end %>
 
 <%= render "events/filter_bar", url: url, frame: frame, clear_url: clear_url,

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,24 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Filter registrants by registration date"
+  area: events
+  display_status: user_facing
+  released_on: 2026-08-21
+  action_path: "/events"
+  summary: >-
+    Narrow the registrants roster to people who registered within a date range, using new
+    "Registered from" and "Registered to" filters.
+  description: >-
+    The registrants roster now has a registration date range in its filters — set a
+    "Registered from" date, a "Registered to" date, or both, to show only the people who
+    signed up in that window. It works alongside every other filter, so you can combine it
+    with attendance, payment, scholarship and the rest. The same range carries over when
+    you open "Send bulk emails" from the roster, so a date-filtered roster pre-selects the
+    matching recipients for a reminder.
+  pro_tips:
+    - "Leave one end blank for an open-ended range — e.g. just \"Registered from\" for everyone who signed up on or after a date."
+
 - name: "Choose how you're credited on what you share"
   area: people
   display_status: user_facing

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1684,3 +1684,20 @@ if facilitator_training && registration_form
     end
   end
 end
+
+# Spread each registration's "registered on" date (created_at) around its event's
+# start instead of leaving it at the seed run's "today", so the roster's
+# registration-date filter has realistic data to work with. Most people register
+# in advance (days to weeks before the event); a couple register a day or two
+# after it starts (late / at-the-door). The offset is derived from the
+# registration id, so re-seeding keeps the same spread and this stays idempotent.
+puts "Spreading registration dates around each event's start…"
+# Days BEFORE the event start; the two negatives put a couple registrations just
+# after the start. Weighted toward the final weeks, with a long early-bird tail.
+registration_day_offsets = [ 56, 45, 38, 30, 28, 24, 21, 18, 16, 14, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, -1, -2 ]
+EventRegistration.includes(:event).find_each do |registration|
+  start = registration.event&.start_date
+  next unless start
+  offset_days = registration_day_offsets[registration.id % registration_day_offsets.length]
+  registration.update_column(:created_at, start - offset_days.days)
+end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -487,6 +487,27 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe ".registered_between" do
+    let!(:early) { create(:event_registration).tap { |r| r.update_column(:created_at, Time.zone.parse("2026-01-10 09:00")) } }
+    let!(:mid) { create(:event_registration).tap { |r| r.update_column(:created_at, Time.zone.parse("2026-02-15 09:00")) } }
+    let!(:late) { create(:event_registration).tap { |r| r.update_column(:created_at, Time.zone.parse("2026-03-20 09:00")) } }
+
+    it "filters to registrations created within an inclusive date range" do
+      results = EventRegistration.registered_between("2026-02-01", "2026-02-28")
+      expect(results).to contain_exactly(mid)
+    end
+
+    it "includes registrations created on the end date (end of day)" do
+      results = EventRegistration.registered_between(nil, "2026-02-15")
+      expect(results).to contain_exactly(early, mid)
+    end
+
+    it "treats a blank or unparseable bound as open-ended" do
+      expect(EventRegistration.registered_between("2026-02-01", "")).to contain_exactly(mid, late)
+      expect(EventRegistration.registered_between("not-a-date", "not-a-date")).to contain_exactly(early, mid, late)
+    end
+  end
+
   describe ".comment_text" do
     it "matches registrations whose comment topic or body contains the term" do
       reg_body = create(:event_registration)

--- a/spec/services/reminder_recipient_filter_spec.rb
+++ b/spec/services/reminder_recipient_filter_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe ReminderRecipientFilter do
       expect(matched({ funder_name: "acme" }, [ reg, ungranted ])).to eq([ reg.id ].to_set)
     end
 
+    it "filters by registration date range" do
+      early = registration(first_name: "Early").tap { |r| r.update_column(:created_at, Time.zone.parse("2026-01-10")) }
+      mid = registration(first_name: "Mid").tap { |r| r.update_column(:created_at, Time.zone.parse("2026-02-15")) }
+      late = registration(first_name: "Late").tap { |r| r.update_column(:created_at, Time.zone.parse("2026-03-20")) }
+      params = { registered_from: "2026-02-01", registered_to: "2026-02-28" }
+      expect(matched(params, [ early, mid, late ])).to eq([ mid.id ].to_set)
+    end
+
     it "filters by email address" do
       amy = registration(first_name: "Amy", email: "amy@example.com", user: nil)
       sam = registration(first_name: "Sam", email: "sam@example.com", user: nil)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one new scope + service wiring behind a shared filter partial, plus dev-seed and CSS support

### What is the goal of this PR and why is this important?
- Let facilitators segment an event's roster by *when* people registered (e.g. remind only recent sign-ups).
- The registrants roster and the bulk-reminder recipient picker share one filter partial, so the range lands on both pages at once.

### How did you approach the change?
- **Filter:** new `EventRegistration.registered_between` scope (filters on `created_at`, inclusive end-of-day, no-ops on blank/unparseable bounds) + `parse_filter_date` helper — mirrors `Payment.created_between`. Added "Registered from" / "Registered to" date inputs to the end of `events/_registrant_filters` via a new `_filter_date` sub-partial; applied in `EventsController#registrants` and in `ReminderRecipientFilter` (new `DATE_KEYS`), so a date-filtered roster carries the range into "Send bulk emails".
- **Dev seeds:** backdate each seeded registration's `created_at` relative to its event's start (mostly days/weeks before, a couple after) so the filter has realistic data — was all "today".
- **Polish:** a native date input has no `::placeholder`, so its `mm/dd/yyyy` hint rendered dark; grey it (only while empty) to match the neighboring `placeholder:text-gray-400` filters.
- Logged the feature in `config/features.yml`; broadened the AI-instruction files so user-facing *improvements* (not just new features) get a features.yml entry.

### UI Testing Checklist
- [ ] On the registrants roster, "Registered from"/"Registered to" narrow to registrations created in the range (either bound optional); active/inactive counts update too.
- [ ] From a date-filtered roster, "Send bulk emails (filtered)" pre-checks only the matching recipients.
- [ ] An active date value auto-expands the collapsed "More filters" section.
- [ ] Empty date fields show a light-grey `mm/dd/yyyy` hint matching the other placeholders.

### Anything else to add?
- No migration — reuses the existing `event_registrations.created_at`. New model + service specs added; full system suite not run.