### PR TITLE
Add filters to the form submissions index

### DIFF
--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -6,13 +6,14 @@ class FormSubmissionsController < ApplicationController
     @form = Form.find_by(id: params[:form_id]) if params[:form_id].present?
 
     if turbo_frame_request?
-      submissions = FormSubmission.includes(:form, :event, :person)
-      submissions = submissions.where(person_id: @person.id) if @person
-      submissions = submissions.where(form_id: @form.id) if @form
-      @form_submissions = submissions.order(created_at: :desc).paginate(page: params[:page], per_page: 50)
+      @form_submissions = FormSubmission.search_by_params(params)
+        .includes(:form, :event, :person)
+        .order(created_at: :desc)
+        .paginate(page: params[:page], per_page: 50)
       render :form_submissions_results
     else
       @forms = Form.order(:name)
+      @roles = FormSubmission.distinct.pluck(:role).compact.sort
       render :index
     end
   end

--- a/app/helpers/form_submissions_helper.rb
+++ b/app/helpers/form_submissions_helper.rb
@@ -1,0 +1,20 @@
+module FormSubmissionsHelper
+  # The index filters that a submission's detail page must hand back so the trip
+  # to View a submission and back lands on the same filtered list. `person_id` and
+  # `form_id` are threaded separately (the View link scopes person_id to the row),
+  # so only the newer filters live here. Blank values are dropped.
+  def form_submission_carryover_params(params)
+    {
+      event_id: params[:event_id].presence,
+      organization_id: params[:organization_id].presence,
+      role: params[:role].presence,
+      start_date: params[:start_date].presence,
+      end_date: params[:end_date].presence
+    }.compact
+  end
+
+  # True when any index filter is active — drives whether "Clear filters" shows.
+  def form_submission_filters_active?(params)
+    params.values_at(:person_id, :form_id, :event_id, :organization_id, :role, :start_date, :end_date).any?(&:present?)
+  end
+end

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -15,11 +15,45 @@ class FormSubmission < ApplicationRecord
 
   scope :bulk_payment, -> { where(role: "bulk_payment") }
 
+  # Submitted on `created_at` — there is no separate submitted_at column.
+  scope :submitted_between, ->(start_date, end_date) {
+    scope = all
+    scope = scope.where(created_at: start_date.beginning_of_day..) if start_date
+    scope = scope.where(created_at: ..end_date.end_of_day) if end_date
+    scope
+  }
+
+  # Submissions linked to an organization through an event registration. This is
+  # the only queryable submission → organization path (the org an answer names is
+  # otherwise just free text); submissions that never linked an org won't match.
+  scope :for_organization, ->(organization_id) {
+    where(id: EventRegistrationOrganization.where(organization_id: organization_id).select(:form_submission_id))
+  }
+
   validates :slug, uniqueness: true, allow_nil: true
 
   # Bulk payment submissions are reachable by their payer (who has no account)
   # through a public, slug-based ticket URL. Other roles are reached by id.
   before_create :generate_slug, if: :bulk_payment?
+
+  # Narrow the admin index by the optional filter params. Each filter is a no-op
+  # when its param is blank, so combinations stack.
+  def self.search_by_params(params)
+    results = all
+    results = results.where(person_id: params[:person_id]) if params[:person_id].present?
+    results = results.where(form_id: params[:form_id]) if params[:form_id].present?
+    results = results.where(event_id: params[:event_id]) if params[:event_id].present?
+    results = results.where(role: params[:role]) if params[:role].present?
+    results = results.for_organization(params[:organization_id]) if params[:organization_id].present?
+    results.submitted_between(parse_date(params[:start_date]), parse_date(params[:end_date]))
+  end
+
+  def self.parse_date(value)
+    return if value.blank?
+    Date.parse(value)
+  rescue ArgumentError, TypeError
+    nil
+  end
 
   def self.generate_unique_slug
     loop do

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -41,7 +41,7 @@
               <td class="px-4 py-3 whitespace-nowrap"><%= submission.created_at.to_fs(:long) %></td>
               <td class="px-4 py-3 text-right">
                 <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. %>
-                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: submission.person_id, form_id: @form&.id), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: submission.person_id, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -32,21 +32,73 @@
       </div>
     </div>
 
-    <%# Filter by form. Auto-submits into the results frame on change. %>
-    <%= form_with url: form_submissions_path, method: :get, data: { controller: "collection", turbo_frame: "form_submissions_results" } do |f| %>
-      <% if @person %><%= hidden_field_tag :person_id, @person.id %><% end %>
+    <%# Filters. Auto-submit into the results frame on change. %>
+    <%= form_with url: form_submissions_path, method: :get, autocomplete: "off",
+          data: { controller: "collection", turbo_frame: "form_submissions_results" } do |f| %>
       <%# Carried so a filter change keeps the eyebrow, and the View links keep their origin. %>
       <% if params[:return_to].present? %><%= hidden_field_tag :return_to, params[:return_to] %><% end %>
