### PR TITLE
Make an affiliation's linked registration re-linkable

### DIFF
--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -1,5 +1,6 @@
 class AffiliationsController < ApplicationController
   before_action :set_affiliation, only: %i[ edit update destroy ]
+  before_action :set_registration_choices, only: %i[ edit update ]
 
   def edit
     authorize! @affiliation
@@ -60,6 +61,19 @@ class AffiliationsController < ApplicationController
 
   def set_affiliation
     @affiliation = Affiliation.find(params[:id])
+  end
+
+  # The registration picker offers this person's own registrations, newest event
+  # first, plus the currently-linked one even if it belongs to someone else (so an
+  # existing link never silently drops out of the options).
+  def set_registration_choices
+    ids = EventRegistration.where(registrant_id: @affiliation.person_id).ids
+    ids |= [ @affiliation.event_registration_id ].compact
+    @registration_choices = EventRegistration
+      .where(id: ids)
+      .includes(:event, :organizations)
+      .references(:event)
+      .order(Arel.sql("events.start_date DESC"))
   end
 
   def affiliation_params

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -117,6 +117,15 @@ class EventRegistrationDecorator < ApplicationDecorator
     name
   end
 
+  # Option label for the affiliation editor's linked-registration picker: event
+  # date + title with the registration's linked org(s). Omits the registrant,
+  # which is already the affiliation's person.
+  def affiliation_choice_label
+    date = event&.start_date&.strftime("%Y-%m-%d")
+    orgs = organizations.map(&:name).join(", ").presence
+    [ date, event&.title.presence || "Untitled event", orgs && "— #{orgs}" ].compact.join(" ")
+  end
+
   def detail(length: nil)
   end
 

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -111,15 +111,12 @@
       <% if params[:admin] == "true" && allowed_to?(:manage?, @affiliation) %>
         <div class="admin-only rounded-md bg-blue-100 p-3">
           <%= f.input :event_registration_id,
-                collection: @affiliation.event_registration ? [ [ @affiliation.event_registration.remote_search_label[:label], @affiliation.event_registration_id ] ] : [],
+                collection: @registration_choices.map { |er| [ er.decorate.affiliation_choice_label, er.id ] },
                 selected: @affiliation.event_registration_id,
-                include_blank: "— None",
+                include_blank: "— Not linked to a registration —",
                 label: "Linked registration",
                 label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                hint: "Search by registrant or event to link (or clear) the source registration. Reassigning the organization clears this automatically.",
-                input_html: {
-                  data: { controller: "remote-select", remote_select_model_value: "event_registration" }
-                } %>
+                hint: "This person's registrations, labelled with the linked organization. Clearing the link marks the row as manually created, so reconciliation leaves it alone. Reassigning the organization clears it automatically." %>
           <% if @affiliation.event_registration.present? %>
             <%= link_to edit_event_registration_path(@affiliation.event_registration),
                   class: "mt-1 inline-block text-xs underline font-medium text-gray-600", target: "_blank", rel: "noopener" do %>
@@ -137,7 +134,8 @@
                   edit_event_registration_path(er), class: "underline font-medium", target: "_blank", rel: "noopener" %><%= " — #{er.event.title}" if er.event %>.
             Reassigning the organization here unlinks that registration from this affiliation; update the organization in the
             <%= link_to "registration's organization-linking step",
-                  link_organization_event_registration_path(er), class: "underline font-medium", target: "_blank", rel: "noopener" %> as well.
+                  link_organization_event_registration_path(er),
+                  class: "underline font-medium", target: "_blank", rel: "noopener" %> as well.
           </p>
         </div>
       <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -42,8 +42,9 @@
   released_on: 2026-08-22
   pr_number: 2332
   summary: >-
-    In admin mode the affiliation editor adds a searchable picker to link, change, or clear
-    the registration an affiliation came from, with a link straight to that registration.
+    In admin mode the affiliation editor adds a picker of that person's registrations — each
+    labelled with its linked organization — to link, change, or clear the registration an
+    affiliation came from, with a link straight to that registration.
   pro_tips:
     - "Add ?admin=true to the affiliation editor URL to reveal the registration picker."
 

--- a/spec/decorators/event_registration_decorator_spec.rb
+++ b/spec/decorators/event_registration_decorator_spec.rb
@@ -16,6 +16,23 @@ RSpec.describe EventRegistrationDecorator, type: :decorator do
     end
   end
 
+  describe "#affiliation_choice_label" do
+    it "combines the event date, title, and linked orgs, omitting the registrant" do
+      event = create(:event, title: "Spring Training", start_date: Time.zone.parse("2026-03-14 10:00"))
+      org = create(:organization, name: "Sunrise House")
+      reg = create(:event_registration, event: event, organizations: [ org ]).decorate
+
+      expect(reg.affiliation_choice_label).to eq("2026-03-14 Spring Training — Sunrise House")
+    end
+
+    it "drops the org clause when the registration has no linked org" do
+      event = create(:event, title: "Spring Training", start_date: Time.zone.parse("2026-03-14 10:00"))
+      reg = create(:event_registration, event: event, organizations: []).decorate
+
+      expect(reg.affiliation_choice_label).to eq("2026-03-14 Spring Training")
+    end
+  end
+
   describe "#deletion_blocked_reason" do
     it "returns nil for a deletable registration" do
       reg = create(:event_registration, status: "registered")

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -18,37 +18,42 @@ RSpec.describe "/affiliations", type: :request do
         expect(response).to be_successful
       end
 
