### PR TITLE
Add Form answers index (filterable answer browser)

### DIFF
--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -10,6 +10,7 @@ class FormAnswersController < ApplicationController
       render :form_answers_results
     else
       @forms = Form.order(:name)
+      @events = Event.order(start_date: :desc)
       render :index
     end
   end
@@ -29,6 +30,9 @@ class FormAnswersController < ApplicationController
     end
     if params[:form_id].present?
       scope = scope.joins(:form_submission).where(form_submissions: { form_id: params[:form_id] })
+    end
+    if params[:event_id].present?
+      scope = scope.joins(:form_submission).where(form_submissions: { event_id: params[:event_id] })
     end
     if params[:person].present?
       term = "%#{Person.sanitize_sql_like(params[:person])}%"

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -1,0 +1,42 @@
+class FormAnswersController < ApplicationController
+  def index
+    authorize! FormAnswer
+
+    if turbo_frame_request?
+      @form_answers = filter_answers(FormAnswer.all)
+                        .includes(:form_field, form_submission: [ :form, :person ])
+                        .order(created_at: :desc)
+                        .paginate(page: params[:page], per_page: 50)
+      render :form_answers_results
+    else
+      @forms = Form.order(:name)
+      render :index
+    end
+  end
+
+  private
+
+  # Each filter is a no-op when its param is blank, so combinations stack.
+  def filter_answers(scope)
+    if params[:q].present?
+      scope = scope.where("form_answers.submitted_answer LIKE ?", "%#{FormAnswer.sanitize_sql_like(params[:q])}%")
+    end
+    if params[:form_id].present?
+      scope = scope.joins(:form_submission).where(form_submissions: { form_id: params[:form_id] })
+    end
+    if params[:person].present?
+      term = "%#{Person.sanitize_sql_like(params[:person])}%"
+      scope = scope.joins(form_submission: :person).where(
+        "people.first_name LIKE :t OR people.last_name LIKE :t OR people.email LIKE :t OR CONCAT(people.first_name, ' ', people.last_name) LIKE :t",
+        t: term
+      )
+    end
+    if params[:form_submission_id].present?
+      scope = scope.where(form_submission_id: params[:form_submission_id])
+    end
+    if params[:answer_type].present? && FormField.answer_types.key?(params[:answer_type])
+      scope = scope.joins(:form_field).where(form_fields: { answer_type: FormField.answer_types[params[:answer_type]] })
+    end
+    scope
+  end
+end

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -21,6 +21,12 @@ class FormAnswersController < ApplicationController
     if params[:q].present?
       scope = scope.where("form_answers.submitted_answer LIKE ?", "%#{FormAnswer.sanitize_sql_like(params[:q])}%")
     end
+    if params[:question].present?
+      term = "%#{FormField.sanitize_sql_like(params[:question])}%"
+      scope = scope.left_joins(:form_field).where(
+        "form_fields.name LIKE :t OR form_answers.question_name_when_answered LIKE :t", t: term
+      )
+    end
     if params[:form_id].present?
       scope = scope.joins(:form_submission).where(form_submissions: { form_id: params[:form_id] })
     end

--- a/app/decorators/form_answer_decorator.rb
+++ b/app/decorators/form_answer_decorator.rb
@@ -1,0 +1,14 @@
+class FormAnswerDecorator < ApplicationDecorator
+  delegate_all
+
+  # Full answer text for a hover tooltip, pretty-printed when it's a JSON
+  # object/array so structured answers are readable instead of one long line.
+  def tooltip_text
+    text = submitted_answer.to_s
+    return text unless text.strip.start_with?("{", "[")
+
+    JSON.pretty_generate(JSON.parse(text))
+  rescue JSON::ParserError
+    text
+  end
+end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -83,7 +83,7 @@ module AdminCardsHelper
       custom_card("Forms", forms_path, icon: "📋", color: :sky, intensity: 100),
       custom_card("Licenses", professional_licenses_path, icon: "🪪", color: :sky, intensity: 100),
       disabled_card("Form submissions", icon: "📨"),
