### PR TITLE
Add role, facilitator/membership status, age range, topic & staff-tag filters to the people directory

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -115,6 +115,10 @@
   color: rgb(156 163 175);   /* gray-400 */
   font-size: 0.875rem;       /* text-sm */
   line-height: 1.5rem;       /* text-sm/6: keeps the select the height of a text input */
+  /* Safari sizes a <select> by its font-size, ignoring line-height, so the smaller
+     placeholder font would render shorter than the paired text input. Pin the box to
+     the text-input height: 1.5rem line + py-2 (1rem) + 2px border. */
+  min-height: 2.625rem;
 }
 
 /* Optional fields get a subtle gray background */

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -193,7 +193,7 @@ class Person < ApplicationRecord
     return all if tag_ids.empty?
     joins(:staff_taggings).where(staff_taggings: { staff_tag_id: tag_ids }).distinct }
   scope :story_authors, -> { joins(:stories_as_author).distinct }
-  scope :blog_authors, -> { joins(:community_news_as_author).distinct }
+  scope :blog_contributors, -> { where(blog_contributor: true) }
   scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
   scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
   # WorkshopLog has no author column — it is created_by a User, so "author" here
@@ -240,7 +240,7 @@ class Person < ApplicationRecord
   scope :by_role, ->(role) {
     case role
     when "story_author" then story_authors
-    when "blog_author" then blog_authors
+    when "blog_contributor" then blog_contributors
     when "workshop_author" then workshop_authors
     when "workshop_variation_author" then workshop_variation_authors
     when "workshop_log_author" then workshop_log_authors
@@ -270,7 +270,7 @@ class Person < ApplicationRecord
     end }
 
   ROLE_FILTER_OPTIONS = [
-    [ "Blog authors", "blog_author" ],
+    [ "Blog contributors", "blog_contributor" ],
     [ "Sector leaders", "sector_leader" ],
     [ "Story authors", "story_author" ],
     [ "Workshop authors", "workshop_author" ],

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -270,12 +270,12 @@ class Person < ApplicationRecord
     end }
 
   ROLE_FILTER_OPTIONS = [
-    [ "Story authors", "story_author" ],
     [ "Blog authors", "blog_author" ],
+    [ "Sector leaders", "sector_leader" ],
+    [ "Story authors", "story_author" ],
     [ "Workshop authors", "workshop_author" ],
-    [ "Workshop variation authors", "workshop_variation_author" ],
     [ "Workshop log authors", "workshop_log_author" ],
-    [ "Sector leaders", "sector_leader" ]
+    [ "Workshop variation authors", "workshop_variation_author" ]
   ].freeze
 
   MEMBERSHIP_STATUS_FILTER_OPTIONS = [

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -192,12 +192,116 @@ class Person < ApplicationRecord
     tag_ids = Array(ids).reject(&:blank?)
     return all if tag_ids.empty?
     joins(:staff_taggings).where(staff_taggings: { staff_tag_id: tag_ids }).distinct }
