### PR TITLE
Expose blog contributor toggle on the person edit form

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -545,6 +545,7 @@ class PeopleController < ApplicationController
       :racial_ethnic_identity,
       :filemaker_code,
       :mailing_list_consented,
+      :blog_contributor,
       :bio, :shoutout_text, :notes,
       :display_name_preference,
       :anonymous_contributions,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -443,14 +443,20 @@
           </div>
         </div>
 
-        <div class="w-full">
+        <div class="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
           <%= f.input :mailing_list_consented,
                       as: :boolean,
                       label: "Consented to mailing list",
                       hint: f.object.mailing_list_consent_at.present? ?
                               "Consented #{f.object.mailing_list_consent_at.to_date.to_fs(:long)} (#{f.object.mailing_list_consent_source}). Uncheck to withdraw." :
                               "No consent on file. Check to record consent.",
-                      wrapper_html: { class: "w-full" } %>
+                      wrapper_html: { class: "w-full sm:flex-1" } %>
+
+          <%= f.input :blog_contributor,
+                      as: :boolean,
+                      label: "Blog contributor",
+                      hint: "Adds a blog contributor badge to this person's profile.",
+                      wrapper_html: { class: "w-full sm:w-auto sm:text-right" } %>
         </div>
       </div>
     <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1900,3 +1900,13 @@
       matches people still subscribed, staff tag matches people carrying that tag.
     - The age range dropdown lists your published age ranges and matches anyone
       tagged with that range.
+
+- name: "Flag blog contributors from the person edit form"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  pr_number: 2323
+  summary: >-
+    Admins can now check "Blog contributor" on a person's edit page to add the
+    orange Blog Contributor badge to their profile. Previously the flag could
+    only be set outside the app.

--- a/spec/requests/people_blog_contributor_spec.rb
+++ b/spec/requests/people_blog_contributor_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Person blog contributor flag", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+
+  context "as an admin" do
+    before { sign_in admin }
+
+    it "renders the blog-contributor toggle on the edit form" do
+      get edit_person_path(person)
+
+      expect(response.body).to include("Blog contributor")
+    end
+
+    it "persists the blog-contributor flag on update" do
+      patch person_path(person), params: { person: { blog_contributor: "1" } }
+
+      expect(person.reload.blog_contributor).to be(true)
+    end
+  end
+
+  context "as the profile owner (non-admin)" do
+    let(:owner_user) { create(:user, :with_person) }
+    let(:person) { owner_user.person }
+
+    before { sign_in owner_user }
+
+    it "does not render the admin-only blog-contributor toggle" do
+      get edit_person_path(person)
+
+      expect(response.body).not_to include("Blog contributor")
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one admin-only form field + one permitted param

### What is the goal of this PR and why is this important?
The `blog_contributor` boolean and its orange "Blog Contributor" profile badge already existed, but the flag could only be set outside the app (console/import). This gives admins a checkbox on the person edit form so they can flag blog contributors directly.

### How did you approach the change?
Added a "Blog contributor" boolean input in the bottom-right of the existing admin-only section (next to "Consented to mailing list") and permitted `:blog_contributor` in `person_params`. The field renders only inside the existing `allowed_to?(:manage?, Person)` block, matching the sibling admin-only fields.

### UI Testing Checklist
- [ ] As a manager, edit a person and confirm the "Blog contributor" checkbox appears bottom-right of the admin section.
- [ ] Check it, save, and confirm the orange "Blog Contributor" badge shows on the profile.
- [ ] Uncheck it, save, and confirm the badge is removed.

### Anything else to add?
Like the neighboring `racial_ethnic_identity`/`filemaker_code` fields, the param is permitted unconditionally in the controller but only rendered for managers.