### PR TITLE
Remove dead agency_id column from users (completes #414)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -423,7 +423,7 @@ class UsersController < ApplicationController
       :email, :comment, :person_id, :inactive, :locked, :primary_address, :time_zone, :super_user, :favorite_event_id,
 
       ##### legacy to remove later
-      :agency_id, :legacy, :legacy_id, :subscribecode, :first_name, :last_name, # legacy to remove later
+      :legacy, :legacy_id, :subscribecode, :first_name, :last_name, # legacy to remove later
       :address, :address2, :city, :city2, :state, :state2, :zip, :zip2, # legacy to remove later
       :phone, :phone2, :phone3, :birthday, :best_time_to_call, :notes, # legacy to remove later
       #####

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -49,7 +49,7 @@ class WorkshopsController < ApplicationController
 
     combined_windows_type = WindowsType.where(short_name: "Combined").first
     @combined_workshop_logs = current_user.organization_workshop_logs(
-      @report.date, combined_windows_type, current_user.agency_id
+      @report.date, combined_windows_type, nil
     )
     authorize! @combined_workshop_logs
   end

--- a/db/migrate/20260822092423_remove_agency_id_from_users.rb
+++ b/db/migrate/20260822092423_remove_agency_id_from_users.rb
@@ -1,0 +1,18 @@
+class RemoveAgencyIdFromUsers < ActiveRecord::Migration[8.1]
+  # Legacy column carried over from the old schema. Prod holds no values (all NULL),
+  # and its only remaining readers are being cut over in the same change. Second and
+  # final half of #414 (the affiliations half shipped in #2305).
+  def up
+    remove_foreign_key :users, column: :agency_id, if_exists: true
+    remove_index :users, :agency_id, if_exists: true
+    remove_column :users, :agency_id, if_exists: true
+  end
+
+  def down
+    add_column :users, :agency_id, :integer unless column_exists?(:users, :agency_id)
+    add_index :users, :agency_id unless index_exists?(:users, :agency_id)
+    unless foreign_key_exists?(:users, column: :agency_id)
+      add_foreign_key :users, :organizations, column: :agency_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1490,7 +1490,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
   create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "address"
     t.string "address2"
-    t.integer "agency_id"
     t.string "avatar_content_type"
     t.string "avatar_file_name"
     t.integer "avatar_file_size"
@@ -1545,7 +1544,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
     t.string "welcome_instructions_token"
     t.string "zip"
     t.string "zip2"
-    t.index ["agency_id"], name: "index_users_on_agency_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_by_id"], name: "index_users_on_created_by_id"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -1992,7 +1990,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
   add_foreign_key "user_permissions", "permissions"
   add_foreign_key "user_permissions", "users"
   add_foreign_key "users", "events", column: "favorite_event_id"
-  add_foreign_key "users", "organizations", column: "agency_id"
   add_foreign_key "users", "people"
   add_foreign_key "users", "users", column: "created_by_id"
   add_foreign_key "users", "users", column: "updated_by_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -35,7 +35,6 @@ FactoryBot.define do
     # legacy { false }
     # legacy_id { 1 }
     # super_user { false }
-    # agency_id { 1 }
     # person_id { "" }
     # created_by_id { 1 }
     # updated_by_id { 1 }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 drops an unused column + FK + index and cuts over two legacy readers; behavior-preserving

## Why
- `users.agency_id` is a legacy FK carried from the old schema. Prod holds no values (all NULL — re-verified: `SELECT COUNT(*) FROM users WHERE agency_id IS NOT NULL;` → 0).
- Completes #414 — the `affiliations.organization_agency_id` half shipped in #2305; this is the `users.agency_id` half.

## What
- **Migration** drops the FK, index, and column. Reversible `up`/`down`, both idempotent and rollback-tested.
- **`workshops_controller#summary`** passed `current_user.agency_id` as the org filter into `organization_workshop_logs`. Since that value is always NULL in prod, the method already returns nil; swapped to an explicit `nil` — identical behavior, no column dependency.
- **`users_controller`** dropped `:agency_id` from the legacy permitted-params list.
- Removed a stale commented reference in the users factory.

## Notes for reviewer
- Pre-existing oddity left untouched: `summary` does `authorize! @combined_workshop_logs`, which is `authorize! nil` whenever the combined logs are empty (i.e. always, in prod). Not introduced here — flagging as a possible follow-up.

Closes #414