### PR TITLE
Add author/person name search to index filter boxes

### DIFF
--- a/app/controllers/membership_invoices_controller.rb
+++ b/app/controllers/membership_invoices_controller.rb
@@ -6,6 +6,7 @@ class MembershipInvoicesController < ApplicationController
     authorize!
     @membership_invoices = MembershipInvoice
       .includes(:allocations, membership: :person)
+      .by_person_name(params[:person_name])
       .order(start_date: :desc)
       .paginate(page: params[:page], per_page: params[:number_of_items_per_page].presence || 25)
 

--- a/app/controllers/workshop_ideas_controller.rb
+++ b/app/controllers/workshop_ideas_controller.rb
@@ -5,11 +5,10 @@ class WorkshopIdeasController < ApplicationController
     authorize!
     per_page = params[:number_of_items_per_page].presence || 25
     base_scope = authorized_scope(WorkshopIdea.includes(:workshops))
-    filtered = base_scope.search(params.slice(:title, :created_by_id, :author_name))
+    filtered = base_scope.search(params.slice(:title, :author_name))
     filtered = filtered.created_by_person(params[:created_by_person_id]) if params[:created_by_person_id].present?
     @workshop_ideas_count = filtered.size
     @workshop_ideas = filtered.paginate(page: params[:page], per_page: per_page).decorate
-    @users = User.has_access.includes(:person).references(:person).order(Arel.sql("LOWER(people.first_name), LOWER(people.last_name), LOWER(users.email), LOWER(people.email_2), LOWER(people.email)"))
   end
 
   def show

--- a/app/models/membership_invoice.rb
+++ b/app/models/membership_invoice.rb
@@ -10,6 +10,15 @@ class MembershipInvoice < ApplicationRecord
   delegate :person, to: :membership
   alias_method :registrant, :person
 
+  scope :by_person_name, ->(query) {
+    return all if query.blank?
+    needle = "%#{sanitize_sql_like(query.to_s.strip.downcase)}%"
+    joins(membership: :person).where(
+      "LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
+      "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle",
+      needle: needle)
+  }
+
   scope :active_on, ->(date = Date.current) { where(start_date: ..date, end_date: date..) }
   scope :expiring_between, ->(from, to) { where(end_date: from..to) }
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -46,6 +46,7 @@ class Payment < ApplicationRecord
     results = results.by_type(params[:type]) if params[:type].present?
     results = results.where(payer_type: params[:payer_type]) if params[:payer_type].present?
     results = results.where(person_id: params[:person_id]) if params[:person_id].present?
+    results = results.by_person_name(params[:person_name]) if params[:person_name].present?
     results = results.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     results = results.has_remaining(params[:has_remaining]) if params[:has_remaining].present? && params[:has_remaining] != "all"
     results = results.matching_search(params[:search]) if params[:search].present?
@@ -67,6 +68,15 @@ class Payment < ApplicationRecord
     pattern = "%#{sanitize_sql_like(query)}%"
     where("CAST(metadata AS CHAR) LIKE :q OR stripe_charge_id LIKE :q", q: pattern)
   end
+
+  scope :by_person_name, ->(query) {
+    return all if query.blank?
+    needle = "%#{sanitize_sql_like(query.to_s.strip.downcase)}%"
+    joins(:person).where(
+      "LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
+      "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle",
+      needle: needle)
+  }
 
   def payer
     case payer_type

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -105,6 +105,10 @@ class Story < ApplicationRecord
                        .or(stories.where(id: by_credited_person_name(query).select("stories.id")))
     end
 
