### PR TITLE
Consolidate event "name (month year)" display into one decorator method

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -47,6 +47,15 @@ class EventDecorator < ApplicationDecorator
     start_date&.strftime("%B %Y")
   end
 
+  # The canonical "which occurrence" label: title with its month and year
+  # appended (e.g. "AWBW Facilitator Training (October 2026)"). Falls back to the
+  # bare title when the event has no start date.
+  def title_with_month_year
+    return title if start_date.blank?
+
+    "#{title} (#{month_year})"
+  end
+
   # Subject pre-filled on the bulk reminder page and used as the send-time
   # fallback, so the preview and the delivered email always agree. An on-demand
   # event's start date bounds enrollment rather than naming a session, so putting

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -463,9 +463,8 @@ module ApplicationHelper
   # Training (August 2026)") so a registration reads as which occurrence it's for.
   def event_title_with_month_year(event)
     return if event.blank?
-    return event.title if event.start_date.blank?
 
-    "#{event.title} (#{event.start_date.strftime('%B %Y')})"
+    event.decorate.title_with_month_year
   end
 
   def search_page(params)

--- a/app/views/event_registrations/_transfer_notice.html.erb
+++ b/app/views/event_registrations/_transfer_notice.html.erb
@@ -7,8 +7,7 @@
   <div class="mb-4 flex items-start gap-3 rounded-lg border border-teal-200 bg-teal-50 px-4 py-3 text-sm text-teal-900">
     <i class="fa-solid fa-right-to-bracket mt-0.5 text-teal-600"></i>
     <div>
-      <% in_month_year = event_registration.event.decorate.month_year %>
-      You transferred into <strong><%= event_registration.event.title %></strong><%= " (#{in_month_year})" if in_month_year %>. Your payment,
+      You transferred into <strong><%= event_registration.event.decorate.title_with_month_year %></strong>. Your payment,
       scholarship, and continuing-education records stay on your
       <%= link_to "original registration", registration_ticket_path(source.slug), class: "font-semibold underline" %>
       — your attendance here and your certificate for these hours are earned at this event.
@@ -18,8 +17,7 @@
   <div class="mb-4 flex items-start gap-3 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 text-sm text-purple-900">
     <i class="fa-solid fa-right-from-bracket mt-0.5 text-purple-600"></i>
     <div>
-      <% out_month_year = event_registration.event.decorate.month_year %>
-      You transferred out of <strong><%= event_registration.event.title %></strong><%= " (#{out_month_year})" if out_month_year %> to
+      You transferred out of <strong><%= event_registration.event.decorate.title_with_month_year %></strong> to
       <%= link_to "your new registration", registration_ticket_path(destination.slug), class: "font-semibold underline" %>.
       Attend there and earn your certificate at that event; your payment, scholarship, and
       continuing-education records remain here.

--- a/app/views/event_registrations/transfer.html.erb
+++ b/app/views/event_registrations/transfer.html.erb
@@ -60,7 +60,7 @@
               <i class="fa-solid fa-right-from-bracket text-gray-400"></i> This registration
             </p>
             <p class="mb-2 truncate text-2xs text-gray-500" title="<%= source.event.title %>">
-              <%= source.event.title %><% if source.event.decorate.month_year %> <span class="text-gray-400">&middot;</span> <%= source.event.decorate.month_year %><% end %>
+              <%= source.event.decorate.title_with_month_year %>
             </p>
             <ul class="list-disc space-y-1 pl-4 text-xs text-gray-600">
               <li>Marked "Transferred out" (not deleted)</li>

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#title_with_month_year" do
+    it "appends the start month and year in parentheses" do
+      event = build(:event, title: "Facilitator Training", start_date: Time.zone.local(2026, 10, 3)).decorate
+      expect(event.title_with_month_year).to eq("Facilitator Training (October 2026)")
+    end
+
+    it "falls back to the bare title when there is no start date" do
+      event = build(:event, title: "Facilitator Training", start_date: nil).decorate
+      expect(event.title_with_month_year).to eq("Facilitator Training")
+    end
+  end
+
   describe "#archive_status_label" do
     it "reads as Draft for an unpublished event" do
       event = build(:event, :unpublished).decorate


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small display refactor centralizing a repeated title+month/year string; only the transfer page changes visually

### What is the goal of this PR and why is this important?
The event "title + month/year" label was rebuilt by hand in four places and had drifted between a dot separator and parentheses. This centralizes it so there's one canonical way to show which occurrence of an event a record belongs to.

### How did you approach the change?
- Added `EventDecorator#title_with_month_year` (e.g. `Facilitator Training (October 2026)`), falling back to the bare title when there's no start date.
- Routed the transfer page, the transfer notice (both branches), and the `event_title_with_month_year` helper through it.
- Standardized on the parenthesized form — it reads best inline in prose and in the `·`-joined notification labels; only the transfer page changes visually (dot → parens).

### Anything else to add?
Added decorator specs; existing `noticeable_label` / `{{event_month_year}}` helper specs still pass.