+  scope :story_authors, -> { joins(:stories_as_author).distinct }
+  scope :blog_authors, -> { joins(:community_news_as_author).distinct }
+  scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
+  scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
+  # WorkshopLog has no author column — it is created_by a User, so "author" here
+  # means the person whose linked user account created the log.
+  scope :workshop_log_authors, -> {
+    creator_user_ids = WorkshopLog.where.not(created_by_id: nil).select(:created_by_id)
+    where(id: User.where(id: creator_user_ids).where.not(person_id: nil).select(:person_id)) }
+  # People with at least one currently-active facilitator affiliation.
+  scope :facilitators_active, -> {
+    where(id: Affiliation.facilitators.active.select(:person_id)) }
+  # People with facilitator affiliation(s) but none currently active.
+  scope :facilitators_inactive, -> {
+    where(id: Affiliation.facilitators.select(:person_id))
+      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+  # Not currently active, but a past facilitator term genuinely ended (real end
+  # date in the past) — distinguishes "used to facilitate" from merely flagged inactive.
+  scope :facilitators_formerly_active, -> {
+    ended = Affiliation.facilitators.where.not(end_date: nil)
+      .where("affiliations.end_date < ?", Date.current).select(:person_id)
+    where(id: ended).where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+  # Facilitators tied to 2+ facilitator affiliations with at least one still active
+  # (e.g. moved between partner orgs, or serve more than one at once).
+  scope :boomerang_facilitators, -> {
+    multiple = Affiliation.facilitators.group(:person_id).having("COUNT(affiliations.id) >= 2").select(:person_id)
+    where(id: multiple).where(id: Affiliation.facilitators.active.select(:person_id)) }
+  scope :by_facilitator_status, ->(status) {
+    case status
+    when "active" then facilitators_active
+    when "inactive" then facilitators_inactive
+    when "boomerang" then boomerang_facilitators
+    when "formerly_active" then facilitators_formerly_active
+    else all
+    end }
+  scope :subscribed_to_topic, ->(topic_subscription_type_id) {
+    joins(:topic_subscriptions)
+      .where(topic_subscriptions: { topic_subscription_type_id: topic_subscription_type_id, unsubscribed_at: nil })
+      .distinct }
+  scope :age_range_names_all, ->(name) {
+    return all if name.blank?
+    joins(categories: :category_type)
+      .where(category_types: { name: AgeGroupTaggable::AGE_RANGE_CATEGORY_TYPE })
+      .where("LOWER(categories.name) = ?", name.to_s.strip.downcase)
+      .distinct }
+  scope :by_role, ->(role) {
+    case role
+    when "story_author" then story_authors
+    when "blog_author" then blog_authors
+    when "workshop_author" then workshop_authors
+    when "workshop_variation_author" then workshop_variation_authors
+    when "workshop_log_author" then workshop_log_authors
+    when "sector_leader" then sector_leaders
+    else all
+    end }
+  # People whose membership/current invoice is in the given state.
+  scope :membership_active, -> { where(id: Membership.not_cancelled.select(:person_id)) }
+  scope :membership_inactive, -> {
+    where(id: Membership.select(:person_id))
+      .where.not(id: Membership.not_cancelled.select(:person_id)) }
+  scope :membership_paid, -> {
+    where(id: MembershipInvoice.active_on.paid_in_full.joins(:membership).select("memberships.person_id")) }
+  scope :membership_due, -> {
+    where(id: MembershipInvoice.active_on.not_paid_in_full.paid_or_within_grace
+      .joins(:membership).select("memberships.person_id")) }
+  scope :membership_overdue, -> {
+    where(id: MembershipInvoice.active_on.overdue.joins(:membership).select("memberships.person_id")) }
+  scope :by_membership_status, ->(status) {
+    case status
+    when "active" then membership_active
+    when "inactive" then membership_inactive
+    when "paid" then membership_paid
+    when "due" then membership_due
+    when "overdue" then membership_overdue
+    else all
+    end }
+
+  ROLE_FILTER_OPTIONS = [
+    [ "Story authors", "story_author" ],
+    [ "Blog authors", "blog_author" ],
+    [ "Workshop authors", "workshop_author" ],
+    [ "Workshop variation authors", "workshop_variation_author" ],
+    [ "Workshop log authors", "workshop_log_author" ],
+    [ "Sector leaders", "sector_leader" ]
+  ].freeze
+
+  MEMBERSHIP_STATUS_FILTER_OPTIONS = [
+    [ "Active", "active" ],
+    [ "Inactive", "inactive" ],
+    [ "Paid", "paid" ],
+    [ "Due", "due" ],
+    [ "Overdue", "overdue" ]
+  ].freeze
+
+  FACILITATOR_STATUS_FILTER_OPTIONS = [
+    [ "Active", "active" ],
+    [ "Inactive", "inactive" ],
+    [ "Boomerang (2+ affiliations, 1+ active)", "boomerang" ],
+    [ "Formerly active", "formerly_active" ]
+  ].freeze
 
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.search(params[:contact_info]) if params[:contact_info].present?
-    results = results.sector_leaders if ActiveModel::Type::Boolean.new.cast(params[:sector_leaders_only])
+    results = results.by_role(params[:role]) if params[:role].present?
+    results = results.by_facilitator_status(params[:facilitator_status]) if params[:facilitator_status].present?
+    results = results.by_membership_status(params[:membership_status]) if params[:membership_status].present?
+    results = results.subscribed_to_topic(params[:topic_subscription_type_id]) if params[:topic_subscription_type_id].present?
     results = results.sector_names_all(params[:sector_names_all]) if params[:sector_names_all].present?
+    results = results.age_range_names_all(params[:age_range_names_all]) if params[:age_range_names_all].present?
     results = results.category_names_all(params[:category_names_all]) if params[:category_names_all].present?
     results = results.organization_name(params[:organization_name]) if params[:organization_name].present?
     results = results.organization_id(params[:organization_id]) if params[:organization_id].present?

--- a/app/views/people/_search_boxes.html.erb
+++ b/app/views/people/_search_boxes.html.erb
@@ -6,23 +6,12 @@
   autocomplete: "off",
   class: "space-y-4") do |f| %>
   <%= hidden_field_tag "organization_id", params[:organization_id] if params[:organization_id].present? %>
-  <div class="mb-6 flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
+  <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
     <!-- Contact info -->
     <div class="w-full md:flex-1">
       <%= label_tag :contact_info, "Name, email, or phone", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :contact_info, params[:contact_info],
-                           class: search_field_class(extra: "pr-10"),
-                           placeholder: "" %>
-        <%= render "shared/search_submit" %>
-      </div>
-    </div>
-
-    <!-- Sector name -->
-    <div class="w-full md:flex-1">
-      <%= label_tag :sector_names_all, "Sector name(s)", class: search_label_class %>
-      <div class="relative">
-        <%= text_field_tag :sector_names_all, params[:sector_names_all],
                            class: search_field_class(extra: "pr-10"),
                            placeholder: "" %>
         <%= render "shared/search_submit" %>
@@ -40,32 +29,68 @@
       </div>
     </div>
 
-    <!-- Sector leaders only -->
-    <div class="flex w-full items-center md:w-auto">
-      <label class="inline-flex cursor-pointer items-center gap-2 py-2 text-sm font-medium text-gray-700">
-        <%= check_box_tag :sector_leaders_only, "1", params[:sector_leaders_only].present?,
-                          class: "rounded border-gray-300 text-blue-600 focus:ring focus:ring-blue-200" %>
-        <span>Sector leaders only</span>
-      </label>
+    <!-- Sector name -->
+    <div class="w-full md:flex-1">
+      <%= label_tag :sector_names_all, "Sector name(s)", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :sector_names_all, params[:sector_names_all],
+                           class: search_field_class(extra: "pr-10"),
+                           placeholder: "" %>
+        <%= render "shared/search_submit" %>
+      </div>
     </div>
 
-    <!-- Staff tag (internal, admin-only) -->
-    <% if allowed_to?(:index?, StaffTag) %>
-      <% staff_tags = StaffTag.published.ordered %>
-      <% if staff_tags.any? %>
-        <div class="w-full md:flex-1">
-          <%= label_tag :staff_tag_ids, "Staff tag", class: search_label_class %>
-          <%= select_tag :staff_tag_ids,
-                         options_from_collection_for_select(staff_tags, :id, :name, params[:staff_tag_ids]),
-                         include_blank: "Any",
-                         class: search_field_class %>
-        </div>
-      <% end %>
-    <% end %>
+    <!-- Age range -->
+    <%= render "events/filter_select", param: :age_range_names_all, label: "Age range",
+          options: Category.age_ranges.published.ordered_by_position_and_name.map { |c| [ c.decorate.age_group_label, c.name ] },
+          selected: params[:age_range_names_all], blank: "Any age range",
+          field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
+  </div>
 
-    <!-- Clear filters -->
-    <div class="flex w-full justify-end md:w-auto">
-      <%= render "shared/search_clear", url: people_path %>
+  <% if allowed_to?(:manage?, Person) %>
+    <div class="rounded-xl border border-blue-200 bg-blue-100 p-4">
+      <p class="mb-3 text-xs font-semibold tracking-wide text-blue-800 uppercase">Admin-only filters</p>
+      <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
+        <!-- Role -->
+        <%= render "events/filter_select", param: :role, label: "Role",
+              options: Person::ROLE_FILTER_OPTIONS, selected: params[:role],
+              blank: "All people", field_class: search_field_class,
+              wrapper_class: "w-full md:w-56" %>
+
+        <!-- Facilitator status -->
+        <%= render "events/filter_select", param: :facilitator_status, label: "Facilitator status",
+              options: Person::FACILITATOR_STATUS_FILTER_OPTIONS, selected: params[:facilitator_status],
+              blank: "Any status", field_class: search_field_class,
+              wrapper_class: "w-full md:w-56" %>
+
+        <!-- Membership status -->
+        <%= render "events/filter_select", param: :membership_status, label: "Membership status",
+              options: Person::MEMBERSHIP_STATUS_FILTER_OPTIONS, selected: params[:membership_status],
+              blank: "Any status", field_class: search_field_class,
+              wrapper_class: "w-full md:w-56" %>
+
+        <!-- Topic subscription -->
+        <%= render "events/filter_select", param: :topic_subscription_type_id, label: "Topic subscription",
+              options: TopicSubscriptionType.active.ordered.pluck(:name, :id),
+              selected: params[:topic_subscription_type_id], blank: "Any topic",
+              field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
+
+        <!-- Staff tag -->
+        <% if allowed_to?(:index?, StaffTag) %>
+          <% staff_tags = StaffTag.published.ordered %>
+          <% if staff_tags.any? %>
+            <%= render "events/filter_select", param: :staff_tag_ids, label: "Staff tag",
+                  options: staff_tags.map { |t| [ t.name, t.id ] },
+                  selected: params[:staff_tag_ids], blank: "Any",
+                  field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
+  <% end %>
+
+  <!-- Clear filters -->
+  <div class="flex justify-end">
+    <%= render "shared/search_clear", url: people_path %>
   </div>
 <% end %>

--- a/app/views/people/_search_boxes.html.erb
+++ b/app/views/people/_search_boxes.html.erb
@@ -69,12 +69,6 @@
               blank: "Any status", field_class: search_field_class,
               wrapper_class: "w-full md:w-56" %>
 
-        <!-- Topic subscription -->
-        <%= render "events/filter_select", param: :topic_subscription_type_id, label: "Topic subscription",
-              options: TopicSubscriptionType.active.ordered.pluck(:name, :id),
-              selected: params[:topic_subscription_type_id], blank: "Any topic",
-              field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
-
         <!-- Staff tag -->
         <% if allowed_to?(:index?, StaffTag) %>
           <% staff_tags = StaffTag.published.ordered %>
@@ -85,6 +79,12 @@
                   field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
           <% end %>
         <% end %>
+
+        <!-- Topic subscription -->
+        <%= render "events/filter_select", param: :topic_subscription_type_id, label: "Topic subscription",
+              options: TopicSubscriptionType.active.ordered.pluck(:name, :id),
+              selected: params[:topic_subscription_type_id], blank: "Any topic",
+              field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
       </div>
     </div>
   <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1876,3 +1876,27 @@
     A new Form answers page lists every individual answer submitted across the
     site's forms. Search the answer text or filter by form, person, submission,
     event, or question type, then jump straight to the full submission.
+
+- name: "Filter the people directory by role, status, age range, topic, and staff tag"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    New dropdowns filter the people directory by age range, by what a person
+    creates (story, blog, workshop, variation, and log authors, plus sector
+    leaders), by facilitator status, by membership status, by topic subscription,
+    and by staff tag. The admin-only filters sit together in a blue panel.
+  pro_tips:
+    - The role dropdown replaces the old "Sector leaders only" checkbox; pick
+      "Sector leaders" there to get the same list.
+    - "Facilitator status: \"boomerang\" means two or more facilitator affiliations
+      with at least one still active; \"formerly active\" means a past term ended
+      and none is active now."
+    - "Membership status reads the current invoice: \"due\" still owes but is within
+      the grace period, \"overdue\" has passed it."
+    - The topic and staff tag dropdowns sit in the same blue admin panel; topic
+      matches people still subscribed, staff tag matches people carrying that tag.
+    - The age range dropdown lists your published age ranges and matches anyone
+      tagged with that range.

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -539,10 +539,10 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    context "role: blog_author" do
-      it "returns only people who authored community news" do
-        create(:community_news, author: person_bob)
-        results = Person.search_by_params(role: "blog_author")
+    context "role: blog_contributor" do
+      it "returns only people flagged as blog contributors" do
+        person_bob.update!(blog_contributor: true)
+        results = Person.search_by_params(role: "blog_contributor")
         expect(results).to include(person_bob)
         expect(results).not_to include(person_alice)
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Person, type: :model do
       }.not_to raise_error
     end
 