+    if params[:author_name].present?
+      stories = stories.where(id: by_credited_person_name(params[:author_name]).select("stories.id"))
+    end
+
     stories = stories.by_year(params[:year]) if params[:year].present? && params[:year].match?(/\A\d{4}\z/)
     stories = stories.facilitator_spotlights(params[:facilitator_spotlights]) if params[:facilitator_spotlights].present?
     stories = stories.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -89,7 +89,6 @@ class WorkshopIdea < ApplicationRecord
   def self.search(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.title(params[:title]) if params[:title].present?
-    results = results.where(created_by_id: params[:created_by_id]) if params[:created_by_id].present?
     results = results.author_name(params[:author_name]) if params[:author_name].present?
     results
   end

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -50,6 +50,15 @@ class WorkshopLog < ApplicationRecord
   scope :workshop_id, ->(workshop_id) { where(workshop_id: workshop_id) if workshop_id.present? }
   scope :organization_id, ->(organization_id) { where(organization_id: organization_id) if organization_id.present? }
   scope :created_by_id, ->(created_by_id) { where(created_by_id: created_by_id.to_i) if created_by_id.present? }
+  scope :author_name, ->(author_name) {
+    return all if author_name.blank?
+    needle = "%#{sanitize_sql_like(author_name.to_s.strip.downcase)}%"
+    joins("INNER JOIN users ON users.id = workshop_logs.created_by_id")
+      .joins("LEFT OUTER JOIN people ON people.id = users.person_id")
+      .where("LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
+             "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle " \
+             "OR LOWER(users.email) LIKE :needle", needle: needle)
+  }
   scope :month_and_year, ->(month_and_year) {
     if month_and_year.present?
       year, month = month_and_year.split("-").map(&:to_i)
@@ -65,6 +74,7 @@ class WorkshopLog < ApplicationRecord
   def self.search(params)
     logs = is_a?(ActiveRecord::Relation) ? self : all
     logs = logs.created_by_id(params[:created_by_id]) if params[:created_by_id].present?
+    logs = logs.author_name(params[:author_name]) if params[:author_name].present?
     logs = logs.month_and_year(params[:month_and_year]) if params[:month_and_year].present?
     logs = logs.year(params[:year]) if params[:year].present?
     logs = logs.workshop_id(params[:workshop_id]) if params[:workshop_id].present?

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -50,15 +50,6 @@ class WorkshopLog < ApplicationRecord
   scope :workshop_id, ->(workshop_id) { where(workshop_id: workshop_id) if workshop_id.present? }
   scope :organization_id, ->(organization_id) { where(organization_id: organization_id) if organization_id.present? }
   scope :created_by_id, ->(created_by_id) { where(created_by_id: created_by_id.to_i) if created_by_id.present? }
-  scope :author_name, ->(author_name) {
-    return all if author_name.blank?
-    needle = "%#{sanitize_sql_like(author_name.to_s.strip.downcase)}%"
-    joins("INNER JOIN users ON users.id = workshop_logs.created_by_id")
-      .joins("LEFT OUTER JOIN people ON people.id = users.person_id")
-      .where("LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
-             "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle " \
-             "OR LOWER(users.email) LIKE :needle", needle: needle)
-  }
   scope :month_and_year, ->(month_and_year) {
     if month_and_year.present?
       year, month = month_and_year.split("-").map(&:to_i)
@@ -74,7 +65,6 @@ class WorkshopLog < ApplicationRecord
   def self.search(params)
     logs = is_a?(ActiveRecord::Relation) ? self : all
     logs = logs.created_by_id(params[:created_by_id]) if params[:created_by_id].present?
-    logs = logs.author_name(params[:author_name]) if params[:author_name].present?
     logs = logs.month_and_year(params[:month_and_year]) if params[:month_and_year].present?
     logs = logs.year(params[:year]) if params[:year].present?
     logs = logs.workshop_id(params[:workshop_id]) if params[:workshop_id].present?

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -18,6 +18,10 @@ class WorkshopVariation < ApplicationRecord
       by_person = results.by_credited_person_name(params[:query]).select("workshop_variations.id")
       results = results.where(id: by_text).or(results.where(id: by_person))
     end
+    if params[:author_name].present?
+      by_name = results.by_credited_person_name(params[:author_name]).select("workshop_variations.id")
+      results = results.where(id: by_name)
+    end
     results = results.authored_by(params[:author_id])
     results
   end

--- a/app/views/membership_invoices/_search_boxes.html.erb
+++ b/app/views/membership_invoices/_search_boxes.html.erb
@@ -1,0 +1,24 @@
+<% field_class = search_field_class(extra: "bg-white pr-10") %>
+<% label_class = search_label_class %>
+<div class="mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+  <%= form_with url: membership_invoices_path, method: :get,
+        data: { controller: "collection", turbo_frame: "membership_invoices_results" },
+        autocomplete: "off", class: "space-y-2" do %>
+    <div class="flex flex-wrap items-end gap-4 md:flex-nowrap">
+      <div class="min-w-[200px] flex-1">
+        <%= label_tag :person_name, "Person name", class: label_class %>
+        <div class="relative">
+          <%= text_field_tag :person_name, params[:person_name],
+                             placeholder: "e.g. Jane Doe",
+                             class: field_class %>
+
+          <%= render "shared/search_submit" %>
+        </div>
+      </div>
+      <div>
+        <label class="<%= label_class %>">&nbsp;</label>
+        <%= render "shared/search_clear", url: membership_invoices_path %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/membership_invoices/index.html.erb
+++ b/app/views/membership_invoices/index.html.erb
@@ -1,9 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-6xl mx-auto">
-  <div class="flex justify-between items-center mb-6">
+<div class="mx-auto max-w-6xl">
+  <div class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold">Membership invoices</h1>
   </div>
+
+  <%= render "search_boxes" %>
 
   <% result_src = membership_invoices_path + "?" + request.query_string %>
 

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -3,13 +3,13 @@
 <% label_class = search_label_class %>
 <% placeholder_select_class = "#{field_class} search-select-placeholder" %>
 
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
+<div class="mb-6 rounded-lg border border-gray-200 bg-white p-4">
   <%= form_tag payments_path, method: :get, class: "space-y-4",
     data: {
       controller: "collection",
       turbo_frame: "payments_results"
     }, autocomplete: "off" do %>
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-12">
       <div class="md:col-span-2">
         <label for="person_id" class="<%= label_class %>">Person</label>
 
@@ -38,7 +38,15 @@
           prompt: "Search for an organization" %>
       </div>
 
-      <div class="md:col-span-4">
+      <div class="md:col-span-2">
+        <label for="person_name" class="<%= label_class %>">Person name</label>
+
+        <%= text_field_tag "person_name", params[:person_name],
+          placeholder: "e.g. Jane Doe",
+          class: field_class %>
+      </div>
+
+      <div class="md:col-span-2">
         <label for="search" class="<%= label_class %>">Search metadata / Stripe charge ID</label>
 
         <%= text_field_tag "search", params[:search],
@@ -101,7 +109,7 @@
           class: placeholder_select_class %>
       </div>
 
-      <div class="md:col-span-2 flex flex-col">
+      <div class="flex flex-col md:col-span-2">
         <span class="<%= label_class %>" aria-hidden="true">&nbsp;</span>
 
         <%= link_to "Clear filters", payments_path, class: "btn btn-utility-outline flex-1 w-full justify-center", data: { action: "collection#clearAndSubmit" } %>

--- a/app/views/stories/_search_boxes.html.erb
+++ b/app/views/stories/_search_boxes.html.erb
@@ -5,7 +5,7 @@
                     turbo_frame: "stories_results" },
                     autocomplete: "off",
               class: "space-y-2" do |f| %>
-  <div class="flex flex-wrap md:flex-nowrap items-end gap-6">
+  <div class="flex flex-wrap items-end gap-6 md:flex-nowrap">
     <!-- TITLE -->
     <div class="min-w-[150px] pb-2">
       <label for="title" class="<%= search_label_class %>">
@@ -20,7 +20,7 @@
     </div>
 
     <!-- KEYWORDS -->
-    <div class="flex-1 min-w-[200px] pb-2">
+    <div class="min-w-[200px] flex-1 pb-2">
       <label for="query" class="<%= search_label_class %>">
         Keywords
       </label>
@@ -28,6 +28,22 @@
       <div class="relative">
         <%= f.text_field :query,
                          value: params[:query],
+                         class: search_field_class(extra: "bg-white pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
+    <!-- AUTHOR NAME -->
+    <div class="min-w-[180px] pb-2">
+      <label for="author_name" class="<%= search_label_class %>">
+        Author name
+      </label>
+
+      <div class="relative">
+        <%= f.text_field :author_name,
+                         value: params[:author_name],
+                         placeholder: "e.g. Jane Doe",
                          class: search_field_class(extra: "bg-white pr-10") %>
 
         <%= render "shared/search_submit" %>

--- a/app/views/stories/_stories_results.html.erb
+++ b/app/views/stories/_stories_results.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_stream.replace("stories_count", partial: "stories_count") %>
 <%
-  sort_base = params.permit(:title, :query, :published, :year, :author_id, :number_of_items_per_page).to_h.symbolize_keys
+  sort_base = params.permit(:title, :query, :author_name, :published, :year, :author_id, :number_of_items_per_page).to_h.symbolize_keys
   sort_link = sort_header_link(frame: "stories_results", path: ->(p) { stories_path(p) }, base: sort_base)
 %>
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @stories.any? %>">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm <%= 'animate-fade blur-on-submit' if @stories.any? %>">
   <table class="w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
@@ -21,7 +21,7 @@
       <% if @stories.any? %>
         <% @stories.each do |story| %>
           <tr class="hover:bg-gray-50">
-            <td class="px-4 py-2 text-sm text-gray-800 flex items-center gap-2">
+            <td class="flex items-center gap-2 px-4 py-2 text-sm text-gray-800">
               <!-- BOOKMARK -->
               <span class="pointer-events-auto"><%= render "bookmarks/editable_bookmark_icon", resource: story %></span>
 
@@ -81,8 +81,8 @@
         <% end %>
       <% else %>
         <tr>
-          <td colspan="7" class="text-center py-16">
-            <h2 class="text-gray-600 text-lg mb-2">No stories found</h2>
+          <td colspan="7" class="py-16 text-center">
+            <h2 class="mb-2 text-lg text-gray-600">No stories found</h2>
             <% if allowed_to?(:new?, Story) %>
               <div class="admin-only bg-blue-100 p-3">
                 <%= link_to "Create a story",

--- a/app/views/workshop_ideas/_search_boxes.html.erb
+++ b/app/views/workshop_ideas/_search_boxes.html.erb
@@ -4,7 +4,7 @@
     <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Search filters</h3>
   </div>
   <!-- Search Fields -->
-  <div class="mb-0 grid grid-cols-1 gap-4 px-4 py-0 md:grid-cols-4">
+  <div class="mb-0 grid grid-cols-1 gap-4 px-4 py-0 md:grid-cols-3">
     <div class="relative">
       <%= text_field_tag :title,
                          params[:title],
@@ -18,13 +18,6 @@
                          placeholder: "Author name",
                          class: search_field_class(extra: "pr-10") %>
       <%= render "shared/search_submit" %>
-    </div>
-    <div data-controller="searchable-select" data-searchable-select-mode-value="person">
-      <%= select_tag :created_by_id,
-                     options_from_collection_for_select(@users, :id, :full_name_with_email, params[:created_by_id].to_i),
-                     include_blank: "Author",
-                     data: { searchable_select_target: "select", action: "change->searchable-select#submit" },
-                     class: search_field_class %>
     </div>
     <!-- Clear filters -->
     <div class="flex items-end sm:justify-end">

--- a/app/views/workshop_ideas/_search_boxes.html.erb
+++ b/app/views/workshop_ideas/_search_boxes.html.erb
@@ -1,14 +1,21 @@
 <%= form_tag(workshop_ideas_path, method: :get, class: "space-y-4") do |f| %>
   <!-- Filters Header -->
   <div>
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Search filters</h3>
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Search filters</h3>
   </div>
   <!-- Search Fields -->
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 px-4 py-0 mb-0">
+  <div class="mb-0 grid grid-cols-1 gap-4 px-4 py-0 md:grid-cols-4">
     <div class="relative">
       <%= text_field_tag :title,
                          params[:title],
                          placeholder: "Title",
+                         class: search_field_class(extra: "pr-10") %>
+      <%= render "shared/search_submit" %>
+    </div>
+    <div class="relative">
+      <%= text_field_tag :author_name,
+                         params[:author_name],
+                         placeholder: "Author name",
                          class: search_field_class(extra: "pr-10") %>
       <%= render "shared/search_submit" %>
     </div>
@@ -20,7 +27,7 @@
                      class: search_field_class %>
     </div>
     <!-- Clear filters -->
-    <div class="flex sm:justify-end items-end">
+    <div class="flex items-end sm:justify-end">
       <%= render "shared/search_clear", url: workshop_ideas_path %>
     </div>
   </div>

--- a/app/views/workshop_ideas/index.html.erb
+++ b/app/views/workshop_ideas/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> rounded-xl border border-gray-200 p-6 shadow">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
+        <div class="mb-6 flex items-center justify-between">
           <h1 class="text-2xl font-semibold text-gray-900">
             <%= WorkshopIdea.model_name.human.pluralize %> (<%= @workshop_ideas_count %>)
           </h1>
@@ -21,18 +21,18 @@
           <table class="w-full border-collapse border border-gray-200">
             <thead class="bg-gray-100">
             <tr>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Main Image</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Title</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Timeframe</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Author</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Promoted?</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+              <th class="w-[60px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Main Image</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Title</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Timeframe</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Author</th>
+              <th class="w-[60px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Promoted?</th>
+              <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
             </tr>
             </thead>
 
             <tbody class="divide-y divide-gray-200">
             <% @workshop_ideas.each do |workshop_idea| %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <tr class="transition-colors duration-150 hover:bg-gray-50">
                 <td>
                   <div class="p-3">
                     <%= render "assets/display_image",
@@ -45,8 +45,8 @@
                 </td>
                 <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.title %></td>
                 <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.time_frame_total %></td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= workshop_idea.created_by.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-800 text-center">
+                <td class="px-4 py-2 text-sm text-gray-800"><%= credited_author_link(workshop_idea, class: eyebrow_link_class) %></td>
+                <td class="px-4 py-2 text-center text-sm text-gray-800">
                   <% if workshop_idea.workshops.any? %>
                     <span class='fa fa-check-circle text-green-500'></span>
                   <% else %>
@@ -55,7 +55,7 @@
                 </td>
 
                 <!-- Actions -->
-                <td class="px-4 py-2 flex justify-center gap-2">
+                <td class="flex justify-center gap-2 px-4 py-2">
                   <%= link_to 'Edit', edit_workshop_idea_path(workshop_idea), class: "btn btn-secondary-outline" %>
                 </td>
               </tr>
@@ -67,7 +67,7 @@
 
         <!-- Empty state -->
         <% unless @workshop_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= WorkshopIdea.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>

--- a/app/views/workshop_logs/_search_boxes.html.erb
+++ b/app/views/workshop_logs/_search_boxes.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag workshop_logs_path, method: :get, id: "filter-form", class: "w-full" do %>
-  <div class="flex flex-wrap items-end gap-4 mb-4">
+  <div class="mb-4 flex flex-wrap items-end gap-4">
     <!-- Month -->
-    <div class="flex flex-col w-full sm:w-auto min-w-[10rem]">
+    <div class="flex w-full min-w-[10rem] flex-col sm:w-auto">
       <%= label_tag :month_and_year, "Month Submitted", class: search_label_class %>
       <%= select_tag :month_and_year,
                      options_for_select(@month_year_options, params[:month_and_year]),
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Year -->
-    <div class="flex flex-col w-full sm:w-auto min-w-[9rem]">
+    <div class="flex w-full min-w-[9rem] flex-col sm:w-auto">
       <%= label_tag :year, "Year", class: search_label_class %>
       <%= select_tag :year,
                      options_for_select(@year_options, params[:year]),
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Workshop -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5">
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
       <%= label_tag :workshop_id, "Workshop", class: search_label_class %>
       <%= select_tag :workshop_id,
                      options_from_collection_for_select(@workshops, :id, :type_name, params[:workshop_id]),
@@ -30,8 +30,20 @@
                      onchange: "this.form.requestSubmit()" %>
     </div>
 
+    <!-- Author name -->
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
     <!-- Person -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
       <%= label_tag :created_by_id, "Person", class: search_label_class %>
       <%= select_tag :created_by_id,
                      options_from_collection_for_select(@users, :id, :full_name_with_email, params[:created_by_id]),
@@ -41,7 +53,7 @@
     </div>
 
     <!-- Organization -->
-    <div class="flex flex-col w-full sm:w-2/3 md:w-1/3 lg:flex-1">
+    <div class="flex w-full flex-col sm:w-2/3 md:w-1/3 lg:flex-1">
       <%= label_tag :organization_id, "Organization", class: search_label_class %>
       <%= select_tag :organization_id,
                      options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),

--- a/app/views/workshop_logs/_search_boxes.html.erb
+++ b/app/views/workshop_logs/_search_boxes.html.erb
@@ -30,18 +30,6 @@
                      onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <!-- Author name -->
-    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
-      <%= label_tag :author_name, "Author name", class: search_label_class %>
-      <div class="relative">
-        <%= text_field_tag :author_name, params[:author_name],
-                           placeholder: "e.g. Jane Doe",
-                           class: search_field_class(extra: "pr-10") %>
-
-        <%= render "shared/search_submit" %>
-      </div>
-    </div>
-
     <!-- Person -->
     <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
       <%= label_tag :created_by_id, "Person", class: search_label_class %>

--- a/app/views/workshop_variations/_search_boxes.html.erb
+++ b/app/views/workshop_variations/_search_boxes.html.erb
@@ -1,11 +1,23 @@
 <%= form_tag(workshop_variations_path, method: :get, class: "space-y-4",
              data: { controller: "collection", turbo_frame: "workshop_variations_results" }) do %>
-  <div class="flex flex-col md:flex-row md:items-end md:gap-4 mb-6">
+  <div class="mb-6 flex flex-col md:flex-row md:items-end md:gap-4">
     <!-- Search -->
-    <div class="w-full md:flex-1 mb-3 md:mb-0">
+    <div class="mb-3 w-full md:mb-0 md:flex-1">
       <%= label_tag :query, "Search", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :query, params[:query],
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
+    <!-- Author name -->
+    <div class="mb-3 w-full md:mb-0 md:w-64">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
                            class: search_field_class(extra: "pr-10") %>
 
         <%= render "shared/search_submit" %>

--- a/app/views/workshop_variations/_workshop_variations_results.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_results.html.erb
@@ -1,28 +1,28 @@
 <%= turbo_stream.replace("workshop_variations_count", partial: "workshop_variations_count") %>
 <%
-  sort_base = params.permit(:query, :author_id, :number_of_items_per_page).to_h.symbolize_keys
+  sort_base = params.permit(:query, :author_name, :author_id, :number_of_items_per_page).to_h.symbolize_keys
   sort_link = sort_header_link(frame: "workshop_variations_results", path: ->(p) { workshop_variations_path(p) }, base: sort_base)
 %>
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @workshop_variations.any? %>">
-  <table class="table table-responsive table-bordered table-curved">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm <%= 'animate-fade blur-on-submit' if @workshop_variations.any? %>">
+  <table class="table-responsive table-bordered table-curved table">
     <thead>
       <tr id="table-thead-tr">
-        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]"></th>
-        <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 whitespace-nowrap"><%= sort_link.call("name", "Name") %></th>
+        <th class="w-[2%] px-4 py-2 text-center text-sm font-semibold text-gray-700"></th>
+        <th class="px-4 py-2 text-left text-sm font-semibold whitespace-nowrap text-gray-700"><%= sort_link.call("name", "Name") %></th>
         <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Description</th>
         <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700"><%= sort_link.call("author", "Author") %></th>
         <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">From idea</th>
         <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700"><%= sort_link.call("updated_at", "Updated") %></th>
-        <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]">Edit</th>
+        <th class="w-[2%] px-4 py-2 text-center text-sm font-semibold text-gray-700">Edit</th>
       </tr>
     </thead>
 
     <tbody class="divide-y divide-gray-100">
       <% if @workshop_variations.any? %>
         <% @workshop_variations.each do |workshop_variation| %>
