### PR TITLE
Ahoy activities: readable before/after details column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ action, or `authorize! :workshop, to: :summary?`).
 - `Analytics::EventBuilder` — Constructs analytics event payloads
 - `Analytics::AhoyTracker` — Coordinates ahoy event tracking
 - `Analytics::PersonActivityEvents` — Aggregates Ahoy events for a person, their user, and associated data (powers the person edit History card + `person_id` filter on the Ahoy activities index)
+- `Analytics::EventReferenceLoader` — Batch-loads the records referenced in a page of Ahoy event properties (association changes, associated records), one query per type, so the activity table's Details column links each to its show page without an N+1
 
 ### Business Logic
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -105,10 +105,14 @@ module Admin
         ).entries
         @timeline = entries.paginate(page: page, per_page: per_page)
         @total_count = @timeline.total_entries
+        activity_events = @timeline.reject(&:communication?).map(&:record)
       else
         @events = scope.paginate(page: page, per_page: per_page)
         @total_count = @events.total_entries
+        activity_events = @events
       end
+
+      @record_cache = Analytics::EventReferenceLoader.new(activity_events).records
 
       render :activity_results
     end

--- a/app/controllers/concerns/ahoy_tracking.rb
+++ b/app/controllers/concerns/ahoy_tracking.rb
@@ -36,15 +36,14 @@ module AhoyTracking
 
     return if sectors.blank? && categories.blank?
 
-    # total_results = grouped_results.values.sum { |r| r.respond_to?(:total_entries) ? r.total_entries : r.size }
+    # Use each group's paginated total (total_entries) so this matches the
+    # result_count the index searches record, not just the loaded page.
+    result_count = grouped_results.values.sum { |r| r.respond_to?(:total_entries) ? r.total_entries : r.size }
+
     ahoy.track "search.taggings", {
       sectors: sectors,
       categories: categories,
-      # result_count: total_results,
-      # result_breakdown: grouped_results.transform_values do |r|
-      #   r.respond_to?(:total_entries) ? r.total_entries : r.size
-      # end,
-      page_result_count: grouped_results.values.sum(&:size) # only loaded page
+      result_count: result_count
     }
   end
 

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -31,10 +31,13 @@ module Ahoy
       end
     end
 
-    # Every non-change extra property flattened into readable, humanized rows
-    # for inline display: [{ label:, value:, depth: }, ...]. Nested hashes and
-    # arrays are indented under their parent (depth) so the whole payload is
-    # visible in the table without opening the detail page.
+    # Every non-change extra property flattened into compact, humanized rows for
+    # inline display. Row shapes:
+    #   { label:, value:, depth: }                  plain label/value (value nil = header)
+    #   { label:, action:, link: { text:, path: }, depth: }  record reference (linked)
+    # Lists of named entities (filter sectors/categories) collapse onto one line;
+    # record references (association changes, associated records) become links to
+    # the record's show page so admins can jump straight to it.
     def detail_rows
       rows = extra_properties.except("changes")
       return [] if rows.empty?
@@ -54,37 +57,84 @@ module Ahoy
 
     def flatten_rows(value, label = nil, depth = 0)
       case value
-      when Hash
-        nested_rows(value, label, depth)
-      when Array
-        array_rows(value, label, depth)
-      else
-        [ { label: label, value: display_value(value), depth: depth } ]
+      when Hash then hash_rows(value, label, depth)
+      when Array then array_rows(value, label, depth)
+      else [ { label: label, value: display_value(value), depth: depth } ]
       end
     end
 
-    def nested_rows(hash, label, depth)
+    def hash_rows(hash, label, depth)
+      return [ reference_row(label, hash, depth) ] if reference?(hash)
       return [ { label: label, value: "(empty)", depth: depth } ] if hash.empty?
 
       rows = label ? [ { label: label, value: nil, depth: depth } ] : []
       child_depth = label ? depth + 1 : depth
-      hash.each do |key, val|
-        rows.concat(flatten_rows(val, key.to_s.humanize, child_depth))
-      end
+      hash.each { |key, val| rows.concat(flatten_rows(val, key.to_s.humanize, child_depth)) }
       rows
     end
 
     def array_rows(array, label, depth)
       return [ { label: label, value: "(empty)", depth: depth } ] if array.empty?
 
-      if array.all? { |item| item.is_a?(Hash) }
-        rows = label ? [ { label: label, value: nil, depth: depth } ] : []
+      if array.all? { |item| named_entity?(item) }
+        [ { label: label, value: array.map { |item| entity_label(item) }.join(", "), depth: depth } ]
+      elsif array.all? { |item| reference?(item) }
+        header = label ? [ { label: label, value: nil, depth: depth } ] : []
         child_depth = label ? depth + 1 : depth