-    context 'sector_leaders_only' do
+    context "role: sector_leader" do
       let(:sector) { create(:sector) }
 
       before do
@@ -512,21 +512,186 @@ RSpec.describe Person, type: :model do
         person_bob.sectorable_items.create!(sector: sector, is_leader: false)
       end
 
-      it 'returns only people who lead a sector when truthy' do
-        results = Person.search_by_params(sector_leaders_only: '1')
+      it "returns only people who lead a sector" do
+        results = Person.search_by_params(role: "sector_leader")
         expect(results).to include(person_alice)
         expect(results).not_to include(person_bob)
       end
 
-      it 'returns a person once even when they lead several sectors' do
+      it "returns a person once even when they lead several sectors" do
         person_alice.sectorable_items.create!(sector: create(:sector), is_leader: true)
-        results = Person.search_by_params(sector_leaders_only: '1')
+        results = Person.search_by_params(role: "sector_leader")
         expect(results.to_a.count(person_alice)).to eq(1)
       end
 
-      it 'ignores the filter when unchecked' do
-        results = Person.search_by_params(sector_leaders_only: '0')
+      it "ignores the filter when role is blank" do
+        results = Person.search_by_params(role: "")
         expect(results).to include(person_alice, person_bob)
+      end
+    end
+
+    context "role: story_author" do
+      it "returns only people who authored a story" do
+        create(:story, author: person_alice)
+        results = Person.search_by_params(role: "story_author")
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+    end
+
+    context "role: blog_author" do
+      it "returns only people who authored community news" do
+        create(:community_news, author: person_bob)
+        results = Person.search_by_params(role: "blog_author")
+        expect(results).to include(person_bob)
+        expect(results).not_to include(person_alice)
+      end
+    end
+
+    context "role: workshop_author" do
+      it "returns only people who authored a workshop" do
+        create(:workshop, author: person_alice)
+        results = Person.search_by_params(role: "workshop_author")
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+    end
+
+    context "role: workshop_variation_author" do
+      it "returns only people who authored a workshop variation" do
+        create(:workshop_variation, author: person_bob)
+        results = Person.search_by_params(role: "workshop_variation_author")
+        expect(results).to include(person_bob)
+        expect(results).not_to include(person_alice)
+      end
+    end
+
+    context "role: workshop_log_author" do
+      it "returns people whose linked user created a workshop log" do
+        user = create(:user, person: person_alice)
+        create(:workshop_log, created_by: user)
+        results = Person.search_by_params(role: "workshop_log_author")
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+    end
+
+    context "membership_status" do
+      it "active: includes people with a non-cancelled membership" do
+        member = create(:person, first_name: "Member", last_name: "Active")
+        create(:membership, person: member)
+        results = Person.search_by_params(membership_status: "active")
+        expect(results).to include(member)
+        expect(results).not_to include(person_alice)
+      end
+
+      it "inactive: includes people whose only membership is cancelled" do
+        former = create(:person, first_name: "Former", last_name: "Member")
+        create(:membership, :cancelled, person: former)
+        results = Person.search_by_params(membership_status: "inactive")
+        expect(results).to include(former)
+        expect(results).not_to include(person_alice)
+      end
+
+      it "paid: includes people with a covered current invoice" do
+        member = create(:person, first_name: "Paid", last_name: "Member")
+        create(:membership_invoice, :comped, membership: create(:membership, person: member))
+        results = Person.search_by_params(membership_status: "paid")
+        expect(results).to include(member)
+      end
+
+      it "due: includes people owing on a current invoice still within grace" do
+        member = create(:person, first_name: "Due", last_name: "Member")
+        create(:membership_invoice, membership: create(:membership, person: member),
+                                    start_date: Date.current)
+        results = Person.search_by_params(membership_status: "due")
+        expect(results).to include(member)
+      end
+
+      it "overdue: includes people owing past the grace period" do
+        member = create(:person, first_name: "Overdue", last_name: "Member")
+        create(:membership_invoice, membership: create(:membership, person: member),
+                                    start_date: 60.days.ago, end_date: 305.days.from_now)
+        results = Person.search_by_params(membership_status: "overdue")
+        expect(results).to include(member)
+      end
+    end
+
+    context "facilitator_status" do
+      # person_alice and person_bob each already have one active facilitator affiliation.
+
+      it "active: includes people with a currently-active facilitator affiliation" do
+        results = Person.search_by_params(facilitator_status: "active")
+        expect(results).to include(person_alice, person_bob)
+      end
+
+      it "inactive: includes people whose facilitator affiliations are all inactive" do
+        lapsed = create(:person, first_name: "Lapsed", last_name: "Fac")
+        create(:affiliation, person: lapsed, title: "Facilitator", end_date: 1.year.ago)
+
+        results = Person.search_by_params(facilitator_status: "inactive")
+        expect(results).to include(lapsed)
+        expect(results).not_to include(person_alice)
+      end
+
+      it "boomerang: includes people with 2+ facilitator affiliations and at least one active" do
+        multi = create(:person, first_name: "Multi", last_name: "Fac")
+        create(:affiliation, person: multi, title: "Facilitator", end_date: nil)
+        create(:affiliation, person: multi, title: "Facilitator", end_date: 1.year.from_now)
+
+        results = Person.search_by_params(facilitator_status: "boomerang")
+        expect(results).to include(multi)
+        expect(results).not_to include(person_alice)
+      end
+
+      it "formerly_active: includes people whose facilitator term ended and none is active" do
+        former = create(:person, first_name: "Former", last_name: "Fac")
+        create(:affiliation, person: former, title: "Facilitator", end_date: 1.year.ago)
+
+        results = Person.search_by_params(facilitator_status: "formerly_active")
+        expect(results).to include(former)
+        expect(results).not_to include(person_alice)
+      end
+    end
+
+    context "topic_subscription_type_id" do
+      let(:topic) { create(:topic_subscription_type) }
+
+      it "returns people with an active subscription to the topic" do
+        create(:topic_subscription, person: person_alice, topic_subscription_type: topic)
+        results = Person.search_by_params(topic_subscription_type_id: topic.id)
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+
+      it "excludes people whose subscription to the topic is unsubscribed" do
+        create(:topic_subscription, :unsubscribed, person: person_bob, topic_subscription_type: topic)
+        results = Person.search_by_params(topic_subscription_type_id: topic.id)
+        expect(results).not_to include(person_bob)
+      end
+    end
+
+    context "age_range_names_all" do
+      let(:age_type) { create(:category_type, name: "AgeRange", published: true) }
+      let(:teens) { create(:category, :published, name: "Teens", category_type: age_type) }
+      let(:seniors) { create(:category, :published, name: "Seniors", category_type: age_type) }
+
+      it "returns only people tagged with the named age range" do
+        person_alice.categorizable_items.create!(category: teens)
+        person_bob.categorizable_items.create!(category: seniors)
+
+        results = Person.search_by_params(age_range_names_all: "Teens")
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+
+      it "does not match a same-named category from another category type" do
+        other_type = create(:category_type, name: "Setting", published: true)
+        other_teens = create(:category, :published, name: "Teens", category_type: other_type)
+        person_bob.categorizable_items.create!(category: other_teens)
+
+        results = Person.search_by_params(age_range_names_all: "Teens")
+        expect(results).not_to include(person_bob)
       end
     end
   end