-          <tr class="hover:bg-gray-50 transition-colors duration-150">
+          <tr class="transition-colors duration-150 hover:bg-gray-50">
             <td class="px-4 py-2">
-              <div class="w-12 h-9 rounded bg-gray-200 overflow-hidden">
+              <div class="h-9 w-12 overflow-hidden rounded bg-gray-200">
                 <%= render "assets/display_image",
                            resource: workshop_variation,
                            width: 12, height: 9,
@@ -33,13 +33,13 @@
               </div>
             </td>
             <td class="px-4 py-2" title="<%= workshop_variation.name %>">
-              <div class="flex items-center gap-2 text-sm text-gray-800 font-semibold">
+              <div class="flex items-center gap-2 text-sm font-semibold text-gray-800">
                 <%= link_to workshop_variation_path(workshop_variation), data: { turbo_frame: "_top" }, class: "hover:text-blue-600 hover:underline" do %>
                   <%= truncate(workshop_variation.name, length: 30) %> (<%= workshop_variation.windows_type&.short_name || "Combined" %>)
                 <% end %>
                 <% unless workshop_variation.published? %>
-                  <span class="inline-flex items-center pl-2 pr-3 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap">
-                    <span class="inline-flex justify-center w-4"><i class="fa-solid fa-eye-slash"></i></span>
+                  <span class="inline-flex items-center rounded-full bg-blue-100 py-0.5 pr-3 pl-2 text-xs font-medium whitespace-nowrap text-gray-600">
+                    <span class="inline-flex w-4 justify-center"><i class="fa-solid fa-eye-slash"></i></span>
                     <span class="ml-1">Unpublished</span>
                   </span>
                 <% end %>