-        array.each { |item| rows.concat(nested_rows(item, nil, child_depth)) }
-        rows
+        header + array.map { |item| reference_row(nil, item, child_depth) }
       else
         [ { label: label, value: array.map { |item| display_value(item) }.join(", "), depth: depth } ]
       end
+    end
+
+    # A referenced record: a type + id and nothing but reference bookkeeping — no
+    # name/title (those collapse to a label instead) and no snapshot columns.
+    REFERENCE_KEYS = %w[type id record_type record_id action blob_id changes].freeze
+    private_constant :REFERENCE_KEYS
+
+    def reference?(item)
+      return false unless item.is_a?(Hash)
+
+      type = item["type"] || item["record_type"]
+      has_id = item.key?("id") || item.key?("record_id")
+      type.present? && has_id && item["name"].blank? && item["title"].blank? &&
+        (item.keys - REFERENCE_KEYS).empty?
+    end
+
+    def named_entity?(item)
+      item.is_a?(Hash) && (item["name"].present? || item["title"].present?)
+    end
+
+    def entity_label(item)
+      name = item["name"] || item["title"]
+      type = item["type"]
+      type.present? ? "#{name} (#{type.to_s.underscore.humanize})" : name
+    end
+
+    def reference_row(label, item, depth)
+      type = item["type"] || item["record_type"]
+      id = item["id"] || item["record_id"]
+      record = find_referenced_record(type, id)
+      text = record.try(:title).presence || record.try(:name).presence || "#{type} ##{id}"
+      { label: label, depth: depth, action: item["action"],
+        link: { text: text, path: show_path_for(record) } }
+    end
+
+    def find_referenced_record(type, id)
+      klass = type.to_s.safe_constantize
+      return nil unless klass.respond_to?(:find_by) && klass < ApplicationRecord
+
+      klass.find_by(id: id)
+    rescue StandardError
+      nil
+    end
+
+    def show_path_for(record)
+      return nil unless record
+
+      h.polymorphic_path(record)
+    rescue StandardError
+      nil
     end
 
     def display_value(value)

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -69,7 +69,7 @@ module Ahoy
 
       rows = label ? [ { label: label, value: nil, depth: depth } ] : []
       child_depth = label ? depth + 1 : depth
-      hash.each { |key, val| rows.concat(flatten_rows(val, key.to_s.humanize, child_depth)) }
+      hash.each { |key, val| rows.concat(flatten_rows(val, humanize_key(key), child_depth)) }
       rows
     end
 
@@ -135,6 +135,19 @@ module Ahoy
       h.polymorphic_path(record)
     rescue StandardError
       nil
+    end
+
+    # Friendlier labels for keys whose humanized form is dev-speak. Both
+    # result_count (index searches) and the legacy page_result_count (older
+    # tagging events, before both unified on result_count) read the same.
+    KEY_LABELS = {
+      "result_count" => "Results found",
+      "page_result_count" => "Results found"
+    }.freeze
+    private_constant :KEY_LABELS
+
+    def humanize_key(key)
+      KEY_LABELS[key.to_s] || key.to_s.humanize
     end
 
     def display_value(value)

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -1,0 +1,58 @@
+module Ahoy
+  class EventDecorator < ApplicationDecorator
+    # Already surfaced in their own table columns, so redundant inside the details cell.
+    REDUNDANT_KEYS = %w[resource_type resource_id resource_title].freeze
+
+    # Everything the dedicated columns don't already show.
+    def extra_properties
+      properties_hash.except(*REDUNDANT_KEYS)
+    end
+
+    def extra_details?
+      extra_properties.present?
+    end
+
+    def changes?
+      change_diffs.is_a?(Hash) && change_diffs.present?
+    end
+
+    # Field-level before/after diffs for update events, humanized for a
+    # non-technical reader: [{ field:, before:, after: }, ...].
+    def changes_summary
+      return [] unless changes?
+
+      change_diffs.map do |field, diff|
+        diff = {} unless diff.is_a?(Hash)
+        {
+          field: field.to_s.humanize,
+          before: display_value(diff["before"]),
+          after: display_value(diff["after"])
+        }
+      end
+    end
+
+    def properties_count
+      properties_hash.size
+    end
+
+    private
+
+    def properties_hash
+      object.properties || {}
+    end
+
+    def change_diffs
+      properties_hash["changes"]
+    end
+
+    def display_value(value)
+      case value
+      when nil, "" then "(empty)"
+      when true then "Yes"
+      when false then "No"
+      when Hash, Array then value.to_json
+      else value.to_s
+      end
+    end
+  end
+end

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -87,18 +87,8 @@ module Ahoy
       end
     end
 