--- a/spec/requests/people_search_spec.rb
+++ b/spec/requests/people_search_spec.rb
@@ -38,6 +38,45 @@ RSpec.describe "People search", type: :request do
       expect(response.body).to include("Alice")
       expect(response.body).not_to include("Bob")
     end
+
+    it "filters by role" do
+      create(:story, author: person_alice)
+
+      get people_path, params: { role: "story_author" }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Alice")
+      expect(response.body).not_to include("Bob")
+    end
+
+    it "filters by facilitator status" do
+      create(:affiliation, person: person_alice, title: "Facilitator", end_date: nil)
+      create(:affiliation, person: person_bob, title: "Facilitator", end_date: 1.year.ago)
+
+      get people_path, params: { facilitator_status: "active" }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Alice")
+      expect(response.body).not_to include("Bob")
+    end
+
+    it "filters by topic subscription" do
+      topic = create(:topic_subscription_type)
+      create(:topic_subscription, person: person_bob, topic_subscription_type: topic)
+
+      get people_path, params: { topic_subscription_type_id: topic.id }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Bob")
+      expect(response.body).not_to include("Alice")
+    end
+
+    it "filters by staff tag" do
+      tag = create(:staff_tag)
+      create(:staff_tagging, staff_tag: tag, staff_taggable: person_alice)
+
+      get people_path, params: { staff_tag_ids: tag.id }, headers: turbo_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Alice")
+      expect(response.body).not_to include("Bob")
+    end
   end
 
   describe "GET /people?organization_id=X (full page)" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 filter scopes wired through one dispatcher per dropdown; model + request specs cover each branch