@@ -61,10 +61,10 @@
                 </span>
               <% end %>
             </td>
-            <td class="px-4 py-2 text-sm text-gray-800 text-center">
+            <td class="px-4 py-2 text-center text-sm text-gray-800">
               <%= credited_author_link(workshop_variation, class: "#{eyebrow_link_class}") %>
             </td>
-            <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
+            <td class="px-4 py-2 text-center text-sm whitespace-nowrap">
               <% if workshop_variation.workshop_variation_idea %>
                 <%= link_to "Idea ##{workshop_variation.workshop_variation_idea.id}",
                             workshop_variation_idea_path(workshop_variation.workshop_variation_idea),
@@ -74,7 +74,7 @@
                 <span class="text-gray-300">--</span>
               <% end %>
             </td>
-            <td class="px-4 py-2 text-sm text-gray-500 text-center whitespace-nowrap"><%= workshop_variation.updated_at&.strftime('%m/%d/%y') %></td>
+            <td class="px-4 py-2 text-center text-sm whitespace-nowrap text-gray-500"><%= workshop_variation.updated_at&.strftime('%m/%d/%y') %></td>
             <td class="px-4 py-2 text-center whitespace-nowrap">
               <%= link_to "Edit",
                           edit_workshop_variation_path(workshop_variation),