-    # A referenced record: a type + id and nothing but reference bookkeeping — no
-    # name/title (those collapse to a label instead) and no snapshot columns.
-    REFERENCE_KEYS = %w[type id record_type record_id action blob_id changes].freeze
-    private_constant :REFERENCE_KEYS
-
     def reference?(item)
-      return false unless item.is_a?(Hash)
-
-      type = item["type"] || item["record_type"]
-      has_id = item.key?("id") || item.key?("record_id")
-      type.present? && has_id && item["name"].blank? && item["title"].blank? &&
-        (item.keys - REFERENCE_KEYS).empty?
+      Analytics::EventReferenceLoader.reference?(item)
     end
 
     def named_entity?(item)
@@ -120,7 +110,13 @@ module Ahoy
         link: { text: text, path: show_path_for(record) } }
     end
 
+    # Prefer the page-level cache (one query per type, built by
+    # Analytics::EventReferenceLoader) and only fall back to a direct lookup when
+    # no cache was supplied (e.g. specs or the single-event detail page).
     def find_referenced_record(type, id)
+      cache = context[:record_cache]
+      return cache[[ type.to_s, id ]] if cache
+
       klass = type.to_s.safe_constantize
       return nil unless klass.respond_to?(:find_by) && klass < ApplicationRecord
 

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -31,8 +31,15 @@ module Ahoy
       end
     end
 
-    def properties_count
-      properties_hash.size
+    # Every non-change extra property flattened into readable, humanized rows
+    # for inline display: [{ label:, value:, depth: }, ...]. Nested hashes and
+    # arrays are indented under their parent (depth) so the whole payload is
+    # visible in the table without opening the detail page.
+    def detail_rows
+      rows = extra_properties.except("changes")
+      return [] if rows.empty?
+
+      flatten_rows(rows)
     end
 
     private
@@ -43,6 +50,41 @@ module Ahoy
 
     def change_diffs
       properties_hash["changes"]
+    end
+
+    def flatten_rows(value, label = nil, depth = 0)
+      case value
+      when Hash
+        nested_rows(value, label, depth)
+      when Array
+        array_rows(value, label, depth)
+      else
+        [ { label: label, value: display_value(value), depth: depth } ]
+      end
+    end
+
+    def nested_rows(hash, label, depth)
+      return [ { label: label, value: "(empty)", depth: depth } ] if hash.empty?
+
+      rows = label ? [ { label: label, value: nil, depth: depth } ] : []
+      child_depth = label ? depth + 1 : depth
+      hash.each do |key, val|
+        rows.concat(flatten_rows(val, key.to_s.humanize, child_depth))
+      end
+      rows
+    end
+
+    def array_rows(array, label, depth)
+      return [ { label: label, value: "(empty)", depth: depth } ] if array.empty?
+
+      if array.all? { |item| item.is_a?(Hash) }
+        rows = label ? [ { label: label, value: nil, depth: depth } ] : []
+        child_depth = label ? depth + 1 : depth
+        array.each { |item| rows.concat(nested_rows(item, nil, child_depth)) }
+        rows
+      else
+        [ { label: label, value: array.map { |item| display_value(item) }.join(", "), depth: depth } ]
+      end
     end
 
     def display_value(value)

--- a/app/services/analytics/event_reference_loader.rb
+++ b/app/services/analytics/event_reference_loader.rb
@@ -1,0 +1,63 @@
+module Analytics
+  # Batch-loads the records that Ahoy event properties reference (association
+  # changes, associated records), so the activity table can link each one to its
+  # show page without a per-reference query. Given the page's events, it scans
+  # every properties tree once and issues a single query per referenced type.
+  class EventReferenceLoader
+    # A referenced record inside event properties: a type + id and nothing but
+    # reference bookkeeping — no name/title (those render as a plain label) and
+    # no snapshot columns.
+    REFERENCE_KEYS = %w[type id record_type record_id action blob_id changes].freeze
+
+    def self.reference?(item)
+      return false unless item.is_a?(Hash)
+
+      type = item["type"] || item["record_type"]
+      has_id = item.key?("id") || item.key?("record_id")
+      type.present? && has_id && item["name"].blank? && item["title"].blank? &&
+        (item.keys - REFERENCE_KEYS).empty?
+    end
+
+    def self.pair(item)
+      [ (item["type"] || item["record_type"]).to_s, item["id"] || item["record_id"] ]
+    end
+
+    def initialize(events)
+      @events = events
+    end
+
+    # { [type, id] => record } for every reference across the events. A missing
+    # record is simply absent from the map (the caller renders it as text).
+    def records
+      @records ||= load_records
+    end
+
+    private
+
+    def load_records
+      pairs = @events.flat_map { |event| references_in(event.properties || {}) }.uniq
+      pairs.group_by(&:first).each_with_object({}) do |(type, type_pairs), map|
+        klass = type.safe_constantize
+        next unless klass.respond_to?(:where) && klass < ApplicationRecord
+
+        ids = type_pairs.map(&:last).uniq
+        klass.where(id: ids).each { |record| map[[ type, record.id ]] = record }
+      end
+    rescue StandardError
+      {}
+    end
+
+    def references_in(value)
+      case value
+      when Hash
+        return [ self.class.pair(value) ] if self.class.reference?(value)
+
+        value.each_value.flat_map { |nested| references_in(nested) }
+      when Array
+        value.flat_map { |nested| references_in(nested) }
+      else
+        []
+      end
+    end
+  end
+end

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -51,9 +51,16 @@
         <% activity.detail_rows.each do |row| %>
           <div class="text-xs" style="padding-left: <%= row[:depth] * 12 %>px;">
             <% if row[:label] %>