-      disabled_card("Form answers", icon: "✅"),
+      custom_card("Form answers", form_answers_path, icon: "✅", color: :sky, intensity: 100),
       custom_card("Monthly reports", monthly_reports_path, icon: "📈", color: :sky, intensity: 100),
       custom_card("Payments", payments_path, icon: "💳", color: :sky, intensity: 100),
       custom_card("Bookmarks", bookmarks_path, icon: "🔖", color: :sky, intensity: 100),

--- a/app/policies/form_answer_policy.rb
+++ b/app/policies/form_answer_policy.rb
@@ -1,0 +1,10 @@
+class FormAnswerPolicy < ApplicationPolicy
+  relation_scope do |relation|
+    next relation if admin?
+    relation.none
+  end
+
+  def index?
+    admin?
+  end
+end

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -1,0 +1,69 @@
+<%= turbo_frame_tag :form_answers_results do %>
+  <div class="mb-3 text-sm text-gray-600">
+    <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> px-2.5 py-0.5 font-semibold">
+      <%= pluralize(@form_answers.total_entries, "answer") %>
+    </span>
+  </div>
+
+  <% if @form_answers.any? %>
+    <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">
+            <th class="px-4 py-3">Question</th>
+            <th class="px-4 py-3">Answer</th>
+            <th class="px-4 py-3">Type</th>
+            <th class="px-4 py-3">Form</th>
+            <th class="px-4 py-3">Person</th>
+            <th class="px-4 py-3">Submitted</th>
+            <th class="px-4 py-3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @form_answers.each do |answer| %>
+            <% submission = answer.form_submission %>
+            <tr class="border-b border-gray-100 align-top text-sm text-gray-800 last:border-0">
+              <td class="px-4 py-3 font-medium"><%= answer.form_field&.name.presence || answer.question_name_when_answered %></td>
+              <td class="max-w-md px-4 py-3">
+                <% if answer.submitted_answer.present? %>
+                  <%# submitted_answer is stored verbatim and unsanitized — always auto-escape it. %>
+                  <span class="line-clamp-3 whitespace-pre-line"><%= answer.submitted_answer %></span>
+                <% else %>
+                  <span class="text-gray-300">—</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3">
+                <% if answer.form_field %>
+                  <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-600">
+                    <%= FormField::ANSWER_TYPE_LABELS[answer.form_field.answer_type] %>
+                  </span>
+                <% else %>
+                  <span class="text-gray-300">—</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3"><%= submission.form&.display_name %></td>
+              <td class="px-4 py-3"><%= submission.person&.name %></td>
+              <td class="px-4 py-3 whitespace-nowrap"><%= answer.created_at.to_fs(:long) %></td>
+              <td class="px-4 py-3 text-right">
+                <%= link_to "View submission",
+                      form_submission_path(submission, return_to: "form_answers",
+                        q: params[:q].presence, person: params[:person].presence,
+                        form_id: params[:form_id].presence, answer_type: params[:answer_type].presence,
+                        form_submission_id: params[:form_submission_id].presence),
+                      data: { turbo_frame: "_top" },
+                      class: "whitespace-nowrap text-blue-600 hover:underline" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagination mt-6 flex w-full justify-center"><%= tailwind_paginate @form_answers %></div>
+  <% else %>
+    <div class="rounded-xl border border-dashed border-gray-300 bg-white py-12 text-center">
+      <i class="fa-solid fa-list-check text-3xl text-gray-300" aria-hidden="true"></i>
+      <p class="mt-3 text-gray-500">No form answers found.</p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -13,8 +13,7 @@
             <th class="px-4 py-3">Question</th>
             <th class="px-4 py-3">Answer</th>
             <th class="px-4 py-3">Type</th>
-            <th class="px-4 py-3">Form</th>
-            <th class="px-4 py-3">Person</th>
+            <th class="px-4 py-3">Form &amp; person</th>
             <th class="px-4 py-3">Submitted</th>
             <th class="px-4 py-3"></th>
           </tr>
@@ -41,8 +40,10 @@
                   <span class="text-gray-300">—</span>
                 <% end %>
               </td>
