### PR TITLE
Rename agency_ form field identifiers to organization_ (legacy names still valid)

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -632,8 +632,13 @@ class EventRegistrationsController < ApplicationController
     form = registration.event.registration_form
     return [] unless form
 
+    organization_identifiers = %w[
+      organization_name organization_position organization_website organization_type
+      organization_street organization_city organization_state organization_zip organization_country
+    ]
+    accepted = organization_identifiers.flat_map { |identifier| FormField.aliased_identifiers(identifier) }
     field_ids = form.form_fields
-      .where(field_identifier: %w[agency_name agency_position agency_website agency_type agency_street agency_city agency_state agency_zip agency_country])
+      .where(field_identifier: accepted)
       .pluck(:field_identifier, :id).to_h
 
     entries = registration.registrant.form_submissions
@@ -642,19 +647,24 @@ class EventRegistrationsController < ApplicationController
       .includes(:form_answers)
       .map do |submission|
         answers = submission.form_answers.index_by(&:form_field_id)
-        answer = ->(identifier) { (id = field_ids[identifier]) && answers[id]&.submitted_answer }
+        # Resolve the canonical identifier to whichever spelling this form used
+        # (canonical or legacy "agency_*"), then read its answer.
+        answer = ->(identifier) do
+          id = FormField.aliased_identifiers(identifier).lazy.filter_map { |name| field_ids[name] }.first
+          id && answers[id]&.submitted_answer
+        end
         {
           submission: submission,
-          org_name: answer.call("agency_name"),
-          position: answer.call("agency_position"),
-          website: answer.call("agency_website"),
-          agency_type: answer.call("agency_type"),
+          org_name: answer.call("organization_name"),
+          position: answer.call("organization_position"),
+          website: answer.call("organization_website"),
+          agency_type: answer.call("organization_type"),
           address: {
-            street_address: answer.call("agency_street"),
-            city: answer.call("agency_city"),
-            state: answer.call("agency_state"),
-            zip_code: answer.call("agency_zip"),
-            country: answer.call("agency_country")
+            street_address: answer.call("organization_street"),
+            city: answer.call("organization_city"),
+            state: answer.call("organization_state"),
+            zip_code: answer.call("organization_zip"),
+            country: answer.call("organization_country")
           }
         }
       end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1067,12 +1067,13 @@ class EventsController < ApplicationController
   end
 
   # Maps registrant person_id => the organization name they typed on the
-  # registration form (the `agency_name` answer), in one batch query. Drives both
+  # registration form (the organization-name answer, canonical or legacy), in one
+  # batch query. Drives both
   # the roster's Pending/None org chip and the readiness "Organization not linked"
   # check, so both read the same resolved answer.
   def submitted_org_names_for(registrations)
     registration_form = @event.registration_form
-    field = registration_form&.form_fields&.find_by(field_identifier: "agency_name")
+    field = registration_form&.form_fields&.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
     return {} unless field
 
     FormAnswer.joins(:form_submission)

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -474,15 +474,16 @@ class EventRegistration < ApplicationRecord
   }
   # The registrant's organization-LINKING status, not the org's own
   # OrganizationStatus: "linked" = at least one org linked; "unlinked" = none;
