### PR TITLE
Admin "what this form submission changed" page

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -230,6 +230,30 @@ reachable from several origins, the eyebrow must adapt to whichever one the user
   `EventHelper#bulk_payments_return_path` centralizes the expand + anchor logic for the bulk
   payments flow).
 
+## Form submission displays
+
+**A form submission's answers are shown on several different pages — know which is which
+before linking between them.** They share the answer-display partials
+(`form_submissions/submission`, `shared/form_answer_value`, the section grouping), so keep
+presentation in those partials, not forked per page.
+
+- **"Public submission" / "public form display" = the person's own slug-accessible view of
+  their submission, reached through the ticket** (and linkable from lists). Today that's the
+  event **public registration confirmation** (`events/public_registrations#show`,
+  `page_bg "public"`), accessed publicly via `?reg=<registration_slug>` (the unguessable
+  ticket token) or, for admins, `?person_id=` (gated by `person_form_submission?`). When
+  someone says "public form display," this is what they mean — **not** the admin `show`.
+- **Admin submission views** (both `page_bg admin-only`; both carry the admin-only "What this
+  submission changed" bar when `FormSubmissionChanges#edited?`):
+  - `form_submissions#show` — top-level `/form_submissions/:id` (admin-or-slug).
+  - `events/form_submissions#show` — event-scoped registrant submissions ("← Back to registrants").
+- **Link-organizations pages** (admin) also render a submission summary and the changes link:
+  `event_registrations/link_organization` and `form_submissions/link_organization`.
+- The **"What this submission changed"** audit page is `form_submissions#changes` (admin-only);
+  its eyebrow branches on `params[:return_to]` to return to whichever page linked in.
+- **Standalone (non-event) submissions currently have no submitter-facing view** — tracked in
+  rubyforgood/awbw#2407 (confirmation email → slug-based own-view reusing these partials).
+
 ## Page background class (`page_bg_class`)
 
 Every page view sets `<% content_for(:page_bg_class, "...") %>` at the top — the layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,30 @@ reachable from several origins, the eyebrow must adapt to whichever one the user
   `EventHelper#bulk_payments_return_path` centralizes the expand + anchor logic for the bulk
   payments flow).
 
+## Form submission displays
+
+**A form submission's answers are shown on several different pages — know which is which
+before linking between them.** They share the answer-display partials
+(`form_submissions/submission`, `shared/form_answer_value`, the section grouping), so keep
+presentation in those partials, not forked per page.
+
+- **"Public submission" / "public form display" = the person's own slug-accessible view of
+  their submission, reached through the ticket** (and linkable from lists). Today that's the
+  event **public registration confirmation** (`events/public_registrations#show`,
+  `page_bg "public"`), accessed publicly via `?reg=<registration_slug>` (the unguessable
+  ticket token) or, for admins, `?person_id=` (gated by `person_form_submission?`). When
+  someone says "public form display," this is what they mean — **not** the admin `show`.
+- **Admin submission views** (both `page_bg admin-only`; both carry the admin-only "What this
+  submission changed" bar when `FormSubmissionChanges#edited?`):
+  - `form_submissions#show` — top-level `/form_submissions/:id` (admin-or-slug).
+  - `events/form_submissions#show` — event-scoped registrant submissions ("← Back to registrants").
+- **Link-organizations pages** (admin) also render a submission summary and the changes link:
+  `event_registrations/link_organization` and `form_submissions/link_organization`.
+- The **"What this submission changed"** audit page is `form_submissions#changes` (admin-only);
+  its eyebrow branches on `params[:return_to]` to return to whichever page linked in.
+- **Standalone (non-event) submissions currently have no submitter-facing view** — tracked in
+  rubyforgood/awbw#2407 (confirmation email → slug-based own-view reusing these partials).
+
 ## Page background class (`page_bg_class`)
 
 Every page view sets `<% content_for(:page_bg_class, "...") %>` at the top — the layout

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -58,6 +58,10 @@ class EventRegistrationsController < ApplicationController
   def edit
     authorize! @event_registration
     set_form_variables
+    registration_form = @event_registration.event&.registration_form
+    @form_submission = registration_form && @event_registration.registrant.form_submissions
+      .where(form: registration_form, event: @event_registration.event)
+      .order(:created_at).first
 
     if @event_registration.checkout_session_id.present? &&
        @event_registration.payment_unresolved.nil? &&

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -29,6 +29,14 @@ class FormSubmissionsController < ApplicationController
     authorize! @form_submission
   end
 
+  # Admin-only audit of everything this submission's smart-field answers changed
+  # across records, read back from the stamped Ahoy lifecycle events.
+  def changes
+    @form_submission = FormSubmission.find(params[:id])
+    authorize! @form_submission, to: :changes?
+    @change_groups = FormSubmissionChanges.new(@form_submission).groups
+  end
+
   # Org-linking editor for a standalone submission, mirroring the event
   # registration one. "Linked" here means an org was explicitly linked to this
   # submission (metadata) or the person holds an active affiliation matching the

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -34,7 +34,9 @@ class FormSubmissionsController < ApplicationController
   def changes
     @form_submission = FormSubmission.find(params[:id])
     authorize! @form_submission, to: :changes?
-    @change_groups = FormSubmissionChanges.new(@form_submission).groups
+    changes = FormSubmissionChanges.new(@form_submission)
+    @change_groups = changes.edited_groups
+    @changed_count = changes.edited_count
   end
 
   # Org-linking editor for a standalone submission, mirroring the event

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -27,6 +27,8 @@ class FormSubmissionsController < ApplicationController
   def changes
     @form_submission = FormSubmission.find(params[:id])
     authorize! @form_submission, to: :changes?
-    @change_groups = FormSubmissionChanges.new(@form_submission).groups
+    changes = FormSubmissionChanges.new(@form_submission)
+    @change_groups = changes.edited_groups
+    @changed_count = changes.edited_count
   end
 end

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -21,4 +21,12 @@ class FormSubmissionsController < ApplicationController
     @form_submission = FormSubmission.find(params[:id])
     authorize! @form_submission
   end
+
+  # Admin-only audit of everything this submission's smart-field answers changed
+  # across records, read back from the stamped Ahoy lifecycle events.
+  def changes
+    @form_submission = FormSubmission.find(params[:id])
+    authorize! @form_submission, to: :changes?
+    @change_groups = FormSubmissionChanges.new(@form_submission).groups
+  end
 end

--- a/app/policies/form_submission_policy.rb
+++ b/app/policies/form_submission_policy.rb
@@ -10,6 +10,10 @@ class FormSubmissionPolicy < ApplicationPolicy
     admin? || (slug.present? && record.slug == slug)
   end
 
+  def changes?
+    admin?
+  end
+
   def ticket?
     admin? || (slug.present? && record.slug == slug)
   end

--- a/app/services/form_submission_changes.rb
+++ b/app/services/form_submission_changes.rb
@@ -16,8 +16,13 @@ class FormSubmissionChanges
     "street_address" => "Street address"
   }.freeze
 
-  Change = Struct.new(:outcome, :label, :value, :previous_value, keyword_init: true)
-  Group = Struct.new(:record_type, :title, :changes, keyword_init: true)
+  # Sub-record attributes edit a section of the owner's edit page rather than a
+  # single input; own-record columns anchor to their form input (person_<attr> /
+  # organization_<attr>), so a change row can deep-link to where it's edited.
+  SECTION_ANCHORS = { "Address" => "addresses", "ContactMethod" => "phones" }.freeze
+
+  Change = Struct.new(:outcome, :label, :value, :previous_value, :anchor, keyword_init: true)
+  Group = Struct.new(:record_type, :record_id, :title, :changes, keyword_init: true)
 
   def initialize(form_submission)
     @form_submission = form_submission
@@ -31,22 +36,24 @@ class FormSubmissionChanges
       .sort_by { |group| [ GROUP_ORDER.index(group.record_type) || GROUP_ORDER.size, group.title.to_s ] }
   end
 
-  # A submission "changed" a value only when it edited a record that already
-  # existed — a value replaced, or a blank filled, on that record (both come from
-  # an update event). Creating new records and adding tags are a new submission's
-  # own data, not edits, so they don't count. (This is why linking an org that
-  # wasn't a clean match can raise the count: the fill lands on the existing org.)
+  # A submission "changed" a value when it edited a record that already existed —
+  # a value replaced, or a blank filled, on that record (both come from an update
+  # event) — or when it added an organization to the database through the linking
+  # flow (a created org). A person's own new records and added tags are the
+  # submission's own data, not edits, so they stay out. (This is why linking an
+  # org that wasn't a clean match can raise the count: the fill lands on the org,
+  # and creating one shows the org itself.)
   EDIT_OUTCOMES = %w[Replaced Filled].freeze
 
   def edited_groups
     groups.filter_map do |group|
-      edits = group.changes.select { |change| EDIT_OUTCOMES.include?(change.outcome) }
-      Group.new(record_type: group.record_type, title: group.title, changes: edits) if edits.any?
+      edits = group.changes.select { |change| edit?(change, group) }
+      Group.new(record_type: group.record_type, record_id: group.record_id, title: group.title, changes: edits) if edits.any?
     end
   end
 
   def edited_count
-    relevant_events.sum { |event| attribute_changes(event.properties["changes"] || {}).size }
+    edited_groups.sum { |group| group.changes.size }
   end
 
   def edited?
@@ -76,21 +83,27 @@ class FormSubmissionChanges
 
   def build_group(type, id, events)
     changes = events.flat_map { |event| changes_for(event) }.compact
-    Group.new(record_type: type, title: owner_title(type, id), changes: changes)
+    Group.new(record_type: type, record_id: id, title: owner_title(type, id), changes: changes)
+  end
+
+  # A created org (or the fill on an existing one) reads as a change; a new
+  # person/record or a tag is the submission's own data, not an edit.
+  def edit?(change, group)
+    EDIT_OUTCOMES.include?(change.outcome) || (change.outcome == "Added" && group.record_type == "Organization")
   end
 
   def changes_for(event)
     action = event.name.split(".").first
     props = event.properties
 
-    return attribute_changes(props["changes"]) if props["changes"].present?
+    return attribute_changes(props["changes"], props["resource_type"]) if props["changes"].present?
     return [ tag_change(action, event) ] if props["resource_type"].in?(%w[SectorableItem CategorizableItem])
     return [ record_change(action, event) ] if action.in?(%w[create destroy])
 
     []
   end
 
-  def attribute_changes(changes)
+  def attribute_changes(changes, resource_type)
     changes.except(*IGNORED_ATTRIBUTES).filter_map do |attribute, before_after|
       before, after = before_after.values_at("before", "after")
       next if after.blank? && before.blank?
@@ -99,9 +112,17 @@ class FormSubmissionChanges
         outcome: before.present? ? "Replaced" : "Filled",
         label: ATTRIBUTE_LABELS[attribute] || attribute.humanize,
         value: display_value(after),