@@ -85,8 +85,8 @@
         <% end %>
       <% else %>
         <tr>
-          <td colspan="7" class="text-center py-16">
-            <h2 class="text-gray-600 text-lg mb-2">No <%= WorkshopVariation.model_name.human.pluralize.downcase %> found.</h2>
+          <td colspan="7" class="py-16 text-center">
+            <h2 class="mb-2 text-lg text-gray-600">No <%= WorkshopVariation.model_name.human.pluralize.downcase %> found.</h2>
             <% if allowed_to?(:new?, WorkshopVariation) %>
               <div class="p-3">
                 <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",

--- a/config/features.yml
+++ b/config/features.yml
@@ -1797,6 +1797,7 @@
   area: content
   display_status: user_facing
   released_on: 2026-08-22
+  pr_number: 2311
   summary: >-
     Type a name into the filter box to narrow an index by who authored or is
     named on each record. Added to Stories, Workshop variations, Workshop logs,

--- a/config/features.yml
+++ b/config/features.yml
@@ -1792,3 +1792,15 @@
     - Transferring someone a second time collapses the chain — the new
       registration points straight at the original source and the middle stop is
       removed.
+
+- name: "Filter index pages by author or person name"
+  area: content
+  display_status: user_facing
+  released_on: 2026-08-22
+  summary: >-
+    Type a name into the filter box to narrow an index by who authored or is
+    named on each record. Added to Stories, Workshop variations, Workshop logs,
+    Workshop ideas, Membership invoices, and Payments.
+  pro_tips:
+    - Partial names work — "jane" matches "Jane Doe" — and it honors each author's
+      credit preference, so it never surfaces a name shown as anonymous.