-              <td class="px-4 py-3"><%= submission.form&.display_name %></td>
-              <td class="px-4 py-3"><%= submission.person&.name %></td>
+              <td class="px-4 py-3">
+                <div class="font-medium text-gray-900"><%= submission.form&.display_name %></div>
+                <div class="text-gray-600"><%= submission.person&.name %></div>
+              </td>
               <td class="px-4 py-3 whitespace-nowrap"><%= answer.created_at.to_fs(:long) %></td>
               <td class="px-4 py-3 text-right">
                 <%= link_to "View submission",

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -47,8 +47,9 @@
               <td class="px-4 py-3 text-right">
                 <%= link_to "View submission",
                       form_submission_path(submission, return_to: "form_answers",
-                        q: params[:q].presence, person: params[:person].presence,
-                        form_id: params[:form_id].presence, answer_type: params[:answer_type].presence,
+                        q: params[:q].presence, question: params[:question].presence,
+                        person: params[:person].presence, form_id: params[:form_id].presence,
+                        answer_type: params[:answer_type].presence,
                         form_submission_id: params[:form_submission_id].presence),
                       data: { turbo_frame: "_top" },
                       class: "whitespace-nowrap text-blue-600 hover:underline" %>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -48,7 +48,7 @@
                       form_submission_path(submission, return_to: "form_answers",
                         q: params[:q].presence, question: params[:question].presence,
                         person: params[:person].presence, form_id: params[:form_id].presence,
-                        answer_type: params[:answer_type].presence,
+                        event_id: params[:event_id].presence, answer_type: params[:answer_type].presence,
                         form_submission_id: params[:form_submission_id].presence),
                       data: { turbo_frame: "_top" },
                       class: "mt-1 inline-block text-sm whitespace-nowrap text-blue-600 hover:underline" %>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -19,26 +19,28 @@
         <tbody>
           <% @form_answers.each do |answer| %>
             <% submission = answer.form_submission %>
-            <tr class="border-b border-gray-100 align-top text-sm text-gray-800 last:border-0">
+            <tr class="border-b border-gray-100 align-top text-sm text-gray-500 last:border-0">
               <td class="px-4 py-3">
-                <div class="font-medium"><%= answer.form_field&.name.presence || answer.question_name_when_answered %></div>
+                <span class="font-medium text-gray-700"><%= answer.form_field&.name.presence || answer.question_name_when_answered %></span>
                 <% if answer.form_field %>
-                  <span class="mt-1 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-600">
+                  <span class="ml-1.5 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 align-middle text-xs font-medium whitespace-nowrap text-gray-500">
                     <%= FormField::ANSWER_TYPE_LABELS[answer.form_field.answer_type] %>
                   </span>
                 <% end %>
               </td>
               <td class="max-w-md px-4 py-3">
                 <% if answer.submitted_answer.present? %>
-                  <%# submitted_answer is stored verbatim and unsanitized — always auto-escape it. %>
-                  <span class="line-clamp-3 whitespace-pre-line"><%= answer.submitted_answer %></span>
+                  <%# The answer is the focal column — larger, darker, heavier than its neighbours.
+                      submitted_answer is stored verbatim and unsanitized — always auto-escape it.
+                      title shows the full text (pretty-printed if JSON) on hover. %>
+                  <span class="line-clamp-3 cursor-help text-base font-medium whitespace-pre-line text-gray-900" title="<%= answer.decorate.tooltip_text %>"><%= answer.submitted_answer %></span>
                 <% else %>
                   <span class="text-gray-300">—</span>
                 <% end %>
               </td>
               <td class="px-4 py-3">
-                <div class="font-medium text-gray-900"><%= submission.form&.display_name %></div>
-                <div class="text-gray-600"><%= submission.person&.name %></div>
+                <div class="font-medium text-gray-600"><%= submission.form&.display_name %></div>
+                <div class="text-gray-400"><%= submission.person&.name %></div>
               </td>
               <td class="px-4 py-3 whitespace-nowrap">
                 <div><%= answer.created_at.to_fs(:long) %></div>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -15,7 +15,6 @@
             <th class="px-4 py-3">Type</th>
             <th class="px-4 py-3">Form &amp; person</th>
             <th class="px-4 py-3">Submitted</th>
-            <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
@@ -44,8 +43,8 @@
                 <div class="font-medium text-gray-900"><%= submission.form&.display_name %></div>
                 <div class="text-gray-600"><%= submission.person&.name %></div>
               </td>