-              <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] %></span>
+              <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] %></span>
             <% end %>
-            <% if row[:value] %>
+            <% if row[:link] %>
+              <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
+              <% if row[:link][:path] %>
+                <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline" %>
+              <% else %>
+                <span class="text-gray-600"><%= row[:link][:text] %></span>
+              <% end %>
+            <% elsif row[:value] %>
               <span class="text-gray-600"><%= row[:value] %></span>
             <% end %>
           </div>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -25,7 +25,7 @@
     <%= event.visit_id %>
   </td>
 
-  <% activity = event.decorate %>
+  <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
   <td data-label="Details" class="px-4 py-3 align-top text-gray-500">
     <% if activity.extra_details? %>
       <div class="space-y-1.5">

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,4 +1,4 @@
-<tr class="hover:bg-gray-50 transition">
+<tr class="transition hover:bg-gray-50">
   <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
@@ -25,40 +25,29 @@
     <%= event.visit_id %>
   </td>
 
-  <td data-label="Properties" class="px-4 py-3 text-gray-500 relative group">
-    <% if event.properties.present? && event.properties.any? %>
-      <%= link_to admin_activities_event_path(event),
-                  class: "cursor-default text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
-        <%= event.properties.size %> <%= "prop".pluralize(event.properties.size) %>
-      <% end %>
-      <%
-        props = event.properties.dup
-        display_props = []
-        # Combine polymorphic _type/_id pairs
-        props.keys.select { |k| k.end_with?("_type") }.each do |type_key|
-          prefix = type_key.chomp("_type")
-          id_key = "#{prefix}_id"
-          if props.key?(id_key)
-            display_props << [prefix, "#{props[type_key]}.find(#{props[id_key]})"]
-            props.delete(type_key)
-            props.delete(id_key)
-          end
-        end
-        # Show resource_title first, then remaining props
-        if props.key?("resource_title")
-          display_props.unshift(["resource_title", props.delete("resource_title")])
-        end
-        props.each do |key, value|
-          display_props << [key, value.is_a?(Hash) ? value.to_json : value]
-        end
-      %>
-      <div class="hidden group-hover:block absolute z-50 right-0 top-full bg-gray-900 text-gray-100 text-xs rounded-lg shadow-lg px-3 py-3 max-h-64 overflow-y-auto" style="width: 400px;">
-        <% display_props.each do |key, value| %>
-          <div class="py-1"><span class="text-indigo-300 font-semibold"><%= key %>:</span> <%= value.nil? ? "nil" : value.to_s.delete('"') %></div>
+  <% activity = event.decorate %>
+  <td data-label="Details" class="px-4 py-3 align-top text-gray-500">
+    <% if activity.changes? %>
+      <ul class="space-y-1.5">
+        <% activity.changes_summary.each do |change| %>
+          <li>
+            <span class="font-medium text-gray-700"><%= change[:field] %></span>
+            <div class="mt-0.5 flex flex-wrap items-center gap-1 text-xs">
+              <span class="text-gray-400">Before:</span>
+              <span class="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through"><%= change[:before] %></span>
+              <span class="text-gray-400">After:</span>
+              <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
+            </div>
+          </li>
         <% end %>
-      </div>
+      </ul>
+    <% elsif activity.extra_details? %>
+      <%= link_to admin_activities_event_path(event),
+                  class: "text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
+        View details
+      <% end %>
     <% else %>
-      <span class="text-gray-300 italic">none</span>
+      <span class="text-gray-300">—</span>
     <% end %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -27,25 +27,34 @@
 
   <% activity = event.decorate %>
   <td data-label="Details" class="px-4 py-3 align-top text-gray-500">