-      it "surfaces a linked registration with the org-linking warning" do
-        registration = create(:event_registration)
-        affiliation.update_column(:event_registration_id, registration.id)
-
-        get edit_affiliation_path(affiliation)
-
-        expect(response.body).to include("Linked to a registration")
-        expect(response.body).to include(link_organization_event_registration_path(registration))
-      end
-
       it "surfaces the FileMaker code field" do
         get edit_affiliation_path(affiliation)
 
         expect(response.body).to include("affiliation[filemaker_code]")
       end
 
-      it "shows the registration remote-search picker only in admin mode" do
-        get edit_affiliation_path(affiliation)
-        expect(response.body).not_to include("Linked registration")
+      it "hides the registration picker outside admin mode, showing the read-only banner instead" do
+        registration = create(:event_registration, registrant: person)
+        affiliation.update_column(:event_registration_id, registration.id)
 
-        get edit_affiliation_path(affiliation, admin: "true")
-        expect(response.body).to include("Linked registration")
-        expect(response.body).to include("event_registration")
+        get edit_affiliation_path(affiliation)
+
+        expect(response.body).not_to include("Linked registration")
+        expect(response.body).to include(link_organization_event_registration_path(registration))
       end
 
-      it "surfaces a link to the linked registration in the admin picker" do
+      it "in admin mode offers the person's registrations, labelled with the linked org" do
+        event = create(:event, title: "Spring Training")
+        org = create(:organization, name: "Sunrise House")
+        registration = create(:event_registration, registrant: person, event: event, organizations: [ org ])
+
+        get edit_affiliation_path(affiliation, admin: "true")
+
+        expect(response.body).to include("Linked registration")
+        expect(response.body).to include("Spring Training")
+        expect(response.body).to include("Sunrise House")
+        expect(response.body).to include(%(value="#{registration.id}"))
+      end
+
+      it "in admin mode keeps the current link selectable even when it isn't the person's own" do
         registration = create(:event_registration)
         affiliation.update_column(:event_registration_id, registration.id)
 
         get edit_affiliation_path(affiliation, admin: "true")
 
+        expect(response.body).to include(%(value="#{registration.id}"))
         expect(response.body).to include(edit_event_registration_path(registration))
       end
     end
@@ -96,6 +101,18 @@ RSpec.describe "/affiliations", type: :request do
         expect(comment.created_by).to eq(admin)
       end
 
+      it "links and unlinks the affiliation's registration through the picker" do
+        registration = create(:event_registration, registrant: person)
+
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { event_registration_id: registration.id } }
+        expect(affiliation.reload.event_registration_id).to eq(registration.id)
+
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { event_registration_id: "" } }
+        expect(affiliation.reload.event_registration_id).to be_nil
+      end
+
       it "assigns the organization address through the editor" do
         address = create(:address, addressable: organization)
 
@@ -110,15 +127,6 @@ RSpec.describe "/affiliations", type: :request do
               params: { affiliation: { filemaker_code: "FM-123" } }
 
         expect(affiliation.reload.filemaker_code).to eq("FM-123")
-      end
-
-      it "links a registration through the picker" do
-        registration = create(:event_registration)
-
-        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id, admin: "true"),
-              params: { affiliation: { event_registration_id: registration.id } }
-
-        expect(affiliation.reload.event_registration_id).to eq(registration.id)
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 refines an already-merged admin picker — scoping + label + one decorator method

## Why
- #2332 (already on main) added an admin-mode registration picker on the affiliation editor, but it's a **remote search over *all* registrations**, labelled by registrant (no org).
- An affiliation's registration is always the person's own, so an unscoped anyone-search invites mis-links, and the label doesn't show the organization.

## What (builds on #2332, keeps its admin gate + banner + FileMaker field)
- **Scope the picker to the affiliation person's own registrations** (`AffiliationsController#set_registration_choices`), plus the currently-linked one so an existing link never drops out of the options.
- **Label each option with the linked org** — `2026-03-14 Spring Training — Sunrise House` via new `EventRegistrationDecorator#affiliation_choice_label` (registrant omitted; it's already the affiliation's person).
- Swaps the remote-search select for this collection select; everything else from #2332 (the `?admin=true` gate, read-only banner fallback, "Open the linked registration" link, FileMaker field, `event_registration_id` permit) is unchanged.

## Notes
- Changing the **organization** still unlinks the registration (existing `reset_org_scoped_links_on_org_change` invariant) — the banner/hint call this out.
- Updated the existing #2332 Features & tips entry to describe the person-scoped, org-labelled picker instead of adding a duplicate card.

## Tests
- Request specs: picker offers the person's registrations (labelled with org) in admin mode; hidden outside admin mode (banner shown); current link stays selectable even if not the person's own; link/unlink round-trip.
- Decorator specs: label with and without a linked org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)