--- a/config/features.yml
+++ b/config/features.yml
@@ -1800,8 +1800,10 @@
   pr_number: 2311
   summary: >-
     Type a name into the filter box to narrow an index by who authored or is
-    named on each record. Added to Stories, Workshop variations, Workshop logs,
-    Workshop ideas, Membership invoices, and Payments.
+    named on each record. Added to Stories, Workshop variations, Workshop ideas,
+    Membership invoices, and Payments.
   pro_tips:
     - Partial names work — "jane" matches "Jane Doe" — and it honors each author's
       credit preference, so it never surfaces a name shown as anonymous.
+    - Workshop ideas now list the credited author (per that person's display
+      preference) rather than whoever entered the idea.

--- a/spec/models/membership_invoice_spec.rb
+++ b/spec/models/membership_invoice_spec.rb
@@ -285,4 +285,21 @@ RSpec.describe MembershipInvoice, type: :model do
       expect(create(:membership_invoice, membership: subscription).person).to eq(subscription.person)
     end
   end
+
+  describe ".by_person_name" do
+    it "filters to invoices whose person's name matches" do
+      named = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      matching = create(:membership_invoice, membership: create(:membership, person: named))
+      other = create(:membership_invoice)
+
+      expect(described_class.by_person_name("Bartholomew")).to include(matching)
+      expect(described_class.by_person_name("Bartholomew")).not_to include(other)
+    end
+
+    it "is a no-op when the query is blank" do
+      invoice = create(:membership_invoice)
+      expect(described_class.by_person_name("")).to include(invoice)
+      expect(described_class.by_person_name(nil)).to include(invoice)
+    end
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -186,6 +186,15 @@ RSpec.describe Payment, type: :model do
         expect(result).to include(person_payment, org_payment)
       end
 