-    <% if activity.changes? %>
-      <ul class="space-y-1.5">
-        <% activity.changes_summary.each do |change| %>
-          <li>
-            <span class="font-medium text-gray-700"><%= change[:field] %></span>
-            <div class="mt-0.5 flex flex-wrap items-center gap-1 text-xs">
-              <span class="text-gray-400">Before:</span>
-              <span class="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through"><%= change[:before] %></span>
-              <span class="text-gray-400">After:</span>
-              <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
-            </div>
-          </li>
+    <% if activity.extra_details? %>
+      <div class="space-y-1.5">
+        <% if activity.changes? %>
+          <ul class="space-y-1.5">
+            <% activity.changes_summary.each do |change| %>
+              <li>
+                <span class="font-medium text-gray-700"><%= change[:field] %></span>
+                <div class="mt-0.5 flex flex-wrap items-center gap-1 text-xs">
+                  <span class="text-gray-400">Before:</span>
+                  <span class="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through"><%= change[:before] %></span>
+                  <span class="text-gray-400">After:</span>
+                  <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
+                </div>
+              </li>
+            <% end %>
+          </ul>
         <% end %>
-      </ul>
-    <% elsif activity.extra_details? %>
-      <%= link_to admin_activities_event_path(event),
-                  class: "text-indigo-600 text-xs font-medium bg-indigo-50 px-2 py-0.5 rounded hover:bg-indigo-100" do %>
-        View details
-      <% end %>
+        <% activity.detail_rows.each do |row| %>
+          <div class="text-xs" style="padding-left: <%= row[:depth] * 12 %>px;">
+            <% if row[:label] %>
+              <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] %></span>
+            <% end %>
+            <% if row[:value] %>
+              <span class="text-gray-600"><%= row[:value] %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <span class="text-gray-300">—</span>
     <% end %>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -34,11 +34,15 @@
             <% activity.changes_summary.each do |change| %>
               <li>
                 <span class="font-medium text-gray-700"><%= change[:field] %></span>
-                <div class="mt-0.5 flex flex-wrap items-center gap-1 text-xs">
-                  <span class="text-gray-400">Before:</span>
-                  <span class="rounded bg-red-50 px-1.5 py-0.5 text-red-700 line-through"><%= change[:before] %></span>
-                  <span class="text-gray-400">After:</span>
-                  <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
+                <div class="mt-0.5 space-y-0.5 text-xs">
+                  <div class="flex flex-wrap items-baseline gap-1">
+                    <span class="text-gray-400">Before:</span>
+                    <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= change[:before] %></span>
+                  </div>
+                  <div class="flex flex-wrap items-baseline gap-1">
+                    <span class="text-gray-400">After:</span>
+                    <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
+                  </div>
                 </div>
               </li>
             <% end %>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -51,16 +51,16 @@
   <% end %>
 
   <!-- Activities Table -->
-  <div class="blur-on-submit bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
+  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
     <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
-      <thead class="bg-gray-50 text-gray-600 uppercase tracking-wider text-xs">
+      <thead class="bg-gray-50 text-xs tracking-wider text-gray-600 uppercase">
       <tr>
-        <th class="px-4 py-3 text-left rounded-tl-xl">Time</th>
+        <th class="rounded-tl-xl px-4 py-3 text-left">Time</th>
         <th class="px-4 py-3 text-left">Activity</th>
         <th class="px-4 py-3 text-left">Resource</th>
         <th class="px-4 py-3 text-left">User</th>
         <th class="px-4 py-3 text-left">Visit ID</th>
-        <th class="px-4 py-3 text-left rounded-tr-xl">Properties</th>
+        <th class="rounded-tr-xl px-4 py-3 text-left">Details</th>
       </tr>
       </thead>
 
@@ -83,7 +83,7 @@
   </div>
 
   <!-- Pagination -->
-  <div class="flex justify-center mt-8">
+  <div class="mt-8 flex justify-center">
     <%= tailwind_paginate(@person ? @timeline : @events) %>
   </div>
 <% end %>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -70,12 +70,12 @@
           <% if entry.communication? %>
             <%= render "communication_row", notification: entry.record %>
           <% else %>
-            <%= render "activity_row", event: entry.record %>
+            <%= render "activity_row", event: entry.record, record_cache: @record_cache %>
           <% end %>
         <% end %>
       <% else %>
         <% @events.each do |event| %>
-          <%= render "activity_row", event: event %>
+          <%= render "activity_row", event: event, record_cache: @record_cache %>
         <% end %>
       <% end %>
       </tbody>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -51,11 +51,11 @@
 
             <div class="flex-1 min-w-0">
               <label class="<%= search_label_class %>">
-                Properties
+                Details
               </label>
               <%= text_field_tag :props,
                                  params[:props],
-                                 placeholder: "Search properties...",
+                                 placeholder: "Search details...",
                                  class: search_field_class %>
             </div>
 

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -42,7 +42,7 @@
   <% end %>
   <% if params[:props].present? %>
     <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800">