-        previous_value: display_value(before)
+        previous_value: display_value(before),
+        anchor: anchor_for(resource_type, attribute)
       )
     end
+  end
+
+  # Own-record columns anchor to their form input (person_racial_ethnic_identity,
+  # organization_website_url); sub-records anchor to their section on the owner's
+  # edit page (addresses, contact-methods).
+  def anchor_for(resource_type, attribute)
+    SECTION_ANCHORS[resource_type] || "#{resource_type.underscore}_#{attribute}"
   end
 
   def tag_change(action, event)

--- a/app/services/form_submission_changes.rb
+++ b/app/services/form_submission_changes.rb
@@ -25,18 +25,22 @@ class FormSubmissionChanges
       .sort_by { |group| [ GROUP_ORDER.index(group.record_type) || GROUP_ORDER.size, group.title.to_s ] }
   end
 
-  # A submission "changed" a value only when it overwrote one that was already
-  # there. Creating records, adding tags, and filling blanks are new data from a
-  # new submission — not edits — so they don't count here.
+  # A submission "changed" a value only when it edited a record that already
+  # existed — a value replaced, or a blank filled, on that record (both come from
+  # an update event). Creating new records and adding tags are a new submission's
+  # own data, not edits, so they don't count. (This is why linking an org that
+  # wasn't a clean match can raise the count: the fill lands on the existing org.)
+  EDIT_OUTCOMES = %w[Replaced Filled].freeze
+
   def edited_groups
     groups.filter_map do |group|
-      edits = group.changes.select { |change| change.outcome == "Replaced" }
+      edits = group.changes.select { |change| EDIT_OUTCOMES.include?(change.outcome) }
       Group.new(record_type: group.record_type, title: group.title, changes: edits) if edits.any?
     end
   end
 
   def edited_count
-    relevant_events.sum { |event| replaced_changes(event.properties["changes"]).size }
+    relevant_events.sum { |event| attribute_changes(event.properties["changes"] || {}).size }
   end
 
   def edited?
@@ -78,12 +82,6 @@ class FormSubmissionChanges
     return [ record_change(action, event) ] if action.in?(%w[create destroy])
 
     []
-  end
-
-  def replaced_changes(changes)
-    return [] if changes.blank?
-
-    attribute_changes(changes).select { |change| change.outcome == "Replaced" }
   end
 
   def attribute_changes(changes)

--- a/app/services/form_submission_changes.rb
+++ b/app/services/form_submission_changes.rb
@@ -1,0 +1,114 @@
+# Reconstructs everything one form submission changed across records, read back
+# from the Ahoy lifecycle events each write already emits (stamped with the
+# submission id by the registration flow). Groups the changes by the record they
+# happened to and labels each with what actually happened to it — added, removed,
+# replaced, or filled (a blank) — for the admin "what this submission changed" page.
+class FormSubmissionChanges
+  # The records whose changes are worth surfacing. Bookkeeping rows a submission
+  # also touches (the submission, its answers, the registration link) are noise here.
+  RELEVANT_TYPES = %w[Person Organization Address ContactMethod Affiliation SectorableItem CategorizableItem].freeze
+  GROUP_ORDER = %w[Person Organization Affiliation].freeze
+  IGNORED_ATTRIBUTES = %w[id created_at updated_at slug locality].freeze
+
+  Change = Struct.new(:outcome, :label, :value, :previous_value, keyword_init: true)
+  Group = Struct.new(:record_type, :title, :changes, keyword_init: true)
+
+  def initialize(form_submission)
+    @form_submission = form_submission
+  end
+
+  def groups
+    relevant_events
+      .group_by { |event| owner_key(event) }
+      .filter_map { |(type, id), events| build_group(type, id, events) }
+      .reject { |group| group.changes.empty? }
+      .sort_by { |group| [ GROUP_ORDER.index(group.record_type) || GROUP_ORDER.size, group.title.to_s ] }
+  end
+
+  def any?
+    groups.any?
+  end
+
+  private
+
+  def relevant_events
+    Ahoy::Event
+      .where("properties->>'$.form_submission_id' = ?", @form_submission.id.to_s)
+      .order(:time, :id)
+      .select { |event| event.properties["resource_type"].in?(RELEVANT_TYPES) }
+  end
+
+  # A tag row belongs to the person/organization it tags, not to itself, so its
+  # changes group under that owner. Everything else owns its own changes.
+  def owner_key(event)
+    props = event.properties
+    case props["resource_type"]
+    when "SectorableItem" then [ props.dig("attributes", "sectorable_type"), props.dig("attributes", "sectorable_id") ]
+    when "CategorizableItem" then [ props.dig("attributes", "categorizable_type"), props.dig("attributes", "categorizable_id") ]
+    when "Address", "ContactMethod" then [ props.dig("attributes", "addressable_type") || props.dig("attributes", "contactable_type"), props.dig("attributes", "addressable_id") || props.dig("attributes", "contactable_id") ]
+    else [ props["resource_type"], props["resource_id"] ]
+    end
+  end
+
+  def build_group(type, id, events)
+    changes = events.flat_map { |event| changes_for(event) }.compact
+    Group.new(record_type: type, title: owner_title(type, id), changes: changes)
+  end
+
+  def changes_for(event)
+    action = event.name.split(".").first
+    props = event.properties
+
+    return attribute_changes(props["changes"]) if props["changes"].present?
+    return [ tag_change(action, event) ] if props["resource_type"].in?(%w[SectorableItem CategorizableItem])
+    return [ record_change(action, event) ] if action.in?(%w[create destroy])
+
+    []
+  end
+
+  def attribute_changes(changes)
+    changes.except(*IGNORED_ATTRIBUTES).filter_map do |attribute, before_after|
+      before, after = before_after.values_at("before", "after")
+      next if after.blank? && before.blank?
+
+      Change.new(
+        outcome: before.present? ? "Replaced" : "Filled",
+        label: attribute.humanize,
+        value: display_value(after),
+        previous_value: display_value(before)
+      )
+    end
+  end
+
+  def tag_change(action, event)
+    props = event.properties
+    if props["resource_type"] == "SectorableItem"
+      name = Sector.find_by(id: props.dig("attributes", "sector_id"))&.name
+      kind = "sector"
+    else
+      name = Category.find_by(id: props.dig("attributes", "category_id"))&.name
+      kind = "age group"
+    end
+    primary = props.dig("attributes", "is_primary") ? " (primary)" : ""
+    Change.new(outcome: action == "destroy" ? "Removed" : "Added", label: kind.humanize, value: "#{name}#{primary}")
+  end
+
+  def record_change(action, event)
+    Change.new(
+      outcome: action == "destroy" ? "Removed" : "Added",
+      label: event.properties["resource_type"].underscore.humanize,
+      value: event.properties["resource_title"]
+    )
+  end
+
+  def owner_title(type, id)
+    return type.to_s if id.blank?
+
+    record = type.safe_constantize&.find_by(id: id)
+    record&.try(:full_name).presence || record&.try(:name).presence || "#{type} ##{id}"
+  end
+
+  def display_value(value)
+    value.is_a?(Array) ? value.join(", ") : value
+  end
+end

--- a/app/services/form_submission_changes.rb
+++ b/app/services/form_submission_changes.rb
@@ -9,6 +9,12 @@ class FormSubmissionChanges
   RELEVANT_TYPES = %w[Person Organization Address ContactMethod Affiliation SectorableItem CategorizableItem].freeze
   GROUP_ORDER = %w[Person Organization Affiliation].freeze
   IGNORED_ATTRIBUTES = %w[id created_at updated_at slug locality].freeze
+  # Friendlier than humanizing the raw column (e.g. "value" on a phone contact).
+  ATTRIBUTE_LABELS = {
+    "website_url" => "Website", "agency_type" => "Type", "value" => "Phone",
+    "racial_ethnic_identity" => "Racial / ethnic identity", "zip_code" => "ZIP",
+    "street_address" => "Street address"
+  }.freeze
 
   Change = Struct.new(:outcome, :label, :value, :previous_value, keyword_init: true)
   Group = Struct.new(:record_type, :title, :changes, keyword_init: true)
@@ -91,7 +97,7 @@ class FormSubmissionChanges
 
       Change.new(
         outcome: before.present? ? "Replaced" : "Filled",
-        label: attribute.humanize,
+        label: ATTRIBUTE_LABELS[attribute] || attribute.humanize,
         value: display_value(after),
         previous_value: display_value(before)
       )

--- a/app/services/form_submission_changes.rb
+++ b/app/services/form_submission_changes.rb
@@ -25,8 +25,22 @@ class FormSubmissionChanges
       .sort_by { |group| [ GROUP_ORDER.index(group.record_type) || GROUP_ORDER.size, group.title.to_s ] }
   end
 
-  def any?
-    groups.any?
+  # A submission "changed" a value only when it overwrote one that was already
+  # there. Creating records, adding tags, and filling blanks are new data from a
+  # new submission — not edits — so they don't count here.
+  def edited_groups
+    groups.filter_map do |group|
+      edits = group.changes.select { |change| change.outcome == "Replaced" }
+      Group.new(record_type: group.record_type, title: group.title, changes: edits) if edits.any?
+    end
+  end
+
+  def edited_count
+    relevant_events.sum { |event| replaced_changes(event.properties["changes"]).size }
+  end
+
+  def edited?
+    edited_count.positive?
   end
 
   private
@@ -64,6 +78,12 @@ class FormSubmissionChanges
     return [ record_change(action, event) ] if action.in?(%w[create destroy])
 
     []
+  end
+
+  def replaced_changes(changes)
+    return [] if changes.blank?
+
+    attribute_changes(changes).select { |change| change.outcome == "Replaced" }
   end
 
   def attribute_changes(changes)

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -62,6 +62,19 @@
              event: @event_registration.event,
              event_url: dashboard_event_path(@event_registration.event) %>
 
+  <%# Admin-only jump to the audit of the values this registration's form overwrote —
+      shown only once it has overwritten something on existing records. %>
+  <% submission_changes = @form_submission && FormSubmissionChanges.new(@form_submission) %>
+  <% if submission_changes&.edited? && allowed_to?(:changes?, @form_submission) %>
+    <%= link_to changes_form_submission_path(@form_submission, return_to: "event_registration", event_registration_id: @event_registration.id),
+                class: "group mt-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+      <i class="fa-solid fa-circle-info text-blue-500"></i>
+      What this registration's form changed
+      <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
+      <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+    <% end %>
+  <% end %>
+
   <%= render "form", event_registration: @event_registration %>
   <%= render "shared/audit_info", resource: @event_registration %>
   <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -64,16 +64,12 @@
 
   <%# Admin-only jump to the audit of the values this registration's form overwrote —
       shown only once it has overwritten something on existing records. %>
