### PR TITLE
Drop vestigial user_id from affiliations

### DIFF
--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -350,12 +350,6 @@
                                         :affiliations,
                                         class: "btn btn-secondary-outline" %></div>
         </div>
-      <% else %>
-        <% f.object.user&.person&.affiliations&.each do |affiliation| %>
-          <div class="ps-6 mb-2">
-            <li><%= affiliation.title %> - <%= person_profile_button(affiliation.user.person, subtitle: (affiliation.user.person.preferred_email if affiliation.user.person.profile_show_email? || allowed_to?(:manage?, Person))) if affiliation.persisted? && affiliation.user.person %></li>
-          </div>
-        <% end %>
       <% end %>
     </div>
   </div>

--- a/db/migrate/20260822133627_remove_user_id_from_affiliations.rb
+++ b/db/migrate/20260822133627_remove_user_id_from_affiliations.rb
@@ -1,0 +1,21 @@
+class RemoveUserIdFromAffiliations < ActiveRecord::Migration[8.1]
+  # Vestigial column: never backed by an association, and every populated row's
+  # user already resolves to the affiliation's own person (users.person_id =
+  # affiliations.person_id for all 1,537 non-null rows, 0 mismatches). The person
+  # link is the source of truth, so user_id carries no unique information.
+  def up
+    remove_foreign_key :affiliations, :users, if_exists: true
+    remove_index :affiliations, :user_id, if_exists: true
+    remove_column :affiliations, :user_id, if_exists: true
+  end
+
+  def down
+    add_column :affiliations, :user_id, :integer unless column_exists?(:affiliations, :user_id)
+    unless index_exists?(:affiliations, :user_id, name: "index_affiliations_on_user_id")
+      add_index :affiliations, :user_id, name: "index_affiliations_on_user_id"
+    end
+    unless foreign_key_exists?(:affiliations, :users)
+      add_foreign_key :affiliations, :users
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_112435) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_133627) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -117,12 +117,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_112435) do
     t.date "start_date"
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "user_id"
     t.index ["event_registration_id"], name: "index_affiliations_on_event_registration_id"
     t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
     t.index ["person_id"], name: "index_affiliations_on_person_id"
-    t.index ["user_id"], name: "index_affiliations_on_user_id"
   end
 
   create_table "age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1875,7 +1873,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_112435) do
   add_foreign_key "affiliations", "event_registrations", on_delete: :nullify
   add_foreign_key "affiliations", "organizations"
   add_foreign_key "affiliations", "people"
-  add_foreign_key "affiliations", "users"
   add_foreign_key "age_ranges", "windows_types"
   add_foreign_key "allocations", "allocations", column: "reverted_id"
   add_foreign_key "banners", "users", column: "created_by_id"


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 verified-redundant column drop + dead-view removal, no code reads the column

### What is the goal of this PR and why is this important?
Remove the vestigial `user_id` column from `affiliations`. It was never backed by a model association and carried no unique information — the person link is the source of truth.

### How did you approach the change?
- Confirmed the column is fully redundant: `users.person_id = affiliations.person_id` for all 1,537 non-null rows, with 0 mismatches (and no dangling/unlinked users).
- Migration drops the `affiliations → users` foreign key, the `index_affiliations_on_user_id` index, then the column; `down` restores all three (verified reversible).
- Deleted the already-dead org-form branch that read the non-existent `affiliation.user`.

### Anything else to add?
No `config/features.yml` entry — internal schema cleanup with no user-facing change.