-      Properties: <%= params[:props] %>
+      Details: <%= params[:props] %>
     </span>
   <% end %>
   <% if params[:user_search].present? %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,24 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Activity log: readable details column"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/admin/activities/events"
+  summary: >-
+    The activity log's properties column is now a plain-language "Details" column: edits show
+    what changed as before/after, searches list the sectors and categories by name, and any
+    records involved link straight to their pages.
+  pr_number: 2316
+  pro_tips:
+    - "Use the Details search box to find activity by what's inside it (a name, a search term)."
+  description: >-
+    Each row's Details column now reads like a sentence instead of a raw property dump. For an
+    edit, every changed field shows its before and after value. For a search or filter, the
+    sectors, categories, and windows types are listed by name and the total results found. When
+    an activity touches other records, those records link straight to their show pages.
+
 - name: "Quotes: standout flag, linked author, and preserved original"
   area: content
   display_status: admin_facing

--- a/db/seeds/dev/analytics.rb
+++ b/db/seeds/dev/analytics.rb
@@ -125,7 +125,7 @@ else
     visit = ahoy_visits.sample
     cats = seed_categories.sample(rand(1..3)).map { |c| { id: c.id, name: c.name, type: c.category_type&.name } }
     secs = seed_sectors.sample(rand(1..2)).map { |s| { id: s.id, name: s.name } }
-    wts = seed_windows_types.sample(rand(1..2)).map(&:id)
+    wts = seed_windows_types.sample(rand(1..2)).map { |wt| { id: wt.id, name: wt.name } }
 
     props = {
       resource_type: "Workshop",
@@ -147,7 +147,7 @@ else
     visit = ahoy_visits.sample
     cats = seed_categories.sample(rand(1..2)).map { |c| { id: c.id, name: c.name, type: c.category_type&.name } }
     secs = seed_sectors.sample(rand(1..2)).map { |s| { id: s.id, name: s.name } }
-    wts = seed_windows_types.sample(rand(1..2)).map(&:id)
+    wts = seed_windows_types.sample(rand(1..2)).map { |wt| { id: wt.id, name: wt.name } }
 
     props = {
       resource_type: "Workshop",

--- a/spec/controllers/concerns/ahoy_view_tracking_spec.rb
+++ b/spec/controllers/concerns/ahoy_view_tracking_spec.rb
@@ -165,6 +165,27 @@ RSpec.describe AhoyTracking, type: :controller do
     end
   end
 
+  describe "#track_tagging_browse" do
+    before do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(sector_names_all: "Youth", category_names_all: "Healing")
+      )
+    end
+
+    it "records the paginated total across groups as result_count" do
+      grouped = {
+        workshops: double("page", total_entries: 12, size: 9),
+        resources: double("page", total_entries: 3, size: 3)
+      }
+
+      controller.send(:track_tagging_browse, grouped)
+
+      event = Ahoy::Event.find_by(name: "search.taggings")
+      expect(event.properties).to include("result_count" => 15)
+      expect(event.properties).not_to have_key("page_result_count")
+    end
+  end
+
   describe "session isolation" do
     xit "tracks different actions separately" do
       get  :index, params: { id: workshop.id }

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -141,5 +141,23 @@ RSpec.describe Ahoy::EventDecorator do
       expect(link_row[:link][:text]).to eq("Workshop #0")
       expect(link_row[:link][:path]).to be_nil
     end
+
+    it "resolves references from the page record_cache without its own query" do
+      workshop = create(:workshop)
+      cache = { [ "Workshop", workshop.id ] => workshop }
+      event = create(:ahoy_event, properties: {
+        "association_changes" => { "workshops" => [ { "action" => "added", "id" => workshop.id, "type" => "Workshop" } ] }
+      }).reload.decorate(context: { record_cache: cache })
+
+      link_row = nil
+      queries = 0
+      counter = ->(_n, _s, _f, _i, payload) { queries += 1 if payload[:sql]&.include?("`workshops`") }
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        link_row = event.detail_rows.find { |r| r[:link] }
+      end
+
+      expect(link_row[:link][:text]).to eq(workshop.title)
+      expect(queries).to eq(0)
+    end
   end
 end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -65,9 +65,16 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.detail_rows).to match_array(
         [
           { label: "Source", value: "import", depth: 0 },
-          { label: "Result count", value: "3", depth: 0 }
+          { label: "Results found", value: "3", depth: 0 }
         ]
       )