-              <td class="px-4 py-3 whitespace-nowrap"><%= answer.created_at.to_fs(:long) %></td>
-              <td class="px-4 py-3 text-right">
+              <td class="px-4 py-3 whitespace-nowrap">
+                <div><%= answer.created_at.to_fs(:long) %></div>
                 <%= link_to "View submission",
                       form_submission_path(submission, return_to: "form_answers",
                         q: params[:q].presence, question: params[:question].presence,
@@ -53,7 +52,7 @@
                         answer_type: params[:answer_type].presence,
                         form_submission_id: params[:form_submission_id].presence),
                       data: { turbo_frame: "_top" },
-                      class: "whitespace-nowrap text-blue-600 hover:underline" %>
+                      class: "mt-1 inline-block text-sm whitespace-nowrap text-blue-600 hover:underline" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -12,7 +12,6 @@
           <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">
             <th class="px-4 py-3">Question</th>
             <th class="px-4 py-3">Answer</th>
-            <th class="px-4 py-3">Type</th>
             <th class="px-4 py-3">Form &amp; person</th>
             <th class="px-4 py-3">Submitted</th>
           </tr>
@@ -21,20 +20,18 @@
           <% @form_answers.each do |answer| %>
             <% submission = answer.form_submission %>
             <tr class="border-b border-gray-100 align-top text-sm text-gray-800 last:border-0">
-              <td class="px-4 py-3 font-medium"><%= answer.form_field&.name.presence || answer.question_name_when_answered %></td>
+              <td class="px-4 py-3">
+                <div class="font-medium"><%= answer.form_field&.name.presence || answer.question_name_when_answered %></div>
+                <% if answer.form_field %>
+                  <span class="mt-1 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-600">
+                    <%= FormField::ANSWER_TYPE_LABELS[answer.form_field.answer_type] %>
+                  </span>
+                <% end %>
+              </td>
               <td class="max-w-md px-4 py-3">
                 <% if answer.submitted_answer.present? %>
                   <%# submitted_answer is stored verbatim and unsanitized — always auto-escape it. %>
                   <span class="line-clamp-3 whitespace-pre-line"><%= answer.submitted_answer %></span>
-                <% else %>
-                  <span class="text-gray-300">—</span>
-                <% end %>
-              </td>
-              <td class="px-4 py-3">
-                <% if answer.form_field %>
-                  <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-600">
-                    <%= FormField::ANSWER_TYPE_LABELS[answer.form_field.answer_type] %>
-                  </span>
                 <% else %>
                   <span class="text-gray-300">—</span>
                 <% end %>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,0 +1,62 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="form-answers-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-xl border border-gray-200 p-6 shadow">
+  <div class="w-full">
+    <div class="mb-6 flex items-start gap-4">
+      <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
+        <i class="fa-solid fa-list-check text-xl" aria-hidden="true"></i>
+      </span>
+      <div>
+        <h2 class="text-2xl font-semibold text-gray-900">Form answers</h2>
+        <p class="mt-1 text-gray-600">
+          Every answer submitted across the site's forms — search the answer text or
+          filter by form, person, submission, or question type.
+        </p>
+      </div>
+    </div>
+
+    <%# GET filter form outside the frame. The collection controller debounce-submits
+        the text boxes and submits the selects on change, into the results frame. %>
+    <%= form_with url: form_answers_path, method: :get, data: { controller: "collection", turbo_frame: "form_answers_results" }, autocomplete: "off" do %>
+      <div class="mb-6 flex flex-wrap items-end gap-3">
+        <div class="min-w-64 flex-1">
+          <%= label_tag :q, "Answer text", class: search_label_class %>
+          <%= text_field_tag :q, params[:q], class: search_field_class, placeholder: "Search answer text" %>
+        </div>
+        <div class="min-w-48">
+          <%= label_tag :person, "Person", class: search_label_class %>
+          <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
+        </div>
+        <div class="min-w-56">
+          <%= label_tag :form_id, "Form", class: search_label_class %>
+          <%= select_tag :form_id,
+                options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
+                include_blank: "All forms",
+                class: search_field_class(extra: "search-select-placeholder") %>
+        </div>
+        <div class="min-w-52">
+          <%= label_tag :answer_type, "Question type", class: search_label_class %>
+          <%= select_tag :answer_type,
+                options_for_select(FormField::ANSWER_TYPE_LABELS.map { |key, label| [ label, key ] }, params[:answer_type]),
+                include_blank: "All types",
+                class: search_field_class(extra: "search-select-placeholder") %>
+        </div>
+        <div class="w-32">
+          <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
+          <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
+        </div>
+        <% if params.slice(:q, :person, :form_id, :answer_type, :form_submission_id).values.any?(&:present?) %>
+          <%= render "shared/search_clear", url: form_answers_path %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% result_src = form_answers_path(request.query_parameters) %>
+    <%= turbo_frame_tag :form_answers_results, src: result_src, data: { turbo: "temporary" } do %>
+      <div class="rounded-xl border border-gray-200 bg-white py-16 text-center text-gray-400 shadow-sm">
+        <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
+        <p class="mt-2 text-sm">Loading answers…</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -36,8 +36,9 @@
         </div>
         <div class="w-44">
           <%= label_tag :answer_type, "Question type", class: search_label_class %>
