### PR TITLE
Remove vestigial position column from affiliations

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -429,7 +429,7 @@ class UsersController < ApplicationController
       #####
 
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
-      affiliations_attributes: [ :id, :organization_id, :position, :title, :inactive, :primary_contact, :start_date, :end_date, :_destroy ],
+      affiliations_attributes: [ :id, :organization_id, :title, :inactive, :primary_contact, :start_date, :end_date, :_destroy ],
     )
   end
 end

--- a/app/decorators/affiliation_decorator.rb
+++ b/app/decorators/affiliation_decorator.rb
@@ -1,5 +1,5 @@
 class AffiliationDecorator < ApplicationDecorator
   def detail(length: nil)
-    "#{person.full_name}: #{title.presence || position} - #{organization.name}"
+    "#{person.full_name}: #{title.presence || Affiliation::FACILITATOR_TITLE} - #{organization.name}"
   end
 end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -4,9 +4,11 @@ class Affiliation < ApplicationRecord
   # (both treat exactly "Facilitator" as canonical).
   FACILITATOR_TITLE = "Facilitator".freeze
 
-  # Legacy role title, seeded when the old integer `position` enum (liaison: 1)
-  # was converted to free-text `title` (#432/#735). Gates monthly-report editing.
+  # Legacy role titles, seeded when the old integer `position` enum (liaison: 1,
+  # leader: 2) was converted to free-text `title` (#432/#735). LIAISON_TITLE gates
+  # monthly-report editing; LEADER_TITLE backs Organization#leader / #led_by?.
   LIAISON_TITLE = "Liaison".freeze
+  LEADER_TITLE = "Leader".freeze
 
   # Status taxonomy shown as a chip on each person's row, in display order.
   STATUSES = %w[ Active Upcoming Inactive ].freeze

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -4,6 +4,10 @@ class Affiliation < ApplicationRecord
   # (both treat exactly "Facilitator" as canonical).
   FACILITATOR_TITLE = "Facilitator".freeze
 
+  # Legacy role title, seeded when the old integer `position` enum (liaison: 1)
+  # was converted to free-text `title` (#432/#735). Gates monthly-report editing.
+  LIAISON_TITLE = "Liaison".freeze
+
   # Status taxonomy shown as a chip on each person's row, in display order.
   STATUSES = %w[ Active Upcoming Inactive ].freeze
   # Filter-only value combining the two current-or-future statuses — never a chip,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -332,6 +332,10 @@ class Organization < ApplicationRecord
     end
   end
 
+  def leader
+    affiliations.find_by(title: Affiliation::LEADER_TITLE)
+  end
+
   def remove_duplicate_sectorable_items
     sectorable_items
       .group_by(&:sector_id)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -332,10 +332,6 @@ class Organization < ApplicationRecord
     end
   end
 
-  def leader
-    affiliations.find_by(position: 2)
-  end
-
   def remove_duplicate_sectorable_items
     sectorable_items
       .group_by(&:sector_id)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -304,7 +304,7 @@ class Person < ApplicationRecord
   end
 
   def has_liasion_position_for?(organization_id)
-    !affiliations.where(organization_id: organization_id, position: 1).first.nil?
+    affiliations.where(organization_id: organization_id, title: Affiliation::LIAISON_TITLE).exists?
   end
 
   def primary_organization

--- a/db/migrate/20260822093639_remove_position_from_affiliations.rb
+++ b/db/migrate/20260822093639_remove_position_from_affiliations.rb
@@ -1,0 +1,12 @@
+class RemovePositionFromAffiliations < ActiveRecord::Migration[8.1]
+  # Vestigial column: the old integer role enum (default: 0, liaison: 1, leader: 2,
+  # assistant: 3) was converted to free-text `title` on prod and removed from the
+  # model in #432/#735, but the column itself was never dropped.
+  def up
+    remove_column :affiliations, :position, if_exists: true
+  end
+
+  def down
+    add_column :affiliations, :position, :integer unless column_exists?(:affiliations, :position)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,7 +113,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_112435) do
     t.bigint "organization_address_id"
     t.integer "organization_id", null: false
     t.bigint "person_id", null: false