+    end
+
+    it "labels both result_count and the legacy page_result_count as Results found" do
+      current = decorate("result_count" => 8)
+      legacy = decorate("page_result_count" => 21)
+      expect(current.detail_rows).to eq([ { label: "Results found", value: "8", depth: 0 } ])
+      expect(legacy.detail_rows).to eq([ { label: "Results found", value: "21", depth: 0 } ])
     end
 
     it "indents a nested hash under its label" do

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Ahoy::EventDecorator do
+  def decorate(properties)
+    create(:ahoy_event, properties: properties).reload.decorate
+  end
+
+  describe "#extra_properties" do
+    it "drops the keys already shown in their own columns" do
+      event = decorate(
+        "resource_type" => "Workshop",
+        "resource_id" => 1,
+        "resource_title" => "Test",
+        "source" => "import"
+      )
+      expect(event.extra_properties).to eq("source" => "import")
+    end
+
+    it "is empty when only the redundant keys are present" do
+      event = decorate("resource_type" => "Workshop", "resource_id" => 1, "resource_title" => "Test")
+      expect(event.extra_details?).to be(false)
+    end
+  end
+
+  describe "#changes?" do
+    it "is true for an update event with a changes diff" do
+      event = decorate("changes" => { "title" => { "before" => "Old", "after" => "New" } })
+      expect(event.changes?).to be(true)
+    end
+
+    it "is false when there is no changes diff" do
+      event = decorate("resource_title" => "Test")
+      expect(event.changes?).to be(false)
+    end
+  end
+
+  describe "#changes_summary" do
+    it "humanizes the field and formats before/after values" do
+      event = decorate(
+        "changes" => {
+          "display_name" => { "before" => "Old", "after" => "New" },
+          "active" => { "before" => false, "after" => true },
+          "note" => { "before" => nil, "after" => "" }
+        }
+      )
+
+      expect(event.changes_summary).to match_array(
+        [
+          { field: "Display name", before: "Old", after: "New" },
+          { field: "Active", before: "No", after: "Yes" },
+          { field: "Note", before: "(empty)", after: "(empty)" }
+        ]
+      )
+    end
+
+    it "is empty when the event has no changes" do
+      event = decorate("resource_title" => "Test")
+      expect(event.changes_summary).to eq([])
+    end
+  end
+end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -85,9 +85,54 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.detail_rows).to eq([ { label: "Sectors", value: "Veterans, Youth", depth: 0 } ])
     end
 
+    it "collapses an array of named entities onto one line" do
+      event = decorate(
+        "filters" => {
+          "sectors" => [ { "id" => 9, "name" => "Education" }, { "id" => 2, "name" => "Youth" } ],
+          "categories" => [ { "id" => 10, "name" => "Journaling", "type" => "ArtType" } ]
+        }
+      )
+      expect(event.detail_rows).to eq(
+        [
+          { label: "Filters", value: nil, depth: 0 },
+          { label: "Sectors", value: "Education, Youth", depth: 1 },
+          { label: "Categories", value: "Journaling (Art type)", depth: 1 }
+        ]
+      )
+    end
+
     it "excludes the changes diff (rendered separately)" do
       event = decorate("changes" => { "title" => { "before" => "A", "after" => "B" } })
       expect(event.detail_rows).to eq([])
+    end
+  end
+
+  describe "record references" do
+    it "links an association change to the record's show page" do
+      workshop = create(:workshop)
+      event = decorate(
+        "association_changes" => {
+          "workshops" => [ { "action" => "added", "id" => workshop.id, "type" => "Workshop" } ]
+        }
+      )
+      rows = event.detail_rows
+
+      header = rows.find { |r| r[:label] == "Association changes" }
+      expect(header[:value]).to be_nil
+
+      link_row = rows.find { |r| r[:link] }
+      expect(link_row[:action]).to eq("added")
+      expect(link_row[:link][:text]).to eq(workshop.title)
+      expect(link_row[:link][:path]).to eq(Rails.application.routes.url_helpers.workshop_path(workshop))
+    end
+
+    it "falls back to type + id when the record is gone" do
+      event = decorate(
+        "associated_records" => [ { "record_type" => "Workshop", "record_id" => 0 } ]
+      )
+      link_row = event.detail_rows.find { |r| r[:link] }
+      expect(link_row[:link][:text]).to eq("Workshop #0")
+      expect(link_row[:link][:path]).to be_nil
     end
   end
 end

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -58,4 +58,36 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.changes_summary).to eq([])
     end
   end