-  # "pending" = an agency name was submitted but nothing is linked yet (the Pending
-  # chip on the roster). Needs the event to resolve its agency_name field.
+  # "pending" = an organization name was submitted but nothing is linked yet (the
+  # Pending chip on the roster). Needs the event to resolve its organization-name
+  # field (canonical "organization_name" or the legacy "agency_name").
   scope :organization_linking_status, ->(value, event) {
     linked = EventRegistrationOrganization.select(:event_registration_id)
     case value
     when "linked" then where(id: linked)
     when "unlinked" then where.not(id: linked)
     when "pending"
-      field = event.registration_form&.form_fields&.find_by(field_identifier: "agency_name")
+      field = event.registration_form&.form_fields&.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
       next none unless field
       submitted = FormAnswer.joins(:form_submission)
         .where(form_field_id: field.id, form_submissions: { form_id: event.registration_form.id })

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -52,6 +52,37 @@ class FormField < ApplicationRecord
   # field offers one.
   DYNAMIC_FIELD_CATEGORY_TYPES = AGE_GROUP_FIELD_IDENTIFIERS.index_with { "AgeRange" }.freeze
 
+  # Organization ("agency") contact-info field identifiers. New forms are built
+  # with the canonical "organization_" names; the legacy "agency_" names stay
+  # valid so existing forms — and the submissions already stored against them —
+  # keep resolving. Maps each canonical identifier to every identifier accepted
+  # for it (canonical first, legacy second). This is the single source of truth
+  # for the rename: a lookup keyed on either spelling matches a field carrying
+  # either one.
+  ORGANIZATION_FIELD_ALIASES = {
+    "organization_name" => %w[organization_name agency_name],
+    "organization_position" => %w[organization_position agency_position],
+    "organization_website" => %w[organization_website agency_website],
+    "organization_type" => %w[organization_type agency_type],
+    "organization_street" => %w[organization_street agency_street],
+    "organization_city" => %w[organization_city agency_city],
+    "organization_state" => %w[organization_state agency_state],
+    "organization_zip" => %w[organization_zip agency_zip],
+    "organization_country" => %w[organization_country agency_country]
+  }.freeze
+
+  # Every identifier that should match a field for the given identifier — a
+  # renamed organization field's canonical name plus its legacy "agency_" alias,
+  # or just the identifier itself for everything else. Accepts either spelling as
+  # input, so callers can key on the canonical name and still match legacy data
+  # (or pass a legacy literal and still match a new form). Use it to build the
+  # `field_identifier IN (…)` set for a lookup, or to compare an identifier.
+  def self.aliased_identifiers(identifier)
+    ORGANIZATION_FIELD_ALIASES[identifier] ||
+      ORGANIZATION_FIELD_ALIASES.values.find { |names| names.include?(identifier) } ||
+      [ identifier ]
+  end
+
   # The payment-method field. Its answer options ("Credit card (now)", etc.) are
   # wired to Stripe charge logic in the controllers, so they must not be edited
   # casually from the form builder — the editor shows them read-only unless the
@@ -175,6 +206,14 @@ class FormField < ApplicationRecord
 
   def selectable?
     answer_type.in?(SELECTABLE_ANSWER_TYPES)
+  end
+
+  # True when this field's identifier matches the given identifier, treating a
+  # renamed organization field's canonical and legacy "agency_" spellings as
+  # equivalent (see ORGANIZATION_FIELD_ALIASES). Lets a caller compare against the
+  # canonical name and still match a field seeded under the legacy one.
+  def matches_identifier?(identifier)
+    field_identifier.in?(FormField.aliased_identifiers(identifier))
   end
 
   # True for fields whose answer options are tied to backend logic (currently the

--- a/app/models/other_response.rb
+++ b/app/models/other_response.rb
@@ -24,9 +24,11 @@ class OtherResponse < ApplicationRecord
   # Kinds that can be promoted into a real tag today.
   PROMOTABLE_KINDS = %w[sector].freeze
 
-  # The organization-type question. Its "Other" is org-owned (see
-  # PublicRegistration#sync_agency_type).
-  ORGANIZATION_TYPE_FIELD_IDENTIFIER = "agency_type"
+  # The organization-type question. Its "Other" is org-owned (captured against
+  # the Organization in PublicRegistration#sync_organization_profile). The
+  # canonical identifier is "organization_type"; the legacy "agency_type" still
+  # resolves (see FormField.aliased_identifiers).
+  ORGANIZATION_TYPE_FIELD_IDENTIFIER = "organization_type"
 
   # A response starts life as `pending` (awaiting a curator's decision) and is
   # then either promoted into a real tag, kept as auxiliary data, or dismissed.
@@ -66,7 +68,7 @@ class OtherResponse < ApplicationRecord
     identifier = field_identifier.to_s
     if identifier.in?(FormField::SECTOR_FIELD_IDENTIFIERS)
       "sector"
-    elsif identifier == ORGANIZATION_TYPE_FIELD_IDENTIFIER
+    elsif identifier.in?(FormField.aliased_identifiers(ORGANIZATION_TYPE_FIELD_IDENTIFIER))
       "organization_type"
     else
       "generic"

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -30,12 +30,12 @@ module EventRegistrationServices
     ADDITIONAL_FORMS_W9 = "W-9".freeze
 
     # Well-known field_identifiers for the registrant's organization name and
-    # position on the registration form. We name them in organization terms here
-    # as we move the vocabulary away from "agency"; the stored identifiers are
-    # still "agency_*" pending a form-field rename. Kept here so the service,
-    # controller, and specs agree on a single source.
-    ORGANIZATION_NAME_IDENTIFIER = "agency_name".freeze
-    ORGANIZATION_POSITION_IDENTIFIER = "agency_position".freeze
+    # position on the registration form. New forms carry the canonical
+    # "organization_*" names; legacy "agency_*" forms still resolve because
+    # field_value expands both (see FormField.aliased_identifiers). Kept here so
+    # the service, controller, and specs agree on a single source.
+    ORGANIZATION_NAME_IDENTIFIER = "organization_name".freeze
+    ORGANIZATION_POSITION_IDENTIFIER = "organization_position".freeze
 
     # Well-known field_identifier of the "Will someone else be paying?" question
     # seeded after the payment method. Answering it "Yes" sets the registration's
@@ -156,7 +156,7 @@ module EventRegistrationServices
     end
 
     def field_value(key)
-      field = @registration_form.form_fields.find_by(field_identifier: key)
+      field = @registration_form.form_fields.find_by(field_identifier: FormField.aliased_identifiers(key))
       return nil unless field
       @form_params[field.id.to_s]
     end
@@ -231,8 +231,8 @@ module EventRegistrationServices
     def sync_organization_profile(organization)
       OrganizationServices::SyncProfile.call(
         organization: organization,
-        website: field_value("agency_website"),
-        agency_type: field_value("agency_type")
+        website: field_value("organization_website"),
+        agency_type: field_value("organization_type")
       )
     end
 
@@ -368,11 +368,11 @@ module EventRegistrationServices
     def create_agency_address(organization)
       OrganizationServices::UpsertAddress.call(
         organization: organization,
-        street_address: field_value("agency_street"),
-        city: field_value("agency_city"),
-        state: field_value("agency_state"),
-        zip_code: field_value("agency_zip"),
-        country: field_value("agency_country")
+        street_address: field_value("organization_street"),
+        city: field_value("organization_city"),
+        state: field_value("organization_state"),
+        zip_code: field_value("organization_zip"),
+        country: field_value("organization_country")
       )
     end
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -46,8 +46,8 @@ class FormBuilderService
     person_contact_info: %w[
       primary_email_type nickname pronouns secondary_email secondary_email_type
       mailing_street mailing_address_type mailing_city mailing_state mailing_zip mailing_country
-      phone phone_type agency_name agency_position agency_website agency_type
-      agency_street agency_city agency_state agency_zip agency_country
+      phone phone_type organization_name organization_position organization_website organization_type
+      organization_street organization_city organization_state organization_zip organization_country
     ],
     person_background: %w[racial_ethnic_identity],
     professional_info: %w[primary_sector additional_sectors primary_age_group additional_age_groups],
@@ -412,24 +412,24 @@ class FormBuilderService
 
     position = add_header(form, position, "Organization Information", group: "person_contact_info")
     position = add_field(form, position, "Organization Name", :free_form_input_one_line,
-                         key: "agency_name", group: "person_contact_info", required: false, width: :half)
+                         key: "organization_name", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Position / Title", :free_form_input_one_line,
-                         key: "agency_position", group: "person_contact_info", required: false, width: :half)
+                         key: "organization_position", group: "person_contact_info", required: false, width: :half)
     position = add_field(form, position, "Organization Website", :free_form_input_one_line,
-                         key: "agency_website", group: "person_contact_info", required: false)
+                         key: "organization_website", group: "person_contact_info", required: false)
     position = add_field(form, position, "Organization Type", :single_select_radio,
-                         key: "agency_type", group: "person_contact_info", required: false,
+                         key: "organization_type", group: "person_contact_info", required: false,
                          options: Organization::AGENCY_TYPES)
     position = add_field(form, position, "Organization Street Address", :free_form_input_one_line,
-                         key: "agency_street", group: "person_contact_info", required: false)
+                         key: "organization_street", group: "person_contact_info", required: false)
     position = add_field(form, position, "Organization City", :free_form_input_one_line,
-                         key: "agency_city", group: "person_contact_info", required: false, width: :third)
+                         key: "organization_city", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Organization State / Province", :free_form_input_one_line,
-                         key: "agency_state", group: "person_contact_info", required: false, width: :third)
+                         key: "organization_state", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Organization Zip / Postal Code", :free_form_input_one_line,
-                         key: "agency_zip", group: "person_contact_info", required: false, width: :third)
+                         key: "organization_zip", group: "person_contact_info", required: false, width: :third)
     position = add_field(form, position, "Organization Country", :free_form_input_one_line,
-                         key: "agency_country", group: "person_contact_info", required: false)
+                         key: "organization_country", group: "person_contact_info", required: false)
     position
   end
 

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -88,17 +88,18 @@ class SmartFormFields
                "below fill in the organization's profile. Both affiliations are connected to the " \
                "organization's address when it has exactly one; with several addresses the address is " \
                "left blank for an admin to set. When it doesn't match, nothing is written and " \
