### PR TITLE
Index affiliation title + centralize the facilitator seam

### DIFF
--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { isFacilitatorTitle } from "../lib/affiliation"
 
 export default class extends Controller {
   static targets = ["facilitatorSince", "affiliatedNote", "affiliatedNoteText", "memberSinceFlag", "affiliationsContainer", "programStatus"]
@@ -51,11 +52,7 @@ export default class extends Controller {
     const now = new Date()
     const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()))
 
-    // Mirrors Affiliation#facilitator?: exact, case-sensitive, trimmed — so the
-    // live figure matches the server render.
-    const facilitatorAffiliations = affiliations.filter(a =>
-      a.title.trim() === "Facilitator"
-    )
+    const facilitatorAffiliations = affiliations.filter(a => isFacilitatorTitle(a.title))
     const facStartDates = facilitatorAffiliations.map(a => a.startDate).filter(Boolean)
     const facilitatorSince = facStartDates.length
       ? new Date(Math.min(...facStartDates.map(d => new Date(d))))

--- a/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_facilitator_warning_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { isFacilitatorTitle } from "../lib/affiliation";
 
 // Connects to data-controller="affiliation-facilitator-warning"
 //
@@ -65,8 +66,7 @@ export default class extends Controller {
       startDate,
       endDate,
       destroyed,
-      // Mirror Affiliation#facilitator?: exact, case-sensitive "Facilitator" (trimmed).
-      facilitator: title.trim() === "Facilitator",
+      facilitator: isFacilitatorTitle(title),
     };
   }
 

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { isFacilitatorTitle } from "../lib/affiliation";
 
 // Live styling for the affiliation editor row as you edit, before saving. Four
 // states by colour: role is the hue (facilitator = purple, else blue) and status
@@ -92,9 +93,7 @@ export default class extends Controller {
     return this.expiredValue;
   }
 
-  // Mirror Affiliation#facilitator? — an exact, case-sensitive match on
-  // "Facilitator" (trimmed), so the live styling matches what the server renders.
   isFacilitator() {
-    return this.hasTitleTarget && this.titleTarget.value.trim() === "Facilitator";
+    return this.hasTitleTarget && isFacilitatorTitle(this.titleTarget.value);
   }
 }

--- a/app/frontend/javascript/lib/affiliation.js
+++ b/app/frontend/javascript/lib/affiliation.js
@@ -1,0 +1,6 @@
+// Single JS source of the facilitator rule, mirroring Affiliation#facilitator? /
+// .facilitators: the title must be exactly "Facilitator" (trimmed, case-sensitive).
+// The affiliation editors drive their live preview off the typed title through this.
+export const facilitatorTitle = "Facilitator"
+
+export const isFacilitatorTitle = (title) => (title ?? "").trim() === facilitatorTitle

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -49,11 +49,9 @@ class Affiliation < ApplicationRecord
       .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", date)
   }
 
-  # Only the exact, case-sensitive title "Facilitator" counts — variants like
-  # "Lead Facilitator" or "facilitator" are deliberately excluded. BINARY forces
-  # a case-sensitive comparison under MySQL's default case-insensitive collation;
-  # TRIM mirrors the in-memory #facilitator? strip so stray whitespace still matches.
-  scope :facilitators, -> { where("BINARY TRIM(title) = ?", "Facilitator") }
+  # Exactly "Facilitator" (case-sensitive; BINARY on the literal keeps the plain
+  # title index usable). Titles are normalized on write, so no TRIM is needed.
+  scope :facilitators, -> { where("affiliations.title = BINARY ?", FACILITATOR_TITLE) }
 
   # Affiliations whose #status_on(date) equals the given status, expressed in SQL
   # so it composes as a subquery (e.g. person-id narrowing). Kept in lock-step with
@@ -78,6 +76,7 @@ class Affiliation < ApplicationRecord
     end
   }
 
+  before_validation :normalize_title
   before_validation :skip_if_duplicate
   # Runs before validation so a reassigned org drops its stale organization_address_id
   # before organization_address_belongs_to_organization would reject it.
@@ -89,12 +88,10 @@ class Affiliation < ApplicationRecord
   after_destroy :sync_organization_affiliation_dates
 
   # Methods
-  # A facilitator affiliation is one whose title is *exactly* "Facilitator"
-  # (trimmed, case-sensitive). Variants like "Lead Facilitator" or "facilitator"
-  # are deliberately excluded. Mirrors the .facilitators scope so in-memory and
-  # SQL checks agree.
+  # In-memory twin of the .facilitators scope: exactly "Facilitator", case-sensitive.
+  # An executable agreement spec locks the two together.
   def facilitator?