-    t.integer "position"
     t.boolean "primary_contact", default: false, null: false
     t.date "start_date"
     t.string "title"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -143,7 +143,7 @@ end
   Affiliation.create!(
     person: user.person,
     organization: awbw_org,
-    position: :leader,
+    title: Affiliation::LEADER_TITLE,
     start_date: 1.year.ago.to_date
   )
 end

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -30,7 +30,7 @@ puts "Creating Persons and Affiliations for seed users…"
   Affiliation.create!(
     person: person,
     organization: org,
-    position: :leader,
+    title: Affiliation::LEADER_TITLE,
     start_date: 1.year.ago.to_date
   )
 end
@@ -182,7 +182,6 @@ Person.where(
       person: person,
       organization: org,
       title: title,
-      position: [ :default, :liaison, :leader, :assistant ].sample,
       start_date: rand(1..5).years.ago.to_date,
       inactive: [ false, false, false, true ].sample
     )

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -633,6 +633,35 @@ RSpec.describe Person, type: :model do
       expect(person.mailing_list_consent_source).to be_nil
     end
   end
+
+  describe "#has_liasion_position_for?" do
+    let(:person) { create(:person) }
+    let(:organization) { create(:organization) }
+
+    it "is true when the person has a Liaison affiliation with that organization" do
+      create(:affiliation, person: person, organization: organization, title: Affiliation::LIAISON_TITLE)
+
+      expect(person.has_liasion_position_for?(organization.id)).to be(true)
+    end
+
+    it "matches the legacy title regardless of case" do
+      create(:affiliation, person: person, organization: organization, title: "liaison")
+
+      expect(person.has_liasion_position_for?(organization.id)).to be(true)
+    end
+
+    it "is false for a non-liaison affiliation with that organization" do
+      create(:affiliation, person: person, organization: organization, title: "Facilitator")
+
+      expect(person.has_liasion_position_for?(organization.id)).to be(false)
+    end
+
+    it "is false when the Liaison affiliation is with a different organization" do
+      create(:affiliation, person: person, organization: organization, title: Affiliation::LIAISON_TITLE)
+
+      expect(person.has_liasion_position_for?(create(:organization).id)).to be(false)
+    end
+  end
 end
 
 RSpec.describe Person, "scholarship index helpers" do

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe "/organizations", type: :request do
       org = create(:organization, organization_status: organization_status)
       create(:sectorable_item, sector: create(:sector, name: "Direct Sector 1"), sectorable: org)
       create(:sectorable_item, sector: create(:sector, name: "Direct Sector 2"), sectorable: org)
-      create(:affiliation, organization: org, person: person_1, position: :default)
-      create(:affiliation, organization: org, person: person_2, position: :default)
+      create(:affiliation, organization: org, person: person_1)
+      create(:affiliation, organization: org, person: person_2)
       org
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 column drop touching a live monthly-report gate + two model methods and seeds — check the title-based rewrites

Finishes #432: the old integer role enum on `affiliations` (`liaison: 1, leader: 2, assistant: 3`) was converted to free-text `title` on prod and removed from the model in #735, but the column itself was never dropped.

## Changes
- **Drop the column** — reversible migration (`down` re-adds the bare integer column).
- **Rewrite the two methods that still read `position` by integer** — both to a `title` lookup:
  - `Person#has_liasion_position_for?` (gates monthly-report editing) → matches `title` == "Liaison". New spec covers it.
  - `Organization#leader` (private; called by `led_by?`) → finds by `title` == "Leader".
- **Seeds** no longer set `position:` on affiliations (would now be an unknown attribute) — use `title:` instead. Verified `db:seed:dev` runs clean.
- Decorator fallback (`title.presence || position`) and the `users_controller` permitted param no longer reference `position`.
- New `Affiliation::LIAISON_TITLE` / `LEADER_TITLE` constants document the legacy mapping.

## Why title-based works
#735 already converted every positioned prod row into the human-readable `title`, and no current code writes `position`. Both the old integer check and the new title check only ever match legacy rows, so behavior is preserved. The comparisons are case-insensitive under the table's `utf8mb4_unicode_ci` collation.

## Noticed, left alone
`Organization#led_by?` is pre-existing dead code (no callers repo-wide) and is broken independently of this PR — it calls `leader.user`, but `Affiliation` has no `user` association. Out of scope; flagging for a future cleanup.