+
+  describe "#detail_rows" do
+    it "flattens scalar extras into humanized rows" do
+      event = decorate("resource_title" => "Test", "source" => "import", "result_count" => 3)
+      expect(event.detail_rows).to match_array(
+        [
+          { label: "Source", value: "import", depth: 0 },
+          { label: "Result count", value: "3", depth: 0 }
+        ]
+      )
+    end
+
+    it "indents a nested hash under its label" do
+      event = decorate("keywords" => { "full_text" => "watercolor" })
+      expect(event.detail_rows).to eq(
+        [
+          { label: "Keywords", value: nil, depth: 0 },
+          { label: "Full text", value: "watercolor", depth: 1 }
+        ]
+      )
+    end
+
+    it "joins an array of scalars into one row" do
+      event = decorate("sectors" => %w[Veterans Youth])
+      expect(event.detail_rows).to eq([ { label: "Sectors", value: "Veterans, Youth", depth: 0 } ])
+    end
+
+    it "excludes the changes diff (rendered separately)" do
+      event = decorate("changes" => { "title" => { "before" => "A", "after" => "B" } })
+      expect(event.detail_rows).to eq([])
+    end
+  end
 end

--- a/spec/services/analytics/event_reference_loader_spec.rb
+++ b/spec/services/analytics/event_reference_loader_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Analytics::EventReferenceLoader do
+  def event(properties)
+    build(:ahoy_event, properties: properties)
+  end
+
+  describe ".reference?" do
+    it "recognizes a bare type + id reference" do
+      expect(described_class.reference?({ "type" => "Workshop", "id" => 1, "action" => "added" })).to be(true)
+      expect(described_class.reference?({ "record_type" => "Sector", "record_id" => 2 })).to be(true)
+    end
+
+    it "rejects named entities and attribute snapshots" do
+      expect(described_class.reference?({ "id" => 1, "name" => "Education" })).to be(false)
+      expect(described_class.reference?({ "title" => "A workshop", "published" => true })).to be(false)
+    end
+  end
+
+  describe "#records" do
+    it "loads every referenced record across events into a { [type, id] => record } map" do
+      workshop = create(:workshop)
+      sector = create(:sector)
+
+      events = [
+        event("association_changes" => { "workshops" => [ { "action" => "added", "id" => workshop.id, "type" => "Workshop" } ] }),
+        event("associated_records" => [ { "record_type" => "Sector", "record_id" => sector.id } ])
+      ]
+
+      map = described_class.new(events).records
+
+      expect(map[[ "Workshop", workshop.id ]]).to eq(workshop)
+      expect(map[[ "Sector", sector.id ]]).to eq(sector)
+    end
+
+    it "omits records that no longer exist" do
+      events = [ event("associated_records" => [ { "record_type" => "Workshop", "record_id" => 0 } ]) ]
+      expect(described_class.new(events).records).to eq({})
+    end
+
+    it "issues one query per referenced type, not one per reference" do
+      workshops = create_list(:workshop, 3)
+      events = workshops.map do |w|
+        event("association_changes" => { "workshops" => [ { "action" => "added", "id" => w.id, "type" => "Workshop" } ] })
+      end
+      loader = described_class.new(events)
+
+      workshop_selects = 0
+      counter = ->(_n, _s, _f, _i, payload) do
+        workshop_selects += 1 if payload[:sql]&.include?("`workshops`")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { loader.records }
+
+      expect(workshop_selects).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view + decorator + a small preloader service on one admin page

## Why
The activity table's **Properties** column showed a `N props` badge and a hover-only, raw-JSON tooltip — unusable for the non-technical admins this page is built for.

## What
- **New `Ahoy::EventDecorator`** — drops keys already shown in their own columns (`resource_type`/`resource_id`/`resource_title`), exposes humanized before/after diffs, and flattens the rest into compact, readable rows.
- **Column renamed Properties → Details**, rendered inline per row (no click-through):
  - update events → each changed field as **Before / After** on separate lines (grey struck old value, green new value)
  - filter/search → **compact**: entity lists (sectors, categories, windows types) collapse onto one line by name
  - association changes & associated records → **links** to each record's show page
  - nothing beyond the other columns → `—`
- **Filter renamed to match** — search box label/placeholder + active-filter chip now read "Details" (`:props` param key unchanged).
- **Unified `result_count`** — `search.taggings` recorded `page_result_count` (loaded page only); now records the paginated total under `result_count` like every other search. Both keys (incl. legacy rows) display as **"Results found"**. No chart reads either field.

## Performance
- **New `Analytics::EventReferenceLoader`** preloads every referenced record for the page in **one query per type**, so linking association changes / associated records doesn't N+1 as activity volume grows. The decorator reads that cache (direct lookup only when none supplied).

## Test
- `spec/decorators/ahoy/event_decorator_spec.rb`, `spec/services/analytics/event_reference_loader_spec.rb` (both new; include query-count assertions)
- `spec/controllers/concerns/ahoy_view_tracking_spec.rb` (tagging total), `spec/requests/admin/ahoy_activities_spec.rb` green
- Seed fix: windows_types stored as `{id, name}` to match real tracked shape