-      <div class="mb-6 flex flex-wrap items-end gap-3">
-        <div class="min-w-64">
+      <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        <div>
           <%= f.label :form_id, "Form", class: search_label_class %>
           <%= f.select :form_id,
                 options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
                 { include_blank: "All forms" },
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <% if params[:form_id].present? %>
-          <%= render "shared/search_clear", url: form_submissions_path(person_id: @person&.id, return_to: params[:return_to].presence) %>
+
+        <div>
+          <%= f.label :role, "Role", class: search_label_class %>
+          <%= f.select :role,
+                options_for_select(@roles.map { |role| [ role.humanize, role ] }, params[:role]),
+                { include_blank: "All roles" },
+                class: search_field_class(extra: "search-select-placeholder") %>
+        </div>
+
+        <div>
+          <%= label_tag :event_id, "Event", class: search_label_class %>
+          <%= select_tag :event_id,
+                options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.name, event.id ] }, params[:event_id]),
+                include_blank: true,
+                prompt: "Search for an event",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "event" } %>
+        </div>
+
+        <div>
+          <%= label_tag :person_id, "Person", class: search_label_class %>
+          <%= select_tag :person_id,
+                options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
+                include_blank: true,
+                prompt: "Search for a person",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "person" } %>
+        </div>
+
+        <div>
+          <%= label_tag :organization_id, "Organization", class: search_label_class %>
+          <%= select_tag :organization_id,
+                options_for_select(Organization.where(id: params[:organization_id]).map { |org| [ org.name, org.id ] }, params[:organization_id]),
+                include_blank: true,
+                prompt: "Search for an organization",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+        </div>
+
+        <div>
+          <%= label_tag :start_date, "Submitted from", class: search_label_class %>
+          <%= date_field_tag :start_date, params[:start_date], class: search_field_class %>
+        </div>
+
+        <div>
+          <%= label_tag :end_date, "Submitted to", class: search_label_class %>
+          <%= date_field_tag :end_date, params[:end_date], class: search_field_class %>
+        </div>
+
+        <% if form_submission_filters_active?(params) %>
+          <div class="flex flex-col">
+            <span class="<%= search_label_class %>" aria-hidden="true">&nbsp;</span>
+            <%= render "shared/search_clear", url: form_submissions_path(return_to: params[:return_to].presence) %>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -1,8 +1,8 @@
 <% event = @form_submission.resolved_event %>
-<div class="max-w-2xl mx-auto px-4 pt-4">
+<div class="mx-auto max-w-2xl px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>
-      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, **form_submission_carryover_params(params), return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>
@@ -17,21 +17,21 @@
   </div>
 </div>
 
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+<div class="mx-auto max-w-2xl px-4 pt-6 pb-12">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Form submission</h1>
+          <h1 class="text-xl leading-tight font-semibold tracking-wide">Form submission</h1>
           <p class="text-sm text-blue-200"><%= @form_submission.form.name %></p>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
-    <div class="px-6 sm:px-8 py-7">
+    <div class="px-6 py-7 sm:px-8">
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -48,6 +48,23 @@
     - "Edit the \"Published quote\" to clean up wording for display — the \"Original submission\" is preserved automatically."
     - "Link an author when the speaker is a person on file; otherwise just type their name in \"Speaker name\"."
 
+- name: "Filter form submissions by date, event, person, organization, and role"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/form_submissions"
+  summary: >-
+    The form submissions index now has a full filter bar — narrow submissions by submission
+    date range, event, person, organization, and role, on top of the existing form filter.
+  description: >-
+    The admin form submissions index used to filter by form only. It now has a filter bar
+    matching the other index pages: a submitted-from / submitted-to date range, searchable
+    Event, Person, and Organization pickers, and a Role dropdown. Filters stack, and a
+    "Clear filters" button appears once any is set. The chosen filters carry over when you
+    open a submission and come back, so you land on the same filtered list.
+  pro_tips:
+    - "The Organization filter matches submissions linked to an org through an event registration."
+
 - name: "Filter registrants by registration date"
   area: events
   display_status: user_facing

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -9,6 +9,43 @@ RSpec.describe FormSubmission do
     it { should accept_nested_attributes_for(:form_answers) }
   end
 