-               "an admin resolves it on the event registration's Link organization page.",
+               "an admin resolves it on the event registration's Link organization page. Older forms " \
+               "may carry the legacy \"agency_\" names for these questions; both spellings still work.",
       fields: [
-        [ "agency_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],
-        [ "agency_position", "Position / title", "Becomes the job title on the registrant's Job Affiliation with that organization." ],
-        [ "agency_website", "Organization website", "Sets the organization's website. Replaces what is on file when the registrant submits it; when an admin links it by hand (Link or Create and link) it only fills a blank, and a conflicting answer is flagged instead. Note: a raw URL is saved exactly as entered, so it may not be clickable if it isn't a properly formed URL." ],
-        [ "agency_type", "Organization type", "Sets the organization's type. An \"Other\" choice stores the typed text separately and adds it to the Other responses review queue." ],
-        [ "agency_street", "Organization street address", "Sets the street of the organization's work address." ],
-        [ "agency_city", "Organization city", "Sets the city, and decides whether an organization address is saved at all — no city answered means no address." ],
-        [ "agency_state", "Organization state / province", "Sets the state. Without it, no new address can be saved (an address requires a state), though an address already on file is still updated." ],
-        [ "agency_zip", "Organization zip / postal code", "Sets the postal code. Also used to recognize an address already on file whose city is spelled differently." ],
-        [ "agency_country", "Organization country", "Sets the country of the organization's work address." ]
+        [ "organization_name", "Organization name", "Looked up against existing organizations by exact name. A match is linked to the registration; no match leaves the registration unlinked for an admin to resolve." ],
+        [ "organization_position", "Position / title", "Becomes the job title on the registrant's Job Affiliation with that organization." ],
+        [ "organization_website", "Organization website", "Sets the organization's website. Replaces what is on file when the registrant submits it; when an admin links it by hand (Link or Create and link) it only fills a blank, and a conflicting answer is flagged instead. Note: a raw URL is saved exactly as entered, so it may not be clickable if it isn't a properly formed URL." ],
+        [ "organization_type", "Organization type", "Sets the organization's type. An \"Other\" choice stores the typed text separately and adds it to the Other responses review queue." ],
+        [ "organization_street", "Organization street address", "Sets the street of the organization's work address." ],
+        [ "organization_city", "Organization city", "Sets the city, and decides whether an organization address is saved at all — no city answered means no address." ],
+        [ "organization_state", "Organization state / province", "Sets the state. Without it, no new address can be saved (an address requires a state), though an address already on file is still updated." ],
+        [ "organization_zip", "Organization zip / postal code", "Sets the postal code. Also used to recognize an address already on file whose city is spelled differently." ],
+        [ "organization_country", "Organization country", "Sets the country of the organization's work address." ]
       ]
     },
     {

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -57,7 +57,7 @@
                      end
         extra_attrs = []
         extra_attrs << 'min="1" step="1" pattern="[0-9]*" inputmode="numeric"' if field.number_integer?
-        extra_attrs << 'inputmode="url"' if field.field_identifier == "agency_website"
+        extra_attrs << 'inputmode="url"' if field.matches_identifier?("organization_website")
         extra_attrs << %(maxlength="#{field.effective_max_characters}") if field.effective_max_characters
       %>
       <input type="<%= html_type %>"

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1086,20 +1086,20 @@ form_submissions.each do |data|
   data[:form].form_fields.where(answer_type: [ :free_form_input_one_line, :free_form_input_paragraph ]).each do |field|
     # Organization Name + Position / Title are seeded later with org-matching values
     # (record_organization_answers), so leave them blank here.
-    next if %w[agency_name agency_position].include?(field.field_identifier)
+    next if field.matches_identifier?("organization_name") || field.matches_identifier?("organization_position")
 
     sample_text = case field.field_identifier
     when "first_name" then data[:person].first_name
     when "last_name" then data[:person].last_name
     when "primary_email", "enter_email", "confirm_email" then data[:person].preferred_email || "sample@example.com"
     when "phone" then "(555) #{rand(100..999)}-#{rand(1000..9999)}"
-    when "street_address", "agency_street_address" then Faker::Address.street_address
-    when "city", "agency_city" then Faker::Address.city
-    when "state_province", "agency_state_province" then Faker::Address.state_abbr
-    when "zip_postal_code", "agency_zip_postal_code" then Faker::Address.zip_code
+    when "street_address", "agency_street_address", "organization_street" then Faker::Address.street_address
+    when "city", "agency_city", "organization_city" then Faker::Address.city
+    when "state_province", "agency_state_province", "organization_state" then Faker::Address.state_abbr
+    when "zip_postal_code", "agency_zip_postal_code", "organization_zip" then Faker::Address.zip_code
     when "agency_organization_name" then Faker::Company.name
     when "position_title" then "Facilitator"
-    when "agency_website" then "https://example.org"
+    when "agency_website", "organization_website" then "https://example.org"
     when "secondary_email" then data[:person].email_2
     when "preferred_nickname" then data[:person].first_name
     when "pronouns" then [ "she/her", "he/him", "they/them" ].sample
@@ -1231,14 +1231,14 @@ record_organization_answers = ->(registration, submission, i) do
   # A title on most submissions, but leave roughly one in five blank so dev data
   # exercises both registration/linking outcomes: a job + Facilitator affiliation
   # when a title was given, and a Facilitator-only affiliation when it wasn't.
-  position_field = form.form_fields.find_by(field_identifier: "agency_position")
+  position_field = form.form_fields.find_by(field_identifier: FormField.aliased_identifiers("organization_position"))
   if position_field && i % 5 != 4 && submission.form_answers.where(form_field: position_field).none?
     submission.form_answers.create!(form_field: position_field,
                                     submitted_answer: job_titles[i % job_titles.size],
                                     question_name_when_answered: position_field.name)
   end
 
-  agency_field = form.form_fields.find_by(field_identifier: "agency_name")
+  agency_field = form.form_fields.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
   next unless agency_field && org_answer_orgs.any?
   next if submission.form_answers.where(form_field: agency_field).any?
 
@@ -1439,14 +1439,14 @@ puts "Creating organization-link demo registrants on the flagship training…"
 if facilitator_training && registration_form
   # "Pending" only exists when the form has the Organization Name field,
   # which lives in the person_contact_info section the dev form otherwise omits.
-  unless registration_form.form_fields.exists?(field_identifier: "agency_name")
+  unless registration_form.form_fields.exists?(field_identifier: FormField.aliased_identifiers("organization_name"))
     FormBuilderService.update_sections!(
       registration_form,
       (registration_form.sections || []).map(&:to_sym) | [ :person_contact_info ]
     )
   end
-  agency_field = registration_form.form_fields.find_by(field_identifier: "agency_name")
-  agency_position_field = registration_form.form_fields.find_by(field_identifier: "agency_position")
+  agency_field = registration_form.form_fields.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
+  agency_position_field = registration_form.form_fields.find_by(field_identifier: FormField.aliased_identifiers("organization_position"))
 
   # Real, existing orgs to link against / match on (skip the AWBW house org).
   demo_orgs = Organization.where.not(name: "A Window Between Worlds").order(:name).to_a
@@ -1611,7 +1611,7 @@ if facilitator_training && registration_form
   # --- Affiliation-status demo: two affiliations per org (a real job title plus the
   # Facilitator role that gates AWBW-active), plus the position typed on the form, so
   # the org-link editor's affiliation pills can be seen across their states. ---
-  position_field = registration_form.form_fields.find_by(field_identifier: "agency_position")
+  position_field = registration_form.form_fields.find_by(field_identifier: FormField.aliased_identifiers("organization_position"))
   submit_field = ->(registration, field, value) do
     if field
       submission = FormSubmission.find_or_create_by!(person: registration.registrant, form: registration_form, role: "registration", event: registration.event)

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1186,6 +1186,25 @@ RSpec.describe EventRegistration, type: :model do
       expect(EventRegistration.organization_linking_status("linked", event)).to contain_exactly(linked)
       expect(EventRegistration.organization_linking_status("unlinked", event)).to contain_exactly(unlinked)
     end
+
+    it "filters pending: a submitted organization name with nothing linked yet" do
+      form = create(:form)
+      create(:event_form, :registration, event: event, form: form)
+      field = create(:form_field, form: form, field_identifier: "organization_name")
+
+      pending = create(:event_registration, event: event)
+      pending_submission = create(:form_submission, person: pending.registrant, form: form)
+      create(:form_answer, form_submission: pending_submission, form_field: field, submitted_answer: "Unlisted Org")
+
+      linked = create(:event_registration, event: event)
+      linked_submission = create(:form_submission, person: linked.registrant, form: form)
+      create(:form_answer, form_submission: linked_submission, form_field: field, submitted_answer: "Linked Org")
+      create(:event_registration_organization, event_registration: linked)
+
+      create(:event_registration, event: event)
+
+      expect(EventRegistration.organization_linking_status("pending", event)).to contain_exactly(pending)
+    end
   end
 
   describe "#paid_in_full?" do

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -619,4 +619,37 @@ RSpec.describe FormField do
       expect(field.answer_type_label).to eq("One line")
     end
   end
+
+  describe ".aliased_identifiers" do
+    it "expands a canonical organization identifier to its canonical and legacy names" do
+      expect(described_class.aliased_identifiers("organization_name")).to eq(%w[organization_name agency_name])
+    end
+
+    it "expands a legacy agency identifier to the same canonical and legacy names" do
+      expect(described_class.aliased_identifiers("agency_type")).to eq(%w[organization_type agency_type])
+    end
+
+    it "returns the identifier alone when it isn't a renamed organization field" do
+      expect(described_class.aliased_identifiers("first_name")).to eq(%w[first_name])
+    end
+  end
+
+  describe "#matches_identifier?" do
+    let(:form) { create(:form) }
+
+    it "matches a field carrying the canonical organization identifier" do
+      field = build(:form_field, form: form, field_identifier: "organization_website")
+      expect(field.matches_identifier?("organization_website")).to be(true)
+    end
+
+    it "matches a field carrying the legacy agency identifier against the canonical name" do
+      field = build(:form_field, form: form, field_identifier: "agency_website")
+      expect(field.matches_identifier?("organization_website")).to be(true)
+    end
+
+    it "does not match an unrelated identifier" do
+      field = build(:form_field, form: form, field_identifier: "phone")
+      expect(field.matches_identifier?("organization_website")).to be(false)
+    end
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1691,12 +1691,12 @@ RSpec.describe "Events", type: :request do
           .at_css("tr#registrant-row-#{registration.id} td[data-column-toggle-col='organization']")&.text&.squish
       end
 
-      # Stores a submitted "agency_name" answer for the registrant, mirroring what
-      # public registration captures, so the Pending/None chip logic has data.
+      # Stores a submitted "organization_name" answer for the registrant, mirroring
+      # what public registration captures, so the Pending/None chip logic has data.
       def submit_agency_name(name)
         registration_form = Form.find_by(name: "Registration") || create(:form, name: "Registration")
-        field = registration_form.form_fields.find_by(field_identifier: "agency_name") ||
-          create(:form_field, form: registration_form, field_identifier: "agency_name")
+        field = registration_form.form_fields.find_by(field_identifier: "organization_name") ||
+          create(:form_field, form: registration_form, field_identifier: "organization_name")
         create(:event_form, :registration, event: event, form: registration_form) unless event.registration_form
         submission = create(:form_submission, person: person, form: registration_form)
         create(:form_answer, form_submission: submission, form_field: field, submitted_answer: name)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Forms", type: :request do
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Smart field settings")
-        expect(response.body).to include("agency_name")
+        expect(response.body).to include("organization_name")
         expect(response.body).to include("Looked up against existing organizations by exact name")
       end
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     f
   end
 
+  # Resolve a field by identifier, tolerating the organization rename: the seeded
+  # form carries the canonical "organization_*" names, but specs may reference
+  # either spelling (see FormField.aliased_identifiers).
   def field_id(key)
-    form.form_fields.find_by!(field_identifier: key).id.to_s
+    form.form_fields.find_by!(field_identifier: FormField.aliased_identifiers(key)).id.to_s
   end
 
   def base_form_params(first_name:, last_name:, email:)
@@ -1110,6 +1113,59 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       answer = result.form_submission.form_answers.find_by(form_field: upload_field)
       expect(answer.uploaded_file).to be_attached
       expect(answer.submitted_answer).to eq("sample.png")
+    end
+  end
+
+  # Guards the rename: forms built before the "agency_" -> "organization_" rename
+  # still carry the legacy identifiers, and the pipeline must keep reading them.
+  describe "legacy agency_ organization identifiers" do
+    let!(:organization) { create(:organization, name: "Legacy Org") }
+
+    let(:legacy_form) do
+      f = FormBuilderService.new(name: "Legacy", sections: %i[person_identifier]).call
+      header = f.form_fields.create!(name: "Organization", answer_type: :group_header, status: :active, position: 100)
+      {
+        "agency_name" => "Organization name",
+        "agency_position" => "Position",
+        "agency_website" => "Website",
+        "agency_type" => "Type",
+        "agency_street" => "Street",
+        "agency_city" => "City",
+        "agency_state" => "State",
+        "agency_zip" => "Zip",
+        "agency_country" => "Country"
+      }.each_with_index do |(identifier, name), index|
+        f.form_fields.create!(name: name, answer_type: :free_form_input_one_line, status: :active,
+                              position: 101 + index, field_identifier: identifier)
+      end
+      event.event_forms.create!(form: f, role: "registration")
+      f
+    end
+
+    def legacy_field_id(identifier)
+      legacy_form.form_fields.find_by!(field_identifier: identifier).id.to_s
+    end
+
+    it "links the organization and fills its profile from the legacy identifiers" do
+      params = {
+        legacy_field_id("first_name") => "Lee",
+        legacy_field_id("last_name") => "Legacy",
+        legacy_field_id("primary_email") => "lee@example.com",
+        legacy_field_id("agency_name") => "Legacy Org",
+        legacy_field_id("agency_website") => "legacy.org",
+        legacy_field_id("agency_type") => "501c3/nonprofit",
+        legacy_field_id("agency_city") => "Reno",
+        legacy_field_id("agency_state") => "NV"
+      }
+
+      result = described_class.call(event: event, registration_form: legacy_form, form_params: params)
+      organization.reload
+
+      expect(result.success?).to be true
+      expect(result.event_registration.organizations).to include(organization)
+      expect(organization.agency_type).to eq("501c3/nonprofit")
+      expect(organization.website_url).to include("legacy.org")
+      expect(organization.addresses.find_by(city: "Reno")).to be_present
     end
   end
 end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       register_with_agency_type("Other: Equine therapy")
 
       answer = FormAnswer.joins(:form_field)
-        .find_by(form_fields: { field_identifier: "agency_type" })
+        .find_by(form_fields: { field_identifier: FormField.aliased_identifiers("organization_type") })
       expect(answer.submitted_answer).to eq("Other: Equine therapy")
     end
 
@@ -1123,7 +1123,6 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
 
     let(:legacy_form) do
       f = FormBuilderService.new(name: "Legacy", sections: %i[person_identifier]).call
-      header = f.form_fields.create!(name: "Organization", answer_type: :group_header, status: :active, position: 100)
       {
         "agency_name" => "Organization name",
         "agency_position" => "Position",

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FormBuilderService do
       end
 
       it "leaves unlisted fields at full width" do
-        field = form.form_fields.find_by(field_identifier: "agency_website")
+        field = form.form_fields.find_by(field_identifier: "organization_website")
         expect(field.width).to eq("full")
       end
     end
@@ -56,31 +56,40 @@ RSpec.describe FormBuilderService do
 
       it "creates contact info fields" do
         keys = form.form_fields.pluck(:field_identifier).compact
-        expect(keys).to include("nickname", "pronouns", "phone", "mailing_city", "agency_name")
+        expect(keys).to include("nickname", "pronouns", "phone", "mailing_city", "organization_name")
+      end
+
+      it "seeds the organization fields under the canonical organization_ identifiers" do
+        keys = form.form_fields.pluck(:field_identifier).compact
+        expect(keys).to include(
+          "organization_name", "organization_position", "organization_website", "organization_type",
+          "organization_street", "organization_city", "organization_state", "organization_zip"
+        )
+        expect(keys.grep(/\Aagency_/)).to be_empty
       end
 
       it "captures a mailing and organization country" do
         keys = form.form_fields.pluck(:field_identifier).compact
-        expect(keys).to include("mailing_country", "agency_country")
+        expect(keys).to include("mailing_country", "organization_country")
       end
 
       it "asks for the organization website and type before its street address" do
         positions = form.form_fields.where(
-          field_identifier: %w[agency_website agency_type agency_street]
+          field_identifier: %w[organization_website organization_type organization_street]
         ).pluck(:field_identifier, :position).to_h
-        expect(positions["agency_website"]).to be < positions["agency_street"]
-        expect(positions["agency_type"]).to be < positions["agency_street"]
+        expect(positions["organization_website"]).to be < positions["organization_street"]
+        expect(positions["organization_type"]).to be < positions["organization_street"]
       end
 
-      it "offers the agency type as the four organization classifications" do
-        field = form.form_fields.find_by(field_identifier: "agency_type")
+      it "offers the organization type as the four organization classifications" do
+        field = form.form_fields.find_by(field_identifier: "organization_type")
         expect(field.answer_options.pluck(:name)).to contain_exactly(
           "501c3/nonprofit", "For-profit", "Government agency", "Other"
         )
       end
 
-      it "treats the agency type 'Other' as a specify option that reveals a free-text box" do
-        field = form.form_fields.find_by(field_identifier: "agency_type")
+      it "treats the organization type 'Other' as a specify option that reveals a free-text box" do
+        field = form.form_fields.find_by(field_identifier: "organization_type")
         expect(field.specify_option_labels).to contain_exactly("Other")
       end
     end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -98,11 +98,11 @@ RSpec.describe "Public form submissions", type: :system do
         "mailing_country" => "United States",
         "phone" => "555-123-4567",
         "phone_type" => "Work",
-        "agency_name" => "Hope Center",
-        "agency_position" => "Art Therapist",
-        "agency_website" => "https://hope.example.org",
-        "agency_type" => "501c3/nonprofit",
-        "agency_country" => "United States",
+        "organization_name" => "Hope Center",
+        "organization_position" => "Art Therapist",
+        "organization_website" => "https://hope.example.org",
+        "organization_type" => "501c3/nonprofit",
+        "organization_country" => "United States",
         "primary_sector" => sector_education.id.to_s,
         "additional_sectors" => sector_mental_health.id.to_s,
         "primary_age_group" => age_adults.id.to_s,
@@ -399,15 +399,15 @@ RSpec.describe "Public form submissions", type: :system do
     fill_pr_text reg_field("phone"), with: "555-123-4567"
     choose_pr_radio reg_field("phone_type"), "Work"
 
-    fill_pr_text reg_field("agency_name"), with: "Hope Center"
-    fill_pr_text reg_field("agency_position"), with: "Art Therapist"
-    fill_pr_text reg_field("agency_website"), with: "https://hope.example.org"
-    choose_pr_radio reg_field("agency_type"), "501c3/nonprofit"
-    fill_pr_text reg_field("agency_street"), with: "9 Center Ave"
-    fill_pr_text reg_field("agency_city"), with: "Pasadena"
-    select_pr reg_field("agency_state"), "California (CA)"
-    fill_pr_text reg_field("agency_zip"), with: "91101"
-    fill_pr_text reg_field("agency_country"), with: "United States"
+    fill_pr_text reg_field("organization_name"), with: "Hope Center"
+    fill_pr_text reg_field("organization_position"), with: "Art Therapist"
+    fill_pr_text reg_field("organization_website"), with: "https://hope.example.org"
+    choose_pr_radio reg_field("organization_type"), "501c3/nonprofit"
+    fill_pr_text reg_field("organization_street"), with: "9 Center Ave"
+    fill_pr_text reg_field("organization_city"), with: "Pasadena"
+    select_pr reg_field("organization_state"), "California (CA)"
+    fill_pr_text reg_field("organization_zip"), with: "91101"
+    fill_pr_text reg_field("organization_country"), with: "United States"
 
     select_pr reg_field("primary_sector"), "Education"
     check_pr_box reg_field("additional_sectors"), sector_mental_health.id.to_s


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mechanical identifier rename behind a single alias map, low blast radius

### What is the goal of this PR and why is this important?

- Renames the nine organization contact-field identifiers on the registration form from `agency_*` to `organization_*`.
- Continues the project's move away from "agency" vocabulary toward "organization".
- Keeps every legacy `agency_*` identifier valid, so forms and submissions already stored keep resolving.

### How did you approach the change?

#### Single source of truth
- `FormField::ORGANIZATION_FIELD_ALIASES` maps each canonical `organization_*` name to `[canonical, legacy]`.
- `FormField.aliased_identifiers(id)` expands either spelling to both; `FormField#matches_identifier?` compares tolerantly.

#### Canonical everywhere new
- `FormBuilderService` now seeds `organization_*`.
- Registration pipeline, controllers, `OtherResponse#kind_for`, the URL-input view hint, and the Smart form settings catalog all read through the alias helper.

#### Not touched
- DB columns/associations that happen to share the word (`organizations.agency_type`, `users.agency_id`, etc.) — those are unrelated to the form-field identifier.

### Anything else to add?

- New coverage: `FormField` alias helpers, and a `PublicRegistration` test that registers through a genuinely legacy `agency_*` form and asserts the org links and its profile fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