Adds several filters to the people directory, built on the event-registration filter mechanism (shared `events/_filter_select` partial + `collection` Stimulus controller — no new JS). Rebased on main, so it also carries in and integrates the staff-tag filter from #2313.

## General filter (everyone who can reach the index)
- **Age range** — dropdown of published AgeRange categories; matches people tagged with that range.

## Admin-only filters (grouped in a blue panel)
- **Role** — story / blog / workshop / workshop-variation / workshop-log authors, and sector leaders.
- **Facilitator status** — active, inactive, boomerang (2+ facilitator affiliations, 1+ active), formerly active.
- **Membership status** — active/inactive (membership `cancelled_at`) and paid/due/overdue (current invoice vs. allocations + grace period).
- **Topic subscription** — people with an *active* (not unsubscribed) subscription.
- **Staff tag** — from #2313 (`staff_tagged_with`); moved into this blue panel and restyled to match, gated by `allowed_to?(:index?, StaffTag)`.

## Field order
Name/email/phone → Organization → Sector name → Age range, then the blue admin panel (Role → Facilitator status → Membership status → Topic subscription → Staff tag), then Clear.

## Notes
- The old "Sector leaders only" checkbox is folded into the Role dropdown.
- **Workshop log authorship**: `WorkshopLog` has no Person column — only `created_by → User`. So "workshop log author" = the person whose linked user created the log (routed through `User`). Flagging in case a different tie is intended.
- All filters flow through `Person.search_by_params`; no controller/strong-params change. New scopes return plain relations (`where(id: subquery)`) so `count`/`paginate` are unaffected.
- Blue is the admin/status marker here (matches the `bg-blue-100` admin convention), not a DomainTheme color.
- Branch squashed to one commit and rebased onto main; updated the `Features & tips` seed.

Closes #2322