+  describe ".search_by_params" do
+    it "returns all submissions when no filters are given" do
+      a = create(:form_submission)
+      b = create(:form_submission)
+
+      expect(FormSubmission.search_by_params({})).to contain_exactly(a, b)
+    end
+
+    it "filters by form, role, event, and person" do
+      form = create(:form)
+      event = create(:event)
+      person = create(:person)
+      wanted = create(:form_submission, form: form, role: "registration", event: event, person: person)
+      create(:form_submission, role: "scholarship")
+
+      expect(FormSubmission.search_by_params(form_id: form.id, role: "registration",
+                                             event_id: event.id, person_id: person.id)).to contain_exactly(wanted)
+    end
+
+    it "filters by submission date range on created_at, ignoring unparseable dates" do
+      old = create(:form_submission, created_at: 2.years.ago)
+      recent = create(:form_submission, created_at: Date.current)
+
+      expect(FormSubmission.search_by_params(start_date: 1.month.ago.to_date.iso8601)).to contain_exactly(recent)
+      expect(FormSubmission.search_by_params(end_date: "not-a-date")).to contain_exactly(old, recent)
+    end
+
+    it "filters by organization through the registration link" do
+      organization = create(:organization)
+      linked = create(:form_submission)
+      create(:form_submission)
+      create(:event_registration_organization, organization: organization, form_submission: linked)
+
+      expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(linked)
+    end
+  end
+
   describe "slug" do
     it "generates a unique slug for bulk payment submissions" do
       submission = create(:form_submission, role: "bulk_payment")

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -43,6 +43,61 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).not_to include(form_submission_path(theirs))
       end
 
+      it "filters by role" do
+        registration = create(:form_submission, role: "registration")
+        scholarship = create(:form_submission, role: "scholarship")
+
+        get form_submissions_path(role: "registration"), headers: frame_headers
+
+        expect(response.body).to include(form_submission_path(registration))
+        expect(response.body).not_to include(form_submission_path(scholarship))
+      end
+
+      it "filters by event" do
+        event = create(:event)
+        here = create(:form_submission, event: event)
+        elsewhere = create(:form_submission, event: create(:event))
+
+        get form_submissions_path(event_id: event.id), headers: frame_headers
+
+        expect(response.body).to include(form_submission_path(here))
+        expect(response.body).not_to include(form_submission_path(elsewhere))
+      end
+
+      it "filters by submission date range" do
+        old = create(:form_submission, created_at: 1.year.ago)
+        recent = create(:form_submission, created_at: Date.current)
+
+        get form_submissions_path(start_date: 1.week.ago.to_date.iso8601), headers: frame_headers
+
+        expect(response.body).to include(form_submission_path(recent))
+        expect(response.body).not_to include(form_submission_path(old))
+      end
+
+      it "filters by organization through its registration link" do
+        organization = create(:organization)
+        linked = create(:form_submission)
+        other = create(:form_submission)
+        create(:event_registration_organization, organization: organization, form_submission: linked)
+
+        get form_submissions_path(organization_id: organization.id), headers: frame_headers
+
+        expect(response.body).to include(form_submission_path(linked))
+        expect(response.body).not_to include(form_submission_path(other))
+      end
+
+      it "carries the new filters back through each View link" do
+        event = create(:event)
+        submission = create(:form_submission, event: event, role: "registration")
+
+        get form_submissions_path(event_id: event.id, role: "registration"), headers: frame_headers
+
+        expect(response.body).to include(
+          CGI.escapeHTML(form_submission_path(submission, return_to: "form_submissions",
+                                              person_id: submission.person_id, event_id: event.id, role: "registration"))
+        )
+      end
+
       it "breaks the View link out of the results frame" do
         create(:form_submission)
         get form_submissions_path, headers: frame_headers


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained filter logic on one admin index (model scope + view), no data migration

## What
The admin form submissions index filtered by **form** only. Adds the same filter bar the other index pages use.

### New filters
- Submission **date range** (`created_at`) — Submitted from / to
- **Event** (searchable picker)
- **Person** (searchable picker)
- **Organization** (searchable picker)
- **Role** (dropdown of roles present in the data)

## How
- `FormSubmission.search_by_params` + `submitted_between` / `for_organization` scopes (payment-style, testable); controller delegates to it.
- Filter bar restyled to the shared grid + `search_field_class`/`search_label_class`, remote-select pickers for event/person/org.
- Chosen filters carry over on the View-a-submission round trip (`form_submission_carryover_params` helper), so back lands on the same list.

## Notes
- Organization is only queryable via the event-registration → org link (`event_registration_organizations.form_submission_id`); submissions that never linked an org won't match. No new column, no backfill.
- Cataloged in `config/features.yml`.