+          <%# Section headers and informational-only fields never capture answers, so they're omitted. %>
           <%= select_tag :answer_type,
-                options_for_select(FormField::ANSWER_TYPE_LABELS.map { |key, label| [ label, key ] }, params[:answer_type]),
+                options_for_select(FormField::ANSWER_TYPE_LABELS.except(*FormField::NON_INPUT_ANSWER_TYPES).map { |key, label| [ label, key ] }, params[:answer_type]),
                 include_blank: "All types",
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -18,40 +18,40 @@
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
     <%= form_with url: form_answers_path, method: :get, data: { controller: "collection", turbo_frame: "form_answers_results" }, autocomplete: "off" do %>
-      <div class="mb-6 flex flex-wrap items-end gap-3">
-        <div class="min-w-64 flex-1">
+      <div class="mb-6 flex flex-wrap items-end gap-2">
+        <div class="min-w-40 flex-1">
           <%= label_tag :q, "Answer text", class: search_label_class %>
           <%= text_field_tag :q, params[:q], class: search_field_class, placeholder: "Search answer text" %>
         </div>
-        <div class="min-w-56 flex-1">
+        <div class="w-40">
           <%= label_tag :question, "Question text", class: search_label_class %>
-          <%= text_field_tag :question, params[:question], class: search_field_class, placeholder: "Search question text" %>
+          <%= text_field_tag :question, params[:question], class: search_field_class, placeholder: "Search question" %>
         </div>
-        <div class="min-w-48">
-          <%= label_tag :person, "Person", class: search_label_class %>
-          <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
-        </div>
-        <div class="min-w-56">
-          <%= label_tag :form_id, "Form", class: search_label_class %>
-          <%= select_tag :form_id,
-                options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
-                include_blank: "All forms",
-                class: search_field_class(extra: "search-select-placeholder") %>
-        </div>
-        <div class="min-w-52">
+        <div class="w-40">
           <%= label_tag :answer_type, "Question type", class: search_label_class %>
           <%= select_tag :answer_type,
                 options_for_select(FormField::ANSWER_TYPE_LABELS.map { |key, label| [ label, key ] }, params[:answer_type]),
                 include_blank: "All types",
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <div class="w-32">
+        <div class="w-40">
+          <%= label_tag :person, "Person", class: search_label_class %>
+          <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
+        </div>
+        <div class="w-40">
+          <%= label_tag :form_id, "Form", class: search_label_class %>
+          <%= select_tag :form_id,
+                options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
+                include_blank: "All forms",
+                class: search_field_class(extra: "search-select-placeholder") %>
+        </div>
+        <div class="w-24">
           <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
           <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
         </div>
-        <% if params.slice(:q, :question, :person, :form_id, :answer_type, :form_submission_id).values.any?(&:present?) %>
+        <div class="flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>
-        <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -46,18 +46,28 @@
           <%= label_tag :person, "Person", class: search_label_class %>
           <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
         </div>
