### PR TITLE
Remove dead Organization#led_by? and #leader

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -4,11 +4,9 @@ class Affiliation < ApplicationRecord
   # (both treat exactly "Facilitator" as canonical).
   FACILITATOR_TITLE = "Facilitator".freeze
 
-  # Legacy role titles, seeded when the old integer `position` enum (liaison: 1,
-  # leader: 2) was converted to free-text `title` (#432/#735). LIAISON_TITLE gates
-  # monthly-report editing; LEADER_TITLE backs Organization#leader / #led_by?.
+  # Legacy role title from the old integer `position` enum (liaison: 1), converted
+  # to free-text `title` on prod (#432/#735). Gates monthly-report editing.
   LIAISON_TITLE = "Liaison".freeze
-  LEADER_TITLE = "Leader".freeze
 
   # Status taxonomy shown as a chip on each person's row, in display order.
   STATUSES = %w[ Active Upcoming Inactive ].freeze

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -186,12 +186,6 @@ class Organization < ApplicationRecord
     facilitator_program_status(as_of: reference_date).status
   end
 
-  # Methods
-  def led_by?(user)
-    return false unless leader
-    leader.user == user
-  end
-
   def state
     addresses.active.first&.state
   end
@@ -330,10 +324,6 @@ class Organization < ApplicationRecord
     if end_date_changed?
       errors.add(:end_date, "is managed automatically by affiliations")
     end
-  end
-
-  def leader
-    affiliations.find_by(title: Affiliation::LEADER_TITLE)
   end
 
   def remove_duplicate_sectorable_items

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -155,7 +155,8 @@ end
   Affiliation.create!(
     person: user.person,
     organization: awbw_org,
-    title: Affiliation::LEADER_TITLE,
+    title: Affiliation::FACILITATOR_TITLE,
+    primary_contact: true,
     start_date: 1.year.ago.to_date
   )
 end

--- a/db/seeds/dev/people_profiles.rb
+++ b/db/seeds/dev/people_profiles.rb
@@ -30,7 +30,8 @@ puts "Creating Persons and Affiliations for seed users…"
   Affiliation.create!(
     person: person,
     organization: org,
-    title: Affiliation::LEADER_TITLE,
+    title: Affiliation::FACILITATOR_TITLE,
+    primary_contact: true,
     start_date: 1.year.ago.to_date
   )
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 dead-code removal + seed reshuffle; note the monthly-report gate follow-up

Closes #2319

## What
- Remove `Organization#led_by?` — no callers repo-wide, and broken regardless: it calls `leader.user`, but `Affiliation` has no `user` association (only a bare, never-written `user_id` column).
- Remove the private `Organization#leader` — existed only to back `led_by?`.
- Remove the now-unused `Affiliation::LEADER_TITLE` constant.
- Seeds that minted `"Leader"` affiliations now mint `Facilitator` + `primary_contact: true` — the role "Leader" is being folded into.

## Follow-up decision (not in this PR)
The retirement plan folds the legacy **Liaison** role into Facilitator + `primary_contact` too — but `Person#has_liasion_position_for?` (the monthly-report edit gate) still keys on `title == "Liaison"`. Converting Liaison rows to Facilitator will **break that gate** unless it's repointed at `primary_contact`. Flagging for a separate decision + PR.