### PR TITLE
Catalog recently-shipped features in the Features & tips seed

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -45,6 +45,56 @@
   pro_tips:
     - "Leave one end blank for an open-ended range — e.g. just \"Registered from\" for everyone who signed up on or after a date."
 
+- name: "Portal colors aligned with the AWBW brand"
+  area: content
+  display_status: public_facing
+  released_on: 2026-08-21
+  pr_number: 2282
+  external_url: "https://github.com/rubyforgood/awbw/blob/main/app/assets/images/brand/awbw-brand-guide.pdf"
+  summary: >-
+    The portal's core colors now match AWBW's official brand palette, so it looks like
+    the rest of AWBW. The primary blue, the green on action buttons, and the orange
+    accent all use the exact brand values.
+  description: >-
+    We reconciled the portal's theme with the official AWBW brand guide. The primary
+    color moved from a darker navy to the true brand blue (#24479E), the green on
+    "registered" and confirmation buttons is now the brand green (#4E8324), and the
+    orange accent is the brand orange (#D56027). These carry across buttons, links,
+    banners, and highlights throughout the portal. The brand guide is linked below for
+    reference.
+
+- name: "Smart field name on every form field"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-21
+  action_path: "/forms"
+  pr_number: 2273
+  summary: >-
+    Every form field now shows its "smart field name" — the identifier that wires a
+    field to backend logic — with a "What's this?" link to a reference page, instead
+    of hiding it behind a URL flag.
+
+- name: "Name pronunciation on profiles"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-20
+  action_path: "/people/1"
+  pr_number: 2271
+  summary: >-
+    A person's edit form has a name-pronunciation field, so you can record how to say
+    someone's name alongside their pronouns.
+
+- name: "License credentials on staff cards"
+  area: people
+  display_status: public_facing
+  released_on: 2026-08-19
+  action_path: "/events/1/staff"
+  pr_number: 2263
+  summary: >-
+    Staff flip-cards — on the event staff page and the registrant staff callout — show
+    a person's license-derived credentials after their name, matching their profile,
+    when their profile is set to display credentials.
+
 - name: "Choose how you're credited on what you share"
   area: people
   display_status: user_facing
@@ -187,6 +237,18 @@
       people's primary tags.
     - The "Facilitators since" chip shows each stretch of facilitating separately,
       so a lapse and a return read as two periods.
+
+- name: "\"In memoriam\" designation on legacy grants"
+  area: scholarships
+  display_status: admin_facing
+  released_on: 2026-08-17
+  action_path: "/grants"
+  pr_number: 2244
+  summary: >-
+    Legacy Circle grants can be flagged "in memoriam" so memorial gifts are
+    distinguishable from other legacy scholarships, with a chip on the grant.
+  pro_tips:
+    - "The designation is for recognizing memorial gifts on the Story Share pages."
 
 - name: "Edit an affiliation's details and comments"
   area: people
@@ -783,6 +845,48 @@
     person, not just people with active login accounts.
 
 # ── 2026-06 ─────────────────────────────────────────────────────────────────
+
+- name: "\"Events attended\" on organization profiles"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-06-21
+  action_path: "/organizations/1"
+  pr_number: 1816
+  summary: >-
+    An organization's profile lists the events its people attended, mirroring the
+    events list already shown on person profiles.
+
+- name: "Associated records on person and organization pages"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-07-04
+  action_path: "/people/1"
+  pr_number: 1889
+  summary: >-
+    Person and organization edit and profile pages gather links to everything related
+    to that record — registrations, scholarships, affiliations, the login account, and
+    more — so you can jump straight to any of it from one place.
+
+- name: "Time zone on profiles"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-02-16
+  action_path: "/people/1"
+  pr_number: 1001
+  summary: >-
+    A person can have a time zone set on their profile, so times shown to them line up
+    with where they are.
+
+- name: "Admin account-flow reference"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-03-28
+  action_path: "/users/flow_diagram"
+  pr_number: 1442
+  summary: >-
+    A reference page (linked from the users index) diagramming how invitations, password
+    resets, email changes, and account lockout/unlock work, with an admin triage cheat
+    sheet for common "I can't sign in" situations.
 
 - name: "Refreshed registration ticket"
   area: registration

--- a/config/features.yml
+++ b/config/features.yml
@@ -250,6 +250,18 @@
   pro_tips:
     - "The designation is for recognizing memorial gifts on the Story Share pages."
 
+- name: "Features & tips page"
+  area: content
+  display_status: user_facing
+  released_on: 2026-08-16
+  action_path: "/features"
+  pr_number: 2170
+  summary: >-
+    A login-gated page listing the portal's shipped features — newest first, filterable
+    by area, audience, and date — so facilitators and admins can see what the portal does.
+  pro_tips:
+    - "Super-admins can edit any feature in place (rich descriptions with screenshots) and click \"Sync latest updates\" to pull in newly-shipped ones."
+
 - name: "Edit an affiliation's details and comments"
   area: people
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -230,13 +230,28 @@
   action_path: "/organizations"
   pr_number: 1993
   summary: >-
-    The organization list gains Sectors and Age group columns and a "Facilitators
-    since" chip, filterable by sector, age group and program status.
+    The organization list gains Sectors and Age group columns, filterable by sector,
+    age group and program status.
   pro_tips:
     - Sector and age group match the organization's own tags plus its affiliated
       people's primary tags.
-    - The "Facilitators since" chip shows each stretch of facilitating separately,
-      so a lapse and a return read as two periods.
+
+- name: "\"Facilitators since\" on organizations"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-18
+  action_path: "/organizations"
+  pr_number: 1993
+  summary: >-
+    Each organization shows how long it has been facilitating — a "Facilitators since"
+    chip on the organization index, profile, and edit form, at month precision. This is
+    about tenure, separate from the New / Ongoing / Reinstated program status.
+  pro_tips:
+    - The chip shows each stretch of facilitating separately, so a lapse and a return
+      read as two periods.
+    - A grey "Affiliated since" line appears underneath only when the org's first
+      affiliation predates its first facilitator affiliation, so the two aren't
+      redundant.
 
 - name: "\"In memoriam\" designation on legacy grants"
   area: scholarships


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 seed-data only (config/features.yml); no code or logic

### What is the goal of this PR and why is this important?
- Backfill user-facing features that shipped without a `/features` entry, so facilitators and admins can see what the portal does.

### How did you approach the change?
- Audited merged PRs against the catalog and added the gaps as `config/features.yml` entries (seed only — safe to sync in-app; never overwrites admin edits).
- **Brand-color alignment** folds the primary/success/accent changes into one entry and links the brand guide PDF.
- Added: smart field name on form fields, name pronunciation, license credentials on staff cards, "In memoriam" grants, org "Events attended", associated-records section, profile time zone, the admin account-flow reference, and the Features & tips page itself.
- Split **"Facilitators since"** (facilitating tenure) out of the program-status filters entry, since it's a separate feature from program status.

### Anything else to add?
- Data-only change; no schema, model, or view logic touched.