-        <div class="w-44">
+        <div class="w-24">
+          <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
+          <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
+        </div>
+      </div>
+
+      <div class="mt-3 flex flex-wrap items-end gap-3">
+        <div class="w-56">
           <%= label_tag :form_id, "Form", class: search_label_class %>
           <%= select_tag :form_id,
                 options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
                 include_blank: "All forms",
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <div class="w-24">
-          <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
-          <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
+        <div class="w-56">
+          <%= label_tag :event_id, "Event", class: search_label_class %>
+          <%= select_tag :event_id,
+                options_from_collection_for_select(@events, :id, :time_title, params[:event_id].to_i),
+                include_blank: "All events",
+                class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <div class="ml-auto flex items-end">
+        <div class="flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>
         </div>
       </div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -23,6 +23,10 @@
           <%= label_tag :q, "Answer text", class: search_label_class %>
           <%= text_field_tag :q, params[:q], class: search_field_class, placeholder: "Search answer text" %>
         </div>
+        <div class="min-w-56 flex-1">
+          <%= label_tag :question, "Question text", class: search_label_class %>
+          <%= text_field_tag :question, params[:question], class: search_field_class, placeholder: "Search question text" %>
+        </div>
         <div class="min-w-48">
           <%= label_tag :person, "Person", class: search_label_class %>
           <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
@@ -45,7 +49,7 @@
           <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
           <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
         </div>
-        <% if params.slice(:q, :person, :form_id, :answer_type, :form_submission_id).values.any?(&:present?) %>
+        <% if params.slice(:q, :question, :person, :form_id, :answer_type, :form_submission_id).values.any?(&:present?) %>
           <%= render "shared/search_clear", url: form_answers_path %>
         <% end %>
       </div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -17,28 +17,35 @@
 
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
-    <%= form_with url: form_answers_path, method: :get, data: { controller: "collection", turbo_frame: "form_answers_results" }, autocomplete: "off" do %>
-      <div class="mb-6 flex flex-wrap items-end gap-2">
-        <div class="min-w-40 flex-1">
+    <%= form_with url: form_answers_path, method: :get,
+          data: { controller: "collection", turbo_frame: "form_answers_results" },
+          autocomplete: "off",
+          class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
+      <div class="mb-3 flex items-center gap-2 text-gray-600">
+        <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
+        <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>
+      </div>
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="min-w-48 flex-1">
           <%= label_tag :q, "Answer text", class: search_label_class %>
           <%= text_field_tag :q, params[:q], class: search_field_class, placeholder: "Search answer text" %>
         </div>
-        <div class="w-40">
+        <div class="min-w-48 flex-1">
           <%= label_tag :question, "Question text", class: search_label_class %>
           <%= text_field_tag :question, params[:question], class: search_field_class, placeholder: "Search question" %>
         </div>
-        <div class="w-40">
+        <div class="w-44">
           <%= label_tag :answer_type, "Question type", class: search_label_class %>
           <%= select_tag :answer_type,
                 options_for_select(FormField::ANSWER_TYPE_LABELS.map { |key, label| [ label, key ] }, params[:answer_type]),
                 include_blank: "All types",
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <div class="w-40">
+        <div class="w-44">
           <%= label_tag :person, "Person", class: search_label_class %>
           <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
         </div>
-        <div class="w-40">
+        <div class="w-44">
           <%= label_tag :form_id, "Form", class: search_label_class %>
           <%= select_tag :form_id,
                 options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
@@ -49,7 +56,7 @@
           <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>
           <%= number_field_tag :form_submission_id, params[:form_submission_id], class: search_field_class, placeholder: "ID" %>
         </div>
-        <div class="flex items-end">
+        <div class="ml-auto flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>
         </div>
       </div>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -6,7 +6,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif params[:return_to] == "form_answers" %>