-    title.to_s.strip == "Facilitator"
+    title.to_s.strip == FACILITATOR_TITLE
   end
 
   # Current: not flagged inactive and not past its end date. Mirrors the `active`
@@ -126,6 +123,12 @@ class Affiliation < ApplicationRecord
     valid = organization_address.addressable_type == "Organization" &&
             organization_address.addressable_id == organization_id
     errors.add(:organization_address_id, "must be an address of this organization") unless valid
+  end
+
+  # Store titles trimmed (blank → nil) so the .facilitators scope matches the bare
+  # column and uses the title index without a TRIM wrapper.
+  def normalize_title
+    self.title = title&.strip.presence
   end
 
   def skip_if_duplicate

--- a/db/migrate/20260822154252_add_index_to_affiliations_title.rb
+++ b/db/migrate/20260822154252_add_index_to_affiliations_title.rb
@@ -1,0 +1,12 @@
+class AddIndexToAffiliationsTitle < ActiveRecord::Migration[8.1]
+  # The .facilitators scope filters on the title. A plain index is usable because
+  # the scope matches the bare column (`title = BINARY ?`) rather than wrapping it
+  # in TRIM — titles are normalized on write, so no function is needed in the query.
+  def up
+    add_index :affiliations, :title unless index_exists?(:affiliations, :title)
+  end
+
+  def down
+    remove_index :affiliations, :title, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -121,6 +121,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
     t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
     t.index ["person_id"], name: "index_affiliations_on_person_id"
+    t.index ["title"], name: "index_affiliations_on_title"
   end
 
   create_table "age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -152,6 +152,28 @@ RSpec.describe Affiliation, type: :model do
     end
   end
 
+  describe 'title normalization on write' do
+    it 'stores the title trimmed' do
+      affiliation = create(:affiliation, title: "  Facilitator ")
+      expect(affiliation.reload.title).to eq("Facilitator")
+    end
+
+    it 'stores a blank title as nil' do
+      affiliation = create(:affiliation, title: "   ")
+      expect(affiliation.reload.title).to be_nil
+    end
+  end
+
+  describe 'facilitator seam (#facilitator? <-> .facilitators agree)' do
+    it '.facilitators returns exactly the saved rows whose #facilitator? is true' do
+      [ "Facilitator", "  Facilitator ", "Lead Facilitator", "facilitator", "FACILITATOR", "Volunteer", nil ]
+        .each { |t| create(:affiliation, title: t) }
+
+      in_ruby = described_class.all.select(&:facilitator?).map(&:id).sort
+      expect(described_class.facilitators.ids.sort).to eq(in_ruby)
+    end
+  end
+
   describe '#sync_organization_status_with_affiliations' do
     let!(:active_status) { OrganizationStatus.find_or_create_by!(name: "Active") }
     let!(:inactive_status) { OrganizationStatus.find_or_create_by!(name: "Inactive") }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small model/JS refactor + one index migration; behavior-preserving

### What is the goal of this PR and why is this important?

Keep facilitator-ness derived from the title (no boolean, no STI) but turn it into a clean, swappable **seam** and make the query actually fast. This is the lightweight alternative to denormalizing.

### How did you approach the change?

**Index the query**
- The old `.facilitators` scope — `WHERE BINARY TRIM(title) = 'Facilitator'` — can *never* use an index (the `TRIM` wraps the column; verified with `EXPLAIN`, full scan).
- Normalize titles on write (strip → blank becomes nil), so the scope can match the bare column: `WHERE affiliations.title = BINARY 'Facilitator'` (BINARY on the literal keeps it case-sensitive).
- Add a plain index on `affiliations.title`. `EXPLAIN` now shows the scope using it.

**Centralize the seam**
- `#facilitator?` and `.facilitators` both key off `FACILITATOR_TITLE`, locked together by an agreement spec.
- The three Stimulus editors share one `lib/affiliation.js` `isFacilitatorTitle` helper instead of each inlining `title.trim() === "Facilitator"`.

### Why this shape

Swapping the backing store later (boolean / STI / generated column) becomes a change *behind* `.facilitators` / `#facilitator?` / `isFacilitatorTitle`, with the agreement spec catching drift. No new column, no backfill, no data migration.

### Notes for reviewers

- Migration is schema-only (index add). No data backfill.
- Behavior-preserving: dev data has zero untrimmed titles; normalization only affects future writes, and a legacy stray-whitespace title (if any existed) self-heals on next save.