+      it "filters by person_name matching the linked person" do
+        named = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+        named_payment = create(:payment, person: named, organization: nil)
+
+        result = Payment.search_by_params({ person_name: "Bartholomew" })
+        expect(result).to include(named_payment)
+        expect(result).not_to include(person_payment, org_payment)
+      end
+
       describe "search (metadata / stripe charge id)" do
         let!(:metadata_match) { create(:payment, metadata: { "note" => "reunion gala" }) }
         let!(:stripe_match) { create(:payment, stripe_charge_id: "ch_ABC123") }

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -185,6 +185,17 @@ RSpec.describe Story, type: :model do
         expect(results).not_to include(created_story)
       end
     end
+
+    context 'when filtering by the author_name field' do
+      let(:facilitator) { create(:person, first_name: 'Bartholomew', last_name: 'Snazzlepants') }
+      let!(:authored_story) { create(:story, :published, title: 'No Name Match', author: facilitator) }
+
+      it 'filters to stories whose credited author name matches' do
+        results = Story.search_by_params(author_name: 'Bartholomew')
+        expect(results).to include(authored_story)
+        expect(results).not_to include(published_story)
+      end
+    end
   end
 
   describe "#to_param" do

--- a/spec/models/workshop_log_spec.rb
+++ b/spec/models/workshop_log_spec.rb
@@ -143,6 +143,23 @@ RSpec.describe WorkshopLog do
         results = WorkshopLog.search({})
         expect(results).to include(log1, log2)
       end