-      <%= link_to form_answers_path(q: params[:q].presence, question: params[:question].presence, person: params[:person].presence, form_id: params[:form_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to form_answers_path(q: params[:q].presence, question: params[:question].presence, person: params[:person].presence, form_id: params[:form_id].presence, event_id: params[:event_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form answers
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -6,7 +6,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif params[:return_to] == "form_answers" %>
-      <%= link_to form_answers_path(q: params[:q].presence, person: params[:person].presence, form_id: params[:form_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to form_answers_path(q: params[:q].presence, question: params[:question].presence, person: params[:person].presence, form_id: params[:form_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form answers
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -1,9 +1,13 @@
 <% event = @form_submission.resolved_event %>
-<div class="max-w-2xl mx-auto px-4 pt-4">
+<div class="mx-auto max-w-2xl px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>
       <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
+      <% end %>
+    <% elsif params[:return_to] == "form_answers" %>
+      <%= link_to form_answers_path(q: params[:q].presence, person: params[:person].presence, form_id: params[:form_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Back to form answers
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>
       <%= link_to bulk_payments_return_path(event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -17,21 +21,21 @@
   </div>
 </div>
 
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+<div class="mx-auto max-w-2xl px-4 pt-6 pb-12">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Form submission</h1>
+          <h1 class="text-xl leading-tight font-semibold tracking-wide">Form submission</h1>
           <p class="text-sm text-blue-200"><%= @form_submission.form.name %></p>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
-    <div class="px-6 sm:px-8 py-7">
+    <div class="px-6 py-7 sm:px-8">
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1848,3 +1848,13 @@
       pickers while keeping its history; you can only delete a tag that isn't in
       use.
     - Each tag records which admin applied it, and when.
+
+- name: "Browse and search all form answers"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/form_answers"
+  summary: >-
+    A new Form answers page lists every individual answer submitted across the
+    site's forms. Search the answer text or filter by form, person, submission,
+    event, or question type, then jump straight to the full submission.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
     end
   end
   resources :form_submissions, only: [ :index, :show ]
+  resources :form_answers, only: [ :index ]
   resources :grants
   resources :scholarships, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     member do

--- a/spec/decorators/form_answer_decorator_spec.rb
+++ b/spec/decorators/form_answer_decorator_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe FormAnswerDecorator do
+  describe "#tooltip_text" do
+    it "returns plain text unchanged" do
+      answer = build(:form_answer, submitted_answer: "Just a plain answer")
+      expect(answer.decorate.tooltip_text).to eq("Just a plain answer")
+    end
+
+    it "pretty-prints a JSON object" do
+      answer = build(:form_answer, submitted_answer: '{"role":"admin","active":true}')
+      expect(answer.decorate.tooltip_text).to eq(<<~JSON.strip)
+        {
+          "role": "admin",
+          "active": true
+        }
+      JSON
+    end
+
+    it "leaves malformed JSON as-is" do
+      answer = build(:form_answer, submitted_answer: "{not really json")
+      expect(answer.decorate.tooltip_text).to eq("{not really json")
+    end
+  end
+end

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe "FormAnswers", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  describe "GET /form_answers" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      # The rows load lazily inside the results Turbo frame.
+      let(:frame_headers) { { "Turbo-Frame" => "form_answers_results" } }
+
+      it "renders the filterable index shell" do
+        get form_answers_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Form answers")
+      end
+
+      it "searches by answer text" do
+        wanted = create(:form_answer, submitted_answer: "Loves painting murals")
+        other = create(:form_answer, submitted_answer: "Prefers sculpture")
+
+        get form_answers_path(q: "murals"), headers: frame_headers
+
+        expect(response.body).to include("Loves painting murals")
+        expect(response.body).not_to include("Prefers sculpture")
+      end
+
+      it "filters by form" do
+        wanted_form = create(:form, name: "Volunteer interest")
+        other_form = create(:form, name: "Something else")
+        mine = create(:form_answer, submitted_answer: "keep-me",
+                      form_submission: create(:form_submission, form: wanted_form))
+        create(:form_answer, submitted_answer: "drop-me",
+               form_submission: create(:form_submission, form: other_form))
+
+        get form_answers_path(form_id: wanted_form.id), headers: frame_headers
+
+        expect(response.body).to include("keep-me")
+        expect(response.body).not_to include("drop-me")
+      end
+
+      it "filters by person name" do
+        priya = create(:person, first_name: "Priya", last_name: "Patel")
+        other = create(:person, first_name: "Sam", last_name: "Jones")
+        create(:form_answer, submitted_answer: "priya-answer",
+               form_submission: create(:form_submission, person: priya))
+        create(:form_answer, submitted_answer: "sam-answer",
+               form_submission: create(:form_submission, person: other))
+
+        get form_answers_path(person: "Priya"), headers: frame_headers
+
+        expect(response.body).to include("priya-answer")
+        expect(response.body).not_to include("sam-answer")
+      end
+
+      it "filters by submission" do
+        mine = create(:form_submission)
+        theirs = create(:form_submission)
+        create(:form_answer, submitted_answer: "in-submission", form_submission: mine)
+        create(:form_answer, submitted_answer: "other-submission", form_submission: theirs)
+
+        get form_answers_path(form_submission_id: mine.id), headers: frame_headers
+
+        expect(response.body).to include("in-submission")
+        expect(response.body).not_to include("other-submission")
+      end
+
+      it "filters by question type" do
+        form = create(:form)
+        paragraph = create(:form_field, form: form, answer_type: :free_form_input_paragraph)
+        one_line = create(:form_field, form: form, answer_type: :free_form_input_one_line)
+        create(:form_answer, submitted_answer: "long-answer", form_field: paragraph)
+        create(:form_answer, submitted_answer: "short-answer", form_field: one_line)
+
+        get form_answers_path(answer_type: "free_form_input_paragraph"), headers: frame_headers
+
+        expect(response.body).to include("long-answer")
+        expect(response.body).not_to include("short-answer")
+      end
+
+      it "breaks the View link out of the results frame" do
+        create(:form_answer)
+        get form_answers_path, headers: frame_headers
+        expect(response.body).to include('data-turbo-frame="_top"')
+      end
+
+      it "each View link returns to form answers" do
+        answer = create(:form_answer)
+        get form_answers_path, headers: frame_headers
+        expect(response.body).to include(
+          CGI.escapeHTML(form_submission_path(answer.form_submission, return_to: "form_answers"))
+        )
+      end
+    end
+
+    context "as a non-admin" do
+      before { sign_in create(:user) }
+
+      it "redirects away" do
+        get form_answers_path
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("Prefers sculpture")
       end
 
+      it "searches by question text" do
+        form = create(:form)
+        wanted = create(:form_field, form: form, name: "What is your favorite medium?")
+        other = create(:form_field, form: form, name: "How did you hear about us?")
+        create(:form_answer, submitted_answer: "medium-answer", form_field: wanted)
+        create(:form_answer, submitted_answer: "referral-answer", form_field: other)
+
+        get form_answers_path(question: "favorite medium"), headers: frame_headers
+
+        expect(response.body).to include("medium-answer")
+        expect(response.body).not_to include("referral-answer")
+      end
+
       it "filters by form" do
         wanted_form = create(:form, name: "Volunteer interest")
         other_form = create(:form, name: "Something else")

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("drop-me")
       end
 
+      it "filters by event" do
+        wanted_event = create(:event)
+        other_event = create(:event)
+        create(:form_answer, submitted_answer: "at-my-event",
+               form_submission: create(:form_submission, event: wanted_event))
+        create(:form_answer, submitted_answer: "at-other-event",
+               form_submission: create(:form_submission, event: other_event))
+
+        get form_answers_path(event_id: wanted_event.id), headers: frame_headers
+
+        expect(response.body).to include("at-my-event")
+        expect(response.body).not_to include("at-other-event")
+      end
+
       it "filters by person name" do
         priya = create(:person, first_name: "Priya", last_name: "Patel")
         other = create(:person, first_name: "Sam", last_name: "Jones")

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/topic_subscription_types/new.html.erb"  => "admin-only bg-blue-100",
     "app/views/topic_subscription_types/edit.html.erb" => "admin-only bg-blue-100",
     "app/views/form_submissions/index.html.erb"        => "admin-only bg-blue-100",
+    "app/views/form_answers/index.html.erb"            => "admin-only bg-blue-100",
     # show
     "app/views/banners/show.html.erb"                  => "admin-only bg-blue-100",
     "app/views/categories/show.html.erb"               => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new admin index with plain guarded-scope filters, one new controller/policy/view

New admin **Form answers** page: browse every individual form answer in one place.

## Filters (all stack, each a no-op when blank)
- Answer text — `LIKE` on `submitted_answer`
- Question text — `LIKE` on the field name / `question_name_when_answered`
- Person — name or email
- Form — dropdown
- Question type — `answer_type` dropdown
- Submission — by id

## Notes
- Lazy `:form_answers_results` Turbo frame, matching the form_submissions pattern.
- `submitted_answer` is rendered auto-escaped (stored verbatim/unsanitized).
- Surfaced from the admin home **Additional data** section (replaces the disabled placeholder card).
- Feature entry added to `config/features.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)