-  <% submission_changes = @form_submission && FormSubmissionChanges.new(@form_submission) %>
-  <% if submission_changes&.edited? && allowed_to?(:changes?, @form_submission) %>
-    <%= link_to changes_form_submission_path(@form_submission, return_to: "event_registration", event_registration_id: @event_registration.id),
-                class: "group mt-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-      <i class="fa-solid fa-circle-info text-blue-500"></i>
-      What this registration's form changed
-      <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-      <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-    <% end %>
-  <% end %>
+  <%= render "form_submissions/changes_link",
+             submission: @form_submission,
+             return_to: "event_registration",
+             extra_params: { event_registration_id: @event_registration.id },
+             label: "What this registration's form changed",
+             wrapper_class: "mt-4" %>
 
   <%= render "form", event_registration: @event_registration %>
   <%= render "shared/audit_info", resource: @event_registration %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -65,14 +65,18 @@
               </li>
             <% end %>
           </ul>
-          <%# Admin-only jump to the audit of what these answers changed across records. %>
+          <%# Admin-only jump to the audit of the values these answers overwrote —
+              shown only once the submission has overwritten something (e.g. after
+              linking an org that wasn't a clean match writes onto it). %>
           <% changes_submission = present_entries.first[:submission] %>
-          <% if changes_submission && allowed_to?(:changes?, changes_submission) %>
+          <% submission_changes = changes_submission && FormSubmissionChanges.new(changes_submission) %>
+          <% if submission_changes&.edited? && allowed_to?(:changes?, changes_submission) %>
             <%= link_to changes_form_submission_path(changes_submission, return_to: "link_organization", event_registration_id: @event_registration.id),
                         data: { turbo_frame: "_top" },
                         class: "group mt-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
               <i class="fa-solid fa-circle-info text-blue-500"></i>
               What this registration's form changed
+              <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
               <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
             <% end %>
           <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -68,18 +68,13 @@
           <%# Admin-only jump to the audit of the values these answers overwrote —
               shown only once the submission has overwritten something (e.g. after
               linking an org that wasn't a clean match writes onto it). %>
-          <% changes_submission = present_entries.first[:submission] %>
-          <% submission_changes = changes_submission && FormSubmissionChanges.new(changes_submission) %>
-          <% if submission_changes&.edited? && allowed_to?(:changes?, changes_submission) %>
-            <%= link_to changes_form_submission_path(changes_submission, return_to: "link_organization", event_registration_id: @event_registration.id),
-                        data: { turbo_frame: "_top" },
-                        class: "group mt-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-              <i class="fa-solid fa-circle-info text-blue-500"></i>
-              What this registration's form changed
-              <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-              <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-            <% end %>
-          <% end %>
+          <%= render "form_submissions/changes_link",
+                     submission: present_entries.first[:submission],
+                     return_to: "link_organization",
+                     extra_params: { event_registration_id: @event_registration.id },
+                     label: "What this registration's form changed",
+                     wrapper_class: "mt-3",
+                     turbo_top: true %>
         <% elsif @form_submission %>
           <p class="text-sm text-gray-500">
             No organization was submitted on the <%= link_to "registration form submission", event_registrant_submissions_path(@event_registration.event, person_id: @person.id, form_submission_id: @form_submission.id, return_to: "link_organization", link_org_return_to: params[:return_to]), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>.

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -65,16 +65,16 @@
               </li>
             <% end %>
           </ul>
-          <%# Admin-only jump to the audit of the values these answers overwrote —
-              shown only once the submission has overwritten something (e.g. after
-              linking an org that wasn't a clean match writes onto it). %>
+          <%# Admin-only jump to the audit — always shown here, since this is where
+              the admin makes the org links/creates that produce those changes. %>
           <%= render "form_submissions/changes_link",
                      submission: present_entries.first[:submission],
                      return_to: "link_organization",
                      extra_params: { event_registration_id: @event_registration.id },
                      label: "What this registration's form changed",
                      wrapper_class: "mt-3",
-                     turbo_top: true %>
+                     turbo_top: true,
+                     always: true %>
         <% elsif @form_submission %>
           <p class="text-sm text-gray-500">
             No organization was submitted on the <%= link_to "registration form submission", event_registrant_submissions_path(@event_registration.event, person_id: @person.id, form_submission_id: @form_submission.id, return_to: "link_organization", link_org_return_to: params[:return_to]), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>.

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -65,6 +65,17 @@
               </li>
             <% end %>
           </ul>
+          <%# Admin-only jump to the audit of what these answers changed across records. %>
+          <% changes_submission = present_entries.first[:submission] %>
+          <% if changes_submission && allowed_to?(:changes?, changes_submission) %>
+            <%= link_to changes_form_submission_path(changes_submission, return_to: "link_organization", event_registration_id: @event_registration.id),
+                        data: { turbo_frame: "_top" },
+                        class: "group mt-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+              <i class="fa-solid fa-circle-info text-blue-500"></i>
+              What this registration's form changed
+              <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+            <% end %>
+          <% end %>
         <% elsif @form_submission %>
           <p class="text-sm text-gray-500">
             No organization was submitted on the <%= link_to "registration form submission", event_registrant_submissions_path(@event_registration.event, person_id: @person.id, form_submission_id: @form_submission.id, return_to: "link_organization", link_org_return_to: params[:return_to]), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>.

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -68,14 +68,18 @@
               </li>
             <% end %>
           </ul>
-          <%# Admin-only jump to the audit of what these answers changed across records. %>
+          <%# Admin-only jump to the audit of the values these answers overwrote —
+              shown only once the submission has overwritten something (e.g. after
+              linking an org that wasn't a clean match writes onto it). %>
           <% changes_submission = present_entries.first[:submission] %>
-          <% if changes_submission && allowed_to?(:changes?, changes_submission) %>
+          <% submission_changes = changes_submission && FormSubmissionChanges.new(changes_submission) %>
+          <% if submission_changes&.edited? && allowed_to?(:changes?, changes_submission) %>
             <%= link_to changes_form_submission_path(changes_submission, return_to: "link_organization", event_registration_id: @event_registration.id),
                         data: { turbo_frame: "_top" },
                         class: "group mt-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
               <i class="fa-solid fa-circle-info text-blue-500"></i>
               What this registration's form changed
+              <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
               <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
             <% end %>
           <% end %>

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -68,6 +68,17 @@
               </li>
             <% end %>
           </ul>
+          <%# Admin-only jump to the audit of what these answers changed across records. %>
+          <% changes_submission = present_entries.first[:submission] %>
+          <% if changes_submission && allowed_to?(:changes?, changes_submission) %>
+            <%= link_to changes_form_submission_path(changes_submission, return_to: "link_organization", event_registration_id: @event_registration.id),
+                        data: { turbo_frame: "_top" },
+                        class: "group mt-3 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+              <i class="fa-solid fa-circle-info text-blue-500"></i>
+              What this registration's form changed
+              <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+            <% end %>
+          <% end %>
         <% elsif @form_submission %>
           <p class="text-sm text-gray-500">
             No organization was submitted on the <%= link_to "registration form submission", event_registrant_submissions_path(@event_registration.event, person_id: @person.id, form_submission_id: @form_submission.id, return_to: "link_organization", link_org_return_to: params[:return_to]), target: "_blank", class: "text-blue-600 hover:underline", data: { turbo_frame: "_top" } %>.

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -19,6 +19,17 @@
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %><%= render "form_submissions/via_callout_badge", submission: submission %></p>
       </div>
 
+      <%# Admin-only jump to the audit of what this submission's answers changed. %>
+      <% if allowed_to?(:changes?, submission) %>
+        <%= link_to changes_form_submission_path(submission, return_to: "event_registrant_submissions"),
+                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+          <i class="fa-solid fa-circle-info text-blue-500"></i>
+          What this submission changed
+          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+        <% end %>
+      <% end %>
+
       <% sections = [] %>
       <% current = nil %>
 

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -6,6 +6,14 @@
   <h1 class="text-primary mt-3 font-display text-lg font-semibold">
     <%= @person.name %> &mdash; <%= @event.title %>
   </h1>
+
+  <%# Jump to the registrant's own (public) view of this registration — what they
+      see from their ticket. Opens in a new tab so the admin keeps their place. %>
+  <%= link_to event_public_registration_path(@event, person_id: @person.id),
+              target: "_blank", rel: "noopener",
+              class: "mt-2 inline-flex items-center gap-1.5 text-sm text-blue-700 hover:text-blue-900 px-2 py-1" do %>
+    <i class="fa-solid fa-up-right-from-square text-xs"></i> View the registrant's public version
+  <% end %>
 </div>
 
 <div class="mx-auto max-w-5xl space-y-10 px-4 pt-4 pb-12">

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -27,18 +27,7 @@
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %><%= render "form_submissions/via_callout_badge", submission: submission %></p>
       </div>
 
-      <%# Admin-only jump to the audit of the values this submission overwrote. %>
-      <% submission_changes = FormSubmissionChanges.new(submission) %>
-      <% if allowed_to?(:changes?, submission) && submission_changes.edited? %>
-        <%= link_to changes_form_submission_path(submission, return_to: "event_registrant_submissions"),
-                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-          <i class="fa-solid fa-circle-info text-blue-500"></i>
-          What this submission changed
-          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
-          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-        <% end %>
-      <% end %>
+      <%= render "form_submissions/changes_link", submission: submission, return_to: "event_registrant_submissions", badge: true %>
 
       <% sections = [] %>
       <% current = nil %>

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -19,12 +19,14 @@
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %><%= render "form_submissions/via_callout_badge", submission: submission %></p>
       </div>
 
-      <%# Admin-only jump to the audit of what this submission's answers changed. %>
-      <% if allowed_to?(:changes?, submission) %>
+      <%# Admin-only jump to the audit of the values this submission overwrote. %>
+      <% submission_changes = FormSubmissionChanges.new(submission) %>
+      <% if allowed_to?(:changes?, submission) && submission_changes.edited? %>
         <%= link_to changes_form_submission_path(submission, return_to: "event_registrant_submissions"),
                     class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
           <i class="fa-solid fa-circle-info text-blue-500"></i>
           What this submission changed
+          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
           <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
           <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
         <% end %>

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -19,12 +19,14 @@
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %></p>
       </div>
 
-      <%# Admin-only jump to the audit of what this submission's answers changed. %>
-      <% if allowed_to?(:changes?, submission) %>
+      <%# Admin-only jump to the audit of the values this submission overwrote. %>
+      <% submission_changes = FormSubmissionChanges.new(submission) %>
+      <% if allowed_to?(:changes?, submission) && submission_changes.edited? %>
         <%= link_to changes_form_submission_path(submission, return_to: "event_registrant_submissions"),
                     class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
           <i class="fa-solid fa-circle-info text-blue-500"></i>
           What this submission changed
+          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
           <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
           <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
         <% end %>

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -19,6 +19,17 @@
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %></p>
       </div>
 
+      <%# Admin-only jump to the audit of what this submission's answers changed. %>
+      <% if allowed_to?(:changes?, submission) %>
+        <%= link_to changes_form_submission_path(submission, return_to: "event_registrant_submissions"),
+                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+          <i class="fa-solid fa-circle-info text-blue-500"></i>
+          What this submission changed
+          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+        <% end %>
+      <% end %>
+
       <% sections = [] %>
       <% current = nil %>
 

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -27,12 +27,19 @@
       <% end %>
     <% end %>
     <% if reg && allowed_to?(:index?, EventRegistration) %>
-      <%= link_to "Edit registration", edit_event_registration_path(reg), class: "ml-auto admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%# Admin's counterpart to this public view — jump back to the event-scoped
+          submission page this page's "View public version" link came from. %>
+      <%= link_to "Admin view", event_registrant_submissions_path(@event, person_id: @form_submission.person_id), class: "ml-auto admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "Edit registration", edit_event_registration_path(reg), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 </div>
 
 <div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
+
+  <%# Admin-only audit banner — sits above the registrant-facing card so it
+      stands out to admins as an overlay, not part of what the registrant sees. %>
+  <%= render "form_submissions/changes_link", submission: @form_submission, return_to: "public_registration", badge: true %>
 
   <%# ---- FORM RESPONSES CARD ---- %>
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
@@ -53,8 +60,6 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
-      <%# Admin-only jump to the audit of the values this submission overwrote. %>
-      <%= render "form_submissions/changes_link", submission: @form_submission, return_to: "public_registration", badge: true %>
       <%= render "forms/header", form: @registration_form, event: @event %>
 
       <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -53,19 +53,8 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
-      <%# Admin-only jump to the audit of the values this submission overwrote —
-          shown only to admins, and only when it actually overwrote something. %>
-      <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
-      <% if allowed_to?(:changes?, @form_submission) && submission_changes.edited? %>
-        <%= link_to changes_form_submission_path(@form_submission, return_to: "public_registration"),
-                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-          <i class="fa-solid fa-circle-info text-blue-500"></i>
-          What this submission changed
-          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
-          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-        <% end %>
-      <% end %>
+      <%# Admin-only jump to the audit of the values this submission overwrote. %>
+      <%= render "form_submissions/changes_link", submission: @form_submission, return_to: "public_registration", badge: true %>
       <%= render "forms/header", form: @registration_form, event: @event %>
 
       <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -53,6 +53,19 @@
 
     <%# Card Body %>
     <div class="px-6 sm:px-8 py-7">
+      <%# Admin-only jump to the audit of the values this submission overwrote —
+          shown only to admins, and only when it actually overwrote something. %>
+      <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
+      <% if allowed_to?(:changes?, @form_submission) && submission_changes.edited? %>
+        <%= link_to changes_form_submission_path(@form_submission, return_to: "public_registration"),
+                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+          <i class="fa-solid fa-circle-info text-blue-500"></i>
+          What this submission changed
+          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
+          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+        <% end %>
+      <% end %>
       <%= render "forms/header", form: @registration_form, event: @event %>
 
       <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">

--- a/app/views/form_submissions/_changes_link.html.erb
+++ b/app/views/form_submissions/_changes_link.html.erb
@@ -1,0 +1,31 @@
+<%#
+  Admin-only bar linking to the "what this submission changed" audit for a form
+  submission. Renders nothing unless the viewer may see the audit and the
+  submission actually overwrote something (edited?). Dropped wherever a
+  submission is shown; only return_to/label/margins differ per place. locals:
+    submission:    FormSubmission (may be nil — renders nothing)
+    return_to:     eyebrow origin key for the changes page (optional)
+    extra_params:  extra query params the eyebrow needs, e.g. { event_registration_id: 1 } (optional)
+    label:         bar text (default "What this submission changed")
+    wrapper_class: margin/utility classes for the link (default "mb-5")
+    badge:         show the little "admin" lock chip (default false)
+    turbo_top:     break out of the enclosing turbo frame on click (default false)
+%>
+<% submission = local_assigns[:submission] %>
+<% if submission && allowed_to?(:changes?, submission) %>
+  <% submission_changes = FormSubmissionChanges.new(submission) %>
+  <% if submission_changes.edited? %>
+    <% path_params = { return_to: local_assigns[:return_to] }.compact.merge(local_assigns[:extra_params] || {}) %>
+    <%= link_to changes_form_submission_path(submission, **path_params),
+                data: local_assigns[:turbo_top] ? { turbo_frame: "_top" } : {},
+                class: "group #{local_assigns.fetch(:wrapper_class, "mb-5")} flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+      <i class="fa-solid fa-circle-info text-blue-500"></i>
+      <%= local_assigns.fetch(:label, "What this submission changed") %>
+      <span class="text-2xs rounded-full bg-blue-200 px-1.5"><%= submission_changes.edited_count %></span>
+      <% if local_assigns[:badge] %>
+        <span class="text-2xs ml-1 rounded-full border border-blue-200 bg-white/70 px-1.5 py-0.5 font-normal text-blue-700"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+      <% end %>
+      <i class="fa-solid fa-arrow-right ml-auto text-xs text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/form_submissions/_changes_link.html.erb
+++ b/app/views/form_submissions/_changes_link.html.erb
@@ -1,8 +1,9 @@
 <%#
   Admin-only bar linking to the "what this submission changed" audit for a form
-  submission. Renders nothing unless the viewer may see the audit and the
-  submission actually overwrote something (edited?). Dropped wherever a
-  submission is shown; only return_to/label/margins differ per place. locals:
+  submission. By default renders nothing unless the submission actually overwrote
+  something (edited?); pass always: true on the pages where an admin makes those
+  changes (the link-organization editors) so the audit is always reachable there.
+  Dropped wherever a submission is shown; only return_to/label/margins differ. locals:
     submission:    FormSubmission (may be nil — renders nothing)
     return_to:     eyebrow origin key for the changes page (optional)
     extra_params:  extra query params the eyebrow needs, e.g. { event_registration_id: 1 } (optional)
@@ -10,18 +11,21 @@
     wrapper_class: margin/utility classes for the link (default "mb-5")
     badge:         show the little "admin" lock chip (default false)
     turbo_top:     break out of the enclosing turbo frame on click (default false)
+    always:        show the link even when nothing has changed yet (default false)
 %>
 <% submission = local_assigns[:submission] %>
 <% if submission && allowed_to?(:changes?, submission) %>
   <% submission_changes = FormSubmissionChanges.new(submission) %>
-  <% if submission_changes.edited? %>
+  <% if submission_changes.edited? || local_assigns[:always] %>
     <% path_params = { return_to: local_assigns[:return_to] }.compact.merge(local_assigns[:extra_params] || {}) %>
     <%= link_to changes_form_submission_path(submission, **path_params),
                 data: local_assigns[:turbo_top] ? { turbo_frame: "_top" } : {},
                 class: "group #{local_assigns.fetch(:wrapper_class, "mb-5")} flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
       <i class="fa-solid fa-circle-info text-blue-500"></i>
       <%= local_assigns.fetch(:label, "What this submission changed") %>
-      <span class="text-2xs rounded-full bg-blue-200 px-1.5"><%= submission_changes.edited_count %></span>
+      <% if submission_changes.edited_count.positive? %>
+        <span class="text-2xs rounded-full bg-blue-200 px-1.5"><%= submission_changes.edited_count %></span>
+      <% end %>
       <% if local_assigns[:badge] %>
         <span class="text-2xs ml-1 rounded-full border border-blue-200 bg-white/70 px-1.5 py-0.5 font-normal text-blue-700"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
       <% end %>

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -5,6 +5,9 @@
   back_link = case params[:return_to]
   when "link_organization"
     { label: "← Back to linked organizations", path: link_organization_event_registration_path(params[:event_registration_id]) } if params[:event_registration_id].present?
+  when "event_registrant_submissions"
+    event = @form_submission.resolved_event
+    { label: "← Back to submissions", path: event_registrant_submissions_path(event, person_id: @form_submission.person_id) } if event
   end
   back_link ||= { label: "← Back to submission", path: form_submission_path(@form_submission) }
 

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -28,13 +28,13 @@
     "Person" => "fa-user", "Organization" => "fa-building", "Affiliation" => "fa-link"
   }
 %>
-<div class="max-w-3xl mx-auto py-8 px-4">
+<div class="mx-auto max-w-3xl px-4 py-8">
   <div class="mb-4">
     <%= link_to back_link[:label], back_link[:path], class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>
 
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-white">
-    <div class="px-6 pt-5 pb-5 border-b border-gray-100">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-lg ring-1 ring-black/5">
+    <div class="border-b border-gray-100 px-6 pt-5 pb-5">
       <div class="flex items-center gap-3">
         <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-900 text-white">
           <i class="fa-solid fa-wand-magic-sparkles"></i>
@@ -42,7 +42,7 @@
         <div class="min-w-0">
           <div class="flex items-center gap-2">
             <h1 class="text-2xl font-bold tracking-tight text-gray-900">What this form submission changed</h1>
-            <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 text-blue-900 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide"><i class="fa-solid fa-lock text-2xs"></i> Admin</span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold tracking-wide text-blue-900 uppercase"><i class="fa-solid fa-lock text-2xs"></i> Admin</span>
           </div>
           <p class="text-sm text-gray-500">
             <%= @form_submission.person&.full_name %> · <%= @form_submission.form&.display_name || @form_submission.form&.name %> · <%= @form_submission.created_at.to_date.to_fs(:long) %>
@@ -51,11 +51,16 @@
       </div>
     </div>
 
-    <div class="px-6 py-6 space-y-5">
+    <div class="space-y-5 px-6 py-6">
       <% if @change_groups.any? %>
-        <p class="text-xs text-gray-500"><strong><%= pluralize(@changed_count, "value") %></strong> this submission changed on records that already existed — a value replaced or a blank filled. A replaced value keeps its previous entry so it can be put back. (Brand-new records and added tags aren't shown — they're new data, not changes.)</p>
+        <p class="text-xs text-gray-500"><strong><%= pluralize(@changed_count, "change") %></strong> from this submission — values replaced or filled on records that already existed, plus any organization it added through the linking flow. A replaced value keeps its previous entry so it can be put back. (The submitter's own new records and tags aren't shown.) Each row opens that record's edit page at the field.</p>
 
         <% @change_groups.each do |group| %>
+          <%# Each row deep-links to the owner record's edit page at the changed field. %>
+          <% edit_at = case group.record_type
+             when "Person" then ->(anchor) { edit_person_path(group.record_id, anchor: anchor) }
+             when "Organization" then ->(anchor) { edit_organization_path(group.record_id, anchor: anchor) }
+             end %>
           <section class="rounded-xl border border-gray-200 overflow-hidden">
             <div class="flex items-center gap-2 px-5 py-3 bg-gray-50 border-b border-gray-200">
               <i class="fa-solid <%= group_icon.fetch(group.record_type, "fa-database") %> text-gray-500"></i>
@@ -63,15 +68,22 @@
             </div>
             <ul class="divide-y divide-gray-100">
               <% group.changes.each do |change| %>
-                <li class="px-5 py-3 flex items-start justify-between gap-3 text-sm">
+                <% row = capture do %>
                   <div class="min-w-0">
-                    <p class="text-gray-500"><%= change.label %></p>
+                    <p class="text-gray-500 flex items-center gap-1.5"><%= change.label %><% if edit_at %> <i class="fa-solid fa-pen text-2xs text-gray-300 group-hover/row:text-blue-500"></i><% end %></p>
                     <p class="text-gray-800">
                       <span class="font-medium"><%= change.value.presence || "—" %></span><%
                       %><% if change.outcome == "Replaced" && change.previous_value.present? %> <span class="text-rose-600">(replaced “<%= change.previous_value %>”)</span><% end %>
                     </p>
                   </div>
                   <span class="shrink-0 inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold <%= outcome_chip.fetch(change.outcome, "bg-gray-100 text-gray-700 border-gray-200") %>"><%= change.outcome %></span>
+                <% end %>
+                <li>
+                  <% if edit_at %>
+                    <%= link_to edit_at.call(change.anchor), class: "group/row flex items-start justify-between gap-3 px-5 py-3 text-sm hover:bg-blue-50 transition-colors" do %><%= row %><% end %>
+                  <% else %>
+                    <div class="flex items-start justify-between gap-3 px-5 py-3 text-sm"><%= row %></div>
+                  <% end %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -1,0 +1,78 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<%
+  # Reachable from the linked-organizations page and from a submission view, so the
+  # eyebrow returns to whichever origin sent us.
+  back_link = case params[:return_to]
+  when "link_organization"
+    { label: "← Back to linked organizations", path: link_organization_event_registration_path(params[:event_registration_id]) } if params[:event_registration_id].present?
+  end
+  back_link ||= { label: "← Back to submission", path: form_submission_path(@form_submission) }
+
+  outcome_chip = {
+    "Added"    => "bg-emerald-100 text-emerald-800 border-emerald-200",
+    "Removed"  => "bg-amber-100 text-amber-800 border-amber-200",
+    "Replaced" => "bg-rose-100 text-rose-800 border-rose-200",
+    "Filled"   => "bg-slate-200 text-slate-700 border-slate-300"
+  }
+  group_icon = {
+    "Person" => "fa-user", "Organization" => "fa-building", "Affiliation" => "fa-link"
+  }
+%>
+<div class="max-w-3xl mx-auto py-8 px-4">
+  <div class="mb-4">
+    <%= link_to back_link[:label], back_link[:path], class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+
+  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-white">
+    <div class="px-6 pt-5 pb-5 border-b border-gray-100">
+      <div class="flex items-center gap-3">
+        <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-900 text-white">
+          <i class="fa-solid fa-wand-magic-sparkles"></i>
+        </div>
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <h1 class="text-2xl font-bold tracking-tight text-gray-900">What this form submission changed</h1>
+            <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 text-blue-900 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide"><i class="fa-solid fa-lock text-2xs"></i> Admin</span>
+          </div>
+          <p class="text-sm text-gray-500">
+            <%= @form_submission.person&.full_name %> · <%= @form_submission.form&.display_name || @form_submission.form&.name %> · <%= @form_submission.created_at.to_date.to_fs(:long) %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="px-6 py-6 space-y-5">
+      <% if @change_groups.any? %>
+        <p class="text-xs text-gray-500">Each row shows what actually happened to the record — a value <strong>replaced</strong> or <strong>filled</strong>, or a tag <strong>added</strong> / <strong>removed</strong>.</p>
+
+        <% @change_groups.each do |group| %>
+          <section class="rounded-xl border border-gray-200 overflow-hidden">
+            <div class="flex items-center gap-2 px-5 py-3 bg-gray-50 border-b border-gray-200">
+              <i class="fa-solid <%= group_icon.fetch(group.record_type, "fa-database") %> text-gray-500"></i>
+              <h2 class="text-sm font-semibold text-gray-800"><%= group.record_type.underscore.humanize %><% if group.title.present? %> — <%= group.title %><% end %></h2>
+            </div>
+            <ul class="divide-y divide-gray-100">
+              <% group.changes.each do |change| %>
+                <li class="px-5 py-3 flex items-start justify-between gap-3 text-sm">
+                  <div class="min-w-0">
+                    <p class="text-gray-500"><%= change.label %></p>
+                    <p class="text-gray-800">
+                      <span class="font-medium"><%= change.value.presence || "—" %></span><%
+                      %><% if change.outcome == "Replaced" && change.previous_value.present? %> <span class="text-rose-600">(replaced “<%= change.previous_value %>”)</span><% end %>
+                    </p>
+                  </div>
+                  <span class="shrink-0 inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold <%= outcome_chip.fetch(change.outcome, "bg-gray-100 text-gray-700 border-gray-200") %>"><%= change.outcome %></span>
+                </li>
+              <% end %>
+            </ul>
+          </section>
+        <% end %>
+      <% else %>
+        <div class="rounded-xl border border-gray-200 bg-gray-50 px-5 py-8 text-center text-gray-500">
+          <i class="fa-solid fa-circle-check text-gray-400 text-xl mb-2"></i>
+          <p>This submission didn't change any records.</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -5,9 +5,16 @@
   back_link = case params[:return_to]
   when "link_organization"
     { label: "← Back to linked organizations", path: link_organization_event_registration_path(params[:event_registration_id]) } if params[:event_registration_id].present?
+  when "form_submission_link_organization"
+    { label: "← Back to linked organizations", path: link_organization_form_submission_path(@form_submission) }
   when "event_registrant_submissions"
     event = @form_submission.resolved_event
     { label: "← Back to submissions", path: event_registrant_submissions_path(event, person_id: @form_submission.person_id) } if event
+  when "event_registration"
+    { label: "← Back to registration", path: edit_event_registration_path(params[:event_registration_id]) } if params[:event_registration_id].present?
+  when "public_registration"
+    event = @form_submission.resolved_event
+    { label: "← Back to registration confirmation", path: event_public_registration_path(event, person_id: @form_submission.person_id) } if event
   end
   back_link ||= { label: "← Back to submission", path: form_submission_path(@form_submission) }
 

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -46,7 +46,7 @@
 
     <div class="px-6 py-6 space-y-5">
       <% if @change_groups.any? %>
-        <p class="text-xs text-gray-500">Each row shows what actually happened to the record — a value <strong>replaced</strong> or <strong>filled</strong>, or a tag <strong>added</strong> / <strong>removed</strong>.</p>
+        <p class="text-xs text-gray-500"><strong><%= pluralize(@changed_count, "value") %></strong> this submission overwrote on records that already existed. The previous value is kept so it can be put back. (New records, added tags, and filled-in blanks aren't shown — they're new data, not changes.)</p>
 
         <% @change_groups.each do |group| %>
           <section class="rounded-xl border border-gray-200 overflow-hidden">
@@ -73,7 +73,7 @@
       <% else %>
         <div class="rounded-xl border border-gray-200 bg-gray-50 px-5 py-8 text-center text-gray-500">
           <i class="fa-solid fa-circle-check text-gray-400 text-xl mb-2"></i>
-          <p>This submission didn't change any records.</p>
+          <p>This submission didn't overwrite any existing values.</p>
         </div>
       <% end %>
     </div>

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -46,7 +46,7 @@
 
     <div class="px-6 py-6 space-y-5">
       <% if @change_groups.any? %>
-        <p class="text-xs text-gray-500"><strong><%= pluralize(@changed_count, "value") %></strong> this submission overwrote on records that already existed. The previous value is kept so it can be put back. (New records, added tags, and filled-in blanks aren't shown — they're new data, not changes.)</p>
+        <p class="text-xs text-gray-500"><strong><%= pluralize(@changed_count, "value") %></strong> this submission changed on records that already existed — a value replaced or a blank filled. A replaced value keeps its previous entry so it can be put back. (Brand-new records and added tags aren't shown — they're new data, not changes.)</p>
 
         <% @change_groups.each do |group| %>
           <section class="rounded-xl border border-gray-200 overflow-hidden">
@@ -73,7 +73,7 @@
       <% else %>
         <div class="rounded-xl border border-gray-200 bg-gray-50 px-5 py-8 text-center text-gray-500">
           <i class="fa-solid fa-circle-check text-gray-400 text-xl mb-2"></i>
-          <p>This submission didn't overwrite any existing values.</p>
+          <p>This submission didn't change any existing records.</p>
         </div>
       <% end %>
     </div>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -47,6 +47,21 @@
       <% end %>
     </div>
 
+    <%# Admin-only jump to the audit of the values this submission overwrote —
+        shown only once it has overwritten something (e.g. after linking an org
+        that wasn't a clean match writes onto it). %>
+    <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
+    <% if submission_changes.edited? && allowed_to?(:changes?, @form_submission) %>
+      <%= link_to changes_form_submission_path(@form_submission, return_to: "form_submission_link_organization"),
+                  data: { turbo_frame: "_top" },
+                  class: "group -mt-4 mb-8 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+        <i class="fa-solid fa-circle-info text-blue-500"></i>
+        What this submission changed
+        <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
+        <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+      <% end %>
+    <% end %>
+
     <%# === The linked organization (an explicit link, or the registration-org row
         this submission is pinned to) + add actions — tinted
         green to stand apart, like the registration editor's linked cards. %>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -47,14 +47,14 @@
       <% end %>
     </div>
 
-    <%# Admin-only jump to the audit of the values this submission overwrote —
-        shown only once it has overwritten something (e.g. after linking an org
-        that wasn't a clean match writes onto it). %>
+    <%# Admin-only jump to the audit — always shown here, since this is where the
+        admin makes the org links/creates that produce those changes. %>
     <%= render "form_submissions/changes_link",
                submission: @form_submission,
                return_to: "form_submission_link_organization",
                wrapper_class: "-mt-4 mb-8",
-               turbo_top: true %>
+               turbo_top: true,
+               always: true %>
 
     <%# === The linked organization (an explicit link, or the registration-org row
         this submission is pinned to) + add actions — tinted

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -50,17 +50,11 @@
     <%# Admin-only jump to the audit of the values this submission overwrote —
         shown only once it has overwritten something (e.g. after linking an org
         that wasn't a clean match writes onto it). %>
-    <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
-    <% if submission_changes.edited? && allowed_to?(:changes?, @form_submission) %>
-      <%= link_to changes_form_submission_path(@form_submission, return_to: "form_submission_link_organization"),
-                  data: { turbo_frame: "_top" },
-                  class: "group -mt-4 mb-8 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-        <i class="fa-solid fa-circle-info text-blue-500"></i>
-        What this submission changed
-        <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-        <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-      <% end %>
-    <% end %>
+    <%= render "form_submissions/changes_link",
+               submission: @form_submission,
+               return_to: "form_submission_link_organization",
+               wrapper_class: "-mt-4 mb-8",
+               turbo_top: true %>
 
     <%# === The linked organization (an explicit link, or the registration-org row
         this submission is pinned to) + add actions — tinted

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -46,12 +46,15 @@
       <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
     <div class="px-6 py-7 sm:px-8">
-      <%# Admin-only jump to the audit of what this submission's answers changed. %>
-      <% if allowed_to?(:changes?, @form_submission) %>
+      <%# Admin-only jump to the audit of the values this submission overwrote —
+          shown only when it actually overwrote something. %>
+      <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
+      <% if allowed_to?(:changes?, @form_submission) && submission_changes.edited? %>
         <%= link_to changes_form_submission_path(@form_submission),
                     class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
           <i class="fa-solid fa-circle-info text-blue-500"></i>
           What this submission changed
+          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
           <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
           <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
         <% end %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -46,6 +46,16 @@
       <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
     <div class="px-6 py-7 sm:px-8">
+      <%# Admin-only jump to the audit of what this submission's answers changed. %>
+      <% if allowed_to?(:changes?, @form_submission) %>
+        <%= link_to changes_form_submission_path(@form_submission),
+                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+          <i class="fa-solid fa-circle-info text-blue-500"></i>
+          What this submission changed
+          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+        <% end %>
+      <% end %>
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -46,19 +46,7 @@
       <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
     <div class="px-6 py-7 sm:px-8">
-      <%# Admin-only jump to the audit of the values this submission overwrote —
-          shown only when it actually overwrote something. %>
-      <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
-      <% if allowed_to?(:changes?, @form_submission) && submission_changes.edited? %>
-        <%= link_to changes_form_submission_path(@form_submission),
-                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
-          <i class="fa-solid fa-circle-info text-blue-500"></i>
-          What this submission changed
-          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
-          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
-          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
-        <% end %>
-      <% end %>
+      <%= render "form_submissions/changes_link", submission: @form_submission, badge: true %>
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -32,12 +32,15 @@
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
     <div class="px-6 sm:px-8 py-7">
-      <%# Admin-only jump to the audit of what this submission's answers changed. %>
-      <% if allowed_to?(:changes?, @form_submission) %>
+      <%# Admin-only jump to the audit of the values this submission overwrote —
+          shown only when it actually overwrote something. %>
+      <% submission_changes = FormSubmissionChanges.new(@form_submission) %>
+      <% if allowed_to?(:changes?, @form_submission) && submission_changes.edited? %>
         <%= link_to changes_form_submission_path(@form_submission),
                     class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
           <i class="fa-solid fa-circle-info text-blue-500"></i>
           What this submission changed
+          <span class="rounded-full bg-blue-200 px-1.5 text-2xs"><%= submission_changes.edited_count %></span>
           <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
           <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
         <% end %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -32,6 +32,16 @@
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
     <div class="px-6 sm:px-8 py-7">
+      <%# Admin-only jump to the audit of what this submission's answers changed. %>
+      <% if allowed_to?(:changes?, @form_submission) %>
+        <%= link_to changes_form_submission_path(@form_submission),
+                    class: "group mb-5 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 hover:bg-blue-100" do %>
+          <i class="fa-solid fa-circle-info text-blue-500"></i>
+          What this submission changed
+          <span class="ml-1 rounded-full bg-white/70 text-blue-700 px-1.5 py-0.5 text-2xs font-normal border border-blue-200"><i class="fa-solid fa-lock text-2xs mr-0.5"></i>admin</span>
+          <i class="fa-solid fa-arrow-right text-xs ml-auto text-blue-400 transition-transform group-hover:translate-x-0.5"></i>
+        <% end %>
+      <% end %>
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -80,7 +80,7 @@
     <div class="flex w-full flex-col items-center gap-4 md:w-1/6"><%= render "shared/form_image_field", f: f, field_name: :avatar %></div>
   </div>
 
-  <div class="phones">
+  <div class="phones scroll-mt-4" id="phones">
     <div class="form-group space-y-4">
       <div class="mb-2 font-semibold text-gray-700">
         Phones
@@ -104,7 +104,7 @@
     </div>
   </div>
 
-  <div class="addresses">
+  <div class="addresses scroll-mt-4" id="addresses">
     <!-- Primary Address Choice -->
     <div class="flex flex-col gap-4 md:flex-row"><%# = f.input :primary_address, collection: [['Work', 1], ['Home', 2]], prompt: "Select Primary Address" %></div>
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -2648,3 +2648,19 @@
       against a person.
     - Anonymous responses send the team the usual FYI email but no confirmation
       goes back (there's no email to send it to).
+
+- name: "See what a form submission changed"
+  area: registration
+  display_status: admin_facing
+  released_on: 2026-08-29
+  pr_number: 2303
+  summary: >-
+    A "What this submission changed" page shows admins what a form submission
+    overwrote on existing records — profile, address, phone, org — plus an org it
+    created through the linking flow. A counted blue bar links to it wherever the
+    submission appears.
+  pro_tips:
+    - "Reach it from the submission page, the registrant's submissions, the linked-organizations editor, the registration edit page, and the registrant's own public confirmation."
+    - "Counts edits to records that already existed, plus an org created through linking; a submitter's own brand-new records and tags aren't counted."
+    - "Each row links to that record's edit page at the changed field."
+    - "The admin submission view now links straight to the registrant's own public version of the form (opens in a new tab)."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
   end
   resources :form_submissions, only: [ :index, :show ] do
     member do
+      get :changes
       get :link_organization
       post :select_organization
       post :create_organization

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,9 @@ Rails.application.routes.draw do
       patch :update_sections
     end
   end
-  resources :form_submissions, only: [ :index, :show ]
+  resources :form_submissions, only: [ :index, :show ] do
+    member { get :changes }
+  end
   resources :grants
   resources :scholarships, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     member do

--- a/db/seeds/dev/form_submission_changes.rb
+++ b/db/seeds/dev/form_submission_changes.rb
@@ -1,0 +1,74 @@
+# Dev-only: give one known-named person (Maria Johnson) a registration that
+# arrived AFTER she was already in the database and edited several details that
+# were already on record — so the admin "what this form submission changed" page
+# has a rich, realistic example. The edits are stored as stamped Ahoy lifecycle
+# events (the same shape the live registration flow produces), keyed to her
+# registration's form submission.
+
+event = Event.joins(:event_forms).where(event_forms: { role: "registration" }).first
+registration_form = event&.registration_form
+maria = Person.find_by("LOWER(first_name) = ? AND LOWER(last_name) = ?", "maria", "johnson")
+
+if maria.nil? || registration_form.nil?
+  puts "  Skipping form-submission-changes seed (missing Maria or a registration form/event)."
+else
+  org = maria.organizations.first || Organization.first
+
+  # Move Maria and her org into their post-registration ("after") state; the
+  # events below carry the previous values so the page can show what changed.
+  maria.update!(racial_ethnic_identity: "Latina")
+  address = maria.addresses.order(:id).first ||
+    maria.addresses.create!(street_address: "250 New Ave", city: "Los Angeles", state: "CA", zip_code: "90012", locality: "LA City", address_type: "mailing", primary: true)
+  address.update!(street_address: "250 New Ave", zip_code: "90012")
+  phone = maria.contact_methods.where(kind: :phone).order(:id).first ||
+    maria.contact_methods.create!(kind: :phone, value: "(310) 555-0199", contact_type: "personal", primary: true)
+  phone.update!(value: "(310) 555-0199")
+  org&.update!(website_url: "newsite.org", agency_type: "Hospital")
+
+  submission = FormSubmission.find_or_create_by!(person: maria, form: registration_form, event: event, role: "registration") do |record|
+    record.created_at = 2.days.ago
+  end
+
+  # Surface it on the linked-organizations and registrant-submission pages too.
+  begin
+    if org
+      registration = EventRegistration.find_or_create_by!(registrant: maria, event: event)
+      registration.event_registration_organizations.find_or_create_by!(organization: org).record_form_submission(submission)
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    puts "  (Couldn't attach a registration for the linking-page demo: #{e.message})"
+  end
+
+  if Ahoy::Event.where("properties->>'$.form_submission_id' = ?", submission.id.to_s).exists?
+    puts "  Form-submission-changes seed already present for #{maria.full_name}."
+  else
+    visit = Ahoy::Visit.create!(visit_token: SecureRandom.uuid, visitor_token: SecureRandom.uuid, started_at: 2.days.ago)
+
+    edits = [
+      { name: "update.person", type: "Person", id: maria.id, title: maria.full_name,
+        changes: { "racial_ethnic_identity" => { "before" => "Prefer not to say", "after" => "Latina" } } },
+      { name: "update.address", type: "Address", id: address.id, title: maria.full_name,
+        attributes: { "addressable_type" => "Person", "addressable_id" => maria.id },
+        changes: { "street_address" => { "before" => "100 Old St", "after" => "250 New Ave" },
+                   "zip_code" => { "before" => "90001", "after" => "90012" } } },
+      { name: "update.contact_method", type: "ContactMethod", id: phone.id, title: maria.full_name,
+        attributes: { "contactable_type" => "Person", "contactable_id" => maria.id },
+        changes: { "value" => { "before" => "(310) 555-0001", "after" => "(310) 555-0199" } } }
+    ]
+    if org
+      edits << { name: "update.organization", type: "Organization", id: org.id, title: org.name,
+                 changes: { "website_url" => { "before" => "oldsite.org", "after" => "newsite.org" },
+                            "agency_type" => { "before" => "Nonprofit", "after" => "Hospital" } } }
+    end
+
+    edits.each do |edit|
+      properties = { "resource_type" => edit[:type], "resource_id" => edit[:id], "resource_title" => edit[:title],
+                     "form_submission_id" => submission.id, "changes" => edit[:changes] }
+      properties["attributes"] = edit[:attributes] if edit[:attributes]
+      Ahoy::Event.create!(visit: visit, name: edit[:name], resource_type: edit[:type], resource_id: edit[:id],
+                          properties: properties, time: 2.days.ago)
+    end
+
+    puts "  Seeded a post-registration edit trail for #{maria.full_name} (#{edits.sum { |edit| edit[:changes].size }} changed values)."
+  end
+end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,6 +13,7 @@ namespace :db do
       workshop_logs
       monthly_reports
       events_management
+      form_submission_changes
       resources
       faqs
       video_recordings
@@ -79,6 +80,11 @@ namespace :db do
     desc "Seed dev resources"
     task resources: :environment do
       load Rails.root.join("db/seeds/dev/resources.rb")
+    end
+
+    desc "Seed a post-registration edit trail for a known person (dev only)"
+    task form_submission_changes: :environment do
+      load Rails.root.join("db/seeds/dev/form_submission_changes.rb")
     end
 
     desc "Seed dev FAQs"

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,6 +13,7 @@ namespace :db do
       workshop_logs
       monthly_reports
       events_management
+      form_submission_changes
       resources
       faqs
       video_recordings
@@ -78,6 +79,11 @@ namespace :db do
     desc "Seed dev resources"
     task resources: :environment do
       load Rails.root.join("db/seeds/dev/resources.rb")
+    end
+
+    desc "Seed a post-registration edit trail for a known person (dev only)"
+    task form_submission_changes: :environment do
+      load Rails.root.join("db/seeds/dev/form_submission_changes.rb")
     end
 
     desc "Seed dev FAQs"

--- a/spec/requests/events/form_submissions_spec.rb
+++ b/spec/requests/events/form_submissions_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe "Events::FormSubmissions", type: :request do
         expect(response.body).to include(form.name)
       end
 
+      it "links each submission to its admin changes audit" do
+        get event_registrant_submissions_path(event, person_id: person.id)
+
+        expect(response.body).to include(changes_form_submission_path(submission))
+        expect(response.body).to include("What this submission changed")
+      end
+
       it "returns 404 when person does not exist" do
         get event_registrant_submissions_path(event, person_id: 999999)
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/events/form_submissions_spec.rb
+++ b/spec/requests/events/form_submissions_spec.rb
@@ -20,11 +20,24 @@ RSpec.describe "Events::FormSubmissions", type: :request do
         expect(response.body).to include(form.name)
       end
 
-      it "links each submission to its admin changes audit" do
+      it "links a submission to its changes audit once it has overwritten a value" do
+        org = create(:organization)
+        create(:ahoy_event, name: "update.organization", properties: {
+          "resource_type" => "Organization", "resource_id" => org.id,
+          "form_submission_id" => submission.id,
+          "changes" => { "website_url" => { "before" => "old.com", "after" => "new.com" } }
+        })
+
         get event_registrant_submissions_path(event, person_id: person.id)
 
         expect(response.body).to include(changes_form_submission_path(submission))
         expect(response.body).to include("What this submission changed")
+      end
+
+      it "omits the changes link for a submission that only created new data" do
+        get event_registrant_submissions_path(event, person_id: person.id)
+
+        expect(response.body).not_to include(changes_form_submission_path(submission))
       end
 
       it "returns 404 when person does not exist" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -709,4 +709,49 @@ RSpec.describe "FormSubmissions", type: :request do
       end
     end
   end
+
+  describe "GET /form_submissions/:id/changes" do
+    def stamp(name, resource_type:, resource_id: 0, properties: {})
+      create(:ahoy_event, name: name, properties: {
+        "resource_type" => resource_type, "resource_id" => resource_id,
+        "form_submission_id" => submission.id
+      }.merge(properties))
+    end
+
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders what the submission changed, grouped by record" do
+        org = create(:organization, name: "Riverside Community Arts")
+        stamp("update.organization", resource_type: "Organization", resource_id: org.id,
+              properties: { "resource_title" => org.name,
+                            "changes" => { "website_url" => { "before" => "old.com", "after" => "new.com" } } })
+
+        get changes_form_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("What this form submission changed")
+        expect(response.body).to include("Riverside Community Arts")
+        expect(response.body).to include("Replaced")
+        expect(response.body).to include("new.com")
+      end
+
+      it "shows an empty state when nothing changed" do
+        get changes_form_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("didn't change any records")
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in create(:user) }
+
+      it "redirects away" do
+        get changes_form_submission_path(submission)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -742,6 +742,15 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("didn't change any records")
       end
+
+      it "returns to the event registrant submissions when arriving from there" do
+        submission = create(:form_submission, :with_event)
+
+        get changes_form_submission_path(submission, return_to: "event_registrant_submissions")
+
+        expect(response.body).to include("Back to submissions")
+        expect(response.body).to include(event_registrant_submissions_path(submission.resolved_event, person_id: submission.person_id))
+      end
     end
 
     context "as a non-admin" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -736,11 +736,11 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("new.com")
       end
 
-      it "shows an empty state when nothing was overwritten" do
+      it "shows an empty state when no existing record was changed" do
         get changes_form_submission_path(submission)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("didn't overwrite any existing values")
+        expect(response.body).to include("didn't change any existing records")
       end
 
       it "returns to the event registrant submissions when arriving from there" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -736,11 +736,11 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("new.com")
       end
 
-      it "shows an empty state when nothing changed" do
+      it "shows an empty state when nothing was overwritten" do
         get changes_form_submission_path(submission)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("didn't change any records")
+        expect(response.body).to include("didn't overwrite any existing values")
       end
 
       it "returns to the event registrant submissions when arriving from there" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -227,11 +227,11 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("new.com")
       end
 
-      it "shows an empty state when nothing was overwritten" do
+      it "shows an empty state when no existing record was changed" do
         get changes_form_submission_path(submission)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("didn't overwrite any existing values")
+        expect(response.body).to include("didn't change any existing records")
       end
 
       it "returns to the event registrant submissions when arriving from there" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -200,4 +200,49 @@ RSpec.describe "FormSubmissions", type: :request do
       end
     end
   end
+
+  describe "GET /form_submissions/:id/changes" do
+    def stamp(name, resource_type:, resource_id: 0, properties: {})
+      create(:ahoy_event, name: name, properties: {
+        "resource_type" => resource_type, "resource_id" => resource_id,
+        "form_submission_id" => submission.id
+      }.merge(properties))
+    end
+
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders what the submission changed, grouped by record" do
+        org = create(:organization, name: "Riverside Community Arts")
+        stamp("update.organization", resource_type: "Organization", resource_id: org.id,
+              properties: { "resource_title" => org.name,
+                            "changes" => { "website_url" => { "before" => "old.com", "after" => "new.com" } } })
+
+        get changes_form_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("What this form submission changed")
+        expect(response.body).to include("Riverside Community Arts")
+        expect(response.body).to include("Replaced")
+        expect(response.body).to include("new.com")
+      end
+
+      it "shows an empty state when nothing changed" do
+        get changes_form_submission_path(submission)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("didn't change any records")
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in create(:user) }
+
+      it "redirects away" do
+        get changes_form_submission_path(submission)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -233,6 +233,15 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("didn't change any records")
       end
+
+      it "returns to the event registrant submissions when arriving from there" do
+        submission = create(:form_submission, :with_event)
+
+        get changes_form_submission_path(submission, return_to: "event_registrant_submissions")
+
+        expect(response.body).to include("Back to submissions")
+        expect(response.body).to include(event_registrant_submissions_path(submission.resolved_event, person_id: submission.person_id))
+      end
     end
 
     context "as a non-admin" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -227,11 +227,11 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("new.com")
       end
 
-      it "shows an empty state when nothing changed" do
+      it "shows an empty state when nothing was overwritten" do
         get changes_form_submission_path(submission)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("didn't change any records")
+        expect(response.body).to include("didn't overwrite any existing values")
       end
 
       it "returns to the event registrant submissions when arriving from there" do

--- a/spec/seeds/form_submission_changes_seed_spec.rb
+++ b/spec/seeds/form_submission_changes_seed_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "dev seed: form_submission_changes" do
+  it "gives Maria Johnson a stamped post-registration edit trail on the changes page" do
+    maria = create(:person, first_name: "Maria", last_name: "Johnson")
+    form = create(:form)
+    event = create(:event)
+    create(:event_form, :registration, event: event, form: form)
+    org = create(:organization, name: "Helping Hands")
+    create(:affiliation, person: maria, organization: org)
+
+    load Rails.root.join("db/seeds/dev/form_submission_changes.rb")
+
+    submission = FormSubmission.find_by!(person: maria, role: "registration")
+    changes = FormSubmissionChanges.new(submission)
+
+    expect(changes.edited?).to be(true)
+    expect(changes.edited_count).to eq(6)
+    expect(changes.edited_groups.map(&:record_type)).to contain_exactly("Person", "Organization")
+  end
+
+  it "is idempotent — re-running adds no duplicate events" do
+    create(:person, first_name: "Maria", last_name: "Johnson")
+    event = create(:event)
+    create(:event_form, :registration, event: event, form: create(:form))
+    create(:organization)
+
+    load Rails.root.join("db/seeds/dev/form_submission_changes.rb")
+    submission = FormSubmission.find_by!(role: "registration")
+    first_count = Ahoy::Event.where("properties->>'$.form_submission_id' = ?", submission.id.to_s).count
+
+    load Rails.root.join("db/seeds/dev/form_submission_changes.rb")
+    second_count = Ahoy::Event.where("properties->>'$.form_submission_id' = ?", submission.id.to_s).count
+
+    expect(second_count).to eq(first_count)
+  end
+end

--- a/spec/services/form_submission_changes_spec.rb
+++ b/spec/services/form_submission_changes_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe FormSubmissionChanges do
     expect(described_class.new(submission).groups).to be_empty
   end
 
-  describe "edited (overwritten) values" do
-    it "counts and groups only values that overwrote an existing one" do
+  describe "edited values (changes to records that already existed)" do
+    it "counts both replaced and filled values on an existing record" do
       org = create(:organization, name: "Riverside")
       stamp("update.organization", resource_type: "Organization", resource_id: org.id,
             properties: { "resource_title" => org.name, "changes" => {
@@ -72,16 +72,16 @@ RSpec.describe FormSubmissionChanges do
 
       changes = described_class.new(submission)
       expect(changes.edited?).to be(true)
-      expect(changes.edited_count).to eq(1)
-      expect(changes.edited_groups.sum { |group| group.changes.size }).to eq(1)
-      expect(changes.edited_groups.first.changes.first).to have_attributes(outcome: "Replaced", value: "new.com")
+      expect(changes.edited_count).to eq(2)
+      expect(changes.edited_groups.sum { |group| group.changes.size }).to eq(2)
+      expect(changes.edited_groups.first.changes.map(&:outcome)).to contain_exactly("Replaced", "Filled")
     end
 
-    it "does not count a fresh submission that only creates, adds, and fills blanks" do
+    it "does not count a fresh submission that only creates records and adds tags" do
       person = create(:person)
       sector = create(:sector, :published)
-      stamp("update.person", resource_type: "Person", resource_id: person.id,
-            properties: { "changes" => { "pronouns" => { "before" => nil, "after" => "she/her" } } })
+      stamp("create.person", resource_type: "Person", resource_id: person.id,
+            properties: { "resource_title" => person.full_name, "attributes" => { "first_name" => "Dana" } })
       stamp("create.sectorable_item", resource_type: "SectorableItem",
             properties: { "attributes" => { "sector_id" => sector.id, "sectorable_type" => "Person", "sectorable_id" => person.id } })
 

--- a/spec/services/form_submission_changes_spec.rb
+++ b/spec/services/form_submission_changes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe FormSubmissionChanges do
     group = described_class.new(submission).groups.find { |g| g.record_type == "Organization" }
     expect(group.title).to eq("Riverside Community Arts")
     change = group.changes.first
-    expect(change).to have_attributes(outcome: "Replaced", label: "Website url", value: "new.com", previous_value: "old.com")
+    expect(change).to have_attributes(outcome: "Replaced", label: "Website", value: "new.com", previous_value: "old.com")
   end
 
   it "labels a change from blank as filled" do

--- a/spec/services/form_submission_changes_spec.rb
+++ b/spec/services/form_submission_changes_spec.rb
@@ -61,6 +61,37 @@ RSpec.describe FormSubmissionChanges do
     expect(described_class.new(submission).groups).to be_empty
   end
 
+  describe "edited (overwritten) values" do
+    it "counts and groups only values that overwrote an existing one" do
+      org = create(:organization, name: "Riverside")
+      stamp("update.organization", resource_type: "Organization", resource_id: org.id,
+            properties: { "resource_title" => org.name, "changes" => {
+              "website_url" => { "before" => "old.com", "after" => "new.com" },
+              "agency_type" => { "before" => nil, "after" => "Hospital" }
+            } })
+
+      changes = described_class.new(submission)
+      expect(changes.edited?).to be(true)
+      expect(changes.edited_count).to eq(1)
+      expect(changes.edited_groups.sum { |group| group.changes.size }).to eq(1)
+      expect(changes.edited_groups.first.changes.first).to have_attributes(outcome: "Replaced", value: "new.com")
+    end
+
+    it "does not count a fresh submission that only creates, adds, and fills blanks" do
+      person = create(:person)
+      sector = create(:sector, :published)
+      stamp("update.person", resource_type: "Person", resource_id: person.id,
+            properties: { "changes" => { "pronouns" => { "before" => nil, "after" => "she/her" } } })
+      stamp("create.sectorable_item", resource_type: "SectorableItem",
+            properties: { "attributes" => { "sector_id" => sector.id, "sectorable_type" => "Person", "sectorable_id" => person.id } })
+
+      changes = described_class.new(submission)
+      expect(changes.edited?).to be(false)
+      expect(changes.edited_count).to eq(0)
+      expect(changes.edited_groups).to be_empty
+    end
+  end
+
   it "only reads events stamped with this submission" do
     other = create(:form_submission)
     create(:ahoy_event, name: "update.person", properties: {

--- a/spec/services/form_submission_changes_spec.rb
+++ b/spec/services/form_submission_changes_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe FormSubmissionChanges do
+  let(:submission) { create(:form_submission) }
+
+  def stamp(name, resource_type:, resource_id: 0, properties: {})
+    create(:ahoy_event, name: name, properties: {
+      "resource_type" => resource_type,
+      "resource_id" => resource_id,
+      "form_submission_id" => submission.id
+    }.merge(properties))
+  end
+
+  it "groups an organization profile change under the org and labels it replaced" do
+    org = create(:organization, name: "Riverside Community Arts")
+    stamp("update.organization", resource_type: "Organization", resource_id: org.id,
+          properties: { "resource_title" => org.name,
+                        "changes" => { "website_url" => { "before" => "old.com", "after" => "new.com" } } })
+
+    group = described_class.new(submission).groups.find { |g| g.record_type == "Organization" }
+    expect(group.title).to eq("Riverside Community Arts")
+    change = group.changes.first
+    expect(change).to have_attributes(outcome: "Replaced", label: "Website url", value: "new.com", previous_value: "old.com")
+  end
+
+  it "labels a change from blank as filled" do
+    person = create(:person)
+    stamp("update.person", resource_type: "Person", resource_id: person.id,
+          properties: { "changes" => { "racial_ethnic_identity" => { "before" => nil, "after" => "Prefer not to say" } } })
+
+    change = described_class.new(submission).groups.first.changes.first
+    expect(change).to have_attributes(outcome: "Filled", value: "Prefer not to say")
+  end
+
+  it "attributes a sector tag to its owner and resolves the sector name" do
+    org = create(:organization, name: "Riverside")
+    sector = create(:sector, :published, name: "Healthcare")
+    stamp("create.sectorable_item", resource_type: "SectorableItem",
+          properties: { "attributes" => { "sector_id" => sector.id, "sectorable_type" => "Organization",
+                                           "sectorable_id" => org.id, "is_primary" => true } })
+
+    change = described_class.new(submission).groups.find { |g| g.record_type == "Organization" }.changes.first
+    expect(change).to have_attributes(outcome: "Added", label: "Sector", value: "Healthcare (primary)")
+  end
+
+  it "resolves an age group tag name" do
+    person = create(:person)
+    category = create(:category, :published, name: "Adolescents (13-17)")
+    stamp("create.categorizable_item", resource_type: "CategorizableItem",
+          properties: { "attributes" => { "category_id" => category.id, "categorizable_type" => "Person",
+                                          "categorizable_id" => person.id, "is_primary" => false } })
+
+    change = described_class.new(submission).groups.find { |g| g.record_type == "Person" }.changes.first
+    expect(change).to have_attributes(outcome: "Added", label: "Age group", value: "Adolescents (13-17)")
+  end
+
+  it "ignores bookkeeping records like form answers and the submission itself" do
+    stamp("create.form_answer", resource_type: "FormAnswer", resource_id: 1)
+    stamp("create.form_submission", resource_type: "FormSubmission", resource_id: submission.id)
+
+    expect(described_class.new(submission).groups).to be_empty
+  end
+
+  it "only reads events stamped with this submission" do
+    other = create(:form_submission)
+    create(:ahoy_event, name: "update.person", properties: {
+      "resource_type" => "Person", "resource_id" => 1, "form_submission_id" => other.id,
+      "changes" => { "first_name" => { "before" => "A", "after" => "B" } }
+    })
+
+    expect(described_class.new(submission).groups).to be_empty
+  end
+end

--- a/spec/services/form_submission_changes_spec.rb
+++ b/spec/services/form_submission_changes_spec.rb
@@ -90,6 +90,38 @@ RSpec.describe FormSubmissionChanges do
       expect(changes.edited_count).to eq(0)
       expect(changes.edited_groups).to be_empty
     end
+
+    it "surfaces an organization created through the linking process, alongside any fills on it" do
+      org = create(:organization, name: "Haven Hills")
+      stamp("create.organization", resource_type: "Organization", resource_id: org.id,
+            properties: { "resource_title" => org.name })
+      stamp("update.organization", resource_type: "Organization", resource_id: org.id,
+            properties: { "resource_title" => org.name,
+                          "changes" => { "website_url" => { "before" => nil, "after" => "haven.org" } } })
+
+      changes = described_class.new(submission)
+      expect(changes.edited?).to be(true)
+      expect(changes.edited_count).to eq(2)
+      group = changes.edited_groups.find { |g| g.record_type == "Organization" }
+      expect(group.changes.map(&:outcome)).to contain_exactly("Added", "Filled")
+    end
+  end
+
+  describe "field anchors for deep-linking to the record's edit page" do
+    it "carries the owner id and anchors own fields to their input, sub-records to their section" do
+      person = create(:person)
+      stamp("update.person", resource_type: "Person", resource_id: person.id,
+            properties: { "changes" => { "racial_ethnic_identity" => { "before" => "a", "after" => "b" } } })
+      stamp("update.address", resource_type: "Address", resource_id: 1,
+            properties: { "attributes" => { "addressable_type" => "Person", "addressable_id" => person.id },
+                          "changes" => { "zip_code" => { "before" => "1", "after" => "2" } } })
+
+      group = described_class.new(submission).groups.find { |g| g.record_type == "Person" }
+      expect(group.record_id).to eq(person.id)
+      anchors = group.changes.to_h { |c| [ c.label, c.anchor ] }
+      expect(anchors["Racial / ethnic identity"]).to eq("person_racial_ethnic_identity")
+      expect(anchors["ZIP"]).to eq("addresses")
+    end
   end
 
   it "only reads events stamped with this submission" do

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/story_imports/create.html.erb"          => "admin-only bg-blue-100",
     "app/views/event_registration_imports/new.html.erb"    => "admin-only bg-blue-100",
     "app/views/event_registration_imports/create.html.erb" => "admin-only bg-blue-100",
+    "app/views/form_submissions/changes.html.erb"      => "admin-only bg-blue-100",
     # index
     "app/views/allocations/index.html.erb"             => "admin-only bg-blue-100",
     "app/views/other_responses/index.html.erb"         => "admin-only bg-blue-100",

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/story_share_admin/show.html.erb"        => "admin-only bg-blue-100",
     "app/views/story_imports/new.html.erb"             => "admin-only bg-blue-100",
     "app/views/story_imports/create.html.erb"          => "admin-only bg-blue-100",
+    "app/views/form_submissions/changes.html.erb"      => "admin-only bg-blue-100",
     # index
     "app/views/allocations/index.html.erb"             => "admin-only bg-blue-100",
     "app/views/other_responses/index.html.erb"         => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 a read-model PORO + an admin page, now reachable from several pages and with per-row deep-links; contained logic, spec-covered

## Why
Gives admins a per-submission audit of everything a registration's smart-field answers changed across records — the consumer side of the change-tracking foundation. Admins can reach that audit (and the registrant's own public view) from wherever they're working, and jump from any change straight to the record's edit page.

## What
- **`FormSubmissionChanges`** — reads the Ahoy lifecycle events stamped with a submission id, groups them by the record they touched, and labels each change **Added / Removed / Replaced / Filled**.
- **Admin-only page** at `/form_submissions/:id/changes` (`changes?` → `admin?`).
- **A counted blue bar** links to it wherever a submission is shown — only when it actually changed something (`edited?`).
- **What counts as a change:** values replaced or filled on records that already existed, **plus an organization added to the DB through the linking flow** (a created org). A submitter's own new person/records and tags stay out.
- **Each change row deep-links** to that record's edit page at the changed field — own columns anchor to their form input, address/phone to their section (`#addresses` / `#phones`).

## Entry points (all admin-gated, shown only when `edited?`)
- Top-level submission view and event-registrant submissions view
- Standalone **link-organizations** editor and the event-registration one
- **Public registration confirmation** — admin-only bar, lifted above the registrant card into the admin-tools row, beside a new **"Admin view"** link
- **Registration edit** page
- Admin submission view → **"View the registrant's public version"** (new tab)
- The changes-page eyebrow resolves five `return_to` origins.

## Depends on
- The event **stamping** (attributing writes — incl. the link-organization flow's org creates — to the submission) is **#2301**. This page + read model are self-contained and tested against synthetic Ahoy events, so they merge independently; end-to-end data appears once #2301 lands.

## Docs & catalog
- CLAUDE.md + copilot-instructions.md: **"Form submission displays"** section.
- `config/features.yml`: admin-facing entry.
- Opened #2407 — standalone (non-event) submissions still have no submitter-facing view.

## Tests
- `form_submission_changes_spec` — grouping, owner attribution, replaced/filled, created-org surfacing, field anchors, submission scoping.
- `form_submissions_spec`, `events/form_submissions_spec`, `events/public_registrations_spec`, `event_registrations_spec` — pages render; access gated.
- `feature_catalog_spec`, `page_bg_class_alignment_spec`, people/org edit view specs.