+
+      it "filters by author_name matching the creating user's person" do
+        author = create(:user, person: create(:person, first_name: "Marguerite", last_name: "Enterer"))
+        log = create(:workshop_log, created_by: author)
+        other_log = create(:workshop_log)
+
+        results = WorkshopLog.search(author_name: "Marguerite")
+        expect(results).to include(log)
+        expect(results).not_to include(other_log)
+      end
+
+      it "matches author_name against the creating user's email" do
+        author = create(:user, email: "quackenbush@example.com")
+        log = create(:workshop_log, created_by: author)
+
+        expect(WorkshopLog.search(author_name: "quackenbush")).to include(log)
+      end
     end
   end
 

--- a/spec/models/workshop_log_spec.rb
+++ b/spec/models/workshop_log_spec.rb
@@ -143,23 +143,6 @@ RSpec.describe WorkshopLog do
         results = WorkshopLog.search({})
         expect(results).to include(log1, log2)
       end
-
-      it "filters by author_name matching the creating user's person" do
-        author = create(:user, person: create(:person, first_name: "Marguerite", last_name: "Enterer"))
-        log = create(:workshop_log, created_by: author)
-        other_log = create(:workshop_log)
-
-        results = WorkshopLog.search(author_name: "Marguerite")
-        expect(results).to include(log)
-        expect(results).not_to include(other_log)
-      end
-
-      it "matches author_name against the creating user's email" do
-        author = create(:user, email: "quackenbush@example.com")
-        log = create(:workshop_log, created_by: author)
-
-        expect(WorkshopLog.search(author_name: "quackenbush")).to include(log)
-      end
     end
   end
 

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -159,5 +159,14 @@ RSpec.describe WorkshopVariation do
       results = WorkshopVariation.search_by_params(query: "nonexistent")
       expect(results).not_to include(variation_a, variation_b)
     end
+
+    it "filters by author_name matching the credited author" do
+      facilitator = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      authored = create(:workshop_variation, name: "Authored", author: facilitator)
+
+      results = WorkshopVariation.search_by_params(author_name: "Bartholomew")
+      expect(results).to include(authored)
+      expect(results).not_to include(variation_a, variation_b)
+    end
   end
 end

--- a/spec/requests/membership_invoices_spec.rb
+++ b/spec/requests/membership_invoices_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe "MembershipInvoices", type: :request do
 
         expect(response.body).to include("No membership invoices yet")
       end
+
+      it "renders the person-name filter box on the index" do
+        get membership_invoices_path
+
+        expect(response.body).to include("person_name")
+      end
+
+      it "filters the frame results by person name" do
+        term_for("Ada")
+        term_for("Grace")
+
+        get membership_invoices_path(person_name: "Ada"), headers: frame
+
+        expect(response.body).to include("Ada Tester")
+        expect(response.body).not_to include("Grace Tester")
+      end
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained filter/scope additions + one display change across five indexes, no data migration

### Goal
Let facilitators/admins narrow an index by who authored or is named on each record, and make sure the displayed name is the **author** (per that person's display preference), not whoever entered the record.

### Author-name search (new free-text field)
- **Stories**, **Workshop variations** — "Author name" field reusing `by_credited_person_name` (honors credit preference; never surfaces an anonymized name).
- **Workshop ideas** — the `author_name` backend was already wired; this exposes the form field.

### Person-name search (new free-text field)
- **Payments** — new `by_person_name` scope; field added beside the existing person picker.
- **Membership invoices** — new `by_person_name` scope + the page's **first filter box**.

### Cleanup on workshop ideas
- Removed the redundant **created_by "Author" dropdown** — author-name search replaces it.
- The index now shows the **credited author** (honoring the person's display preference) instead of the creator, matching Stories and Workshop variations.

### Not changed
- **Workshop logs** have no author concept, so they keep their creator "Person" filter and creator column — no author search there.
- Existing person pickers on Payments/Membership flows are left in place; the new fields are additive partial-name search.

### Tests
- Model specs for each new scope/param; a request spec covers the membership-invoices filter end-to-end through its Turbo frame.
- Features & tips seed entry added.